### PR TITLE
feat(api): add speed limits toggle functionality

### DIFF
--- a/internal/api/handlers/speed_limits.go
+++ b/internal/api/handlers/speed_limits.go
@@ -1,0 +1,195 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/rs/zerolog/log"
+
+	internalqbittorrent "github.com/autobrr/qui/internal/qbittorrent"
+)
+
+type SpeedLimitsHandler struct {
+	clientPool  *internalqbittorrent.ClientPool
+	syncManager *internalqbittorrent.SyncManager
+}
+
+func NewSpeedLimitsHandler(clientPool *internalqbittorrent.ClientPool, syncManager *internalqbittorrent.SyncManager) *SpeedLimitsHandler {
+	return &SpeedLimitsHandler{
+		clientPool:  clientPool,
+		syncManager: syncManager,
+	}
+}
+
+// SpeedLimitsStatus represents the current speed limits status
+type SpeedLimitsStatus struct {
+	AlternativeSpeedLimitsEnabled bool  `json:"alternativeSpeedLimitsEnabled"`
+	DownloadLimit                 int64 `json:"downloadLimit"`    // Current download limit (0 = unlimited)
+	UploadLimit                   int64 `json:"uploadLimit"`      // Current upload limit (0 = unlimited)
+	AlternativeDownloadLimit      int64 `json:"altDownloadLimit"` // Alternative download limit
+	AlternativeUploadLimit        int64 `json:"altUploadLimit"`   // Alternative upload limit
+}
+
+// ToggleResponse represents the response after toggling speed limits
+type ToggleResponse struct {
+	Success                       bool   `json:"success"`
+	AlternativeSpeedLimitsEnabled bool   `json:"alternativeSpeedLimitsEnabled"`
+	Message                       string `json:"message,omitempty"`
+}
+
+// GetSpeedLimitsStatus godoc
+// @Summary Get speed limits status for an instance
+// @Description Get current speed limits status including alternative speed limits and current/alternative limits
+// @Tags instances
+// @Accept json
+// @Produce json
+// @Param instanceID path int true "Instance ID"
+// @Success 200 {object} SpeedLimitsStatus
+// @Failure 400 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Router /api/instances/{instanceID}/speed-limits [get]
+func (h *SpeedLimitsHandler) GetSpeedLimitsStatus(w http.ResponseWriter, r *http.Request) {
+	instanceIDStr := chi.URLParam(r, "instanceID")
+	instanceID, err := strconv.Atoi(instanceIDStr)
+	if err != nil {
+		log.Error().Err(err).Str("instanceID", instanceIDStr).Msg("Invalid instance ID")
+		http.Error(w, "Invalid instance ID", http.StatusBadRequest)
+		return
+	}
+
+	ctx := r.Context()
+	client, err := h.clientPool.GetClient(ctx, instanceID)
+	if err != nil {
+		log.Error().Err(err).Int("instanceID", instanceID).Msg("Failed to get client")
+		http.Error(w, "Failed to connect to instance", http.StatusNotFound)
+		return
+	}
+
+	// Get alternative speed limits mode
+	altSpeedEnabled, err := client.GetAlternativeSpeedLimitsModeCtx(ctx)
+	if err != nil {
+		log.Error().Err(err).Int("instanceID", instanceID).Msg("Failed to get alternative speed limits mode")
+		http.Error(w, "Failed to get speed limits status", http.StatusInternalServerError)
+		return
+	}
+
+	// Get current global limits
+	downloadLimit, err := client.GetGlobalDownloadLimitCtx(ctx)
+	if err != nil {
+		log.Error().Err(err).Int("instanceID", instanceID).Msg("Failed to get download limit")
+		http.Error(w, "Failed to get download limit", http.StatusInternalServerError)
+		return
+	}
+
+	uploadLimit, err := client.GetGlobalUploadLimitCtx(ctx)
+	if err != nil {
+		log.Error().Err(err).Int("instanceID", instanceID).Msg("Failed to get upload limit")
+		http.Error(w, "Failed to get upload limit", http.StatusInternalServerError)
+		return
+	}
+
+	// Get app preferences to get alternative limits
+	prefs, err := client.GetAppPreferencesCtx(ctx)
+	if err != nil {
+		log.Error().Err(err).Int("instanceID", instanceID).Msg("Failed to get app preferences")
+		http.Error(w, "Failed to get app preferences", http.StatusInternalServerError)
+		return
+	}
+
+	status := SpeedLimitsStatus{
+		AlternativeSpeedLimitsEnabled: altSpeedEnabled,
+		DownloadLimit:                 downloadLimit,
+		UploadLimit:                   uploadLimit,
+		AlternativeDownloadLimit:      int64(prefs.AltDlLimit),
+		AlternativeUploadLimit:        int64(prefs.AltUpLimit),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(status); err != nil {
+		log.Error().Err(err).Msg("Failed to encode speed limits status response")
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+}
+
+// ToggleSpeedLimits godoc
+// @Summary Toggle alternative speed limits for an instance
+// @Description Toggle alternative speed limits on/off for a qBittorrent instance
+// @Tags instances
+// @Accept json
+// @Produce json
+// @Param instanceID path int true "Instance ID"
+// @Success 200 {object} ToggleResponse
+// @Failure 400 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Router /api/instances/{instanceID}/speed-limits/toggle [post]
+func (h *SpeedLimitsHandler) ToggleSpeedLimits(w http.ResponseWriter, r *http.Request) {
+	instanceIDStr := chi.URLParam(r, "instanceID")
+	instanceID, err := strconv.Atoi(instanceIDStr)
+	if err != nil {
+		log.Error().Err(err).Str("instanceID", instanceIDStr).Msg("Invalid instance ID")
+		http.Error(w, "Invalid instance ID", http.StatusBadRequest)
+		return
+	}
+
+	ctx := r.Context()
+	client, err := h.clientPool.GetClient(ctx, instanceID)
+	if err != nil {
+		log.Error().Err(err).Int("instanceID", instanceID).Msg("Failed to get client")
+		http.Error(w, "Failed to connect to instance", http.StatusNotFound)
+		return
+	}
+
+	// Get current state before toggling
+	altSpeedEnabledBefore, err := client.GetAlternativeSpeedLimitsModeCtx(ctx)
+	if err != nil {
+		log.Error().Err(err).Int("instanceID", instanceID).Msg("Failed to get alternative speed limits mode")
+		http.Error(w, "Failed to get current speed limits status", http.StatusInternalServerError)
+		return
+	}
+
+	// Toggle alternative speed limits
+	err = client.ToggleAlternativeSpeedLimitsCtx(ctx)
+	if err != nil {
+		log.Error().Err(err).Int("instanceID", instanceID).Msg("Failed to toggle alternative speed limits")
+		http.Error(w, "Failed to toggle speed limits", http.StatusInternalServerError)
+		return
+	}
+
+	// Get new state after toggling to confirm
+	altSpeedEnabledAfter, err := client.GetAlternativeSpeedLimitsModeCtx(ctx)
+	if err != nil {
+		log.Warn().Err(err).Int("instanceID", instanceID).Msg("Failed to verify speed limits state after toggle")
+		// Still return success since the toggle command was sent successfully
+		altSpeedEnabledAfter = !altSpeedEnabledBefore
+	}
+
+	var message string
+	if altSpeedEnabledAfter {
+		message = "Alternative speed limits enabled"
+	} else {
+		message = "Alternative speed limits disabled"
+	}
+
+	log.Info().Int("instanceID", instanceID).Bool("enabled", altSpeedEnabledAfter).Msg("Speed limits toggled")
+
+	response := ToggleResponse{
+		Success:                       true,
+		AlternativeSpeedLimitsEnabled: altSpeedEnabledAfter,
+		Message:                       message,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		log.Error().Err(err).Msg("Failed to encode toggle response")
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -139,6 +139,7 @@ func NewRouter(deps *Dependencies) *chi.Mux {
 					// Speed limits
 					r.Get("/speed-limits", speedLimitsHandler.GetSpeedLimitsStatus)
 					r.Post("/speed-limits/toggle", speedLimitsHandler.ToggleSpeedLimits)
+					r.Put("/speed-limits", speedLimitsHandler.SetSpeedLimits)
 				})
 			})
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -57,6 +57,7 @@ func NewRouter(deps *Dependencies) *chi.Mux {
 	authHandler := handlers.NewAuthHandler(deps.AuthService)
 	instancesHandler := handlers.NewInstancesHandler(deps.InstanceStore, deps.ClientPool, deps.SyncManager)
 	torrentsHandler := handlers.NewTorrentsHandler(deps.SyncManager)
+	speedLimitsHandler := handlers.NewSpeedLimitsHandler(deps.ClientPool, deps.SyncManager)
 
 	// Theme license handler (optional, only if service is configured)
 	var themeLicenseHandler *handlers.ThemeLicenseHandler
@@ -134,6 +135,10 @@ func NewRouter(deps *Dependencies) *chi.Mux {
 					r.Get("/tags", torrentsHandler.GetTags)
 					r.Post("/tags", torrentsHandler.CreateTags)
 					r.Delete("/tags", torrentsHandler.DeleteTags)
+
+					// Speed limits
+					r.Get("/speed-limits", speedLimitsHandler.GetSpeedLimitsStatus)
+					r.Post("/speed-limits/toggle", speedLimitsHandler.ToggleSpeedLimits)
 				})
 			})
 

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -351,6 +351,66 @@ paths:
               schema:
                 $ref: '#/components/schemas/InstanceStats'
 
