### PR TITLE
feat(sync): periodic instance syncing

### DIFF
--- a/PERIODIC_SYNC_IMPLEMENTATION.md
+++ b/PERIODIC_SYNC_IMPLEMENTATION.md
@@ -1,7 +1,17 @@
 # Periodic Cache Refresh Implementation
 
 ## Overview
-This document describes the implementation of automatic periodic cache refresh for qBittorrent instances in qui. The feature allows instances to automatically sync their cache at configurable intervals (measured in minutes, with a 5-minute minimum).
+This document describes the implementation of automatic periodic cache refresh for qBittorrent instances in qui. The feature allows instances to automatically sync their cache at configurable intervals (measured in minutes, with a 1-minute minimum). The periodic sync timer **resets after every sync operation**, ensuring the interval represents "time since last sync" rather than a fixed schedule.
+
+## Key Behavior
+
+**Timer Reset on ANY Sync**: The periodic sync timer resets whenever a sync occurs from any source:
+- ✅ Periodic sync triggers → Timer resets
+- ✅ User manually refreshes from frontend → Timer resets  
+- ✅ Proxy performs a sync → Timer resets
+- ✅ Any operation that triggers sync manager → Timer resets
+
+This prevents unnecessary syncs and ensures the configured interval represents the **minimum time between syncs**, not a rigid schedule that ignores other sync activity.
 
 ## Architecture
 
@@ -9,8 +19,8 @@ This document describes the implementation of automatic periodic cache refresh f
 - **Migration**: `010_add_sync_interval.sql`
   - Adds `sync_interval` INTEGER column to `instances` table
   - Default value: 0 (disabled)
-  - Values: 0 = disabled, 5+ = minutes between syncs
-  - Minimum enforced: 5 minutes
+  - Values: 0 = disabled, 1+ = minutes between syncs
+  - Minimum enforced: 1 minute
 
 ### Model Layer (`internal/models/instance.go`)
 - Added `SyncInterval int` field to `Instance` struct
@@ -28,34 +38,40 @@ This document describes the implementation of automatic periodic cache refresh f
   - `InstanceResponse`: Added `SyncInterval int` field
 - Added validation:
   - Both Create and Update handlers validate sync_interval
-  - Must be 0 (disabled) or >= 5 minutes
+  - Must be 0 (disabled) or >= 1 minute
 - Updated handlers:
   - `CreateInstance`: Passes syncInterval to Create method
   - `UpdateInstance`: Passes syncInterval to Update method and calls UpdateClientSyncInterval
 
 ### Client Layer (`internal/qbittorrent/client.go`)
 - Added periodic sync fields to `Client` struct:
-  - `syncInterval int`: Minutes between automatic syncs
-  - `syncTicker *time.Ticker`: Ticker for periodic syncs
-  - `stopSync chan struct{}`: Channel to stop sync ticker
-  - `lastSyncTime time.Time`: Time of last sync
-  - `syncMu sync.RWMutex`: Protects sync ticker fields
+  - `syncInterval int`: Minutes between automatic syncs (0 = disabled)
+  - `syncTimer *time.Timer`: Timer for next periodic sync
+  - `lastSyncTime time.Time`: Time of last sync (from any source)
+  - `syncCtx context.Context`: Dedicated context for sync manager lifecycle
+  - `syncCancel context.CancelFunc`: Function to stop sync manager
+  - `syncMu sync.RWMutex`: Protects sync timer and timing fields
 
 - **Key Methods**:
-  - `StartSyncManager(ctx, syncInterval)`: Starts sync manager with periodic sync
-  - `startPeriodicSync()`: Starts the ticker for periodic syncs
-  - `performPeriodicSync()`: Executes a sync operation
-  - `recordSyncTime()`: Records sync time and resets ticker
-  - `UpdateSyncInterval(syncInterval)`: Updates interval and restarts ticker
+  - `StartSyncManager(ctx, syncInterval)`: Creates and starts sync manager with custom periodic sync
+    - Creates dedicated context using `context.Background()` (not request context)
+    - Configures `SyncOptions` with `DynamicSync=true` and `AutoSync=false`
+    - Sets up OnUpdate callback to call `recordSyncTime()` after every sync
+    - Starts custom periodic sync timer if interval >= 1
+  - `startPeriodicSync()`: Starts the periodic sync timer
+  - `performPeriodicSync()`: Executes a periodic sync
+  - `recordSyncTime()`: Records sync time and **resets the timer** (called after ANY sync)
+  - `UpdateSyncInterval(syncInterval)`: Updates interval by stopping timer and recreating sync manager
   - `StartSyncManagerLegacy(ctx)`: Backward-compatible wrapper (0 interval)
 
-- **Ticker Reset Logic**:
-  - Ticker is reset on **every** sync, not just periodic ones
-  - Added `recordSyncTime()` call in `OnUpdate` callback
-  - This ensures the interval countdown restarts whenever:
-    - Manual sync occurs via frontend
-    - Periodic sync triggers
-    - Any operation that forces a sync (add, delete, etc.)
+- **Timer Reset Logic**:
+  - `recordSyncTime()` is called in the `OnUpdate` callback
+  - This means the timer resets on **every successful sync**, regardless of source:
+    - Periodic sync via our timer
+    - Manual sync from frontend (torrent table)
+    - Sync triggered by proxy operations
+    - Any other sync operation
+  - Timer is stopped and restarted with full interval duration
 
 ### Pool Layer (`internal/qbittorrent/pool.go`)
 - Updated `createClientWithTimeout`:
