### PR TITLE
fix(auth): improve sessionSecret change handling with better UX

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -224,6 +224,8 @@ port = {{ .port }}
 
 # Session secret
 # Auto-generated if not provided
+# WARNING: Changing this value will break decryption of existing instance passwords!
+# If changed, you'll need to re-enter passwords for all existing qBittorrent instances in the UI.
 sessionSecret = "{{ .sessionSecret }}"
 
 # Log file path

--- a/web/src/components/instances/InstanceCard.tsx
+++ b/web/src/components/instances/InstanceCard.tsx
@@ -94,13 +94,13 @@ export function InstanceCard({ instance, onEdit }: InstanceCardProps) {
   return (
     <Card>
       <div>
-        <CardHeader className="flex flex-row items-center justify-between space-y-0">
+        <CardHeader className="flex flex-row items-center justify-between pr-2 space-y-0">
           <div>
             <CardTitle className="text-base font-medium">
               {instance.name}
             </CardTitle>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1">
             <Badge 
               variant={instance.connected ? "default" : "destructive"}
             >

--- a/web/src/components/instances/InstanceCard.tsx
+++ b/web/src/components/instances/InstanceCard.tsx
@@ -41,6 +41,13 @@ export function InstanceCard({ instance, onEdit }: InstanceCardProps) {
   const [incognitoMode, setIncognitoMode] = useIncognitoMode()
   const displayUrl = instance.host
 
+  // Helper to check if connection error is decryption-related
+  const isDecryptionError = (error: string) => {
+    const errorLower = error.toLowerCase()
+    return errorLower.includes("decrypt") && 
+           (errorLower.includes("password") || errorLower.includes("cipher"))
+  }
+
   const handleTest = async () => {
     setTestResult(null)
     try {
@@ -169,7 +176,29 @@ export function InstanceCard({ instance, onEdit }: InstanceCardProps) {
           )}
         </div>
         
-        {instance.connectionError && (
+        {instance.hasDecryptionError && (
+          <div className="mt-4 p-3 rounded-lg bg-muted border border-border">
+            <div className="flex items-start gap-2 text-sm text-foreground">
+              <XCircle className="h-4 w-4 mt-0.5 flex-shrink-0 text-destructive" />
+              <div className="flex-1">
+                <div className="font-medium mb-1 text-destructive">Password Required</div>
+                <div className="text-muted-foreground mb-2">
+                  Unable to decrypt saved password. This usually happens when the session secret has changed.
+                </div>
+                <Button 
+                  onClick={onEdit}
+                  size="sm" 
+                  variant="outline"
+                >
+                  <Edit className="mr-2 h-3 w-3" />
+                  Re-enter Password
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {instance.connectionError && !(instance.hasDecryptionError && isDecryptionError(instance.connectionError)) && (
           <div className="mt-4 p-3 rounded-lg bg-destructive/10 border border-destructive/20">
             <div className="flex items-start gap-2 text-sm text-destructive">
               <XCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />

--- a/web/src/components/ui/alert.tsx
+++ b/web/src/components/ui/alert.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground",
+  {
+    variants: {
+      variant: {
+        default: "bg-background text-foreground",
+        destructive:
+          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    ref={ref}
+    role="alert"
+    className={cn(alertVariants({ variant }), className)}
+    {...props}
+  />
+))
+Alert.displayName = "Alert"
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+AlertTitle.displayName = "AlertTitle"
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm [&_p]:leading-relaxed", className)}
+    {...props}
+  />
+))
+AlertDescription.displayName = "AlertDescription"
+
+export { Alert, AlertTitle, AlertDescription }

--- a/web/src/lib/base-url.ts
+++ b/web/src/lib/base-url.ts
@@ -6,7 +6,7 @@
 // Get the base URL injected by the backend
 // Falls back to '/' if not set
 export function getBaseUrl(): string {
-  // @ts-ignore - This is injected by the backend
+  // @ts-expect-error - This is injected by the backend
   const baseUrl = window.__QUI_BASE_URL__ || "/"
   
   // Ensure it ends with /

--- a/web/src/pages/Instances.tsx
+++ b/web/src/pages/Instances.tsx
@@ -23,7 +23,7 @@ import type { Instance } from "@/types"
 export function Instances() {
   const { instances, isLoading } = useInstances()
   const navigate = useNavigate()
-  const search = useSearch({ strict: false }) as any
+  const search = useSearch({ strict: false }) as Record<string, unknown>
   const [editingInstance, setEditingInstance] = useState<Instance | undefined>()
 
   // Check if modal should be open based on URL params
@@ -32,16 +32,17 @@ export function Instances() {
   const handleOpenDialog = (instance?: Instance) => {
     setEditingInstance(instance)
     navigate({ 
-      search: { ...search, modal: "add-instance" },
+      to: "/instances",
+      search: { modal: "add-instance" },
       replace: true, 
     })
   }
 
   const handleCloseDialog = () => {
     setEditingInstance(undefined)
-    const { modal, ...restSearch } = search || {}
     navigate({ 
-      search: restSearch,
+      to: "/instances",
+      search: {},
       replace: true, 
     })
   }

--- a/web/src/pages/Instances.tsx
+++ b/web/src/pages/Instances.tsx
@@ -15,7 +15,8 @@ import {
   DialogHeader,
   DialogTitle
 } from "@/components/ui/dialog"
-import { Plus } from "lucide-react"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Plus, AlertTriangle } from "lucide-react"
 import { useNavigate, useSearch } from "@tanstack/react-router"
 import type { Instance } from "@/types"
 
@@ -71,8 +72,20 @@ export function Instances() {
         </Button>
       </div>
 
+      {/* Show banner if any instances have decryption errors */}
+      {instances && instances.some(instance => instance.hasDecryptionError) && (
+        <Alert className="mb-6">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertTitle>Password Issues Detected</AlertTitle>
+          <AlertDescription>
+            Some instances cannot decrypt their saved passwords, likely due to a configuration change. 
+            Click "Re-enter Password" on the affected instances below to resolve this issue.
+          </AlertDescription>
+        </Alert>
+      )}
+
       {instances && instances.length > 0 ? (
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 items-start">
           {instances.map((instance) => (
             <InstanceCard
               key={instance.id}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -30,6 +30,7 @@ export interface Instance {
 export interface InstanceResponse extends Instance {
   connected: boolean
   connectionError?: string
+  hasDecryptionError: boolean
 }
 
 export interface Torrent {


### PR DESCRIPTION
- Add warning comments to config template about sessionSecret changes
- Implement smart error logging to reduce spam for decryption failures
- Add decryption error tracking in ClientPool to log only once per instance
- Expose decryption error status via API for frontend handling
- Add user-friendly "Password Required" UI prompts in instance cards
- Add global banner on instances page when decryption errors exist
- Hide redundant connection errors when showing password prompts
- Fix card height stretching issue with items-start grid alignment
- Add shadcn/ui Alert component for better messaging
- Use proper semantic theme colors for error states

The solution provides clear recovery path for users when sessionSecret changes.

<img width="697" height="667" alt="PixelSnap 2025-08-26 at 11 24 27@2x" src="https://github.com/user-attachments/assets/dcae0f8b-18b8-4a39-8237-e9d0c98495ef" />
