### PR TITLE
feat(web): add copy button to torrent name in DetailsPanel

### DIFF
--- a/web/src/components/torrents/TorrentDetailsPanel.tsx
+++ b/web/src/components/torrents/TorrentDetailsPanel.tsx
@@ -243,9 +243,9 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
 
   return (
     <div className="h-full flex flex-col">
-      <div className="flex items-center px-4 py-3 sm:px-6 border-b bg-muted/30 gap-2 pr-12">
-        <div className="flex flex-1 items-center gap-2 min-w-0">
-          <h3 className="text-sm font-semibold truncate" title={displayName}>
+      <div className="flex items-center px-4 py-3 sm:px-6 border-b bg-muted/30 gap-2">
+        <div className="flex flex-1 items-center gap-2 min-w-0 pr-12">
+          <h3 className="text-sm font-semibold truncate flex-1 min-w-0" title={displayName}>
             {displayName}
           </h3>
           {displayName && (


### PR DESCRIPTION
## Summary
- reposition the torrent title copy button next to the name while adding header padding so it no longer overlaps the sheet close control

## Testing
- pnpm lint *(fails: ESLint flat config requires plugin objects in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6901c864c0bc83219b3a50b928ac5bec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a copy-to-clipboard button next to the torrent name in the details panel header so users can quickly copy torrent names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->