### PR TITLE
fix(torrents): context menu aligment and bar recheck icon

### DIFF
--- a/web/src/components/torrents/QueueSubmenu.tsx
+++ b/web/src/components/torrents/QueueSubmenu.tsx
@@ -39,7 +39,7 @@ export const QueueSubmenu = memo(function QueueSubmenu({
   return (
     <Sub>
       <SubTrigger disabled={isPending}>
-        <List className="mr-2 h-4 w-4" />
+        <List className="mr-4 h-4 w-4" />
         Queue
       </SubTrigger>
       <SubContent>

--- a/web/src/components/torrents/TorrentLimitSubmenus.tsx
+++ b/web/src/components/torrents/TorrentLimitSubmenus.tsx
@@ -62,7 +62,7 @@ export const ShareLimitSubmenu = memo(function ShareLimitSubmenu({
   return (
     <Sub>
       <SubTrigger disabled={isPending}>
-        <Sprout className="mr-2 h-4 w-4" />
+        <Sprout className="mr-4 h-4 w-4" />
         Set Share Limits
       </SubTrigger>
       <SubContent className="w-72">
@@ -200,7 +200,7 @@ export const SpeedLimitsSubmenu = memo(function SpeedLimitsSubmenu({
   return (
     <Sub>
       <SubTrigger disabled={isPending}>
-        <Gauge className="mr-2 h-4 w-4" />
+        <Gauge className="mr-4 h-4 w-4" />
         Set Speed Limits
       </SubTrigger>
       <SubContent className="w-64">

--- a/web/src/components/torrents/TorrentManagementBar.tsx
+++ b/web/src/components/torrents/TorrentManagementBar.tsx
@@ -38,7 +38,23 @@ import { api } from "@/lib/api"
 import { getCommonCategory, getCommonSavePath, getCommonTags } from "@/lib/torrent-utils"
 import type { Torrent } from "@/types"
 import { useQuery } from "@tanstack/react-query"
-import { ArrowDown, ArrowUp, ChevronsDown, ChevronsUp, Folder, FolderOpen, List, LoaderCircle, Pause, Play, Radio, Settings2, Share2, Tag, Trash2 } from "lucide-react"
+import {
+  ArrowDown,
+  ArrowUp,
+  CheckCircle,
+  ChevronsDown,
+  ChevronsUp,
+  Folder,
+  FolderOpen,
+  List,
+  Pause,
+  Play,
+  Radio,
+  Settings2,
+  Share2,
+  Tag,
+  Trash2
+} from "lucide-react"
 import type { ChangeEvent } from "react"
 import { memo, useCallback, useMemo } from "react"
 import { AddTagsDialog, SetCategoryDialog, SetLocationDialog, SetTagsDialog } from "./TorrentDialogs"
@@ -344,7 +360,7 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
                 onClick={handleRecheckClick}
                 disabled={isPending || isDisabled}
               >
-                <LoaderCircle className="h-4 w-4" />
+                <CheckCircle className="h-4 w-4" />
               </Button>
             </TooltipTrigger>
             <TooltipContent>Force Recheck</TooltipContent>


### PR DESCRIPTION
This fixes the alignment in the torrent context menu and also changes the torrent management bar to use the same icon for rechecking as the context menu.

Before:
<img height="500" alt="Screenshot 2025-09-27 at 10 42 37" src="https://github.com/user-attachments/assets/f6bd42a3-21a8-4483-bc3c-5467b4a48f2d" />

After:
<img height="500" alt="Screenshot 2025-09-27 at 10 42 12" src="https://github.com/user-attachments/assets/7e17ab38-6f32-4ab3-aa1d-622fb0b7886b" />
