### PR TITLE
fix(web): don't expand sidebar on dropdown click

### DIFF
--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -6,11 +6,7 @@
 import { useAuth } from "@/hooks/useAuth"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger
-} from "@/components/ui/tooltip"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -18,23 +14,22 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu"
-import { Menu, LogOut, Settings, Search, Info, Filter, Plus, X, Home, Server, HardDrive } from "lucide-react"
+import { Filter, HardDrive, Home, Info, LogOut, Menu, Plus, Search, Server, Settings, X } from "lucide-react"
 import { ThemeToggle } from "@/components/ui/ThemeToggle"
 import { cn } from "@/lib/utils"
-import { Link, useNavigate, useSearch, useRouterState } from "@tanstack/react-router"
-import { useEffect, useMemo, useState, useRef } from "react"
+import { Link, useNavigate, useRouterState, useSearch } from "@tanstack/react-router"
+import { type ReactNode, useEffect, useMemo, useRef, useState } from "react"
 import { useDebounce } from "@/hooks/useDebounce"
 import { usePersistedFilterSidebarState } from "@/hooks/usePersistedFilterSidebarState"
 import { useInstances } from "@/hooks/useInstances"
 import { useHotkeys } from "react-hotkeys-hook"
 
 interface HeaderProps {
-  children?: React.ReactNode
+  children?: ReactNode
   sidebarCollapsed?: boolean
-  onSidebarToggle?: () => void
 }
 
