### PR TITLE
fix(server): respect baseUrl when serving web UI

### DIFF
--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -66,7 +66,8 @@ func (h *Handler) RegisterRoutes(r chi.Router) {
 	r.Get("/pwa-512x512.png", h.serveAssets)
 	r.Get("/swizzin.png", h.serveAssets)
 
-	// SPA catch-all route
+	// SPA routes
+	r.Get("/", h.serveSPA)
 	r.Get("/*", h.serveSPA)
 }
 


### PR DESCRIPTION
Respect baseUrl when serving web UI
- mount the embedded frontend router beneath the configured baseUrl so `/qui/assets/...` resolves correctly
- add an explicit SPA root handler to serve `index.html` for both `/qui` and `/qui/`