### PR TITLE
refactor(client-api-keys): derive proxy instructions client-side

### DIFF
--- a/internal/api/handlers/client_api_keys.go
+++ b/internal/api/handlers/client_api_keys.go
@@ -36,7 +36,6 @@ type CreateClientAPIKeyResponse struct {
 	ClientAPIKey *models.ClientAPIKey `json:"clientApiKey"`
 	Instance     *models.Instance     `json:"instance,omitempty"`
 	ProxyURL     string               `json:"proxyUrl"`
-	Instructions string               `json:"instructions"`
 }
 
 type ClientAPIKeyWithInstance struct {
@@ -85,16 +84,14 @@ func (h *ClientAPIKeysHandler) CreateClientAPIKey(w http.ResponseWriter, r *http
 		return
 	}
 
-	// Generate proxy URL and instructions
+	// Generate proxy URL
 	proxyURL := "/proxy/" + rawKey
-	instructions := generateProxyInstructions(req.ClientName, proxyURL, instance.Host)
 
 	response := CreateClientAPIKeyResponse{
 		Key:          rawKey,
 		ClientAPIKey: clientAPIKey,
 		Instance:     instance,
 		ProxyURL:     proxyURL,
-		Instructions: instructions,
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -164,22 +161,4 @@ func (h *ClientAPIKeysHandler) DeleteClientAPIKey(w http.ResponseWriter, r *http
 	}
 
 	w.WriteHeader(http.StatusNoContent)
-}
-
-// generateProxyInstructions creates usage instructions for different client types
-func generateProxyInstructions(clientName, proxyURL, instanceHost string) string {
-	switch clientName {
-	case "Sonarr", "sonarr":
-		return "In Sonarr, set the qBittorrent host to your qui server URL + '" + proxyURL + "'. " +
-			"Example: If qui runs on http://localhost:8080, use http://localhost:8080" + proxyURL
-	case "Radarr", "radarr":
-		return "In Radarr, set the qBittorrent host to your qui server URL + '" + proxyURL + "'. " +
-			"Example: If qui runs on http://localhost:8080, use http://localhost:8080" + proxyURL
-	case "Lidarr", "lidarr":
-		return "In Lidarr, set the qBittorrent host to your qui server URL + '" + proxyURL + "'. " +
-			"Example: If qui runs on http://localhost:8080, use http://localhost:8080" + proxyURL
-	default:
-		return "Replace your qBittorrent host (" + instanceHost + ") with your qui server URL + '" + proxyURL + "'. " +
-			"Example: If qui runs on http://localhost:8080, use http://localhost:8080" + proxyURL
-	}
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -414,7 +414,6 @@ class ApiClient {
       host: string
     }
     proxyUrl: string
-    instructions: string
   }> {
     return this.request("/client-api-keys", {
       method: "POST",


### PR DESCRIPTION
Refactor client API key instructions rendering

- remove backend-generated instructions for client API keys and rely on proxy URL payload
- render tailored setup guidance in the UI based on client name with richer formatting
- adjust API typings and dialog copy to match the simplified server response

Old:
<img width="1434" height="1224" alt="CleanShot 2025-09-22 at 20 38 58@2x" src="https://github.com/user-attachments/assets/e8346bf5-9ff7-4370-a916-81b2ef59c5c7" />

New:
<img width="1424" height="1080" alt="CleanShot 2025-09-22 at 20 37 48@2x" src="https://github.com/user-attachments/assets/65e3d555-3a16-4a49-88d8-5741a9984bf6" />
