### PR TITLE
fix(web): normalize torrent hash fallbacks

### DIFF
--- a/web/src/components/torrents/TorrentContextMenu.tsx
+++ b/web/src/components/torrents/TorrentContextMenu.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { memo, useCallback } from "react"
+import { memo, useCallback, useMemo } from "react"
 import {
   ContextMenu,
   ContextMenuContent,
@@ -31,7 +31,7 @@ import { TORRENT_ACTIONS } from "@/hooks/useTorrentActions"
 import { QueueSubmenu } from "./QueueSubmenu"
 import { ShareLimitSubmenu, SpeedLimitsSubmenu } from "./TorrentLimitSubmenus"
 import { getLinuxIsoName, useIncognitoMode } from "@/lib/incognito"
-import { useMemo } from "react"
+import { getTorrentDisplayHash } from "@/lib/torrent-utils"
 
 interface TorrentContextMenuProps {
   children: React.ReactNode
@@ -85,6 +85,17 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
       toast.error("Failed to copy to clipboard")
     }
   }, [])
+
+  const displayHash = useMemo(() => getTorrentDisplayHash(torrent), [torrent])
+
+  const copyHash = useCallback(() => {
+    const value = displayHash || torrent.hash
+    if (!value) {
+      toast.error("Hash not available")
+      return
+    }
+    void copyToClipboard(value, "hash")
+  }, [copyToClipboard, displayHash, torrent.hash])
 
   // Determine if we should use selection or just this torrent
   const useSelection = isSelected || isAllSelected
@@ -254,7 +265,7 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
           <Copy className="mr-2 h-4 w-4" />
           Copy Name
         </ContextMenuItem>
-        <ContextMenuItem onClick={() => copyToClipboard(torrent.hash, "hash")}>
+        <ContextMenuItem onClick={copyHash}>
           <Copy className="mr-2 h-4 w-4" />
           Copy Hash
         </ContextMenuItem>

--- a/web/src/components/torrents/TorrentDetailsPanel.tsx
+++ b/web/src/components/torrents/TorrentDetailsPanel.tsx
@@ -16,6 +16,7 @@ import { Textarea } from "@/components/ui/textarea"
 import { useInstanceMetadata } from "@/hooks/useInstanceMetadata"
 import { api } from "@/lib/api"
 import { formatSpeedWithUnit, useSpeedUnits } from "@/lib/speedUnits"
+import { resolveTorrentHashes } from "@/lib/torrent-utils"
 import { formatBytes, formatDuration, formatTimestamp } from "@/lib/utils"
 import type { Torrent } from "@/types"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
@@ -115,6 +116,8 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
     gcTime: 5 * 60 * 1000, // Keep in cache for 5 minutes
   })
 
+  const { infohashV1: resolvedInfohashV1, infohashV2: resolvedInfohashV2 } = resolveTorrentHashes(properties as { hash?: string; infohash_v1?: string; infohash_v2?: string } | undefined, torrent ?? undefined)
+
   // Fetch torrent trackers
   const { data: trackers, isLoading: loadingTrackers } = useQuery({
     queryKey: ["torrent-trackers", instanceId, torrent?.hash],
@@ -134,21 +137,24 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
   })
 
   // Fetch torrent peers with optimized refetch
+  const isPeersTabActive = activeTab === "peers"
+  const peersQueryKey = ["torrent-peers", instanceId, torrent?.hash] as const
+
   const { data: peersData, isLoading: loadingPeers } = useQuery<TorrentPeersResponse>({
-    queryKey: ["torrent-peers", instanceId, torrent?.hash],
+    queryKey: peersQueryKey,
     queryFn: async () => {
       const data = await api.getTorrentPeers(instanceId, torrent!.hash)
       return data as TorrentPeersResponse
     },
-    enabled: !!torrent && isReady,
-    // Only refetch when tab is active and document is visible
+    enabled: !!torrent && isReady && isPeersTabActive,
     refetchInterval: () => {
-      if (activeTab === "peers" && document.visibilityState === "visible" && isReady) {
+      if (!isPeersTabActive) return false
+      if (typeof document !== "undefined" && document.visibilityState === "visible") {
         return 2000
       }
       return false
     },
-    staleTime: activeTab === "peers" ? 0 : 30000, // No stale time when viewing peers
+    staleTime: 0,
     gcTime: 5 * 60 * 1000,
   })
 
@@ -434,34 +440,34 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
                           <p className="text-xs text-muted-foreground">Info Hash v1</p>
                           <div className="flex items-center gap-2">
                             <div className="text-xs font-mono bg-background/50 p-2.5 rounded flex-1 break-all select-text">
-                              {properties.infohash_v1 && properties.infohash_v1.length > 0 ? properties.infohash_v1 : "N/A"}
+                              {resolvedInfohashV1 || "N/A"}
                             </div>
-                            {properties.infohash_v1 && properties.infohash_v1.length > 0 && (
+                            {resolvedInfohashV1 && (
                               <Button
                                 variant="ghost"
                                 size="icon"
                                 className="h-8 w-8 shrink-0"
-                                onClick={() => copyToClipboard(properties.infohash_v1, "Info Hash v1")}
+                                onClick={() => copyToClipboard(resolvedInfohashV1, "Info Hash v1")}
                               >
                                 <Copy className="h-3.5 w-3.5" />
                               </Button>
                             )}
                           </div>
                         </div>
-                        {properties.infohash_v2 && properties.infohash_v2.length > 0 && (
+                        {resolvedInfohashV2 && (
                           <>
                             <Separator className="opacity-50" />
                             <div className="space-y-2">
                               <p className="text-xs text-muted-foreground">Info Hash v2</p>
                               <div className="flex items-center gap-2">
                                 <div className="text-xs font-mono bg-background/50 p-2.5 rounded flex-1 break-all select-text">
-                                  {properties.infohash_v2}
+                                  {resolvedInfohashV2}
                                 </div>
                                 <Button
                                   variant="ghost"
                                   size="icon"
                                   className="h-8 w-8 shrink-0"
-                                  onClick={() => copyToClipboard(properties.infohash_v2, "Info Hash v2")}
+                                  onClick={() => copyToClipboard(resolvedInfohashV2, "Info Hash v2")}
                                 >
                                   <Copy className="h-3.5 w-3.5" />
                                 </Button>


### PR DESCRIPTION
Fix:
- centralize torrent hash normalization so v1/v2 fields fall back to the legacy hash when servers omit them
- reuse the helper in the details panel and context menu so copy + display work on qBittorrent 4.3.x without extra API calls

New:
- keep the peers query tab-gated while leaving existing reopen behavior untouched