### PR TITLE
feat: add all-time statistics display across application

### DIFF
--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -82,7 +82,7 @@ import {
   getLinuxRatio,
   useIncognitoMode,
 } from '@/lib/incognito'
-import { formatBytes, formatSpeed } from '@/lib/utils'
+import { formatBytes, formatSpeed, getRatioColor } from '@/lib/utils'
 import { applyOptimisticUpdates } from '@/lib/torrent-state-utils'
 
 interface TorrentTableOptimizedProps {
@@ -254,21 +254,7 @@ const createColumns = (incognitoMode: boolean): ColumnDef<Torrent>[] => [
     cell: ({ row }) => {
       const ratio = incognitoMode ? getLinuxRatio(row.original.hash) : row.original.ratio
       const displayRatio = ratio === -1 ? "∞" : ratio.toFixed(2)
-      
-      let colorVar = ''
-      if (ratio >= 0) {
-        if (ratio < 0.5) {
-          colorVar = 'var(--chart-5)' // very bad - lowest/darkest
-        } else if (ratio < 1.0) {
-          colorVar = 'var(--chart-4)' // bad - below 1.0
-        } else if (ratio < 2.0) {
-          colorVar = 'var(--chart-3)' // okay - above 1.0
-        } else if (ratio < 5.0) {
-          colorVar = 'var(--chart-2)' // good - healthy ratio
-        } else {
-          colorVar = 'var(--chart-1)' // excellent - best ratio
-        }
-      }
+      const colorVar = getRatioColor(ratio)
       
       return (
         <span 
@@ -462,6 +448,7 @@ export function TorrentTableOptimized({ instanceId, filters, selectedTorrent, on
     counts,
     categories,
     tags,
+    serverState, 
     isLoading,
     isFetching,
     isLoadingMore,
@@ -897,18 +884,106 @@ export function TorrentTableOptimized({ instanceId, filters, selectedTorrent, on
   return (
     <div className="h-full flex flex-col">
       {/* Desktop Stats bar - shown at top on desktop */}
-      <div className="hidden sm:flex flex-wrap gap-2 sm:gap-4 text-xs sm:text-sm flex-shrink-0">
-        <div>Total: <strong>{stats.total}</strong></div>
-        <div className="hidden lg:block">Downloading: <strong>{stats.downloading}</strong></div>
-        <div className="hidden lg:block">Seeding: <strong>{stats.seeding}</strong></div>
-        <div className="hidden lg:block">Paused: <strong>{stats.paused}</strong></div>
-        <div className="hidden lg:block">Error: <strong className={stats.error > 0 ? "text-destructive" : ""}>{stats.error}</strong></div>
-        <div className="ml-auto text-xs sm:text-sm flex items-center gap-1">
-          <ChevronDown className="h-3.5 w-3.5" />
-          {formatSpeed(stats.totalDownloadSpeed || 0)}
-          <span className="text-muted-foreground mx-1">|</span>
-          <ChevronUp className="h-3.5 w-3.5" />
-          {formatSpeed(stats.totalUploadSpeed || 0)}
+      <div className="hidden sm:flex items-center justify-between gap-3 text-xs sm:text-sm flex-shrink-0">
+        {/* Torrent counts - more compact */}
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-1.5">
+            <span className="text-muted-foreground">Total:</span>
+            <strong>{stats.total}</strong>
+          </div>
+          
+          {/* Show key stats with colors */}
+          <div className="flex items-center gap-3 text-xs">
+            {stats.downloading > 0 && (
+              <div className="flex items-center gap-1">
+                <div className="w-2 h-2 rounded-full bg-blue-500" />
+                <span>{stats.downloading}</span>
+              </div>
+            )}
+            {stats.seeding > 0 && (
+              <div className="flex items-center gap-1">
+                <div className="w-2 h-2 rounded-full bg-emerald-500" />
+                <span>{stats.seeding}</span>
+              </div>
+            )}
+            {stats.paused > 0 && (
+              <div className="flex items-center gap-1">
+                <div className="w-2 h-2 rounded-full bg-gray-500" />
+                <span>{stats.paused}</span>
+              </div>
+            )}
+            {stats.error > 0 && (
+              <div className="flex items-center gap-1">
+                <div className="w-2 h-2 rounded-full bg-red-500" />
+                <span className="text-destructive">{stats.error}</span>
+              </div>
+            )}
+          </div>
+        </div>
+        
+        {/* User statistics - more compact */}
+        {serverState && (
+          <div className="flex items-center gap-3">
+            {/* All-time stats */}
+            {serverState.alltime_dl !== undefined && (
+              <div className="flex items-center gap-2 text-xs">
+                <span className="text-muted-foreground">All-time stats:</span>
+                <div className="flex items-center gap-1">
+                  <ChevronDown className="h-3 w-3 text-muted-foreground" />
+                  <span className="font-medium">{formatBytes(serverState.alltime_dl || 0)}</span>
+                </div>
+                <span className="text-muted-foreground">|</span>
+                <div className="flex items-center gap-1">
+                  <ChevronUp className="h-3 w-3 text-muted-foreground" />
+                  <span className="font-medium">{formatBytes(serverState.alltime_ul || 0)}</span>
+                </div>
+              </div>
+            )}
+            
+            {/* Ratio with color coding */}
+            {(serverState.global_ratio !== undefined || (serverState.alltime_dl !== undefined && serverState.alltime_ul !== undefined)) && (() => {
+              let ratioValue = 0
+              let displayRatio = '0.00'
+              
+              if (serverState.global_ratio && serverState.global_ratio !== '') {
+                ratioValue = parseFloat(serverState.global_ratio)
+                displayRatio = serverState.global_ratio
+              } else if (serverState.alltime_dl && serverState.alltime_dl > 0 && serverState.alltime_ul !== undefined) {
+                ratioValue = (serverState.alltime_ul || 0) / serverState.alltime_dl
+                displayRatio = ratioValue.toFixed(2)
+              }
+              
+              const colorVar = getRatioColor(ratioValue)
+              
+              return (
+                <div className="flex items-center gap-1.5 text-xs">
+                  <span className="text-muted-foreground">Ratio:</span>
+                  <strong style={{ color: colorVar }}>{displayRatio}</strong>
+                </div>
+              )
+            })()}
+            
+            {/* Peers */}
+            {serverState.total_peer_connections !== undefined && (
+              <div className="flex items-center gap-1.5 text-xs">
+                <span className="text-muted-foreground">Peers:</span>
+                <span className="font-medium">{serverState.total_peer_connections || 0}</span>
+              </div>
+            )}
+          </div>
+        )}
+        
+        {/* Current speeds - right aligned */}
+        <div className="flex items-center gap-2 text-xs ml-auto">
+          <div className="flex items-center gap-1">
+            <ChevronDown className="h-3 w-3 text-muted-foreground" />
+            <span className="font-medium">{formatSpeed(stats.totalDownloadSpeed || 0)}</span>
+          </div>
+          <span className="text-muted-foreground">|</span>
+          <div className="flex items-center gap-1">
+            <ChevronUp className="h-3 w-3 text-muted-foreground" />
+            <span className="font-medium">{formatSpeed(stats.totalUploadSpeed || 0)}</span>
+          </div>
         </div>
       </div>
 

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -27,6 +27,27 @@ export function formatTimestamp(timestamp: number): string {
   return new Date(timestamp * 1000).toLocaleString()
 }
 
+/**
+ * Get the appropriate color for a torrent ratio based on predefined thresholds
+ * @param ratio - The ratio value (uploaded/downloaded)
+ * @returns CSS custom property string for the appropriate color
+ */
+export function getRatioColor(ratio: number): string {
+  if (ratio < 0) return ''
+  
+  if (ratio < 0.5) {
+    return 'var(--chart-5)' // very bad - lowest/darkest
+  } else if (ratio < 1.0) {
+    return 'var(--chart-4)' // bad - below 1.0
+  } else if (ratio < 2.0) {
+    return 'var(--chart-3)' // okay - above 1.0
+  } else if (ratio < 5.0) {
+    return 'var(--chart-2)' // good - healthy ratio
+  } else {
+    return 'var(--chart-1)' // excellent - best ratio
+  }
+}
+
 export function formatDuration(seconds: number): string {
   if (seconds === 0) return '0s'
   const days = Math.floor(seconds / 86400)

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -4,10 +4,13 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge'
 import { Progress } from '@/components/ui/progress'
 import { Button } from '@/components/ui/button'
-import { HardDrive, Download, Upload, AlertCircle, Activity, Plus, Zap, ChevronDown } from 'lucide-react'
+import { HardDrive, Download, Upload, AlertCircle, Activity, Plus, Zap, ChevronDown, ChevronUp } from 'lucide-react'
 import { Link } from '@tanstack/react-router'
 import { useMemo } from 'react'
-import { formatSpeed } from '@/lib/utils'
+import { formatSpeed, formatBytes, getRatioColor } from '@/lib/utils'
+import { useQuery } from '@tanstack/react-query'
+import { api } from '@/lib/api'
+import type { ServerState } from '@/types'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -16,6 +19,25 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+
+// Custom hook to fetch serverState for an instance
+function useInstanceServerState(instanceId: number, enabled: boolean) {
+  return useQuery({
+    queryKey: ['server-state', instanceId],
+    queryFn: async () => {
+      try {
+        const data = await api.syncMainData(instanceId, 0)
+        return (data as any).server_state || data.serverState || null
+      } catch (error) {
+        console.error('Error fetching server state for instance', instanceId, error)
+        return null
+      }
+    },
+    staleTime: 30000, // 30 seconds
+    refetchInterval: 30000, // Refetch every 30 seconds
+    enabled: enabled && !!instanceId,
+  })
+}
 
 // Custom hook to safely get all instance stats
 function useAllInstanceStats(instances: any[]) {
@@ -30,9 +52,14 @@ function useAllInstanceStats(instances: any[]) {
     })
   )
   
+  const serverStateQueries = fixedInstances.map((instance) =>
+    useInstanceServerState(instance?.id || -1, instance !== null)
+  )
+  
   return instances.map((instance, index) => ({
     instance,
-    stats: statsQueries[index].data
+    stats: statsQueries[index].data,
+    serverState: serverStateQueries[index].data as ServerState | null
   }))
 }
 
@@ -173,7 +200,7 @@ function InstanceCard({ instance }: { instance: any }) {
   )
 }
 
-function GlobalStatsCards({ statsData }: { statsData: Array<{ instance: any, stats: any }> }) {
+function GlobalStatsCards({ statsData }: { statsData: Array<{ instance: any, stats: any, serverState: ServerState | null }> }) {
   const globalStats = useMemo(() => {
     const connected = statsData.filter(({ stats }) => stats?.connected).length
     const totalTorrents = statsData.reduce((sum, { stats }) => 
@@ -186,6 +213,20 @@ function GlobalStatsCards({ statsData }: { statsData: Array<{ instance: any, sta
       sum + (stats?.speeds?.upload || 0), 0)
     const totalErrors = statsData.reduce((sum, { stats }) => 
       sum + (stats?.torrents?.error || 0), 0)
+    
+    // Calculate all-time stats
+    const alltimeDl = statsData.reduce((sum, { serverState }) => 
+      sum + (serverState?.alltime_dl || 0), 0)
+    const alltimeUl = statsData.reduce((sum, { serverState }) => 
+      sum + (serverState?.alltime_ul || 0), 0)
+    const totalPeers = statsData.reduce((sum, { serverState }) => 
+      sum + (serverState?.total_peer_connections || 0), 0)
+    
+    // Calculate global ratio
+    let globalRatio = 0
+    if (alltimeDl > 0) {
+      globalRatio = alltimeUl / alltimeDl
+    }
 
     return {
       connected,
@@ -194,7 +235,11 @@ function GlobalStatsCards({ statsData }: { statsData: Array<{ instance: any, sta
       activeTorrents,
       totalDownload,
       totalUpload,
-      totalErrors
+      totalErrors,
+      alltimeDl,
+      alltimeUl,
+      globalRatio,
+      totalPeers
     }
   }, [statsData])
 
@@ -265,7 +310,73 @@ function GlobalStatsCards({ statsData }: { statsData: Array<{ instance: any, sta
   )
 }
 
-function QuickActionsDropdown({ statsData }: { statsData: Array<{ instance: any, stats: any }> }) {
+function GlobalAllTimeStats({ statsData }: { statsData: Array<{ instance: any, stats: any, serverState: ServerState | null }> }) {
+  const globalStats = useMemo(() => {
+    // Calculate all-time stats
+    const alltimeDl = statsData.reduce((sum, { serverState }) => 
+      sum + (serverState?.alltime_dl || 0), 0)
+    const alltimeUl = statsData.reduce((sum, { serverState }) => 
+      sum + (serverState?.alltime_ul || 0), 0)
+    const totalPeers = statsData.reduce((sum, { serverState }) => 
+      sum + (serverState?.total_peer_connections || 0), 0)
+    
+    // Calculate global ratio
+    let globalRatio = 0
+    if (alltimeDl > 0) {
+      globalRatio = alltimeUl / alltimeDl
+    }
+
+    return {
+      alltimeDl,
+      alltimeUl,
+      globalRatio,
+      totalPeers
+    }
+  }, [statsData])
+
+  // Apply color grading to ratio
+  const ratioColor = getRatioColor(globalStats.globalRatio)
+
+  // Don't show if no data
+  if (globalStats.alltimeDl === 0 && globalStats.alltimeUl === 0) {
+    return null
+  }
+
+  return (
+    <div className="rounded-lg border bg-card p-4">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div className="items-center"><h3 className="text-base font-medium">All-Time Statistics <Badge className="ml-1">combined</Badge></h3></div>
+        <div className="flex flex-wrap items-center gap-6 text-sm">
+          <div className="flex items-center gap-2">
+            <ChevronDown className="h-4 w-4 text-muted-foreground" />
+            <span className="text-lg font-semibold">{formatBytes(globalStats.alltimeDl)}</span>
+          </div>
+          
+          <div className="flex items-center gap-2">
+            <ChevronUp className="h-4 w-4 text-muted-foreground" />
+            <span className="text-lg font-semibold">{formatBytes(globalStats.alltimeUl)}</span>
+          </div>
+          
+          <div className="flex items-center gap-2">
+            <span className="text-muted-foreground">Ratio:</span>
+            <span className="text-lg font-semibold" style={{ color: ratioColor }}>
+              {globalStats.globalRatio.toFixed(2)}
+            </span>
+          </div>
+          
+          {globalStats.totalPeers > 0 && (
+            <div className="flex items-center gap-2">
+              <span className="text-muted-foreground">Peers:</span>
+              <span className="text-lg font-semibold">{globalStats.totalPeers}</span>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function QuickActionsDropdown({ statsData }: { statsData: Array<{ instance: any, stats: any, serverState: ServerState | null }> }) {
   const connectedInstances = statsData
     .filter(({ stats }) => stats?.connected)
     .map(({ instance }) => instance)
@@ -352,6 +463,9 @@ export function Dashboard() {
       
       {instances && instances.length > 0 ? (
         <div className="space-y-6">
+            {/* All-Time Stats Bar */}
+            <GlobalAllTimeStats statsData={statsData} />
+          
           {/* Global Stats */}
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
             <GlobalStatsCards statsData={statsData} />

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -344,8 +344,45 @@ function GlobalAllTimeStats({ statsData }: { statsData: Array<{ instance: any, s
 
   return (
     <div className="rounded-lg border bg-card p-4">
-      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-        <div className="items-center"><h3 className="text-base font-medium">All-Time Statistics <Badge className="ml-1">combined</Badge></h3></div>
+      {/* Mobile layout */}
+      <div className="sm:hidden">
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="text-sm font-medium text-muted-foreground">All-Time Statistics</h3>
+          <Badge variant="secondary" className="text-xs">combined</Badge>
+        </div>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            <div className="flex items-center gap-1.5">
+              <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+              <span className="text-sm font-semibold">{formatBytes(globalStats.alltimeDl)}</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <ChevronUp className="h-3.5 w-3.5 text-muted-foreground" />
+              <span className="text-sm font-semibold">{formatBytes(globalStats.alltimeUl)}</span>
+            </div>
+          </div>
+          <div className="flex items-center gap-4 text-sm">
+            <div>
+              <span className="text-xs text-muted-foreground">Ratio: </span>
+              <span className="font-semibold" style={{ color: ratioColor }}>
+                {globalStats.globalRatio.toFixed(2)}
+              </span>
+            </div>
+            {globalStats.totalPeers > 0 && (
+              <div>
+                <span className="text-xs text-muted-foreground">Peers: </span>
+                <span className="font-semibold">{globalStats.totalPeers}</span>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+      
+      {/* Desktop layout - unchanged */}
+      <div className="hidden sm:flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div className="items-center">
+          <h3 className="text-base font-medium">All-Time Statistics <Badge variant="secondary" className="ml-1">combined</Badge></h3>
+        </div>
         <div className="flex flex-wrap items-center gap-6 text-sm">
           <div className="flex items-center gap-2">
             <ChevronDown className="h-4 w-4 text-muted-foreground" />

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -125,4 +125,10 @@ export interface ServerState {
   queueing: boolean
   use_alt_speed_limits: boolean
   refresh_interval: number
+  // User statistics
+  alltime_dl?: number
+  alltime_ul?: number
+  total_wasted_session?: number
+  global_ratio?: string
+  total_peer_connections?: number
 }


### PR DESCRIPTION
### Summary

- Display user statistics (downloaded/uploaded/ratio/peers) on individual instance pages
- Add combined all-time statistics for all instances on dashboard
- Fetch serverState data using syncMainData API endpoint
- Create reusable getRatioColor() utility function to eliminate code duplication

### Dashboard
<img width="2269" height="783" alt="CleanShot 2025-08-08 at 23 16 34@2x" src="https://github.com/user-attachments/assets/5a94a809-516f-4b23-a81e-75642552ab3f" />

#### Dashboard Mobile
<img width="868" height="703" alt="CleanShot 2025-08-08 at 23 24 02@2x" src="https://github.com/user-attachments/assets/70cbfead-456d-458d-8840-d992a0bec721" />


### Instance
<img width="1691" height="403" alt="CleanShot 2025-08-08 at 23 17 43@2x" src="https://github.com/user-attachments/assets/489f1b98-90b5-404e-940d-162a8c108a42" />
