### PR TITLE
fix(torrents): remove unused refetch indicator

### DIFF
--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -160,7 +160,6 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({ insta
   const [globalFilter, setGlobalFilter] = useState("")
   const [immediateSearch] = useState("")
   const [rowSelection, setRowSelection] = useState({})
-  const [showRefetchIndicator, setShowRefetchIndicator] = useState(false)
 
   // Custom "select all" state for handling large datasets
   const [isAllSelected, setIsAllSelected] = useState(false)
@@ -312,7 +311,6 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({ insta
     tags,
 
     isLoading,
-    isFetching,
     isCachedData,
     isStaleData,
     isLoadingMore,
@@ -386,22 +384,6 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({ insta
       torrentsLength: torrents.length,
     }
   }, [counts, categories, tags, totalCount, torrents, isLoading, onFilteredDataUpdate])
-
-
-  // Show refetch indicator only if fetching takes more than 2 seconds
-  useEffect(() => {
-    let timeoutId: ReturnType<typeof setTimeout>
-
-    if (isFetching && !isLoading && torrents.length > 0) {
-      timeoutId = setTimeout(() => {
-        setShowRefetchIndicator(true)
-      }, 2000)
-    } else {
-      setShowRefetchIndicator(false)
-    }
-
-    return () => clearTimeout(timeoutId)
-  }, [isFetching, isLoading, torrents.length])
 
   // Use torrents directly from backend (already sorted)
   const sortedTorrents = torrents
@@ -1225,12 +1207,6 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({ insta
                   • Shift+click for range • {isMac ? "Cmd" : "Ctrl"}+click for multiple
                 </span>
               </>
-            )}
-            {showRefetchIndicator && (
-              <span className="ml-2">
-                <Loader2 className="h-3 w-3 animate-spin inline mr-1" />
-                Updating...
-              </span>
             )}
           </div>
 


### PR DESCRIPTION
This refetch indicator did not bring any useful info other than providing spam every 2 seconds or so on slow instances.

We already have a state for tables without cached data.