+  /api/instances/{instanceId}/speed-limits:
+    get:
+      tags:
+        - Speed Limits
+      summary: Get speed limits status
+      description: Get current speed limit settings for an instance
+      parameters:
+        - $ref: '#/components/parameters/instanceId'
+      responses:
+        '200':
+          description: Speed limits status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SpeedLimitsStatus'
+        '404':
+          description: Instance not found
+    put:
+      tags:
+        - Speed Limits
+      summary: Set speed limits
+      description: Configure speed limit settings for an instance
+      parameters:
+        - $ref: '#/components/parameters/instanceId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetSpeedLimitsRequest'
+      responses:
+        '200':
+          description: Speed limits updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SetSpeedLimitsResponse'
+        '400':
+          description: Invalid request
+        '404':
+          description: Instance not found
+
+  /api/instances/{instanceId}/speed-limits/toggle:
+    post:
+      tags:
+        - Speed Limits
+      summary: Toggle speed limits mode
+      description: Toggle between global and alternative speed limits
+      parameters:
+        - $ref: '#/components/parameters/instanceId'
+      responses:
+        '200':
+          description: Speed limits toggled successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SpeedLimitsToggleResponse'
+        '404':
+          description: Instance not found
+
   /api/instances/{instanceId}/torrents:
     get:
       tags:
@@ -1007,6 +1067,78 @@ components:
               type: integer
             freeSpace:
               type: integer