@@ -68,44 +84,52 @@ This document describes the implementation of automatic periodic cache refresh f
 
 ### Sync Interval Rules
 1. **0**: Periodic sync disabled (default)
-2. **1-4 minutes**: Invalid, rejected by API validation
-3. **5+ minutes**: Valid, enables periodic sync
+2. **1+ minutes**: Valid, enables periodic sync with timer reset
 
-### Ticker Reset Behavior
-The periodic sync ticker is reset on **every sync operation**, ensuring the countdown always starts from the last successful sync:
+### Timer Reset Behavior
+The periodic sync timer is **reset on every sync operation**, ensuring the countdown always starts from the last successful sync:
 
-1. **Periodic sync triggers** → Timer resets
-2. **User manually refreshes** → Timer resets
-3. **Torrent added/deleted** → Forces sync → Timer resets
-4. **Any operation calling sync manager** → Timer resets
+1. **Periodic sync triggers** → Sync executes → OnUpdate called → recordSyncTime() → Timer resets
+2. **User manually refreshes via frontend** → Sync executes → OnUpdate called → recordSyncTime() → Timer resets
+3. **Proxy performs sync** → Sync executes → OnUpdate called → recordSyncTime() → Timer resets
+4. **Any operation that triggers sync** → OnUpdate called → recordSyncTime() → Timer resets
 
-This prevents unnecessary syncs and ensures the interval represents "time since last sync" rather than a fixed schedule.
+This prevents redundant syncs and ensures the interval represents **"time since last sync from any source"** rather than a fixed schedule.
 
 ### Example Timeline
 If sync_interval = 10 minutes:
 ```
-T+0:  User opens dashboard → Sync occurs → Timer starts
-T+5:  User adds torrent → Sync occurs → Timer resets to 0
-T+10: No activity → Periodic sync triggers → Timer resets
-T+20: Periodic sync triggers again
+T+0:  Client created → Initial sync → Timer starts (next sync at T+10)
+T+5:  User manually refreshes → Sync occurs → Timer resets (next sync at T+15)
+T+7:  Proxy performs sync → Sync occurs → Timer resets (next sync at T+17)
+T+17: No activity → Periodic sync triggers → Timer resets (next sync at T+27)
+T+27: Periodic sync triggers again
 ```
+
+Note: Manual syncs don't interrupt the timer countdown - they reset it to a fresh interval.
 
 ### Client Lifecycle
 1. **Client Creation**: 
    - syncInterval loaded from database
    - Passed to StartSyncManager
-   - Ticker started if syncInterval >= 5
+   - SyncManager created with DynamicSync enabled, AutoSync disabled
+   - Dedicated context (`syncCtx`) created from `context.Background()`
+   - If syncInterval >= 1, custom periodic sync timer started
 
 2. **Instance Update**:
    - API handler updates database
    - Calls UpdateClientSyncInterval on pool
-   - Existing client updates its ticker
+   - Existing timer stopped
+   - Existing context canceled (stops sync manager)
+   - New SyncManager created with updated settings
+   - New timer started with new interval
    - Client removed from pool (forces reconnect with new settings)
 
 3. **Sync Operations**:
-   - Every successful sync calls recordSyncTime()
-   - Ticker is reset to full interval
-   - Countdown starts from current time
+   - **Periodic Sync**: Happens when timer fires (custom timer, not library AutoSync)
+   - **Manual Sync**: User-initiated from frontend (torrent table refresh button)
+   - **Proxy Sync**: Triggered by proxy operations
+   - **All syncs** trigger OnUpdate callback → recordSyncTime() → Timer resets
 
 ## Frontend Integration
 
@@ -118,8 +142,8 @@ The frontend should add:
   type: "number",
   min: 0,
   step: 1,
-  placeholder: "0 (disabled) or 5+ minutes",
-  helperText: "Automatically refresh cache every N minutes. Minimum 5 minutes, 0 to disable."
+  placeholder: "0 (disabled) or 1+ minutes",
+  helperText: "Automatically refresh cache every N minutes. Timer resets after any sync. Minimum 1 minute, 0 to disable."
 }
 ```
 
@@ -166,14 +190,14 @@ The frontend should add:
 
 ### qBittorrent Client
 - `internal/qbittorrent/client.go`
-  - Client struct (new fields)
-  - NewClientWithTimeout (initialize stopSync channel)
-  - StartSyncManager (accept syncInterval, start ticker)
-  - startPeriodicSync (new)
-  - performPeriodicSync (new)
-  - recordSyncTime (new, called on every sync)
-  - UpdateSyncInterval (new)
-  - OnUpdate callback (added recordSyncTime call)
+  - Client struct (added syncInterval, syncTimer, lastSyncTime, syncCtx, syncCancel fields)
+  - StartSyncManager (creates SyncManager with DynamicSync, starts custom periodic sync timer)
+  - startPeriodicSync (starts the timer for periodic syncs)
+  - performPeriodicSync (executes periodic sync when timer fires)
+  - recordSyncTime (records sync time and resets timer - called after ANY sync)
+  - UpdateSyncInterval (stops timer, recreates SyncManager with new interval)
+  - Custom timer-based implementation that resets after any sync
+  - Does NOT use go-qbittorrent's AutoSync (would run on fixed schedule)
 
 ### Client Pool
 - `internal/qbittorrent/pool.go`
@@ -188,27 +212,40 @@ The frontend should add:
 
 ### Manual Testing Steps
 1. **Create instance with sync interval**:
-   - POST to /api/instances with syncInterval: 5
-   - Verify database has sync_interval = 5
-   - Check logs for "Started periodic cache refresh" message
+   - POST to /api/instances with syncInterval: 1 or higher
+   - Verify database has sync_interval = configured value
+   - Check logs for "Started periodic background syncing" message
 
 2. **Verify periodic sync**:
-   - Wait 5 minutes
+   - Wait for the configured interval
    - Check logs for "Performing periodic cache refresh"
-   - Verify ticker reset after manual sync
+   - Verify next sync is scheduled
 
-3. **Update sync interval**:
-   - PATCH instance with syncInterval: 10
+3. **Verify timer reset on manual sync**:
+   - Set sync interval to 10 minutes
+   - Wait 3 minutes
+   - Manually refresh from frontend
+   - Check logs for "Periodic sync timer reset after sync"
+   - Wait - next periodic sync should occur 10 minutes after manual sync, not 7
+
+4. **Update sync interval**:
+   - PATCH instance with syncInterval: different value
    - Verify logs show "Updating periodic sync interval"
-   - Old ticker should stop, new one should start
+   - Old timer should stop, new one should start with new duration
 
-4. **Disable sync**:
+5. **Disable sync**:
    - PATCH instance with syncInterval: 0
-   - Verify logs show "Stopped periodic cache refresh"
+   - Verify timer is stopped, no more periodic syncs
 
-5. **Validation**:
-   - Try creating with syncInterval: 3
-   - Should get 400 error: "must be 0 or at least 5 minutes"
+6. **Validation**:
+   - Try creating with syncInterval: 0.5
+   - Should get 400 error: "must be 0 or at least 1 minute"
+
+7. **Background Operation**:
+   - Start instance with sync interval
+   - Close all frontend connections
+   - Verify syncing continues in background (check logs)
+   - Uses context.Background() so not tied to request lifecycle
 
 ### Integration Testing
 ```bash
