### PR TITLE
fix(docs): quick install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,18 @@ A fast, modern web interface for qBittorrent. Manage multiple qBittorrent instan
 
 ```bash
 # Download and extract the latest release
-wget $(curl -s https://api.github.com/repos/autobrr/qui/releases/latest | grep download | grep linux_x86_64 | cut -d\" -f4)
-tar -C /usr/local/bin -xzf qui*.tar.gz
-rm qui*.tar.gz
+wget $(curl -s https://api.github.com/repos/autobrr/qui/releases/latest | grep browser_download_url | grep linux_x86_64 | cut -d\" -f4)
 ```
+
+### Unpack
+
+Run with root or sudo. If you do not have root, or are on a shared system, place the binaries somewhere in your home directory like ~/.bin.
+
+```bash
+tar -C /usr/local/bin -xzf qui*.tar.gz
+```
+
+This will extract both qui to /usr/local/bin. Note: If the command fails, prefix it with sudo and re-run again.
 
 ### Manual Download
 


### PR DESCRIPTION
This PR adapts the README.md so that the grep command only looks for `browser_download_url` so that i won't pick up the word `download` in the release message which makes the consequent grep command fail.
Also added a note for the extract command which needs root / sudo to successfully run.