### PR TITLE
feat(mobile) add long press support for FilterSidebar exclusions

### DIFF
--- a/web/src/components/torrents/CategoryTree.tsx
+++ b/web/src/components/torrents/CategoryTree.tsx
@@ -37,6 +37,7 @@ interface CategoryTreeProps {
   getCheckboxState: (state: "include" | "exclude" | "neutral") => boolean | "indeterminate"
   onCategoryCheckboxChange: (category: string) => void
   onCategoryPointerDown?: (event: ReactPointerEvent<HTMLElement>, category: string) => void
+  onCategoryPointerLeave?: (event: ReactPointerEvent<HTMLElement>) => void
   onCreateSubcategory: (parent: string) => void
   onEditCategory: (category: string) => void
   onDeleteCategory: (category: string) => void
@@ -109,6 +110,7 @@ const CategoryTreeNode = memo(({
   getCheckboxState,
   onCategoryCheckboxChange,
   onCategoryPointerDown,
+  onCategoryPointerLeave,
   onCreateSubcategory,
   onEditCategory,
   onDeleteCategory,
@@ -125,6 +127,7 @@ const CategoryTreeNode = memo(({
   getCheckboxState: (state: "include" | "exclude" | "neutral") => boolean | "indeterminate"
   onCategoryCheckboxChange: (category: string) => void
   onCategoryPointerDown?: (event: ReactPointerEvent<HTMLElement>, category: string) => void
+  onCategoryPointerLeave?: (event: ReactPointerEvent<HTMLElement>) => void
   onCreateSubcategory: (parent: string) => void
   onEditCategory: (category: string) => void
   onDeleteCategory: (category: string) => void
@@ -184,11 +187,12 @@ const CategoryTreeNode = memo(({
       <ContextMenu>
         <ContextMenuTrigger asChild>
           <li
-            className="flex items-center gap-2 px-2 py-1.5 hover:bg-accent rounded-md cursor-pointer select-none"
-            style={{ paddingLeft: `${indentLevel + 8}px` }}
-            onPointerDown={handlePointerDown}
-            role="presentation"
-          >
+          className="flex items-center gap-2 px-2 py-1.5 hover:bg-accent rounded-md cursor-pointer select-none"
+          style={{ paddingLeft: `${indentLevel + 8}px` }}
+          onPointerDown={handlePointerDown}
+          onPointerLeave={onCategoryPointerLeave}
+          role="presentation"
+        >
             {useSubcategories && (
               <button
                 onClick={handleToggleCollapse}
@@ -265,6 +269,7 @@ const CategoryTreeNode = memo(({
               getCheckboxState={getCheckboxState}
               onCategoryCheckboxChange={onCategoryCheckboxChange}
               onCategoryPointerDown={onCategoryPointerDown}
+              onCategoryPointerLeave={onCategoryPointerLeave}
               onCreateSubcategory={onCreateSubcategory}
               onEditCategory={onEditCategory}
               onDeleteCategory={onDeleteCategory}
@@ -293,6 +298,7 @@ export const CategoryTree = memo(({
   getCheckboxState,
   onCategoryCheckboxChange,
   onCategoryPointerDown,
+  onCategoryPointerLeave,
   onCreateSubcategory,
   onEditCategory,
   onDeleteCategory,
@@ -340,6 +346,7 @@ export const CategoryTree = memo(({
         className="flex items-center gap-2 px-2 py-1.5 hover:bg-accent rounded-md cursor-pointer"
         onClick={() => onCategoryCheckboxChange("")}
         onPointerDown={(event) => onCategoryPointerDown?.(event, "")}
+        onPointerLeave={onCategoryPointerLeave}
       >
         <Checkbox
           checked={uncategorizedCheckboxState}
@@ -364,6 +371,7 @@ export const CategoryTree = memo(({
           getCheckboxState={getCheckboxState}
           onCategoryCheckboxChange={onCategoryCheckboxChange}
           onCategoryPointerDown={onCategoryPointerDown}
+          onCategoryPointerLeave={onCategoryPointerLeave}
           onCreateSubcategory={onCreateSubcategory}
           onEditCategory={onEditCategory}
           onDeleteCategory={onDeleteCategory}

--- a/web/src/components/torrents/FilterSidebar.tsx
+++ b/web/src/components/torrents/FilterSidebar.tsx
@@ -911,6 +911,14 @@ const FilterSidebarComponent = ({
     }
   }, [cancelLongPress, handleStatusExcludeToggle, isMobile, makeToggleKey, scheduleLongPressExclude])
 
+  const handlePointerLeave = useCallback((event: React.PointerEvent<HTMLElement>) => {
+    const pointerType = event.pointerType
+    if (pointerType === "mouse") {
+      return
+    }
+    cancelLongPress()
+  }, [cancelLongPress])
+
   const handleCategoryIncludeToggle = useCallback((category: string) => {
     const currentState = getCategoryState(category)
 
@@ -1343,14 +1351,15 @@ const FilterSidebarComponent = ({
                     return (
                       <label
                         key={state.value}
-                        className={cn(
-                          "flex items-center gap-2 px-2 py-1.5 rounded cursor-pointer",
-                          statusState === "exclude"
-                            ? "bg-destructive/10 text-destructive hover:bg-destructive/15"
-                            : "hover:bg-muted"
-                        )}
-                        onPointerDown={(event) => handleStatusPointerDown(event, state.value)}
-                      >
+                      className={cn(
+                        "flex items-center gap-2 px-2 py-1.5 rounded cursor-pointer",
+                        statusState === "exclude"
+                          ? "bg-destructive/10 text-destructive hover:bg-destructive/15"
+                          : "hover:bg-muted"
+                      )}
+                      onPointerDown={(event) => handleStatusPointerDown(event, state.value)}
+                      onPointerLeave={handlePointerLeave}
+                    >
                         <Checkbox
                           checked={getCheckboxVisualState(statusState)}
                           onCheckedChange={() => handleStatusCheckboxChange(state.value)}
@@ -1425,6 +1434,7 @@ const FilterSidebarComponent = ({
                         uncategorizedState === "exclude"? "bg-destructive/10 text-destructive hover:bg-destructive/15": "hover:bg-muted"
                       )}
                       onPointerDown={(event) => handleCategoryPointerDown(event, "")}
+                      onPointerLeave={handlePointerLeave}
                     >
                       <Checkbox
                         checked={getCheckboxVisualState(uncategorizedState)}
@@ -1484,6 +1494,7 @@ const FilterSidebarComponent = ({
                       getCheckboxState={getCheckboxVisualState}
                       onCategoryCheckboxChange={handleCategoryCheckboxChange}
                       onCategoryPointerDown={handleCategoryPointerDown}
+                      onCategoryPointerLeave={handlePointerLeave}
                       onCreateSubcategory={handleCreateSubcategory}
                       onEditCategory={handleEditCategoryByName}
                       onDeleteCategory={handleDeleteCategoryByName}
@@ -1529,6 +1540,7 @@ const FilterSidebarComponent = ({
                                         : "hover:bg-muted"
                                     )}
                                     onPointerDown={(event) => handleCategoryPointerDown(event, name)}
+                                    onPointerLeave={handlePointerLeave}
                                   >
                                     <Checkbox
                                       checked={getCheckboxVisualState(categoryState)}
@@ -1622,14 +1634,15 @@ const FilterSidebarComponent = ({
                         <ContextMenu key={name}>
                           <ContextMenuTrigger asChild>
                             <label
-                              className={cn(
-                                "flex items-center gap-2 px-2 py-1.5 rounded cursor-pointer",
-                                categoryState === "exclude"
-                                  ? "bg-destructive/10 text-destructive hover:bg-destructive/15"
-                                  : "hover:bg-muted"
-                              )}
-                              onPointerDown={(event) => handleCategoryPointerDown(event, name)}
-                            >
+                            className={cn(
+                              "flex items-center gap-2 px-2 py-1.5 rounded cursor-pointer",
+                              categoryState === "exclude"
+                                ? "bg-destructive/10 text-destructive hover:bg-destructive/15"
+                                : "hover:bg-muted"
+                            )}
+                            onPointerDown={(event) => handleCategoryPointerDown(event, name)}
+                            onPointerLeave={handlePointerLeave}
+                          >
                               <Checkbox
                                 checked={getCheckboxVisualState(categoryState)}
                                 onCheckedChange={() => handleCategoryCheckboxChange(name)}
@@ -1756,6 +1769,7 @@ const FilterSidebarComponent = ({
                       untaggedState === "exclude" ? "bg-destructive/10 text-destructive hover:bg-destructive/15" : "hover:bg-muted"
                     )}
                     onPointerDown={(event) => handleTagPointerDown(event, "")}
+                    onPointerLeave={handlePointerLeave}
                   >
                     <Checkbox
                       checked={getCheckboxVisualState(untaggedState)}
@@ -1836,6 +1850,7 @@ const FilterSidebarComponent = ({
                                         : "hover:bg-muted"
                                     )}
                                     onPointerDown={(event) => handleTagPointerDown(event, tag)}
+                                    onPointerLeave={handlePointerLeave}
                                   >
                                     <Checkbox
                                       checked={getCheckboxVisualState(tagState)}
@@ -1893,14 +1908,15 @@ const FilterSidebarComponent = ({
                         <ContextMenu key={tag}>
                           <ContextMenuTrigger asChild>
                             <label
-                              className={cn(
-                                "flex items-center gap-2 px-2 py-1.5 rounded cursor-pointer",
-                                tagState === "exclude"
-                                  ? "bg-destructive/10 text-destructive hover:bg-destructive/15"
-                                  : "hover:bg-muted"
-                              )}
-                              onPointerDown={(event) => handleTagPointerDown(event, tag)}
-                            >
+                            className={cn(
+                              "flex items-center gap-2 px-2 py-1.5 rounded cursor-pointer",
+                              tagState === "exclude"
+                                ? "bg-destructive/10 text-destructive hover:bg-destructive/15"
+                                : "hover:bg-muted"
+                            )}
+                            onPointerDown={(event) => handleTagPointerDown(event, tag)}
+                            onPointerLeave={handlePointerLeave}
+                          >
                               <Checkbox
                                 checked={getCheckboxVisualState(tagState)}
                                 onCheckedChange={() => handleTagCheckboxChange(tag)}
@@ -1987,6 +2003,7 @@ const FilterSidebarComponent = ({
                         : "hover:bg-muted"
                     )}
                     onPointerDown={(event) => handleTrackerPointerDown(event, "")}
+                    onPointerLeave={handlePointerLeave}
                   >
                     <Checkbox
                       checked={getCheckboxVisualState(noTrackerState)}
@@ -2060,6 +2077,7 @@ const FilterSidebarComponent = ({
                                         : "hover:bg-muted"
                                     )}
                                     onPointerDown={(event) => handleTrackerPointerDown(event, tracker)}
+                                    onPointerLeave={handlePointerLeave}
                                   >
                                     <Checkbox
                                       checked={getCheckboxVisualState(trackerState)}
@@ -2114,14 +2132,15 @@ const FilterSidebarComponent = ({
                         <ContextMenu key={tracker}>
                           <ContextMenuTrigger asChild>
                             <label
-                              className={cn(
-                                "flex items-center gap-2 px-2 py-1.5 rounded cursor-pointer",
-                                trackerState === "exclude"
-                                  ? "bg-destructive/10 text-destructive hover:bg-destructive/15"
-                                  : "hover:bg-muted"
-                              )}
-                              onPointerDown={(event) => handleTrackerPointerDown(event, tracker)}
-                            >
+                            className={cn(
+                              "flex items-center gap-2 px-2 py-1.5 rounded cursor-pointer",
+                              trackerState === "exclude"
+                                ? "bg-destructive/10 text-destructive hover:bg-destructive/15"
+                                : "hover:bg-muted"
+                            )}
+                            onPointerDown={(event) => handleTrackerPointerDown(event, tracker)}
+                            onPointerLeave={handlePointerLeave}
+                          >
                               <Checkbox
                                 checked={getCheckboxVisualState(trackerState)}
                                 onCheckedChange={() => handleTrackerCheckboxChange(tracker)}


### PR DESCRIPTION
## Summary
- add a long-press gesture fallback to toggle exclusions in the filter sidebar
- reuse the existing cmd/ctrl click logic while preventing accidental toggles
- document the new long-press gesture in the filter tips tooltip

## Testing
- pnpm lint *(fails: ESLint flat config incompatibility in repo)*

------
https://chatgpt.com/codex/tasks/task_e_6906511cdd6c8321829d694500088edc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Long-press on filter items (status, categories, tags, trackers) toggles exclusion from results.
  * Tooltips updated to show long-press alongside Cmd/Ctrl+click.

* **Bug Fixes / Reliability**
  * Long-press reliably cancels when gestures are aborted or pointer leaves, improving touch and pointer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->