### PR TITLE
fix(torrents): show ratio limit correctly

### DIFF
--- a/web/src/components/torrents/TorrentTableColumns.tsx
+++ b/web/src/components/torrents/TorrentTableColumns.tsx
@@ -23,7 +23,7 @@ import {
 import { formatSpeedWithUnit, type SpeedUnit } from "@/lib/speedUnits"
 import { getStateLabel } from "@/lib/torrent-state-utils"
 import { formatBytes, formatDuration, getRatioColor } from "@/lib/utils"
-import type { Torrent } from "@/types"
+import type { AppPreferences, Torrent } from "@/types"
 import type { ColumnDef } from "@tanstack/react-table"
 import { ListOrdered } from "lucide-react"
 
@@ -80,7 +80,8 @@ export const createColumns = (
     excludedFromSelectAll?: Set<string>
   },
   speedUnit: SpeedUnit = "bytes",
-  formatTimestamp?: (timestamp: number) => string
+  formatTimestamp?: (timestamp: number) => string,
+  instancePreferences?: AppPreferences | null
 ): ColumnDef<Torrent>[] => [
   {
     id: "select",
@@ -580,7 +581,8 @@ export const createColumns = (
     header: "Ratio Limit",
     cell: ({ row }) => {
       const ratioLimit = row.original.ratio_limit
-      const displayRatioLimit = ratioLimit === -2 || -1 ? "∞" : ratioLimit.toFixed(2)
+      const instanceRatioLimit = instancePreferences?.max_ratio
+      const displayRatioLimit = ratioLimit === -2 ? (instanceRatioLimit === -1 ? "∞" : instanceRatioLimit?.toFixed(2) || "∞") :ratioLimit === -1 ? "∞" :ratioLimit.toFixed(2)
 
       return (
         <span

--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -90,6 +90,7 @@ import {
   SpeedLimitsDialog
 } from "./TorrentDialogs"
 import { createColumns } from "./TorrentTableColumns"
+import { useInstancePreferences } from "@/hooks/useInstancePreferences.ts";
 
 // Default values for persisted state hooks (module scope for stable references)
 const DEFAULT_COLUMN_VISIBILITY = {
@@ -177,6 +178,7 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({ insta
   const [incognitoMode, setIncognitoMode] = useIncognitoMode()
   const [speedUnit, setSpeedUnit] = useSpeedUnits()
   const { formatTimestamp } = useDateTimeFormatters()
+  const { preferences } = useInstancePreferences(instanceId)
 
   // Detect platform for keyboard shortcuts
   const isMac = useMemo(() => {
@@ -485,8 +487,8 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({ insta
       onRowSelection: handleRowSelection,
       isAllSelected,
       excludedFromSelectAll,
-    }, speedUnit, formatTimestamp),
-    [incognitoMode, speedUnit, formatTimestamp, handleSelectAll, isSelectAllChecked, isSelectAllIndeterminate, handleRowSelection, isAllSelected, excludedFromSelectAll]
+    }, speedUnit, formatTimestamp, preferences),
+    [incognitoMode, speedUnit, formatTimestamp, handleSelectAll, isSelectAllChecked, isSelectAllIndeterminate, handleRowSelection, isAllSelected, excludedFromSelectAll, preferences]
   )
 
   const table = useReactTable({


### PR DESCRIPTION
This changes how the ratio limit gets shown in the table and correctly displays the global limit if required.