### PR TITLE
feat(torrents): clear column filters

### DIFF
--- a/web/src/components/torrents/ColumnFilterPopover.tsx
+++ b/web/src/components/torrents/ColumnFilterPopover.tsx
@@ -427,8 +427,11 @@ export function ColumnFilterPopover({
     setValue("")
     setValue2("")
     setSizeUnit("MiB")
+    setSizeUnit2("MiB")
     setSpeedUnit("MiB/s")
+    setSpeedUnit2("MiB/s")
     setDurationUnit("hours")
+    setDurationUnit2("hours")
     setCaseSensitive(true)
     setOperation(getDefaultOperation(columnType))
     onApply(null)
@@ -481,7 +484,7 @@ export function ColumnFilterPopover({
           size="icon"
           ref={triggerRef}
           className={`h-6 w-6 p-0 transition-opacity ${
-            hasActiveFilter || open ? "opacity-100 text-primary" : "opacity-0 group-hover:opacity-100 text-muted-foreground"
+            hasActiveFilter || open ? "opacity-100 text-primary" : "opacity-10 group-hover:opacity-100 focus:opacity-100 focus-visible:opacity-100 active:opacity-100 text-muted-foreground"
           }`}
           onClick={(e) => {
             e.stopPropagation()

--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -1468,86 +1468,89 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
           {/* Action buttons - now handled by Management Bar in Header */}
           <div className="flex gap-1 sm:gap-2 flex-shrink-0">
 
-            {/* Column visibility dropdown moved next to search via portal, with inline fallback */}
+            {/* Column controls next to search via portal, with inline fallback */}
             {(() => {
               const container = typeof document !== "undefined" ? document.getElementById("header-search-actions") : null
-              const dropdown = (
-                <DropdownMenu>
-                  <Tooltip disableHoverableContent={true}>
-                    <TooltipTrigger
-                      asChild
-                      onFocus={(e) => {
-                        // Prevent tooltip from showing on focus - only show on hover
-                        e.preventDefault()
-                      }}
-                    >
-                      <DropdownMenuTrigger asChild>
+              const actions = (
+                <>
+                  {columnFilters.length > 0 && (
+                    <Tooltip>
+                      <TooltipTrigger
+                        asChild
+                        onFocus={(e) => {
+                          // Prevent tooltip from showing on focus - only show on hover
+                          e.preventDefault()
+                        }}
+                      >
                         <Button
                           variant="outline"
                           size="icon"
-                          className="relative"
+                          className="relative mr-1"
+                          onClick={() => setColumnFilters([])}
                         >
-                          <Columns3 className="h-4 w-4"/>
-                          <span className="sr-only">Toggle columns</span>
+                          <X className="h-4 w-4"/>
+                          <span className="sr-only">Clear all column filters</span>
                         </Button>
-                      </DropdownMenuTrigger>
-                    </TooltipTrigger>
-                    <TooltipContent>Toggle columns</TooltipContent>
-                  </Tooltip>
-                  <DropdownMenuContent align="end" className="w-48">
-                    <DropdownMenuLabel>Toggle columns</DropdownMenuLabel>
-                    <DropdownMenuSeparator/>
-                    {table
-                      .getAllColumns()
-                      .filter(
-                        (column) =>
-                          column.id !== "select" && // Never show select in visibility options
-                          column.getCanHide()
-                      )
-                      .map((column) => {
-                        return (
-                          <DropdownMenuCheckboxItem
-                            key={column.id}
-                            className="capitalize"
-                            checked={column.getIsVisible()}
-                            onCheckedChange={(value) =>
-                              column.toggleVisibility(!!value)
-                            }
-                            onSelect={(e) => e.preventDefault()}
-                          >
-                            <span className="truncate">
-                              {(column.columnDef.meta as { headerString?: string })?.headerString ||
-                                (typeof column.columnDef.header === "string" ? column.columnDef.header : column.id)}
-                            </span>
-                          </DropdownMenuCheckboxItem>
-                        )
-                      })}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              )
-              return container ? createPortal(dropdown, container) : dropdown
-            })()}
+                      </TooltipTrigger>
+                      <TooltipContent>Clear all column filters ({columnFilters.length})</TooltipContent>
+                    </Tooltip>
+                  )}
 
-            {/* Clear column filters button - only show when filters are active */}
-            {columnFilters.length > 0 && (() => {
-              const container = typeof document !== "undefined" ? document.getElementById("header-search-actions") : null
-              const clearButton = (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="outline"
-                      size="icon"
-                      className="ml-1"
-                      onClick={() => setColumnFilters([])}
-                    >
-                      <X className="h-4 w-4"/>
-                      <span className="sr-only">Clear all column filters</span>
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>Clear all column filters ({columnFilters.length})</TooltipContent>
-                </Tooltip>
+                  <DropdownMenu>
+                    <Tooltip disableHoverableContent={true}>
+                      <TooltipTrigger
+                        asChild
+                        onFocus={(e) => {
+                          // Prevent tooltip from showing on focus - only show on hover
+                          e.preventDefault()
+                        }}
+                      >
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant="outline"
+                            size="icon"
+                          >
+                            <Columns3 className="h-4 w-4"/>
+                            <span className="sr-only">Toggle columns</span>
+                          </Button>
+                        </DropdownMenuTrigger>
+                      </TooltipTrigger>
+                      <TooltipContent>Toggle columns</TooltipContent>
+                    </Tooltip>
+                    <DropdownMenuContent align="end" className="w-48">
+                      <DropdownMenuLabel>Toggle columns</DropdownMenuLabel>
+                      <DropdownMenuSeparator/>
+                      {table
+                        .getAllColumns()
+                        .filter(
+                          (column) =>
+                            column.id !== "select" && // Never show select in visibility options
+                            column.getCanHide()
+                        )
+                        .map((column) => {
+                          return (
+                            <DropdownMenuCheckboxItem
+                              key={column.id}
+                              className="capitalize"
+                              checked={column.getIsVisible()}
+                              onCheckedChange={(value) =>
+                                column.toggleVisibility(!!value)
+                              }
+                              onSelect={(e) => e.preventDefault()}
+                            >
+                              <span className="truncate">
+                                {(column.columnDef.meta as { headerString?: string })?.headerString ||
+                                  (typeof column.columnDef.header === "string" ? column.columnDef.header : column.id)}
+                              </span>
+                            </DropdownMenuCheckboxItem>
+                          )
+                        })}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </>
               )
-              return container ? createPortal(clearButton, container) : clearButton
+
+              return container ? createPortal(actions, container) : actions
             })()}
 
             <AddTorrentDialog


### PR DESCRIPTION
This adds a button in the header next to the column toggle to clear all active column filters.
Additionally the filter icon now only shows in the column header on hover or when it's active.
<img width="1240" height="560" alt="image" src="https://github.com/user-attachments/assets/e3f7b926-c83a-4417-903a-ca3511329a86" />
