### PR TITLE
fix(web): raise mobile scroll button

### DIFF
--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -1651,7 +1651,7 @@ export function TorrentCardsMobile({
       <div className="sm:hidden">
         <ScrollToTopButton
           scrollContainerRef={parentRef}
-          className="bottom-24 right-4"
+          className="bottom-28 right-4"
         />
       </div>
     </div>


### PR DESCRIPTION
Lift the mobile `ScrollToTopButton` to avoid overlap with the bottom navigation