### PR TITLE
feat(web): add expandable dashboard all-time statistics

### DIFF
--- a/web/src/components/ui/table.tsx
+++ b/web/src/components/ui/table.tsx
@@ -1,0 +1,114 @@
+import * as React from "react"
+
+import { cn, } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">,) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className,)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">,) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className,)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">,) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className,)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">,) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">,) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">,) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">,) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">,) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("text-muted-foreground mt-4 text-sm", className,)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -6,12 +6,13 @@
 import { useInstances, } from "@/hooks/useInstances"
 import { useInstanceStats, } from "@/hooks/useInstanceStats"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle, } from "@/components/ui/card"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow, } from "@/components/ui/table"
 import { Badge, } from "@/components/ui/badge"
 import { Progress, } from "@/components/ui/progress"
 import { Button, } from "@/components/ui/button"
-import { HardDrive, Download, Upload, Activity, Plus, Zap, ChevronDown, ChevronUp, Eye, EyeOff, } from "lucide-react"
+import { HardDrive, Download, Upload, Activity, Plus, Zap, ChevronDown, ChevronUp, Eye, EyeOff, ChevronRight, } from "lucide-react"
 import { Link, } from "@tanstack/react-router"
-import { useMemo, } from "react"
+import { useMemo, useState, } from "react"
 import { formatSpeed, formatBytes, getRatioColor, } from "@/lib/utils"
 import { useQuery, useQueries, } from "@tanstack/react-query"
 import { api, } from "@/lib/api"
