### PR TITLE
fix(dashboard): update dropdown copy based on expansion state

### DIFF
--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -340,7 +340,7 @@ function InstanceCard({
               <Collapsible open={isAdvancedMetricsOpen} onOpenChange={setIsAdvancedMetricsOpen}>
                 <CollapsibleTrigger className="flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors w-full [&[data-state=open]>svg]:rotate-180">
                   <ChevronDown className="h-3 w-3 transition-transform" />
-                  <span>Show More</span>
+                  <span>{`Show ${isAdvancedMetricsOpen ? "less" : "more"}`}</span>
                 </CollapsibleTrigger>
                 <CollapsibleContent className="space-y-2 mt-2">
                   {serverState?.total_peer_connections !== undefined && (


### PR DESCRIPTION
I noticed a small copy bug with the dropdown in the 'Instances' section.

<img width="996" height="652" alt="show_more" src="https://github.com/user-attachments/assets/f6343b9b-3b6f-4f8f-bb8f-5135d03c8c1b" />

<img width="992" height="936" alt="show_less" src="https://github.com/user-attachments/assets/0a7907ea-1385-4d6c-a58e-6b52b9e42133" />

