### PR TITLE
feat(torrents): add support for temporary download paths in torrent handling

### DIFF
--- a/internal/api/handlers/torrents.go
+++ b/internal/api/handlers/torrents.go
@@ -357,18 +357,6 @@ func (h *TorrentsHandler) AddTorrent(w http.ResponseWriter, r *http.Request) {
 		options["autoTMM"] = "false"
 	}
 
-	if tempPath := r.FormValue("temppath"); tempPath != "" {
-		options["temppath"] = tempPath
-		// When temppath is provided, disable autoTMM
-		options["autoTMM"] = "false"
-	}
-
-	if tempPathEnabled := r.FormValue("tempPathEnabled"); tempPathEnabled == "true" {
-		options["temp_path_enabled"] = "true"
-		// When tempPathEnabled is true, disable autoTMM
-		options["autoTMM"] = "false"
-	}
-
 	// Handle autoTMM explicitly if provided
 	if autoTMM := r.FormValue("autoTMM"); autoTMM != "" {
 		options["autoTMM"] = autoTMM

--- a/web/src/components/instances/preferences/FileManagementForm.tsx
+++ b/web/src/components/instances/preferences/FileManagementForm.tsx
@@ -202,18 +202,22 @@ export function FileManagementForm({ instanceId, onSuccess }: FileManagementForm
 
         <form.Field name="temp_path">
           {(field) => (
-            <div className="space-y-2">
-              <Label className="text-sm font-medium">Temporary Download Path</Label>
-              <p className="text-xs text-muted-foreground">
-                Directory where torrents are downloaded before moving to save path
-              </p>
-              <Input
-                value={field.state.value as string}
-                onChange={(e) => field.handleChange(e.target.value)}
-                placeholder="/temp-downloads"
-                disabled={!(form.getFieldValue("temp_path_enabled") as boolean)}
-              />
-            </div>
+            <form.Subscribe selector={(state) => state.values.temp_path_enabled}>
+              {(tempPathEnabled) => (
+                <div className="space-y-2">
+                  <Label className="text-sm font-medium">Temporary Download Path</Label>
+                  <p className="text-xs text-muted-foreground">
+                    Directory where torrents are downloaded before moving to save path
+                  </p>
+                  <Input
+                    value={field.state.value as string}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                    placeholder="/temp-downloads"
+                    disabled={!tempPathEnabled}
+                  />
+                </div>
+              )}
+            </form.Subscribe>
           )}
         </form.Field>
 

--- a/web/src/components/torrents/AddTorrentDialog.tsx
+++ b/web/src/components/torrents/AddTorrentDialog.tsx
@@ -38,6 +38,7 @@ import {
 import { useInstanceMetadata } from "@/hooks/useInstanceMetadata"
 import { usePersistedStartPaused } from "@/hooks/usePersistedStartPaused"
 import { api } from "@/lib/api"
+import { cn } from '@/lib/utils'
 import type { Torrent } from "@/types"
 import { useForm } from "@tanstack/react-form"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
@@ -491,6 +492,22 @@ export function AddTorrentDialog({ instanceId, open: controlledOpen, onOpenChang
       // Use the user's explicit TMM choice
       const autoTMM = data.autoTMM
 
+      // When autoTMM is enabled, temp path settings aren't visible/relevant
+      if (!autoTMM) {
+        // Check if temp path settings have changed from instance preferences
+        const tempPathChanged =
+          data.tempPathEnabled !== (preferences?.temp_path_enabled ?? false) ||
+          (data.tempPathEnabled && data.tempPath !== (preferences?.temp_path || ""))
+
+        // If temp path settings changed, update instance preferences first
+        if (tempPathChanged) {
+          await api.updateInstancePreferences(instanceId, {
+            temp_path_enabled: data.tempPathEnabled,
+            temp_path: data.tempPathEnabled ? data.tempPath : undefined,
+          })
+        }
+      }
+
       const submitData: Parameters<typeof api.addTorrent>[1] = {
         startPaused: data.startPaused,
         savePath: !autoTMM && data.savePath ? data.savePath : undefined,
@@ -506,8 +523,6 @@ export function AddTorrentDialog({ instanceId, open: controlledOpen, onOpenChang
         limitSeedTime: data.limitSeedTime > 0 ? data.limitSeedTime : undefined,
         contentLayout: data.contentLayout === "__global__" ? undefined : data.contentLayout || undefined,
         rename: data.rename || undefined,
-        tempPathEnabled: data.tempPathEnabled,
-        tempPath: data.tempPath || undefined,
       }
 
       if (activeTab === "file" && data.torrentFiles && data.torrentFiles.length > 0) {
@@ -583,7 +598,7 @@ export function AddTorrentDialog({ instanceId, open: controlledOpen, onOpenChang
     const rawUrls = form.getFieldValue("urls")
     const currentUrls = typeof rawUrls === "string" ? rawUrls : ""
 
-    const filteredFiles = currentFiles? currentFiles.filter((file) => !duplicateFileKeySet.has(createFileKey(file))): []
+    const filteredFiles = currentFiles ? currentFiles.filter((file) => !duplicateFileKeySet.has(createFileKey(file))) : []
 
     const filteredUrls = currentUrls
       .split("\n")
@@ -704,9 +719,10 @@ export function AddTorrentDialog({ instanceId, open: controlledOpen, onOpenChang
               <button
                 type="button"
                 onClick={() => setActiveTab("file")}
-                className={`flex-1 rounded-sm px-3 py-1.5 text-sm font-medium transition-colors flex items-center justify-center ${
-                  activeTab === "file"? "bg-accent text-accent-foreground shadow-sm": "text-muted-foreground hover:text-foreground hover:bg-accent/50"
-                  }`}
+                className={cn(
+                  "flex-1 rounded-sm px-3 py-1.5 text-sm font-medium transition-colors flex items-center justify-center",
+                  activeTab === "file" ? "bg-accent text-accent-foreground shadow-sm" : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
+                )}
               >
                 <Upload className="mr-2 h-4 w-4" />
                 File
@@ -714,9 +730,10 @@ export function AddTorrentDialog({ instanceId, open: controlledOpen, onOpenChang
               <button
                 type="button"
                 onClick={() => setActiveTab("url")}
-                className={`flex-1 rounded-sm px-3 py-1.5 text-sm font-medium transition-colors flex items-center justify-center ${
-                  activeTab === "url"? "bg-accent text-accent-foreground shadow-sm": "text-muted-foreground hover:text-foreground hover:bg-accent/50"
-                  }`}
+                className={cn(
+                  "flex-1 rounded-sm px-3 py-1.5 text-sm font-medium transition-colors flex items-center justify-center",
+                  activeTab === "url" ? "bg-accent text-accent-foreground shadow-sm" : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
+                )}
               >
                 <Link className="mr-2 h-4 w-4" />
                 URL
@@ -1026,7 +1043,7 @@ export function AddTorrentDialog({ instanceId, open: controlledOpen, onOpenChang
                               {[
                                 // Selected category first (if it matches search)
                                 ...(field.state.value && field.state.value !== "__none__" &&
-                                    (categorySearch === "" || field.state.value.toLowerCase().includes(categorySearch.toLowerCase()))? [{ name: field.state.value, isSelected: true }]: []),
+                                  (categorySearch === "" || field.state.value.toLowerCase().includes(categorySearch.toLowerCase())) ? [{ name: field.state.value, isSelected: true }] : []),
                                 // Then unselected categories
                                 ...Object.entries(categories)
                                   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -1227,25 +1244,28 @@ export function AddTorrentDialog({ instanceId, open: controlledOpen, onOpenChang
                             )}
                           </form.Field>
 
-                          {form.getFieldValue("tempPathEnabled") && (
-                            <form.Field name="tempPath">
-                              {(field) => (
-                                <div className="space-y-2 pl-4 border-l-2 border-primary animate-in fade-in slide-in-from-top-2 duration-200">
-                                  <Label htmlFor="tempPath">Temporary Download Path</Label>
-                                  <Input
-                                    id="tempPath"
-                                    placeholder={preferences?.temp_path || "Leave empty for default"}
-                                    value={field.state.value}
-                                    onBlur={field.handleBlur}
-                                    onChange={(e) => field.handleChange(e.target.value)}
-                                  />
-                                  <p className="text-xs text-muted-foreground">
-                                    Torrents will be downloaded here before moving to save path
-                                  </p>
-                                </div>
-                              )}
-                            </form.Field>
-                          )}
+                          <form.Field name="tempPath">
+                            {(field) => (
+                              <form.Subscribe selector={(state) => state.values.tempPathEnabled}>
+                                {(tempPathEnabled) => {
+                                  return (
+                                    <div className="space-y-2 pl-4 border-l-2 border-primary border-opacity-50 data-[temp-path-enabled=true]:block hidden" data-temp-path-enabled={tempPathEnabled}>
+                                      <Label htmlFor="tempPath">Temporary Download Path</Label>
+                                      <Input
+                                        id="tempPath"
+                                        placeholder={preferences?.temp_path || "Leave empty for default"}
+                                        value={field.state.value}
+                                        onBlur={field.handleBlur}
+                                        onChange={(e) => field.handleChange(e.target.value)} />
+                                      <p className="text-xs text-muted-foreground">
+                                        Torrents will be downloaded here before moving to save path
+                                      </p>
+                                    </div>
+                                  )
+                                }}
+                              </form.Subscribe>
+                            )}
+                          </form.Field>
                         </>
                       ) : (
                         <div className="space-y-2">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -329,8 +329,6 @@ class ApiClient {
       limitSeedTime?: number
       contentLayout?: string
       rename?: string
-      tempPathEnabled?: boolean
-      tempPath?: string
     }
   ): Promise<{ success: boolean; message?: string }> {
     const formData = new FormData()
@@ -354,8 +352,6 @@ class ApiClient {
     if (data.rename) formData.append("rename", data.rename)
     // Only send savePath if autoTMM is false or undefined
     if (data.savePath && !data.autoTMM) formData.append("savepath", data.savePath)
-    if (data.tempPathEnabled !== undefined) formData.append("tempPathEnabled", data.tempPathEnabled.toString())
-    if (data.tempPath && data.tempPathEnabled) formData.append("temppath", data.tempPath)
 
     const response = await fetch(`${API_BASE}/instances/${instanceId}/torrents`, {
       method: "POST",


### PR DESCRIPTION
Feature request: https://github.com/autobrr/qui/issues/555

## Implement temp path
- Added temp path input and temp path enabled in instance settings
  <img width="1175" height="622" alt="Screenshot 2025-11-05 at 10 30 34" src="https://github.com/user-attachments/assets/1fc6dd3c-8679-4c9e-bc6f-246da32c1e2c" />
- The instance settings will be the default whenever adding new torrent modal opened.
  <img width="693" height="740" alt="Screenshot 2025-11-05 at 10 28 39" src="https://github.com/user-attachments/assets/7736d6a6-c8bd-49e3-a2c8-bbb1eef04a6d" />
- Handle show the temp path in torrent details panel (called download path in the properties)
  <img width="828" height="571" alt="Screenshot 2025-11-05 at 10 28 19" src="https://github.com/user-attachments/assets/075f32ae-883f-4484-b89b-fa428b8c862c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring temporary download paths in application preferences
  * Added ability to set temporary download paths when adding new torrents
  * Added temporary download path information display in torrent details panel with copy-to-clipboard functionality
<!-- end of auto-generated comment: release notes by coderabbit.ai -->