@@ -412,6 +413,7 @@ function GlobalStatsCards({ statsData, }: { statsData: Array<{ instance: Instanc
 }
 
 function GlobalAllTimeStats({ statsData, }: { statsData: Array<{ instance: InstanceResponse, stats: InstanceStats | undefined, serverState: ServerState | null }> },) {
+  const [isExpanded, setIsExpanded,] = useState(false,)
   const globalStats = useMemo(() => {
     // Calculate all-time stats
     const alltimeDl = statsData.reduce((sum, { serverState, },) => 
@@ -444,72 +446,132 @@ function GlobalAllTimeStats({ statsData, }: { statsData: Array<{ instance: Insta
   }
 
   return (
-    <div className="rounded-lg border bg-card p-4">
-      {/* Mobile layout */}
-      <div className="sm:hidden">
-        <div className="flex items-center justify-between mb-3">
-          <h3 className="text-sm font-medium text-muted-foreground">All-Time Statistics</h3>
-          <Badge variant="secondary" className="text-xs">combined</Badge>
-        </div>
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-4">
-            <div className="flex items-center gap-1.5">
-              <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
-              <span className="text-sm font-semibold">{formatBytes(globalStats.alltimeDl,)}</span>
+    <div className="rounded-lg border bg-card">
+      {/* Combined Stats Header - Clickable */}
+      <div 
+        className="p-4 cursor-pointer hover:bg-muted/50 transition-colors"
+        onClick={() => setIsExpanded(!isExpanded,)}
+      >
+        {/* Mobile layout */}
+        <div className="sm:hidden">
+          <div className="flex items-center justify-between mb-3">
+            <div className="flex items-center gap-2">
+              <h3 className="text-sm font-medium text-muted-foreground">All-Time Statistics</h3>
             </div>
-            <div className="flex items-center gap-1.5">
-              <ChevronUp className="h-3.5 w-3.5 text-muted-foreground" />
-              <span className="text-sm font-semibold">{formatBytes(globalStats.alltimeUl,)}</span>
+            <Badge variant="secondary" className="text-xs">combined</Badge>
+          </div>
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-4">
+              <div className="flex items-center gap-1.5">
+                <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+                <span className="text-sm font-semibold">{formatBytes(globalStats.alltimeDl,)}</span>
+              </div>
+              <div className="flex items-center gap-1.5">
+                <ChevronUp className="h-3.5 w-3.5 text-muted-foreground" />
+                <span className="text-sm font-semibold">{formatBytes(globalStats.alltimeUl,)}</span>
+              </div>
+            </div>
+            <div className="flex items-center gap-4 text-sm">
+              <div>
+                <span className="text-xs text-muted-foreground">Ratio: </span>
+                <span className="font-semibold" style={{ color: ratioColor, }}>
+                  {globalStats.globalRatio.toFixed(2,)}
+                </span>
+              </div>
+              {globalStats.totalPeers > 0 && (
+                <div>
+                  <span className="text-xs text-muted-foreground">Peers: </span>
+                  <span className="font-semibold">{globalStats.totalPeers}</span>
+                </div>
+              )}
             </div>
           </div>
-          <div className="flex items-center gap-4 text-sm">
-            <div>
-              <span className="text-xs text-muted-foreground">Ratio: </span>
-              <span className="font-semibold" style={{ color: ratioColor, }}>
+        </div>
+        
+        {/* Desktop layout */}
+        <div className="hidden sm:flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div className="flex items-center gap-2">
+            <ChevronRight className={`h-4 w-4 text-muted-foreground transition-transform ${isExpanded ? "rotate-90" : ""}`} />
+            <h3 className="text-base font-medium">All-Time Statistics <Badge variant="secondary" className="ml-1">combined</Badge></h3>
+          </div>
+          <div className="flex flex-wrap items-center gap-6 text-sm">
+            <div className="flex items-center gap-2">
+              <ChevronDown className="h-4 w-4 text-muted-foreground" />
+              <span className="text-lg font-semibold">{formatBytes(globalStats.alltimeDl,)}</span>
+            </div>
+            
+            <div className="flex items-center gap-2">
+              <ChevronUp className="h-4 w-4 text-muted-foreground" />
+              <span className="text-lg font-semibold">{formatBytes(globalStats.alltimeUl,)}</span>
+            </div>
+            
+            <div className="flex items-center gap-2">
+              <span className="text-muted-foreground">Ratio:</span>
+              <span className="text-lg font-semibold" style={{ color: ratioColor, }}>
                 {globalStats.globalRatio.toFixed(2,)}
               </span>
             </div>
+            
             {globalStats.totalPeers > 0 && (
-              <div>
-                <span className="text-xs text-muted-foreground">Peers: </span>
-                <span className="font-semibold">{globalStats.totalPeers}</span>
+              <div className="flex items-center gap-2">
+                <span className="text-muted-foreground">Peers:</span>
+                <span className="text-lg font-semibold">{globalStats.totalPeers}</span>
               </div>
             )}
           </div>
         </div>
       </div>
-      
-      {/* Desktop layout - unchanged */}
-      <div className="hidden sm:flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-        <div className="items-center">
-          <h3 className="text-base font-medium">All-Time Statistics <Badge variant="secondary" className="ml-1">combined</Badge></h3>
+
+      {/* Individual Instance Stats - Expandable Table */}
+      {isExpanded && (
+        <div className="border-t px-4">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[200px]">Instance</TableHead>
+                <TableHead className="text-right">
+                  <div className="flex items-center justify-end gap-1">
+                    <span>Downloaded</span>
+                  </div>
+                </TableHead>
+                <TableHead className="text-right">
+                  <div className="flex items-center justify-end gap-1">
+                    <span>Uploaded</span>
+                  </div>
+                </TableHead>
+                <TableHead className="text-right">Ratio</TableHead>
+                <TableHead className="text-right">Peers</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {statsData
+                .filter(({ serverState, },) => serverState?.alltime_dl || serverState?.alltime_ul,)
+                .map(({ instance, serverState, },) => {
+                  const instanceRatio = serverState?.alltime_dl ? (serverState.alltime_ul || 0) / serverState.alltime_dl : 0
+                  const instanceRatioColor = getRatioColor(instanceRatio,)
+                  
+                  return (
+                    <TableRow key={instance.id}>
+                      <TableCell className="font-medium">{instance.name}</TableCell>
+                      <TableCell className="text-right font-semibold">
+                        {formatBytes(serverState?.alltime_dl || 0,)}
+                      </TableCell>
+                      <TableCell className="text-right font-semibold">
+                        {formatBytes(serverState?.alltime_ul || 0,)}
+                      </TableCell>
+                      <TableCell className="text-right font-semibold" style={{ color: instanceRatioColor, }}>
+                        {instanceRatio.toFixed(2,)}
+                      </TableCell>
+                      <TableCell className="text-right font-semibold">
+                        {serverState?.total_peer_connections || "-"}
+                      </TableCell>
+                    </TableRow>
+                  )
+                },)}
+            </TableBody>
+          </Table>
         </div>
-        <div className="flex flex-wrap items-center gap-6 text-sm">
-          <div className="flex items-center gap-2">
-            <ChevronDown className="h-4 w-4 text-muted-foreground" />
-            <span className="text-lg font-semibold">{formatBytes(globalStats.alltimeDl,)}</span>
-          </div>
-          
-          <div className="flex items-center gap-2">
-            <ChevronUp className="h-4 w-4 text-muted-foreground" />
-            <span className="text-lg font-semibold">{formatBytes(globalStats.alltimeUl,)}</span>
-          </div>
-          
-          <div className="flex items-center gap-2">
-            <span className="text-muted-foreground">Ratio:</span>
-            <span className="text-lg font-semibold" style={{ color: ratioColor, }}>
-              {globalStats.globalRatio.toFixed(2,)}
-            </span>
-          </div>
-          
-          {globalStats.totalPeers > 0 && (
-            <div className="flex items-center gap-2">
-              <span className="text-muted-foreground">Peers:</span>
-              <span className="text-lg font-semibold">{globalStats.totalPeers}</span>
-            </div>
-          )}
-        </div>
-      </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Implement feature request #69 to make all-time statistics clickable and expandable to show per-instance breakdown.

Features:
- Click all-time statistics bar to expand/collapse
- Table view showing individual instance stats
- Smooth animations with rotating chevron icon
- Hover effects and visual feedback
- Responsive design for mobile and desktop
- Consistent padding with header layout

Closes #69

![CleanShot 2025-08-25 at 11 40 23](https://github.com/user-attachments/assets/80db21d2-533b-48b0-8b67-eed1e5fac461)
