### PR TITLE
fix(torrents): preload limit dialogs with current values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/alexedwards/scs/v2 v2.9.0
 	github.com/autobrr/autobrr v1.66.1
-	github.com/autobrr/go-qbittorrent v1.15.0-rc1.0.20250924072341-79e00669bb9b
+	github.com/autobrr/go-qbittorrent v1.15.0-rc1.0.20250927193517-9c39ddd8464d
 	github.com/creativeprojects/go-selfupdate v1.5.1
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-chi/chi/v5 v5.2.3

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwTo
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/autobrr/autobrr v1.66.1 h1:BRHHR6XzdGXGil0/yYJm32pEkDgLs4CoySZucnoe0cs=
 github.com/autobrr/autobrr v1.66.1/go.mod h1:K+tIezuXcQr04ntKb8wE3Gq3PVL2ZkTvcXeGvA/VwBY=
-github.com/autobrr/go-qbittorrent v1.15.0-rc1.0.20250924072341-79e00669bb9b h1:ZG4ndMO8ak86imFYT3XGFdVQ1o87lXsYUWUCEcgfRkU=
-github.com/autobrr/go-qbittorrent v1.15.0-rc1.0.20250924072341-79e00669bb9b/go.mod h1:GY9yW+L45etf6xobkKz4hODqL/EfSw/CWPC9SzS2q8U=
+github.com/autobrr/go-qbittorrent v1.15.0-rc1.0.20250927193517-9c39ddd8464d h1:5aYpNwSI+5Y+k7gmTpFw2cSMD8ZaUO0xpwgpV6UySZI=
+github.com/autobrr/go-qbittorrent v1.15.0-rc1.0.20250927193517-9c39ddd8464d/go.mod h1:GY9yW+L45etf6xobkKz4hODqL/EfSw/CWPC9SzS2q8U=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/web/src/components/torrents/TorrentDialogs.tsx
+++ b/web/src/components/torrents/TorrentDialogs.tsx
@@ -3,29 +3,6 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { memo, useState, useEffect, useRef, useCallback } from "react"
-import type { ChangeEvent, KeyboardEvent } from "react"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Checkbox } from "@/components/ui/checkbox"
-import { Switch } from "@/components/ui/switch"
-import { ScrollArea } from "@/components/ui/scroll-area"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue
-} from "@/components/ui/select"
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle
-} from "@/components/ui/dialog"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -36,7 +13,30 @@ import {
   AlertDialogHeader,
   AlertDialogTitle
 } from "@/components/ui/alert-dialog"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
+import { Switch } from "@/components/ui/switch"
 import { Plus, X } from "lucide-react"
