### PR TITLE
fix(torrents): align torrent bulk action counts with selection state

### DIFF
--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -935,17 +935,48 @@ export function TorrentCardsMobile({
   }, [selectedHashes, handleAction, isAllSelected, filters, effectiveSearch, excludedFromSelectAll])
 
   const handleDeleteWrapper = useCallback(async () => {
-    const hashes = torrentToDelete ? [torrentToDelete.hash] : (isAllSelected ? [] : Array.from(selectedHashes))
+    let hashes: string[]
+    if (torrentToDelete) {
+      hashes = [torrentToDelete.hash]
+    } else if (isAllSelected) {
+      hashes = []
+    } else {
+      hashes = Array.from(selectedHashes)
+    }
+
+    let visibleHashes: string[]
+    if (torrentToDelete) {
+      visibleHashes = [torrentToDelete.hash]
+    } else if (isAllSelected) {
+      visibleHashes = torrents
+        .filter(t => !excludedFromSelectAll.has(t.hash))
+        .map(t => t.hash)
+    } else {
+      visibleHashes = Array.from(selectedHashes)
+    }
+
+    let totalSelected: number
+    if (torrentToDelete) {
+      totalSelected = 1
+    } else if (isAllSelected) {
+      totalSelected = effectiveSelectionCount
+    } else {
+      totalSelected = visibleHashes.length
+    }
 
     await handleDelete(
       hashes,
       !torrentToDelete && isAllSelected,
       !torrentToDelete && isAllSelected ? filters : undefined,
       !torrentToDelete && isAllSelected ? effectiveSearch : undefined,
-      !torrentToDelete && isAllSelected ? Array.from(excludedFromSelectAll) : undefined
+      !torrentToDelete && isAllSelected ? Array.from(excludedFromSelectAll) : undefined,
+      {
+        clientHashes: visibleHashes,
+        totalSelected,
+      }
     )
     setTorrentToDelete(null)
-  }, [torrentToDelete, isAllSelected, selectedHashes, handleDelete, filters, effectiveSearch, excludedFromSelectAll])
+  }, [torrentToDelete, isAllSelected, selectedHashes, handleDelete, filters, effectiveSearch, excludedFromSelectAll, torrents, effectiveSelectionCount])
 
   const handleSetTagsWrapper = useCallback(async (tags: string[]) => {
     const hashes = isAllSelected ? [] : actionTorrents.map(t => t.hash)

--- a/web/src/components/torrents/TorrentManagementBar.tsx
+++ b/web/src/components/torrents/TorrentManagementBar.tsx
@@ -128,6 +128,8 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
     onActionComplete: onComplete,
   })
 