@@ -222,21 +259,96 @@ curl -X POST http://localhost:7476/api/instances \
   -d '{"name":"Test","host":"http://localhost:8080","username":"admin","password":"admin","syncInterval":5}'
 
 # Verify logs
-# Should see: "Started periodic cache refresh" with intervalMinutes=5
+# Should see: "Started periodic background syncing" with intervalMinutes configured
+# Should see: "Sync manager started successfully" with periodicSyncEnabled=true
 ```
+
+## Architecture Notes
+
+### Why Custom Timer Instead of go-qbittorrent's AutoSync?
+
+**go-qbittorrent's AutoSync:**
+- Runs on a **fixed schedule** with `time.After(interval)`
+- Syncs occur at regular intervals regardless of other sync activity
+- Example: If interval is 10 minutes, syncs happen at T+10, T+20, T+30...
+- Manual syncs or proxy syncs don't affect the schedule
+
+**Our Custom Timer Implementation:**
+- Timer **resets after every sync** from any source
+- Ensures configured interval is **minimum time between syncs**
+- Prevents redundant syncs when other operations already triggered sync
+- Example: If interval is 10 minutes and user syncs manually at T+5, next periodic sync is at T+15 (not T+10)
+
+### Timer Reset Mechanism
+
+The `recordSyncTime()` method is called in the `OnUpdate` callback, which fires after **every successful sync**:
+
+```go
+syncOpts.OnUpdate = func(data *qbt.MainData) {
+    c.updateHealthStatus(true)
+    c.updateServerState(data)
+    c.rebuildHashIndex(data.Torrents)
+    c.recordSyncTime() // ← Resets timer after ANY sync
+    log.Debug()...
+}
+```
+
+This means:
+- ✅ Periodic sync triggers → OnUpdate → Timer resets
+- ✅ User clicks refresh → Sync → OnUpdate → Timer resets
+- ✅ Proxy performs sync → OnUpdate → Timer resets
+- ✅ Any sync operation → OnUpdate → Timer resets
+
+### Context Management
+
+**Critical Design Decision:**
+The sync manager context is based on `context.Background()` rather than HTTP request contexts:
+
+```go
+// CORRECT: Uses Background() for long-lived operation
+c.syncCtx, c.syncCancel = context.WithCancel(context.Background())
+
+// WRONG: Would stop when HTTP request ends
+syncManager.Start(ctx) // where ctx is from HTTP handler
+```
+
+This ensures the sync manager and periodic syncs continue running even when:
+- No users are connected to the frontend
+- HTTP requests complete
+- WebSocket connections close
+- Dynamic syncs finish
+
+### Timer vs Ticker
+
+We use `time.Timer` (via `time.AfterFunc`) instead of `time.Ticker`:
+
+**Timer** (what we use):
+- Single-shot, fires once
+- Can be stopped and reset with new duration
+- Perfect for "reset after sync" behavior
+- `recordSyncTime()` stops old timer and creates new one
+
+**Ticker** (what we don't use):
+- Fires repeatedly at fixed intervals
+- Can't easily adjust duration without recreating
+- Would require manual reset logic on every sync
+- Not ideal for our use case
 
 ## Future Enhancements
 
 1. **Per-Instance Status**: Show time until next sync in UI
 2. **Sync History**: Track sync success/failure rate
 3. **Adaptive Intervals**: Adjust interval based on activity
-4. **Sync on Demand**: Manual trigger button in UI
+4. **Sync on Demand**: Manual trigger button in UI (already exists via DynamicSync)
 5. **Health-Based Sync**: Skip sync if instance is unhealthy
 
 ## Notes
 
-- Minimum 5 minutes chosen to prevent excessive API calls to qBittorrent
-- Ticker resets on every sync to prevent redundant syncs after manual refresh
-- Client recreation on update ensures all settings are fresh
+- Minimum 1 minute chosen as reasonable lower bound for periodic syncing
+- Timer resets on every sync to prevent redundant syncs after manual/proxy operations
+- SyncManager recreation on interval change ensures clean state
 - Backward compatible: existing instances default to 0 (disabled)
-- Goroutine-safe: all ticker operations protected by syncMu
+- Goroutine-safe: all timer operations protected by syncMu
+- Custom timer implementation instead of go-qbittorrent's AutoSync
+- True background operation via context.Background() based context
+- Timer ensures configured interval is **minimum time between syncs**

--- a/PERIODIC_SYNC_IMPLEMENTATION.md
+++ b/PERIODIC_SYNC_IMPLEMENTATION.md
@@ -1,0 +1,242 @@
+# Periodic Cache Refresh Implementation
+
+## Overview
+This document describes the implementation of automatic periodic cache refresh for qBittorrent instances in qui. The feature allows instances to automatically sync their cache at configurable intervals (measured in minutes, with a 5-minute minimum).
+
+## Architecture
+
+### Database Layer
+- **Migration**: `010_add_sync_interval.sql`
+  - Adds `sync_interval` INTEGER column to `instances` table
+  - Default value: 0 (disabled)
+  - Values: 0 = disabled, 5+ = minutes between syncs
+  - Minimum enforced: 5 minutes
+
+### Model Layer (`internal/models/instance.go`)
+- Added `SyncInterval int` field to `Instance` struct
+- Updated JSON marshaling/unmarshaling to include sync_interval
+- Updated all CRUD operations:
+  - `Create`: Accepts syncInterval parameter
+  - `Get`: Selects sync_interval from database
+  - `List`: Selects sync_interval from database
+  - `Update`: Accepts and updates sync_interval
+
+### API Layer (`internal/api/handlers/instances.go`)
+- Updated request/response structs:
+  - `CreateInstanceRequest`: Added `SyncInterval int` field
+  - `UpdateInstanceRequest`: Added `SyncInterval *int` field (optional)
+  - `InstanceResponse`: Added `SyncInterval int` field
+- Added validation:
+  - Both Create and Update handlers validate sync_interval
+  - Must be 0 (disabled) or >= 5 minutes
+- Updated handlers:
+  - `CreateInstance`: Passes syncInterval to Create method
+  - `UpdateInstance`: Passes syncInterval to Update method and calls UpdateClientSyncInterval
+
+### Client Layer (`internal/qbittorrent/client.go`)
+- Added periodic sync fields to `Client` struct:
+  - `syncInterval int`: Minutes between automatic syncs
+  - `syncTicker *time.Ticker`: Ticker for periodic syncs
+  - `stopSync chan struct{}`: Channel to stop sync ticker
+  - `lastSyncTime time.Time`: Time of last sync
+  - `syncMu sync.RWMutex`: Protects sync ticker fields
+
+- **Key Methods**:
+  - `StartSyncManager(ctx, syncInterval)`: Starts sync manager with periodic sync
+  - `startPeriodicSync()`: Starts the ticker for periodic syncs
+  - `performPeriodicSync()`: Executes a sync operation
+  - `recordSyncTime()`: Records sync time and resets ticker
+  - `UpdateSyncInterval(syncInterval)`: Updates interval and restarts ticker
+  - `StartSyncManagerLegacy(ctx)`: Backward-compatible wrapper (0 interval)
+
+- **Ticker Reset Logic**:
+  - Ticker is reset on **every** sync, not just periodic ones
+  - Added `recordSyncTime()` call in `OnUpdate` callback
+  - This ensures the interval countdown restarts whenever:
+    - Manual sync occurs via frontend
+    - Periodic sync triggers
+    - Any operation that forces a sync (add, delete, etc.)
+
+### Pool Layer (`internal/qbittorrent/pool.go`)
+- Updated `createClientWithTimeout`:
+  - Passes instance.SyncInterval to StartSyncManager
+- Added `UpdateClientSyncInterval(instanceID, syncInterval)`:
+  - Updates sync interval for existing clients in pool
+  - Called when instance settings are updated
+
+## Behavior
+
+### Sync Interval Rules
+1. **0**: Periodic sync disabled (default)
+2. **1-4 minutes**: Invalid, rejected by API validation
+3. **5+ minutes**: Valid, enables periodic sync
+
+### Ticker Reset Behavior
+The periodic sync ticker is reset on **every sync operation**, ensuring the countdown always starts from the last successful sync:
+
+1. **Periodic sync triggers** → Timer resets
+2. **User manually refreshes** → Timer resets
+3. **Torrent added/deleted** → Forces sync → Timer resets
+4. **Any operation calling sync manager** → Timer resets
+
+This prevents unnecessary syncs and ensures the interval represents "time since last sync" rather than a fixed schedule.
+
+### Example Timeline
+If sync_interval = 10 minutes:
+```
+T+0:  User opens dashboard → Sync occurs → Timer starts
+T+5:  User adds torrent → Sync occurs → Timer resets to 0
+T+10: No activity → Periodic sync triggers → Timer resets
+T+20: Periodic sync triggers again
+```
+
+### Client Lifecycle
+1. **Client Creation**: 
+   - syncInterval loaded from database
+   - Passed to StartSyncManager
+   - Ticker started if syncInterval >= 5
+
+2. **Instance Update**:
+   - API handler updates database
+   - Calls UpdateClientSyncInterval on pool
+   - Existing client updates its ticker
+   - Client removed from pool (forces reconnect with new settings)
+
+3. **Sync Operations**:
+   - Every successful sync calls recordSyncTime()
+   - Ticker is reset to full interval
+   - Countdown starts from current time
+
+## Frontend Integration
+
+### Instance Settings Modal
+The frontend should add:
+```typescript
+// In the instance form
+{
+  label: "Sync Interval (minutes)",
+  type: "number",
+  min: 0,
+  step: 1,
+  placeholder: "0 (disabled) or 5+ minutes",
+  helperText: "Automatically refresh cache every N minutes. Minimum 5 minutes, 0 to disable."
+}
+```
+
+### API Request/Response
+```json
+// POST /api/instances
+{
+  "name": "Instance Name",
+  "host": "http://localhost:8080",
+  "username": "admin",
+  "password": "password",
+  "syncInterval": 10  // Minutes
+}
+
+// Response
+{
+  "id": 1,
+  "name": "Instance Name",
+  "syncInterval": 10,
+  ...
+}
+```
+
+## Implementation Files Changed
+
+### Database
+- `internal/database/migrations/010_add_sync_interval.sql` (new)
+
+### Models
+- `internal/models/instance.go`
+  - Instance struct
+  - MarshalJSON/UnmarshalJSON
+  - Create/Get/List/Update methods
+
+### API
+- `internal/api/handlers/instances.go`
+  - CreateInstanceRequest
+  - UpdateInstanceRequest  
+  - InstanceResponse
+  - CreateInstance handler (validation)
+  - UpdateInstance handler (validation + update)
+  - buildInstanceResponse
+  - buildQuickInstanceResponse
+
+### qBittorrent Client
+- `internal/qbittorrent/client.go`
+  - Client struct (new fields)
+  - NewClientWithTimeout (initialize stopSync channel)
+  - StartSyncManager (accept syncInterval, start ticker)
+  - startPeriodicSync (new)
+  - performPeriodicSync (new)
+  - recordSyncTime (new, called on every sync)
+  - UpdateSyncInterval (new)
+  - OnUpdate callback (added recordSyncTime call)
+
+### Client Pool
+- `internal/qbittorrent/pool.go`
+  - createClientWithTimeout (pass syncInterval)
+  - UpdateClientSyncInterval (new)
+
+### Tests
+- `internal/models/instance_test.go`
+  - Updated Create/Update test calls to include syncInterval
+
+## Testing
+
+### Manual Testing Steps
+1. **Create instance with sync interval**:
+   - POST to /api/instances with syncInterval: 5
+   - Verify database has sync_interval = 5
+   - Check logs for "Started periodic cache refresh" message
+
+2. **Verify periodic sync**:
+   - Wait 5 minutes
+   - Check logs for "Performing periodic cache refresh"
+   - Verify ticker reset after manual sync
+
+3. **Update sync interval**:
+   - PATCH instance with syncInterval: 10
+   - Verify logs show "Updating periodic sync interval"
+   - Old ticker should stop, new one should start
+
+4. **Disable sync**:
+   - PATCH instance with syncInterval: 0
+   - Verify logs show "Stopped periodic cache refresh"
+
+5. **Validation**:
+   - Try creating with syncInterval: 3
+   - Should get 400 error: "must be 0 or at least 5 minutes"
+
+### Integration Testing
+```bash
+# Build and run
+go build -v ./...
+./qui
+
+# Test API
+curl -X POST http://localhost:7476/api/instances \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Test","host":"http://localhost:8080","username":"admin","password":"admin","syncInterval":5}'
+
+# Verify logs
+# Should see: "Started periodic cache refresh" with intervalMinutes=5
+```
+
+## Future Enhancements
+
+1. **Per-Instance Status**: Show time until next sync in UI
+2. **Sync History**: Track sync success/failure rate
+3. **Adaptive Intervals**: Adjust interval based on activity
+4. **Sync on Demand**: Manual trigger button in UI
+5. **Health-Based Sync**: Skip sync if instance is unhealthy
+
+## Notes
+
+- Minimum 5 minutes chosen to prevent excessive API calls to qBittorrent
+- Ticker resets on every sync to prevent redundant syncs after manual refresh
+- Client recreation on update ensures all settings are fresh
+- Backward compatible: existing instances default to 0 (disabled)
+- Goroutine-safe: all ticker operations protected by syncMu

--- a/internal/api/handlers/instances.go
+++ b/internal/api/handlers/instances.go
@@ -260,9 +260,9 @@ func (h *InstancesHandler) CreateInstance(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Validate sync interval (0 = disabled, or minimum 5 minutes)
-	if req.SyncInterval != 0 && req.SyncInterval < 5 {
-		RespondError(w, http.StatusBadRequest, "Sync interval must be 0 (disabled) or at least 5 minutes")
+	// Validate sync interval (0 = disabled, or minimum 1 minute)
+	if req.SyncInterval != 0 && req.SyncInterval < 1 {
+		RespondError(w, http.StatusBadRequest, "Sync interval must be 0 (disabled) or at least 1 minute")
 		return
 	}
 
@@ -304,10 +304,10 @@ func (h *InstancesHandler) UpdateInstance(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Validate sync interval (0 = disabled, or minimum 5 minutes)
+	// Validate sync interval (0 = disabled, or minimum 1 minute)
 	if req.SyncInterval != nil {
-		if *req.SyncInterval != 0 && *req.SyncInterval < 5 {
-			RespondError(w, http.StatusBadRequest, "Sync interval must be 0 (disabled) or at least 5 minutes")
+		if *req.SyncInterval != 0 && *req.SyncInterval < 1 {
+			RespondError(w, http.StatusBadRequest, "Sync interval must be 0 (disabled) or at least 1 minute")
 			return
 		}
 	}

--- a/internal/api/handlers/instances.go
+++ b/internal/api/handlers/instances.go
@@ -94,6 +94,7 @@ func (h *InstancesHandler) buildInstanceResponsesParallel(ctx context.Context, i
 				TLSSkipVerify:      instances[i].TLSSkipVerify,
 				Connected:          false,
 				HasDecryptionError: false,
+				SyncInterval:       instances[i].SyncInterval,
 			}
 		}
 	}
@@ -127,6 +128,7 @@ func (h *InstancesHandler) buildInstanceResponse(ctx context.Context, instance *
 		Connected:          healthy,
 		HasDecryptionError: hasDecryptionError,
 		ConnectionStatus:   connectionStatus,
+		SyncInterval:       instance.SyncInterval,
 	}
 
 	// Fetch recent errors for disconnected instances
@@ -154,6 +156,7 @@ func (h *InstancesHandler) buildQuickInstanceResponse(instance *models.Instance)
 		TLSSkipVerify:      instance.TLSSkipVerify,
 		Connected:          false, // Will be updated asynchronously
 		HasDecryptionError: false,
+		SyncInterval:       instance.SyncInterval,
 	}
 }
 
@@ -187,6 +190,7 @@ type CreateInstanceRequest struct {
 	BasicUsername *string `json:"basicUsername,omitempty"`
 	BasicPassword *string `json:"basicPassword,omitempty"`
 	TLSSkipVerify bool    `json:"tlsSkipVerify,omitempty"`
+	SyncInterval  int     `json:"syncInterval,omitempty"`
 }
 
 // UpdateInstanceRequest represents a request to update an instance
@@ -198,6 +202,7 @@ type UpdateInstanceRequest struct {
 	BasicUsername *string `json:"basicUsername,omitempty"`
 	BasicPassword *string `json:"basicPassword,omitempty"`
 	TLSSkipVerify *bool   `json:"tlsSkipVerify,omitempty"`
+	SyncInterval  *int    `json:"syncInterval,omitempty"`
 }
 
 // InstanceResponse represents an instance in API responses
@@ -212,6 +217,7 @@ type InstanceResponse struct {
 	HasDecryptionError bool                   `json:"hasDecryptionError"`
 	RecentErrors       []models.InstanceError `json:"recentErrors,omitempty"`
 	ConnectionStatus   string                 `json:"connectionStatus,omitempty"`
+	SyncInterval       int                    `json:"syncInterval,omitempty"`
 }
 
 // TestConnectionResponse represents connection test results
@@ -254,8 +260,14 @@ func (h *InstancesHandler) CreateInstance(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	// Validate sync interval (0 = disabled, or minimum 5 minutes)
+	if req.SyncInterval != 0 && req.SyncInterval < 5 {
+		RespondError(w, http.StatusBadRequest, "Sync interval must be 0 (disabled) or at least 5 minutes")
+		return
+	}
+
 	// Create instance
-	instance, err := h.instanceStore.Create(r.Context(), req.Name, req.Host, req.Username, req.Password, req.BasicUsername, req.BasicPassword, req.TLSSkipVerify)
+	instance, err := h.instanceStore.Create(r.Context(), req.Name, req.Host, req.Username, req.Password, req.BasicUsername, req.BasicPassword, req.TLSSkipVerify, req.SyncInterval)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to create instance")
 		RespondError(w, http.StatusInternalServerError, "Failed to create instance")
@@ -292,6 +304,14 @@ func (h *InstancesHandler) UpdateInstance(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	// Validate sync interval (0 = disabled, or minimum 5 minutes)
+	if req.SyncInterval != nil {
+		if *req.SyncInterval != 0 && *req.SyncInterval < 5 {
+			RespondError(w, http.StatusBadRequest, "Sync interval must be 0 (disabled) or at least 5 minutes")
+			return
+		}
+	}
+
 	// Fetch existing instance to handle redacted values
 	existingInstance, err := h.instanceStore.Get(r.Context(), instanceID)
 	if err != nil {
@@ -315,7 +335,7 @@ func (h *InstancesHandler) UpdateInstance(w http.ResponseWriter, r *http.Request
 	}
 
 	// Update instance
-	instance, err := h.instanceStore.Update(r.Context(), instanceID, req.Name, req.Host, req.Username, req.Password, req.BasicUsername, req.BasicPassword, req.TLSSkipVerify)
+	instance, err := h.instanceStore.Update(r.Context(), instanceID, req.Name, req.Host, req.Username, req.Password, req.BasicUsername, req.BasicPassword, req.TLSSkipVerify, req.SyncInterval)
 	if err != nil {
 		if errors.Is(err, models.ErrInstanceNotFound) {
 			RespondError(w, http.StatusNotFound, "Instance not found")
@@ -326,7 +346,15 @@ func (h *InstancesHandler) UpdateInstance(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Remove old client from pool to force reconnection
+	// Update sync interval for existing client (if it exists in pool)
+	// This handles the case where only sync interval changed
+	if req.SyncInterval != nil {
+		if err := h.clientPool.UpdateClientSyncInterval(instanceID, *req.SyncInterval); err != nil {
+			log.Warn().Err(err).Int("instanceID", instanceID).Msg("Failed to update client sync interval")
+		}
+	}
+
+	// Remove old client from pool to force reconnection with new credentials/settings
 	h.clientPool.RemoveClient(instanceID)
 
 	// Return quickly without testing connection

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -159,6 +159,7 @@ var expectedSchema = map[string][]columnSpec{
 		{Name: "basic_username", Type: "TEXT"},
 		{Name: "basic_password_encrypted", Type: "TEXT"},
 		{Name: "tls_skip_verify", Type: "BOOLEAN"},
+		{Name: "sync_interval", Type: "INTEGER"},
 	},
 	"licenses": {
 		{Name: "id", Type: "INTEGER", PrimaryKey: true},

--- a/internal/database/migrations/010_add_sync_interval.sql
+++ b/internal/database/migrations/010_add_sync_interval.sql
@@ -1,3 +1,4 @@
 -- Add sync_interval column to instances table
--- sync_interval: Number of minutes between automatic sync updates (0 = disabled, minimum 5 minutes)
+-- sync_interval: Number of minutes between automatic sync updates (0 = disabled, minimum 1 minute)
+-- Timer resets after any sync operation (periodic, manual, or proxy-initiated)
 ALTER TABLE instances ADD COLUMN sync_interval INTEGER NOT NULL DEFAULT 0;

--- a/internal/database/migrations/010_add_sync_interval.sql
+++ b/internal/database/migrations/010_add_sync_interval.sql
@@ -1,0 +1,3 @@
+-- Add sync_interval column to instances table
+-- sync_interval: Number of minutes between automatic sync updates (0 = disabled, minimum 5 minutes)
+ALTER TABLE instances ADD COLUMN sync_interval INTEGER NOT NULL DEFAULT 0;

--- a/internal/models/instance_test.go
+++ b/internal/models/instance_test.go
@@ -153,7 +153,8 @@ func TestInstanceStoreWithHost(t *testing.T) {
 			is_active BOOLEAN DEFAULT 1,
 			last_connected_at TIMESTAMP,
 			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-			updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+			updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+			sync_interval INTEGER NOT NULL
 		)
 	`)
 	require.NoError(t, err, "Failed to create test table")

