### PR TITLE
fix(cache): add invalidation after file priority changes

### DIFF
--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -3260,6 +3260,14 @@ func (sm *SyncManager) SetTorrentFilePriority(ctx context.Context, instanceID in
 		}
 	}
 
+	// Invalidate file cache since priorities changed
+	if fm := sm.getFilesManager(); fm != nil {
+		if err := fm.InvalidateCache(ctx, instanceID, hash); err != nil {
+			log.Warn().Err(err).Int("instanceID", instanceID).Str("hash", hash).
+				Msg("Failed to invalidate file cache after priority change")
+		}
+	}
+
 	sm.syncAfterModification(instanceID, client, "set_file_priority")
 
 	return nil


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data accuracy when updating torrent file priorities by refreshing cached file information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->