### PR TITLE
feat: add collapsible filter sidebar with smooth animations

### DIFF
--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -98,6 +98,7 @@ interface TorrentTableOptimizedProps {
   addTorrentModalOpen?: boolean
   onAddTorrentModalChange?: (open: boolean) => void
   onFilteredDataUpdate?: (torrents: Torrent[], total: number, counts?: any, categories?: any, tags?: string[]) => void
+  filterButton?: React.ReactNode
 }
 
 
@@ -386,7 +387,7 @@ const createColumns = (incognitoMode: boolean): ColumnDef<Torrent>[] => [
   },
 ]
 
-export function TorrentTableOptimized({ instanceId, filters, selectedTorrent, onTorrentSelect, addTorrentModalOpen, onAddTorrentModalChange, onFilteredDataUpdate }: TorrentTableOptimizedProps) {
+export function TorrentTableOptimized({ instanceId, filters, selectedTorrent, onTorrentSelect, addTorrentModalOpen, onAddTorrentModalChange, onFilteredDataUpdate, filterButton }: TorrentTableOptimizedProps) {
   // State management
   const [sorting, setSorting] = usePersistedColumnSorting([])
   const [globalFilter, setGlobalFilter] = useState('')
@@ -916,6 +917,12 @@ export function TorrentTableOptimized({ instanceId, filters, selectedTorrent, on
       <div className="flex flex-col gap-2 flex-shrink-0 sm:mt-3">
         {/* Search bar row */}
         <div className="flex items-center gap-1 sm:gap-2">
+          {/* Filter button - only on desktop */}
+          {filterButton && (
+            <div className="hidden xl:block">
+              {filterButton}
+            </div>
+          )}
           <div className="relative flex-1">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
             <Input

--- a/web/src/components/torrents/TorrentTableResponsive.tsx
+++ b/web/src/components/torrents/TorrentTableResponsive.tsx
@@ -16,6 +16,7 @@ interface TorrentTableResponsiveProps {
   addTorrentModalOpen?: boolean
   onAddTorrentModalChange?: (open: boolean) => void
   onFilteredDataUpdate?: (torrents: Torrent[], total: number, counts?: any, categories?: any, tags?: string[]) => void
+  filterButton?: React.ReactNode
 }
 
 export function TorrentTableResponsive(props: TorrentTableResponsiveProps) {

--- a/web/src/hooks/usePersistedFilterSidebarState.ts
+++ b/web/src/hooks/usePersistedFilterSidebarState.ts
@@ -1,0 +1,30 @@
+import { useState, useEffect } from 'react'
+
+export function usePersistedFilterSidebarState(defaultCollapsed: boolean = false) {
+  const storageKey = 'qui-filter-sidebar-collapsed'
+  
+  // Initialize state from localStorage or default value
+  const [filterSidebarCollapsed, setFilterSidebarCollapsed] = useState<boolean>(() => {
+    try {
+      const stored = localStorage.getItem(storageKey)
+      if (stored !== null) {
+        return stored === 'true'
+      }
+    } catch (error) {
+      console.error('Failed to load filter sidebar state from localStorage:', error)
+    }
+    
+    return defaultCollapsed
+  })
+  
+  // Persist to localStorage whenever state changes
+  useEffect(() => {
+    try {
+      localStorage.setItem(storageKey, filterSidebarCollapsed.toString())
+    } catch (error) {
+      console.error('Failed to save filter sidebar state to localStorage:', error)
+    }
+  }, [filterSidebarCollapsed])
+  
+  return [filterSidebarCollapsed, setFilterSidebarCollapsed] as const
+}

--- a/web/src/pages/Torrents.tsx
+++ b/web/src/pages/Torrents.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Filter } from 'lucide-react'
 import { usePersistedFilters } from '@/hooks/usePersistedFilters'
+import { usePersistedFilterSidebarState } from '@/hooks/usePersistedFilterSidebarState'
 import { useNavigate, useSearch } from '@tanstack/react-router'
 import type { Torrent } from '@/types'
 
@@ -18,6 +19,7 @@ interface TorrentsProps {
 
 export function Torrents({ instanceId, instanceName }: TorrentsProps) {
   const [filters, setFilters] = usePersistedFilters()
+  const [filterSidebarCollapsed, setFilterSidebarCollapsed] = usePersistedFilterSidebarState(false)
   const [selectedTorrent, setSelectedTorrent] = useState<Torrent | null>(null)
   const [mobileFilterOpen, setMobileFilterOpen] = useState(false)
   const navigate = useNavigate()
@@ -105,10 +107,26 @@ export function Torrents({ instanceId, instanceName }: TorrentsProps) {
            filters.trackers.length
   }, [filters])
 
+  // Create the filter toggle button for the table toolbar
+  const filterToggleButton = (
+    <Button
+      variant="outline"
+      size="icon"
+      onClick={() => setFilterSidebarCollapsed(!filterSidebarCollapsed)}
+      className="relative"
+      title={filterSidebarCollapsed ? "Show filters" : "Hide filters"}
+    >
+      <Filter className="h-4 w-4" />
+      {activeFilterCount > 0 && (
+        <span className="absolute -top-1 -right-1 h-2 w-2 bg-primary rounded-full" />
+      )}
+    </Button>
+  )
+
   return (
-    <div className="flex h-full">
-      {/* Desktop Sidebar - hidden on mobile */}
-      <div className="hidden xl:block">
+    <div className="flex h-full relative">
+      {/* Desktop Sidebar - hidden on mobile, with slide animation */}
+      <div className={`hidden xl:block ${filterSidebarCollapsed ? 'w-0' : 'w-full xl:max-w-xs'} transition-all duration-300 ease-in-out overflow-hidden`}>
         <FilterSidebar
           instanceId={instanceId}
           selectedFilters={filters}
@@ -116,6 +134,8 @@ export function Torrents({ instanceId, instanceName }: TorrentsProps) {
           torrentCounts={torrentCounts}
           categories={categories}
           tags={tags}
+          collapsed={filterSidebarCollapsed}
+          onCollapsedChange={setFilterSidebarCollapsed}
         />
       </div>
       
@@ -179,6 +199,7 @@ export function Torrents({ instanceId, instanceName }: TorrentsProps) {
               addTorrentModalOpen={isAddTorrentModalOpen}
               onAddTorrentModalChange={handleAddTorrentModalChange}
               onFilteredDataUpdate={handleFilteredDataUpdate}
+              filterButton={filterToggleButton}
             />
           </div>
         </div>


### PR DESCRIPTION
- Add collapsible FilterSidebar that slides in/out smoothly
- Implement persistent collapsed state using localStorage
- Add filter toggle button in table toolbar next to search bar
- Memoize FilterSidebar component to prevent animation breaks during polling
- Add text truncation for long category/tag/tracker names
- Show active filter indicator on toggle button

The FilterSidebar now has a clean slide animation and maintains state across page refreshes. The toggle button is consistently positioned in the toolbar for easy access.