### PR TITLE
feat(qbittorrent): add version-aware SetTags fallback

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/autobrr/qui
 go 1.24
 
 require (
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/autobrr/go-qbittorrent v1.14.0
 	github.com/dgraph-io/ristretto v0.2.0
 	github.com/fsnotify/fsnotify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
+github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/autobrr/go-qbittorrent v1.14.0 h1:H+/HWDmNUSwkWCTwgK8+f7vzIdXCJLWj6MZlGs8+WZE=
 github.com/autobrr/go-qbittorrent v1.14.0/go.mod h1:N+sISEJr1hM+AQiTD7pnsilgBcfGzIQsjwoEjWWvnng=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=

--- a/internal/qbittorrent/client.go
+++ b/internal/qbittorrent/client.go
@@ -97,16 +97,16 @@ func (c *Client) IsHealthy() bool {
 }
 
 func (c *Client) HealthCheck(ctx context.Context) error {
-	_, err := c.Client.GetWebAPIVersionCtx(ctx)
+	_, err := c.GetWebAPIVersionCtx(ctx)
 	if err != nil {
-		if loginErr := c.Client.LoginCtx(ctx); loginErr != nil {
+		if loginErr := c.LoginCtx(ctx); loginErr != nil {
 			c.mu.Lock()
 			c.isHealthy = false
 			c.lastHealthCheck = time.Now()
 			c.mu.Unlock()
 			return fmt.Errorf("health check failed: login error: %w", loginErr)
 		}
-		if _, err = c.Client.GetWebAPIVersionCtx(ctx); err != nil {
+		if _, err = c.GetWebAPIVersionCtx(ctx); err != nil {
 			c.mu.Lock()
 			c.isHealthy = false
 			c.lastHealthCheck = time.Now()

--- a/internal/qbittorrent/client.go
+++ b/internal/qbittorrent/client.go
@@ -9,29 +9,29 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/rs/zerolog/log"
 )
 
-// Client wraps the qBittorrent client with additional functionality
 type Client struct {
 	*qbt.Client
 	instanceID      int
+	webAPIVersion   string
+	supportsSetTags bool
 	lastHealthCheck time.Time
 	isHealthy       bool
 	mu              sync.RWMutex
 }
 
-// NewClient creates a new qBittorrent client wrapper
 func NewClient(instanceID int, instanceHost, username, password string, basicUsername, basicPassword *string) (*Client, error) {
-	// Create the base client
 	cfg := qbt.Config{
 		Host:     instanceHost,
 		Username: username,
 		Password: password,
-		Timeout:  30, // timeout in seconds
+		Timeout:  30,
 	}
 
-	// Set Basic Auth credentials if provided
 	if basicUsername != nil && *basicUsername != "" {
 		cfg.BasicUser = *basicUsername
 		if basicPassword != nil {
@@ -41,8 +41,6 @@ func NewClient(instanceID int, instanceHost, username, password string, basicUse
 
 	qbtClient := qbt.NewClient(cfg)
 
-	// Test connection - use 30 seconds to match the client timeout configuration
-	// This is especially important for large instances with 10k+ torrents
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
@@ -50,43 +48,57 @@ func NewClient(instanceID int, instanceHost, username, password string, basicUse
 		return nil, fmt.Errorf("failed to connect to qBittorrent instance: %w", err)
 	}
 
+	webAPIVersion, err := qbtClient.GetWebAPIVersionCtx(ctx)
+	if err != nil {
+		webAPIVersion = ""
+	}
+
+	supportsSetTags := false
+	if webAPIVersion != "" {
+		if v, err := semver.NewVersion(webAPIVersion); err == nil {
+			minVersion := semver.MustParse("2.11.4")
+			supportsSetTags = !v.LessThan(minVersion)
+		}
+	}
+
 	client := &Client{
 		Client:          qbtClient,
 		instanceID:      instanceID,
+		webAPIVersion:   webAPIVersion,
+		supportsSetTags: supportsSetTags,
 		lastHealthCheck: time.Now(),
 		isHealthy:       true,
 	}
 
+	log.Debug().
+		Int("instanceID", instanceID).
+		Str("host", instanceHost).
+		Str("webAPIVersion", webAPIVersion).
+		Bool("supportsSetTags", supportsSetTags).
+		Msg("qBittorrent client created successfully")
+
 	return client, nil
 }
 
-// GetInstanceID returns the instance ID associated with this client
 func (c *Client) GetInstanceID() int {
 	return c.instanceID
 }
 
-// GetLastHealthCheck returns the time of the last health check
 func (c *Client) GetLastHealthCheck() time.Time {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.lastHealthCheck
 }
 
-// IsHealthy returns whether the client connection is healthy
 func (c *Client) IsHealthy() bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.isHealthy
 }
 
-// HealthCheck performs a health check on the qBittorrent connection
 func (c *Client) HealthCheck(ctx context.Context) error {
-	// Use a lightweight API call instead of full login
-	// GetWebAPIVersion is perfect - it's fast and doesn't load torrent data
 	_, err := c.Client.GetWebAPIVersionCtx(ctx)
 	if err != nil {
-		// If the version check fails, it might be an auth issue
-		// Try to re-login once
 		if loginErr := c.Client.LoginCtx(ctx); loginErr != nil {
 			c.mu.Lock()
 			c.isHealthy = false
@@ -94,7 +106,6 @@ func (c *Client) HealthCheck(ctx context.Context) error {
 			c.mu.Unlock()
 			return fmt.Errorf("health check failed: login error: %w", loginErr)
 		}
-		// Retry the version check after login
 		if _, err = c.Client.GetWebAPIVersionCtx(ctx); err != nil {
 			c.mu.Lock()
 			c.isHealthy = false
@@ -109,4 +120,16 @@ func (c *Client) HealthCheck(ctx context.Context) error {
 	c.lastHealthCheck = time.Now()
 	c.mu.Unlock()
 	return nil
+}
+
+func (c *Client) SupportsSetTags() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.supportsSetTags
+}
+
+func (c *Client) GetWebAPIVersion() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.webAPIVersion
 }

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -1408,7 +1408,7 @@ func (sm *SyncManager) RemoveTags(ctx context.Context, instanceID int, hashes []
 }
 
 // SetTags sets tags on the specified torrents (replaces all existing tags)
-// This uses the new qBittorrent 5.1+ API if available, otherwise returns error
+// This uses the new qBittorrent 5.1+ API if available, otherwise falls back to RemoveTags + AddTags
 func (sm *SyncManager) SetTags(ctx context.Context, instanceID int, hashes []string, tags string) error {
 	client, err := sm.clientPool.GetClient(ctx, instanceID)
 	if err != nil {
@@ -1417,8 +1417,62 @@ func (sm *SyncManager) SetTags(ctx context.Context, instanceID int, hashes []str
 
 	// Try to use the new SetTags method (qBittorrent 5.1+)
 	if err := client.Client.SetTags(ctx, hashes, tags); err != nil {
-		// If it fails due to version requirement, return the error
-		// The frontend will handle the fallback to addTags
+		// Check if this is a version-related error
+		if strings.Contains(err.Error(), "version too old") || strings.Contains(err.Error(), "WebAPI version") {
+			log.Debug().Msg("SetTags: qBittorrent version too old, falling back to RemoveTags + AddTags")
+
+			// Fallback: use RemoveTags + AddTags for older versions
+			// First get current torrents to find existing tags
+			torrents, err := client.Client.GetTorrentsCtx(ctx, qbt.TorrentFilterOptions{
+				Hashes: hashes,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to get torrents for fallback: %w", err)
+			}
+
+			// Collect all unique existing tags from all torrents
+			existingTagsSet := make(map[string]bool)
+			for _, torrent := range torrents {
+				if torrent.Tags != "" {
+					torrentTags := strings.SplitSeq(torrent.Tags, ", ")
+					for tag := range torrentTags {
+						if strings.TrimSpace(tag) != "" {
+							existingTagsSet[strings.TrimSpace(tag)] = true
+						}
+					}
+				}
+			}
+
+			// Convert existing tags map to slice
+			var existingTags []string
+			for tag := range existingTagsSet {
+				existingTags = append(existingTags, tag)
+			}
+
+			// Remove all existing tags if any exist
+			if len(existingTags) > 0 {
+				existingTagsStr := strings.Join(existingTags, ",")
+				if err := client.Client.RemoveTagsCtx(ctx, hashes, existingTagsStr); err != nil {
+					return fmt.Errorf("failed to remove existing tags during fallback: %w", err)
+				}
+				log.Debug().Strs("removedTags", existingTags).Msg("SetTags fallback: removed existing tags")
+			}
+
+			// Add new tags if any specified
+			if tags != "" {
+				if err := client.Client.AddTagsCtx(ctx, hashes, tags); err != nil {
+					return fmt.Errorf("failed to add new tags during fallback: %w", err)
+				}
+				newTags := strings.Split(tags, ",")
+				log.Debug().Strs("addedTags", newTags).Msg("SetTags fallback: added new tags")
+			}
+
+			// Apply optimistic update to cache
+			sm.applyOptimisticCacheUpdate(instanceID, hashes, "setTags", map[string]any{"tags": tags})
+			return nil
+		}
+
+		// If it's not a version error, return the original error
 		return err
 	}
 

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -1382,7 +1382,7 @@ func (sm *SyncManager) AddTags(ctx context.Context, instanceID int, hashes []str
 		return fmt.Errorf("failed to get client: %w", err)
 	}
 
-	if err := client.Client.AddTagsCtx(ctx, hashes, tags); err != nil {
+	if err := client.AddTagsCtx(ctx, hashes, tags); err != nil {
 		return err
 	}
 
@@ -1398,7 +1398,7 @@ func (sm *SyncManager) RemoveTags(ctx context.Context, instanceID int, hashes []
 		return fmt.Errorf("failed to get client: %w", err)
 	}
 
-	if err := client.Client.RemoveTagsCtx(ctx, hashes, tags); err != nil {
+	if err := client.RemoveTagsCtx(ctx, hashes, tags); err != nil {
 		return err
 	}
 
@@ -1417,7 +1417,7 @@ func (sm *SyncManager) SetTags(ctx context.Context, instanceID int, hashes []str
 
 	// Check version support before attempting API call
 	if client.SupportsSetTags() {
-		if err := client.Client.SetTags(ctx, hashes, tags); err != nil {
+		if err := client.SetTags(ctx, hashes, tags); err != nil {
 			return err
 		}
 		log.Debug().Str("webAPIVersion", client.GetWebAPIVersion()).Msg("Used SetTags API directly")
@@ -1426,7 +1426,7 @@ func (sm *SyncManager) SetTags(ctx context.Context, instanceID int, hashes []str
 			Str("webAPIVersion", client.GetWebAPIVersion()).
 			Msg("SetTags: qBittorrent version < 2.11.4, using fallback RemoveTags + AddTags")
 
-		torrents, err := client.Client.GetTorrentsCtx(ctx, qbt.TorrentFilterOptions{
+		torrents, err := client.GetTorrentsCtx(ctx, qbt.TorrentFilterOptions{
 			Hashes: hashes,
 		})
 		if err != nil {
@@ -1452,14 +1452,14 @@ func (sm *SyncManager) SetTags(ctx context.Context, instanceID int, hashes []str
 
 		if len(existingTags) > 0 {
 			existingTagsStr := strings.Join(existingTags, ",")
-			if err := client.Client.RemoveTagsCtx(ctx, hashes, existingTagsStr); err != nil {
+			if err := client.RemoveTagsCtx(ctx, hashes, existingTagsStr); err != nil {
 				return fmt.Errorf("failed to remove existing tags during fallback: %w", err)
 			}
 			log.Debug().Strs("removedTags", existingTags).Msg("SetTags fallback: removed existing tags")
 		}
 
 		if tags != "" {
-			if err := client.Client.AddTagsCtx(ctx, hashes, tags); err != nil {
+			if err := client.AddTagsCtx(ctx, hashes, tags); err != nil {
 				return fmt.Errorf("failed to add new tags during fallback: %w", err)
 			}
 			newTags := strings.Split(tags, ",")
@@ -1479,7 +1479,7 @@ func (sm *SyncManager) SetCategory(ctx context.Context, instanceID int, hashes [
 		return fmt.Errorf("failed to get client: %w", err)
 	}
 
-	if err := client.Client.SetCategoryCtx(ctx, hashes, category); err != nil {
+	if err := client.SetCategoryCtx(ctx, hashes, category); err != nil {
 		return err
 	}
 
@@ -1495,7 +1495,7 @@ func (sm *SyncManager) SetAutoTMM(ctx context.Context, instanceID int, hashes []
 		return fmt.Errorf("failed to get client: %w", err)
 	}
 
-	if err := client.Client.SetAutoManagementCtx(ctx, hashes, enable); err != nil {
+	if err := client.SetAutoManagementCtx(ctx, hashes, enable); err != nil {
 		return err
 	}
 
@@ -1511,7 +1511,7 @@ func (sm *SyncManager) CreateTags(ctx context.Context, instanceID int, tags []st
 		return fmt.Errorf("failed to get client: %w", err)
 	}
 
-	if err := client.Client.CreateTagsCtx(ctx, tags); err != nil {
+	if err := client.CreateTagsCtx(ctx, tags); err != nil {
 		return err
 	}
 
@@ -1529,7 +1529,7 @@ func (sm *SyncManager) DeleteTags(ctx context.Context, instanceID int, tags []st
 		return fmt.Errorf("failed to get client: %w", err)
 	}
 
-	if err := client.Client.DeleteTagsCtx(ctx, tags); err != nil {
+	if err := client.DeleteTagsCtx(ctx, tags); err != nil {
 		return err
 	}
 
@@ -1547,7 +1547,7 @@ func (sm *SyncManager) CreateCategory(ctx context.Context, instanceID int, name 
 		return fmt.Errorf("failed to get client: %w", err)
 	}
 
-	if err := client.Client.CreateCategoryCtx(ctx, name, path); err != nil {
+	if err := client.CreateCategoryCtx(ctx, name, path); err != nil {
 		return err
 	}
 
@@ -1565,7 +1565,7 @@ func (sm *SyncManager) EditCategory(ctx context.Context, instanceID int, name st
 		return fmt.Errorf("failed to get client: %w", err)
 	}
 
-	if err := client.Client.EditCategoryCtx(ctx, name, path); err != nil {
+	if err := client.EditCategoryCtx(ctx, name, path); err != nil {
 		return err
 	}
 
@@ -1583,7 +1583,7 @@ func (sm *SyncManager) RemoveCategories(ctx context.Context, instanceID int, cat
 		return fmt.Errorf("failed to get client: %w", err)
 	}
 
-	if err := client.Client.RemoveCategoriesCtx(ctx, categories); err != nil {
+	if err := client.RemoveCategoriesCtx(ctx, categories); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Adds proactive WebAPI version checking to determine SetTags support before API calls, with automatic fallback to RemoveTags + AddTags for older qBittorrent versions (< 5.1).

- Cache WebAPI version during client initialization  
- Check version support before SetTags calls
- Fallback to RemoveTags + AddTags for unsupported versions
- Add semver dependency for reliable version comparison

Fixes #74