### PR TITLE
fix(database): refresh closed sqlite statements

### DIFF
--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -236,13 +236,13 @@ func isWriteQuery(query string) bool {
 		strings.HasPrefix(upper, "DELETE")
 }
 
-const stmtClosedErrMsg = "sql: statement is closed"
+const stmtClosedErrMsg = "statement is closed"
 
 func isStmtClosedErr(err error) bool {
 	if err == nil {
 		return false
 	}
-	return err.Error() == stmtClosedErrMsg
+	return strings.Contains(err.Error(), stmtClosedErrMsg)
 }
 
 // ExecContext routes write queries through the single writer goroutine and


### PR DESCRIPTION
This change teaches our SQLite wrapper to recover automatically when a cached prepared statement has already been closed by the driver. Whenever we hit the `sql: statement is closed` condition, the cache now drops that entry, recreates the statement, and retries the operation across exec, query, and writer paths. With the cache able to self-heal, long-running jobs like the session cleanup goroutine stop spamming the logs and can complete their work even when a statement expires mid-flight.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience for database operations when prepared statements become invalid or closed.
  * Automatic detection and transparent retry of affected reads and writes after re-preparing statements.
  * Retries preserve existing control flow and fall back to a direct connection if re-preparation fails, reducing transient failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->