### PR TITLE
refactor(torrents): retain sorting when searching

### DIFF
--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -11,7 +11,6 @@ import (
 	"net/url"
 	"path/filepath"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -1692,11 +1691,6 @@ func (sm *SyncManager) filterTorrentsBySearch(torrents []qbt.Torrent, search str
 			}
 		}
 	}
-
-	// Sort by score (lower is better)
-	sort.Slice(matches, func(i, j int) bool {
-		return matches[i].score < matches[j].score
-	})
 
 	// Extract just the torrents
 	filtered := make([]qbt.Torrent, len(matches))


### PR DESCRIPTION
Retain the initial torrent sorting when searching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Search results now display in their original order instead of being sorted by score, simplifying the result presentation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->