### PR TITLE
refactor(proxy): tighten reverse proxy request preparation

### DIFF
--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -4,6 +4,7 @@
 package proxy
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httputil"
@@ -24,6 +25,23 @@ type Handler struct {
 	instanceStore     *models.InstanceStore
 	bufferPool        *BufferPool
 	proxy             *httputil.ReverseProxy
+}
+
+const (
+	proxyContextKey   contextKey = "proxy_request_context"
+	proxyErrorPayload string     = `{"error":"Failed to connect to qBittorrent instance"}`
+)
+
+type basicAuthCredentials struct {
+	username string
+	password string
+}
+
+type proxyContext struct {
+	instanceID  int
+	instanceURL *url.URL
+	httpClient  *http.Client
+	basicAuth   *basicAuthCredentials
 }
 
 // NewHandler creates a new proxy handler
@@ -49,6 +67,13 @@ func NewHandler(clientPool *qbittorrent.ClientPool, clientAPIKeyStore *models.Cl
 
 // ServeHTTP handles the reverse proxy request
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	proxyCtx, err := h.prepareProxyContext(r)
+	if err != nil {
+		h.writeProxyError(w)
+		return
+	}
+
+	r = r.WithContext(context.WithValue(r.Context(), proxyContextKey, proxyCtx))
 	h.proxy.ServeHTTP(w, r)
 }
 
