### PR TITLE
fix(web): guard speed formatter against NaN

### DIFF
--- a/web/src/lib/speedUnits.ts
+++ b/web/src/lib/speedUnits.ts
@@ -5,7 +5,7 @@
 
 // Speed units utilities for toggling between B/s and bps display
 
-import { useState, useEffect } from "react"
+import { useEffect, useState } from "react"
 
 // Speed unit types
 export type SpeedUnit = "bytes" | "bits"
@@ -53,7 +53,7 @@ export function formatSpeedWithUnit(
   unit: SpeedUnit,
   compact: boolean = false
 ): string {
-  if (!bytesPerSecond || bytesPerSecond === 0) {
+  if (!Number.isFinite(bytesPerSecond) || bytesPerSecond <= 0) {
     if (compact) return "0"
     return unit === "bits" ? "0 bps" : "0 B/s"
   }
@@ -62,16 +62,29 @@ export function formatSpeedWithUnit(
     // Convert bytes to bits (multiply by 8)
     const bitsPerSecond = bytesPerSecond * 8
     const k = 1000 // Use decimal for bits (standard networking convention)
-    const sizes = compact ? ["bps", "Kbps", "Mbps", "Gbps"] : ["bps", "Kbps", "Mbps", "Gbps"]
-    const i = Math.floor(Math.log(bitsPerSecond) / Math.log(k))
-    const value = parseFloat((bitsPerSecond / Math.pow(k, i)).toFixed(i > 0 ? 1 : 0))
-    return `${value} ${sizes[i]}`
+    const sizes = compact ? ["bps", "Kbps", "Mbps", "Gbps", "Tbps"] : ["bps", "Kbps", "Mbps", "Gbps", "Tbps"]
+    const rawIndex = Math.log(bitsPerSecond) / Math.log(k)
+    const i = Math.min(sizes.length - 1, Math.max(0, Math.floor(rawIndex)))
+    const value = bitsPerSecond / Math.pow(k, i)
+    const decimals = value >= 100 ? 0 : value >= 10 ? 1 : 2
+    const formatted = Number(value.toFixed(decimals))
+    if (formatted === 0) {
+      return compact ? "0" : "0 bps"
+    }
+    return `${formatted} ${sizes[i]}`
   } else {
     // Use existing bytes format
     const k = 1024
-    const sizes = compact ? ["B", "KiB", "MiB", "GiB"] : ["B/s", "KiB/s", "MiB/s", "GiB/s"]
-    const i = Math.floor(Math.log(bytesPerSecond) / Math.log(k))
-    const value = parseFloat((bytesPerSecond / Math.pow(k, i)).toFixed(i > 0 ? 1 : 0))
-    return `${value}${compact ? "" : " "}${sizes[i]}`
+    const sizes = compact ? ["B", "KiB", "MiB", "GiB", "TiB"] : ["B/s", "KiB/s", "MiB/s", "GiB/s", "TiB/s"]
+    const rawIndex = Math.log(bytesPerSecond) / Math.log(k)
+    const i = Math.min(sizes.length - 1, Math.max(0, Math.floor(rawIndex)))
+    const value = bytesPerSecond / Math.pow(k, i)
+    const decimals = value >= 100 ? 0 : value >= 10 ? 1 : 2
+    const formatted = Number(value.toFixed(decimals))
+    if (formatted === 0) {
+      if (compact) return "0"
+      return "0 B/s"
+    }
+    return `${formatted}${compact ? "" : " "}${sizes[i]}`
   }
 }


### PR DESCRIPTION
Ensure torrents with no downloaded data render 0 speeds instead of `NaN undefined`

Closes #234 