### PR TITLE
fix(web): correct stepping to -1 when step is a decimal value

### DIFF
--- a/web/src/components/forms/NumberInputWithUnlimited.tsx
+++ b/web/src/components/forms/NumberInputWithUnlimited.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
+import React from "react"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 
@@ -37,6 +38,36 @@ export function NumberInputWithUnlimited({
   // Default placeholder based on unlimited support
   const defaultPlaceholder = allowUnlimited ? "Unlimited" : undefined
   const actualPlaceholder = placeholder ?? defaultPlaceholder
+  
+  // Track previous value to detect when we hit 0 and should transition to unlimited
+  const prevValueRef = React.useRef(value)
+  
+  React.useEffect(() => {
+    if (!allowUnlimited) return
+    
+    const prevValue = prevValueRef.current
+    const currentValue = value
+    
+    // If we stepped down to exactly 0 from a positive value, transition to unlimited
+    if (prevValue > 0 && currentValue === 0) {
+      // Small delay to let the UI update, then transition to unlimited
+      setTimeout(() => onChange(-1), 50)
+    }
+    
+    prevValueRef.current = value
+  }, [value, allowUnlimited, onChange])
+
+  // Handle stepping up from unlimited (-1) back to a valid positive value
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!allowUnlimited) return
+
+    if (e.key === 'ArrowUp' && value === -1) {
+      e.preventDefault()
+      const stepValue = typeof step === 'string' ? parseFloat(step) : (step || 1)
+      const minPositive = stepValue // Use the step value as the starting point
+      onChange(minPositive)
+    }
+  }
 
   return (
     <div className="space-y-2">
@@ -69,15 +100,25 @@ export function NumberInputWithUnlimited({
           const num = parseFloat(inputValue)
           if (isNaN(num)) return
 
-          // Allow -1 for unlimited if allowUnlimited is true
-          if (allowUnlimited && num === -1) {
-            onChange(-1)
-            return
+          // Handle unlimited values when allowUnlimited is true
+          if (allowUnlimited) {
+            // Allow exactly -1 for unlimited
+            if (num === -1) {
+              onChange(-1)
+              return
+            }
+            
+            // Prevent invalid negative values between -1 and 0
+            if (num < 0 && num > -1) {
+              // Don't update the value, effectively blocking invalid negative values
+              return
+            }
           }
 
           // Otherwise enforce min/max bounds
           onChange(Math.max(min, Math.min(max, num)))
         }}
+        onKeyDown={handleKeyDown}
         min={allowUnlimited ? -1 : min}
         max={max}
         step={step}

--- a/web/src/components/instances/preferences/SeedingLimitsForm.tsx
+++ b/web/src/components/instances/preferences/SeedingLimitsForm.tsx
@@ -117,9 +117,9 @@ export function SeedingLimitsForm({ instanceId, onSuccess }: SeedingLimitsFormPr
                   label="Maximum Share Ratio"
                   value={(field.state.value as number) ?? 2.0}
                   onChange={field.handleChange}
-                  min={0.1}
+                  min={-1}
                   max={10}
-                  step="0.1"
+                  step="0.05"
                   description="Stop seeding at this upload/download ratio"
                   allowUnlimited={true}
                   disabled={!(enabledField.state.value as boolean)}
@@ -148,7 +148,7 @@ export function SeedingLimitsForm({ instanceId, onSuccess }: SeedingLimitsFormPr
                   label="Maximum Seeding Time (minutes)"
                   value={(field.state.value as number) ?? 1440}
                   onChange={field.handleChange}
-                  min={1}
+                  min={-1}
                   max={525600} // 1 year in minutes
                   description="Stop seeding after this many minutes"
                   allowUnlimited={true}


### PR DESCRIPTION
When step is a decimal value like `step="0.05"`, html builtin input behavior prevents stepping correctly from `0` to `-1` and skipping intermediate values such as `-0.3`.

This results in these input boxes being unable to reset to default `-1`, aka `unlimited` state (without passing through invalid values).

This fix tracks the input value state, to force the correct state change.

Also update `max_ratio_enabled` to `0.05` steps to mimic client behavior.

