### PR TITLE
fix(filters): show scrollbar for smaller lists

### DIFF
--- a/web/src/components/torrents/FilterSidebar.tsx
+++ b/web/src/components/torrents/FilterSidebar.tsx
@@ -210,7 +210,7 @@ const FilterSidebarComponent = ({
   }, [incognitoMode, torrentCounts, isLoading, isStaleData])
 
   // Use virtual scrolling for large lists to handle performance efficiently
-  const VIRTUAL_THRESHOLD = 100 // Use virtual scrolling for lists > 100 items
+  const VIRTUAL_THRESHOLD = 30 // Use virtual scrolling for lists > 30 items
 
   // Refs for virtual scrolling
   const categoryListRef = useRef<HTMLDivElement>(null)


### PR DESCRIPTION
Enable virtual scrolling from 30 instead of 100.