### PR TITLE
feat(api,web): async instance operations with non-blocking UI

### DIFF
--- a/cmd/qui/main.go
+++ b/cmd/qui/main.go
@@ -386,7 +386,7 @@ func NewApplication(version, configDir, dataDir, logPath string, pprofFlag bool,
 }
 
 func (app *Application) runServer() {
-	log.Info().Str("version", app.version).Msg("Starting qBittorrent WebUI")
+	log.Info().Str("version", app.version).Msg("Starting qui")
 
 	// Initialize configuration
 	cfg, err := config.New(app.configDir)
@@ -436,6 +436,36 @@ func (app *Application) runServer() {
 	// Initialize managers
 	syncManager := qbittorrent.NewSyncManager(clientPool)
 	metricsManager := metrics.NewManager(syncManager, clientPool)
+
+	// Initialize client connections for all active instances on startup
+	go func() {
+		listCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		instances, err := instanceStore.List(listCtx, true) // Only active instances
+		cancel()
+
+		if err != nil {
+			log.Error().Err(err).Msg("Failed to get instances for startup connection")
+			return
+		}
+
+		// Connect to instances in parallel with separate timeouts
+		for _, instance := range instances {
+			go func(instanceID int) {
+				// Use separate context for each connection attempt with longer timeout
+				connCtx, connCancel := context.WithTimeout(context.Background(), 60*time.Second)
+				defer connCancel()
+
+				// Trigger connection by trying to get client
+				// This will populate the pool for GetClientOffline calls
+				_, err := clientPool.GetClient(connCtx, instanceID)
+				if err != nil {
+					log.Debug().Err(err).Int("instanceID", instanceID).Msg("Failed to connect to instance on startup")
+				} else {
+					log.Debug().Int("instanceID", instanceID).Msg("Successfully connected to instance on startup")
+				}
+			}(instance.ID)
+		}
+	}()
 
 	// Initialize web handler (for embedded frontend)
 	webHandler, err := web.NewHandler(Version, cfg.Config.BaseURL, webfs.DistDirFS)

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,13 @@ go 1.24
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
-	github.com/autobrr/go-qbittorrent v1.14.0
+	github.com/autobrr/go-qbittorrent v1.14.1-0.20250831024619-0910d3de2f48
 	github.com/dgraph-io/ristretto v0.2.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-chi/chi/v5 v5.2.2
 	github.com/gorilla/sessions v1.4.0
 	github.com/lithammer/fuzzysearch v1.1.8
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.20.5
 	github.com/rs/zerolog v1.34.0
 	github.com/spf13/cobra v1.9.1
@@ -39,7 +40,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
@@ -54,7 +54,7 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b // indirect
-	golang.org/x/net v0.42.0 // indirect
+	golang.org/x/net v0.43.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
 	google.golang.org/protobuf v1.36.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
-	github.com/autobrr/go-qbittorrent v1.14.1-0.20250831024619-0910d3de2f48
+	github.com/autobrr/go-qbittorrent v1.14.0
 	github.com/dgraph-io/ristretto v0.2.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-chi/chi/v5 v5.2.2

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3Q
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
-github.com/autobrr/go-qbittorrent v1.14.0 h1:H+/HWDmNUSwkWCTwgK8+f7vzIdXCJLWj6MZlGs8+WZE=
-github.com/autobrr/go-qbittorrent v1.14.0/go.mod h1:N+sISEJr1hM+AQiTD7pnsilgBcfGzIQsjwoEjWWvnng=
+github.com/autobrr/go-qbittorrent v1.14.1-0.20250831024619-0910d3de2f48 h1:S3SYO6IuYy6TXVBiLsHmbPV1NbqY+OPGZfRGVK4txC4=
+github.com/autobrr/go-qbittorrent v1.14.1-0.20250831024619-0910d3de2f48/go.mod h1:GY9yW+L45etf6xobkKz4hODqL/EfSw/CWPC9SzS2q8U=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -125,8 +125,8 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
-golang.org/x/net v0.42.0 h1:jzkYrhi3YQWD6MLBJcsklgQsoAcw89EcZbJw8Z614hs=
-golang.org/x/net v0.42.0/go.mod h1:FF1RA5d3u7nAYA4z2TkclSCKh68eSXtiFwcWQpPXdt8=
+golang.org/x/net v0.43.0 h1:lat02VYK2j4aLzMzecihNvTlJNQUq316m2Mr9rnM6YE=
+golang.org/x/net v0.43.0/go.mod h1:vhO1fvI4dGsIjh73sWfUVjj3N7CA9WkKJNQm2svM6Jg=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3Q
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
-github.com/autobrr/go-qbittorrent v1.14.1-0.20250831024619-0910d3de2f48 h1:S3SYO6IuYy6TXVBiLsHmbPV1NbqY+OPGZfRGVK4txC4=
-github.com/autobrr/go-qbittorrent v1.14.1-0.20250831024619-0910d3de2f48/go.mod h1:GY9yW+L45etf6xobkKz4hODqL/EfSw/CWPC9SzS2q8U=
+github.com/autobrr/go-qbittorrent v1.14.0 h1:H+/HWDmNUSwkWCTwgK8+f7vzIdXCJLWj6MZlGs8+WZE=
+github.com/autobrr/go-qbittorrent v1.14.0/go.mod h1:N+sISEJr1hM+AQiTD7pnsilgBcfGzIQsjwoEjWWvnng=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/internal/api/handlers/instances.go
+++ b/internal/api/handlers/instances.go
@@ -121,10 +121,8 @@ func (h *InstancesHandler) buildInstanceResponsesParallel(ctx context.Context, i
 
 func (h *InstancesHandler) buildInstanceResponse(ctx context.Context, instance *models.Instance) InstanceResponse {
 	// Use cached connection status only, do not test connection synchronously
-	client, err := h.clientPool.GetClientOffline(ctx, instance.ID)
-	if err != nil {
-		log.Warn().Err(err).Int("instanceID", instance.ID).Msg("Failed to get client from pool")
-	}
+	client, _ := h.clientPool.GetClientOffline(ctx, instance.ID)
+	healthy := client != nil && client.IsHealthy()
 
 	decryptionErrorInstances := h.clientPool.GetInstancesWithDecryptionErrors()
 	hasDecryptionError := slices.Contains(decryptionErrorInstances, instance.ID)
@@ -139,7 +137,7 @@ func (h *InstancesHandler) buildInstanceResponse(ctx context.Context, instance *
 		LastConnectedAt:    instance.LastConnectedAt,
 		CreatedAt:          instance.CreatedAt,
 		UpdatedAt:          instance.UpdatedAt,
-		Connected:          client.IsHealthy(),
+		Connected:          healthy,
 		HasDecryptionError: hasDecryptionError,
 	}
 	/*

--- a/internal/qbittorrent/client.go
+++ b/internal/qbittorrent/client.go
@@ -25,11 +25,15 @@ type Client struct {
 }
 
 func NewClient(instanceID int, instanceHost, username, password string, basicUsername, basicPassword *string) (*Client, error) {
+	return NewClientWithTimeout(instanceID, instanceHost, username, password, basicUsername, basicPassword, 30*time.Second)
+}
+
+func NewClientWithTimeout(instanceID int, instanceHost, username, password string, basicUsername, basicPassword *string, timeout time.Duration) (*Client, error) {
 	cfg := qbt.Config{
 		Host:     instanceHost,
 		Username: username,
 		Password: password,
-		Timeout:  30,
+		Timeout:  int(timeout.Seconds()),
 	}
 
 	if basicUsername != nil && *basicUsername != "" {
@@ -41,7 +45,7 @@ func NewClient(instanceID int, instanceHost, username, password string, basicUse
 
 	qbtClient := qbt.NewClient(cfg)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	if err := qbtClient.LoginCtx(ctx); err != nil {

--- a/internal/qbittorrent/client.go
+++ b/internal/qbittorrent/client.go
@@ -110,7 +110,7 @@ func (c *Client) HealthCheck(ctx context.Context) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.lastHealthCheck = time.Now()
-	c.isHealthy = err != nil
+	c.isHealthy = err == nil
 
 	if err != nil {
 		return errors.Wrap(err, "health check failed")

--- a/internal/qbittorrent/client.go
+++ b/internal/qbittorrent/client.go
@@ -102,7 +102,7 @@ func (c *Client) IsHealthy() bool {
 }
 
 func (c *Client) HealthCheck(ctx context.Context) error {
-	if time.Now().Add(-minHealthCheckInterval).Before(c.GetLastHealthCheck()) {
+	if c.isHealthy && time.Now().Add(-minHealthCheckInterval).Before(c.GetLastHealthCheck()) {
 		return nil
 	}
 

--- a/internal/qbittorrent/client.go
+++ b/internal/qbittorrent/client.go
@@ -26,7 +26,7 @@ type Client struct {
 }
 
 func NewClient(instanceID int, instanceHost, username, password string, basicUsername, basicPassword *string) (*Client, error) {
-	return NewClientWithTimeout(instanceID, instanceHost, username, password, basicUsername, basicPassword, 30*time.Second)
+	return NewClientWithTimeout(instanceID, instanceHost, username, password, basicUsername, basicPassword, 60*time.Second)
 }
 
 func NewClientWithTimeout(instanceID int, instanceHost, username, password string, basicUsername, basicPassword *string, timeout time.Duration) (*Client, error) {

--- a/internal/qbittorrent/pool.go
+++ b/internal/qbittorrent/pool.go
@@ -126,7 +126,7 @@ func (cp *ClientPool) GetClientOffline(ctx context.Context, instanceID int) (*Cl
 
 // GetClient returns a qBittorrent client for the given instance ID with default timeout
 func (cp *ClientPool) GetClient(ctx context.Context, instanceID int) (*Client, error) {
-	return cp.GetClientWithTimeout(ctx, instanceID, 30*time.Second)
+	return cp.GetClientWithTimeout(ctx, instanceID, 60*time.Second)
 }
 
 // GetClientWithTimeout returns a qBittorrent client for the given instance ID with custom timeout
@@ -158,7 +158,7 @@ func (cp *ClientPool) GetClientWithTimeout(ctx context.Context, instanceID int, 
 
 // createClient creates a new client connection with default timeout
 func (cp *ClientPool) createClient(ctx context.Context, instanceID int) (*Client, error) {
-	return cp.createClientWithTimeout(ctx, instanceID, 30*time.Second)
+	return cp.createClientWithTimeout(ctx, instanceID, 60*time.Second)
 }
 
 // createClientWithTimeout creates a new client connection with custom timeout

--- a/internal/qbittorrent/pool.go
+++ b/internal/qbittorrent/pool.go
@@ -107,6 +107,23 @@ func (cp *ClientPool) getInstanceLock(instanceID int) *sync.Mutex {
 	return lock
 }
 
+// GetClientOffline returns a qBittorrent client for the given instance ID if it exists in the pool, without attempting to create a new one
+func (cp *ClientPool) GetClientOffline(ctx context.Context, instanceID int) (*Client, error) {
+	cp.mu.RLock()
+	defer cp.mu.RUnlock()
+
+	if cp.closed {
+		return nil, ErrPoolClosed
+	}
+
+	client, exists := cp.clients[instanceID]
+	if !exists {
+		return nil, ErrClientNotFound
+	}
+
+	return client, nil
+}
+
 // GetClient returns a qBittorrent client for the given instance ID with default timeout
 func (cp *ClientPool) GetClient(ctx context.Context, instanceID int) (*Client, error) {
 	return cp.GetClientWithTimeout(ctx, instanceID, 30*time.Second)

--- a/web/src/components/instances/InstanceCard.tsx
+++ b/web/src/components/instances/InstanceCard.tsx
@@ -171,7 +171,7 @@ export function InstanceCard({ instance, onEdit }: InstanceCardProps) {
           )}
         </div>
 
-        <InstanceErrorDisplay instance={instance} onEdit={onEdit} showEditButton={true} />
+        <InstanceErrorDisplay instance={instance} onEdit={onEdit} showEditButton={true} compact />
 
         {testResult && (
           <div className={cn(

--- a/web/src/components/instances/InstanceForm.tsx
+++ b/web/src/components/instances/InstanceForm.tsx
@@ -68,16 +68,10 @@ export function InstanceForm({ instance, onSuccess, onCancel }: InstanceFormProp
 
     if (instance) {
       updateInstance({ id: instance.id, data: submitData }, {
-        onSuccess: (data) => {
-          if (data.connected) {
-            toast.success("Instance Updated", {
-              description: "Instance updated and connected successfully",
-            })
-          } else {
-            toast.warning("Instance Updated with Connection Issue", {
-              description: data.connectionError ? formatErrorMessage(data.connectionError) : "Instance updated but could not connect",
-            })
-          }
+        onSuccess: () => {
+          toast.success("Instance Updated", {
+            description: "Instance updated successfully. Connection testing in background...",
+          })
           onSuccess()
         },
         onError: (error) => {
@@ -88,16 +82,10 @@ export function InstanceForm({ instance, onSuccess, onCancel }: InstanceFormProp
       })
     } else {
       createInstance(submitData, {
-        onSuccess: (data) => {
-          if (data.connected) {
-            toast.success("Instance Created", {
-              description: "Instance created and connected successfully",
-            })
-          } else {
-            toast.warning("Instance Created with Connection Issue", {
-              description: data.connectionError ? formatErrorMessage(data.connectionError) : "Instance created but could not connect",
-            })
-          }
+        onSuccess: () => {
+          toast.success("Instance Created", {
+            description: "Instance created successfully. Connection testing in background...",
+          })
           onSuccess()
         },
         onError: (error) => {

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -173,7 +173,7 @@ function InstanceCard({ instance }: { instance: InstanceResponse }) {
   }
 
   // If we have stats but instance is not connected, show with zero values
-  if (stats && !stats.connected) {
+  if (stats && !instance.connected) {
     const hasErrors = instance.hasDecryptionError || instance.connectionError
     return (
       <>
@@ -285,7 +285,7 @@ function InstanceCard({ instance }: { instance: InstanceResponse }) {
               <ExternalLink className="h-3.5 w-3.5 text-muted-foreground" />
             </Link>
             <div className="flex items-center gap-2">
-              {stats.connected && (
+              {instance.connected && (
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button
@@ -311,14 +311,14 @@ function InstanceCard({ instance }: { instance: InstanceResponse }) {
                   </TooltipContent>
                 </Tooltip>
               )}
-              {stats.connected && (
+              {instance.connected && (
                 <InstanceSettingsButton
                   instanceId={instance.id}
                   instanceName={instance.name}
                 />
               )}
-              <Badge variant={stats.connected ? "default" : "destructive"}>
-                {stats.connected ? "Connected" : "Disconnected"}
+              <Badge variant={instance.connected ? "default" : "destructive"}>
+                {instance.connected ? "Connected" : "Disconnected"}
               </Badge>
             </div>
           </div>
@@ -377,7 +377,7 @@ function InstanceCard({ instance }: { instance: InstanceResponse }) {
 
 function GlobalStatsCards({ statsData }: { statsData: Array<{ instance: InstanceResponse, stats: InstanceStats | undefined, serverState: ServerState | null, torrentCounts: TorrentCounts | null | undefined }> }) {
   const globalStats = useMemo(() => {
-    const connected = statsData.filter(({ stats }) => stats?.connected).length
+    const connected = statsData.filter(({ instance }) => instance?.connected).length
     const totalTorrents = statsData.reduce((sum, { torrentCounts }) =>
       sum + (torrentCounts?.total || 0), 0)
     const activeTorrents = statsData.reduce((sum, { torrentCounts }) =>
@@ -642,7 +642,7 @@ function GlobalAllTimeStats({ statsData }: { statsData: Array<{ instance: Instan
 
 function QuickActionsDropdown({ statsData }: { statsData: Array<{ instance: InstanceResponse, stats: InstanceStats | undefined, serverState: ServerState | null }> }) {
   const connectedInstances = statsData
-    .filter(({ stats }) => stats?.connected)
+    .filter(({ instance }) => instance?.connected)
     .map(({ instance }) => instance)
 
   if (connectedInstances.length === 0) {

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -211,11 +211,10 @@ function InstanceCard({ instance }: { instance: InstanceResponse }) {
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <p className="text-sm text-muted-foreground text-center">
-              Instance is disconnected
-            </p>
-
-            <InstanceErrorDisplay instance={instance} />
+            <div className="text-sm text-muted-foreground text-center">
+              <p>Instance is disconnected</p>
+              <InstanceErrorDisplay instance={instance} compact />
+            </div>
           </CardContent>
         </Card>
       </>
@@ -261,11 +260,10 @@ function InstanceCard({ instance }: { instance: InstanceResponse }) {
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <p className="text-sm text-muted-foreground">
-              Failed to load stats
-            </p>
-
-            <InstanceErrorDisplay instance={instance} />
+            <div className="text-sm text-muted-foreground text-center">
+              <p>Failed to load stats</p>
+              <InstanceErrorDisplay instance={instance} compact />
+            </div>
           </CardContent>
         </Card>
       </>
@@ -370,7 +368,7 @@ function InstanceCard({ instance }: { instance: InstanceResponse }) {
             </div>
           </div>
 
-          <InstanceErrorDisplay instance={instance} />
+          <InstanceErrorDisplay instance={instance} compact />
         </CardContent>
       </Card>
     </>

--- a/web/src/pages/Instances.tsx
+++ b/web/src/pages/Instances.tsx
@@ -77,7 +77,7 @@ export function Instances() {
       <PasswordIssuesBanner instances={instances || []} />
 
       {instances && instances.length > 0 ? (
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 items-start">
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
           {instances.map((instance) => (
             <InstanceCard
               key={instance.id}


### PR DESCRIPTION
## Summary

Implements async instance operations to prevent UI freezing when connecting to slow/unresponsive qBittorrent instances. Replaces global locks with per-instance locking and adds collapsible error displays.

## Key Changes

- Async create/update: Operations return immediately after database save
- Per-instance locking: Prevents one slow instance from blocking others  
- Background connection testing: Non-blocking with 30-second timeouts
- Collapsible error display: Replace tooltips with expandable error cards
- Single connection status source: Eliminate inconsistencies across components
- Startup client initialization: Pre-connect to instances on app start

## Problem Solved

Before: Adding non-responding instances froze UI for 30+ seconds
After: Instant responses, background testing, working instances unaffected