### PR TITLE
feat(torrents): improvements to column filtering

### DIFF
--- a/web/src/components/torrents/ColumnFilterPopover.tsx
+++ b/web/src/components/torrents/ColumnFilterPopover.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { type ColumnType, type FilterOperation } from "@/lib/column-constants"
 import { getDefaultOperation, getOperations } from "@/lib/column-filter-utils"
 import { CaseSensitive, Filter, X } from "lucide-react"
@@ -271,15 +272,20 @@ function ValueInput({
           onKeyDown={onKeyDown}
           className="flex-1"
         />
-        <Button
-          type="button"
-          variant="outline"
-          size="icon"
-          className={`${caseSensitive ? "text-primary hover:text-primary/80" : "text-muted-foreground"}`}
-          onClick={() => onCaseSensitiveChange(!caseSensitive)}
-        >
-          <CaseSensitive className="size-4"/>
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              className={`${caseSensitive ? "text-primary hover:text-primary/80" : "text-muted-foreground"}`}
+              onClick={() => onCaseSensitiveChange(!caseSensitive)}
+            >
+              <CaseSensitive className="size-4"/>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{caseSensitive ? "Match case (click to ignore)" : "Ignore case (click to match)"}</TooltipContent>
+        </Tooltip>
       </div>
     )
   }

--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
@@ -40,25 +40,24 @@ const buttonVariants = cva(
   }
 )
 
-function Button({
-  className,
-  variant,
-  size,
-  asChild = false,
-  ...props
-}: React.ComponentProps<"button"> &
-  VariantProps<typeof buttonVariants> & {
-    asChild?: boolean
-  }) {
+const Button = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<"button"> &
+    VariantProps<typeof buttonVariants> & {
+      asChild?: boolean
+    }
+>(({ className, variant, size, asChild = false, ...props }, ref) => {
   const Comp = asChild ? Slot : "button"
 
   return (
     <Comp
       data-slot="button"
       className={cn(buttonVariants({ variant, size, className }))}
+      ref={ref}
       {...props}
     />
   )
-}
+})
+Button.displayName = "Button"
 
 export { Button, buttonVariants }

--- a/web/src/lib/column-constants.ts
+++ b/web/src/lib/column-constants.ts
@@ -6,30 +6,26 @@
 import type { Torrent } from "@/types"
 
 export const NUMERIC_COLUMNS = [
-  "size",
-  "total_size",
-  "progress",
+  // "size",
+  // "total_size",
+  // "progress",
   "num_seeds",
   "num_complete",
   "num_leechs",
   "num_incomplete",
-  "dlspeed",
-  "upspeed",
-  "eta",
+  // "eta",
   "ratio",
   "ratio_limit",
-  "dl_limit",
-  "up_limit",
-  "downloaded",
-  "uploaded",
-  "downloaded_session",
-  "uploaded_session",
-  "amount_left",
-  "time_active",
-  "seeding_time",
-  "completed",
+  // "downloaded",
+  // "uploaded",
+  // "downloaded_session",
+  // "uploaded_session",
+  // "amount_left",
+  // "time_active",
+  // "seeding_time",
+  // "completed",
   "availability",
-  "reannounce",
+  // "reannounce",
   "priority",
   "popularity",
 ] as const satisfies readonly (keyof Torrent)[]
@@ -45,11 +41,11 @@ export const SIZE_COLUMNS = [
   "completed",
 ] as const satisfies readonly (keyof Torrent)[]
 
-export const DATE_COLUMNS = [
-  "added_on",
-  "completion_on",
-  "seen_complete",
-  "last_activity",
+export const SPEED_COLUMNS = [
+  "dlspeed",
+  "upspeed",
+  "dl_limit",
+  "up_limit",
 ] as const satisfies readonly (keyof Torrent)[]
 
 export const DURATION_COLUMNS = [
@@ -59,11 +55,36 @@ export const DURATION_COLUMNS = [
   "reannounce",
 ] as const satisfies readonly (keyof Torrent)[]
 
+export const PERCENTAGE_COLUMNS = [
+  "progress",
+] as const satisfies readonly (keyof Torrent)[]
+
+export const DATE_COLUMNS = [
+  "added_on",
+  "completion_on",
+  "seen_complete",
+  "last_activity",
+] as const satisfies readonly (keyof Torrent)[]
+
 export const BOOLEAN_COLUMNS = [
   "private",
 ] as const satisfies readonly (keyof Torrent)[]
 
-export type ColumnType = "number" | "size" | "date" | "duration" | "boolean" | "string"
+export const ENUM_COLUMNS = [
+  "state",
+] as const satisfies readonly (keyof Torrent)[]
+
+
+export type ColumnType =
+  "number"
+  | "size"
+  | "speed"
+  | "duration"
+  | "percentage"
+  | "date"
+  | "boolean"
+  | "enum"
+  | "string"
 
 export type FilterOperation =
   | "eq" // equals


### PR DESCRIPTION
This brings several improvements to the column filtering, adding unit selection for speed, a dropdown for selecting a state, a case sensitivity toggle for strings and a clearer indication that you are filtering a percentage in the progress column.
Additionally fixes a bug where clicking and holding left click and moving your cursor inside the popover would drag the column.
<img width="400" alt="image" src="https://github.com/user-attachments/assets/9a43501b-e952-4fb3-b065-15fff7016528" /><img width="400" alt="image" src="https://github.com/user-attachments/assets/8fe3d18a-59e0-4ad3-b2bc-49d6f82d47b8" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/5a16f2a1-bc2d-41fd-9913-a8b17ab0088a" /><img width="200" alt="Screenshot 2025-10-07 at 18 21 58" src="https://github.com/user-attachments/assets/0956520b-2a95-4d59-9f74-42a36d891842" />
