### PR TITLE
perf(torrents): smooth sidebar during pagination

### DIFF
--- a/web/src/pages/Torrents.tsx
+++ b/web/src/pages/Torrents.tsx
@@ -3,15 +3,15 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useState, useCallback, useEffect, useRef } from "react"
-import { TorrentTableResponsive } from "@/components/torrents/TorrentTableResponsive"
 import { FilterSidebar } from "@/components/torrents/FilterSidebar"
 import { TorrentDetailsPanel } from "@/components/torrents/TorrentDetailsPanel"
+import { TorrentTableResponsive } from "@/components/torrents/TorrentTableResponsive"
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
 import { VisuallyHidden } from "@/components/ui/visually-hidden"
 import { usePersistedFilters } from "@/hooks/usePersistedFilters"
 import { usePersistedFilterSidebarState } from "@/hooks/usePersistedFilterSidebarState"
 import type { Category, Torrent, TorrentCounts } from "@/types"
+import { useCallback, useEffect, useRef, useState } from "react"
 
 interface TorrentsProps {
   instanceId: number
@@ -107,9 +107,13 @@ export function Torrents({ instanceId, search, onSearchChange }: TorrentsProps) 
       setTorrentCounts(transformedCounts)
     }
 
-    // Store categories and tags - always set them even if empty to indicate data has been received
-    setCategories(categoriesData || {})
-    setTags(tagsData || [])
+    // Store categories and tags only when new data arrives; preserve previous values during pagination fetches
+    if (categoriesData !== undefined) {
+      setCategories(categoriesData)
+    }
+    if (tagsData !== undefined) {
+      setTags(tagsData)
+    }
   }, [instanceId])
 
   // Calculate total active filters for badge


### PR DESCRIPTION
This resolves the FilterSidebar flashing during pagination calls, mostly noticeable during fast scrolling.

- keep torrent filter metadata around while pagination fetches run so the sidebar no longer flashes empty state
- gate TorrentTable callbacks behind metadata diffs to avoid redundant sidebar renders
- reuse the previous page response as placeholder data while React Query loads the next slice, keeping TanStack Virtual stable