-export function Header({ children, sidebarCollapsed = false, onSidebarToggle }: HeaderProps) {
+export function Header({ children, sidebarCollapsed = false }: HeaderProps) {
   const { logout } = useAuth()
   const navigate = useNavigate()
   const routeSearch = useSearch({ strict: false }) as { q?: string; modal?: string; [key: string]: unknown }
@@ -116,7 +111,7 @@ export function Header({ children, sidebarCollapsed = false, onSidebarToggle }: 
                 navigate({ search: next as any, replace: true }) // eslint-disable-line @typescript-eslint/no-explicit-any
               }}
             >
-              <Plus className="h-4 w-4 sm:mr-2" />
+              <Plus className="h-4 w-4 sm:mr-2"/>
               <span className="hidden sm:inline">Add Torrent</span>
             </Button>
           </div>
@@ -128,8 +123,8 @@ export function Header({ children, sidebarCollapsed = false, onSidebarToggle }: 
         <div className="flex-1 max-w-xl mx-2">
           <div className="flex items-center gap-2">
             {/* Slot to place actions directly to the left of the filter button (desktop only) */}
-            <span id="header-left-of-filter" className="hidden xl:inline-flex" />
-            <Tooltip >
+            <span id="header-left-of-filter" className="hidden xl:inline-flex"/>
+            <Tooltip>
               <TooltipTrigger asChild>
                 <Button
                   variant="outline"
@@ -137,14 +132,14 @@ export function Header({ children, sidebarCollapsed = false, onSidebarToggle }: 
                   className="hidden xl:inline-flex"
                   onClick={() => setFilterSidebarCollapsed(!filterSidebarCollapsed)}
                 >
-                  <Filter className="h-4 w-4" />
+                  <Filter className="h-4 w-4"/>
                 </Button>
               </TooltipTrigger>
               <TooltipContent>{filterSidebarCollapsed ? "Show filters" : "Hide filters"}</TooltipContent>
             </Tooltip>
             {/* Mobile filter button moved to card/table toolbars */}
             <div className="relative flex-1">
-              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none"/>
               <Input
                 ref={searchInputRef}
                 placeholder={isGlobSearch ? "Glob pattern..." : `Search torrents... (${shortcutKey})`}
@@ -165,7 +160,7 @@ export function Header({ children, sidebarCollapsed = false, onSidebarToggle }: 
               <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-1">
                 {/* Clear search button */}
                 {searchValue && (
-                  <Tooltip >
+                  <Tooltip>
                     <TooltipTrigger asChild>
                       <button
                         type="button"
@@ -177,21 +172,21 @@ export function Header({ children, sidebarCollapsed = false, onSidebarToggle }: 
                           navigate({ search: next as any, replace: true }) // eslint-disable-line @typescript-eslint/no-explicit-any
                         }}
                       >
-                        <X className="h-3.5 w-3.5 text-muted-foreground" />
+                        <X className="h-3.5 w-3.5 text-muted-foreground"/>
                       </button>
                     </TooltipTrigger>
                     <TooltipContent>Clear search</TooltipContent>
                   </Tooltip>
                 )}
                 {/* Slot for actions next to search (e.g., Toggle columns) */}
-                <Tooltip >
+                <Tooltip>
                   <TooltipTrigger asChild>
                     <button
                       type="button"
                       className="p-1 hover:bg-muted rounded-sm transition-colors hidden sm:block"
                       onClick={(e) => e.preventDefault()}
                     >
-                      <Info className="h-3.5 w-3.5 text-muted-foreground" />
+                      <Info className="h-3.5 w-3.5 text-muted-foreground"/>
                     </button>
                   </TooltipTrigger>
                   <TooltipContent className="max-w-xs">
@@ -210,13 +205,13 @@ export function Header({ children, sidebarCollapsed = false, onSidebarToggle }: 
                 </Tooltip>
               </div>
             </div>
-            <span id="header-search-actions" className="flex items-center gap-1" />
+            <span id="header-search-actions" className="flex items-center gap-1"/>
           </div>
         </div>
       )}
 
       <div className="grid grid-cols-[auto_auto] items-center gap-3 transition-all duration-300 ease-out">
-        <ThemeToggle />
+        <ThemeToggle/>
         <div className={cn(
           "transition-all duration-300 ease-out overflow-hidden",
           sidebarCollapsed ? "w-10 opacity-100" : "w-0 opacity-0"
@@ -224,7 +219,7 @@ export function Header({ children, sidebarCollapsed = false, onSidebarToggle }: 
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button variant="ghost" size="icon" className="hover:bg-muted hover:text-foreground transition-colors">
-                <Menu className="h-4 w-4" />
+                <Menu className="h-4 w-4"/>
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-52">
@@ -232,13 +227,8 @@ export function Header({ children, sidebarCollapsed = false, onSidebarToggle }: 
                 <Link
                   to="/dashboard"
                   className="flex cursor-pointer"
-                  onClick={() => {
-                    if (sidebarCollapsed && onSidebarToggle) {
-                      onSidebarToggle()
-                    }
-                  }}
                 >
-                  <Home className="mr-2 h-4 w-4" />
+                  <Home className="mr-2 h-4 w-4"/>
                   Dashboard
                 </Link>
               </DropdownMenuItem>
@@ -246,13 +236,8 @@ export function Header({ children, sidebarCollapsed = false, onSidebarToggle }: 
                 <Link
                   to="/instances"
                   className="flex cursor-pointer"
-                  onClick={() => {
-                    if (sidebarCollapsed && onSidebarToggle) {
-                      onSidebarToggle()
-                    }
-                  }}
                 >
-                  <Server className="mr-2 h-4 w-4" />
+                  <Server className="mr-2 h-4 w-4"/>
                   Instances
                 </Link>
               </DropdownMenuItem>
@@ -265,7 +250,7 @@ export function Header({ children, sidebarCollapsed = false, onSidebarToggle }: 
                         params={{ instanceId: instance.id.toString() }}
                         className="flex cursor-pointer pl-6"
                       >
-                        <HardDrive className="mr-2 h-4 w-4" />
+                        <HardDrive className="mr-2 h-4 w-4"/>
                         <span className="truncate">{instance.name}</span>
                         <span
                           className={cn(
@@ -278,24 +263,19 @@ export function Header({ children, sidebarCollapsed = false, onSidebarToggle }: 
                   ))}
                 </>
               )}
-              <DropdownMenuSeparator />
+              <DropdownMenuSeparator/>
               <DropdownMenuItem asChild>
                 <Link
                   to="/settings"
                   className="flex cursor-pointer"
-                  onClick={() => {
-                    if (sidebarCollapsed && onSidebarToggle) {
-                      onSidebarToggle()
-                    }
-                  }}
                 >
-                  <Settings className="mr-2 h-4 w-4" />
+                  <Settings className="mr-2 h-4 w-4"/>
                   Settings
                 </Link>
               </DropdownMenuItem>
-              <DropdownMenuSeparator />
+              <DropdownMenuSeparator/>
               <DropdownMenuItem onClick={() => logout()}>
-                <LogOut className="mr-2 h-4 w-4" />
+                <LogOut className="mr-2 h-4 w-4"/>
                 Logout
               </DropdownMenuItem>
             </DropdownMenuContent>

--- a/web/src/layouts/AppLayout.tsx
+++ b/web/src/layouts/AppLayout.tsx
@@ -33,7 +33,6 @@ function AppLayoutContent() {
       <div className="flex flex-1 flex-col min-w-0 relative">
         <Header
           sidebarCollapsed={sidebarCollapsed}
-          onSidebarToggle={() => setSidebarCollapsed(!sidebarCollapsed)}
         >
           {/* Desktop toggle button */}
           <Tooltip>


### PR DESCRIPTION
This removes the automatic unhiding of the sidebar when clicking on any items in the top right dropdown that are not an instance.