--- a/internal/models/instance_test.go
+++ b/internal/models/instance_test.go
@@ -159,7 +159,7 @@ func TestInstanceStoreWithHost(t *testing.T) {
 	require.NoError(t, err, "Failed to create test table")
 
 	// Test creating an instance with host
-	instance, err := store.Create(ctx, "Test Instance", "http://localhost:8080", "testuser", "testpass", nil, nil, false)
+	instance, err := store.Create(ctx, "Test Instance", "http://localhost:8080", "testuser", "testpass", nil, nil, false, 0)
 	require.NoError(t, err, "Failed to create instance")
 	assert.Equal(t, "http://localhost:8080", instance.Host, "host should match")
 	assert.False(t, instance.TLSSkipVerify)
@@ -172,7 +172,7 @@ func TestInstanceStoreWithHost(t *testing.T) {
 
 	// Test updating the instance
 	newTLSSetting := true
-	updated, err := store.Update(ctx, instance.ID, "Updated Instance", "https://example.com:8443/qbittorrent", "newuser", "", nil, nil, &newTLSSetting)
+	updated, err := store.Update(ctx, instance.ID, "Updated Instance", "https://example.com:8443/qbittorrent", "newuser", "", nil, nil, &newTLSSetting, nil)
 	require.NoError(t, err, "Failed to update instance")
 	assert.Equal(t, "https://example.com:8443/qbittorrent", updated.Host, "updated host should match")
 	assert.True(t, updated.TLSSkipVerify)

--- a/internal/qbittorrent/client.go
+++ b/internal/qbittorrent/client.go
@@ -470,6 +470,26 @@ func (c *Client) StartSyncManager(ctx context.Context, syncInterval int) error {
 	return nil
 }
 
+// StopSyncManager cancels the client's sync context and stops periodic timers.
+func (c *Client) StopSyncManager() {
+	c.mu.Lock()
+	// Stop periodic timer if running
+	c.syncMu.Lock()
+	if c.syncTimer != nil {
+		c.syncTimer.Stop()
+		c.syncTimer = nil
+	}
+	c.syncMu.Unlock()
+
+	// Cancel sync context to halt background sync goroutines
+	if c.syncCancel != nil {
+		c.syncCancel()
+		c.syncCancel = nil
+	}
+	c.syncCtx = nil
+	c.mu.Unlock()
+}
+
 // UpdateSyncInterval updates the periodic sync interval by recreating the sync manager
 func (c *Client) UpdateSyncInterval(syncInterval int) {
 	c.syncMu.Lock()

--- a/internal/qbittorrent/pool.go
+++ b/internal/qbittorrent/pool.go
@@ -228,9 +228,18 @@ func (cp *ClientPool) createClientWithTimeout(ctx context.Context, instanceID in
 
 // RemoveClient removes a client from the pool
 func (cp *ClientPool) RemoveClient(instanceID int) {
+	var client *Client
+
 	cp.mu.Lock()
-	delete(cp.clients, instanceID)
+	if existing, ok := cp.clients[instanceID]; ok {
+		client = existing
+		delete(cp.clients, instanceID)
+	}
 	cp.mu.Unlock()
+
+	if client != nil {
+		client.StopSyncManager()
+	}
 
 	// Also clean up the per-instance lock to prevent memory leaks
 	cp.creationMu.Lock()

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -486,18 +486,27 @@ func (sm *SyncManager) GetTorrentsWithFilters(ctx context.Context, instanceID in
 		if syncManager != nil {
 			lastSyncTime := syncManager.LastSyncTime()
 			now := time.Now()
+
+			// Check if sync has occurred (lastSyncTime is not zero)
+			hasSynced := !lastSyncTime.IsZero()
 			age := int(now.Sub(lastSyncTime).Seconds())
-			isFresh := age <= 1 // Fresh if updated within the last second
+
+			// Consider cache fresh if:
+			// 1. Sync has occurred AND
+			// 2. Updated within the last 30 seconds (to account for initial sync and periodic syncs)
+			isFresh := hasSynced && age <= 30
 
 			source := "cache"
 			if isFresh {
 				source = "fresh"
+			} else if !hasSynced {
+				source = "no-sync"
 			}
 
 			cacheMetadata = &CacheMetadata{
 				Source:      source,
 				Age:         age,
-				IsStale:     !isFresh,
+				IsStale:     !hasSynced || age > 300, // Stale if no sync or older than 5 minutes
 				NextRefresh: now.Add(time.Second).Format(time.RFC3339),
 			}
 		}

--- a/web/src/components/instances/InstanceForm.tsx
+++ b/web/src/components/instances/InstanceForm.tsx
@@ -126,6 +126,7 @@ export function InstanceForm({ instance, onSuccess, onCancel }: InstanceFormProp
       basicUsername: instance?.basicUsername ?? "",
       basicPassword: instance?.basicUsername ? "<redacted>" : "",
       tlsSkipVerify: instance?.tlsSkipVerify ?? false,
+      syncInterval: instance?.syncInterval ?? 0,
     },
     onSubmit: ({ value }) => {
       handleSubmit(value)
@@ -341,6 +342,41 @@ export function InstanceForm({ instance, onSuccess, onCancel }: InstanceFormProp
           )}
         </div>
 
+        <form.Field
+          name="syncInterval"
+          validators={{
+            onChange: ({ value }) => {
+              if (value === undefined || value === null) return undefined
+              const num = Number(value)
+              if (isNaN(num)) return "Must be a number"
+              if (num < 0) return "Must be 0 or greater"
+              if (num > 0 && num < 5) return "Minimum 5 minutes when enabled"
+              return undefined
+            },
+          }}
+        >
+          {(field) => (
+            <div className="space-y-2">
+              <Label htmlFor={field.name}>Automatic Cache Refresh (minutes)</Label>
+              <Input
+                id={field.name}
+                type="number"
+                min={0}
+                step={1}
+                value={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(e) => field.handleChange(Number(e.target.value))}
+                placeholder="0"
+              />
+              <p className="text-sm text-muted-foreground">
+                Automatically refresh cache every N minutes. Set to 0 to disable, minimum 5 minutes when enabled.
+              </p>
+              {field.state.meta.isTouched && field.state.meta.errors[0] && (
+                <p className="text-sm text-destructive">{field.state.meta.errors[0]}</p>
+              )}
+            </div>
+          )}
+        </form.Field>
 
         <div className="flex gap-2">
           <form.Subscribe

--- a/web/src/components/instances/InstanceForm.tsx
+++ b/web/src/components/instances/InstanceForm.tsx
@@ -350,7 +350,7 @@ export function InstanceForm({ instance, onSuccess, onCancel }: InstanceFormProp
               const num = Number(value)
               if (isNaN(num)) return "Must be a number"
               if (num < 0) return "Must be 0 or greater"
-              if (num > 0 && num < 5) return "Minimum 5 minutes when enabled"
+              if (num > 0 && num < 1) return "Minimum 1 minute when enabled"
               return undefined
             },
           }}
@@ -369,7 +369,7 @@ export function InstanceForm({ instance, onSuccess, onCancel }: InstanceFormProp
                 placeholder="0"
               />
               <p className="text-sm text-muted-foreground">
-                Automatically refresh cache every N minutes. Set to 0 to disable, minimum 5 minutes when enabled.
+                Automatically refresh cache every N minutes. Set to 0 to disable, minimum 1 minute when enabled. Timer resets after any sync.
               </p>
               {field.state.meta.isTouched && field.state.meta.errors[0] && (
                 <p className="text-sm text-destructive">{field.state.meta.errors[0]}</p>

--- a/web/src/hooks/useTorrentsList.ts
+++ b/web/src/hooks/useTorrentsList.ts
@@ -196,7 +196,8 @@ export function useTorrentsList(
   }, [data])
 
   // Check if data is from cache or fresh (backend provides this info)
-  const isCachedData = data?.cacheMetadata?.source === "cache"
+  // Backend sets source to "fresh" (synced within 30s), "cache" (older but valid), or "no-sync" (no sync yet)
+  const isCachedData = data?.cacheMetadata?.source === "cache" || data?.cacheMetadata?.source === "fresh"
   const isStaleData = data?.cacheMetadata?.isStale === true
 
   // Use lastKnownTotal when loading more pages to prevent flickering

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -23,6 +23,7 @@ export interface Instance {
   username: string
   basicUsername?: string
   tlsSkipVerify: boolean
+  syncInterval?: number
 }
 
 export interface InstanceFormData {
@@ -33,6 +34,7 @@ export interface InstanceFormData {
   basicUsername?: string
   basicPassword?: string
   tlsSkipVerify: boolean
+  syncInterval?: number
 }
 
 export interface InstanceError {


### PR DESCRIPTION
Implements a per-instance configuration to keep running `autosync` at a periodic (maximum) interval.

The periodic timer resets when any other action is performed in the syncmanager, ensuring that the interval functions correctly, as a maximum autosync interval feature, without interfering with any other actions.

Runs on application start to ensure torrent tables have access to fresh cache on first load.
<img width="315" height="600" alt="syncing" src="https://github.com/user-attachments/assets/663adcce-bf8a-4544-837b-fdaf9a316fa2" />
