### PR TITLE
feat(auth): migrate to SCS database-backed session storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ output/*
 !.claude/agents/git-commit-helper.md
 prd_final.md
 appprefs.md
+web/src/themes/premium/*

--- a/cmd/qui/user_commands_test.go
+++ b/cmd/qui/user_commands_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/alexedwards/scs/v2"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,6 +17,7 @@ import (
 	"github.com/autobrr/qui/internal/auth"
 	"github.com/autobrr/qui/internal/config"
 	"github.com/autobrr/qui/internal/database"
+	"github.com/autobrr/qui/pkg/sqlite3store"
 )
 
 func TestRunCreateUserCommand(t *testing.T) {
@@ -107,7 +109,11 @@ func TestRunCreateUserCommand(t *testing.T) {
 				db, err := database.New(cfg.GetDatabasePath())
 				require.NoError(t, err)
 
-				authService := auth.NewService(db.Conn(), cfg.Config.SessionSecret)
+				// Create minimal session manager for test
+				sessionManager := scs.New()
+				sessionManager.Store = sqlite3store.New(db.Conn())
+
+				authService := auth.NewService(db.Conn(), sessionManager)
 				_, err = authService.SetupUser(context.Background(), "existinguser", "password123")
 				require.NoError(t, err)
 
@@ -237,7 +243,11 @@ func TestRunChangePasswordCommand(t *testing.T) {
 				db, err := database.New(cfg.GetDatabasePath())
 				require.NoError(t, err)
 
-				authService := auth.NewService(db.Conn(), cfg.Config.SessionSecret)
+				// Create minimal session manager for test
+				sessionManager := scs.New()
+				sessionManager.Store = sqlite3store.New(db.Conn())
+
+				authService := auth.NewService(db.Conn(), sessionManager)
 				_, err = authService.SetupUser(context.Background(), "testuser", "oldpassword123")
 				require.NoError(t, err)
 

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,11 @@ go 1.24
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
+	github.com/alexedwards/scs/v2 v2.9.0
 	github.com/autobrr/go-qbittorrent v1.14.0
 	github.com/dgraph-io/ristretto v0.2.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-chi/chi/v5 v5.2.2
-	github.com/gorilla/sessions v1.4.0
 	github.com/lithammer/fuzzysearch v1.1.8
 	github.com/prometheus/client_golang v1.20.5
 	github.com/rs/zerolog v1.34.0
@@ -30,7 +30,6 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3Q
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/alexedwards/scs/v2 v2.9.0 h1:xa05mVpwTBm1iLeTMNFfAWpKUm4fXAW7CeAViqBVS90=
+github.com/alexedwards/scs/v2 v2.9.0/go.mod h1:ToaROZxyKukJKT/xLcVQAChi5k6+Pn1Gvmdl7h3RRj8=
 github.com/autobrr/go-qbittorrent v1.14.0 h1:H+/HWDmNUSwkWCTwgK8+f7vzIdXCJLWj6MZlGs8+WZE=
 github.com/autobrr/go-qbittorrent v1.14.0/go.mod h1:N+sISEJr1hM+AQiTD7pnsilgBcfGzIQsjwoEjWWvnng=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
@@ -32,16 +34,10 @@ github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlnd
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
-github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gorilla/securecookie v1.1.2 h1:YCIWL56dvtr73r6715mJs5ZvhtnY73hBvEF8kXD8ePA=
-github.com/gorilla/securecookie v1.1.2/go.mod h1:NfCASbcHqRSY+3a8tlWJwsQap2VX5pwzwo4h3eOamfo=
-github.com/gorilla/sessions v1.4.0 h1:kpIYOp/oi6MG/p5PgxApU8srsSw9tuFbt46Lt7auzqQ=
-github.com/gorilla/sessions v1.4.0/go.mod h1:FLWm50oby91+hl7p/wRxDth9bWSuk0qVL2emc7lT5ik=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -31,9 +31,9 @@ func IsAuthenticated(authService *auth.Service) func(http.Handler) http.Handler 
 				return
 			}
 
-			// Check session
-			session, _ := authService.GetSessionStore().Get(r, auth.SessionName)
-			if auth, ok := session.Values["authenticated"].(bool); !ok || !auth {
+			// Check session using SCS
+			sessionManager := authService.GetSessionManager()
+			if !sessionManager.GetBool(r.Context(), "authenticated") {
 				http.Error(w, "Unauthorized", http.StatusUnauthorized)
 				return
 			}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -55,6 +55,9 @@ func NewRouter(deps *Dependencies) *chi.Mux {
 	}
 	r.Use(apimiddleware.CORSWithCredentials(allowedOrigins))
 
+	// Session middleware - must be added before any session-dependent middleware
+	r.Use(deps.AuthService.GetSessionManager().LoadAndSave)
+
 	// Create handlers
 	authHandler := handlers.NewAuthHandler(deps.AuthService)
 	instancesHandler := handlers.NewInstancesHandler(deps.InstanceStore, deps.ClientPool, deps.SyncManager)

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -8,9 +8,8 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"net/http"
 
-	"github.com/gorilla/sessions"
+	"github.com/alexedwards/scs/v2"
 	"github.com/rs/zerolog/log"
 
 	"github.com/autobrr/qui/internal/models"
@@ -26,26 +25,16 @@ var (
 )
 
 type Service struct {
-	userStore   *models.UserStore
-	apiKeyStore *models.APIKeyStore
-	store       sessions.Store
+	userStore      *models.UserStore
+	apiKeyStore    *models.APIKeyStore
+	sessionManager *scs.SessionManager
 }
 
-func NewService(db *sql.DB, sessionSecret string) *Service {
-	store := sessions.NewCookieStore([]byte(sessionSecret))
-
-	// Configure session options
-	store.Options = &sessions.Options{
-		Path:     "/",
-		MaxAge:   86400 * 7, // 7 days
-		HttpOnly: true,
-		SameSite: http.SameSiteLaxMode,
-	}
-
+func NewService(db *sql.DB, sessionManager *scs.SessionManager) *Service {
 	return &Service{
-		userStore:   models.NewUserStore(db),
-		apiKeyStore: models.NewAPIKeyStore(db),
-		store:       store,
+		userStore:      models.NewUserStore(db),
+		apiKeyStore:    models.NewAPIKeyStore(db),
+		sessionManager: sessionManager,
 	}
 }
 
@@ -177,7 +166,7 @@ func (s *Service) IsSetupComplete(ctx context.Context) (bool, error) {
 	return s.userStore.Exists(ctx)
 }
 
-// GetSessionStore returns the session store for use in middleware
-func (s *Service) GetSessionStore() sessions.Store {
-	return s.store
+// GetSessionManager returns the session manager for use in middleware
+func (s *Service) GetSessionManager() *scs.SessionManager {
+	return s.sessionManager
 }

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -43,5 +43,5 @@ func TestMigrationIdempotency(t *testing.T) {
 	require.NoError(t, err, "Failed to count migrations")
 
 	assert.Equal(t, count1, count2, "Migration count should be the same after re-initialization")
-	assert.Equal(t, 3, count2, "Should have exactly 3 migrations applied")
+	assert.Equal(t, 4, count2, "Should have exactly 4 migrations applied")
 }

--- a/internal/database/migrations/004_sessions_table.sql
+++ b/internal/database/migrations/004_sessions_table.sql
@@ -1,0 +1,10 @@
+-- Create sessions table for database-backed session storage
+-- This replaces cookie-based sessions with secure database storage
+
+CREATE TABLE sessions (
+    token TEXT PRIMARY KEY,
+    data BLOB NOT NULL,
+    expiry REAL NOT NULL
+);
+
+CREATE INDEX sessions_expiry_idx ON sessions(expiry);

--- a/pkg/sqlite3store/sqlite3store.go
+++ b/pkg/sqlite3store/sqlite3store.go
@@ -1,0 +1,167 @@
+package sqlite3store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"log"
+	"time"
+)
+
+type SqlDB interface {
+	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
+	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
+	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
+}
+
+type OptFunc func(*SQLite3Store)
+
+// WithCleanupInterval sets a custom cleanup interval. The cleanupInterval
+// parameter controls how frequently expired session data is removed by the
+// background cleanup goroutine. Setting it to 0 prevents the cleanup goroutine
+// from running (i.e. expired sessions will not be removed).
+func WithCleanupInterval(interval time.Duration) OptFunc {
+	return func(s *SQLite3Store) {
+		s.cleanupInterval = interval
+	}
+}
+
+// SQLite3Store represents the session store.
+type SQLite3Store struct {
+	db              SqlDB
+	stopCleanup     chan bool
+	cleanupInterval time.Duration
+}
+
+// New returns a new SQLite3Store instance, with a background cleanup goroutine
+// that runs every 5 minutes to remove expired session data.
+func New(db SqlDB, opts ...OptFunc) *SQLite3Store {
+	p := &SQLite3Store{
+		db:              db,
+		cleanupInterval: 5 * time.Minute,
+	}
+
+	for _, opt := range opts {
+		opt(p)
+	}
+
+	if p.cleanupInterval > 0 {
+		p.stopCleanup = make(chan bool)
+		go p.startCleanup()
+	}
+
+	return p
+}
+
+// Find returns the data for a session token from the SQLite3 database. If the
+// session token is not found or is expired, the found return value will be false.
+func (p *SQLite3Store) Find(token string) (b []byte, found bool, err error) {
+	return p.FindCtx(context.Background(), token)
+}
+
+// FindCtx returns the data for a session token from the SQLite3 database. If the
+// session token is not found or is expired, the found return value will be false.
+func (p *SQLite3Store) FindCtx(ctx context.Context, token string) (b []byte, found bool, err error) {
+	row := p.db.QueryRowContext(ctx, "SELECT data FROM sessions WHERE token = ? AND expiry > ?", token, time.Now().Unix())
+	err = row.Scan(&b)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return b, true, nil
+}
+
+// Commit adds a session token and data to the SQLite3 database with the given expiry
+// time. If the session token already exists, then the data and expiry time are updated.
+func (p *SQLite3Store) Commit(token string, b []byte, expiry time.Time) error {
+	return p.CommitCtx(context.Background(), token, b, expiry)
+}
+
+// CommitCtx adds a session token and data to the SQLite3 database with the given
+// expiry time. If the session token already exists, then the data and expiry time are updated.
+func (p *SQLite3Store) CommitCtx(ctx context.Context, token string, b []byte, expiry time.Time) error {
+	_, err := p.db.ExecContext(ctx, "INSERT OR REPLACE INTO sessions (token, data, expiry) VALUES (?, ?, ?)", token, b, expiry.Unix())
+	return err
+}
+
+// Delete removes a session token and corresponding data from the SQLite3 database.
+func (p *SQLite3Store) Delete(token string) error {
+	return p.DeleteCtx(context.Background(), token)
+}
+
+// DeleteCtx removes a session token and corresponding data from the SQLite3 database.
+func (p *SQLite3Store) DeleteCtx(ctx context.Context, token string) error {
+	_, err := p.db.ExecContext(ctx, "DELETE FROM sessions WHERE token = ?", token)
+	return err
+}
+
+// All returns a map containing data for all active sessions. The map key is the
+// session token and the map value is the session data.
+func (p *SQLite3Store) All() (map[string][]byte, error) {
+	return p.AllCtx(context.Background())
+}
+
+// AllCtx returns a map containing data for all active sessions. The map key is the
+// session token and the map value is the session data.
+func (p *SQLite3Store) AllCtx(ctx context.Context) (map[string][]byte, error) {
+	rows, err := p.db.QueryContext(ctx, "SELECT token, data FROM sessions WHERE expiry > ?", time.Now().Unix())
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	sessions := make(map[string][]byte)
+
+	for rows.Next() {
+		var token string
+		var data []byte
+
+		err := rows.Scan(&token, &data)
+		if err != nil {
+			return nil, err
+		}
+
+		sessions[token] = data
+	}
+
+	err = rows.Err()
+	if err != nil {
+		return nil, err
+	}
+
+	return sessions, nil
+}
+
+// StopCleanup terminates the background cleanup goroutine for the SQLite3Store
+// instance. StopCleanup is intended to be called before shutting down your
+// application.
+func (p *SQLite3Store) StopCleanup() {
+	if p.stopCleanup != nil {
+		p.stopCleanup <- true
+	}
+}
+
+// startCleanup runs a background goroutine to delete expired session data.
+func (p *SQLite3Store) startCleanup() {
+	ticker := time.NewTicker(p.cleanupInterval)
+	for {
+		select {
+		case <-ticker.C:
+			err := p.deleteExpired()
+			if err != nil {
+				log.Printf("sqlite3store: unable to delete expired session data: %v", err)
+			}
+		case <-p.stopCleanup:
+			ticker.Stop()
+			return
+		}
+	}
+}
+
+// deleteExpired deletes expired session data from the SQLite3 database.
+func (p *SQLite3Store) deleteExpired() error {
+	_, err := p.db.ExecContext(context.Background(), "DELETE FROM sessions WHERE expiry <= ?", time.Now().Unix())
+	return err
+}

--- a/web/src/hooks/useAuth.ts
+++ b/web/src/hooks/useAuth.ts
@@ -20,8 +20,8 @@ export function useAuth() {
   })
 
   const loginMutation = useMutation({
-    mutationFn: ({ username, password }: { username: string; password: string }) =>
-      api.login(username, password),
+    mutationFn: ({ username, password, rememberMe = false }: { username: string; password: string; rememberMe?: boolean }) =>
+      api.login(username, password, rememberMe),
     onSuccess: (data) => {
       queryClient.setQueryData(["auth", "user"], data.user)
       navigate({ to: "/dashboard" })

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -74,10 +74,10 @@ class ApiClient {
     })
   }
 
-  async login(username: string, password: string): Promise<AuthResponse> {
+  async login(username: string, password: string, rememberMe = false): Promise<AuthResponse> {
     return this.request<AuthResponse>("/auth/login", {
       method: "POST",
-      body: JSON.stringify({ username, password }),
+      body: JSON.stringify({ username, password, remember_me: rememberMe }),
     })
   }
 

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -9,6 +9,7 @@ import { useAuth } from "@/hooks/useAuth"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { Checkbox } from "@/components/ui/checkbox"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { useEffect } from "react"
 import { api } from "@/lib/api"
@@ -31,6 +32,7 @@ export function Login() {
     defaultValues: {
       username: "",
       password: "",
+      rememberMe: false,
     },
     onSubmit: async ({ value }) => {
       login(value)
@@ -100,6 +102,24 @@ export function Login() {
                   {field.state.meta.isTouched && field.state.meta.errors[0] && (
                     <p className="text-sm text-destructive">{field.state.meta.errors[0]}</p>
                   )}
+                </div>
+              )}
+            </form.Field>
+
+            <form.Field name="rememberMe">
+              {(field) => (
+                <div className="flex items-center space-x-2">
+                  <Checkbox
+                    id={field.name}
+                    checked={field.state.value}
+                    onCheckedChange={(checked) => field.handleChange(checked === true)}
+                  />
+                  <Label
+                    htmlFor={field.name}
+                    className="text-sm font-normal leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                  >
+                    Remember me
+                  </Label>
                 </div>
               )}
             </form.Field>


### PR DESCRIPTION
- Replace gorilla/sessions with alexedwards/scs for better reliability
- Add SQLite3 session store implementation following autobrr pattern
- Create database migration for sessions table
- Update auth handlers to use SCS session manager
- Add "Remember me" functionality to login form
- Configure secure session cookies with 7-day lifetime
- Set custom cookie name to "qui_session"