### PR TITLE
chore: add MIT license headers to all source files

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT
+
 package handlers
 
 import (

--- a/internal/api/handlers/helpers.go
+++ b/internal/api/handlers/helpers.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT
+
 package handlers
 
 import (

--- a/internal/api/handlers/instances.go
+++ b/internal/api/handlers/instances.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT
+
 package handlers
 
 import (

--- a/internal/api/handlers/theme_licenses.go
+++ b/internal/api/handlers/theme_licenses.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT
+
 package handlers
 
 import (

--- a/internal/api/handlers/torrents.go
+++ b/internal/api/handlers/torrents.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT
+
 package handlers
 
 import (

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT
+
 package middleware
 
 import (

--- a/internal/api/middleware/cors.go
+++ b/internal/api/middleware/cors.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT
+
 package middleware
 
 import (

--- a/internal/api/middleware/logger.go
+++ b/internal/api/middleware/logger.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT
+
 package middleware
 
 import (

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT
+
 package api
 
 import (

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT
+
 package api
 
 import (

--- a/internal/auth/argon2.go
+++ b/internal/auth/argon2.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT
+
 package auth
 
 import (

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT
+
 package auth
 
 import (

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT
+
 package config
 
 import (

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT
+
 package database
 
 import (

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT
+
 package domain
 
 // Config represents the application configuration

--- a/internal/models/api_key.go
+++ b/internal/models/api_key.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT
+
 package models
 
 import (

--- a/internal/models/instance.go
+++ b/internal/models/instance.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT
+
 package models
 
 import (

--- a/internal/models/theme_license.go
+++ b/internal/models/theme_license.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT
+
 package models
 
 import (

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT
+
 package models
 
 import (

--- a/internal/polar/client.go
+++ b/internal/polar/client.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT
+
 package polar
 
 import (

--- a/internal/qbittorrent/cache_test.go
+++ b/internal/qbittorrent/cache_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT
+
 package qbittorrent
 
 import (

--- a/internal/qbittorrent/client.go
+++ b/internal/qbittorrent/client.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT
+
 package qbittorrent
 
 import (

--- a/internal/qbittorrent/filter_types.go
+++ b/internal/qbittorrent/filter_types.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT
+
 package qbittorrent
 
 // FilterOptions represents the filter options from the frontend

--- a/internal/qbittorrent/integration_test.go
+++ b/internal/qbittorrent/integration_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT
+
 package qbittorrent
 
 import (

--- a/internal/qbittorrent/invalidation_test.go
+++ b/internal/qbittorrent/invalidation_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT
+
 package qbittorrent
 
 import (

--- a/internal/qbittorrent/pool.go
+++ b/internal/qbittorrent/pool.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT
+
 package qbittorrent
 
 import (

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT
+
 package qbittorrent
 
 import (

--- a/internal/services/theme_license.go
+++ b/internal/services/theme_license.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT
+
 package services
 
 import (

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT
+
 package web
 
 import (

--- a/internal/web/swagger/openapi_test.go
+++ b/internal/web/swagger/openapi_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT
+
 package swagger
 
 import (

--- a/internal/web/swagger/swagger.go
+++ b/internal/web/swagger/swagger.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT
+
 package swagger
 
 import (

--- a/license.sh
+++ b/license.sh
@@ -1,0 +1,383 @@
+#!/bin/bash
+
+# Script to update copyright headers in TypeScript, TSX, and Go files
+# Also adds headers to files missing them completely
+# Usage: ./update_copyright_headers.sh [--add-missing|-a]
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Counter variables
+ts_files_updated=0
+ts_files_added=0
+go_files_updated=0
+go_files_added=0
+ts_files_checked=0
+go_files_checked=0
+
+# New header for TypeScript/TSX files
+NEW_TS_HEADER="/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */"
+
+# New header for Go files (using line comments)
+NEW_GO_HEADER="// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: MIT"
+
+echo -e "${GREEN}Starting copyright header update...${NC}"
+echo -e "${BLUE}TypeScript/TSX: s0up and the autobrr contributors${NC}"
+echo -e "${BLUE}Go files: s0up and the autobrr contributors${NC}"
+echo ""
+
+# Function to check if file has the old GPL header
+has_old_header() {
+    local file="$1"
+    # Check first 10 lines for GPL license or incorrect copyright years
+    if head -n 10 "$file" | grep -q "GPL-2.0-or-later"; then
+        return 0
+    fi
+    # Also check for 2024-2025 copyright that needs updating
+    if head -n 10 "$file" | grep -q "Copyright.*2024-2025"; then
+        return 0
+    fi
+    # Check for outdated copyright in Go files
+    if [[ "$file" == *.go ]] && head -n 10 "$file" | grep -q "Ludvig Lundgren and the autobrr"; then
+        return 0
+    fi
+    return 1
+}
+
+# Function to check if file has any copyright header
+has_any_header() {
+    local file="$1"
+    # Check first 10 lines for any copyright or license identifier
+    head -n 10 "$file" | grep -qi "copyright\|spdx-license-identifier"
+}
+
+# Function to add header to file without one
+add_header_to_file() {
+    local file="$1"
+    local header="$2"
+    local temp_file=$(mktemp)
+    
+    # For Go files, use line comments format
+    if [[ "$file" == *.go ]]; then
+        echo "// Copyright (c) 2025, s0up and the autobrr contributors." > "$temp_file"
+        echo "// SPDX-License-Identifier: MIT" >> "$temp_file"
+        echo "" >> "$temp_file"
+        cat "$file" >> "$temp_file"
+    else
+        # For TS/TSX files, use block comment format
+        echo "$header" > "$temp_file"
+        echo "" >> "$temp_file"
+        cat "$file" >> "$temp_file"
+    fi
+    
+    mv "$temp_file" "$file"
+}
+
+# Function to update TypeScript and TSX files
+update_ts_files() {
+    echo -e "${YELLOW}Processing TypeScript and TSX files...${NC}"
+    
+    # Find all .ts and .tsx files
+    while IFS= read -r -d '' file; do
+        ((ts_files_checked++))
+        
+        # Check if file has old GPL header that needs updating
+        if has_old_header "$file"; then
+            # Create a temporary file
+            temp_file=$(mktemp)
+            
+            # Use awk to replace the header
+            awk '
+            BEGIN { 
+                in_header = 0
+                header_end = 0
+                new_header = "/*\n * Copyright (c) 2025, s0up and the autobrr contributors.\n * SPDX-License-Identifier: MIT\n */"
+                printed_new = 0
+            }
+            {
+                # Detect start of old header
+                if (!header_end && /^\/\*/) {
+                    in_header = 1
+                }
+                
+                # If we are in the header and find GPL license
+                if (in_header && /GPL-2\.0-or-later/) {
+                    # Skip the rest of the old header
+                    while ((getline) > 0 && !/\*\//) {
+                        # Skip lines until end of comment
+                    }
+                    # Print new header
+                    if (!printed_new) {
+                        print new_header
+                        printed_new = 1
+                    }
+                    header_end = 1
+                    next
+                }
+                
+                # If we are in header but no GPL found, just print
+                if (in_header && /\*\//) {
+                    in_header = 0
+                    header_end = 1
+                }
+                
+                # Print all other lines
+                if (!in_header || header_end) {
+                    print
+                }
+            }
+            ' "$file" > "$temp_file"
+            
+            # Check if the file was actually changed
+            if ! cmp -s "$file" "$temp_file"; then
+                mv "$temp_file" "$file"
+                echo -e "  ${GREEN}✓${NC} Updated: $file"
+                ((ts_files_updated++))
+            else
+                rm "$temp_file"
+            fi
+        # Check if file has no header at all
+        elif ! has_any_header "$file"; then
+            add_header_to_file "$file" "$NEW_TS_HEADER"
+            echo -e "  ${BLUE}+${NC} Added header to: $file"
+            ((ts_files_added++))
+        fi
+    done < <(find . -type f \( -name "*.ts" -o -name "*.tsx" \) -not -path "*/node_modules/*" -not -path "*/.git/*" -not -path "*/dist/*" -not -path "*/build/*" -print0)
+}
+
+# Function to update Go files
+update_go_files() {
+    echo -e "${YELLOW}Processing Go files...${NC}"
+    
+    # Find all .go files
+    while IFS= read -r -d '' file; do
+        ((go_files_checked++))
+        
+        # Check if file has old GPL header that needs updating
+        if has_old_header "$file"; then
+            # Create a temporary file
+            temp_file=$(mktemp)
+            
+            # Check if it's block comment or line comment style
+            if head -n 1 "$file" | grep -q "^/\*"; then
+                # Block comment style - replace with line comment style
+                awk '
+                BEGIN { 
+                    in_header = 0
+                    header_end = 0
+                    new_header_1 = "// Copyright (c) 2025, s0up and the autobrr contributors."
+                    new_header_2 = "// SPDX-License-Identifier: MIT"
+                    printed_new = 0
+                }
+                {
+                    # Detect start of old header
+                    if (!header_end && /^\/\*/) {
+                        in_header = 1
+                    }
+                    
+                    # If we are in the header and find copyright or license info
+                    if (in_header && (/GPL-2\.0-or-later/ || /Ludvig/ || /2024-2025/ || /2021 - 2025/ || /Copyright/)) {
+                        # Skip the rest of the old header
+                        while ((getline) > 0 && !/\*\//) {
+                            # Skip lines until end of comment
+                        }
+                        # Print new header with line comments
+                        if (!printed_new) {
+                            print new_header_1
+                            print new_header_2
+                            printed_new = 1
+                        }
+                        header_end = 1
+                        next
+                    }
+                    
+                    # If we are in header but no copyright found, just print
+                    if (in_header && /\*\//) {
+                        in_header = 0
+                        header_end = 1
+                    }
+                    
+                    # Print all other lines
+                    if (!in_header || header_end) {
+                        print
+                    }
+                }
+                ' "$file" > "$temp_file"
+            else
+                # Line comment style
+                awk '
+                BEGIN { 
+                    replaced = 0
+                    new_header_1 = "// Copyright (c) 2025, s0up and the autobrr contributors."
+                    new_header_2 = "// SPDX-License-Identifier: MIT"
+                }
+                {
+                    # Replace old copyright line (various patterns)
+                    if (!replaced && /^\/\/ Copyright/) {
+                        if (/2024-2025/ || /2021 - 2025/ || /Ludvig/ || /GPL/) {
+                            print new_header_1
+                            replaced = 1
+                            next
+                        }
+                    }
+                    # Replace old license line
+                    if (replaced == 1 && /^\/\/ SPDX-License-Identifier/) {
+                        print new_header_2
+                        replaced = 2
+                        next
+                    }
+                    print
+                }
+                ' "$file" > "$temp_file"
+            fi
+            
+            # Check if the file was actually changed
+            if ! cmp -s "$file" "$temp_file"; then
+                mv "$temp_file" "$file"
+                echo -e "  ${GREEN}✓${NC} Updated: $file"
+                ((go_files_updated++))
+            else
+                rm "$temp_file"
+            fi
+        # Check if file has no header at all
+        elif ! has_any_header "$file"; then
+            # Check if file starts with package declaration (typical for Go)
+            if head -n 1 "$file" | grep -q "^package "; then
+                # Add header before package declaration with line comments
+                temp_file=$(mktemp)
+                echo "// Copyright (c) 2025, s0up and the autobrr contributors." > "$temp_file"
+                echo "// SPDX-License-Identifier: MIT" >> "$temp_file"
+                echo "" >> "$temp_file"
+                cat "$file" >> "$temp_file"
+                mv "$temp_file" "$file"
+            else
+                # Just add header at the beginning
+                temp_file=$(mktemp)
+                echo "// Copyright (c) 2025, s0up and the autobrr contributors." > "$temp_file"
+                echo "// SPDX-License-Identifier: MIT" >> "$temp_file"
+                echo "" >> "$temp_file"
+                cat "$file" >> "$temp_file"
+                mv "$temp_file" "$file"
+            fi
+            echo -e "  ${BLUE}+${NC} Added header to: $file"
+            ((go_files_added++))
+        fi
+    done < <(find . -type f -name "*.go" -not -path "*/vendor/*" -not -path "*/.git/*" -print0)
+}
+
+# Function to ask for confirmation
+ask_confirmation() {
+    local total_missing=$((ts_files_added + go_files_added))
+    if [ $total_missing -gt 0 ]; then
+        echo -e "${YELLOW}Found $total_missing files without headers.${NC}"
+        echo -n "Do you want to add headers to files missing them? (y/N): "
+        read -r response
+        case "$response" in
+            [yY][eE][sS]|[yY]) 
+                return 0
+                ;;
+            *)
+                return 1
+                ;;
+        esac
+    fi
+    return 0
+}
+
+# Main execution
+main() {
+    # Check if we're in a git repository (optional safety check)
+    if [ -d .git ]; then
+        echo -e "${GREEN}Git repository detected.${NC}"
+        echo -e "${YELLOW}It's recommended to commit your changes before running this script.${NC}"
+        echo ""
+    fi
+    
+    # Parse command line arguments
+    ADD_MISSING=false
+    if [[ "${1:-}" == "--add-missing" ]] || [[ "${1:-}" == "-a" ]]; then
+        ADD_MISSING=true
+        echo -e "${BLUE}Will add headers to files missing them.${NC}"
+        echo ""
+    else
+        echo -e "${BLUE}Run with --add-missing or -a to also add headers to files without any header.${NC}"
+        echo ""
+    fi
+    
+    # Temporarily store counts if we're not adding missing headers
+    if [ "$ADD_MISSING" = false ]; then
+        # First pass: just count and update existing headers
+        ORIGINAL_ADD_MISSING=$ADD_MISSING
+        ts_files_added=0
+        go_files_added=0
+    fi
+    
+    # Update TypeScript and TSX files
+    update_ts_files
+    echo ""
+    
+    # Update Go files
+    update_go_files
+    echo ""
+    
+    # Summary
+    echo -e "${GREEN}=== Summary ===${NC}"
+    echo -e "TypeScript/TSX files checked: $ts_files_checked"
+    echo -e "TypeScript/TSX files with wrong license updated: ${GREEN}$ts_files_updated${NC}"
+    if [ "$ADD_MISSING" = true ]; then
+        echo -e "TypeScript/TSX files with missing headers fixed: ${BLUE}$ts_files_added${NC}"
+    fi
+    echo -e "Go files checked: $go_files_checked"
+    echo -e "Go files with wrong license updated: ${GREEN}$go_files_updated${NC}"
+    if [ "$ADD_MISSING" = true ]; then
+        echo -e "Go files with missing headers fixed: ${BLUE}$go_files_added${NC}"
+    fi
+    
+    total_updated=$((ts_files_updated + go_files_updated))
+    total_added=$((ts_files_added + go_files_added))
+    total_changed=$((total_updated + total_added))
+    
+    if [ $total_changed -gt 0 ]; then
+        echo ""
+        if [ $total_updated -gt 0 ]; then
+            echo -e "${GREEN}Updated $total_updated file(s) with the correct MIT license.${NC}"
+        fi
+        if [ $total_added -gt 0 ]; then
+            echo -e "${BLUE}Added headers to $total_added file(s) that were missing them.${NC}"
+        fi
+        echo -e "${YELLOW}Don't forget to review and commit the changes!${NC}"
+    else
+        echo ""
+        if [ "$ADD_MISSING" = false ]; then
+            # Count files missing headers for informational purposes
+            missing_count=0
+            while IFS= read -r -d '' file; do
+                if ! has_any_header "$file"; then
+                    ((missing_count++))
+                fi
+            done < <(find . -type f \( -name "*.ts" -o -name "*.tsx" -o -name "*.go" \) -not -path "*/node_modules/*" -not -path "*/.git/*" -not -path "*/vendor/*" -not -path "*/dist/*" -not -path "*/build/*" -print0)
+            
+            if [ $missing_count -gt 0 ]; then
+                echo -e "${YELLOW}No files with wrong licenses found.${NC}"
+                echo -e "${BLUE}Found $missing_count file(s) without any header. Run with --add-missing to add headers to them.${NC}"
+            else
+                echo -e "${GREEN}All files have correct headers!${NC}"
+            fi
+        else
+            echo -e "${GREEN}All files have correct headers!${NC}"
+        fi
+    fi
+}
+
+# Run the main function with all arguments
+main "$@"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { RouterProvider } from '@tanstack/react-router'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { router } from './router'

--- a/web/src/components/instances/InstanceCard.tsx
+++ b/web/src/components/instances/InstanceCard.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useState } from 'react'
 import type { Instance } from '@/types'
 import { toast } from 'sonner'

--- a/web/src/components/instances/InstanceForm.tsx
+++ b/web/src/components/instances/InstanceForm.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useState } from 'react'
 import { useForm } from '@tanstack/react-form'
 import { useMutation, useQueryClient } from '@tanstack/react-query'

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useAuth } from '@/hooks/useAuth'
 import { Button } from '@/components/ui/button'
 import { 

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { Link, useLocation } from '@tanstack/react-router'
 import { cn } from '@/lib/utils'
 import { 

--- a/web/src/components/pwa/IOSInstallPrompt.tsx
+++ b/web/src/components/pwa/IOSInstallPrompt.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useState, useEffect } from 'react'
 import { Button } from '@/components/ui/button'
 import {

--- a/web/src/components/pwa/InstallPrompt.tsx
+++ b/web/src/components/pwa/InstallPrompt.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useState, useEffect } from 'react'
 import { Button } from '@/components/ui/button'
 import {

--- a/web/src/components/themes/ThemeLicenseManager.tsx
+++ b/web/src/components/themes/ThemeLicenseManager.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useState } from 'react'
 import { useForm } from '@tanstack/react-form'
 import { toast } from 'sonner'

--- a/web/src/components/themes/ThemeSelector.tsx
+++ b/web/src/components/themes/ThemeSelector.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Separator } from '@/components/ui/separator'

--- a/web/src/components/torrents/AddTorrentDialog.tsx
+++ b/web/src/components/torrents/AddTorrentDialog.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useState } from 'react'
 import { useForm } from '@tanstack/react-form'
 import { useMutation, useQueryClient } from '@tanstack/react-query'

--- a/web/src/components/torrents/DraggableTableHeader.tsx
+++ b/web/src/components/torrents/DraggableTableHeader.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { flexRender, type Header } from '@tanstack/react-table'

--- a/web/src/components/torrents/FilterSidebar.tsx
+++ b/web/src/components/torrents/FilterSidebar.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useState, useMemo, memo, useCallback } from 'react'
 import {
   Accordion,

--- a/web/src/components/torrents/TagCategoryManagement.tsx
+++ b/web/src/components/torrents/TagCategoryManagement.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useState } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { api } from '@/lib/api'

--- a/web/src/components/torrents/TorrentActions.tsx
+++ b/web/src/components/torrents/TorrentActions.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { memo, useState, useCallback } from 'react'
 import type { ChangeEvent } from 'react'
 import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query'

--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useState, useRef, useCallback, useEffect, useMemo } from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { useTorrentsList } from '@/hooks/useTorrentsList'

--- a/web/src/components/torrents/TorrentDetailsPanel.tsx
+++ b/web/src/components/torrents/TorrentDetailsPanel.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { memo, useState, useEffect, useCallback } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'

--- a/web/src/components/torrents/TorrentDialogs.tsx
+++ b/web/src/components/torrents/TorrentDialogs.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { memo, useState, useEffect, useRef, useCallback } from 'react'
 import type { ChangeEvent, KeyboardEvent } from 'react'
 import { Button } from '@/components/ui/button'

--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import React, { memo, useState, useMemo, useRef, useCallback, useEffect } from 'react'
 import {
   useReactTable,

--- a/web/src/components/torrents/TorrentTableResponsive.tsx
+++ b/web/src/components/torrents/TorrentTableResponsive.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useEffect, useState } from 'react'
 import { TorrentTableOptimized } from './TorrentTableOptimized'
 import { TorrentCardsMobile } from './TorrentCardsMobile'

--- a/web/src/components/ui/ThemeToggle.tsx
+++ b/web/src/components/ui/ThemeToggle.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useState, useEffect, useCallback } from "react";
 import {
   getCurrentThemeMode,

--- a/web/src/components/ui/accordion.tsx
+++ b/web/src/components/ui/accordion.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import * as React from "react"
 import * as AccordionPrimitive from "@radix-ui/react-accordion"
 import { ChevronDownIcon } from "lucide-react"

--- a/web/src/components/ui/alert-dialog.tsx
+++ b/web/src/components/ui/alert-dialog.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 "use client"
 
 import * as React from "react"

--- a/web/src/components/ui/badge.tsx
+++ b/web/src/components/ui/badge.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"

--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"

--- a/web/src/components/ui/card.tsx
+++ b/web/src/components/ui/card.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import * as React from "react"
 
 import { cn } from "@/lib/utils"

--- a/web/src/components/ui/checkbox.tsx
+++ b/web/src/components/ui/checkbox.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 "use client"
 
 import * as React from "react"

--- a/web/src/components/ui/collapsible.tsx
+++ b/web/src/components/ui/collapsible.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
 
 function Collapsible({

--- a/web/src/components/ui/context-menu.tsx
+++ b/web/src/components/ui/context-menu.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import * as React from "react"
 import * as ContextMenuPrimitive from "@radix-ui/react-context-menu"
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import * as React from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
 import { XIcon } from "lucide-react"

--- a/web/src/components/ui/drawer.tsx
+++ b/web/src/components/ui/drawer.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import * as React from "react"
 import { Drawer as DrawerPrimitive } from "vaul"
 

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import * as React from "react"
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"

--- a/web/src/components/ui/form.tsx
+++ b/web/src/components/ui/form.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import * as React from "react"
 import * as LabelPrimitive from "@radix-ui/react-label"
 import { Slot } from "@radix-ui/react-slot"

--- a/web/src/components/ui/input.tsx
+++ b/web/src/components/ui/input.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import * as React from "react"
 
 import { cn } from "@/lib/utils"

--- a/web/src/components/ui/label.tsx
+++ b/web/src/components/ui/label.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 "use client"
 
 import * as React from "react"

--- a/web/src/components/ui/progress.tsx
+++ b/web/src/components/ui/progress.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import * as React from "react"
 import * as ProgressPrimitive from "@radix-ui/react-progress"
 

--- a/web/src/components/ui/scroll-area.tsx
+++ b/web/src/components/ui/scroll-area.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import * as React from "react"
 import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
 

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 "use client"
 
 import * as React from "react"

--- a/web/src/components/ui/separator.tsx
+++ b/web/src/components/ui/separator.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 "use client"
 
 import * as React from "react"

--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import * as React from "react"
 import * as SheetPrimitive from "@radix-ui/react-dialog"
 import { XIcon } from "lucide-react"

--- a/web/src/components/ui/sonner.tsx
+++ b/web/src/components/ui/sonner.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useTheme } from "next-themes"
 import { Toaster as Sonner, type ToasterProps } from "sonner"
 

--- a/web/src/components/ui/switch.tsx
+++ b/web/src/components/ui/switch.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import * as React from "react"
 import * as SwitchPrimitive from "@radix-ui/react-switch"
 

--- a/web/src/components/ui/table.tsx
+++ b/web/src/components/ui/table.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 "use client"
 
 import * as React from "react"

--- a/web/src/components/ui/tabs.tsx
+++ b/web/src/components/ui/tabs.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import * as React from "react"
 import * as TabsPrimitive from "@radix-ui/react-tabs"
 

--- a/web/src/components/ui/textarea.tsx
+++ b/web/src/components/ui/textarea.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import * as React from "react"
 
 import { cn } from "@/lib/utils"

--- a/web/src/components/ui/tooltip.tsx
+++ b/web/src/components/ui/tooltip.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import * as React from "react"
 import * as TooltipPrimitive from "@radix-ui/react-tooltip"
 

--- a/web/src/components/ui/visually-hidden.tsx
+++ b/web/src/components/ui/visually-hidden.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import * as React from "react"
 import { cn } from "@/lib/utils"
 

--- a/web/src/config/themes.old.ts
+++ b/web/src/config/themes.old.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 export interface Theme {
   id: string;
   name: string;

--- a/web/src/config/themes.ts
+++ b/web/src/config/themes.ts
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
- * SPDX-License-Identifier: GPL-2.0-or-later
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
  */
 
 import { loadThemes } from '@/utils/themeLoader';

--- a/web/src/hooks/useAuth.ts
+++ b/web/src/hooks/useAuth.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
 import { api } from '@/lib/api'

--- a/web/src/hooks/useDebounce.ts
+++ b/web/src/hooks/useDebounce.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useState, useEffect } from 'react'
 
 export function useDebounce<T>(value: T, delay: number): T {

--- a/web/src/hooks/useInstanceMetadata.ts
+++ b/web/src/hooks/useInstanceMetadata.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useQuery } from '@tanstack/react-query'
 import { api } from '@/lib/api'
 

--- a/web/src/hooks/useInstanceStats.ts
+++ b/web/src/hooks/useInstanceStats.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useQuery } from '@tanstack/react-query'
 import { api } from '@/lib/api'
 

--- a/web/src/hooks/useInstances.ts
+++ b/web/src/hooks/useInstances.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { api } from '@/lib/api'
 import type { Instance } from '@/types'

--- a/web/src/hooks/usePersistedAccordion.ts
+++ b/web/src/hooks/usePersistedAccordion.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useState, useEffect } from 'react'
 
 export function usePersistedAccordion() {

--- a/web/src/hooks/usePersistedColumnOrder.ts
+++ b/web/src/hooks/usePersistedColumnOrder.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useState, useEffect } from 'react'
 import type { ColumnOrderState } from '@tanstack/react-table'
 

--- a/web/src/hooks/usePersistedColumnSizing.ts
+++ b/web/src/hooks/usePersistedColumnSizing.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useState, useEffect } from 'react'
 import type { ColumnSizingState } from '@tanstack/react-table'
 

--- a/web/src/hooks/usePersistedColumnSorting.ts
+++ b/web/src/hooks/usePersistedColumnSorting.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useState, useEffect } from 'react'
 import type { SortingState } from '@tanstack/react-table'
 

--- a/web/src/hooks/usePersistedColumnVisibility.ts
+++ b/web/src/hooks/usePersistedColumnVisibility.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useState, useEffect } from 'react'
 import type { VisibilityState } from '@tanstack/react-table'
 

--- a/web/src/hooks/usePersistedFilterSidebarState.ts
+++ b/web/src/hooks/usePersistedFilterSidebarState.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useState, useEffect } from 'react'
 
 export function usePersistedFilterSidebarState(defaultCollapsed: boolean = false) {

--- a/web/src/hooks/usePersistedFilters.ts
+++ b/web/src/hooks/usePersistedFilters.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useState, useEffect } from 'react'
 
 interface Filters {

--- a/web/src/hooks/usePersistedSidebarState.ts
+++ b/web/src/hooks/usePersistedSidebarState.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useState, useEffect } from 'react'
 
 export function usePersistedSidebarState(defaultCollapsed: boolean = false) {

--- a/web/src/hooks/useTheme.ts
+++ b/web/src/hooks/useTheme.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useState, useEffect } from 'react'
 import { getCurrentTheme, getCurrentThemeMode, setTheme as setThemeUtil, setThemeMode as setThemeModeUtil, type ThemeMode } from '@/utils/theme'
 

--- a/web/src/hooks/useThemeLicense.ts
+++ b/web/src/hooks/useThemeLicense.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { api } from '@/lib/api'
 import { toast } from 'sonner'

--- a/web/src/hooks/useTorrentCounts.ts
+++ b/web/src/hooks/useTorrentCounts.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useMemo } from 'react'
 import type { Torrent } from '@/types'
 import { matchesStatusFilter } from '@/lib/torrent-state-utils'

--- a/web/src/hooks/useTorrents.ts
+++ b/web/src/hooks/useTorrents.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useQuery } from '@tanstack/react-query'
 import { api } from '@/lib/api'
 import type { SortingState, ColumnFiltersState } from '@tanstack/react-table'

--- a/web/src/hooks/useTorrentsList.ts
+++ b/web/src/hooks/useTorrentsList.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useState, useEffect, useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { api } from '@/lib/api'

--- a/web/src/hooks/useTorrentsServerSide.ts
+++ b/web/src/hooks/useTorrentsServerSide.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useState, useEffect, useRef } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { api } from '@/lib/api'

--- a/web/src/hooks/useTorrentsSync.ts
+++ b/web/src/hooks/useTorrentsSync.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useState, useEffect, useRef } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { api } from '@/lib/api'

--- a/web/src/layouts/AppLayout.tsx
+++ b/web/src/layouts/AppLayout.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useState } from 'react'
 import { Outlet } from '@tanstack/react-router'
 import { Sidebar } from '@/components/layout/Sidebar'

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import type { AuthResponse, Instance, TorrentResponse, MainData, User } from '@/types'
 import { getApiBaseUrl } from './base-url'
 

--- a/web/src/lib/base-url.ts
+++ b/web/src/lib/base-url.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 // Get the base URL injected by the backend
 // Falls back to '/' if not set
 export function getBaseUrl(): string {

--- a/web/src/lib/incognito.ts
+++ b/web/src/lib/incognito.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 // Incognito mode utilities for disguising torrents as Linux ISOs
 
 import { useState, useEffect } from 'react'

--- a/web/src/lib/torrent-state-utils.ts
+++ b/web/src/lib/torrent-state-utils.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import type { Torrent } from '@/types'
 
 // State groups for easier checking

--- a/web/src/lib/torrent-utils.ts
+++ b/web/src/lib/torrent-utils.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import type { Torrent } from '@/types'
 
 /**

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { type ClassValue, clsx } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useInstances } from '@/hooks/useInstances'
 import { useInstanceStats } from '@/hooks/useInstanceStats'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'

--- a/web/src/pages/Instances.tsx
+++ b/web/src/pages/Instances.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useState, useEffect } from 'react'
 import { useInstances } from '@/hooks/useInstances'
 import { InstanceCard } from '@/components/instances/InstanceCard'

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useForm } from '@tanstack/react-form'
 import { useNavigate } from '@tanstack/react-router'
 import { useAuth } from '@/hooks/useAuth'

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useState } from 'react'
 import { useForm } from '@tanstack/react-form'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'

--- a/web/src/pages/Setup.tsx
+++ b/web/src/pages/Setup.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useForm } from '@tanstack/react-form'
 import { useNavigate } from '@tanstack/react-router'
 import { useAuth } from '@/hooks/useAuth'

--- a/web/src/pages/Torrents.tsx
+++ b/web/src/pages/Torrents.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react'
 import { TorrentTableResponsive } from '@/components/torrents/TorrentTableResponsive'
 import { FilterSidebar } from '@/components/torrents/FilterSidebar'

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 /* eslint-disable */
 
 // @ts-nocheck

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { createRouter } from '@tanstack/react-router'
 import { routeTree } from './routeTree.gen'
 import { getBaseUrl } from './lib/base-url'

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { createRootRoute, Outlet } from '@tanstack/react-router'
 
 export const Route = createRootRoute({

--- a/web/src/routes/_authenticated.tsx
+++ b/web/src/routes/_authenticated.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { createFileRoute, Navigate } from '@tanstack/react-router'
 import { useAuth } from '@/hooks/useAuth'
 import { AppLayout } from '@/layouts/AppLayout'

--- a/web/src/routes/_authenticated/dashboard.tsx
+++ b/web/src/routes/_authenticated/dashboard.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { createFileRoute } from '@tanstack/react-router'
 import { Dashboard } from '@/pages/Dashboard'
 

--- a/web/src/routes/_authenticated/instances.$instanceId.tsx
+++ b/web/src/routes/_authenticated/instances.$instanceId.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { createFileRoute, Navigate } from '@tanstack/react-router'
 import { Torrents } from '@/pages/Torrents'
 import { useInstances } from '@/hooks/useInstances'

--- a/web/src/routes/_authenticated/instances.index.tsx
+++ b/web/src/routes/_authenticated/instances.index.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { createFileRoute } from '@tanstack/react-router'
 import { Instances } from '@/pages/Instances'
 

--- a/web/src/routes/_authenticated/instances.tsx
+++ b/web/src/routes/_authenticated/instances.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { createFileRoute, Outlet } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/_authenticated/instances')({

--- a/web/src/routes/_authenticated/settings.tsx
+++ b/web/src/routes/_authenticated/settings.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { createFileRoute } from '@tanstack/react-router'
 import { Settings } from '@/pages/Settings'
 

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { createFileRoute, Navigate } from '@tanstack/react-router'
 import { useAuth } from '@/hooks/useAuth'
 

--- a/web/src/routes/login.tsx
+++ b/web/src/routes/login.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { createFileRoute } from '@tanstack/react-router'
 import { Login } from '@/pages/Login'
 

--- a/web/src/routes/setup.tsx
+++ b/web/src/routes/setup.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { createFileRoute } from '@tanstack/react-router'
 import { Setup } from '@/pages/Setup'
 

--- a/web/src/types/import-meta.d.ts
+++ b/web/src/types/import-meta.d.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 /// <reference types="vite/client" />
 
 // Extend ImportMeta to include 'glob' and 'env' for Vite

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 export interface User {
   id: number
   username: string

--- a/web/src/utils/darkMode.ts
+++ b/web/src/utils/darkMode.ts
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
- * SPDX-License-Identifier: GPL-2.0-or-later
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
  */
 
 // Theme constants

--- a/web/src/utils/fontLoader.ts
+++ b/web/src/utils/fontLoader.ts
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
- * SPDX-License-Identifier: GPL-2.0-or-later
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
  */
 
 // Map of font names to their Google Fonts URLs

--- a/web/src/utils/pwaNativeTheme.ts
+++ b/web/src/utils/pwaNativeTheme.ts
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
- * SPDX-License-Identifier: GPL-2.0-or-later
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
  */
 
 import { converter, formatHex } from 'culori'

--- a/web/src/utils/theme.ts
+++ b/web/src/utils/theme.ts
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
- * SPDX-License-Identifier: GPL-2.0-or-later
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
  */
 
 import { themes, getThemeById, getDefaultTheme, type Theme } from '@/config/themes';

--- a/web/src/utils/themeLoader.ts
+++ b/web/src/utils/themeLoader.ts
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
- * SPDX-License-Identifier: GPL-2.0-or-later
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
  */
 
 import { parseThemeCSS, generateThemeId } from './themeParser';

--- a/web/src/utils/themeParser.ts
+++ b/web/src/utils/themeParser.ts
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024-2025, s0up and the autobrr contributors.
- * SPDX-License-Identifier: GPL-2.0-or-later
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
  */
 
 export interface ThemeMetadata {

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,2 +1,7 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-pwa/client" />

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: MIT
+ */
+
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'


### PR DESCRIPTION
- Add copyright headers to all Go files (*.go)
- Add copyright headers to all TypeScript/TSX files (*.ts, *.tsx)
- Add license.sh script for managing license headers
- Standardize copyright format across the codebase
- All headers follow SPDX-License-Identifier: MIT format