+
+    SpeedLimitsStatus:
+      type: object
+      properties:
+        alternativeSpeedLimitsEnabled:
+          type: boolean
+          description: Whether alternative speed limits are currently active
+        downloadLimit:
+          type: integer
+          description: Global download speed limit in bytes/second (0 = unlimited)
+        uploadLimit:
+          type: integer
+          description: Global upload speed limit in bytes/second (0 = unlimited)
+        altDownloadLimit:
+          type: integer
+          description: Alternative download speed limit in bytes/second (0 = unlimited)
+        altUploadLimit:
+          type: integer
+          description: Alternative upload speed limit in bytes/second (0 = unlimited)
+      required:
+        - alternativeSpeedLimitsEnabled
+        - downloadLimit
+        - uploadLimit
+        - altDownloadLimit
+        - altUploadLimit
+
+    SpeedLimitsToggleResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          description: Whether the operation was successful
+        alternativeSpeedLimitsEnabled:
+          type: boolean
+          description: Current state after toggle
+        message:
+          type: string
+          description: Optional message
+      required:
+        - success
+        - alternativeSpeedLimitsEnabled
+
+    SetSpeedLimitsRequest:
+      type: object
+      properties:
+        downloadLimit:
+          type: integer
+          description: Global download speed limit in bytes/second (0 = unlimited)
+        uploadLimit:
+          type: integer
+          description: Global upload speed limit in bytes/second (0 = unlimited)
+        altDownloadLimit:
+          type: integer
+          description: Alternative download speed limit in bytes/second (0 = unlimited)
+        altUploadLimit:
+          type: integer
+          description: Alternative upload speed limit in bytes/second (0 = unlimited)
+        alternativeSpeedLimitsEnabled:
+          type: boolean
+          description: Whether to enable alternative speed limits
+
+    SetSpeedLimitsResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          description: Whether the operation was successful
+        message:
+          type: string
+          description: Optional message
+      required:
+        - success
 
     Torrent:
       type: object

