### PR TITLE
feat(web): report tracker error in torrent table

### DIFF
--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -31,6 +31,7 @@ import {
   getCoreRowModel,
   useReactTable
 } from "@tanstack/react-table"
+
 import { useVirtualizer } from "@tanstack/react-virtual"
 import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { TorrentContextMenu } from "./TorrentContextMenu"
@@ -96,7 +97,7 @@ const DEFAULT_COLUMN_SIZING = {}
 
 // Helper function to get default column order (module scope for stable reference)
 function getDefaultColumnOrder(): string[] {
-  const cols = createColumns(false, undefined, "bytes")
+  const cols = createColumns(false, undefined, "bytes", undefined)
   return cols.map(col => {
     if ("id" in col && col.id) return col.id
     if ("accessorKey" in col && typeof col.accessorKey === "string") return col.accessorKey
@@ -457,8 +458,8 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({ insta
       onRowSelection: handleRowSelection,
       isAllSelected,
       excludedFromSelectAll,
-    }, speedUnit),
-    [incognitoMode, speedUnit, handleSelectAll, isSelectAllChecked, isSelectAllIndeterminate, handleRowSelection, isAllSelected, excludedFromSelectAll]
+    }, speedUnit, instanceId),
+    [incognitoMode, speedUnit, instanceId, handleSelectAll, isSelectAllChecked, isSelectAllIndeterminate, handleRowSelection, isAllSelected, excludedFromSelectAll]
   )
 
   const table = useReactTable({


### PR DESCRIPTION
This actually works much quicker than I was expecting, with no noticeable delay.

Fetch torrent tracker status and report when trackers are in error.
Appropriate check for multiple tracker torrents.

<img width="382" height="554" alt="Screenshot 2025-09-24 215114" src="https://github.com/user-attachments/assets/d64dcfbb-d12d-4528-a628-1634f5b763b3" />