@@ -57,39 +82,22 @@ func (h *Handler) rewriteRequest(pr *httputil.ProxyRequest) {
 	ctx := pr.In.Context()
 	instanceID := GetInstanceIDFromContext(ctx)
 	clientAPIKey := GetClientAPIKeyFromContext(ctx)
+	proxyCtx, ok := getProxyContext(ctx)
 
-	if instanceID == 0 || clientAPIKey == nil {
+	if instanceID == 0 || clientAPIKey == nil || !ok || proxyCtx == nil {
 		log.Error().Msg("Missing instance ID or client API key in proxy request context")
 		return
 	}
 
-	// Get the instance details to get the host
-	instance, err := h.instanceStore.Get(ctx, instanceID)
-	if err != nil {
-		log.Error().Err(err).Int("instanceId", instanceID).Msg("Failed to get instance")
+	instanceURL := proxyCtx.instanceURL
+	if instanceURL == nil {
+		log.Error().Int("instanceId", instanceID).Msg("Proxy context missing target URL")
 		return
 	}
 
-	// Parse the instance host to get the target URL
-	instanceURL, err := url.Parse(instance.Host)
-	if err != nil {
-		log.Error().Err(err).Str("host", instance.Host).Msg("Failed to parse instance host")
-		return
-	}
-
-	// Get the authenticated qBittorrent client from the pool
-	client, err := h.clientPool.GetClient(ctx, instanceID)
-	if err != nil {
-		log.Error().Err(err).Int("instanceId", instanceID).Msg("Failed to get qBittorrent client from pool")
-		return
-	}
-
-	// Get the HTTP client with cookie jar from the authenticated qBittorrent client
-	// TODO: When go-qbittorrent merges GetHTTPClient, change this to: client.Client.GetHTTPClient()
-	httpClient := client.GetHTTPClient()
-	if httpClient != nil && httpClient.Jar != nil {
+	if proxyCtx.httpClient != nil && proxyCtx.httpClient.Jar != nil {
 		// Get cookies for the target URL from the cookie jar
-		cookies := httpClient.Jar.Cookies(instanceURL)
+		cookies := proxyCtx.httpClient.Jar.Cookies(instanceURL)
 		if len(cookies) > 0 {
 			var cookiePairs []string
 			for _, cookie := range cookies {
@@ -102,6 +110,12 @@ func (h *Handler) rewriteRequest(pr *httputil.ProxyRequest) {
 		}
 	} else {
 		log.Debug().Int("instanceId", instanceID).Msg("No HTTP client or cookie jar available")
+	}
+
+	if proxyCtx.basicAuth != nil {
+		pr.Out.SetBasicAuth(proxyCtx.basicAuth.username, proxyCtx.basicAuth.password)
+	} else {
+		pr.Out.Header.Del("Authorization")
 	}
 
 	// Strip the proxy prefix from the path
@@ -131,8 +145,21 @@ func (h *Handler) rewriteRequest(pr *httputil.ProxyRequest) {
 	pr.Out.Host = instanceURL.Host
 
 	// Add headers to identify the proxy
-	pr.Out.Header.Set("X-Forwarded-For", pr.In.RemoteAddr)
-	pr.Out.Header.Set("X-Forwarded-Proto", pr.In.URL.Scheme)
+	if prior := pr.In.Header["X-Forwarded-For"]; len(prior) > 0 {
+		pr.Out.Header["X-Forwarded-For"] = append([]string(nil), prior...)
+	}
+	forwardedProto := pr.In.Header.Get("X-Forwarded-Proto")
+	forwardedHost := pr.In.Header.Get("X-Forwarded-Host")
+	if forwardedHost != "" {
+		pr.Out.Header.Set("X-Forwarded-Host", forwardedHost)
+	}
+	pr.SetXForwarded()
+	if forwardedProto != "" {
+		pr.Out.Header.Set("X-Forwarded-Proto", forwardedProto)
+	}
+	if forwardedHost != "" {
+		pr.Out.Header.Set("X-Forwarded-Host", forwardedHost)
+	}
 	pr.Out.Header.Set("X-Qui-Client", clientAPIKey.ClientName)
 }
 
@@ -164,13 +191,7 @@ func (h *Handler) errorHandler(w http.ResponseWriter, r *http.Request, err error
 		Str("path", r.URL.Path).
 		Msg("Proxy request failed")
 
-	// Return a generic error to avoid leaking internal details
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusBadGateway)
-
-	// Return qBittorrent-style error response
-	errorResponse := `{"error":"Failed to connect to qBittorrent instance"}`
-	w.Write([]byte(errorResponse))
+	h.writeProxyError(w)
 }
 
 // Routes sets up the proxy routes
@@ -183,4 +204,85 @@ func (h *Handler) Routes(r chi.Router) {
 		// Handle all requests under this prefix
 		r.HandleFunc("/*", h.ServeHTTP)
 	})
+}
+
+func (h *Handler) prepareProxyContext(r *http.Request) (*proxyContext, error) {
+	ctx := r.Context()
+	instanceID := GetInstanceIDFromContext(ctx)
+	clientAPIKey := GetClientAPIKeyFromContext(ctx)
+
+	logger := log.With().
+		Int("instanceId", instanceID).
+		Str("method", r.Method).
+		Str("path", r.URL.Path).
+		Logger()
+
+	if clientAPIKey != nil {
+		logger = logger.With().Str("client", clientAPIKey.ClientName).Logger()
+	}
+
+	if instanceID == 0 || clientAPIKey == nil {
+		logger.Error().Msg("Proxy request missing instance ID or client API key")
+		return nil, fmt.Errorf("missing proxy context")
+	}
+
+	instance, err := h.instanceStore.Get(ctx, instanceID)
+	if err != nil {
+		if err == models.ErrInstanceNotFound {
+			logger.Warn().Msg("Instance not found for proxy request")
+		} else {
+			logger.Error().Err(err).Msg("Failed to load instance for proxy request")
+		}
+		return nil, err
+	}
+
+	instanceURL, err := url.Parse(instance.Host)
+	if err != nil {
+		logger.Error().Err(err).Str("host", instance.Host).Msg("Failed to parse instance host for proxy request")
+		return nil, err
+	}
+
+	client, err := h.clientPool.GetClient(ctx, instanceID)
+	if err != nil {
+		logger.Error().Err(err).Msg("Failed to get qBittorrent client from pool for proxy request")
+		return nil, err
+	}
+
+	var basicAuth *basicAuthCredentials
+	if instance.BasicUsername != nil && *instance.BasicUsername != "" {
+		password, err := h.instanceStore.GetDecryptedBasicPassword(instance)
+		if err != nil {
+			logger.Error().Err(err).Msg("Failed to decrypt basic auth password for proxy request")
+			return nil, err
+		}
+		if password != nil {
+			basicAuth = &basicAuthCredentials{
+				username: *instance.BasicUsername,
+				password: *password,
+			}
+		}
+	}
+
+	proxyCtx := &proxyContext{
+		instanceID:  instanceID,
+		instanceURL: instanceURL,
+		httpClient:  client.GetHTTPClient(),
+		basicAuth:   basicAuth,
+	}
+
+	return proxyCtx, nil
+}
+
+func getProxyContext(ctx context.Context) (*proxyContext, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	proxyCtx, ok := ctx.Value(proxyContextKey).(*proxyContext)
+	return proxyCtx, ok
+}
+
+func (h *Handler) writeProxyError(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadGateway)
+	_, _ = w.Write([]byte(proxyErrorPayload))
 }


### PR DESCRIPTION
Refactor proxy request preparation
- preflight proxy requests so we can fail fast with a 502 when prerequisites like instance lookup or pool acquisition fail
- reuse authenticated cookie jars and propagate stored HTTP Basic credentials to avoid 401s against protected instances
- normalize forwarded headers and centralize proxy error responses for cleaner downstream behavior