### PR TITLE
chore(ci): use go.mod for Go version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,6 @@ on:
 env:
   REGISTRY: ghcr.io
   REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
-  GO_VERSION: "1.24"
   NODE_VERSION: "22.18.0"
   POLAR_ORG_ID: ${{ secrets.POLAR_ORG_ID }}
 
@@ -102,7 +101,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
           cache: true
 
       - name: Cache Go modules


### PR DESCRIPTION
Remove hardcoded GO_VERSION environment variable and use go-version-file to read version from go.mod instead.