+  const selectionCount = totalSelectionCount || selectedHashes.length
+
   // Wrapper functions to adapt hook handlers to component needs
   const handleDeleteWrapper = useCallback(() => {
     handleDelete(
@@ -135,9 +137,13 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
       isAllSelected,
       filters,
       search,
-      excludeHashes
+      excludeHashes,
+      {
+        clientHashes: selectedHashes,
+        totalSelected: selectionCount,
+      }
     )
-  }, [handleDelete, selectedHashes, isAllSelected, filters, search, excludeHashes])
+  }, [handleDelete, selectedHashes, isAllSelected, filters, search, excludeHashes, selectionCount])
 
   const handleAddTagsWrapper = useCallback((tags: string[]) => {
     handleAddTags(
@@ -239,7 +245,6 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
     handleSetSpeedLimits(uploadLimit, downloadLimit, selectedHashes)
   }, [handleSetSpeedLimits, selectedHashes])
 
-  const selectionCount = totalSelectionCount || selectedHashes.length
   const hasSelection = selectionCount > 0 || isAllSelected
   const isDisabled = !instanceId || !hasSelection
 

--- a/web/src/components/torrents/TorrentManagementBar.tsx
+++ b/web/src/components/torrents/TorrentManagementBar.tsx
@@ -40,7 +40,7 @@ import type { Torrent } from "@/types"
 import { useQuery } from "@tanstack/react-query"
 import { ArrowDown, ArrowUp, ChevronsDown, ChevronsUp, Folder, FolderOpen, List, LoaderCircle, Pause, Play, Radio, Settings2, Share2, Tag, Trash2 } from "lucide-react"
 import type { ChangeEvent } from "react"
-import { memo, useCallback } from "react"
+import { memo, useCallback, useMemo } from "react"
 import { AddTagsDialog, SetCategoryDialog, SetLocationDialog, SetTagsDialog } from "./TorrentDialogs"
 import { ShareLimitSubmenu, SpeedLimitsSubmenu } from "./TorrentLimitSubmenus"
 
@@ -131,6 +131,28 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
   const selectionCount = totalSelectionCount || selectedHashes.length
 
   // Wrapper functions to adapt hook handlers to component needs
+  const actionHashes = useMemo(() => (isAllSelected ? [] : selectedHashes), [isAllSelected, selectedHashes])
+  const actionOptions = useMemo(() => ({
+    selectAll: isAllSelected,
+    filters: isAllSelected ? filters : undefined,
+    search: isAllSelected ? search : undefined,
+    excludeHashes: isAllSelected ? excludeHashes : undefined,
+    clientHashes: selectedHashes,
+    clientCount: selectionCount,
+  }), [isAllSelected, filters, search, excludeHashes, selectedHashes, selectionCount])
+
+  const clientMeta = useMemo(() => ({
+    clientHashes: selectedHashes,
+    totalSelected: selectionCount,
+  }), [selectedHashes, selectionCount])
+
+  const triggerAction = useCallback((action: (typeof TORRENT_ACTIONS)[keyof typeof TORRENT_ACTIONS], extra?: Parameters<typeof handleAction>[2]) => {
+    handleAction(action, actionHashes, {
+      ...actionOptions,
+      ...extra,
+    })
+  }, [handleAction, actionHashes, actionOptions])
+
   const handleDeleteWrapper = useCallback(() => {
     handleDelete(
       selectedHashes,
@@ -138,12 +160,9 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
       filters,
       search,
       excludeHashes,
-      {
-        clientHashes: selectedHashes,
-        totalSelected: selectionCount,
-      }
+      clientMeta
     )
-  }, [handleDelete, selectedHashes, isAllSelected, filters, search, excludeHashes, selectionCount])
+  }, [handleDelete, selectedHashes, isAllSelected, filters, search, excludeHashes, clientMeta])
 
   const handleAddTagsWrapper = useCallback((tags: string[]) => {
     handleAddTags(
@@ -152,9 +171,10 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
       isAllSelected,
       filters,
       search,
-      excludeHashes
+      excludeHashes,
+      clientMeta
     )
-  }, [handleAddTags, selectedHashes, isAllSelected, filters, search, excludeHashes])
+  }, [handleAddTags, selectedHashes, isAllSelected, filters, search, excludeHashes, clientMeta])
 
   const handleSetTagsWrapper = useCallback((tags: string[]) => {
     handleSetTags(
@@ -163,9 +183,10 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
       isAllSelected,
       filters,
       search,
-      excludeHashes
+      excludeHashes,
+      clientMeta
     )
-  }, [handleSetTags, selectedHashes, isAllSelected, filters, search, excludeHashes])
+  }, [handleSetTags, selectedHashes, isAllSelected, filters, search, excludeHashes, clientMeta])
 
   const handleSetCategoryWrapper = useCallback((category: string) => {
     handleSetCategory(
@@ -174,9 +195,10 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
       isAllSelected,
       filters,
       search,
-      excludeHashes
+      excludeHashes,
+      clientMeta
     )
-  }, [handleSetCategory, selectedHashes, isAllSelected, filters, search, excludeHashes])
+  }, [handleSetCategory, selectedHashes, isAllSelected, filters, search, excludeHashes, clientMeta])
 
   const handleSetLocationWrapper = useCallback((location: string) => {
     handleSetLocation(
@@ -185,9 +207,10 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
       isAllSelected,
       filters,
       search,
-      excludeHashes
+      excludeHashes,
+      clientMeta
     )
-  }, [handleSetLocation, selectedHashes, isAllSelected, filters, search, excludeHashes])
+  }, [handleSetLocation, selectedHashes, isAllSelected, filters, search, excludeHashes, clientMeta])
 
   const handleRecheckWrapper = useCallback(() => {
     handleRecheck(
@@ -195,9 +218,10 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
       isAllSelected,
       filters,
       search,
-      excludeHashes
+      excludeHashes,
+      clientMeta
     )
-  }, [handleRecheck, selectedHashes, isAllSelected, filters, search, excludeHashes])
+  }, [handleRecheck, selectedHashes, isAllSelected, filters, search, excludeHashes, clientMeta])
 
   const handleReannounceWrapper = useCallback(() => {
     handleReannounce(
@@ -205,27 +229,28 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
       isAllSelected,
       filters,
       search,
-      excludeHashes
+      excludeHashes,
+      clientMeta
     )
-  }, [handleReannounce, selectedHashes, isAllSelected, filters, search, excludeHashes])
+  }, [handleReannounce, selectedHashes, isAllSelected, filters, search, excludeHashes, clientMeta])
 
   const handleRecheckClick = useCallback(() => {
     const count = totalSelectionCount || selectedHashes.length
     if (count > 1) {
       prepareRecheckAction(selectedHashes, count)
     } else {
-      handleAction(TORRENT_ACTIONS.RECHECK, selectedHashes)
+      triggerAction(TORRENT_ACTIONS.RECHECK)
     }
-  }, [totalSelectionCount, selectedHashes, prepareRecheckAction, handleAction])
+  }, [totalSelectionCount, selectedHashes, prepareRecheckAction, triggerAction])
 
   const handleReannounceClick = useCallback(() => {
     const count = totalSelectionCount || selectedHashes.length
     if (count > 1) {
       prepareReannounceAction(selectedHashes, count)
     } else {
-      handleAction(TORRENT_ACTIONS.REANNOUNCE, selectedHashes)
+      triggerAction(TORRENT_ACTIONS.REANNOUNCE)
     }
-  }, [totalSelectionCount, selectedHashes, prepareReannounceAction, handleAction])
+  }, [totalSelectionCount, selectedHashes, prepareReannounceAction, triggerAction])
 
   const handleQueueAction = useCallback((action: "topPriority" | "increasePriority" | "decreasePriority" | "bottomPriority") => {
     const actionMap = {
@@ -234,16 +259,35 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
       decreasePriority: TORRENT_ACTIONS.DECREASE_PRIORITY,
       bottomPriority: TORRENT_ACTIONS.BOTTOM_PRIORITY,
     }
-    handleAction(actionMap[action], selectedHashes)
-  }, [handleAction, selectedHashes])
+    triggerAction(actionMap[action])
+  }, [triggerAction])
 
   const handleSetShareLimitWrapper = useCallback((ratioLimit: number, seedingTimeLimit: number, inactiveSeedingTimeLimit: number) => {
-    handleSetShareLimit(ratioLimit, seedingTimeLimit, inactiveSeedingTimeLimit, selectedHashes)
-  }, [handleSetShareLimit, selectedHashes])
+    handleSetShareLimit(
+      ratioLimit,
+      seedingTimeLimit,
+      inactiveSeedingTimeLimit,
+      selectedHashes,
+      isAllSelected,
+      filters,
+      search,
+      excludeHashes,
+      clientMeta
+    )
+  }, [handleSetShareLimit, selectedHashes, isAllSelected, filters, search, excludeHashes, clientMeta])
 
   const handleSetSpeedLimitsWrapper = useCallback((uploadLimit: number, downloadLimit: number) => {
-    handleSetSpeedLimits(uploadLimit, downloadLimit, selectedHashes)
-  }, [handleSetSpeedLimits, selectedHashes])
+    handleSetSpeedLimits(
+      uploadLimit,
+      downloadLimit,
+      selectedHashes,
+      isAllSelected,
+      filters,
+      search,
+      excludeHashes,
+      clientMeta
+    )
+  }, [handleSetSpeedLimits, selectedHashes, isAllSelected, filters, search, excludeHashes, clientMeta])
 
   const hasSelection = selectionCount > 0 || isAllSelected
   const isDisabled = !instanceId || !hasSelection
