### PR TITLE
feat(proxy): add reverse proxy system for external client integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ output/*
 !.claude/agents/git-commit-helper.md
 prd_final.md
 appprefs.md
+
+web/src/themes/premium/*

--- a/README.md
+++ b/README.md
@@ -194,9 +194,9 @@ scrape_configs:
 
 All metrics are labeled with `instance_id` and `instance_name` for multi-instance monitoring.
 
-## Reverse Proxy for *arr Applications
+## Reverse Proxy for External Applications
 
-qui includes a built-in reverse proxy that allows applications like Sonarr, Radarr, and other *arr applications to connect to your qBittorrent instances **without needing qBittorrent credentials**. qui handles authentication transparently, making integration seamless.
+qui includes a built-in reverse proxy that allows external applications like autobrr, Sonarr, Radarr, and other tools to connect to your qBittorrent instances **without needing qBittorrent credentials**. qui handles authentication transparently, making integration seamless.
 
 ### How It Works
 
@@ -217,11 +217,11 @@ The reverse proxy feature:
 5. Enter a name (e.g., "Sonarr")
 6. **Copy the generated key immediately** - it's only shown once
 
-#### 2. Configure Your *arr Application
+#### 2. Configure Your External Application
 
 Use qui as the qBittorrent host with the special proxy URL format:
 
-**Example for Sonarr:**
+**Example for Sonarr or autobrr:**
 - **Host**: `your-qui-server` (e.g., `localhost` or `192.168.1.100`)
 - **Port**: `7476` (or your qui port)
 - **Username**: *Leave empty*
@@ -235,7 +235,7 @@ http://localhost:7476/proxy/abc123def456ghi789jkl012mno345pqr678stu901vwx234yz
 
 #### 3. Test the Connection
 
-Your *arr application should now be able to:
+Your external application should now be able to:
 - Connect successfully to qBittorrent through qui
 - Add torrents, check status, and manage downloads
 - Work without any qBittorrent credentials
@@ -243,6 +243,7 @@ Your *arr application should now be able to:
 ### Supported Applications
 
 This reverse proxy works with any application that supports qBittorrent's Web API:
+- **autobrr** - Automatic torrent downloading
 - **Sonarr** - Automatic TV show downloads
 - **Radarr** - Automatic movie downloads  
 - **Lidarr** - Automatic music downloads
@@ -261,7 +262,7 @@ This reverse proxy works with any application that supports qBittorrent's Web AP
 
 **Connection Refused Error:**
 - Ensure qui is listening on all interfaces: `QUI__HOST=0.0.0.0 ./qui serve`
-- Check that the port is accessible from your *arr application
+- Check that the port is accessible from your external application
 
 **Authentication Errors:**  
 - Verify the Client API Key is correct and hasn't been deleted

--- a/README.md
+++ b/README.md
@@ -194,6 +194,83 @@ scrape_configs:
 
 All metrics are labeled with `instance_id` and `instance_name` for multi-instance monitoring.
 
+## Reverse Proxy for *arr Applications
+
+qui includes a built-in reverse proxy that allows applications like Sonarr, Radarr, and other *arr applications to connect to your qBittorrent instances **without needing qBittorrent credentials**. qui handles authentication transparently, making integration seamless.
+
+### How It Works
+
+The reverse proxy feature:
+- **Handles authentication automatically** - qui manages the qBittorrent login using your configured credentials
+- **Isolates clients** - Each client gets its own API key for security and monitoring  
+- **Works with any qBittorrent security setting** - Even with "bypass authentication for clients on localhost" disabled
+- **Provides transparent access** - Clients see qui as if it were qBittorrent directly
+
+### Setup Instructions
+
+#### 1. Create a Client API Key
+
+1. Open qui in your browser
+2. Go to **Settings → Client API Keys**
+3. Click **"Generate New Key"** 
+4. Choose the qBittorrent instance you want to proxy
+5. Enter a name (e.g., "Sonarr")
+6. **Copy the generated key immediately** - it's only shown once
+
+#### 2. Configure Your *arr Application
+
+Use qui as the qBittorrent host with the special proxy URL format:
+
+**Example for Sonarr:**
+- **Host**: `your-qui-server` (e.g., `localhost` or `192.168.1.100`)
+- **Port**: `7476` (or your qui port)
+- **Username**: *Leave empty*
+- **Password**: *Leave empty*  
+- **URL Base**: `/proxy/YOUR_CLIENT_API_KEY_HERE`
+
+**Complete URL example:**
+```
+http://localhost:7476/proxy/abc123def456ghi789jkl012mno345pqr678stu901vwx234yz
+```
+
+#### 3. Test the Connection
+
+Your *arr application should now be able to:
+- Connect successfully to qBittorrent through qui
+- Add torrents, check status, and manage downloads
+- Work without any qBittorrent credentials
+
+### Supported Applications
+
+This reverse proxy works with any application that supports qBittorrent's Web API:
+- **Sonarr** - Automatic TV show downloads
+- **Radarr** - Automatic movie downloads  
+- **Lidarr** - Automatic music downloads
+- **Prowlarr** - Indexer management
+- **Custom scripts** - Any application using qBittorrent's API
+
+### Security Features
+
+- **API Key Authentication** - Each client requires a unique key
+- **Instance Isolation** - Keys are tied to specific qBittorrent instances
+- **Usage Tracking** - Monitor which clients are accessing your instances
+- **Revocation** - Disable access instantly by deleting the API key
+- **No Credential Exposure** - qBittorrent passwords never leave qui
+
+### Troubleshooting
+
+**Connection Refused Error:**
+- Ensure qui is listening on all interfaces: `QUI__HOST=0.0.0.0 ./qui serve`
+- Check that the port is accessible from your *arr application
+
+**Authentication Errors:**  
+- Verify the Client API Key is correct and hasn't been deleted
+- Ensure the key is mapped to the correct qBittorrent instance
+
+**Version String Errors:**
+- This was a common issue that's now resolved with the new proxy implementation
+- Try regenerating the Client API Key if you still see version parsing errors
+
 ## Docker
 
 ```bash

--- a/cmd/qui/main.go
+++ b/cmd/qui/main.go
@@ -426,6 +426,8 @@ func (app *Application) runServer() {
 		log.Fatal().Err(err).Msg("Failed to initialize instance store")
 	}
 
+	clientAPIKeyStore := models.NewClientAPIKeyStore(db.Conn())
+
 	// Initialize qBittorrent client pool
 	clientPool, err := qbittorrent.NewClientPool(instanceStore)
 	if err != nil {
@@ -470,6 +472,7 @@ func (app *Application) runServer() {
 		DB:                  db.Conn(),
 		AuthService:         authService,
 		InstanceStore:       instanceStore,
+		ClientAPIKeyStore:   clientAPIKeyStore,
 		ClientPool:          clientPool,
 		SyncManager:         syncManager,
 		WebHandler:          webHandler,

--- a/internal/api/handlers/client_api_keys.go
+++ b/internal/api/handlers/client_api_keys.go
@@ -1,0 +1,185 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/rs/zerolog/log"
+
+	"github.com/autobrr/qui/internal/models"
+)
+
+type ClientAPIKeysHandler struct {
+	clientAPIKeyStore *models.ClientAPIKeyStore
+	instanceStore     *models.InstanceStore
+}
+
+func NewClientAPIKeysHandler(clientAPIKeyStore *models.ClientAPIKeyStore, instanceStore *models.InstanceStore) *ClientAPIKeysHandler {
+	return &ClientAPIKeysHandler{
+		clientAPIKeyStore: clientAPIKeyStore,
+		instanceStore:     instanceStore,
+	}
+}
+
+type CreateClientAPIKeyRequest struct {
+	ClientName string `json:"clientName"`
+	InstanceID int    `json:"instanceId"`
+}
+
+type CreateClientAPIKeyResponse struct {
+	Key          string               `json:"key"`
+	ClientAPIKey *models.ClientAPIKey `json:"clientApiKey"`
+	Instance     *models.Instance     `json:"instance,omitempty"`
+	ProxyURL     string               `json:"proxyUrl"`
+	Instructions string               `json:"instructions"`
+}
+
+type ClientAPIKeyWithInstance struct {
+	*models.ClientAPIKey
+	Instance *models.Instance `json:"instance"`
+}
+
+// CreateClientAPIKey handles POST /api/client-api-keys
+func (h *ClientAPIKeysHandler) CreateClientAPIKey(w http.ResponseWriter, r *http.Request) {
+	var req CreateClientAPIKeyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		log.Error().Err(err).Msg("Failed to decode create client API key request")
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// Validate required fields
+	if req.ClientName == "" {
+		http.Error(w, "Client name is required", http.StatusBadRequest)
+		return
+	}
+
+	if req.InstanceID == 0 {
+		http.Error(w, "Instance ID is required", http.StatusBadRequest)
+		return
+	}
+
+	// Verify instance exists
+	ctx := r.Context()
+	instance, err := h.instanceStore.Get(ctx, req.InstanceID)
+	if err != nil {
+		if err == models.ErrInstanceNotFound {
+			http.Error(w, "Instance not found", http.StatusNotFound)
+			return
+		}
+		log.Error().Err(err).Int("instanceId", req.InstanceID).Msg("Failed to get instance")
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	// Create the client API key
+	rawKey, clientAPIKey, err := h.clientAPIKeyStore.Create(ctx, req.ClientName, req.InstanceID)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to create client API key")
+		http.Error(w, "Failed to create API key", http.StatusInternalServerError)
+		return
+	}
+
+	// Generate proxy URL and instructions
+	proxyURL := "/proxy/" + rawKey
+	instructions := generateProxyInstructions(req.ClientName, proxyURL, instance.Host)
+
+	response := CreateClientAPIKeyResponse{
+		Key:          rawKey,
+		ClientAPIKey: clientAPIKey,
+		Instance:     instance,
+		ProxyURL:     proxyURL,
+		Instructions: instructions,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
+}
+
+// ListClientAPIKeys handles GET /api/client-api-keys
+func (h *ClientAPIKeysHandler) ListClientAPIKeys(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// Get all client API keys
+	clientAPIKeys, err := h.clientAPIKeyStore.GetAll(ctx)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to get client API keys")
+		http.Error(w, "Failed to get API keys", http.StatusInternalServerError)
+		return
+	}
+
+	// Enrich with instance information
+	var enrichedKeys []*ClientAPIKeyWithInstance
+	for _, key := range clientAPIKeys {
+		instance, err := h.instanceStore.Get(ctx, key.InstanceID)
+		if err != nil {
+			// Log error but continue - instance might have been deleted
+			log.Warn().Err(err).Int("instanceId", key.InstanceID).Int("keyId", key.ID).
+				Msg("Failed to get instance for client API key")
+			enrichedKeys = append(enrichedKeys, &ClientAPIKeyWithInstance{
+				ClientAPIKey: key,
+				Instance:     nil, // Will be null in JSON
+			})
+			continue
+		}
+
+		enrichedKeys = append(enrichedKeys, &ClientAPIKeyWithInstance{
+			ClientAPIKey: key,
+			Instance:     instance,
+		})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(enrichedKeys)
+}
+
+// DeleteClientAPIKey handles DELETE /api/client-api-keys/{id}
+func (h *ClientAPIKeysHandler) DeleteClientAPIKey(w http.ResponseWriter, r *http.Request) {
+	idStr := chi.URLParam(r, "id")
+	if idStr == "" {
+		http.Error(w, "Missing API key ID", http.StatusBadRequest)
+		return
+	}
+
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		http.Error(w, "Invalid API key ID", http.StatusBadRequest)
+		return
+	}
+
+	ctx := r.Context()
+	if err := h.clientAPIKeyStore.Delete(ctx, id); err != nil {
+		if err == models.ErrClientAPIKeyNotFound {
+			http.Error(w, "API key not found", http.StatusNotFound)
+			return
+		}
+		log.Error().Err(err).Int("keyId", id).Msg("Failed to delete client API key")
+		http.Error(w, "Failed to delete API key", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// generateProxyInstructions creates usage instructions for different client types
+func generateProxyInstructions(clientName, proxyURL, instanceHost string) string {
+	switch clientName {
+	case "Sonarr", "sonarr":
+		return "In Sonarr, set the qBittorrent host to your qui server URL + '" + proxyURL + "'. " +
+			"Example: If qui runs on http://localhost:8080, use http://localhost:8080" + proxyURL
+	case "Radarr", "radarr":
+		return "In Radarr, set the qBittorrent host to your qui server URL + '" + proxyURL + "'. " +
+			"Example: If qui runs on http://localhost:8080, use http://localhost:8080" + proxyURL
+	case "Lidarr", "lidarr":
+		return "In Lidarr, set the qBittorrent host to your qui server URL + '" + proxyURL + "'. " +
+			"Example: If qui runs on http://localhost:8080, use http://localhost:8080" + proxyURL
+	default:
+		return "Replace your qBittorrent host (" + instanceHost + ") with your qui server URL + '" + proxyURL + "'. " +
+			"Example: If qui runs on http://localhost:8080, use http://localhost:8080" + proxyURL
+	}
+}

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -43,5 +43,5 @@ func TestMigrationIdempotency(t *testing.T) {
 	require.NoError(t, err, "Failed to count migrations")
 
 	assert.Equal(t, count1, count2, "Migration count should be the same after re-initialization")
-	assert.Equal(t, 3, count2, "Should have exactly 3 migrations applied")
+	assert.Equal(t, 4, count2, "Should have exactly 4 migrations applied")
 }

--- a/internal/database/migrations/004_add_client_api_keys.sql
+++ b/internal/database/migrations/004_add_client_api_keys.sql
@@ -1,0 +1,16 @@
+-- Create client_api_keys table for proxy authentication
+CREATE TABLE client_api_keys (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    key_hash TEXT NOT NULL UNIQUE,
+    client_name TEXT NOT NULL,
+    instance_id INTEGER NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    last_used_at TIMESTAMP,
+    FOREIGN KEY (instance_id) REFERENCES instances(id) ON DELETE CASCADE
+);
+
+-- Create index for faster lookups by key_hash
+CREATE INDEX idx_client_api_keys_key_hash ON client_api_keys(key_hash);
+
+-- Create index for instance_id lookups
+CREATE INDEX idx_client_api_keys_instance_id ON client_api_keys(instance_id);

--- a/internal/models/client_api_key.go
+++ b/internal/models/client_api_key.go
@@ -1,0 +1,162 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package models
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+var ErrClientAPIKeyNotFound = errors.New("client api key not found")
+
+type ClientAPIKey struct {
+	ID         int        `json:"id"`
+	KeyHash    string     `json:"-"`
+	ClientName string     `json:"clientName"`
+	InstanceID int        `json:"instanceId"`
+	CreatedAt  time.Time  `json:"createdAt"`
+	LastUsedAt *time.Time `json:"lastUsedAt,omitempty"`
+}
+
+type ClientAPIKeyStore struct {
+	db *sql.DB
+}
+
+func NewClientAPIKeyStore(db *sql.DB) *ClientAPIKeyStore {
+	return &ClientAPIKeyStore{db: db}
+}
+
+func (s *ClientAPIKeyStore) Create(ctx context.Context, clientName string, instanceID int) (string, *ClientAPIKey, error) {
+	// Generate new API key
+	rawKey, err := GenerateAPIKey()
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to generate API key: %w", err)
+	}
+
+	// Hash the key for storage
+	keyHash := HashAPIKey(rawKey)
+
+	query := `
+		INSERT INTO client_api_keys (key_hash, client_name, instance_id) 
+		VALUES (?, ?, ?)
+		RETURNING id, key_hash, client_name, instance_id, created_at, last_used_at
+	`
+
+	clientAPIKey := &ClientAPIKey{}
+	err = s.db.QueryRowContext(ctx, query, keyHash, clientName, instanceID).Scan(
+		&clientAPIKey.ID,
+		&clientAPIKey.KeyHash,
+		&clientAPIKey.ClientName,
+		&clientAPIKey.InstanceID,
+		&clientAPIKey.CreatedAt,
+		&clientAPIKey.LastUsedAt,
+	)
+
+	if err != nil {
+		return "", nil, err
+	}
+
+	// Return both the raw key (to show user once) and the model
+	return rawKey, clientAPIKey, nil
+}
+
+func (s *ClientAPIKeyStore) GetAll(ctx context.Context) ([]*ClientAPIKey, error) {
+	query := `
+		SELECT id, key_hash, client_name, instance_id, created_at, last_used_at 
+		FROM client_api_keys 
+		ORDER BY created_at DESC
+	`
+
+	rows, err := s.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var keys []*ClientAPIKey
+	for rows.Next() {
+		key := &ClientAPIKey{}
+		err := rows.Scan(
+			&key.ID,
+			&key.KeyHash,
+			&key.ClientName,
+			&key.InstanceID,
+			&key.CreatedAt,
+			&key.LastUsedAt,
+		)
+		if err != nil {
+			return nil, err
+		}
+		keys = append(keys, key)
+	}
+
+	return keys, rows.Err()
+}
+
+func (s *ClientAPIKeyStore) GetByKeyHash(ctx context.Context, keyHash string) (*ClientAPIKey, error) {
+	query := `
+		SELECT id, key_hash, client_name, instance_id, created_at, last_used_at 
+		FROM client_api_keys 
+		WHERE key_hash = ?
+	`
+
+	key := &ClientAPIKey{}
+	err := s.db.QueryRowContext(ctx, query, keyHash).Scan(
+		&key.ID,
+		&key.KeyHash,
+		&key.ClientName,
+		&key.InstanceID,
+		&key.CreatedAt,
+		&key.LastUsedAt,
+	)
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrClientAPIKeyNotFound
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return key, nil
+}
+
+func (s *ClientAPIKeyStore) ValidateKey(ctx context.Context, rawKey string) (*ClientAPIKey, error) {
+	keyHash := HashAPIKey(rawKey)
+	return s.GetByKeyHash(ctx, keyHash)
+}
+
+func (s *ClientAPIKeyStore) UpdateLastUsed(ctx context.Context, keyHash string) error {
+	query := `UPDATE client_api_keys SET last_used_at = CURRENT_TIMESTAMP WHERE key_hash = ?`
+	_, err := s.db.ExecContext(ctx, query, keyHash)
+	return err
+}
+
+func (s *ClientAPIKeyStore) Delete(ctx context.Context, id int) error {
+	query := `DELETE FROM client_api_keys WHERE id = ?`
+	result, err := s.db.ExecContext(ctx, query, id)
+	if err != nil {
+		return err
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rowsAffected == 0 {
+		return ErrClientAPIKeyNotFound
+	}
+
+	return nil
+}
+
+func (s *ClientAPIKeyStore) DeleteByInstanceID(ctx context.Context, instanceID int) error {
+	query := `DELETE FROM client_api_keys WHERE instance_id = ?`
+	_, err := s.db.ExecContext(ctx, query, instanceID)
+	return err
+}

--- a/internal/proxy/buffer_pool.go
+++ b/internal/proxy/buffer_pool.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package proxy
+
+import "sync"
+
+// BufferPool provides a thread-safe pool of byte slices for the reverse proxy
+type BufferPool struct {
+	pool sync.Pool
+}
+
+// NewBufferPool creates a new buffer pool with 32KB buffers
+func NewBufferPool() *BufferPool {
+	return &BufferPool{
+		pool: sync.Pool{
+			New: func() any {
+				// Create 32KB buffers - good balance between memory usage and performance
+				return make([]byte, 32*1024)
+			},
+		},
+	}
+}
+
+// Get returns a buffer from the pool
+func (p *BufferPool) Get() []byte {
+	return p.pool.Get().([]byte)
+}
+
+// Put returns a buffer to the pool
+func (p *BufferPool) Put(buf []byte) {
+	// Only pool buffers of the expected size to avoid memory bloat
+	if cap(buf) == 32*1024 {
+		p.pool.Put(buf)
+	}
+}

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -1,0 +1,186 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package proxy
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/rs/zerolog/log"
+
+	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/qbittorrent"
+)
+
+// Handler manages reverse proxy requests to qBittorrent instances
+type Handler struct {
+	clientPool        *qbittorrent.ClientPool
+	clientAPIKeyStore *models.ClientAPIKeyStore
+	instanceStore     *models.InstanceStore
+	bufferPool        *BufferPool
+	proxy             *httputil.ReverseProxy
+}
+
+// NewHandler creates a new proxy handler
+func NewHandler(clientPool *qbittorrent.ClientPool, clientAPIKeyStore *models.ClientAPIKeyStore, instanceStore *models.InstanceStore) *Handler {
+	bufferPool := NewBufferPool()
+
+	h := &Handler{
+		clientPool:        clientPool,
+		clientAPIKeyStore: clientAPIKeyStore,
+		instanceStore:     instanceStore,
+		bufferPool:        bufferPool,
+	}
+
+	// Configure the reverse proxy
+	h.proxy = &httputil.ReverseProxy{
+		Rewrite:      h.rewriteRequest,
+		BufferPool:   bufferPool,
+		ErrorHandler: h.errorHandler,
+	}
+
+	return h
+}
+
+// ServeHTTP handles the reverse proxy request
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.proxy.ServeHTTP(w, r)
+}
+
+// rewriteRequest modifies the outbound request to target the correct qBittorrent instance
+func (h *Handler) rewriteRequest(pr *httputil.ProxyRequest) {
+	ctx := pr.In.Context()
+	instanceID := GetInstanceIDFromContext(ctx)
+	clientAPIKey := GetClientAPIKeyFromContext(ctx)
+
+	if instanceID == 0 || clientAPIKey == nil {
+		log.Error().Msg("Missing instance ID or client API key in proxy request context")
+		return
+	}
+
+	// Get the instance details to get the host
+	instance, err := h.instanceStore.Get(ctx, instanceID)
+	if err != nil {
+		log.Error().Err(err).Int("instanceId", instanceID).Msg("Failed to get instance")
+		return
+	}
+
+	// Parse the instance host to get the target URL
+	instanceURL, err := url.Parse(instance.Host)
+	if err != nil {
+		log.Error().Err(err).Str("host", instance.Host).Msg("Failed to parse instance host")
+		return
+	}
+
+	// Get the authenticated qBittorrent client from the pool
+	client, err := h.clientPool.GetClient(ctx, instanceID)
+	if err != nil {
+		log.Error().Err(err).Int("instanceId", instanceID).Msg("Failed to get qBittorrent client from pool")
+		return
+	}
+
+	// Get the HTTP client with cookie jar from the authenticated qBittorrent client
+	// TODO: When go-qbittorrent merges GetHTTPClient, change this to: client.Client.GetHTTPClient()
+	httpClient := client.GetHTTPClient()
+	if httpClient != nil && httpClient.Jar != nil {
+		// Get cookies for the target URL from the cookie jar
+		cookies := httpClient.Jar.Cookies(instanceURL)
+		if len(cookies) > 0 {
+			var cookiePairs []string
+			for _, cookie := range cookies {
+				cookiePairs = append(cookiePairs, fmt.Sprintf("%s=%s", cookie.Name, cookie.Value))
+			}
+			pr.Out.Header.Set("Cookie", strings.Join(cookiePairs, "; "))
+			log.Debug().Int("instanceId", instanceID).Int("cookieCount", len(cookies)).Msg("Added cookies from HTTP client jar to proxy request")
+		} else {
+			log.Debug().Int("instanceId", instanceID).Msg("No cookies found in HTTP client jar")
+		}
+	} else {
+		log.Debug().Int("instanceId", instanceID).Msg("No HTTP client or cookie jar available")
+	}
+
+	// Strip the proxy prefix from the path
+	apiKey := chi.URLParam(pr.In, "api-key")
+	originalPath := pr.In.URL.Path
+	strippedPath := h.stripProxyPrefix(originalPath, apiKey)
+
+	log.Debug().
+		Str("client", clientAPIKey.ClientName).
+		Int("instanceId", instanceID).
+		Str("originalPath", originalPath).
+		Str("strippedPath", strippedPath).
+		Str("targetHost", instanceURL.Host).
+		Msg("Rewriting proxy request")
+
+	// Set the target URL
+	pr.SetURL(instanceURL)
+
+	// Update the path to the stripped version
+	pr.Out.URL.Path = strippedPath
+	pr.Out.URL.RawPath = ""
+
+	// Preserve query parameters
+	pr.Out.URL.RawQuery = pr.In.URL.RawQuery
+
+	// Set proper host header (important for qBittorrent)
+	pr.Out.Host = instanceURL.Host
+
+	// Add headers to identify the proxy
+	pr.Out.Header.Set("X-Forwarded-For", pr.In.RemoteAddr)
+	pr.Out.Header.Set("X-Forwarded-Proto", pr.In.URL.Scheme)
+	pr.Out.Header.Set("X-Qui-Client", clientAPIKey.ClientName)
+}
+
+// stripProxyPrefix removes the proxy prefix from the URL path
+func (h *Handler) stripProxyPrefix(path, apiKey string) string {
+	prefix := "/proxy/" + apiKey
+	if after, found := strings.CutPrefix(path, prefix); found {
+		return after
+	}
+	return path
+}
+
+// errorHandler handles proxy errors
+func (h *Handler) errorHandler(w http.ResponseWriter, r *http.Request, err error) {
+	ctx := r.Context()
+	instanceID := GetInstanceIDFromContext(ctx)
+	clientAPIKey := GetClientAPIKeyFromContext(ctx)
+
+	clientName := "unknown"
+	if clientAPIKey != nil {
+		clientName = clientAPIKey.ClientName
+	}
+
+	log.Error().
+		Err(err).
+		Str("client", clientName).
+		Int("instanceId", instanceID).
+		Str("method", r.Method).
+		Str("path", r.URL.Path).
+		Msg("Proxy request failed")
+
+	// Return a generic error to avoid leaking internal details
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadGateway)
+
+	// Return qBittorrent-style error response
+	errorResponse := `{"error":"Failed to connect to qBittorrent instance"}`
+	w.Write([]byte(errorResponse))
+}
+
+// Routes sets up the proxy routes
+func (h *Handler) Routes(r chi.Router) {
+	// Proxy route with API key parameter
+	r.Route("/proxy/{api-key}", func(r chi.Router) {
+		// Apply client API key validation middleware
+		r.Use(ClientAPIKeyMiddleware(h.clientAPIKeyStore))
+
+		// Handle all requests under this prefix
+		r.HandleFunc("/*", h.ServeHTTP)
+	})
+}

--- a/internal/proxy/middleware.go
+++ b/internal/proxy/middleware.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package proxy
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/rs/zerolog/log"
+
+	"github.com/autobrr/qui/internal/models"
+)
+
+type contextKey string
+
+const (
+	ClientAPIKeyContextKey contextKey = "client_api_key"
+	InstanceIDContextKey   contextKey = "instance_id"
+)
+
+// ClientAPIKeyMiddleware validates client API keys and extracts instance information
+func ClientAPIKeyMiddleware(store *models.ClientAPIKeyStore) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Extract API key from URL path parameter
+			apiKey := chi.URLParam(r, "api-key")
+			if apiKey == "" {
+				log.Warn().Msg("Missing API key in proxy request")
+				http.Error(w, "Missing API key", http.StatusUnauthorized)
+				return
+			}
+
+			// Validate the API key
+			ctx := r.Context()
+			clientAPIKey, err := store.ValidateKey(ctx, apiKey)
+			if err != nil {
+				if err == models.ErrClientAPIKeyNotFound {
+					log.Warn().
+						Str("key_prefix", apiKey[:min(8, len(apiKey))]).
+						Msg("Invalid client API key")
+					http.Error(w, "Invalid API key", http.StatusUnauthorized)
+					return
+				}
+				log.Error().Err(err).Msg("Failed to validate client API key")
+				http.Error(w, "Internal server error", http.StatusInternalServerError)
+				return
+			}
+
+			// Update last used timestamp asynchronously to avoid slowing down the request
+			go func() {
+				if err := store.UpdateLastUsed(context.Background(), clientAPIKey.KeyHash); err != nil {
+					log.Error().Err(err).Int("keyId", clientAPIKey.ID).Msg("Failed to update API key last used timestamp")
+				}
+			}()
+
+			log.Debug().
+				Str("client", clientAPIKey.ClientName).
+				Int("instanceId", clientAPIKey.InstanceID).
+				Str("method", r.Method).
+				Str("path", r.URL.Path).
+				Msg("Client API key validated successfully")
+
+			// Add client API key and instance ID to request context
+			ctx = context.WithValue(ctx, ClientAPIKeyContextKey, clientAPIKey)
+			ctx = context.WithValue(ctx, InstanceIDContextKey, clientAPIKey.InstanceID)
+
+			// Continue with the request
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// GetClientAPIKeyFromContext retrieves the client API key from the request context
+func GetClientAPIKeyFromContext(ctx context.Context) *models.ClientAPIKey {
+	if key, ok := ctx.Value(ClientAPIKeyContextKey).(*models.ClientAPIKey); ok {
+		return key
+	}
+	return nil
+}
+
+// GetInstanceIDFromContext retrieves the instance ID from the request context
+func GetInstanceIDFromContext(ctx context.Context) int {
+	if id, ok := ctx.Value(InstanceIDContextKey).(int); ok {
+		return id
+	}
+	return 0
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/qbittorrent/client.go
+++ b/internal/qbittorrent/client.go
@@ -6,8 +6,11 @@ package qbittorrent
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"reflect"
 	"sync"
 	"time"
+	"unsafe"
 
 	"github.com/Masterminds/semver/v3"
 	qbt "github.com/autobrr/go-qbittorrent"
@@ -132,4 +135,37 @@ func (c *Client) GetWebAPIVersion() string {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.webAPIVersion
+}
+
+// GetHTTPClient allows you to receive the implemented *http.Client with cookie jar
+// This method uses reflection to access the private http field from the embedded qbt.Client
+//
+// TODO: Remove this method and update proxy handler when go-qbittorrent merges GetHTTPClient method
+// When https://github.com/autobrr/go-qbittorrent is updated with GetHTTPClient method:
+// 1. Remove this entire GetHTTPClient method from qui's Client wrapper
+// 2. Update proxy handler to call client.Client.GetHTTPClient() directly instead of client.GetHTTPClient()
+// 3. Remove "reflect" and "unsafe" imports from this file
+// 4. Update go.mod to use the new version of go-qbittorrent
+func (c *Client) GetHTTPClient() *http.Client {
+	// Use reflection to access the private 'http' field from the embedded qbt.Client
+	clientValue := reflect.ValueOf(c.Client).Elem()
+	httpField := clientValue.FieldByName("http")
+
+	if !httpField.IsValid() {
+		log.Error().Msg("Failed to access http field from qBittorrent client")
+		return nil
+	}
+
+	// The field is unexported, so we need to make it accessible
+	if !httpField.CanInterface() {
+		// Make the field accessible using reflection
+		httpField = reflect.NewAt(httpField.Type(), unsafe.Pointer(httpField.UnsafeAddr())).Elem()
+	}
+
+	if httpClient, ok := httpField.Interface().(*http.Client); ok {
+		return httpClient
+	}
+
+	log.Error().Msg("Failed to convert http field to *http.Client")
+	return nil
 }

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -232,6 +232,83 @@ paths:
         '404':
           description: API key not found
 
+  /api/client-api-keys:
+    get:
+      tags:
+        - Client API Keys
+      summary: List client API keys
+      description: Get all client API keys for external applications
+      responses:
+        '200':
+          description: List of client API keys
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ClientApiKey'
+    post:
+      tags:
+        - Client API Keys
+      summary: Create client API key
+      description: Generate a new client API key for external applications
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - clientName
+                - instanceId
+              properties:
+                clientName:
+                  type: string
+                  description: Name of the client application (e.g., "Sonarr")
+                instanceId:
+                  type: integer
+                  description: ID of the qBittorrent instance to proxy to
+      responses:
+        '201':
+          description: Client API key created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  clientName:
+                    type: string
+                  instanceId:
+                    type: integer
+                  key:
+                    type: string
+                    description: The client API key (only shown once)
+                  createdAt:
+                    type: string
+                    format: date-time
+                  message:
+                    type: string
+
+  /api/client-api-keys/{id}:
+    delete:
+      tags:
+        - Client API Keys
+      summary: Delete client API key
+      description: Revoke a client API key
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Client API key deleted successfully
+        '404':
+          description: Client API key not found
+
   /api/instances:
     get:
       tags:
@@ -1035,6 +1112,28 @@ components:
           format: date-time
           nullable: true
 
+    ClientApiKey:
+      type: object
+      properties:
+        id:
+          type: integer
+        clientName:
+          type: string
+          description: Name of the client application
+        instanceId:
+          type: integer
+          description: ID of the qBittorrent instance
+        instanceName:
+          type: string
+          description: Name of the qBittorrent instance
+        createdAt:
+          type: string
+          format: date-time
+        lastUsedAt:
+          type: string
+          format: date-time
+          nullable: true
+
     Instance:
       type: object
       properties:
@@ -1205,6 +1304,8 @@ tags:
     description: User authentication and session management
   - name: API Keys
     description: API key management
+  - name: Client API Keys
+    description: Client API key management for external applications
   - name: Instances
     description: qBittorrent instance management
   - name: Torrents

--- a/web/src/components/settings/ClientApiKeysManager.tsx
+++ b/web/src/components/settings/ClientApiKeysManager.tsx
@@ -1,0 +1,433 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { useState } from "react"
+import { useForm } from "@tanstack/react-form"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { api } from "@/lib/api"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Badge } from "@/components/ui/badge"
+import { Copy, Plus, Trash2, Server, Globe } from "lucide-react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger
+} from "@/components/ui/dialog"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from "@/components/ui/alert-dialog"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+
+interface NewClientAPIKey {
+  key: string
+  clientApiKey: {
+    id: number
+    clientName: string
+    instanceId: number
+    createdAt: string
+  }
+  instance?: {
+    id: number
+    name: string
+    host: string
+  }
+  proxyUrl: string
+  instructions: string
+}
+
+export function ClientApiKeysManager() {
+  const [showCreateDialog, setShowCreateDialog] = useState(false)
+  const [deleteKeyId, setDeleteKeyId] = useState<number | null>(null)
+  const [newKey, setNewKey] = useState<NewClientAPIKey | null>(null)
+  const queryClient = useQueryClient()
+
+  // Fetch client API keys
+  const { data: clientApiKeys, isLoading, error } = useQuery({
+    queryKey: ["clientApiKeys"],
+    queryFn: () => api.getClientApiKeys(),
+    staleTime: 30 * 1000, // 30 seconds
+    retry: (failureCount, error) => {
+      // Don't retry on 404 - endpoint might not be available
+      if (error && error.message?.includes("404")) {
+        return false
+      }
+      return failureCount < 3
+    },
+  })
+
+  // Fetch instances for the dropdown
+  const { data: instances } = useQuery({
+    queryKey: ["instances"],
+    queryFn: () => api.getInstances(),
+    staleTime: 60 * 1000, // 1 minute
+  })
+
+  // Ensure clientApiKeys is always an array
+  const keys = clientApiKeys || []
+
+  const createMutation = useMutation({
+    mutationFn: async (data: { clientName: string; instanceId: number }) => {
+      return api.createClientApiKey(data)
+    },
+    onSuccess: (data) => {
+      setNewKey(data)
+      queryClient.invalidateQueries({ queryKey: ["clientApiKeys"] })
+      toast.success("Client API key created successfully")
+    },
+    onError: () => {
+      toast.error("Failed to create client API key")
+    },
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: async (id: number) => {
+      return api.deleteClientApiKey(id)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["clientApiKeys"] })
+      setDeleteKeyId(null)
+      toast.success("Client API key deleted successfully")
+    },
+    onError: (error) => {
+      console.error("Delete client API key error:", error)
+      toast.error(`Failed to delete client API key: ${error.message || "Unknown error"}`)
+    },
+  })
+
+  const form = useForm({
+    defaultValues: {
+      clientName: "",
+      instanceId: "",
+    },
+    onSubmit: async ({ value }) => {
+      const instanceId = parseInt(value.instanceId)
+      if (!instanceId) {
+        toast.error("Please select an instance")
+        return
+      }
+
+      await createMutation.mutateAsync({
+        clientName: value.clientName,
+        instanceId,
+      })
+      form.reset()
+    },
+  })
+
+  const commonClientNames = [
+    "Sonarr",
+    "Radarr",
+    "Lidarr",
+    "Prowlarr",
+    "Bazarr",
+    "Readarr",
+  ]
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          Client API keys allow external applications like Sonarr/Radarr to connect through qui to your qBittorrent instances.
+        </p>
+        <Dialog open={showCreateDialog} onOpenChange={setShowCreateDialog}>
+          <DialogTrigger asChild>
+            <Button size="sm">
+              <Plus className="mr-2 h-4 w-4" />
+              Create Client API Key
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>Create Client API Key</DialogTitle>
+              <DialogDescription>
+                Create an API key for a specific client to connect to a qBittorrent instance.
+              </DialogDescription>
+            </DialogHeader>
+
+            {newKey ? (
+              <div className="space-y-4">
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="text-base">API Key Created</CardTitle>
+                    <CardDescription>
+                      Save this key now. You won't be able to see it again.
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                    <div>
+                      <Label>API Key</Label>
+                      <div className="mt-2 flex items-center gap-2">
+                        <code className="flex-1 rounded bg-muted px-2 py-1 text-sm font-mono break-all">
+                          {newKey.key}
+                        </code>
+                        <Button
+                          size="icon"
+                          variant="outline"
+                          onClick={() => {
+                            navigator.clipboard.writeText(newKey.key)
+                            toast.success("API key copied to clipboard")
+                          }}
+                        >
+                          <Copy className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </div>
+
+                    <div>
+                      <Label>Proxy URL</Label>
+                      <div className="mt-2 flex items-center gap-2">
+                        <code className="flex-1 rounded bg-muted px-2 py-1 text-sm font-mono break-all">
+                          {newKey.proxyUrl}
+                        </code>
+                        <Button
+                          size="icon"
+                          variant="outline"
+                          onClick={() => {
+                            navigator.clipboard.writeText(newKey.proxyUrl)
+                            toast.success("Proxy URL copied to clipboard")
+                          }}
+                        >
+                          <Copy className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    </div>
+
+                    <div className="rounded-lg bg-blue-50 p-3 text-sm text-blue-800 dark:bg-blue-900/20 dark:text-blue-200">
+                      <div className="font-medium mb-1">Setup Instructions:</div>
+                      <p>{newKey.instructions}</p>
+                    </div>
+                  </CardContent>
+                </Card>
+
+                <Button
+                  onClick={() => {
+                    setNewKey(null)
+                    setShowCreateDialog(false)
+                  }}
+                  className="w-full"
+                >
+                  Done
+                </Button>
+              </div>
+            ) : (
+              <form
+                onSubmit={(e) => {
+                  e.preventDefault()
+                  form.handleSubmit()
+                }}
+                className="space-y-4"
+              >
+                <form.Field
+                  name="clientName"
+                  validators={{
+                    onChange: ({ value }) => !value ? "Client name is required" : undefined,
+                  }}
+                >
+                  {(field) => (
+                    <div className="space-y-2">
+                      <Label htmlFor="clientName">Client Name</Label>
+                      <div className="space-y-2">
+                        <Input
+                          id="clientName"
+                          placeholder="e.g., Sonarr, Radarr"
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(e) => field.handleChange(e.target.value)}
+                          data-1p-ignore
+                          autoComplete='off'
+                        />
+                        <div className="flex flex-wrap gap-1">
+                          {commonClientNames.map((name) => (
+                            <Button
+                              key={name}
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              className="h-6 text-xs"
+                              onClick={() => field.handleChange(name)}
+                            >
+                              {name}
+                            </Button>
+                          ))}
+                        </div>
+                      </div>
+                      {field.state.meta.isTouched && field.state.meta.errors[0] && (
+                        <p className="text-sm text-destructive">{field.state.meta.errors[0]}</p>
+                      )}
+                    </div>
+                  )}
+                </form.Field>
+
+                <form.Field
+                  name="instanceId"
+                  validators={{
+                    onChange: ({ value }) => !value ? "Instance is required" : undefined,
+                  }}
+                >
+                  {(field) => (
+                    <div className="space-y-2">
+                      <Label htmlFor="instanceId">qBittorrent Instance</Label>
+                      <Select
+                        value={field.state.value}
+                        onValueChange={(value) => field.handleChange(value)}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select an instance" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {instances?.map((instance) => (
+                            <SelectItem key={instance.id} value={instance.id.toString()}>
+                              <div className="flex items-center gap-2">
+                                <Server className="h-4 w-4" />
+                                <span>{instance.name}</span>
+                                <span className="text-xs text-muted-foreground">({instance.host})</span>
+                              </div>
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      {field.state.meta.isTouched && field.state.meta.errors[0] && (
+                        <p className="text-sm text-destructive">{field.state.meta.errors[0]}</p>
+                      )}
+                    </div>
+                  )}
+                </form.Field>
+
+                <form.Subscribe
+                  selector={(state) => [state.canSubmit, state.isSubmitting]}
+                >
+                  {([canSubmit, isSubmitting]) => (
+                    <Button
+                      type="submit"
+                      disabled={!canSubmit || isSubmitting || createMutation.isPending}
+                      className="w-full"
+                    >
+                      {isSubmitting || createMutation.isPending ? "Creating..." : "Create Client API Key"}
+                    </Button>
+                  )}
+                </form.Subscribe>
+              </form>
+            )}
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      <div className="space-y-2">
+        {isLoading ? (
+          <p className="text-center text-sm text-muted-foreground py-8">
+            Loading client API keys...
+          </p>
+        ) : error ? (
+          <div className="text-center py-8">
+            <p className="text-sm text-muted-foreground mb-2">
+              Unable to load client API keys
+            </p>
+            <p className="text-xs text-destructive">
+              {error.message?.includes("404")? "Feature may not be available in this version": error.message || "An error occurred"
+              }
+            </p>
+          </div>
+        ) : (
+          <>
+            {keys.map((key) => (
+              <div
+                key={key.id}
+                className="flex items-center justify-between rounded-lg border p-4"
+              >
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium">{key.clientName}</span>
+                    <Badge variant="outline" className="text-xs">
+                      ID: {key.id}
+                    </Badge>
+                    {key.instance ? (
+                      <Badge variant="secondary" className="text-xs flex items-center gap-1">
+                        <Server className="h-3 w-3" />
+                        {key.instance.name}
+                      </Badge>
+                    ) : (
+                      <Badge variant="destructive" className="text-xs">
+                        Instance Deleted
+                      </Badge>
+                    )}
+                  </div>
+                  <div className="text-sm text-muted-foreground space-y-1">
+                    <p>
+                      Created: {new Date(key.createdAt).toLocaleDateString()}
+                      {key.lastUsedAt && (
+                        <> • Last used: {new Date(key.lastUsedAt).toLocaleDateString()}</>
+                      )}
+                    </p>
+                    {key.instance && (
+                      <div className="flex items-center gap-1 text-xs">
+                        <Globe className="h-3 w-3" />
+                        <code className="bg-muted px-1 rounded">/proxy/{"{api-key}"}</code>
+                        <span>→</span>
+                        <span>{key.instance.host}</span>
+                      </div>
+                    )}
+                  </div>
+                </div>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  onClick={() => setDeleteKeyId(key.id)}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            ))}
+
+            {keys.length === 0 && (
+              <p className="text-center text-sm text-muted-foreground py-8">
+                No client API keys created yet
+              </p>
+            )}
+          </>
+        )}
+      </div>
+
+      <AlertDialog open={!!deleteKeyId} onOpenChange={() => setDeleteKeyId(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Client API Key?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This action cannot be undone. Any applications using this key will lose access to the qBittorrent instance.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => deleteKeyId && deleteMutation.mutate(deleteKeyId)}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -46,6 +46,11 @@ class ApiClient {
       throw new Error(errorMessage)
     }
 
+    // Handle empty responses (like 204 No Content)
+    if (response.status === 204 || response.headers.get("content-length") === "0") {
+      return undefined as T
+    }
+
     return response.json()
   }
 
@@ -377,6 +382,51 @@ class ApiClient {
 
   async deleteApiKey(id: number): Promise<void> {
     return this.request(`/api-keys/${id}`, { method: "DELETE" })
+  }
+
+  // Client API Keys for proxy authentication
+  async getClientApiKeys(): Promise<{
+    id: number
+    clientName: string
+    instanceId: number
+    createdAt: string
+    lastUsedAt?: string
+    instance?: {
+      id: number
+      name: string
+      host: string
+    } | null
+  }[]> {
+    return this.request("/client-api-keys")
+  }
+
+  async createClientApiKey(data: {
+    clientName: string
+    instanceId: number
+  }): Promise<{
+    key: string
+    clientApiKey: {
+      id: number
+      clientName: string
+      instanceId: number
+      createdAt: string
+    }
+    instance?: {
+      id: number
+      name: string
+      host: string
+    }
+    proxyUrl: string
+    instructions: string
+  }> {
+    return this.request("/client-api-keys", {
+      method: "POST",
+      body: JSON.stringify(data),
+    })
+  }
+
+  async deleteClientApiKey(id: number): Promise<void> {
+    return this.request(`/client-api-keys/${id}`, { method: "DELETE" })
   }
 
   // Theme License endpoints

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -18,6 +18,7 @@ import { Badge } from "@/components/ui/badge"
 import { Copy, Plus, Trash2, ExternalLink } from "lucide-react"
 import { ThemeLicenseManager } from "@/components/themes/ThemeLicenseManager"
 import { ThemeSelector } from "@/components/themes/ThemeSelector"
+import { ClientApiKeysManager } from "@/components/settings/ClientApiKeysManager"
 import { useSearch } from "@tanstack/react-router"
 import {
   Dialog,
@@ -411,10 +412,11 @@ export function Settings() {
 
       <Tabs defaultValue={defaultTab} className="space-y-4">
         <div className="w-full overflow-x-auto">
-          <TabsList className="inline-flex h-auto min-w-full sm:grid sm:grid-cols-3">
+          <TabsList className="inline-flex h-auto min-w-full sm:grid sm:grid-cols-4">
             <TabsTrigger value="security" className="relative text-xs rounded-none data-[state=active]:bg-transparent data-[state=active]:shadow-none hover:bg-accent/50 transition-all px-3 py-2 min-w-fit cursor-pointer focus-visible:outline-none focus-visible:ring-0 after:absolute after:bottom-0 after:left-0 after:right-0 after:h-[2px] after:bg-primary after:scale-x-0 data-[state=active]:after:scale-x-100 after:transition-transform">Security</TabsTrigger>
             <TabsTrigger value="themes" className="relative text-xs rounded-none data-[state=active]:bg-transparent data-[state=active]:shadow-none hover:bg-accent/50 transition-all px-3 py-2 min-w-fit cursor-pointer focus-visible:outline-none focus-visible:ring-0 after:absolute after:bottom-0 after:left-0 after:right-0 after:h-[2px] after:bg-primary after:scale-x-0 data-[state=active]:after:scale-x-100 after:transition-transform">Themes</TabsTrigger>
             <TabsTrigger value="api" className="relative text-xs rounded-none data-[state=active]:bg-transparent data-[state=active]:shadow-none hover:bg-accent/50 transition-all px-3 py-2 min-w-fit whitespace-nowrap cursor-pointer focus-visible:outline-none focus-visible:ring-0 after:absolute after:bottom-0 after:left-0 after:right-0 after:h-[2px] after:bg-primary after:scale-x-0 data-[state=active]:after:scale-x-100 after:transition-transform">API Keys</TabsTrigger>
+            <TabsTrigger value="client-api" className="relative text-xs rounded-none data-[state=active]:bg-transparent data-[state=active]:shadow-none hover:bg-accent/50 transition-all px-3 py-2 min-w-fit whitespace-nowrap cursor-pointer focus-visible:outline-none focus-visible:ring-0 after:absolute after:bottom-0 after:left-0 after:right-0 after:h-[2px] after:bg-primary after:scale-x-0 data-[state=active]:after:scale-x-100 after:transition-transform">Client Proxy</TabsTrigger>
           </TabsList>
         </div>
 
@@ -462,6 +464,20 @@ export function Settings() {
             </CardHeader>
             <CardContent>
               <ApiKeysManager />
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="client-api" className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle>Client Proxy API Keys</CardTitle>
+              <CardDescription>
+                Manage API keys for external applications to connect to qBittorrent instances through qui
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ClientApiKeysManager />
             </CardContent>
           </Card>
         </TabsContent>


### PR DESCRIPTION
Implements transparent reverse proxy allowing *arr applications, autobrr, and other clients to connect to qBittorrent instances through qui without exposing credentials.

Key features:
- Client API key authentication with instance mapping
- Cookie jar forwarding from qui's authenticated sessions
- Database migration for client API keys storage
- Frontend UI for managing client API keys
- Transparent request/response proxying
- Buffer pooling for performance

Benefits:
- Eliminates credential sharing with external applications
- Provides secure isolation between different clients
- Works regardless of qBittorrent authentication settings
- Centralized access control through qui