### PR TITLE
feat(web): better category edit dialog

### DIFF
--- a/web/src/components/torrents/FilterSidebar.tsx
+++ b/web/src/components/torrents/FilterSidebar.tsx
@@ -157,7 +157,7 @@ const FilterSidebarComponent = ({
   const [showCreateCategoryDialog, setShowCreateCategoryDialog] = useState(false)
   const [showEditCategoryDialog, setShowEditCategoryDialog] = useState(false)
   const [showDeleteCategoryDialog, setShowDeleteCategoryDialog] = useState(false)
-  const [categoryToEdit, setCategoryToEdit] = useState<{ name: string; savePath: string } | null>(null)
+  const [categoryToEdit, setCategoryToEdit] = useState<Category | null>(null)
   const [categoryToDelete, setCategoryToDelete] = useState("")
 
   // Search states for filtering large lists
@@ -219,7 +219,7 @@ const FilterSidebarComponent = ({
 
   // Filtered categories for performance
   const filteredCategories = useMemo(() => {
-    const categoryEntries = Object.entries(categories)
+    const categoryEntries = Object.entries(categories) as [string, Category][]
 
     if (debouncedCategorySearch) {
       const searchLower = debouncedCategorySearch.toLowerCase()
@@ -550,7 +550,7 @@ const FilterSidebarComponent = ({
                                 <ContextMenuContent>
                                   <ContextMenuItem
                                     onClick={() => {
-                                      setCategoryToEdit({ name, savePath: (category as Category).save_path })
+                                      setCategoryToEdit(category)
                                       setShowEditCategoryDialog(true)
                                     }}
                                   >
@@ -576,7 +576,7 @@ const FilterSidebarComponent = ({
                       </div>
                     </div>
                   ) : (
-                    filteredCategories.map(([name, category]: [string, { save_path: string }]) => (
+                    filteredCategories.map(([name, category]: [string, Category]) => (
                       <ContextMenu key={name}>
                         <ContextMenuTrigger asChild>
                           <label className="flex items-center space-x-2 py-1 px-2 hover:bg-muted rounded cursor-pointer">
@@ -595,7 +595,7 @@ const FilterSidebarComponent = ({
                         <ContextMenuContent>
                           <ContextMenuItem
                             onClick={() => {
-                              setCategoryToEdit({ name, savePath: category.save_path })
+                              setCategoryToEdit(category)
                               setShowEditCategoryDialog(true)
                             }}
                           >

--- a/web/src/components/torrents/TagCategoryManagement.tsx
+++ b/web/src/components/torrents/TagCategoryManagement.tsx
@@ -19,6 +19,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle
 } from "@/components/ui/alert-dialog"
+import type { Category } from "@/types";
 
 interface CreateTagDialogProps {
   open: boolean
@@ -226,11 +227,11 @@ interface EditCategoryDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   instanceId: number
-  category: { name: string; savePath: string }
+  category: Category
 }
 
 export function EditCategoryDialog({ open, onOpenChange, instanceId, category }: EditCategoryDialogProps) {
-  const [savePath, setSavePath] = useState(category.savePath)
+  const [newSavePath, setNewSavePath] = useState("")
   const queryClient = useQueryClient()
 
   const mutation = useMutation({
@@ -250,11 +251,18 @@ export function EditCategoryDialog({ open, onOpenChange, instanceId, category }:
   })
 
   const handleSave = () => {
-    mutation.mutate(savePath.trim())
+    mutation.mutate(newSavePath.trim())
+  }
+
+  const handleOpenChange = (isOpen: boolean) => {
+    if (!isOpen) {
+      setNewSavePath("")
+    }
+    onOpenChange(isOpen)
   }
 
   return (
-    <AlertDialog open={open} onOpenChange={onOpenChange}>
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>Edit Category: {category.name}</AlertDialogTitle>
@@ -263,11 +271,19 @@ export function EditCategoryDialog({ open, onOpenChange, instanceId, category }:
           </AlertDialogDescription>
         </AlertDialogHeader>
         <div className="py-4 space-y-2">
-          <Label htmlFor="editSavePath">Save Path</Label>
+          <Label htmlFor="oldSavePath">Current Save Path</Label>
+          <Input
+            id="oldSavePath"
+            value={category.savePath || "No save path configured"}
+            className={!category.savePath ? "text-muted-foreground italic" : ""}
+            disabled={!category.savePath}
+            readOnly
+          />
+          <Label htmlFor="editSavePath">New Save Path</Label>
           <Input
             id="editSavePath"
-            value={savePath}
-            onChange={(e) => setSavePath(e.target.value)}
+            value={newSavePath}
+            onChange={(e) => setNewSavePath(e.target.value)}
             placeholder="e.g. /downloads/movies"
             onKeyDown={(e) => {
               if (e.key === "Enter") {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -6,6 +6,7 @@
 import type {
   AppPreferences,
   AuthResponse,
+  Category,
   InstanceFormData,
   InstanceResponse,
   MainData,
@@ -311,7 +312,7 @@ class ApiClient {
   }
 
   // Categories & Tags
-  async getCategories(instanceId: number): Promise<Record<string, { name: string; savePath: string }>> {
+  async getCategories(instanceId: number): Promise<Record<string, Category>> {
     return this.request(`/instances/${instanceId}/categories`)
   }
 

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -131,7 +131,7 @@ export interface MainData {
 
 export interface Category {
   name: string
-  save_path: string
+  savePath: string
 }
 
 export interface ServerState {


### PR DESCRIPTION
This improves the category edit dialog to also show the old save path.
Before
<img width="516" height="272" alt="image" src="https://github.com/user-attachments/assets/c67ff97a-bbb6-42e7-98c9-2855cc744260" />

After
<img width="516" height="332" alt="image" src="https://github.com/user-attachments/assets/e2bcfbca-fd02-4441-9331-eb51abd42c2b" />
