### PR TITLE
fix(web): scope column widths per instance

### DIFF
--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -276,7 +276,7 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({ insta
   // Column order with persistence (get default order at runtime to avoid initialization order issues)
   const [columnOrder, setColumnOrder] = usePersistedColumnOrder(getDefaultColumnOrder(), instanceId)
   // Column sizing with persistence
-  const [columnSizing, setColumnSizing] = usePersistedColumnSizing(DEFAULT_COLUMN_SIZING)
+  const [columnSizing, setColumnSizing] = usePersistedColumnSizing(DEFAULT_COLUMN_SIZING, instanceId)
 
   // Progressive loading state with async management
   const [loadedRows, setLoadedRows] = useState(100)


### PR DESCRIPTION
- scope torrent table column sizing keys by instance to keep settings isolated
- migrate any legacy global sizing values when an instance-specific key is available
- pass the active instance id through the torrent table so widths persist correctly per view