+import type { ChangeEvent, KeyboardEvent } from "react"
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 interface SetTagsDialogProps {
   open: boolean
@@ -837,65 +837,168 @@ export const EditTrackerDialog = memo(function EditTrackerDialog({
   )
 })
 
+const SHARE_DEFAULT_RATIO_LIMIT = 0
+const SHARE_DEFAULT_SEEDING_LIMIT = 0
+const SHARE_DEFAULT_INACTIVE_LIMIT = 0
+const LIMIT_USE_GLOBAL = -2
+const LIMIT_UNLIMITED = -1
+const SPEED_DEFAULT_LIMIT = 0
+
+type ShareLimitTorrentSnapshot = {
+  ratio_limit?: number
+  seeding_time_limit?: number
+  inactive_seeding_time_limit?: number
+  max_ratio?: number
+  max_seeding_time?: number
+  max_inactive_seeding_time?: number
+}
+
+type SpeedLimitTorrentSnapshot = {
+  dl_limit?: number
+  up_limit?: number
+}
+
 interface ShareLimitDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   hashCount: number
+  torrents?: ShareLimitTorrentSnapshot[]
   onConfirm: (ratioLimit: number, seedingTimeLimit: number, inactiveSeedingTimeLimit: number) => void
   isPending?: boolean
+}
+
+interface ShareLimitFormState {
+  ratioEnabled: boolean
+  ratioLimit: number
+  seedingTimeEnabled: boolean
+  seedingTimeLimit: number
+  inactiveSeedingTimeEnabled: boolean
+  inactiveSeedingTimeLimit: number
+}
+
+const normalizeShareSignature = (torrent: ShareLimitTorrentSnapshot): string => {
+  const safe = (value: number | undefined, fallback: number) =>
+    typeof value === "number" ? value : fallback
+
+  return [
+    safe(torrent.ratio_limit, LIMIT_USE_GLOBAL),
+    safe(torrent.seeding_time_limit, LIMIT_USE_GLOBAL),
+    safe(torrent.inactive_seeding_time_limit, LIMIT_USE_GLOBAL),
+    safe(torrent.max_ratio, LIMIT_UNLIMITED),
+    safe(torrent.max_seeding_time, LIMIT_UNLIMITED),
+    safe(torrent.max_inactive_seeding_time, LIMIT_UNLIMITED),
+  ].join("|")
+}
+
+const buildShareLimitInitialState = (torrents?: ShareLimitTorrentSnapshot[]): ShareLimitFormState => {
+  const base: ShareLimitFormState = {
+    ratioEnabled: false,
+    ratioLimit: SHARE_DEFAULT_RATIO_LIMIT,
+    seedingTimeEnabled: false,
+    seedingTimeLimit: SHARE_DEFAULT_SEEDING_LIMIT,
+    inactiveSeedingTimeEnabled: false,
+    inactiveSeedingTimeLimit: SHARE_DEFAULT_INACTIVE_LIMIT,
+  }
+
+  if (!torrents || torrents.length === 0) {
+    return base
+  }
+
+  const signatures = torrents.map(normalizeShareSignature)
+  const allMatch = signatures.every((signature) => signature === signatures[0])
+
+  if (!allMatch) {
+    return base
+  }
+
+  const [first] = torrents
+  const ratioLimitValue = typeof first.ratio_limit === "number" ? first.ratio_limit : LIMIT_UNLIMITED
+  const seedingTimeLimitValue = typeof first.seeding_time_limit === "number" ? first.seeding_time_limit : LIMIT_UNLIMITED
+  const inactiveSeedingTimeLimitValue = typeof first.inactive_seeding_time_limit === "number"? first.inactive_seeding_time_limit: LIMIT_UNLIMITED
+
+  return {
+    ...base,
+    ratioEnabled: ratioLimitValue >= 0,
+    ratioLimit: ratioLimitValue >= 0 ? ratioLimitValue : base.ratioLimit,
+    seedingTimeEnabled: seedingTimeLimitValue >= 0,
+    seedingTimeLimit: seedingTimeLimitValue >= 0 ? seedingTimeLimitValue : base.seedingTimeLimit,
+    inactiveSeedingTimeEnabled: inactiveSeedingTimeLimitValue >= 0,
+    inactiveSeedingTimeLimit:
+      inactiveSeedingTimeLimitValue >= 0 ? inactiveSeedingTimeLimitValue : base.inactiveSeedingTimeLimit,
+  }
 }
 
 export const ShareLimitDialog = memo(function ShareLimitDialog({
   open,
   onOpenChange,
   hashCount,
+  torrents,
   onConfirm,
   isPending = false,
 }: ShareLimitDialogProps) {
+  const [useGlobalLimits, setUseGlobalLimits] = useState(false)
   const [ratioEnabled, setRatioEnabled] = useState(false)
-  const [ratioLimit, setRatioLimit] = useState(1.5)
+  const [ratioLimit, setRatioLimit] = useState(SHARE_DEFAULT_RATIO_LIMIT)
   const [seedingTimeEnabled, setSeedingTimeEnabled] = useState(false)
-  const [seedingTimeLimit, setSeedingTimeLimit] = useState(1440) // 24 hours in minutes
+  const [seedingTimeLimit, setSeedingTimeLimit] = useState(SHARE_DEFAULT_SEEDING_LIMIT) // 24 hours in minutes
   const [inactiveSeedingTimeEnabled, setInactiveSeedingTimeEnabled] = useState(false)
-  const [inactiveSeedingTimeLimit, setInactiveSeedingTimeLimit] = useState(10080) // 7 days in minutes
+  const [inactiveSeedingTimeLimit, setInactiveSeedingTimeLimit] = useState(SHARE_DEFAULT_INACTIVE_LIMIT) // 7 days in minutes
   const wasOpen = useRef(false)
 
-  // Reset form when dialog opens
+  const shareInitialState = useMemo(() => buildShareLimitInitialState(torrents), [torrents])
+
+  // Reset form when dialog opens with torrent values
   useEffect(() => {
     if (open && !wasOpen.current) {
-      setRatioEnabled(false)
-      setRatioLimit(1.5)
-      setSeedingTimeEnabled(false)
-      setSeedingTimeLimit(1440)
-      setInactiveSeedingTimeEnabled(false)
-      setInactiveSeedingTimeLimit(10080)
+      // Check if all torrents have global limits (-2 for all three)
+      const hasGlobalLimits = torrents && torrents.length > 0 &&
+        torrents.every(t =>
+          t.ratio_limit === LIMIT_USE_GLOBAL &&
+          t.seeding_time_limit === LIMIT_USE_GLOBAL &&
+          t.inactive_seeding_time_limit === LIMIT_USE_GLOBAL
+        )
+
+      setUseGlobalLimits(hasGlobalLimits || false)
+      setRatioEnabled(!hasGlobalLimits && shareInitialState.ratioEnabled)
+      setRatioLimit(shareInitialState.ratioLimit)
+      setSeedingTimeEnabled(!hasGlobalLimits && shareInitialState.seedingTimeEnabled)
+      setSeedingTimeLimit(shareInitialState.seedingTimeLimit)
+      setInactiveSeedingTimeEnabled(!hasGlobalLimits && shareInitialState.inactiveSeedingTimeEnabled)
+      setInactiveSeedingTimeLimit(shareInitialState.inactiveSeedingTimeLimit)
     }
     wasOpen.current = open
-  }, [open])
+  }, [open, shareInitialState, torrents])
 
   const handleConfirm = useCallback((): void => {
-    onConfirm(
-      ratioEnabled ? ratioLimit : -1,
-      seedingTimeEnabled ? seedingTimeLimit : -1,
-      inactiveSeedingTimeEnabled ? inactiveSeedingTimeLimit : -1
-    )
+    if (useGlobalLimits) {
+      // When using global limits, set all to -2
+      onConfirm(LIMIT_USE_GLOBAL, LIMIT_USE_GLOBAL, LIMIT_USE_GLOBAL)
+    } else {
+      onConfirm(
+        ratioEnabled ? ratioLimit : -1,  // -1 means unlimited (no limit)
+        seedingTimeEnabled ? seedingTimeLimit : -1,
+        inactiveSeedingTimeEnabled ? inactiveSeedingTimeLimit : -1
+      )
+    }
     // Reset form
+    setUseGlobalLimits(false)
     setRatioEnabled(false)
-    setRatioLimit(1.5)
+    setRatioLimit(SHARE_DEFAULT_RATIO_LIMIT)
     setSeedingTimeEnabled(false)
-    setSeedingTimeLimit(1440)
+    setSeedingTimeLimit(SHARE_DEFAULT_SEEDING_LIMIT)
     setInactiveSeedingTimeEnabled(false)
-    setInactiveSeedingTimeLimit(10080)
+    setInactiveSeedingTimeLimit(SHARE_DEFAULT_INACTIVE_LIMIT)
     onOpenChange(false)
-  }, [onConfirm, ratioEnabled, ratioLimit, seedingTimeEnabled, seedingTimeLimit, inactiveSeedingTimeEnabled, inactiveSeedingTimeLimit, onOpenChange])
+  }, [onConfirm, useGlobalLimits, ratioEnabled, ratioLimit, seedingTimeEnabled, seedingTimeLimit, inactiveSeedingTimeEnabled, inactiveSeedingTimeLimit, onOpenChange])
 
   const handleCancel = useCallback((): void => {
+    setUseGlobalLimits(false)
     setRatioEnabled(false)
-    setRatioLimit(1.5)
+    setRatioLimit(SHARE_DEFAULT_RATIO_LIMIT)
     setSeedingTimeEnabled(false)
-    setSeedingTimeLimit(1440)
+    setSeedingTimeLimit(SHARE_DEFAULT_SEEDING_LIMIT)
     setInactiveSeedingTimeEnabled(false)
-    setInactiveSeedingTimeLimit(10080)
+    setInactiveSeedingTimeLimit(SHARE_DEFAULT_INACTIVE_LIMIT)
     onOpenChange(false)
   }, [onOpenChange])
 
