### PR TITLE
feat(qbittorrent): derive uptime from log buffer

### DIFF
--- a/internal/qbittorrent/client_test.go
+++ b/internal/qbittorrent/client_test.go
@@ -1,0 +1,108 @@
+package qbittorrent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+)
+
+func TestMaybeRefreshSessionStart_RetryWhenInaccurate(t *testing.T) {
+	c := &Client{
+		sessionStart:    time.Now().Add(-10 * time.Minute),
+		sessionAccurate: false,
+	}
+
+	const logTimestamp = int64(1_720_000_000)
+
+	fetchCalled := make(chan struct{}, 1)
+	c.logsFetcher = func(ctx context.Context) ([]qbt.Log, error) {
+		select {
+		case fetchCalled <- struct{}{}:
+		default:
+		}
+		return []qbt.Log{
+			{Timestamp: logTimestamp},
+			{Timestamp: logTimestamp + 10},
+		}, nil
+	}
+
+	c.maybeRefreshSessionStart(false)
+
+	select {
+	case <-fetchCalled:
+	case <-time.After(time.Second):
+		t.Fatal("expected session logs fetch to be invoked")
+	}
+
+	waitForSessionFetch(t, c, 500*time.Millisecond)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if !c.sessionAccurate {
+		t.Fatalf("expected sessionAccurate to be true")
+	}
+
+	expectedStart := time.Unix(logTimestamp, 0)
+	if !c.sessionStart.Equal(expectedStart) {
+		t.Fatalf("expected sessionStart to be %v, got %v", expectedStart, c.sessionStart)
+	}
+
+	if !c.sessionRetryAfter.IsZero() {
+		t.Fatalf("expected sessionRetryAfter to be cleared, got %v", c.sessionRetryAfter)
+	}
+}
+
+func TestMaybeRefreshSessionStart_SkipWhenAccurate(t *testing.T) {
+	c := &Client{
+		sessionStart:    time.Unix(1_720_000_000, 0),
+		sessionAccurate: true,
+	}
+
+	fetchCalled := make(chan struct{}, 1)
+	c.logsFetcher = func(ctx context.Context) ([]qbt.Log, error) {
+		select {
+		case fetchCalled <- struct{}{}:
+		default:
+		}
+		return nil, nil
+	}
+
+	c.maybeRefreshSessionStart(false)
+
+	select {
+	case <-fetchCalled:
+		t.Fatal("expected no session log fetch when cache is accurate")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.sessionFetching {
+		t.Fatalf("expected sessionFetching to remain false")
+	}
+}
+
+func waitForSessionFetch(t *testing.T, c *Client, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for {
+		c.mu.RLock()
+		fetching := c.sessionFetching
+		c.mu.RUnlock()
+
+		if !fetching {
+			return
+		}
+
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for session fetch to finish")
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -57,7 +57,7 @@ type TorrentResponse struct {
 	Counts                 *TorrentCounts          `json:"counts,omitempty"`      // Include counts for sidebar
 	Categories             map[string]qbt.Category `json:"categories,omitempty"`  // Include categories for sidebar
 	Tags                   []string                `json:"tags,omitempty"`        // Include tags for sidebar
-	ServerState            *qbt.ServerState        `json:"serverState,omitempty"` // Include server state for Dashboard
+	ServerState            *ServerStateView        `json:"serverState,omitempty"` // Include server state for Dashboard
 	HasMore                bool                    `json:"hasMore"`               // Whether more pages are available
 	SessionID              string                  `json:"sessionId,omitempty"`   // Optional session tracking
 	CacheMetadata          *CacheMetadata          `json:"cacheMetadata,omitempty"`
@@ -394,7 +394,7 @@ func (sm *SyncManager) GetTorrentsWithFilters(ctx context.Context, instanceID in
 
 	// Determine cache metadata based on last sync update time
 	var cacheMetadata *CacheMetadata
-	var serverState *qbt.ServerState
+	var serverState *ServerStateView
 	client, clientErr := sm.clientPool.GetClient(ctx, instanceID)
 	if clientErr == nil {
 		syncManager := client.GetSyncManager()
@@ -417,7 +417,7 @@ func (sm *SyncManager) GetTorrentsWithFilters(ctx context.Context, instanceID in
 			}
 		}
 
-		if cached := client.GetCachedServerState(); cached != nil {
+		if cached := client.GetServerStateView(); cached != nil {
 			serverState = cached
 		}
 	}

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -27,11 +27,11 @@ import { useInstances } from "@/hooks/useInstances"
 import { usePersistedAccordionState } from "@/hooks/usePersistedAccordionState"
 import { useQBittorrentAppInfo } from "@/hooks/useQBittorrentAppInfo"
 import { api } from "@/lib/api"
-import { formatBytes, getRatioColor } from "@/lib/utils"
+import { formatBytes, formatDuration, getRatioColor } from "@/lib/utils"
 import type { InstanceResponse, ServerState, TorrentCounts, TorrentResponse, TorrentStats } from "@/types"
 import { useMutation, useQueries, useQueryClient } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
-import { Activity, Ban, ChevronDown, ChevronUp, Download, ExternalLink, Eye, EyeOff, Flame, Globe, HardDrive, Minus, Plus, Rabbit, Turtle, Upload, Zap } from "lucide-react"
+import { Activity, Ban, ChevronDown, ChevronUp, Clock, Download, ExternalLink, Eye, EyeOff, Flame, Globe, HardDrive, Minus, Plus, Rabbit, Turtle, Upload, Zap } from "lucide-react"
 import { useMemo, useState } from "react"
 
 import {
@@ -169,6 +169,10 @@ function InstanceCard({
   const connectionStatusIconClass = hasConnectionStatus? isConnectable? "text-green-500": isFirewalled? "text-amber-500": "text-destructive": ""
 
   const connectionStatusTooltip = connectionStatusDisplay ? (isConnectable ? "Connectable" : connectionStatusDisplay) : ""
+
+  const sessionUptimeSeconds = serverState?.session_uptime_seconds
+  const sessionStartDate = serverState?.session_started_at ? new Date(serverState.session_started_at) : null
+  const sessionStartDisplay = sessionStartDate && !Number.isNaN(sessionStartDate.getTime()) ? sessionStartDate.toLocaleString() : ""
 
   // Determine if settings button should show
   const showSettingsButton = instance.connected && !isFirstLoad && !hasDecryptionOrRecentErrors
@@ -375,6 +379,29 @@ function InstanceCard({
                   <span>{`Show ${isAdvancedMetricsOpen ? "less" : "more"}`}</span>
                 </CollapsibleTrigger>
                 <CollapsibleContent className="space-y-2 mt-2">
+                  {sessionUptimeSeconds !== undefined && sessionUptimeSeconds > 0 && (
+                    <div className="flex items-center gap-2 text-xs">
+                      <Clock className="h-3 w-3 text-muted-foreground" />
+                      <span className="text-muted-foreground">Uptime</span>
+                      {sessionStartDisplay ? (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span className="ml-auto font-medium cursor-default">
+                              {formatDuration(Math.floor(sessionUptimeSeconds))}
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p>Started {sessionStartDisplay}</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      ) : (
+                        <span className="ml-auto font-medium">
+                          {formatDuration(Math.floor(sessionUptimeSeconds))}
+                        </span>
+                      )}
+                    </div>
+                  )}
+
                   {serverState?.total_peer_connections !== undefined && (
                     <div className="flex items-center gap-2 text-xs">
                       <Activity className="h-3 w-3 text-muted-foreground" />

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -204,6 +204,8 @@ export interface ServerState {
   write_cache_overload?: string
   last_external_address_v4?: string
   last_external_address_v6?: string
+  session_started_at?: string
+  session_uptime_seconds?: number
 }
 
 export interface AppPreferences {


### PR DESCRIPTION
This change adds qBittorrent session uptime to the dashboard.

- Captures the start timestamp by polling the qBittorrent log endpoint on startup, and whenever the cached value looks stale, taking the earliest log entry. qbit clears its logs on restart, so that first entry should mark session start.
- We use the cached value until the RID counter suggests a restart
- If fetching logs fail, we mark the cache inaccurate and do a five-minute backoff, and leave the uptime fields empty so the UI shows N/A.

<img width="2510" height="1146" alt="CleanShot 2025-10-09 at 12 52 29@2x" src="https://github.com/user-attachments/assets/7c7c986d-73b7-4254-8723-53f43c128268" />
