### PR TITLE
fix(auth): correctly use `withBasePath` for login/setup check and redirect

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -31,7 +31,7 @@ class ApiClient {
     })
 
     if (!response.ok) {
-      if (response.status === 401 && !window.location.pathname.startsWith(withBasePath("/login")) && !window.location.pathname.startsWith(withBasePath("/setup")) {
+      if (response.status === 401 && !window.location.pathname.startsWith(withBasePath("/login")) && !window.location.pathname.startsWith(withBasePath("/setup"))) {
         window.location.href = withBasePath("/login")
         throw new Error("Session expired")
       }


### PR DESCRIPTION
fixes inability to login if using a base path