### PR TITLE
feat(torrents): add force start action to context menu

### DIFF
--- a/internal/api/handlers/torrents.go
+++ b/internal/api/handlers/torrents.go
@@ -479,7 +479,7 @@ func (h *TorrentsHandler) BulkAction(w http.ResponseWriter, r *http.Request) {
 		"pause", "resume", "delete", "deleteWithFiles",
 		"recheck", "reannounce", "increasePriority", "decreasePriority",
 		"topPriority", "bottomPriority", "addTags", "removeTags", "setTags", "setCategory",
-		"toggleAutoTMM", "setShareLimit", "setUploadLimit", "setDownloadLimit", "setLocation",
+		"toggleAutoTMM", "forceStart", "setShareLimit", "setUploadLimit", "setDownloadLimit", "setLocation",
 		"editTrackers", "addTrackers", "removeTrackers",
 	}
 
@@ -556,6 +556,8 @@ func (h *TorrentsHandler) BulkAction(w http.ResponseWriter, r *http.Request) {
 		err = h.syncManager.SetCategory(r.Context(), instanceID, targetHashes, req.Category)
 	case "toggleAutoTMM":
 		err = h.syncManager.SetAutoTMM(r.Context(), instanceID, targetHashes, req.Enable)
+	case "forceStart":
+		err = h.syncManager.SetForceStart(r.Context(), instanceID, targetHashes, req.Enable)
 	case "setShareLimit":
 		err = h.syncManager.SetTorrentShareLimit(r.Context(), instanceID, targetHashes, req.RatioLimit, req.SeedingTimeLimit, req.InactiveSeedingTimeLimit)
 	case "setUploadLimit":

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -2761,6 +2761,31 @@ func (sm *SyncManager) SetAutoTMM(ctx context.Context, instanceID int, hashes []
 	return nil
 }
 
+// SetForceStart toggles force start state for torrents
+func (sm *SyncManager) SetForceStart(ctx context.Context, instanceID int, hashes []string, enable bool) error {
+	client, _, err := sm.getClientAndSyncManager(ctx, instanceID)
+	if err != nil {
+		return err
+	}
+
+	// Validate that torrents exist
+	if err := sm.validateTorrentsExist(client, hashes, "set force start"); err != nil {
+		return err
+	}
+
+	if err := client.SetForceStartCtx(ctx, hashes, enable); err != nil {
+		return err
+	}
+
+	if enable {
+		sm.applyOptimisticCacheUpdate(instanceID, hashes, "force_resume", nil)
+	}
+
+	sm.syncAfterModification(instanceID, client, "set_force_start")
+
+	return nil
+}
+
 // CreateTags creates new tags
 func (sm *SyncManager) CreateTags(ctx context.Context, instanceID int, tags []string) error {
 	client, err := sm.clientPool.GetClient(ctx, instanceID)

--- a/web/src/components/torrents/TorrentContextMenu.tsx
+++ b/web/src/components/torrents/TorrentContextMenu.tsx
@@ -23,6 +23,7 @@ import {
   CheckCircle,
   Copy,
   Download,
+  FastForward,
   FolderOpen,
   Gauge,
   Pause,
@@ -187,6 +188,11 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
     void onExport(hashes, torrents)
   }, [hashes, onExport, torrents])
 
+  const forceStartStates = torrents.map(t => t.force_start)
+  const allForceStarted = forceStartStates.length > 0 && forceStartStates.every(state => state === true)
+  const allForceDisabled = forceStartStates.length > 0 && forceStartStates.every(state => state === false)
+  const forceStartMixed = forceStartStates.length > 0 && !allForceStarted && !allForceDisabled
+
   // TMM state calculation
   const tmmStates = torrents.map(t => t.auto_tmm)
   const allEnabled = tmmStates.length > 0 && tmmStates.every(state => state === true)
@@ -195,6 +201,10 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
 
   const handleQueueAction = useCallback((action: "topPriority" | "increasePriority" | "decreasePriority" | "bottomPriority") => {
     onAction(action as TorrentAction, hashes)
+  }, [onAction, hashes])
+
+  const handleForceStartToggle = useCallback((enable: boolean) => {
+    onAction(TORRENT_ACTIONS.FORCE_START, hashes, { enable })
   }, [onAction, hashes])
 
   const handleSetCategory = useCallback((category: string) => {
@@ -226,6 +236,34 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
           <Play className="mr-2 h-4 w-4" />
           Resume {count > 1 ? `(${count})` : ""}
         </ContextMenuItem>
+        {forceStartMixed ? (
+          <>
+            <ContextMenuItem
+              onClick={() => handleForceStartToggle(true)}
+              disabled={isPending}
+            >
+              <FastForward className="mr-2 h-4 w-4" />
+              Force Start {count > 1 ? `(${count} Mixed)` : "(Mixed)"}
+            </ContextMenuItem>
+            <ContextMenuItem
+              onClick={() => handleForceStartToggle(false)}
+              disabled={isPending}
+            >
+              <FastForward className="mr-2 h-4 w-4" />
+              Disable Force Start {count > 1 ? `(${count} Mixed)` : "(Mixed)"}
+            </ContextMenuItem>
+          </>
+        ) : (
+          <ContextMenuItem
+            onClick={() => handleForceStartToggle(!allForceStarted)}
+            disabled={isPending}
+          >
+            <FastForward className="mr-2 h-4 w-4" />
+            {allForceStarted
+              ? `Disable Force Start ${count > 1 ? `(${count})` : ""}`
+              : `Force Start ${count > 1 ? `(${count})` : ""}`}
+          </ContextMenuItem>
+        )}
         <ContextMenuItem
           onClick={() => onAction(TORRENT_ACTIONS.PAUSE, hashes)}
           disabled={isPending}

--- a/web/src/hooks/useTorrentActions.ts
+++ b/web/src/hooks/useTorrentActions.ts
@@ -26,6 +26,7 @@ export const TORRENT_ACTIONS = {
   SET_TAGS: "setTags",
   SET_CATEGORY: "setCategory",
   TOGGLE_AUTO_TMM: "toggleAutoTMM",
+  FORCE_START: "forceStart",
   SET_SHARE_LIMIT: "setShareLimit",
   SET_UPLOAD_LIMIT: "setUploadLimit",
   SET_DOWNLOAD_LIMIT: "setDownloadLimit",
@@ -186,7 +187,7 @@ export function useTorrentActions({ instanceId, onActionComplete }: UseTorrentAc
         }, refetchDelay)
       } else {
         // For other operations, refetch after delay
-        const refetchDelay = variables.action === "resume" ? 2000 : 1000
+        const refetchDelay = variables.action === "resume" || variables.action === "forceStart" ? 2000 : 1000
         setTimeout(() => {
           queryClient.refetchQueries({
             queryKey: ["torrents-list", instanceId],
@@ -932,6 +933,9 @@ function showSuccessToast(action: TorrentAction, count: number, deleteFiles?: bo
       break
     case "toggleAutoTMM":
       toast.success(`${enable ? "Enabled" : "Disabled"} Auto TMM for ${count} ${torrentText}`)
+      break
+    case "forceStart":
+      toast.success(`${enable ? "Enabled" : "Disabled"} Force Start for ${count} ${torrentText}`)
       break
     case "setShareLimit":
       toast.success(`Set share limits for ${count} ${torrentText}`)

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -378,7 +378,7 @@ class ApiClient {
     instanceId: number,
     data: {
       hashes: string[]
-      action: "pause" | "resume" | "delete" | "recheck" | "reannounce" | "increasePriority" | "decreasePriority" | "topPriority" | "bottomPriority" | "setCategory" | "addTags" | "removeTags" | "setTags" | "toggleAutoTMM" | "setShareLimit" | "setUploadLimit" | "setDownloadLimit" | "setLocation" | "editTrackers" | "addTrackers" | "removeTrackers"
+      action: "pause" | "resume" | "delete" | "recheck" | "reannounce" | "increasePriority" | "decreasePriority" | "topPriority" | "bottomPriority" | "setCategory" | "addTags" | "removeTags" | "setTags" | "toggleAutoTMM" | "forceStart" | "setShareLimit" | "setUploadLimit" | "setDownloadLimit" | "setLocation" | "editTrackers" | "addTrackers" | "removeTrackers"
       deleteFiles?: boolean
       category?: string
       tags?: string  // Comma-separated tags string


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Force Start" bulk action for torrents, allowing users to force start selected torrents alongside existing pause/resume actions.
  * Integrated force-start toggle in the torrent context menu with support for mixed states.
  * Backend support for force-start operations with proper cache updates and synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->