### PR TITLE
fix: sort tags alphabetically case-insensitive

### DIFF
--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -533,6 +533,10 @@ func (sm *SyncManager) GetTags(ctx context.Context, instanceID int) ([]string, e
 		return nil, fmt.Errorf("failed to get tags: %w", err)
 	}
 
+	sort.Slice(tags, func(i, j int) bool {
+		return strings.ToLower(tags[i]) < strings.ToLower(tags[j])
+	})
+
 	// Cache for 1 minute
 	sm.cache.SetWithTTL(cacheKey, tags, 1, 60*time.Second)
 


### PR DESCRIPTION
## Summary
- Sort tags alphabetically using case-insensitive comparison for consistent UI ordering

## Before/After
- Before: Tags appeared in inconsistent order due to case-sensitive sorting
- After: Tags sorted alphabetically regardless of capitalization (e.g., "AITHER", "aither" group together)