### PR TITLE
fix(http): Chrome Basic Auth popup when using reverse proxy

### DIFF
--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -36,7 +36,7 @@ func IsAuthenticated(authService *auth.Service, sessionManager *scs.SessionManag
 
 			// Check session using SCS
 			if !sessionManager.GetBool(r.Context(), "authenticated") {
-				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				http.Error(w, "Unauthorized", http.StatusForbidden)
 				return
 			}
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -44,7 +44,7 @@ class ApiClient {
       // Don't auto-redirect for auth check endpoints - let React Router handle navigation
       const isAuthCheckEndpoint = endpoint === "/auth/me" || endpoint === "/auth/validate"
 
-      if (response.status === 401 && !isAuthCheckEndpoint && !window.location.pathname.startsWith(withBasePath("/login")) && !window.location.pathname.startsWith(withBasePath("/setup"))) {
+      if ((response.status === 401 || response.status === 403) && !isAuthCheckEndpoint && !window.location.pathname.startsWith(withBasePath("/login")) && !window.location.pathname.startsWith(withBasePath("/setup"))) {
         window.location.href = withBasePath("/login")
         throw new Error("Session expired")
       }
@@ -359,7 +359,7 @@ class ApiClient {
     })
 
     if (!response.ok) {
-      if (response.status === 401 && !window.location.pathname.startsWith(withBasePath("/login")) && !window.location.pathname.startsWith(withBasePath("/setup"))) {
+      if ((response.status === 401 || response.status === 403) && !window.location.pathname.startsWith(withBasePath("/login")) && !window.location.pathname.startsWith(withBasePath("/setup"))) {
         window.location.href = withBasePath("/login")
         throw new Error("Session expired")
       }

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -198,7 +198,7 @@ export function Login() {
 
                 {loginError && (
                   <div className="bg-destructive/10 border border-destructive/20 text-destructive px-4 py-3 rounded-md text-sm">
-                    {typeof loginError === "string"? loginError: loginError.message?.includes("Invalid credentials") || loginError.message?.includes("401")? "Invalid username or password": loginError.message || "Login failed. Please try again."}
+                    {typeof loginError === "string"? loginError: loginError.message?.includes("Invalid credentials") || loginError.message?.includes("401") || loginError.message?.includes("403") ? "Invalid username or password": loginError.message || "Login failed. Please try again."}
                   </div>
                 )}
 


### PR DESCRIPTION
When using a reverse proxy with basic auth and using Chrome, it will keep resetting the reverse proxy basic auth when the middleware responds with 401. FF does not do this.

Changing this to 403 Forbidden fixes this issue.