### PR TITLE
fix(web): remove trailing punctuation from clickable links

### DIFF
--- a/web/src/components/torrents/TorrentDetailsPanel.tsx
+++ b/web/src/components/torrents/TorrentDetailsPanel.tsx
@@ -508,7 +508,7 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
                           {properties.created_by && (
                             <div>
                               <p className="text-xs text-muted-foreground mb-1">Created By</p>
-                              <p className="text-sm">{properties.created_by}</p>
+                              <div className="text-sm">{renderTextWithLinks(properties.created_by)}</div>
                             </div>
                           )}
                           {properties.comment && (

--- a/web/src/lib/linkUtils.tsx
+++ b/web/src/lib/linkUtils.tsx
@@ -22,16 +22,24 @@ export function renderTextWithLinks(text: string): React.ReactNode {
     // Check if this part is a URL
     if (URL_REGEX.test(part)) {
       URL_REGEX.lastIndex = 0 // Reset regex state
+      
+      // Remove trailing punctuation from URLs
+      const trailingPunctuationMatch = part.match(/^(.*?)([\)\]\}.,;!?]*?)$/);
+      const cleanUrl = trailingPunctuationMatch ? trailingPunctuationMatch[1] : part;
+      const trailingPunctuation = trailingPunctuationMatch ? trailingPunctuationMatch[2] : '';
+      
       return (
-        <a
-          key={index}
-          href={part}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-primary hover:underline break-all"
-        >
-          {part}
-        </a>
+        <React.Fragment key={index}>
+          <a
+            href={cleanUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary hover:underline break-all"
+          >
+            {cleanUrl}
+          </a>
+          {trailingPunctuation && <span>{trailingPunctuation}</span>}
+        </React.Fragment>
       )
     }
     


### PR DESCRIPTION
- Adjusts `created_by` field to present clickable links - useful when applications inject links into this field.
- Fixes link regex to remove trailing brackets noticed, with above.