### PR TITLE
feat(web): allow removing all tags from torrents

### DIFF
--- a/internal/api/handlers/torrents.go
+++ b/internal/api/handlers/torrents.go
@@ -361,10 +361,7 @@ func (h *TorrentsHandler) BulkAction(w http.ResponseWriter, r *http.Request) {
 		}
 		err = h.syncManager.RemoveTags(r.Context(), instanceID, req.Hashes, req.Tags)
 	case "setTags":
-		if req.Tags == "" {
-			RespondError(w, http.StatusBadRequest, "Tags parameter is required for setTags action")
-			return
-		}
+		// allow empty tags to clear all tags from torrents
 		err = h.syncManager.SetTags(r.Context(), instanceID, req.Hashes, req.Tags)
 	case "setCategory":
 		err = h.syncManager.SetCategory(r.Context(), instanceID, req.Hashes, req.Category)

--- a/web/src/components/torrents/TorrentActions.tsx
+++ b/web/src/components/torrents/TorrentActions.tsx
@@ -329,7 +329,7 @@ export const TorrentActions = memo(function TorrentActions({ instanceId, selecte
             disabled={mutation.isPending}
           >
             <Tag className="mr-2 h-4 w-4" />
-            Set Tags
+            Manage Tags
           </DropdownMenuItem>
           <DropdownMenuItem
             onClick={() => setShowCategoryDialog(true,)}

--- a/web/src/components/torrents/TorrentDialogs.tsx
+++ b/web/src/components/torrents/TorrentDialogs.tsx
@@ -65,12 +65,10 @@ export const SetTagsDialog = memo(function SetTagsDialog({
     if (newTag.trim() && !allTags.includes(newTag.trim(),)) {
       allTags.push(newTag.trim(),)
     }
-    if (allTags.length > 0) {
-      onConfirm(allTags,)
-      setSelectedTags([],)
-      setNewTag("",)
-    }
-  }, [selectedTags, newTag, onConfirm,],)
+    onConfirm(allTags,)
+    setSelectedTags([],)
+    setNewTag("",)
+  }, [selectedTags, newTag, onConfirm,],) // empty array will clear all tags
 
   const handleCancel = useCallback((): void => {
     setSelectedTags([],)
@@ -82,16 +80,27 @@ export const SetTagsDialog = memo(function SetTagsDialog({
     <AlertDialog open={open} onOpenChange={onOpenChange}>
       <AlertDialogContent className="max-w-md">
         <AlertDialogHeader>
-          <AlertDialogTitle>Set Tags for {hashCount} torrent(s)</AlertDialogTitle>
+          <AlertDialogTitle>Manage Tags for {hashCount} torrent(s)</AlertDialogTitle>
           <AlertDialogDescription>
-            Select tags from the list or add a new one. Selected tags will replace all existing tags on the torrents.
+            Select tags from the list or add a new one. Selected tags will replace all existing tags on the torrents. Leave all unchecked to remove all tags.
           </AlertDialogDescription>
         </AlertDialogHeader>
         <div className="py-4 space-y-4">
           {/* Existing tags */}
           {availableTags && availableTags.length > 0 && (
             <div className="space-y-2">
-              <Label>Available Tags</Label>
+              <div className="flex items-center justify-between">
+                <Label>Available Tags</Label>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setSelectedTags([],)}
+                  disabled={selectedTags.length === 0}
+                >
+                  Deselect All
+                </Button>
+              </div>
               <ScrollArea className="h-48 border rounded-md p-3">
                 <div className="space-y-2">
                   {availableTags.map((tag,) => (
@@ -167,9 +176,9 @@ export const SetTagsDialog = memo(function SetTagsDialog({
           <AlertDialogCancel onClick={handleCancel}>Cancel</AlertDialogCancel>
           <AlertDialogAction
             onClick={handleConfirm}
-            disabled={(selectedTags.length === 0 && !newTag.trim()) || isPending}
+            disabled={isPending}
           >
-            Set Tags
+            Update Tags
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>
@@ -180,7 +189,7 @@ export const SetTagsDialog = memo(function SetTagsDialog({
 interface SetCategoryDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
-  availableCategories: Record<string, any>
+  availableCategories: Record<string, unknown>
   hashCount: number
   onConfirm: (category: string) => void
   isPending?: boolean

--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -1022,7 +1022,7 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({ insta
                           disabled={mutation.isPending}
                         >
                           <Tag className="mr-2 h-4 w-4" />
-                          Set Tags {row.getIsSelected() && selectedHashes.length > 1 ? `(${selectedHashes.length})` : ""}
+                          Manage Tags {row.getIsSelected() && selectedHashes.length > 1 ? `(${selectedHashes.length})` : ""}
                         </ContextMenuItem>
                         <ContextMenuItem 
                           onClick={() => {


### PR DESCRIPTION
Resolves #68 - Users can now remove all tags from selected torrents.

Changes:
- Remove backend validation preventing empty tags in setTags action
- Update SetTagsDialog to allow empty tag selection
- Add "Deselect All" button for easy tag clearing
- Change menu labels from "Set Tags" to "Manage Tags"
- Improve dialog description to clarify tag removal behavior

<img width="1046" height="1190" alt="CleanShot 2025-08-25 at 12 11 49@2x" src="https://github.com/user-attachments/assets/938e67bf-072d-470a-9888-b2af7f05bbd5" />