@@ -905,16 +1008,32 @@ export const ShareLimitDialog = memo(function ShareLimitDialog({
         <DialogHeader>
           <DialogTitle>Set Share Limits for {hashCount} torrent(s)</DialogTitle>
           <DialogDescription>
-            Configure seeding limits. Use -1 or disable to remove limits.
+            Configure seeding limits or use global defaults from qBittorrent settings.
           </DialogDescription>
         </DialogHeader>
         <div className="py-2 space-y-4">
+          {/* Global limits toggle */}
+          <div className="space-y-2 pb-2 border-b">
+            <div className="flex items-center space-x-2">
+              <Switch
+                id="useGlobalLimits"
+                checked={useGlobalLimits}
+                onCheckedChange={setUseGlobalLimits}
+              />
+              <Label htmlFor="useGlobalLimits" className="text-sm font-medium">Use global limits</Label>
+            </div>
+            <p className="text-xs text-muted-foreground ml-6">
+              When enabled, torrents will follow the global share limits configured in qBittorrent settings
+            </p>
+          </div>
+
           <div className="space-y-2">
             <div className="flex items-center space-x-2">
               <Switch
                 id="ratioEnabled"
                 checked={ratioEnabled}
                 onCheckedChange={setRatioEnabled}
+                disabled={useGlobalLimits}
               />
               <Label htmlFor="ratioEnabled" className="text-sm">Set ratio limit</Label>
             </div>
@@ -925,9 +1044,9 @@ export const ShareLimitDialog = memo(function ShareLimitDialog({
                 min="0"
                 step="0.1"
                 value={ratioLimit}
-                disabled={!ratioEnabled}
+                disabled={!ratioEnabled || useGlobalLimits}
                 onChange={(e) => setRatioLimit(parseFloat(e.target.value) || 0)}
-                placeholder="1.5"
+                placeholder="0"
               />
               <p className="text-xs text-muted-foreground">
                 Stop seeding when ratio reaches this value
@@ -941,6 +1060,7 @@ export const ShareLimitDialog = memo(function ShareLimitDialog({
                 id="seedingTimeEnabled"
                 checked={seedingTimeEnabled}
                 onCheckedChange={setSeedingTimeEnabled}
+                disabled={useGlobalLimits}
               />
               <Label htmlFor="seedingTimeEnabled" className="text-sm">Set seeding time limit</Label>
             </div>
@@ -950,9 +1070,9 @@ export const ShareLimitDialog = memo(function ShareLimitDialog({
                 type="number"
                 min="0"
                 value={seedingTimeLimit}
-                disabled={!seedingTimeEnabled}
+                disabled={!seedingTimeEnabled || useGlobalLimits}
                 onChange={(e) => setSeedingTimeLimit(parseInt(e.target.value) || 0)}
-                placeholder="1440"
+                placeholder="0"
               />
               <p className="text-xs text-muted-foreground">
                 Minutes (1440 = 24 hours)
@@ -966,6 +1086,7 @@ export const ShareLimitDialog = memo(function ShareLimitDialog({
                 id="inactiveSeedingTimeEnabled"
                 checked={inactiveSeedingTimeEnabled}
                 onCheckedChange={setInactiveSeedingTimeEnabled}
+                disabled={useGlobalLimits}
               />
               <Label htmlFor="inactiveSeedingTimeEnabled" className="text-sm">Set inactive seeding limit</Label>
             </div>
@@ -975,9 +1096,9 @@ export const ShareLimitDialog = memo(function ShareLimitDialog({
                 type="number"
                 min="0"
                 value={inactiveSeedingTimeLimit}
-                disabled={!inactiveSeedingTimeEnabled}
+                disabled={!inactiveSeedingTimeEnabled || useGlobalLimits}
                 onChange={(e) => setInactiveSeedingTimeLimit(parseInt(e.target.value) || 0)}
-                placeholder="10080"
+                placeholder="0"
               />
               <p className="text-xs text-muted-foreground">
                 Minutes (10080 = 7 days)
@@ -1005,51 +1126,92 @@ interface SpeedLimitsDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   hashCount: number
+  torrents?: SpeedLimitTorrentSnapshot[]
   onConfirm: (uploadLimit: number, downloadLimit: number) => void
   isPending?: boolean
+}
+
+interface SpeedLimitFormState {
+  uploadEnabled: boolean
+  uploadLimit: number
+  downloadEnabled: boolean
+  downloadLimit: number
+}
+
+const buildSpeedLimitInitialState = (torrents?: SpeedLimitTorrentSnapshot[]): SpeedLimitFormState => {
+  const base: SpeedLimitFormState = {
+    uploadEnabled: false,
+    uploadLimit: SPEED_DEFAULT_LIMIT,
+    downloadEnabled: false,
+    downloadLimit: SPEED_DEFAULT_LIMIT,
+  }
+
+  if (!torrents || torrents.length === 0) {
+    return base
+  }
+
+  const uploadValues = torrents.map((torrent) => (typeof torrent.up_limit === "number" ? torrent.up_limit : 0))
+  const downloadValues = torrents.map((torrent) => (typeof torrent.dl_limit === "number" ? torrent.dl_limit : 0))
+
+  const uploadsMatch = uploadValues.every((value) => value === uploadValues[0])
+  const downloadsMatch = downloadValues.every((value) => value === downloadValues[0])
+
+  const firstUpload = uploadValues[0]
+  const firstDownload = downloadValues[0]
+
+  return {
+    ...base,
+    uploadEnabled: uploadsMatch && firstUpload > 0,
+    uploadLimit: uploadsMatch && firstUpload > 0 ? Math.round(firstUpload / 1024) : base.uploadLimit,
+    downloadEnabled: downloadsMatch && firstDownload > 0,
+    downloadLimit: downloadsMatch && firstDownload > 0 ? Math.round(firstDownload / 1024) : base.downloadLimit,
+  }
 }
 
 export const SpeedLimitsDialog = memo(function SpeedLimitsDialog({
   open,
   onOpenChange,
   hashCount,
+  torrents,
   onConfirm,
   isPending = false,
 }: SpeedLimitsDialogProps) {
   const [uploadEnabled, setUploadEnabled] = useState(false)
-  const [uploadLimit, setUploadLimit] = useState(1024)
+  const [uploadLimit, setUploadLimit] = useState(SPEED_DEFAULT_LIMIT)
   const [downloadEnabled, setDownloadEnabled] = useState(false)
-  const [downloadLimit, setDownloadLimit] = useState(1024)
+  const [downloadLimit, setDownloadLimit] = useState(SPEED_DEFAULT_LIMIT)
   const wasOpen = useRef(false)
 
-  // Reset form when dialog opens
+  const speedInitialState = useMemo(() => buildSpeedLimitInitialState(torrents), [torrents])
+
+  // Reset form when dialog opens with torrent values
   useEffect(() => {
     if (open && !wasOpen.current) {
-      setUploadEnabled(false)
-      setUploadLimit(1024)
-      setDownloadEnabled(false)
-      setDownloadLimit(1024)
+      setUploadEnabled(speedInitialState.uploadEnabled)
+      setUploadLimit(speedInitialState.uploadLimit)
+      setDownloadEnabled(speedInitialState.downloadEnabled)
+      setDownloadLimit(speedInitialState.downloadLimit)
     }
     wasOpen.current = open
-  }, [open])
+  }, [open, speedInitialState])
 
   const handleConfirm = useCallback((): void => {
     onConfirm(
-      uploadEnabled ? uploadLimit : -1,
-      downloadEnabled ? downloadLimit : -1
+      uploadEnabled ? uploadLimit : 0,  // 0 means use global limit
+      downloadEnabled ? downloadLimit : 0  // 0 means use global limit
     )
     // Reset form
     setUploadEnabled(false)
-    setUploadLimit(1024)
+    setUploadLimit(SPEED_DEFAULT_LIMIT)
     setDownloadEnabled(false)
-    setDownloadLimit(1024)
+    setDownloadLimit(SPEED_DEFAULT_LIMIT)
   }, [onConfirm, uploadEnabled, uploadLimit, downloadEnabled, downloadLimit])
 
   const handleCancel = useCallback((): void => {
     setUploadEnabled(false)
-    setUploadLimit(1024)
+    setUploadLimit(SPEED_DEFAULT_LIMIT)
     setDownloadEnabled(false)
-    setDownloadLimit(1024)
+    setDownloadLimit(SPEED_DEFAULT_LIMIT)
     onOpenChange(false)
   }, [onOpenChange])
 
@@ -1059,7 +1221,7 @@ export const SpeedLimitsDialog = memo(function SpeedLimitsDialog({
         <DialogHeader>
           <DialogTitle>Set Speed Limits for {hashCount} torrent(s)</DialogTitle>
           <DialogDescription>
-            Set upload and download speed limits in KB/s. Use -1 or disable to remove limits.
+            Set upload and download speed limits in KB/s. Disable to use global limits.
           </DialogDescription>
         </DialogHeader>
         <div className="py-2 space-y-4">
@@ -1078,7 +1240,7 @@ export const SpeedLimitsDialog = memo(function SpeedLimitsDialog({
               value={uploadLimit}
               disabled={!uploadEnabled}
               onChange={(e) => setUploadLimit(parseInt(e.target.value) || 0)}
-              placeholder="1024"
+              placeholder="0"
             />
           </div>
 
@@ -1097,7 +1259,7 @@ export const SpeedLimitsDialog = memo(function SpeedLimitsDialog({
               value={downloadLimit}
               disabled={!downloadEnabled}
               onChange={(e) => setDownloadLimit(parseInt(e.target.value) || 0)}
-              placeholder="1024"
+              placeholder="0"
             />
           </div>
         </div>

--- a/web/src/components/torrents/TorrentManagementBar.tsx
+++ b/web/src/components/torrents/TorrentManagementBar.tsx
@@ -657,6 +657,7 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
         open={showShareLimitDialog}
         onOpenChange={setShowShareLimitDialog}
         hashCount={totalSelectionCount || selectedHashes.length}
+        torrents={selectedTorrents}
         onConfirm={handleSetShareLimitWrapper}
         isPending={isPending}
       />
@@ -665,6 +666,7 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
         open={showSpeedLimitDialog}
         onOpenChange={setShowSpeedLimitDialog}
         hashCount={totalSelectionCount || selectedHashes.length}
+        torrents={selectedTorrents}
         onConfirm={handleSetSpeedLimitsWrapper}
         isPending={isPending}
       />

--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -1338,6 +1338,7 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({ insta
         open={showShareLimitDialog}
         onOpenChange={setShowShareLimitDialog}
         hashCount={isAllSelected ? effectiveSelectionCount : contextHashes.length}
+        torrents={contextTorrents}
         onConfirm={handleSetShareLimitWrapper}
         isPending={isPending}
       />
@@ -1346,6 +1347,7 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({ insta
         open={showSpeedLimitDialog}
         onOpenChange={setShowSpeedLimitDialog}
         hashCount={isAllSelected ? effectiveSelectionCount : contextHashes.length}
+        torrents={contextTorrents}
         onConfirm={handleSetSpeedLimitsWrapper}
         isPending={isPending}
       />

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -74,6 +74,7 @@ export interface Torrent {
   magnet_uri: string
   max_ratio: number
   max_seeding_time: number
+  max_inactive_seeding_time?: number
   name: string
   num_complete: number
   num_incomplete: number
@@ -87,6 +88,7 @@ export interface Torrent {
   save_path: string
   seeding_time: number
   seeding_time_limit: number
+  inactive_seeding_time_limit?: number
   seen_complete: number
   seq_dl: boolean
   size: number


### PR DESCRIPTION
- preload share and speed limit dialogs with the selected torrents' current values and add a global limits toggle
- send qBittorrent's expected sentinel values when toggles are disabled, fixing the silent speed limit failure
- pass torrent snapshots into the dialogs, extend the torrent type definitions, and bump go-qbittorrent to expose the new fields

New global limit override:

<img width="1050" height="1149" alt="PixelSnap 2025-09-27 at 22 27 54@2x" src="https://github.com/user-attachments/assets/f4129d92-0351-4fd4-987c-8dcf91ae7232" />