--- a/web/src/components/instances/SpeedLimitsDialog.tsx
+++ b/web/src/components/instances/SpeedLimitsDialog.tsx
@@ -1,0 +1,332 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { useState, useEffect } from "react"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import { Separator } from "@/components/ui/separator"
+import { useSpeedLimitsStatus, useSetSpeedLimits } from "@/hooks/useSpeedLimits"
+import { formatSpeed } from "@/lib/utils"
+import { Loader2, Rabbit, Turtle } from "lucide-react"
+import type { SetSpeedLimitsRequest } from "@/types"
+
+interface SpeedLimitsDialogProps {
+  instanceId: number
+  instanceName: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+// Convert bytes/s to MB/s for display
+const bytesToMBps = (bytes: number): number => {
+  return bytes === 0 ? 0 : Math.round(bytes / (1024 * 1024) * 100) / 100
+}
+
+// Convert MB/s to bytes/s for API
+const mbpsToBytes = (mbps: number): number => {
+  return mbps === 0 ? 0 : Math.round(mbps * 1024 * 1024)
+}
+
+export function SpeedLimitsDialog({ instanceId, instanceName, open, onOpenChange }: SpeedLimitsDialogProps) {
+  const { data: speedLimits, isLoading } = useSpeedLimitsStatus(instanceId, {
+    enabled: open,
+  })
+  const setSpeedLimitsMutation = useSetSpeedLimits(instanceId)
+
+  // Form state
+  const [globalDownload, setGlobalDownload] = useState("")
+  const [globalUpload, setGlobalUpload] = useState("")
+  const [altDownload, setAltDownload] = useState("")
+  const [altUpload, setAltUpload] = useState("")
+  const [useAltLimits, setUseAltLimits] = useState(false)
+
+  // Initialize form with current values
+  useEffect(() => {
+    if (speedLimits) {
+      setGlobalDownload(bytesToMBps(speedLimits.downloadLimit).toString())
+      setGlobalUpload(bytesToMBps(speedLimits.uploadLimit).toString())
+      setAltDownload(bytesToMBps(speedLimits.altDownloadLimit).toString())
+      setAltUpload(bytesToMBps(speedLimits.altUploadLimit).toString())
+      setUseAltLimits(speedLimits.alternativeSpeedLimitsEnabled)
+    }
+  }, [speedLimits])
+
+  const handleSave = async () => {
+    const request: SetSpeedLimitsRequest = {}
+
+    // Parse and convert values
+    const globalDlValue = parseFloat(globalDownload)
+    const globalUlValue = parseFloat(globalUpload)
+    const altDlValue = parseFloat(altDownload)
+    const altUlValue = parseFloat(altUpload)
+
+    // Set global limits if changed
+    if (!isNaN(globalDlValue) && globalDlValue !== bytesToMBps(speedLimits?.downloadLimit || 0)) {
+      request.downloadLimit = mbpsToBytes(globalDlValue)
+    }
+    if (!isNaN(globalUlValue) && globalUlValue !== bytesToMBps(speedLimits?.uploadLimit || 0)) {
+      request.uploadLimit = mbpsToBytes(globalUlValue)
+    }
+
+    // Set alternative limits if changed
+    if (!isNaN(altDlValue) && altDlValue !== bytesToMBps(speedLimits?.altDownloadLimit || 0)) {
+      request.altDownloadLimit = mbpsToBytes(altDlValue)
+    }
+    if (!isNaN(altUlValue) && altUlValue !== bytesToMBps(speedLimits?.altUploadLimit || 0)) {
+      request.altUploadLimit = mbpsToBytes(altUlValue)
+    }
+
+    // Set alternative mode if changed
+    if (useAltLimits !== speedLimits?.alternativeSpeedLimitsEnabled) {
+      request.alternativeSpeedLimitsEnabled = useAltLimits
+    }
+
+    try {
+      await setSpeedLimitsMutation.mutateAsync(request)
+      onOpenChange(false)
+    } catch (error) {
+      console.error("Failed to set speed limits:", error)
+    }
+  }
+
+  const presetSpeeds = [
+    { label: "1 MB/s", value: 1 },
+    { label: "5 MB/s", value: 5 },
+    { label: "10 MB/s", value: 10 },
+    { label: "25 MB/s", value: 25 },
+    { label: "50 MB/s", value: 50 },
+    { label: "Unlimited", value: 0 },
+  ]
+
+  const applyPreset = (field: "globalDownload" | "globalUpload" | "altDownload" | "altUpload", value: number) => {
+    const stringValue = value.toString()
+    switch (field) {
+      case "globalDownload":
+        setGlobalDownload(stringValue)
+        break
+      case "globalUpload":
+        setGlobalUpload(stringValue)
+        break
+      case "altDownload":
+        setAltDownload(stringValue)
+        break
+      case "altUpload":
+        setAltUpload(stringValue)
+        break
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            Speed Limits - {instanceName}
+          </DialogTitle>
+          <DialogDescription>
+            Configure download and upload speed limits for this qBittorrent instance.
+            Values are in MB/s (0 = unlimited).
+          </DialogDescription>
+        </DialogHeader>
+
+        {isLoading ? (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="h-6 w-6 animate-spin" />
+            <span className="ml-2">Loading current settings...</span>
+          </div>
+        ) : (
+          <div className="space-y-6">
+            {/* Alternative Speed Limits Toggle */}
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                {useAltLimits ? (
+                  <Turtle className="h-4 w-4 text-orange-500" />
+                ) : (
+                  <Rabbit className="h-4 w-4 text-green-500" />
+                )}
+                <Label htmlFor="alt-mode" className="text-sm font-medium">
+                  Use Alternative Speed Limits
+                </Label>
+              </div>
+              <Switch
+                id="alt-mode"
+                checked={useAltLimits}
+                onCheckedChange={setUseAltLimits}
+              />
+            </div>
+
+            <Separator />
+
+            {/* Global Speed Limits */}
+            <div className="space-y-4">
+              <div className="flex items-center gap-2">
+                <Rabbit className="h-4 w-4 text-green-500" />
+                <h3 className="text-sm font-semibold">Global Speed Limits</h3>
+                {!useAltLimits && <span className="text-xs text-muted-foreground">(Currently Active)</span>}
+              </div>
+              
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="global-download">Download (MB/s)</Label>
+                  <Input
+                    id="global-download"
+                    type="number"
+                    min="0"
+                    step="0.1"
+                    placeholder="0 = unlimited"
+                    value={globalDownload}
+                    onChange={(e) => setGlobalDownload(e.target.value)}
+                  />
+                  <div className="flex flex-wrap gap-1">
+                    {presetSpeeds.map((preset) => (
+                      <Button
+                        key={`global-dl-${preset.value}`}
+                        variant="outline"
+                        size="sm"
+                        className="text-xs h-6 px-2"
+                        onClick={() => applyPreset("globalDownload", preset.value)}
+                      >
+                        {preset.label}
+                      </Button>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="global-upload">Upload (MB/s)</Label>
+                  <Input
+                    id="global-upload"
+                    type="number"
+                    min="0"
+                    step="0.1"
+                    placeholder="0 = unlimited"
+                    value={globalUpload}
+                    onChange={(e) => setGlobalUpload(e.target.value)}
+                  />
+                  <div className="flex flex-wrap gap-1">
+                    {presetSpeeds.map((preset) => (
+                      <Button
+                        key={`global-ul-${preset.value}`}
+                        variant="outline"
+                        size="sm"
+                        className="text-xs h-6 px-2"
+                        onClick={() => applyPreset("globalUpload", preset.value)}
+                      >
+                        {preset.label}
+                      </Button>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <Separator />
+
+            {/* Alternative Speed Limits */}
+            <div className="space-y-4">
+              <div className="flex items-center gap-2">
+                <Turtle className="h-4 w-4 text-orange-500" />
+                <h3 className="text-sm font-semibold">Alternative Speed Limits</h3>
+                {useAltLimits && <span className="text-xs text-muted-foreground">(Currently Active)</span>}
+              </div>
+              
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="alt-download">Download (MB/s)</Label>
+                  <Input
+                    id="alt-download"
+                    type="number"
+                    min="0"
+                    step="0.1"
+                    placeholder="0 = unlimited"
+                    value={altDownload}
+                    onChange={(e) => setAltDownload(e.target.value)}
+                  />
+                  <div className="flex flex-wrap gap-1">
+                    {presetSpeeds.map((preset) => (
+                      <Button
+                        key={`alt-dl-${preset.value}`}
+                        variant="outline"
+                        size="sm"
+                        className="text-xs h-6 px-2"
+                        onClick={() => applyPreset("altDownload", preset.value)}
+                      >
+                        {preset.label}
+                      </Button>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="alt-upload">Upload (MB/s)</Label>
+                  <Input
+                    id="alt-upload"
+                    type="number"
+                    min="0"
+                    step="0.1"
+                    placeholder="0 = unlimited"
+                    value={altUpload}
+                    onChange={(e) => setAltUpload(e.target.value)}
+                  />
+                  <div className="flex flex-wrap gap-1">
+                    {presetSpeeds.map((preset) => (
+                      <Button
+                        key={`alt-ul-${preset.value}`}
+                        variant="outline"
+                        size="sm"
+                        className="text-xs h-6 px-2"
+                        onClick={() => applyPreset("altUpload", preset.value)}
+                      >
+                        {preset.label}
+                      </Button>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {speedLimits && (
+              <div className="text-xs text-muted-foreground p-3 bg-muted rounded">
+                <strong>Current Status:</strong><br />
+                Mode: {speedLimits.alternativeSpeedLimitsEnabled ? "Alternative" : "Global"}<br />
+                Active Download: {formatSpeed(speedLimits.alternativeSpeedLimitsEnabled ? speedLimits.altDownloadLimit : speedLimits.downloadLimit)}<br />
+                Active Upload: {formatSpeed(speedLimits.alternativeSpeedLimitsEnabled ? speedLimits.altUploadLimit : speedLimits.uploadLimit)}
+              </div>
+            )}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button 
+            onClick={handleSave} 
+            disabled={isLoading || setSpeedLimitsMutation.isPending}
+          >
+            {setSpeedLimitsMutation.isPending ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                Saving...
+              </>
+            ) : (
+              "Save Changes"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web/src/components/instances/SpeedLimitsToggle.tsx
+++ b/web/src/components/instances/SpeedLimitsToggle.tsx
@@ -3,18 +3,23 @@
  * * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
+import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
+import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuSeparator, ContextMenuTrigger, ContextMenuLabel } from "@/components/ui/context-menu"
 import { useSpeedLimitsStatus, useToggleSpeedLimits } from "@/hooks/useSpeedLimits"
-import { Rabbit, Turtle, Loader2 } from "lucide-react"
+import { Rabbit, Turtle, Loader2, Settings } from "lucide-react"
 import { formatSpeed } from "@/lib/utils"
+import { SpeedLimitsDialog } from "./SpeedLimitsDialog"
 
 interface SpeedLimitsToggleProps {
   instanceId: number
+  instanceName: string
   connected: boolean
 }
 
-export function SpeedLimitsToggle({ instanceId, connected }: SpeedLimitsToggleProps) {
+export function SpeedLimitsToggle({ instanceId, instanceName, connected }: SpeedLimitsToggleProps) {
+  const [dialogOpen, setDialogOpen] = useState(false)
   const { data: speedLimits, isLoading } = useSpeedLimitsStatus(instanceId, {
     enabled: connected,
   })
@@ -29,6 +34,15 @@ export function SpeedLimitsToggle({ instanceId, connected }: SpeedLimitsTogglePr
     toggleMutation.mutate()
   }
 
+  const handleOpenDialog = (e: React.MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    
+    if (!connected) return
+    
+    setDialogOpen(true)
+  }
+
   if (!connected || isLoading || !speedLimits) {
     return null
   }
@@ -37,10 +51,10 @@ export function SpeedLimitsToggle({ instanceId, connected }: SpeedLimitsTogglePr
   const downloadLimit = isEnabled ? speedLimits.altDownloadLimit : speedLimits.downloadLimit
   const uploadLimit = isEnabled ? speedLimits.altUploadLimit : speedLimits.uploadLimit
   
-  const tooltipContent = (
+  const toggleTooltipContent = (
     <div className="space-y-1 text-xs">
       <div className="font-medium">
-        Speed Limits: {isEnabled ? "Enabled" : "Unlimited"}
+        Speed Limits: {isEnabled ? "Alternative" : "Global"}
       </div>
       {isEnabled && (
         <div className="space-y-0.5 opacity-90">
@@ -48,38 +62,79 @@ export function SpeedLimitsToggle({ instanceId, connected }: SpeedLimitsTogglePr
           <div>↑ {uploadLimit > 0 ? formatSpeed(uploadLimit) : "Unlimited"}</div>
         </div>
       )}
-      <div className="opacity-90 pt-1 border-t border-white/20">
-        Click to {isEnabled ? "disable" : "enable"} alternative speed limits
+      <div className="opacity-90 pt-1 border-t border-white/20 space-y-0.5">
+        <div>Left-click: {isEnabled ? "disable" : "enable"} alternative speed limits</div>
+        <div>Right-click: configure speed limits</div>
       </div>
     </div>
   )
 
+
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            className={`h-6 w-6 p-0 transition-colors ${
-              isEnabled? "text-orange-500 hover:text-orange-600 hover:bg-orange-50": "text-green-500 hover:text-green-600 hover:bg-green-50"
-            }`}
-            onClick={handleToggle}
-            disabled={toggleMutation.isPending}
-          >
-            {toggleMutation.isPending ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : isEnabled ? (
-              <Turtle className="h-4 w-4" />
-            ) : (
-              <Rabbit className="h-4 w-4" />
-            )}
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">
-          {tooltipContent}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <>
+      <TooltipProvider>
+        <ContextMenu>
+          <Tooltip>
+            <ContextMenuTrigger asChild>
+              <TooltipTrigger asChild onFocus={(event) => event.preventDefault()}>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className={`h-6 w-6 p-0 transition-colors ${
+                    isEnabled ? "text-orange-500 hover:text-orange-600 hover:bg-orange-50" : "text-green-500 hover:text-green-600 hover:bg-green-50"
+                  }`}
+                  onClick={handleToggle}
+                  disabled={toggleMutation.isPending}
+                >
+                  {toggleMutation.isPending ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  ) : isEnabled ? (
+                    <Turtle className="h-4 w-4" />
+                  ) : (
+                    <Rabbit className="h-4 w-4" />
+                  )}
+                </Button>
+              </TooltipTrigger>
+            </ContextMenuTrigger>
+            <TooltipContent side="bottom">
+              {toggleTooltipContent}
+            </TooltipContent>
+          </Tooltip>
+          <ContextMenuContent className="w-56">
+            <ContextMenuLabel>Speed Limits</ContextMenuLabel>
+            <ContextMenuSeparator />
+          
+            <ContextMenuItem
+              onClick={handleOpenDialog}
+              className="flex items-center gap-2"
+            >
+              <Settings className="h-4 w-4" />
+              Configure Speed Limits...
+            </ContextMenuItem>
+          
+            <ContextMenuSeparator />
+          
+            <div className="px-2 py-1">
+              <div className="text-xs text-muted-foreground mb-1">
+                Current Status: {isEnabled ? "Alternative" : "Global"} Mode
+              </div>
+              {isEnabled && (
+                <div className="text-xs text-muted-foreground space-y-0.5">
+                  <div>↓ {downloadLimit > 0 ? formatSpeed(downloadLimit) : "Unlimited"}</div>
+                  <div>↑ {uploadLimit > 0 ? formatSpeed(uploadLimit) : "Unlimited"}</div>
+                </div>
+              )}
+            </div>
+          </ContextMenuContent>
+        </ContextMenu>
+      </TooltipProvider>
+      
+      <SpeedLimitsDialog
+        instanceId={instanceId}
+        instanceName={instanceName}
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+      />
+    </>
   )
 }

--- a/web/src/components/instances/SpeedLimitsToggle.tsx
+++ b/web/src/components/instances/SpeedLimitsToggle.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { Button } from "@/components/ui/button"
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
+import { useSpeedLimitsStatus, useToggleSpeedLimits } from "@/hooks/useSpeedLimits"
+import { Rabbit, Turtle, Loader2 } from "lucide-react"
+import { formatSpeed } from "@/lib/utils"
+
+interface SpeedLimitsToggleProps {
+  instanceId: number
+  connected: boolean
+}
+
+export function SpeedLimitsToggle({ instanceId, connected }: SpeedLimitsToggleProps) {
+  const { data: speedLimits, isLoading } = useSpeedLimitsStatus(instanceId, {
+    enabled: connected,
+  })
+  const toggleMutation = useToggleSpeedLimits(instanceId)
+
+  const handleToggle = (e: React.MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    
+    if (!connected || toggleMutation.isPending) return
+    
+    toggleMutation.mutate()
+  }
+
+  if (!connected || isLoading || !speedLimits) {
+    return null
+  }
+
+  const isEnabled = speedLimits.alternativeSpeedLimitsEnabled
+  const downloadLimit = isEnabled ? speedLimits.altDownloadLimit : speedLimits.downloadLimit
+  const uploadLimit = isEnabled ? speedLimits.altUploadLimit : speedLimits.uploadLimit
+  
+  const tooltipContent = (
+    <div className="space-y-1 text-xs">
+      <div className="font-medium">
+        Speed Limits: {isEnabled ? "Enabled" : "Unlimited"}
+      </div>
+      {isEnabled && (
+        <div className="space-y-0.5 opacity-90">
+          <div>↓ {downloadLimit > 0 ? formatSpeed(downloadLimit) : "Unlimited"}</div>
+          <div>↑ {uploadLimit > 0 ? formatSpeed(uploadLimit) : "Unlimited"}</div>
+        </div>
+      )}
+      <div className="opacity-90 pt-1 border-t border-white/20">
+        Click to {isEnabled ? "disable" : "enable"} alternative speed limits
+      </div>
+    </div>
+  )
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className={`h-6 w-6 p-0 transition-colors ${
+              isEnabled? "text-orange-500 hover:text-orange-600 hover:bg-orange-50": "text-green-500 hover:text-green-600 hover:bg-green-50"
+            }`}
+            onClick={handleToggle}
+            disabled={toggleMutation.isPending}
+          >
+            {toggleMutation.isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : isEnabled ? (
+              <Turtle className="h-4 w-4" />
+            ) : (
+              <Rabbit className="h-4 w-4" />
+            )}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          {tooltipContent}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}

--- a/web/src/hooks/useSpeedLimits.ts
+++ b/web/src/hooks/useSpeedLimits.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { api } from "@/lib/api"
+import type { SpeedLimitsStatus } from "@/types"
+
+export function useSpeedLimitsStatus(instanceId: number, options?: {
+  enabled?: boolean
+  refetchInterval?: number
+}) {
+  return useQuery({
+    queryKey: ["speed-limits-status", instanceId],
+    queryFn: () => api.getSpeedLimitsStatus(instanceId),
+    enabled: options?.enabled ?? true,
+    refetchInterval: options?.refetchInterval ?? 30000, // Refresh every 30 seconds
+    staleTime: 15000,
+    gcTime: 300000,
+    retry: 1,
+  })
+}
+
+export function useToggleSpeedLimits(instanceId: number) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: () => api.toggleSpeedLimits(instanceId),
+    onMutate: async () => {
+      // Cancel any outgoing refetches
+      await queryClient.cancelQueries({ queryKey: ["speed-limits-status", instanceId] })
+
+      // Snapshot the previous value for rollback
+      const previousStatus = queryClient.getQueryData<SpeedLimitsStatus>(["speed-limits-status", instanceId])
+
+      // Optimistically update the status
+      if (previousStatus) {
+        queryClient.setQueryData<SpeedLimitsStatus>(["speed-limits-status", instanceId], {
+          ...previousStatus,
+          alternativeSpeedLimitsEnabled: !previousStatus.alternativeSpeedLimitsEnabled,
+        })
+      }
+
+      return { previousStatus }
+    },
+    onError: (_error, _variables, context) => {
+      // Rollback on error
+      if (context?.previousStatus) {
+        queryClient.setQueryData(["speed-limits-status", instanceId], context.previousStatus)
+      }
+    },
+    onSuccess: () => {
+      // Invalidate and refetch after successful toggle
+      queryClient.invalidateQueries({ queryKey: ["speed-limits-status", instanceId] })
+      
+      // Also invalidate server state queries since they include speed limit info
+      queryClient.invalidateQueries({ queryKey: ["server-state", instanceId] })
+    },
+  })
+}

--- a/web/src/hooks/useSpeedLimits.ts
+++ b/web/src/hooks/useSpeedLimits.ts
@@ -5,7 +5,7 @@
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { api } from "@/lib/api"
-import type { SpeedLimitsStatus } from "@/types"
+import type { SpeedLimitsStatus, SetSpeedLimitsRequest } from "@/types"
 
 export function useSpeedLimitsStatus(instanceId: number, options?: {
   enabled?: boolean
@@ -52,6 +52,21 @@ export function useToggleSpeedLimits(instanceId: number) {
     },
     onSuccess: () => {
       // Invalidate and refetch after successful toggle
+      queryClient.invalidateQueries({ queryKey: ["speed-limits-status", instanceId] })
+      
+      // Also invalidate server state queries since they include speed limit info
+      queryClient.invalidateQueries({ queryKey: ["server-state", instanceId] })
+    },
+  })
+}
+
+export function useSetSpeedLimits(instanceId: number) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (request: SetSpeedLimitsRequest) => api.setSpeedLimits(instanceId, request),
+    onSuccess: () => {
+      // Invalidate and refetch speed limits status
       queryClient.invalidateQueries({ queryKey: ["speed-limits-status", instanceId] })
       
       // Also invalidate server state queries since they include speed limit info

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import type { AuthResponse, InstanceResponse, TorrentResponse, MainData, User, SpeedLimitsStatus, SpeedLimitsToggleResponse } from "@/types"
+import type { AuthResponse, InstanceResponse, TorrentResponse, MainData, User, SpeedLimitsStatus, SpeedLimitsToggleResponse, SetSpeedLimitsRequest, SetSpeedLimitsResponse } from "@/types"
 import { getApiBaseUrl } from "./base-url"
 
 const API_BASE = getApiBaseUrl()
@@ -154,6 +154,13 @@ class ApiClient {
   async toggleSpeedLimits(id: number): Promise<SpeedLimitsToggleResponse> {
     return this.request(`/instances/${id}/speed-limits/toggle`, {
       method: "POST",
+    })
+  }
+
+  async setSpeedLimits(id: number, request: SetSpeedLimitsRequest): Promise<SetSpeedLimitsResponse> {
+    return this.request(`/instances/${id}/speed-limits`, {
+      method: "PUT",
+      body: JSON.stringify(request),
     })
   }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import type { AuthResponse, InstanceResponse, TorrentResponse, MainData, User } from "@/types"
+import type { AuthResponse, InstanceResponse, TorrentResponse, MainData, User, SpeedLimitsStatus, SpeedLimitsToggleResponse } from "@/types"
 import { getApiBaseUrl } from "./base-url"
 
 const API_BASE = getApiBaseUrl()
@@ -145,6 +145,16 @@ class ApiClient {
     }
   }> {
     return this.request(`/instances/${id}/stats`)
+  }
+
+  async getSpeedLimitsStatus(id: number): Promise<SpeedLimitsStatus> {
+    return this.request(`/instances/${id}/speed-limits`)
+  }
+
+  async toggleSpeedLimits(id: number): Promise<SpeedLimitsToggleResponse> {
+    return this.request(`/instances/${id}/speed-limits/toggle`, {
+      method: "POST",
+    })
   }
 
   // Torrent endpoints

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -20,6 +20,7 @@ import { formatSpeed, formatBytes, getRatioColor } from "@/lib/utils"
 import { useQuery, useQueries } from "@tanstack/react-query"
 import { api } from "@/lib/api"
 import type { ServerState, InstanceResponse, TorrentCounts } from "@/types"
+import { SpeedLimitsToggle } from "@/components/instances/SpeedLimitsToggle"
 
 type InstanceStats = Awaited<ReturnType<typeof api.getInstanceStats>>
 import {
@@ -245,9 +246,12 @@ function InstanceCard({ instance }: { instance: InstanceResponse }) {
         <CardHeader className='gap-0'>
           <div className="flex items-center justify-between">
             <CardTitle className="text-lg">{instance.name}</CardTitle>
-            <Badge variant={stats.connected ? "default" : "destructive"}>
-              {stats.connected ? "Connected" : "Disconnected"}
-            </Badge>
+            <div className="flex items-center gap-2">
+              <SpeedLimitsToggle instanceId={instance.id} connected={stats.connected} />
+              <Badge variant={stats.connected ? "default" : "destructive"}>
+                {stats.connected ? "Connected" : "Disconnected"}
+              </Badge>
+            </div>
           </div>
           <CardDescription className="flex items-center gap-1 text-xs">
             <span className={incognitoMode ? "blur-sm select-none truncate" : "truncate"}>{displayUrl}</span>

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -241,72 +241,72 @@ function InstanceCard({ instance }: { instance: InstanceResponse }) {
   
   const hasErrors = instance.hasDecryptionError || instance.connectionError
   return (
-    <Link to={hasErrors ? "/instances" : "/instances/$instanceId"} params={hasErrors ? {} : { instanceId: instance.id.toString() }}>
-      <Card className="hover:shadow-lg transition-shadow cursor-pointer">
-        <CardHeader className='gap-0'>
-          <div className="flex items-center justify-between">
-            <CardTitle className="text-lg">{instance.name}</CardTitle>
-            <div className="flex items-center gap-2">
-              <SpeedLimitsToggle instanceId={instance.id} connected={stats.connected} />
-              <Badge variant={stats.connected ? "default" : "destructive"}>
-                {stats.connected ? "Connected" : "Disconnected"}
-              </Badge>
+    <Card className="hover:shadow-lg transition-shadow">
+      <CardHeader className='gap-0'>
+        <div className="flex items-center justify-between">
+          <Link to={hasErrors ? "/instances" : "/instances/$instanceId"} params={hasErrors ? {} : { instanceId: instance.id.toString() }}>
+            <CardTitle className="text-lg hover:text-primary cursor-pointer transition-colors">{instance.name}</CardTitle>
+          </Link>
+          <div className="flex items-center gap-2">
+            <SpeedLimitsToggle instanceId={instance.id} instanceName={instance.name} connected={stats.connected} />
+            <Badge variant={stats.connected ? "default" : "destructive"}>
+              {stats.connected ? "Connected" : "Disconnected"}
+            </Badge>
+          </div>
+        </div>
+        <CardDescription className="flex items-center gap-1 text-xs">
+          <span className={incognitoMode ? "blur-sm select-none truncate" : "truncate"}>{displayUrl}</span>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-4 w-4 p-0"
+            onClick={(e) => {
+              e.preventDefault()
+              e.stopPropagation()
+              setIncognitoMode(!incognitoMode)
+            }}
+          >
+            {incognitoMode ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
+          </Button>
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          <div className="mb-6">
+            <div className="flex items-center justify-center mb-1">
+              <span className="flex-1 text-center text-xs text-muted-foreground">Downloading</span>
+              <span className="flex-1 text-center text-xs text-muted-foreground">Active</span>
+              <span className="flex-1 text-center text-xs text-muted-foreground">Error</span>
+              <span className="flex-1 text-center text-xs text-muted-foreground">Total</span>
+            </div>
+            <div className="flex items-center justify-center">
+              <span className="flex-1 text-center text-lg font-semibold">
+                {torrentCounts?.status?.downloading || 0}
+              </span>
+              <span className="flex-1 text-center text-lg font-semibold">{torrentCounts?.status?.active || 0}</span>
+              <span className={`flex-1 text-center text-lg font-semibold ${(torrentCounts?.status?.errored || 0) > 0 ? "text-destructive" : ""}`}>
+                {torrentCounts?.status?.errored || 0}
+              </span>
+              <span className="flex-1 text-center text-lg font-semibold">{torrentCounts?.total || 0}</span>
             </div>
           </div>
-          <CardDescription className="flex items-center gap-1 text-xs">
-            <span className={incognitoMode ? "blur-sm select-none truncate" : "truncate"}>{displayUrl}</span>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-4 w-4 p-0"
-              onClick={(e) => {
-                e.preventDefault()
-                e.stopPropagation()
-                setIncognitoMode(!incognitoMode)
-              }}
-            >
-              {incognitoMode ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
-            </Button>
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-3">
-            <div className="mb-6">
-              <div className="flex items-center justify-center mb-1">
-                <span className="flex-1 text-center text-xs text-muted-foreground">Downloading</span>
-                <span className="flex-1 text-center text-xs text-muted-foreground">Active</span>
-                <span className="flex-1 text-center text-xs text-muted-foreground">Error</span>
-                <span className="flex-1 text-center text-xs text-muted-foreground">Total</span>
-              </div>
-              <div className="flex items-center justify-center">
-                <span className="flex-1 text-center text-lg font-semibold">
-                  {torrentCounts?.status?.downloading || 0}
-                </span>
-                <span className="flex-1 text-center text-lg font-semibold">{torrentCounts?.status?.active || 0}</span>
-                <span className={`flex-1 text-center text-lg font-semibold ${(torrentCounts?.status?.errored || 0) > 0 ? "text-destructive" : ""}`}>
-                  {torrentCounts?.status?.errored || 0}
-                </span>
-                <span className="flex-1 text-center text-lg font-semibold">{torrentCounts?.total || 0}</span>
-              </div>
-            </div>
             
-            <div className="flex items-center gap-2 text-xs">
-              <Download className="h-3 w-3 text-muted-foreground" />
-              <span className="text-muted-foreground">Download</span>
-              <span className="ml-auto font-medium">{formatSpeed(stats.speeds?.download || 0)}</span>
-            </div>
-            
-            <div className="flex items-center gap-2 text-xs">
-              <Upload className="h-3 w-3 text-muted-foreground" />
-              <span className="text-muted-foreground">Upload</span>
-              <span className="ml-auto font-medium">{formatSpeed(stats.speeds?.upload || 0)}</span>
-            </div>
+          <div className="flex items-center gap-2 text-xs">
+            <Download className="h-3 w-3 text-muted-foreground" />
+            <span className="text-muted-foreground">Download</span>
+            <span className="ml-auto font-medium">{formatSpeed(stats.speeds?.download || 0)}</span>
           </div>
+            
+          <div className="flex items-center gap-2 text-xs">
+            <Upload className="h-3 w-3 text-muted-foreground" />
+            <span className="text-muted-foreground">Upload</span>
+            <span className="ml-auto font-medium">{formatSpeed(stats.speeds?.upload || 0)}</span>
+          </div>
+        </div>
           
-          <InstanceErrorDisplay instance={instance} />
-        </CardContent>
-      </Card>
-    </Link>
+        <InstanceErrorDisplay instance={instance} />
+      </CardContent>
+    </Card>
   )
 }
 

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -151,3 +151,16 @@ export interface SpeedLimitsToggleResponse {
   alternativeSpeedLimitsEnabled: boolean
   message?: string
 }
+
+export interface SetSpeedLimitsRequest {
+  downloadLimit?: number
+  uploadLimit?: number
+  altDownloadLimit?: number
+  altUploadLimit?: number
+  alternativeSpeedLimitsEnabled?: boolean
+}
+
+export interface SetSpeedLimitsResponse {
+  success: boolean
+  message?: string
+}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -137,3 +137,17 @@ export interface ServerState {
   global_ratio?: string
   total_peer_connections?: number
 }
+
+export interface SpeedLimitsStatus {
+  alternativeSpeedLimitsEnabled: boolean
+  downloadLimit: number
+  uploadLimit: number
+  altDownloadLimit: number
+  altUploadLimit: number
+}
+
+export interface SpeedLimitsToggleResponse {
+  success: boolean
+  alternativeSpeedLimitsEnabled: boolean
+  message?: string
+}


### PR DESCRIPTION
Add ability to toggle alternative speed limits on/off for qBittorrent instances:
- New speed limits handler with status and toggle endpoints
- Frontend SpeedLimitsToggle component with rabbit/turtle icons
- Integration with Dashboard showing current limits and status
- Optimistic UI updates with proper error handling
- TypeScript types and API methods for speed limits operations

Enables users to quickly switch between normal and alternative speed limits
from the dashboard interface without accessing qBittorrent directly.

Closes #35