### PR TITLE
feat(config): add log rotation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ QUI__SESSION_SECRET=...  # Auto-generated if not set
 # Logging
 QUI__LOG_LEVEL=INFO      # Options: ERROR, DEBUG, INFO, WARN, TRACE
 QUI__LOG_PATH=...        # Optional: log file path
+QUI__LOG_MAX_SIZE=50     # Optional: rotate when log file exceeds N megabytes (default: 50)
+QUI__LOG_MAX_BACKUPS=3   # Optional: retain N rotated files (default: 3, 0 keeps all)
 
 # Storage
 QUI__DATA_DIR=...        # Optional: custom data directory (default: next to config)
@@ -97,6 +99,8 @@ QUI__METRICS_HOST=127.0.0.1  # Optional: metrics server bind address (default: 1
 QUI__METRICS_PORT=9074       # Optional: metrics server port (default: 9074)
 QUI__METRICS_BASIC_AUTH_USERS=user:hash  # Optional: basic auth for metrics (bcrypt hashed)
 ```
+
+When `logPath` is set the server writes to disk using size-based rotation. Adjust `logMaxSize` and `logMaxBackups` in `config.toml` or the corresponding environment variables shown above to control the rotation thresholds and retention.
 
 ## CLI Commands
 

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.42.0
 	golang.org/x/term v0.35.0
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.39.0
 )

--- a/go.sum
+++ b/go.sum
@@ -232,6 +232,8 @@ google.golang.org/protobuf v1.36.8/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXn
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/api/middleware/logger.go
+++ b/internal/api/middleware/logger.go
@@ -39,7 +39,7 @@ func Logger(logger zerolog.Logger) func(next http.Handler) http.Handler {
 				l.Trace().
 					Str("type", "access").
 					Timestamp().
-					Fields(map[string]interface{}{
+					Fields(map[string]any{
 						"remote_ip":  r.RemoteAddr,
 						"url":        r.URL.Path,
 						"proto":      r.Proto,

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -12,6 +12,8 @@ type Config struct {
 	SessionSecret         string `toml:"sessionSecret" mapstructure:"sessionSecret"`
 	LogLevel              string `toml:"logLevel" mapstructure:"logLevel"`
 	LogPath               string `toml:"logPath" mapstructure:"logPath"`
+	LogMaxSize            int    `toml:"logMaxSize" mapstructure:"logMaxSize"`
+	LogMaxBackups         int    `toml:"logMaxBackups" mapstructure:"logMaxBackups"`
 	DataDir               string `toml:"dataDir" mapstructure:"dataDir"`
 	CheckForUpdates       bool   `toml:"checkForUpdates" mapstructure:"checkForUpdates"`
 	PprofEnabled          bool   `toml:"pprofEnabled" mapstructure:"pprofEnabled"`


### PR DESCRIPTION
- add configurable log size and backup limits alongside existing log path option
- switch file logging to lumberjack so qui rotates logs automatically when they grow too large
- document new environment variables and rotation behavior in the README