@@ -269,7 +313,7 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
               <Button
                 variant="ghost"
                 size="sm"
-                onClick={() => handleAction(TORRENT_ACTIONS.RESUME, selectedHashes)}
+                onClick={() => triggerAction(TORRENT_ACTIONS.RESUME)}
                 disabled={isPending || isDisabled}
               >
                 <Play className="h-4 w-4" />
@@ -283,7 +327,7 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
               <Button
                 variant="ghost"
                 size="sm"
-                onClick={() => handleAction(TORRENT_ACTIONS.PAUSE, selectedHashes)}
+                onClick={() => triggerAction(TORRENT_ACTIONS.PAUSE)}
                 disabled={isPending || isDisabled}
               >
                 <Pause className="h-4 w-4" />
@@ -474,7 +518,7 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
                   <Button
                     variant="ghost"
                     size="sm"
-                    onClick={() => handleAction(TORRENT_ACTIONS.TOGGLE_AUTO_TMM, selectedHashes, { enable: !allEnabled })}
+                    onClick={() => triggerAction(TORRENT_ACTIONS.TOGGLE_AUTO_TMM, { enable: !allEnabled })}
                     disabled={isPending || isDisabled}
                   >
                     <Settings2 className="h-4 w-4" />

--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -689,9 +689,13 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({ insta
       isAllSelected,
       filters,
       effectiveSearch,
-      Array.from(excludedFromSelectAll)
+      Array.from(excludedFromSelectAll),
+      {
+        clientHashes: contextHashes,
+        totalSelected: isAllSelected ? effectiveSelectionCount : contextHashes.length,
+      }
     )
-  }, [handleDelete, contextHashes, isAllSelected, filters, effectiveSearch, excludedFromSelectAll])
+  }, [handleDelete, contextHashes, isAllSelected, filters, effectiveSearch, excludedFromSelectAll, effectiveSelectionCount])
 
   const handleAddTagsWrapper = useCallback((tags: string[]) => {
     handleAddTags(

--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -9,7 +9,7 @@ import { usePersistedColumnOrder } from "@/hooks/usePersistedColumnOrder"
 import { usePersistedColumnSizing } from "@/hooks/usePersistedColumnSizing"
 import { usePersistedColumnSorting } from "@/hooks/usePersistedColumnSorting"
 import { usePersistedColumnVisibility } from "@/hooks/usePersistedColumnVisibility"
-import { useTorrentActions } from "@/hooks/useTorrentActions"
+import { TORRENT_ACTIONS, useTorrentActions } from "@/hooks/useTorrentActions"
 import { useTorrentsList } from "@/hooks/useTorrentsList"
 import {
   DndContext,
@@ -683,6 +683,29 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({ insta
 
 
   // Wrapper functions to adapt hook handlers to component needs
+  const selectAllOptions = useMemo(() => ({
+    selectAll: isAllSelected,
+    filters: isAllSelected ? filters : undefined,
+    search: isAllSelected ? effectiveSearch : undefined,
+    excludeHashes: isAllSelected ? Array.from(excludedFromSelectAll) : undefined,
+  }), [isAllSelected, filters, effectiveSearch, excludedFromSelectAll])
+
+  const contextClientMeta = useMemo(() => ({
+    clientHashes: contextHashes,
+    totalSelected: isAllSelected ? effectiveSelectionCount : contextHashes.length,
+  }), [contextHashes, isAllSelected, effectiveSelectionCount])
+
+  const runAction = useCallback((action: (typeof TORRENT_ACTIONS)[keyof typeof TORRENT_ACTIONS], hashes: string[], extra?: Parameters<typeof handleAction>[2]) => {
+    const clientHashes = hashes.length > 0 ? hashes : selectedHashes
+    const clientCount = isAllSelected ? effectiveSelectionCount : (clientHashes.length || hashes.length || 1)
+    handleAction(action, isAllSelected ? [] : hashes, {
+      ...selectAllOptions,
+      clientHashes,
+      clientCount,
+      ...extra,
+    })
+  }, [handleAction, isAllSelected, selectAllOptions, selectedHashes, effectiveSelectionCount])
+
   const handleDeleteWrapper = useCallback(() => {
     handleDelete(
       contextHashes,
@@ -690,12 +713,9 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({ insta
       filters,
       effectiveSearch,
       Array.from(excludedFromSelectAll),
-      {
-        clientHashes: contextHashes,
-        totalSelected: isAllSelected ? effectiveSelectionCount : contextHashes.length,
-      }
+      contextClientMeta
     )
-  }, [handleDelete, contextHashes, isAllSelected, filters, effectiveSearch, excludedFromSelectAll, effectiveSelectionCount])
+  }, [handleDelete, contextHashes, isAllSelected, filters, effectiveSearch, excludedFromSelectAll, contextClientMeta])
 
   const handleAddTagsWrapper = useCallback((tags: string[]) => {
     handleAddTags(
@@ -704,9 +724,10 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({ insta
       isAllSelected,
       filters,
       effectiveSearch,
-      Array.from(excludedFromSelectAll)
+      Array.from(excludedFromSelectAll),
+      contextClientMeta
     )
-  }, [handleAddTags, contextHashes, isAllSelected, filters, effectiveSearch, excludedFromSelectAll])
+  }, [handleAddTags, contextHashes, isAllSelected, filters, effectiveSearch, excludedFromSelectAll, contextClientMeta])
 
   const handleSetTagsWrapper = useCallback((tags: string[]) => {
     handleSetTags(
@@ -715,9 +736,10 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({ insta
       isAllSelected,
       filters,
       effectiveSearch,
-      Array.from(excludedFromSelectAll)
+      Array.from(excludedFromSelectAll),
+      contextClientMeta
     )
-  }, [handleSetTags, contextHashes, isAllSelected, filters, effectiveSearch, excludedFromSelectAll])
+  }, [handleSetTags, contextHashes, isAllSelected, filters, effectiveSearch, excludedFromSelectAll, contextClientMeta])
 
   const handleSetCategoryWrapper = useCallback((category: string) => {
     handleSetCategory(
@@ -726,9 +748,10 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({ insta
       isAllSelected,
       filters,
       effectiveSearch,
-      Array.from(excludedFromSelectAll)
+      Array.from(excludedFromSelectAll),
+      contextClientMeta
     )
-  }, [handleSetCategory, contextHashes, isAllSelected, filters, effectiveSearch, excludedFromSelectAll])
+  }, [handleSetCategory, contextHashes, isAllSelected, filters, effectiveSearch, excludedFromSelectAll, contextClientMeta])
 
   const handleSetLocationWrapper = useCallback((location: string) => {
     handleSetLocation(
@@ -737,9 +760,10 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({ insta
       isAllSelected,
       filters,
       effectiveSearch,
-      Array.from(excludedFromSelectAll)
+      Array.from(excludedFromSelectAll),
+      contextClientMeta
     )
-  }, [handleSetLocation, contextHashes, isAllSelected, filters, effectiveSearch, excludedFromSelectAll])
+  }, [handleSetLocation, contextHashes, isAllSelected, filters, effectiveSearch, excludedFromSelectAll, contextClientMeta])
 
   const handleRemoveTagsWrapper = useCallback((tags: string[]) => {
     handleRemoveTags(
@@ -748,9 +772,10 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({ insta
       isAllSelected,
       filters,
       effectiveSearch,
-      Array.from(excludedFromSelectAll)
+      Array.from(excludedFromSelectAll),
+      contextClientMeta
     )
-  }, [handleRemoveTags, contextHashes, isAllSelected, filters, effectiveSearch, excludedFromSelectAll])
+  }, [handleRemoveTags, contextHashes, isAllSelected, filters, effectiveSearch, excludedFromSelectAll, contextClientMeta])
 
   const handleRecheckWrapper = useCallback(() => {
     handleRecheck(
@@ -758,9 +783,10 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({ insta
       isAllSelected,
       filters,
       effectiveSearch,
-      Array.from(excludedFromSelectAll)
+      Array.from(excludedFromSelectAll),
+      contextClientMeta
     )
-  }, [handleRecheck, contextHashes, isAllSelected, filters, effectiveSearch, excludedFromSelectAll])
+  }, [handleRecheck, contextHashes, isAllSelected, filters, effectiveSearch, excludedFromSelectAll, contextClientMeta])
 
   const handleReannounceWrapper = useCallback(() => {
     handleReannounce(
@@ -768,9 +794,52 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({ insta
       isAllSelected,
       filters,
       effectiveSearch,
-      Array.from(excludedFromSelectAll)
+      Array.from(excludedFromSelectAll),
+      contextClientMeta
     )
-  }, [handleReannounce, contextHashes, isAllSelected, filters, effectiveSearch, excludedFromSelectAll])
+  }, [handleReannounce, contextHashes, isAllSelected, filters, effectiveSearch, excludedFromSelectAll, contextClientMeta])
+
+  const handleSetShareLimitContext = useCallback((
+    ratioLimit: number,
+    seedingTimeLimit: number,
+    inactiveSeedingTimeLimit: number,
+    hashes: string[]
+  ) => {
+    handleSetShareLimit(
+      ratioLimit,
+      seedingTimeLimit,
+      inactiveSeedingTimeLimit,
+      hashes,
+      isAllSelected,
+      filters,
+      effectiveSearch,
+      Array.from(excludedFromSelectAll),
+      {
+        clientHashes: hashes,
+        totalSelected: isAllSelected ? effectiveSelectionCount : hashes.length,
+      }
+    )
+  }, [handleSetShareLimit, isAllSelected, filters, effectiveSearch, excludedFromSelectAll, effectiveSelectionCount])
+
+  const handleSetSpeedLimitsContext = useCallback((
+    uploadLimit: number,
+    downloadLimit: number,
+    hashes: string[]
+  ) => {
+    handleSetSpeedLimits(
+      uploadLimit,
+      downloadLimit,
+      hashes,
+      isAllSelected,
+      filters,
+      effectiveSearch,
+      Array.from(excludedFromSelectAll),
+      {
+        clientHashes: hashes,
+        totalSelected: isAllSelected ? effectiveSelectionCount : hashes.length,
+      }
+    )
+  }, [handleSetSpeedLimits, isAllSelected, filters, effectiveSearch, excludedFromSelectAll, effectiveSelectionCount])
 
 
   // Drag and drop setup
@@ -974,15 +1043,15 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({ insta
                       selectedTorrents={selectedTorrents}
                       effectiveSelectionCount={effectiveSelectionCount}
                       onTorrentSelect={onTorrentSelect}
-                      onAction={handleAction}
+                      onAction={runAction}
                       onPrepareDelete={prepareDeleteAction}
                       onPrepareTags={prepareTagsAction}
                       onPrepareCategory={prepareCategoryAction}
                       onPrepareLocation={prepareLocationAction}
                       onPrepareRecheck={prepareRecheckAction}
                       onPrepareReannounce={prepareReannounceAction}
-                      onSetShareLimit={handleSetShareLimit}
-                      onSetSpeedLimits={handleSetSpeedLimits}
+                      onSetShareLimit={handleSetShareLimitContext}
+                      onSetSpeedLimits={handleSetSpeedLimitsContext}
                       isPending={isPending}
                     >
                       <div

--- a/web/src/hooks/useTorrentActions.ts
+++ b/web/src/hooks/useTorrentActions.ts
@@ -66,6 +66,11 @@ interface TorrentActionData {
   clientCount?: number
 }
 
+interface ClientMeta {
+  clientHashes?: string[]
+  totalSelected?: number
+}
+
 export function useTorrentActions({ instanceId, onActionComplete }: UseTorrentActionsProps) {
   const queryClient = useQueryClient()
 
@@ -219,10 +224,7 @@ export function useTorrentActions({ instanceId, onActionComplete }: UseTorrentAc
     filters?: TorrentActionData["filters"],
     search?: string,
     excludeHashes?: string[],
-    clientMeta?: {
-      clientHashes?: string[]
-      totalSelected?: number
-    }
+    clientMeta?: ClientMeta
   ) => {
     const clientHashes = clientMeta?.clientHashes ?? hashes
     const clientCount = clientMeta?.totalSelected
@@ -250,8 +252,12 @@ export function useTorrentActions({ instanceId, onActionComplete }: UseTorrentAc
     isAllSelected?: boolean,
     filters?: TorrentActionData["filters"],
     search?: string,
-    excludeHashes?: string[]
+    excludeHashes?: string[],
+    clientMeta?: ClientMeta
   ) => {
+    const clientHashes = clientMeta?.clientHashes ?? hashes
+    const clientCount = clientMeta?.totalSelected
+      ?? (clientHashes?.length ?? hashes.length)
     await mutation.mutateAsync({
       action: "addTags",
       tags: tags.join(","),
@@ -260,6 +266,8 @@ export function useTorrentActions({ instanceId, onActionComplete }: UseTorrentAc
       filters: isAllSelected ? filters : undefined,
       search: isAllSelected ? search : undefined,
       excludeHashes: isAllSelected ? excludeHashes : undefined,
+      clientHashes,
+      clientCount,
     })
     setShowAddTagsDialog(false)
     setContextHashes([])
@@ -272,8 +280,12 @@ export function useTorrentActions({ instanceId, onActionComplete }: UseTorrentAc
     isAllSelected?: boolean,
     filters?: TorrentActionData["filters"],
     search?: string,
-    excludeHashes?: string[]
+    excludeHashes?: string[],
+    clientMeta?: ClientMeta
   ) => {
+    const clientHashes = clientMeta?.clientHashes ?? hashes
+    const clientCount = clientMeta?.totalSelected
+      ?? (clientHashes?.length ?? hashes.length)
     try {
       await mutation.mutateAsync({
         action: "setTags",
@@ -283,6 +295,8 @@ export function useTorrentActions({ instanceId, onActionComplete }: UseTorrentAc
         filters: isAllSelected ? filters : undefined,
         search: isAllSelected ? search : undefined,
         excludeHashes: isAllSelected ? excludeHashes : undefined,
+        clientHashes,
+        clientCount,
       })
     } catch (error) {
       // Fallback to addTags for older qBittorrent versions
@@ -295,6 +309,8 @@ export function useTorrentActions({ instanceId, onActionComplete }: UseTorrentAc
           filters: isAllSelected ? filters : undefined,
           search: isAllSelected ? search : undefined,
           excludeHashes: isAllSelected ? excludeHashes : undefined,
+          clientHashes,
+          clientCount,
         })
       } else {
         throw error
@@ -311,8 +327,12 @@ export function useTorrentActions({ instanceId, onActionComplete }: UseTorrentAc
     isAllSelected?: boolean,
     filters?: TorrentActionData["filters"],
     search?: string,
-    excludeHashes?: string[]
+    excludeHashes?: string[],
+    clientMeta?: ClientMeta
   ) => {
+    const clientHashes = clientMeta?.clientHashes ?? hashes
+    const clientCount = clientMeta?.totalSelected
+      ?? (clientHashes?.length ?? hashes.length)
     await mutation.mutateAsync({
       action: "removeTags",
       tags: tags.join(","),
@@ -321,6 +341,8 @@ export function useTorrentActions({ instanceId, onActionComplete }: UseTorrentAc
       filters: isAllSelected ? filters : undefined,
       search: isAllSelected ? search : undefined,
       excludeHashes: isAllSelected ? excludeHashes : undefined,
+      clientHashes,
+      clientCount,
     })
     setShowRemoveTagsDialog(false)
     setContextHashes([])
@@ -333,8 +355,12 @@ export function useTorrentActions({ instanceId, onActionComplete }: UseTorrentAc
     isAllSelected?: boolean,
     filters?: TorrentActionData["filters"],
     search?: string,
-    excludeHashes?: string[]
+    excludeHashes?: string[],
+    clientMeta?: ClientMeta
   ) => {
+    const clientHashes = clientMeta?.clientHashes ?? hashes
+    const clientCount = clientMeta?.totalSelected
+      ?? (clientHashes?.length ?? hashes.length)
     await mutation.mutateAsync({
       action: "setCategory",
       category,
@@ -343,6 +369,8 @@ export function useTorrentActions({ instanceId, onActionComplete }: UseTorrentAc
       filters: isAllSelected ? filters : undefined,
       search: isAllSelected ? search : undefined,
       excludeHashes: isAllSelected ? excludeHashes : undefined,
+      clientHashes,
+      clientCount,
     })
     setShowCategoryDialog(false)
     setContextHashes([])
@@ -353,14 +381,28 @@ export function useTorrentActions({ instanceId, onActionComplete }: UseTorrentAc
     ratioLimit: number,
     seedingTimeLimit: number,
     inactiveSeedingTimeLimit: number,
-    hashes: string[]
+    hashes: string[],
+    isAllSelected?: boolean,
+    filters?: TorrentActionData["filters"],
+    search?: string,
+    excludeHashes?: string[],
+    clientMeta?: ClientMeta
   ) => {
+    const clientHashes = clientMeta?.clientHashes ?? hashes
+    const clientCount = clientMeta?.totalSelected
+      ?? (clientHashes?.length ?? hashes.length)
     await mutation.mutateAsync({
       action: "setShareLimit",
-      hashes,
+      hashes: isAllSelected ? [] : hashes,
+      selectAll: isAllSelected,
+      filters: isAllSelected ? filters : undefined,
+      search: isAllSelected ? search : undefined,
+      excludeHashes: isAllSelected ? excludeHashes : undefined,
       ratioLimit,
       seedingTimeLimit,
       inactiveSeedingTimeLimit,
+      clientHashes,
+      clientCount,
     })
     setContextHashes([])
     setContextTorrents([])
@@ -369,14 +411,40 @@ export function useTorrentActions({ instanceId, onActionComplete }: UseTorrentAc
   const handleSetSpeedLimits = useCallback(async (
     uploadLimit: number,
     downloadLimit: number,
-    hashes: string[]
+    hashes: string[],
+    isAllSelected?: boolean,
+    filters?: TorrentActionData["filters"],
+    search?: string,
+    excludeHashes?: string[],
+    clientMeta?: ClientMeta
   ) => {
+    const clientHashes = clientMeta?.clientHashes ?? hashes
+    const clientCount = clientMeta?.totalSelected
+      ?? (clientHashes?.length ?? hashes.length)
+    const sharedOptions = {
+      selectAll: isAllSelected,
+      filters: isAllSelected ? filters : undefined,
+      search: isAllSelected ? search : undefined,
+      excludeHashes: isAllSelected ? excludeHashes : undefined,
+      clientHashes,
+      clientCount,
+    }
     const promises = []
     if (uploadLimit >= 0) {
-      promises.push(mutation.mutateAsync({ action: "setUploadLimit", hashes, uploadLimit }))
+      promises.push(mutation.mutateAsync({
+        action: "setUploadLimit",
+        hashes: isAllSelected ? [] : hashes,
+        uploadLimit,
+        ...sharedOptions,
+      }))
     }
     if (downloadLimit >= 0) {
-      promises.push(mutation.mutateAsync({ action: "setDownloadLimit", hashes, downloadLimit }))
+      promises.push(mutation.mutateAsync({
+        action: "setDownloadLimit",
+        hashes: isAllSelected ? [] : hashes,
+        downloadLimit,
+        ...sharedOptions,
+      }))
     }
     if (promises.length > 0) {
       await Promise.all(promises)
@@ -390,8 +458,12 @@ export function useTorrentActions({ instanceId, onActionComplete }: UseTorrentAc
     isAllSelected?: boolean,
     filters?: TorrentActionData["filters"],
     search?: string,
-    excludeHashes?: string[]
+    excludeHashes?: string[],
+    clientMeta?: ClientMeta
   ) => {
+    const clientHashes = clientMeta?.clientHashes ?? hashes
+    const clientCount = clientMeta?.totalSelected
+      ?? (clientHashes?.length ?? hashes.length)
     await mutation.mutateAsync({
       action: "recheck",
       hashes: isAllSelected ? [] : hashes,
@@ -399,6 +471,8 @@ export function useTorrentActions({ instanceId, onActionComplete }: UseTorrentAc
       filters: isAllSelected ? filters : undefined,
       search: isAllSelected ? search : undefined,
       excludeHashes: isAllSelected ? excludeHashes : undefined,
+      clientHashes,
+      clientCount,
     })
     setShowRecheckDialog(false)
     setContextHashes([])
@@ -409,8 +483,12 @@ export function useTorrentActions({ instanceId, onActionComplete }: UseTorrentAc
     isAllSelected?: boolean,
     filters?: TorrentActionData["filters"],
     search?: string,
-    excludeHashes?: string[]
+    excludeHashes?: string[],
+    clientMeta?: ClientMeta
   ) => {
+    const clientHashes = clientMeta?.clientHashes ?? hashes
+    const clientCount = clientMeta?.totalSelected
+      ?? (clientHashes?.length ?? hashes.length)
     await mutation.mutateAsync({
       action: "reannounce",
       hashes: isAllSelected ? [] : hashes,
@@ -418,6 +496,8 @@ export function useTorrentActions({ instanceId, onActionComplete }: UseTorrentAc
       filters: isAllSelected ? filters : undefined,
       search: isAllSelected ? search : undefined,
       excludeHashes: isAllSelected ? excludeHashes : undefined,
+      clientHashes,
+      clientCount,
     })
     setShowReannounceDialog(false)
     setContextHashes([])
@@ -429,8 +509,12 @@ export function useTorrentActions({ instanceId, onActionComplete }: UseTorrentAc
     isAllSelected?: boolean,
     filters?: TorrentActionData["filters"],
     search?: string,
-    excludeHashes?: string[]
+    excludeHashes?: string[],
+    clientMeta?: ClientMeta
   ) => {
+    const clientHashes = clientMeta?.clientHashes ?? hashes
+    const clientCount = clientMeta?.totalSelected
+      ?? (clientHashes?.length ?? hashes.length)
     await mutation.mutateAsync({
       action: "setLocation",
       location,
@@ -439,6 +523,8 @@ export function useTorrentActions({ instanceId, onActionComplete }: UseTorrentAc
       filters: isAllSelected ? filters : undefined,
       search: isAllSelected ? search : undefined,
       excludeHashes: isAllSelected ? excludeHashes : undefined,
+      clientHashes,
+      clientCount,
     })
     setShowLocationDialog(false)
     setContextHashes([])


### PR DESCRIPTION
- ensure every bulk torrent action propagates client-side selection metadata so optimistic cache updates and toasts stay in sync across management bar, table, and mobile views
- closes #214 by keeping filtered "select all" operations accurate for delete, queue, recheck, reannounce, share/speed limits, and tag/category workflows

Supersedes #196