### PR TITLE
fix(header): columns toggle remove blue dot

### DIFF
--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -660,11 +660,6 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({ insta
     }, 0)
   }, [table])
 
-  // Derive hidden columns state from table API for accuracy
-  const hasHiddenColumns = useMemo(() => {
-    return table.getAllLeafColumns().filter(c => c.getCanHide()).some(c => !c.getIsVisible())
-  }, [table])
-
   // Reset loaded rows when data changes significantly
   useEffect(() => {
     // Always ensure loadedRows is at least 100 (or total length if less)
@@ -967,9 +962,6 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({ insta
                           className="relative"
                         >
                           <Columns3 className="h-4 w-4" />
-                          {hasHiddenColumns && (
-                            <span className="absolute -top-1 -right-1 h-2 w-2 bg-primary rounded-full" />
-                          )}
                           <span className="sr-only">Toggle columns</span>
                         </Button>
                       </DropdownMenuTrigger>


### PR DESCRIPTION
This removes the blue dot at the top of the column toggle button, because it was getting people confused.

Before:
<img width="403" height="60" alt="Screenshot 2025-09-26 at 17 21 46" src="https://github.com/user-attachments/assets/a962086a-8d2c-4442-a56e-5455e909c8eb" />

After:
<img width="403" height="60" alt="Screenshot 2025-09-26 at 17 21 20" src="https://github.com/user-attachments/assets/4353979b-69af-4893-beb9-32cfaa3d9168" />
