### PR TITLE
feat(web): show app version in sidebar

### DIFF
--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -203,8 +203,8 @@ func (h *Handler) serveSPA(w http.ResponseWriter, r *http.Request) {
 		baseURL += "/"
 	}
 
-	// Create the script tag to inject
-	scriptTag := fmt.Sprintf(`<script>window.__QUI_BASE_URL__="%s";</script>`, baseURL)
+	// Create the script tag to inject both base URL and version metadata
+	scriptTag := fmt.Sprintf(`<script>window.__QUI_BASE_URL__=%q;window.__QUI_VERSION__=%q;</script>`, baseURL, h.version)
 
 	// Inject before the closing </head> tag
 	modifiedContent := strings.Replace(

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -149,11 +149,11 @@ export function Sidebar() {
 
         <div className="flex items-center justify-between px-3 pb-3">
           <div className="flex flex-col gap-1 text-[10px] text-sidebar-foreground/40 select-none">
+            <span className="font-medium text-sidebar-foreground/50">Version {appVersion}</span>
             <div className="flex items-center gap-1">
               <Copyright className="h-2.5 w-2.5" />
               <span>{new Date().getFullYear()} autobrr</span>
             </div>
-            <span className="font-medium text-sidebar-foreground/50">Version {appVersion}</span>
           </div>
           <Button
             variant="ghost"

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -11,6 +11,7 @@ import { UpdateBanner } from "@/components/ui/UpdateBanner"
 import { useAuth } from "@/hooks/useAuth"
 import { useTheme } from "@/hooks/useTheme"
 import { api } from "@/lib/api"
+import { getAppVersion } from "@/lib/build-info"
 import { cn } from "@/lib/utils"
 import { useQuery } from "@tanstack/react-query"
 import { Link, useLocation } from "@tanstack/react-router"
@@ -57,6 +58,8 @@ export function Sidebar() {
     queryKey: ["instances"],
     queryFn: () => api.getInstances(),
   })
+
+  const appVersion = getAppVersion()
 
   return (
     <div className="flex h-full w-64 flex-col border-r bg-sidebar border-sidebar-border">
@@ -145,11 +148,12 @@ export function Sidebar() {
         <Separator className="mx-3 mb-3" />
 
         <div className="flex items-center justify-between px-3 pb-3">
-          <div className="flex items-center gap-1.5">
-            <div className="flex items-center gap-1 text-[10px] text-sidebar-foreground/40 select-none">
+          <div className="flex flex-col gap-1 text-[10px] text-sidebar-foreground/40 select-none">
+            <div className="flex items-center gap-1">
               <Copyright className="h-2.5 w-2.5" />
               <span>{new Date().getFullYear()} autobrr</span>
             </div>
+            <span className="font-medium text-sidebar-foreground/50">Version {appVersion}</span>
           </div>
           <Button
             variant="ghost"

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -505,8 +505,16 @@ class ApiClient {
     published_at: string
   } | null> {
     try {
-      return await this.request("/version/latest")
-    } catch (error) {
+      const response = await this.request<{
+        tag_name: string
+        name?: string
+        html_url: string
+        published_at: string
+      } | null>("/version/latest")
+
+      // Treat empty responses as no update available
+      return response ?? null
+    } catch {
       // Return null if no update available (204 status) or any error
       return null
     }

--- a/web/src/lib/build-info.ts
+++ b/web/src/lib/build-info.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+const FALLBACK_VERSION = "0.0.0-dev"
+
+export function getAppVersion(): string {
+  if (typeof window === "undefined") {
+    return FALLBACK_VERSION
+  }
+
+  const version = window.__QUI_VERSION__
+  if (!version || version.trim() === "") {
+    return FALLBACK_VERSION
+  }
+
+  return version
+}

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -5,3 +5,11 @@
 
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-pwa/client" />
+
+declare global {
+  interface Window {
+    __QUI_VERSION__?: string
+  }
+}
+
+export {}


### PR DESCRIPTION
- inject the backend-provided build version into the SPA shell and surface it in the sidebar footer
- expose a small helper for reading the version in the client bundle
- ensure the latest-version query returns `null` instead of `undefined`, resolving the "Query data cannot be undefined" console error