### PR TITLE
feat: add --pprof command line flag

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -31,8 +31,9 @@ import (
 )
 
 var (
-	Version = "dev"
-	cfgFile string
+	Version   = "dev"
+	cfgFile   string
+	pprofFlag bool
 
 	// Publisher credentials - set during build via ldflags
 	PolarAccessToken = ""           // Set via: -X main.PolarAccessToken=your-token
@@ -54,6 +55,7 @@ multiple qBittorrent instances with support for 10k+ torrents.`,
 func init() {
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is OS-specific: ~/.config/qui/config.toml or %APPDATA%\\qui\\config.toml)")
+	rootCmd.PersistentFlags().BoolVar(&pprofFlag, "pprof", false, "enable pprof server on :6060")
 	rootCmd.Version = Version
 }
 
@@ -71,6 +73,10 @@ func runServer() {
 	cfg, err := config.New(cfgFile)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to initialize configuration")
+	}
+
+	if pprofFlag {
+		cfg.Config.PprofEnabled = true
 	}
 
 	cfg.ApplyLogConfig()
@@ -164,18 +170,18 @@ func runServer() {
 	if cfg.Config.BaseURL != "" && cfg.Config.BaseURL != "/" {
 		// Create a parent router and mount our app under the base URL
 		parentRouter := chi.NewRouter()
-		
+
 		// Strip trailing slash from base URL for mounting
 		mountPath := strings.TrimSuffix(cfg.Config.BaseURL, "/")
-		
+
 		// Mount the application under the base URL
 		parentRouter.Mount(mountPath, router)
-		
+
 		// Redirect root to base URL
 		parentRouter.Get("/", func(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, cfg.Config.BaseURL, http.StatusMovedPermanently)
 		})
-		
+
 		handler = parentRouter
 	} else {
 		handler = router
@@ -185,7 +191,7 @@ func runServer() {
 	readTimeout := time.Duration(cfg.Config.HTTPTimeouts.ReadTimeout) * time.Second
 	writeTimeout := time.Duration(cfg.Config.HTTPTimeouts.WriteTimeout) * time.Second
 	idleTimeout := time.Duration(cfg.Config.HTTPTimeouts.IdleTimeout) * time.Second
-	
+
 	// Use defaults if not configured
 	if readTimeout == 0 {
 		readTimeout = 60 * time.Second
@@ -196,7 +202,7 @@ func runServer() {
 	if idleTimeout == 0 {
 		idleTimeout = 180 * time.Second
 	}
-	
+
 	srv := &http.Server{
 		Addr:         fmt.Sprintf("%s:%d", cfg.Config.Host, cfg.Config.Port),
 		Handler:      handler,
@@ -222,14 +228,16 @@ func runServer() {
 		}
 	}()
 
-	// Start profiling server
-	go func() {
-		log.Info().Msg("Starting pprof server on :6060")
-		log.Info().Msg("Access profiling at: http://localhost:6060/debug/pprof/")
-		if err := http.ListenAndServe(":6060", nil); err != nil {
-			log.Error().Err(err).Msg("Profiling server failed")
-		}
-	}()
+	// Start profiling server if enabled
+	if cfg.Config.PprofEnabled {
+		go func() {
+			log.Info().Msg("Starting pprof server on :6060")
+			log.Info().Msg("Access profiling at: http://localhost:6060/debug/pprof/")
+			if err := http.ListenAndServe(":6060", nil); err != nil {
+				log.Error().Err(err).Msg("Profiling server failed")
+			}
+		}()
+	}
 	// Wait for interrupt signal to gracefully shutdown the server
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,7 +70,8 @@ func (c *AppConfig) defaults() {
 	c.viper.SetDefault("sessionSecret", sessionSecret)
 	c.viper.SetDefault("logLevel", "INFO")
 	c.viper.SetDefault("logPath", "")
-	
+	c.viper.SetDefault("pprofEnabled", false)
+
 	// HTTP timeout defaults - increased for large qBittorrent instances
 	c.viper.SetDefault("httpTimeouts.readTimeout", 60)   // 60 seconds
 	c.viper.SetDefault("httpTimeouts.writeTimeout", 120) // 120 seconds for large responses
@@ -149,7 +150,7 @@ func (c *AppConfig) load(configPath string) error {
 func (c *AppConfig) loadFromEnv() {
 	// DO NOT use AutomaticEnv() - it reads ALL env vars and causes conflicts with K8s
 	// Instead, explicitly bind only the environment variables we want
-	
+
 	// Use double underscore to avoid conflicts with K8s deployment_PORT patterns
 	c.viper.BindEnv("host", "QUI__HOST")
 	c.viper.BindEnv("port", "QUI__PORT")
@@ -157,7 +158,8 @@ func (c *AppConfig) loadFromEnv() {
 	c.viper.BindEnv("sessionSecret", "QUI__SESSION_SECRET")
 	c.viper.BindEnv("logLevel", "QUI__LOG_LEVEL")
 	c.viper.BindEnv("logPath", "QUI__LOG_PATH")
-	
+	c.viper.BindEnv("pprofEnabled", "QUI__PPROF_ENABLED")
+
 	// HTTP timeout environment variables
 	c.viper.BindEnv("httpTimeouts.readTimeout", "QUI__HTTP_READ_TIMEOUT")
 	c.viper.BindEnv("httpTimeouts.writeTimeout", "QUI__HTTP_WRITE_TIMEOUT")
@@ -254,7 +256,7 @@ logLevel = "{{ .logLevel }}"
 `
 
 	// Prepare template data
-	data := map[string]interface{}{
+	data := map[string]any{
 		"host":          c.viper.GetString("host"),
 		"port":          c.viper.GetInt("port"),
 		"sessionSecret": c.viper.GetString("sessionSecret"),

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	SessionSecret string       `toml:"sessionSecret" mapstructure:"sessionSecret"`
 	LogLevel      string       `toml:"logLevel" mapstructure:"logLevel"`
 	LogPath       string       `toml:"logPath" mapstructure:"logPath"`
+	PprofEnabled  bool         `toml:"pprofEnabled" mapstructure:"pprofEnabled"`
 	Polar         PolarConfig  `toml:"polar" mapstructure:"polar"`
 	HTTPTimeouts  HTTPTimeouts `toml:"httpTimeouts" mapstructure:"httpTimeouts"`
 }


### PR DESCRIPTION
Add command line flag to enable pprof server. The flag overrides config file and environment variable settings.

Usage: qui --pprof