### PR TITLE
feat: add URL masking in incognito mode for dashboard

### DIFF
--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -1497,7 +1497,6 @@ export function TorrentTableOptimized({ instanceId, filters, selectedTorrent, on
             <button
               onClick={() => setIncognitoMode(!incognitoMode)}
               className="p-1 rounded-sm transition-all hover:bg-muted/50"
-              style={{ opacity: incognitoMode ? 0.5 : 0.2 }}
               title={incognitoMode ? "Exit incognito mode" : "Enable incognito mode"}
             >
               {incognitoMode ? (

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -4,9 +4,9 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge'
 import { Progress } from '@/components/ui/progress'
 import { Button } from '@/components/ui/button'
-import { HardDrive, Download, Upload, AlertCircle, Activity, Plus, Zap, ChevronDown, ChevronUp } from 'lucide-react'
+import { HardDrive, Download, Upload, AlertCircle, Activity, Plus, Zap, ChevronDown, ChevronUp, Eye, EyeOff } from 'lucide-react'
 import { Link } from '@tanstack/react-router'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { formatSpeed, formatBytes, getRatioColor } from '@/lib/utils'
 import { useQuery } from '@tanstack/react-query'
 import { api } from '@/lib/api'
@@ -19,6 +19,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { useIncognitoMode } from '@/lib/incognito'
 
 // Custom hook to fetch serverState for an instance
 function useInstanceServerState(instanceId: number, enabled: boolean) {
@@ -69,6 +70,12 @@ function InstanceCard({ instance }: { instance: any }) {
     enabled: true, // Always fetch stats, regardless of isActive status
     pollingInterval: 5000 // Slower polling for dashboard
   })
+  const [incognitoMode] = useIncognitoMode()
+  const [showUrl, setShowUrl] = useState(false)
+  
+  // Create the display URL
+  const displayUrl = `${instance.host}:${instance.port}`
+  const shouldBlur = incognitoMode && !showUrl
   
   // Show loading only on first load
   if (isLoading && !stats) {
@@ -82,7 +89,23 @@ function InstanceCard({ instance }: { instance: any }) {
                 Loading...
               </Badge>
             </div>
-            <CardDescription>{instance.host}:{instance.port}</CardDescription>
+            <CardDescription className="flex items-center gap-1">
+              <span className={shouldBlur ? "blur-sm select-none" : ""}>{displayUrl}</span>
+              {incognitoMode && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-5 w-5 p-0 hover:bg-muted/50"
+                  onClick={(e) => {
+                    e.preventDefault()
+                    e.stopPropagation()
+                    setShowUrl(!showUrl)
+                  }}
+                >
+                  {showUrl ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}
+                </Button>
+              )}
+            </CardDescription>
           </CardHeader>
           <CardContent>
             <p className="text-sm text-muted-foreground">Loading stats...</p>
@@ -102,7 +125,23 @@ function InstanceCard({ instance }: { instance: any }) {
               <CardTitle className="text-lg">{instance.name}</CardTitle>
               <Badge variant="destructive">Disconnected</Badge>
             </div>
-            <CardDescription>{instance.host}:{instance.port}</CardDescription>
+            <CardDescription className="flex items-center gap-1">
+              <span className={shouldBlur ? "blur-sm select-none" : ""}>{displayUrl}</span>
+              {incognitoMode && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-5 w-5 p-0 hover:bg-muted/50"
+                  onClick={(e) => {
+                    e.preventDefault()
+                    e.stopPropagation()
+                    setShowUrl(!showUrl)
+                  }}
+                >
+                  {showUrl ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}
+                </Button>
+              )}
+            </CardDescription>
           </CardHeader>
           <CardContent>
             <div className="space-y-4">
@@ -136,7 +175,23 @@ function InstanceCard({ instance }: { instance: any }) {
               <CardTitle className="text-lg">{instance.name}</CardTitle>
               <Badge variant="destructive">Error</Badge>
             </div>
-            <CardDescription>{instance.host}:{instance.port}</CardDescription>
+            <CardDescription className="flex items-center gap-1">
+              <span className={shouldBlur ? "blur-sm select-none" : ""}>{displayUrl}</span>
+              {incognitoMode && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-5 w-5 p-0 hover:bg-muted/50"
+                  onClick={(e) => {
+                    e.preventDefault()
+                    e.stopPropagation()
+                    setShowUrl(!showUrl)
+                  }}
+                >
+                  {showUrl ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}
+                </Button>
+              )}
+            </CardDescription>
           </CardHeader>
           <CardContent>
             <p className="text-sm text-muted-foreground">
@@ -158,7 +213,23 @@ function InstanceCard({ instance }: { instance: any }) {
               {stats.connected ? 'Connected' : 'Disconnected'}
             </Badge>
           </div>
-          <CardDescription className="text-xs">{instance.host}:{instance.port}</CardDescription>
+          <CardDescription className="flex items-center gap-1 text-xs">
+            <span className={shouldBlur ? "blur-sm select-none" : ""}>{displayUrl}</span>
+            {incognitoMode && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-4 w-4 p-0"
+                onClick={(e) => {
+                  e.preventDefault()
+                  e.stopPropagation()
+                  setShowUrl(!showUrl)
+                }}
+              >
+                {showUrl ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}
+              </Button>
+            )}
+          </CardDescription>
         </CardHeader>
         <CardContent>
           <div className="space-y-3">


### PR DESCRIPTION
- Blur instance URLs on dashboard when incognito mode is enabled
- Add eye toggle button to reveal/hide individual URLs
- Consistent icon usage: EyeOff when hidden, Eye when visible
- Addresses issue #11 for privacy protection

<img width="857" height="611" alt="CleanShot 2025-08-09 at 00 39 32@2x" src="https://github.com/user-attachments/assets/e0c292c2-ae20-4241-9d97-4f9be53bfd64" />
