### PR TITLE
feat(update): add web UI self-update and install flow

### DIFF
--- a/cmd/qui/main.go
+++ b/cmd/qui/main.go
@@ -377,7 +377,16 @@ func RunUpdateCommand() *cobra.Command {
 				Repository: "autobrr/qui",
 				Version:    buildinfo.Version,
 			})
-			return updater.Run(cmd.Context())
+			updated, err := updater.Run(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			if !updated {
+				cmd.Println("Already running the latest version.")
+			}
+
+			return nil
 		},
 	}
 

--- a/internal/api/handlers/external_programs.go
+++ b/internal/api/handlers/external_programs.go
@@ -450,6 +450,10 @@ func normalizePath(p string) string {
 
 	if resolved, err := filepath.EvalSymlinks(cleaned); err == nil {
 		cleaned = resolved
+	} else {
+		if dirResolved, dirErr := filepath.EvalSymlinks(filepath.Dir(cleaned)); dirErr == nil {
+			cleaned = filepath.Join(dirResolved, filepath.Base(cleaned))
+		}
 	}
 
 	return normalizePathCase(cleaned)

--- a/internal/api/handlers/version.go
+++ b/internal/api/handlers/version.go
@@ -4,10 +4,17 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
 
 	"github.com/autobrr/qui/internal/update"
+	"github.com/rs/zerolog/log"
 )
 
 type VersionHandler struct {
@@ -21,10 +28,11 @@ func NewVersionHandler(updateService *update.Service) *VersionHandler {
 }
 
 type LatestVersionResponse struct {
-	TagName     string `json:"tag_name"`
-	Name        string `json:"name,omitempty"`
-	HTMLURL     string `json:"html_url"`
-	PublishedAt string `json:"published_at"`
+	TagName             string `json:"tag_name"`
+	Name                string `json:"name,omitempty"`
+	HTMLURL             string `json:"html_url"`
+	PublishedAt         string `json:"published_at"`
+	SelfUpdateSupported bool   `json:"self_update_supported"`
 }
 
 func (h *VersionHandler) GetLatestVersion(w http.ResponseWriter, r *http.Request) {
@@ -37,9 +45,10 @@ func (h *VersionHandler) GetLatestVersion(w http.ResponseWriter, r *http.Request
 	}
 
 	response := LatestVersionResponse{
-		TagName:     release.TagName,
-		HTMLURL:     release.HTMLURL,
-		PublishedAt: release.PublishedAt.Format("2006-01-02T15:04:05Z"),
+		TagName:             release.TagName,
+		HTMLURL:             release.HTMLURL,
+		PublishedAt:         release.PublishedAt.Format("2006-01-02T15:04:05Z"),
+		SelfUpdateSupported: h.updateService.CanSelfUpdate(),
 	}
 
 	if release.Name != nil {
@@ -49,4 +58,59 @@ func (h *VersionHandler) GetLatestVersion(w http.ResponseWriter, r *http.Request
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(response)
+}
+
+// TriggerSelfUpdate downloads the latest release and schedules a restart when supported.
+func (h *VersionHandler) TriggerSelfUpdate(w http.ResponseWriter, r *http.Request) {
+	ctx := context.WithoutCancel(r.Context())
+
+	if !h.updateService.CanSelfUpdate() {
+		http.Error(w, update.ErrSelfUpdateUnsupported.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if err := h.updateService.RunSelfUpdate(ctx); err != nil {
+		if errors.Is(err, update.ErrSelfUpdateUnsupported) {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		log.Error().Err(err).Msg("failed to run self-update")
+		http.Error(w, "failed to run self-update", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	json.NewEncoder(w).Encode(map[string]string{
+		"message": "Update installed. qui will restart shortly.",
+	})
+
+	go func() {
+		time.Sleep(2 * time.Second)
+		log.Info().Msg("restarting process after self-update")
+
+		// Get the executable path
+		execPath, err := os.Executable()
+		if err != nil {
+			log.Error().Err(err).Msg("failed to get executable path for restart")
+			os.Exit(1)
+			return
+		}
+
+		// Get the executable path, resolving any symlinks
+		execPath, err = exec.LookPath(execPath)
+		if err != nil {
+			log.Error().Err(err).Msg("failed to resolve executable path")
+			os.Exit(1)
+			return
+		}
+
+		// Restart the process with the same arguments
+		err = syscall.Exec(execPath, os.Args, os.Environ())
+		if err != nil {
+			log.Error().Err(err).Msg("failed to restart process after update")
+			os.Exit(1)
+		}
+	}()
 }

--- a/internal/api/handlers/version.go
+++ b/internal/api/handlers/version.go
@@ -30,6 +30,7 @@ func NewVersionHandler(updateService *update.Service) *VersionHandler {
 type LatestVersionResponse struct {
 	TagName             string `json:"tag_name"`
 	Name                string `json:"name,omitempty"`
+	Body                string `json:"body,omitempty"`
 	HTMLURL             string `json:"html_url"`
 	PublishedAt         string `json:"published_at"`
 	SelfUpdateSupported bool   `json:"self_update_supported"`
@@ -53,6 +54,10 @@ func (h *VersionHandler) GetLatestVersion(w http.ResponseWriter, r *http.Request
 
 	if release.Name != nil {
 		response.Name = *release.Name
+	}
+
+	if release.Body != nil {
+		response.Body = *release.Body
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -275,6 +275,7 @@ func (s *Server) Handler() (*chi.Mux, error) {
 
 			// Version endpoint for update checks
 			r.Get("/version/latest", versionHandler.GetLatestVersion)
+			r.Post("/version/self-update", versionHandler.TriggerSelfUpdate)
 
 			// Instance management
 			r.Route("/instances", func(r chi.Router) {

--- a/internal/update/environment.go
+++ b/internal/update/environment.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package update
+
+import (
+	"errors"
+	"os"
+	"runtime"
+	"strings"
+)
+
+var (
+	// ErrSelfUpdateUnsupported is returned when the current environment does not support self-updates.
+	ErrSelfUpdateUnsupported = errors.New("self-update is not supported in this environment")
+)
+
+// isRunningInContainer tries to detect whether the application is running inside a container environment.
+//
+// The heuristics are conservative and based on common container markers:
+//   - Presence of /.dockerenv (Docker)
+//   - Presence of /run/.containerenv (Podman, other runtimes)
+//   - Control group identifiers containing well-known container keywords
+//
+// If none of the markers are found or an error occurs, the function returns false.
+func isRunningInContainer() bool {
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return true
+	}
+	if _, err := os.Stat("/run/.containerenv"); err == nil {
+		return true
+	}
+
+	data, err := os.ReadFile("/proc/1/cgroup")
+	if err != nil {
+		return false
+	}
+
+	content := string(data)
+	containerIndicators := []string{"docker", "kubepods", "containerd", "libpod"}
+	for _, indicator := range containerIndicators {
+		if strings.Contains(content, indicator) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isSelfUpdateSupportedPlatform returns true if the current GOOS supports in-place updates.
+// Windows binaries cannot safely replace themselves while running, so we block the feature.
+func isSelfUpdateSupportedPlatform() bool {
+	return runtime.GOOS != "windows"
+}

--- a/internal/update/environment.go
+++ b/internal/update/environment.go
@@ -49,6 +49,10 @@ func isRunningInContainer() bool {
 
 // isSelfUpdateSupportedPlatform returns true if the current GOOS supports in-place updates.
 // Windows binaries cannot safely replace themselves while running, so we block the feature.
+//
+// CRITICAL: This guard prevents runtime panics on Windows because the restart logic in
+// internal/api/handlers/version.go uses syscall.Exec, which only exists on Unix systems.
+// If you modify this function, ensure TestWindowsBlockedFromSelfUpdate still passes.
 func isSelfUpdateSupportedPlatform() bool {
 	return runtime.GOOS != "windows"
 }

--- a/internal/update/environment_nonwindows_test.go
+++ b/internal/update/environment_nonwindows_test.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package update
+
+import "testing"
+
+// TestSelfUpdateSupportedOnNonWindows ensures platforms other than Windows remain eligible for self-update.
+func TestSelfUpdateSupportedOnNonWindows(t *testing.T) {
+	if !isSelfUpdateSupportedPlatform() {
+		t.Fatal("non-Windows platforms must support self-update")
+	}
+}

--- a/internal/update/environment_test.go
+++ b/internal/update/environment_test.go
@@ -11,57 +11,6 @@ import (
 	"github.com/rs/zerolog"
 )
 
-// TestWindowsBlockedFromSelfUpdate ensures that Windows is always blocked from self-update.
-//
-// This is a critical safety check because the restart logic in internal/api/handlers/version.go
-// uses syscall.Exec, which only exists on Unix systems. If this guard is ever removed or bypassed,
-// the Windows build will compile but panic at runtime when users attempt to self-update.
-//
-// This test will fail if:
-//   - isSelfUpdateSupportedPlatform() is changed to allow Windows
-//   - The guard logic is removed or refactored incorrectly
-//
-// Related: internal/api/handlers/version.go:132 (syscall.Exec call)
-func TestWindowsBlockedFromSelfUpdate(t *testing.T) {
-	originalGOOS := runtime.GOOS
-	defer func() {
-		// Note: We can't actually change runtime.GOOS, but this documents the intent
-		_ = originalGOOS
-	}()
-
-	if runtime.GOOS == "windows" {
-		if isSelfUpdateSupportedPlatform() {
-			t.Fatal("CRITICAL: isSelfUpdateSupportedPlatform() must return false on Windows to prevent runtime panic from syscall.Exec")
-		}
-	}
-
-	// Also verify the function logic directly
-	// Since we can't override runtime.GOOS in tests, we verify the implementation
-	// matches the documented contract: "Windows binaries cannot safely replace themselves"
-	t.Run("contract verification", func(t *testing.T) {
-		// If someone changes the implementation, this will serve as documentation
-		// of the required behavior
-		supportedPlatforms := []string{"linux", "darwin", "freebsd"}
-		unsupportedPlatforms := []string{"windows"}
-
-		for _, platform := range supportedPlatforms {
-			if platform == runtime.GOOS {
-				if !isSelfUpdateSupportedPlatform() {
-					t.Errorf("platform %s should support self-update", platform)
-				}
-			}
-		}
-
-		for _, platform := range unsupportedPlatforms {
-			if platform == runtime.GOOS {
-				if isSelfUpdateSupportedPlatform() {
-					t.Fatalf("CRITICAL: platform %s MUST NOT support self-update (syscall.Exec is Unix-only)", platform)
-				}
-			}
-		}
-	})
-}
-
 // TestCanSelfUpdateRespectsWindowsGuard verifies that the Service correctly blocks self-update on Windows
 func TestCanSelfUpdateRespectsWindowsGuard(t *testing.T) {
 	svc := NewService(

--- a/internal/update/environment_test.go
+++ b/internal/update/environment_test.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package update
+
+import (
+	"io"
+	"runtime"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+// TestWindowsBlockedFromSelfUpdate ensures that Windows is always blocked from self-update.
+//
+// This is a critical safety check because the restart logic in internal/api/handlers/version.go
+// uses syscall.Exec, which only exists on Unix systems. If this guard is ever removed or bypassed,
+// the Windows build will compile but panic at runtime when users attempt to self-update.
+//
+// This test will fail if:
+//   - isSelfUpdateSupportedPlatform() is changed to allow Windows
+//   - The guard logic is removed or refactored incorrectly
+//
+// Related: internal/api/handlers/version.go:132 (syscall.Exec call)
+func TestWindowsBlockedFromSelfUpdate(t *testing.T) {
+	originalGOOS := runtime.GOOS
+	defer func() {
+		// Note: We can't actually change runtime.GOOS, but this documents the intent
+		_ = originalGOOS
+	}()
+
+	if runtime.GOOS == "windows" {
+		if isSelfUpdateSupportedPlatform() {
+			t.Fatal("CRITICAL: isSelfUpdateSupportedPlatform() must return false on Windows to prevent runtime panic from syscall.Exec")
+		}
+	}
+
+	// Also verify the function logic directly
+	// Since we can't override runtime.GOOS in tests, we verify the implementation
+	// matches the documented contract: "Windows binaries cannot safely replace themselves"
+	t.Run("contract verification", func(t *testing.T) {
+		// If someone changes the implementation, this will serve as documentation
+		// of the required behavior
+		supportedPlatforms := []string{"linux", "darwin", "freebsd"}
+		unsupportedPlatforms := []string{"windows"}
+
+		for _, platform := range supportedPlatforms {
+			if platform == runtime.GOOS {
+				if !isSelfUpdateSupportedPlatform() {
+					t.Errorf("platform %s should support self-update", platform)
+				}
+			}
+		}
+
+		for _, platform := range unsupportedPlatforms {
+			if platform == runtime.GOOS {
+				if isSelfUpdateSupportedPlatform() {
+					t.Fatalf("CRITICAL: platform %s MUST NOT support self-update (syscall.Exec is Unix-only)", platform)
+				}
+			}
+		}
+	})
+}
+
+// TestCanSelfUpdateRespectsWindowsGuard verifies that the Service correctly blocks self-update on Windows
+func TestCanSelfUpdateRespectsWindowsGuard(t *testing.T) {
+	svc := NewService(
+		noopLogger(),
+		true, // enabled
+		"v1.0.0",
+		"test-agent",
+	)
+
+	canUpdate := svc.CanSelfUpdate()
+
+	if runtime.GOOS == "windows" && canUpdate {
+		t.Fatal("CRITICAL: CanSelfUpdate() must return false on Windows to prevent syscall.Exec panic")
+	}
+}
+
+// noopLogger returns a zerolog.Logger that discards all output
+func noopLogger() zerolog.Logger {
+	return zerolog.New(io.Discard)
+}

--- a/internal/update/environment_windows_test.go
+++ b/internal/update/environment_windows_test.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package update
+
+import "testing"
+
+// TestSelfUpdateUnsupportedOnWindows ensures the guard remains enforced on Windows where syscall.Exec is unavailable.
+func TestSelfUpdateUnsupportedOnWindows(t *testing.T) {
+	if isSelfUpdateSupportedPlatform() {
+		t.Fatal("isSelfUpdateSupportedPlatform() must return false on Windows to prevent syscall.Exec panic")
+	}
+}

--- a/internal/update/service.go
+++ b/internal/update/service.go
@@ -19,6 +19,7 @@ const defaultCheckInterval = 2 * time.Hour
 type Service struct {
 	log            zerolog.Logger
 	currentVersion string
+	repository     string
 
 	mu             sync.RWMutex
 	releaseChecker *version.Checker
@@ -26,6 +27,8 @@ type Service struct {
 	lastChecked    time.Time
 	lastTag        string
 	isEnabled      bool
+
+	updateMu sync.Mutex
 }
 
 // NewService creates a new update Service instance.
@@ -34,6 +37,7 @@ func NewService(log zerolog.Logger, enabled bool, currentVersion, userAgent stri
 		log:            log.With().Str("component", "update").Logger(),
 		currentVersion: currentVersion,
 		releaseChecker: version.NewChecker("autobrr", "qui", userAgent),
+		repository:     "autobrr/qui",
 		isEnabled:      enabled,
 	}
 	return svc
@@ -126,4 +130,38 @@ func (s *Service) CheckUpdateAvailable(ctx context.Context) (*version.Release, e
 // SetEnabled toggles whether periodic update checks should run.
 func (s *Service) SetEnabled(enabled bool) {
 	s.isEnabled = enabled
+}
+
+// CanSelfUpdate returns true if the application supports running a self-update in the current environment.
+func (s *Service) CanSelfUpdate() bool {
+	if !isSelfUpdateSupportedPlatform() {
+		return false
+	}
+	if isRunningInContainer() {
+		return false
+	}
+	return true
+}
+
+// RunSelfUpdate downloads the latest release and replaces the current binary when supported.
+func (s *Service) RunSelfUpdate(ctx context.Context) error {
+	if !s.CanSelfUpdate() {
+		return ErrSelfUpdateUnsupported
+	}
+
+	s.updateMu.Lock()
+	defer s.updateMu.Unlock()
+
+	updater := NewUpdater(Config{
+		Repository: s.repository,
+		Version:    s.currentVersion,
+	})
+
+	if err := updater.Run(ctx); err != nil {
+		return err
+	}
+
+	s.log.Info().Msg("self-update completed successfully")
+
+	return nil
 }

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -2037,6 +2037,30 @@ paths:
         '204':
           description: No update available - current version is latest
 
+  /api/version/self-update:
+    post:
+      tags:
+        - System
+      summary: Trigger self-update
+      description: Download and install the latest release when the server supports self-updating.
+      responses:
+        '202':
+          description: Update scheduled and restart pending
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SelfUpdateResponse'
+        '200':
+          description: Already running the latest version
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SelfUpdateResponse'
+        '400':
+          description: Self-update is not supported in this environment
+        '500':
+          description: Failed to start self-update
+
   /api/instances/{instanceId}/backups/runs/{runId}/restore/preview:
     post:
       tags:
@@ -2562,6 +2586,7 @@ components:
         - tag_name
         - html_url
         - published_at
+        - self_update_supported
       properties:
         tag_name:
           type: string
@@ -2582,6 +2607,28 @@ components:
           format: date-time
           description: When the release was published
           example: "2025-09-23T10:30:00Z"
+        body:
+          type: string
+          nullable: true
+          description: Release notes in Markdown format
+        self_update_supported:
+          type: boolean
+          description: Whether the server supports self-updating in the current environment
+
+    SelfUpdateResponse:
+      type: object
+      description: Status message returned when requesting a self-update
+      required:
+        - message
+        - restart_pending
+      properties:
+        message:
+          type: string
+          description: Human-readable status message
+          example: "Update installed. qui will restart shortly."
+        restart_pending:
+          type: boolean
+          description: Indicates whether the server will restart to apply the update
 
     QBittorrentBuildInfo:
       type: object

--- a/web/package.json
+++ b/web/package.json
@@ -57,6 +57,7 @@
     "react-dom": "^19.2.0",
     "react-hook-form": "^7.65.0",
     "react-hotkeys-hook": "^5.2.1",
+    "react-markdown": "^10.1.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
     "workbox-window": "^7.3.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       react-hotkeys-hook:
         specifier: ^5.2.1
         version: 5.2.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.2)(react@19.2.0)
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -1874,17 +1877,32 @@ packages:
   '@types/culori@4.0.1':
     resolution: {integrity: sha512-43M51r/22CjhbOXyGT361GZ9vncSVQ39u62x5eJdBQFviI8zWp2X5jzqg7k4M6PVgDQAClpy2bUe2dtwEgEDVQ==}
 
+  '@types/debug@4.1.12':
+    resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
   '@types/estree@0.0.39':
     resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/magnet-uri@5.1.5':
     resolution: {integrity: sha512-SbBjlb1KGe38VfjRR+mwqztJd/4skhdKkRbIzPDhTy7IAeEAPZWIVSEkZw00Qr4ZZOGR3/ATJ20WWPBfrKHGdA==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@24.8.1':
     resolution: {integrity: sha512-alv65KGRadQVfVcG69MuB4IzdYVpRwMG/mq8KWOaoOdyY617P5ivaDiMCGOFDWD2sAn5Q0mR3mRtUOgm99hL9Q==}
@@ -1908,6 +1926,12 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@typescript-eslint/eslint-plugin@8.46.1':
     resolution: {integrity: sha512-rUsLh8PXmBjdiPY+Emjz9NX2yHvhS11v0SR6xNJkm5GM1MO9ea/1GoDKlHHZGrOJclL/cZ2i/vRUYVtjRhrHVQ==}
@@ -1971,6 +1995,9 @@ packages:
   '@typescript-eslint/visitor-keys@8.46.1':
     resolution: {integrity: sha512-ptkmIf2iDkNUjdeu2bQqhFPV1m6qTnFFjg7PPDjxKWaMaP0Z6I9l30Jr3g5QqbZGdw8YdYvLp+XnqnWWZOg/NA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
   '@vitejs/plugin-react@5.0.4':
     resolution: {integrity: sha512-La0KD0vGkVkSk6K+piWDKRUyg8Rl5iAIKRMH0vMJI0Eg47bq1eOxmoObAaQG37WMW9MSyk7Cs8EIWwJC1PtzKA==}
@@ -2052,6 +2079,9 @@ packages:
     resolution: {integrity: sha512-ISqQ2frbiNU9vIJkzg7dlPpznPZ4jOiUQ1uSmB0fEHeowtN3COYRsXr/xexn64NpU13P06jc/L5TgiJXOgrbEg==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -2153,9 +2183,24 @@ packages:
   caniuse-lite@1.0.30001751:
     resolution: {integrity: sha512-A0QJhug0Ly64Ii3eIqHu5X51ebln3k4yTUkY1j8drqpWHVreg/VLijN48cZ1bYPiqOQuqpkIKnzr/Ul8V+p6Cw==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
@@ -2178,6 +2223,9 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -2269,6 +2317,9 @@ packages:
   decode-formdata@0.9.0:
     resolution: {integrity: sha512-q5uwOjR3Um5YD+ZWPOF/1sGHVW9A5rCrRwITQChRXlmPkxDFBqCm4jNTIVdGHNH9OnR+V9MoZVgRhsFb+ARbUw==}
 
+  decode-named-character-reference@1.2.0:
+    resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -2284,6 +2335,10 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   des.js@1.1.0:
     resolution: {integrity: sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==}
 
@@ -2296,6 +2351,9 @@ packages:
 
   devalue@5.4.1:
     resolution: {integrity: sha512-YtoaOfsqjbZQKGIMRYDWKjUmSB4VJ/RElB+bXZawQAQYAo4xu08GKTMVlsZDTF6R2MbAgjcAQRPI5eIyRAT2OQ==}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   diffie-hellman@5.0.3:
     resolution: {integrity: sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==}
@@ -2409,6 +2467,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
   estree-walker@1.0.1:
     resolution: {integrity: sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==}
 
@@ -2429,6 +2490,9 @@ packages:
 
   evp_bytestokey@1.0.3:
     resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -2641,6 +2705,12 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
 
@@ -2649,6 +2719,9 @@ packages:
 
   hmac-drbg@1.0.1:
     resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   https-browserify@1.0.0:
     resolution: {integrity: sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==}
@@ -2682,9 +2755,18 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  inline-style-parser@0.2.6:
+    resolution: {integrity: sha512-gtGXVaBdl5mAes3rPcMedEBm12ibjt1kDMFfheul1wUAOVEJW60voNdMVzVkfLN06O7ZaD/rxhfKgtlgtTbMjg==}
+
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
   is-arguments@1.2.0:
     resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
@@ -2722,6 +2804,9 @@ packages:
     resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
     engines: {node: '>= 0.4'}
 
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -2741,6 +2826,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
@@ -2768,6 +2856,10 @@ packages:
   is-obj@1.0.1:
     resolution: {integrity: sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==}
     engines: {node: '>=0.10.0'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -2969,6 +3061,9 @@ packages:
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -2994,9 +3089,96 @@ packages:
   md5.js@1.3.5:
     resolution: {integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==}
 
+  mdast-util-from-markdown@2.0.2:
+    resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.0:
+    resolution: {integrity: sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -3133,6 +3315,9 @@ packages:
     resolution: {integrity: sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==}
     engines: {node: '>= 0.10'}
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   parse-torrent@11.0.19:
     resolution: {integrity: sha512-T0lEkDdFVQsy0YxHIKjzDHSgt/yl57f3INs5jl7OZqAm77XDF0FgRgrv3LCKgSqsTOrMwYaF0t2761WKdvhgig==}
     engines: {node: '>=12.20.0'}
@@ -3202,6 +3387,9 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
   public-encrypt@4.0.3:
     resolution: {integrity: sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==}
 
@@ -3245,6 +3433,12 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
+
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -3316,6 +3510,12 @@ packages:
   regjsparser@0.13.0:
     resolution: {integrity: sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==}
     hasBin: true
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -3475,6 +3675,9 @@ packages:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
     deprecated: Please use @jridgewell/sourcemap-codec instead
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
@@ -3507,6 +3710,9 @@ packages:
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   stringify-object@3.3.0:
     resolution: {integrity: sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==}
     engines: {node: '>=4'}
@@ -3518,6 +3724,12 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  style-to-js@1.1.19:
+    resolution: {integrity: sha512-Ev+SgeqiNGT1ufsXyVC5RrJRXdrkRJ1Gol9Qw7Pb72YCKJXrBvP0ckZhBeVSrw2m06DJpei2528uIpjMb4TsoQ==}
+
+  style-to-object@1.0.12:
+    resolution: {integrity: sha512-ddJqYnoT4t97QvN2C95bCgt+m7AAgXjVnkk/jxAfmp7EAB8nnqqZYEbMd3em7/vEomDb2LAQKAy1RFfv41mdNw==}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -3578,6 +3790,12 @@ packages:
 
   tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
+
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
@@ -3661,9 +3879,27 @@ packages:
     resolution: {integrity: sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==}
     engines: {node: '>=4'}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
   unique-string@2.0.0:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
     engines: {node: '>=8'}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.0.0:
+    resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
 
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
@@ -3716,6 +3952,12 @@ packages:
 
   util@0.12.5:
     resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite-plugin-node-polyfills@0.24.0:
     resolution: {integrity: sha512-GA9QKLH+vIM8NPaGA+o2t8PDfFUl32J8rUp1zQfMKVJQiNkOX4unE51tR6ppl6iKw5yOrDAdSH7r/UIFLCVhLw==}
@@ -3887,6 +4129,9 @@ packages:
 
   zod@4.1.12:
     resolution: {integrity: sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -5638,15 +5883,33 @@ snapshots:
 
   '@types/culori@4.0.1': {}
 
+  '@types/debug@4.1.12':
+    dependencies:
+      '@types/ms': 2.1.0
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
+
   '@types/estree@0.0.39': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
 
   '@types/json-schema@7.0.15': {}
 
   '@types/magnet-uri@5.1.5':
     dependencies:
       '@types/node': 24.8.1
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@24.8.1':
     dependencies:
@@ -5673,6 +5936,10 @@ snapshots:
   '@types/resolve@1.20.2': {}
 
   '@types/trusted-types@2.0.7': {}
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
 
   '@typescript-eslint/eslint-plugin@8.46.1(@typescript-eslint/parser@8.46.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -5768,6 +6035,8 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.46.1
       eslint-visitor-keys: 4.2.1
+
+  '@ungap/structured-clone@1.3.0': {}
 
   '@vitejs/plugin-react@5.0.4(vite@7.1.11(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.3))':
     dependencies:
@@ -5877,6 +6146,8 @@ snapshots:
       '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.4)
     transitivePeerDependencies:
       - supports-color
+
+  bail@2.0.2: {}
 
   balanced-match@1.0.2: {}
 
@@ -5999,10 +6270,20 @@ snapshots:
 
   caniuse-lite@1.0.30001751: {}
 
+  ccount@2.0.1: {}
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   chownr@3.0.0: {}
 
@@ -6023,6 +6304,8 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   commander@2.20.3: {}
 
@@ -6126,6 +6409,10 @@ snapshots:
 
   decode-formdata@0.9.0: {}
 
+  decode-named-character-reference@1.2.0:
+    dependencies:
+      character-entities: 2.0.2
+
   deep-is@0.1.4: {}
 
   deepmerge@4.3.1: {}
@@ -6142,6 +6429,8 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  dequal@2.0.3: {}
+
   des.js@1.1.0:
     dependencies:
       inherits: 2.0.4
@@ -6152,6 +6441,10 @@ snapshots:
   detect-node-es@1.1.0: {}
 
   devalue@5.4.1: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   diffie-hellman@5.0.3:
     dependencies:
@@ -6380,6 +6673,8 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-util-is-identifier-name@3.0.0: {}
+
   estree-walker@1.0.1: {}
 
   estree-walker@2.0.2: {}
@@ -6394,6 +6689,8 @@ snapshots:
     dependencies:
       md5.js: 1.3.5
       safe-buffer: 5.2.1
+
+  extend@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -6604,6 +6901,30 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.19
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   hermes-estree@0.25.1: {}
 
   hermes-parser@0.25.1:
@@ -6615,6 +6936,8 @@ snapshots:
       hash.js: 1.1.7
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
+
+  html-url-attributes@3.0.1: {}
 
   https-browserify@1.0.0: {}
 
@@ -6640,11 +6963,20 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  inline-style-parser@0.2.6: {}
+
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
 
   is-arguments@1.2.0:
     dependencies:
@@ -6691,6 +7023,8 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-decimal@2.0.1: {}
+
   is-extglob@2.1.1: {}
 
   is-finalizationregistry@1.1.1:
@@ -6717,6 +7051,8 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-hexadecimal@2.0.1: {}
+
   is-map@2.0.3: {}
 
   is-module@1.0.0: {}
@@ -6736,6 +7072,8 @@ snapshots:
   is-number@7.0.0: {}
 
   is-obj@1.0.1: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -6894,6 +7232,8 @@ snapshots:
 
   lodash@4.17.21: {}
 
+  longest-streak@3.1.0: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -6924,7 +7264,229 @@ snapshots:
       inherits: 2.0.4
       safe-buffer: 5.2.1
 
+  mdast-util-from-markdown@2.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.2.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.0.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.0.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
   merge2@1.4.1: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.2.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.2.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.12
+      debug: 4.4.3
+      decode-named-character-reference: 1.2.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   micromatch@4.0.8:
     dependencies:
@@ -7084,6 +7646,16 @@ snapshots:
       pbkdf2: 3.1.5
       safe-buffer: 5.2.1
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.2.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   parse-torrent@11.0.19:
     dependencies:
       bencode: 4.0.0
@@ -7140,6 +7712,8 @@ snapshots:
 
   process@0.11.10: {}
 
+  property-information@7.1.0: {}
+
   public-encrypt@4.0.3:
     dependencies:
       bn.js: 4.12.2
@@ -7183,6 +7757,24 @@ snapshots:
     dependencies:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
+
+  react-markdown@10.1.0(@types/react@19.2.2)(react@19.2.0):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.2
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.0
+      react: 19.2.0
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.0.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   react-refresh@0.17.0: {}
 
@@ -7271,6 +7863,23 @@ snapshots:
   regjsparser@0.13.0:
     dependencies:
       jsesc: 3.1.0
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.2
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.0
+      unified: 11.0.5
+      vfile: 6.0.3
 
   require-from-string@2.0.2: {}
 
@@ -7459,6 +8068,8 @@ snapshots:
 
   sourcemap-codec@1.4.8: {}
 
+  space-separated-tokens@2.0.2: {}
+
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -7523,6 +8134,11 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   stringify-object@3.3.0:
     dependencies:
       get-own-enumerable-property-symbols: 3.0.2
@@ -7532,6 +8148,14 @@ snapshots:
   strip-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
+
+  style-to-js@1.1.19:
+    dependencies:
+      style-to-object: 1.0.12
+
+  style-to-object@1.0.12:
+    dependencies:
+      inline-style-parser: 0.2.6
 
   supports-color@7.2.0:
     dependencies:
@@ -7595,6 +8219,10 @@ snapshots:
   tr46@1.0.1:
     dependencies:
       punycode: 2.3.1
+
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
 
   ts-api-utils@2.1.0(typescript@5.9.3):
     dependencies:
@@ -7690,9 +8318,42 @@ snapshots:
 
   unicode-property-aliases-ecmascript@2.2.0: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
   unique-string@2.0.0:
     dependencies:
       crypto-random-string: 2.0.0
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   universalify@2.0.1: {}
 
@@ -7741,6 +8402,16 @@ snapshots:
       is-generator-function: 1.1.1
       is-typed-array: 1.1.15
       which-typed-array: 1.1.19
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite-plugin-node-polyfills@0.24.0(rollup@2.79.2)(vite@7.1.11(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.20.3)):
     dependencies:
@@ -7964,3 +8635,5 @@ snapshots:
       zod: 4.1.12
 
   zod@4.1.12: {}
+
+  zwitch@2.0.4: {}

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -492,21 +492,25 @@ export function Header({
                   {updateInfo.self_update_supported && (
                     <DropdownMenuSeparator />
                   )}
-                  <DropdownMenuItem asChild>
-                    <a
-                      href={updateInfo.html_url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex items-center gap-2 text-green-600 dark:text-green-400 focus:text-green-600 dark:focus:text-green-400 cursor-pointer"
-                    >
-                      <Download className="mr-2 h-4 w-4" />
-                      <div className="flex flex-col">
-                        <span className="font-medium">Update Available</span>
-                        <span className="text-[10px] opacity-80">Version {updateInfo.tag_name}</span>
-                      </div>
-                    </a>
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
+                  {!updateInfo.self_update_supported && (
+                    <>
+                      <DropdownMenuItem asChild>
+                        <a
+                          href={updateInfo.html_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="flex items-center gap-2 text-green-600 dark:text-green-400 focus:text-green-600 dark:focus:text-green-400 cursor-pointer"
+                        >
+                          <Download className="mr-2 h-4 w-4" />
+                          <div className="flex flex-col">
+                            <span className="font-medium">Update Available</span>
+                            <span className="text-[10px] opacity-80">Version {updateInfo.tag_name}</span>
+                          </div>
+                        </a>
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
+                    </>
+                  )}
                 </>
               )}
               <DropdownMenuItem asChild>

--- a/web/src/components/layout/MobileFooterNav.tsx
+++ b/web/src/components/layout/MobileFooterNav.tsx
@@ -32,13 +32,14 @@ import {
   setThemeMode,
   type ThemeMode
 } from "@/utils/theme"
-import { useQuery } from "@tanstack/react-query"
+import { useMutation, useQuery } from "@tanstack/react-query"
 import { Link, useLocation } from "@tanstack/react-router"
 import {
   Archive,
   Check,
   Copyright,
   Download,
+  Loader2,
   Github,
   HardDrive,
   Home,
@@ -106,6 +107,21 @@ export function MobileFooterNav() {
     refetchOnMount: false,
     refetchOnWindowFocus: false,
   })
+
+  const updateMutation = useMutation({
+    mutationFn: () => api.triggerSelfUpdate(),
+    onSuccess: ({ message }) => {
+      toast.success(message)
+    },
+    onError: (error: unknown) => {
+      const message = error instanceof Error ? error.message : "Failed to start self-update"
+      toast.error(message)
+    },
+  })
+
+  const handleTriggerSelfUpdate = () => {
+    updateMutation.mutate()
+  }
 
   const activeInstances = instances?.filter(i => i.connected) || []
   const isOnInstancePage = location.pathname.startsWith("/instances/")
@@ -253,6 +269,26 @@ export function MobileFooterNav() {
           <DropdownMenuContent align="end" side="top" className="mb-2 w-56">
             {updateInfo && (
               <>
+                {updateInfo.self_update_supported && (
+                  <DropdownMenuItem
+                    onSelect={(event) => {
+                      event.preventDefault()
+                      handleTriggerSelfUpdate()
+                    }}
+                    disabled={updateMutation.isPending}
+                    className="text-green-600 dark:text-green-400"
+                  >
+                    {updateMutation.isPending ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <Download className="h-4 w-4" />
+                    )}
+                    <div className="flex flex-col ml-2">
+                      <span className="font-medium text-sm">Update &amp; Restart</span>
+                      <span className="text-[10px] opacity-80">Version {updateInfo.tag_name}</span>
+                    </div>
+                  </DropdownMenuItem>
+                )}
                 <DropdownMenuItem asChild>
                   <a
                     href={updateInfo.html_url}

--- a/web/src/components/layout/MobileFooterNav.tsx
+++ b/web/src/components/layout/MobileFooterNav.tsx
@@ -22,6 +22,7 @@ import { isThemePremium, themes } from "@/config/themes"
 import { useTorrentSelection } from "@/contexts/TorrentSelectionContext"
 import { useAuth } from "@/hooks/useAuth"
 import { useHasPremiumAccess } from "@/hooks/useLicense"
+import { useServerReconnect } from "@/hooks/useServerReconnect"
 import { api } from "@/lib/api"
 import { getAppVersion } from "@/lib/build-info"
 import { cn } from "@/lib/utils"
@@ -92,6 +93,7 @@ export function MobileFooterNav() {
   const { isSelectionMode } = useTorrentSelection()
   const { currentMode, currentTheme } = useThemeChange()
   const { hasPremiumAccess } = useHasPremiumAccess()
+  const { pollForReconnection, storeChangelog, ChangelogDialog } = useServerReconnect()
   const [showThemeDialog, setShowThemeDialog] = useState(false)
   const appVersion = getAppVersion()
 
@@ -108,10 +110,23 @@ export function MobileFooterNav() {
     refetchOnWindowFocus: false,
   })
 
+  // Store changelog data when update info is available
+  useEffect(() => {
+    if (updateInfo?.body) {
+      storeChangelog(updateInfo.tag_name, updateInfo.body)
+    }
+  }, [updateInfo, storeChangelog])
+
   const updateMutation = useMutation({
     mutationFn: () => api.triggerSelfUpdate(),
-    onSuccess: ({ message }) => {
-      toast.success(message)
+    onSuccess: ({ message, restart_pending }) => {
+      const notify = restart_pending ? toast.success : toast.info
+      notify(message)
+
+      if (restart_pending) {
+        // Start polling for reconnection
+        pollForReconnection()
+      }
     },
     onError: (error: unknown) => {
       const message = error instanceof Error ? error.message : "Failed to start self-update"
@@ -490,6 +505,8 @@ export function MobileFooterNav() {
           </div>
         </DialogContent>
       </Dialog>
+
+      <ChangelogDialog />
     </nav>
   )
 }

--- a/web/src/components/layout/MobileFooterNav.tsx
+++ b/web/src/components/layout/MobileFooterNav.tsx
@@ -289,20 +289,22 @@ export function MobileFooterNav() {
                     </div>
                   </DropdownMenuItem>
                 )}
-                <DropdownMenuItem asChild>
-                  <a
-                    href={updateInfo.html_url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex items-center gap-2 text-green-600 dark:text-green-400 focus:text-green-600 dark:focus:text-green-400"
-                  >
-                    <Download className="h-4 w-4" />
-                    <div className="flex flex-col">
-                      <span className="font-medium">Update Available</span>
-                      <span className="text-[10px] opacity-80">Version {updateInfo.tag_name}</span>
-                    </div>
-                  </a>
-                </DropdownMenuItem>
+                {!updateInfo.self_update_supported && (
+                  <DropdownMenuItem asChild>
+                    <a
+                      href={updateInfo.html_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center gap-2 text-green-600 dark:text-green-400 focus:text-green-600 dark:focus:text-green-400"
+                    >
+                      <Download className="h-4 w-4" />
+                      <div className="flex flex-col">
+                        <span className="font-medium">Update Available</span>
+                        <span className="text-[10px] opacity-80">Version {updateInfo.tag_name}</span>
+                      </div>
+                    </a>
+                  </DropdownMenuItem>
+                )}
                 <DropdownMenuSeparator />
               </>
             )}

--- a/web/src/components/ui/UpdateBanner.tsx
+++ b/web/src/components/ui/UpdateBanner.tsx
@@ -4,15 +4,29 @@
  */
 
 import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
 import { api } from "@/lib/api"
 import { cn } from "@/lib/utils"
 import { useMutation, useQuery } from "@tanstack/react-query"
 import { Download, Loader2, X } from "lucide-react"
-import { useState } from "react"
+import { useEffect, useRef, useState } from "react"
+import ReactMarkdown from "react-markdown"
 import { toast } from "sonner"
 
 export function UpdateBanner() {
   const [dismissed, setDismissed] = useState(false)
+  const [showChangelog, setShowChangelog] = useState(false)
+  const [changelogData, setChangelogData] = useState<{
+    version: string
+    body: string
+  } | null>(null)
+  const pollingRef = useRef<NodeJS.Timeout | null>(null)
 
   const { data: updateInfo } = useQuery({
     queryKey: ["latest-version"],
@@ -24,11 +38,83 @@ export function UpdateBanner() {
     refetchOnWindowFocus: false,
   })
 
+  // Poll for server reconnection after update
+  const pollForReconnection = () => {
+    let attempts = 0
+    const maxAttempts = 60 // Poll for up to 60 seconds
+
+    pollingRef.current = setInterval(async () => {
+      attempts++
+
+      try {
+        // Try to fetch version info - if this succeeds, server is back
+        const versionInfo = await api.getLatestVersion()
+
+        // Server is back online
+        if (pollingRef.current) {
+          clearInterval(pollingRef.current)
+          pollingRef.current = null
+        }
+
+        // Show changelog dialog if we have release notes
+        if (versionInfo?.body) {
+          setChangelogData({
+            version: versionInfo.tag_name,
+            body: versionInfo.body
+          })
+          setShowChangelog(true)
+        } else {
+          toast.success("Update completed successfully!")
+          // Reload to update service worker cache
+          setTimeout(() => {
+            window.location.reload()
+          }, 1000)
+        }
+      } catch {
+        // Server not ready yet
+        if (attempts >= maxAttempts) {
+          if (pollingRef.current) {
+            clearInterval(pollingRef.current)
+            pollingRef.current = null
+          }
+          toast.info("Update completed. Please refresh the page.")
+        }
+      }
+    }, 1000) // Poll every second
+  }
+
+  const handleCloseChangelog = () => {
+    setShowChangelog(false)
+    // Reload page to update service worker cache after user reads changelog
+    setTimeout(() => {
+      window.location.reload()
+    }, 200)
+  }
+
+  // Clean up changelog by removing commit hashes
+  const cleanChangelog = (markdown: string) => {
+    // Remove commit hashes (40 hex chars followed by ": ") from list items
+    // Example: "* a7e79d862928c1bf8838b1a30678bdb3844d3315: feat(backups)..." -> "* feat(backups)..."
+    return markdown.replace(/^(\s*[*-]\s+)([a-f0-9]{40}):\s+/gm, '$1')
+  }
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (pollingRef.current) {
+        clearInterval(pollingRef.current)
+        pollingRef.current = null
+      }
+    }
+  }, [])
+
   const updateMutation = useMutation({
     mutationFn: () => api.triggerSelfUpdate(),
     onSuccess: ({ message }) => {
       toast.success(message)
       setDismissed(true)
+      // Start polling for reconnection
+      pollForReconnection()
     },
     onError: (error: unknown) => {
       const message = error instanceof Error ? error.message : "Failed to start self-update"
@@ -38,7 +124,50 @@ export function UpdateBanner() {
 
   // Don't show banner if dismissed or no update available
   if (dismissed || !updateInfo) {
-    return null
+    return (
+      <>
+        {/* Changelog dialog - show even if banner is dismissed */}
+        <Dialog open={showChangelog} onOpenChange={(open) => !open && handleCloseChangelog()}>
+          <DialogContent className="!max-w-[90vw] w-auto max-h-[85vh] overflow-hidden flex flex-col">
+            <DialogHeader>
+              <DialogTitle>Update Completed - Version {changelogData?.version}</DialogTitle>
+              <DialogDescription>
+                qui has been successfully updated. Here's what's new:
+              </DialogDescription>
+            </DialogHeader>
+            <div className="overflow-y-auto flex-1 pr-2">
+              <div className="prose dark:prose-invert max-w-none prose-headings:mb-3 prose-headings:mt-6 prose-p:my-2 prose-ul:my-2 prose-li:my-1">
+                {changelogData?.body && (
+                  <ReactMarkdown
+                    components={{
+                      h1: ({ children }) => <h2 className="text-xl font-bold mt-6 mb-3">{children}</h2>,
+                      h2: ({ children }) => <h3 className="text-lg font-semibold mt-5 mb-2">{children}</h3>,
+                      h3: ({ children }) => <h4 className="text-base font-semibold mt-4 mb-2">{children}</h4>,
+                      ul: ({ children }) => <ul className="list-disc pl-5 space-y-1">{children}</ul>,
+                      li: ({ children }) => <li className="text-sm leading-relaxed break-words">{children}</li>,
+                      p: ({ children }) => <p className="text-sm my-2 break-words">{children}</p>,
+                      code: ({ children }) => <code className="text-xs bg-muted px-1.5 py-0.5 rounded break-all">{children}</code>,
+                      a: ({ href, children }) => (
+                        <a href={href} target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
+                          {children}
+                        </a>
+                      ),
+                    }}
+                  >
+                    {cleanChangelog(changelogData.body)}
+                  </ReactMarkdown>
+                )}
+              </div>
+            </div>
+            <div className="flex justify-end pt-4 border-t">
+              <Button onClick={handleCloseChangelog}>
+                Reload
+              </Button>
+            </div>
+          </DialogContent>
+        </Dialog>
+      </>
+    )
   }
 
   const handleViewUpdate = () => {
@@ -54,57 +183,100 @@ export function UpdateBanner() {
   }
 
   return (
-    <div className={cn(
-      "mb-3 rounded-md border border-green-200 bg-green-50 p-3",
-      "dark:border-green-800 dark:bg-green-950/50"
-    )}>
-      <div className="flex items-start gap-2">
-        <Download className="h-4 w-4 text-green-600 dark:text-green-400 mt-0.5 flex-shrink-0" />
-        <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium text-green-800 dark:text-green-200">
-            Update Available
-          </p>
-          <p className="text-xs text-green-700 dark:text-green-300 mt-1">
-            Version {updateInfo.tag_name} is now available
-          </p>
-          <div className="mt-2 flex flex-wrap gap-2">
-            {updateInfo.self_update_supported && (
+    <>
+      <div className={cn(
+        "mb-3 rounded-md border border-green-200 bg-green-50 p-3",
+        "dark:border-green-800 dark:bg-green-950/50"
+      )}>
+        <div className="flex items-start gap-2">
+          <Download className="h-4 w-4 text-green-600 dark:text-green-400 mt-0.5 flex-shrink-0" />
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium text-green-800 dark:text-green-200">
+              Update Available
+            </p>
+            <p className="text-xs text-green-700 dark:text-green-300 mt-1">
+              Version {updateInfo.tag_name} is now available
+            </p>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {updateInfo.self_update_supported && (
+                <Button
+                  size="sm"
+                  className="h-6 text-xs"
+                  onClick={handleSelfUpdate}
+                  disabled={updateMutation.isPending}
+                >
+                  {updateMutation.isPending ? (
+                    <span className="flex items-center gap-1">
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      Updating...
+                    </span>
+                  ) : (
+                    "Update & Restart"
+                  )}
+                </Button>
+              )}
               <Button
                 size="sm"
-                className="h-6 text-xs"
-                onClick={handleSelfUpdate}
-                disabled={updateMutation.isPending}
+                variant="outline"
+                className="h-6 text-xs border-green-300 text-green-700 hover:bg-green-100 dark:border-green-700 dark:text-green-300 dark:hover:bg-green-900"
+                onClick={handleViewUpdate}
               >
-                {updateMutation.isPending ? (
-                  <span className="flex items-center gap-1">
-                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                    Updating...
-                  </span>
-                ) : (
-                  "Update & Restart"
-                )}
+                View Release
               </Button>
-            )}
-            <Button
-              size="sm"
-              variant="outline"
-              className="h-6 text-xs border-green-300 text-green-700 hover:bg-green-100 dark:border-green-700 dark:text-green-300 dark:hover:bg-green-900"
-              onClick={handleViewUpdate}
-            >
-              View Release
+            </div>
+          </div>
+          <Button
+            size="icon"
+            variant="ghost"
+            className="h-4 w-4 text-green-600 hover:text-green-800 dark:text-green-400 dark:hover:text-green-200"
+            onClick={handleDismiss}
+          >
+            <X className="h-3 w-3" />
+            <span className="sr-only">Dismiss</span>
+          </Button>
+        </div>
+      </div>
+
+      {/* Changelog dialog */}
+      <Dialog open={showChangelog} onOpenChange={(open) => !open && handleCloseChangelog()}>
+        <DialogContent className="max-w-[90vw] w-auto max-h-[85vh] overflow-hidden flex flex-col">
+          <DialogHeader>
+            <DialogTitle>Update Completed - Version {changelogData?.version}</DialogTitle>
+            <DialogDescription>
+              qui has been successfully updated. Here's what's new:
+            </DialogDescription>
+          </DialogHeader>
+          <div className="overflow-y-auto flex-1 pr-2">
+            <div className="prose dark:prose-invert max-w-none prose-headings:mb-3 prose-headings:mt-6 prose-p:my-2 prose-ul:my-2 prose-li:my-1">
+              {changelogData?.body && (
+                <ReactMarkdown
+                  components={{
+                    h1: ({ children }) => <h2 className="text-xl font-bold mt-6 mb-3">{children}</h2>,
+                    h2: ({ children }) => <h3 className="text-lg font-semibold mt-5 mb-2">{children}</h3>,
+                    h3: ({ children }) => <h4 className="text-base font-semibold mt-4 mb-2">{children}</h4>,
+                    ul: ({ children }) => <ul className="list-disc pl-5 space-y-1">{children}</ul>,
+                    li: ({ children }) => <li className="text-sm leading-relaxed break-words">{children}</li>,
+                    p: ({ children }) => <p className="text-sm my-2 break-words">{children}</p>,
+                    code: ({ children }) => <code className="text-xs bg-muted px-1.5 py-0.5 rounded break-all">{children}</code>,
+                    a: ({ href, children }) => (
+                      <a href={href} target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
+                        {children}
+                      </a>
+                    ),
+                  }}
+                >
+                  {cleanChangelog(changelogData.body)}
+                </ReactMarkdown>
+              )}
+            </div>
+          </div>
+          <div className="flex justify-end pt-4 border-t">
+            <Button onClick={handleCloseChangelog}>
+              Close
             </Button>
           </div>
-        </div>
-        <Button
-          size="icon"
-          variant="ghost"
-          className="h-4 w-4 text-green-600 hover:text-green-800 dark:text-green-400 dark:hover:text-green-200"
-          onClick={handleDismiss}
-        >
-          <X className="h-3 w-3" />
-          <span className="sr-only">Dismiss</span>
-        </Button>
-      </div>
-    </div>
+        </DialogContent>
+      </Dialog>
+    </>
   )
 }

--- a/web/src/components/ui/UpdateBanner.tsx
+++ b/web/src/components/ui/UpdateBanner.tsx
@@ -4,33 +4,17 @@
  */
 
 import { Button } from "@/components/ui/button"
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog"
 import { api } from "@/lib/api"
 import { cn } from "@/lib/utils"
+import { useServerReconnect } from "@/hooks/useServerReconnect"
 import { useMutation, useQuery } from "@tanstack/react-query"
 import { Download, Loader2, X } from "lucide-react"
-import { useEffect, useRef, useState } from "react"
-import ReactMarkdown from "react-markdown"
+import { useEffect, useState } from "react"
 import { toast } from "sonner"
 
 export function UpdateBanner() {
   const [dismissed, setDismissed] = useState(false)
-  const [showChangelog, setShowChangelog] = useState(false)
-  const [changelogData, setChangelogData] = useState<{
-    version: string
-    body: string
-  } | null>(null)
-  const pollingRef = useRef<NodeJS.Timeout | null>(null)
-  const changelogRef = useRef<{
-    version: string
-    body: string
-  } | null>(null)
+  const { pollForReconnection, storeChangelog, ChangelogDialog } = useServerReconnect()
 
   const { data: updateInfo } = useQuery({
     queryKey: ["latest-version"],
@@ -42,91 +26,12 @@ export function UpdateBanner() {
     refetchOnWindowFocus: false,
   })
 
-  // Poll for server reconnection after update
-  const pollForReconnection = () => {
-    let attempts = 0
-    const maxAttempts = 60 // Poll for up to 60 seconds
-
-    pollingRef.current = setInterval(async () => {
-      attempts++
-
-      try {
-        // Try to fetch version info - if this succeeds, server is back
-        const versionInfo = await api.getLatestVersion()
-
-        // Server is back online
-        if (pollingRef.current) {
-          clearInterval(pollingRef.current)
-          pollingRef.current = null
-        }
-
-        // Show changelog dialog if we have release notes
-        if (versionInfo?.body) {
-          const latestRelease = {
-            version: versionInfo.tag_name,
-            body: versionInfo.body
-          }
-          setChangelogData(latestRelease)
-          changelogRef.current = latestRelease
-          setShowChangelog(true)
-        } else if (changelogRef.current) {
-          setChangelogData(changelogRef.current)
-          setShowChangelog(true)
-        } else {
-          toast.success("Update completed successfully!")
-          // Reload to update service worker cache
-          setTimeout(() => {
-            window.location.reload()
-          }, 1000)
-        }
-      } catch {
-        // Server not ready yet
-        if (attempts >= maxAttempts) {
-          if (pollingRef.current) {
-            clearInterval(pollingRef.current)
-            pollingRef.current = null
-          }
-          toast.info("Update completed. Please refresh the page.")
-        }
-      }
-    }, 1000) // Poll every second
-  }
-
-  const handleCloseChangelog = () => {
-    setShowChangelog(false)
-    // Reload page to update service worker cache after user reads changelog
-    setTimeout(() => {
-      window.location.reload()
-    }, 200)
-  }
-
-  // Clean up changelog by removing commit hashes
-  const cleanChangelog = (markdown: string) => {
-    // Remove commit hashes (40 hex chars followed by ": ") from list items
-    // Example: "* a7e79d862928c1bf8838b1a30678bdb3844d3315: feat(backups)..." -> "* feat(backups)..."
-    return markdown.replace(/^(\s*[*-]\s+)([a-f0-9]{40}):\s+/gm, "$1")
-  }
-
-  // Cleanup on unmount
-  useEffect(() => {
-    return () => {
-      if (pollingRef.current) {
-        clearInterval(pollingRef.current)
-        pollingRef.current = null
-      }
-    }
-  }, [])
-
+  // Store changelog data when update info is available
   useEffect(() => {
     if (updateInfo?.body) {
-      const latestRelease = {
-        version: updateInfo.tag_name,
-        body: updateInfo.body
-      }
-      setChangelogData(latestRelease)
-      changelogRef.current = latestRelease
+      storeChangelog(updateInfo.tag_name, updateInfo.body)
     }
-  }, [updateInfo])
+  }, [updateInfo, storeChangelog])
 
   const updateMutation = useMutation({
     mutationFn: () => api.triggerSelfUpdate(),
@@ -148,50 +53,7 @@ export function UpdateBanner() {
 
   // Don't show banner if dismissed or no update available
   if (dismissed || !updateInfo) {
-    return (
-      <>
-        {/* Changelog dialog - show even if banner is dismissed */}
-        <Dialog open={showChangelog} onOpenChange={(open) => !open && handleCloseChangelog()}>
-          <DialogContent className="!max-w-[90vw] w-auto max-h-[85vh] overflow-hidden flex flex-col">
-            <DialogHeader>
-              <DialogTitle>Update Completed - Version {changelogData?.version}</DialogTitle>
-              <DialogDescription>
-                qui has been successfully updated. Here's what's new:
-              </DialogDescription>
-            </DialogHeader>
-            <div className="overflow-y-auto flex-1 pr-2">
-              <div className="prose dark:prose-invert max-w-none prose-headings:mb-3 prose-headings:mt-6 prose-p:my-2 prose-ul:my-2 prose-li:my-1">
-                {changelogData?.body && (
-                  <ReactMarkdown
-                    components={{
-                      h1: ({ children }) => <h2 className="text-xl font-bold mt-6 mb-3">{children}</h2>,
-                      h2: ({ children }) => <h3 className="text-lg font-semibold mt-5 mb-2">{children}</h3>,
-                      h3: ({ children }) => <h4 className="text-base font-semibold mt-4 mb-2">{children}</h4>,
-                      ul: ({ children }) => <ul className="list-disc pl-5 space-y-1">{children}</ul>,
-                      li: ({ children }) => <li className="text-sm leading-relaxed break-words">{children}</li>,
-                      p: ({ children }) => <p className="text-sm my-2 break-words">{children}</p>,
-                      code: ({ children }) => <code className="text-xs bg-muted px-1.5 py-0.5 rounded break-all">{children}</code>,
-                      a: ({ href, children }) => (
-                        <a href={href} target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
-                          {children}
-                        </a>
-                      ),
-                    }}
-                  >
-                    {cleanChangelog(changelogData.body)}
-                  </ReactMarkdown>
-                )}
-              </div>
-            </div>
-            <div className="flex justify-end pt-4 border-t">
-              <Button onClick={handleCloseChangelog}>
-                Reload
-              </Button>
-            </div>
-          </DialogContent>
-        </Dialog>
-      </>
-    )
+    return <ChangelogDialog />
   }
 
   const handleViewUpdate = () => {
@@ -261,46 +123,7 @@ export function UpdateBanner() {
         </div>
       </div>
 
-      {/* Changelog dialog */}
-      <Dialog open={showChangelog} onOpenChange={(open) => !open && handleCloseChangelog()}>
-        <DialogContent className="max-w-[90vw] w-auto max-h-[85vh] overflow-hidden flex flex-col">
-          <DialogHeader>
-            <DialogTitle>Update Completed - Version {changelogData?.version}</DialogTitle>
-            <DialogDescription>
-              qui has been successfully updated. Here's what's new:
-            </DialogDescription>
-          </DialogHeader>
-          <div className="overflow-y-auto flex-1 pr-2">
-            <div className="prose dark:prose-invert max-w-none prose-headings:mb-3 prose-headings:mt-6 prose-p:my-2 prose-ul:my-2 prose-li:my-1">
-              {changelogData?.body && (
-                <ReactMarkdown
-                  components={{
-                    h1: ({ children }) => <h2 className="text-xl font-bold mt-6 mb-3">{children}</h2>,
-                    h2: ({ children }) => <h3 className="text-lg font-semibold mt-5 mb-2">{children}</h3>,
-                    h3: ({ children }) => <h4 className="text-base font-semibold mt-4 mb-2">{children}</h4>,
-                    ul: ({ children }) => <ul className="list-disc pl-5 space-y-1">{children}</ul>,
-                    li: ({ children }) => <li className="text-sm leading-relaxed break-words">{children}</li>,
-                    p: ({ children }) => <p className="text-sm my-2 break-words">{children}</p>,
-                    code: ({ children }) => <code className="text-xs bg-muted px-1.5 py-0.5 rounded break-all">{children}</code>,
-                    a: ({ href, children }) => (
-                      <a href={href} target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
-                        {children}
-                      </a>
-                    ),
-                  }}
-                >
-                  {cleanChangelog(changelogData.body)}
-                </ReactMarkdown>
-              )}
-            </div>
-          </div>
-          <div className="flex justify-end pt-4 border-t">
-            <Button onClick={handleCloseChangelog}>
-              Close
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
+      <ChangelogDialog />
     </>
   )
 }

--- a/web/src/hooks/useServerReconnect.tsx
+++ b/web/src/hooks/useServerReconnect.tsx
@@ -35,6 +35,11 @@ export function useServerReconnect() {
 
   // Poll for server reconnection after update
   const pollForReconnection = useCallback(() => {
+    // Prevent multiple concurrent polling sessions
+    if (pollingRef.current) {
+      return
+    }
+
     let attempts = 0
     const maxAttempts = 60 // Poll for up to 60 seconds
 

--- a/web/src/hooks/useServerReconnect.tsx
+++ b/web/src/hooks/useServerReconnect.tsx
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { api } from "@/lib/api"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { useCallback, useEffect, useRef, useState } from "react"
+import { toast } from "sonner"
+import ReactMarkdown from "react-markdown"
+
+interface ChangelogData {
+  version: string
+  body: string
+}
+
+/**
+ * Hook to handle server reconnection after self-update with changelog display.
+ *
+ * Polls the server after a restart to detect when it comes back online,
+ * then shows the changelog and reloads the page to update the service worker cache.
+ */
+export function useServerReconnect() {
+  const [showChangelog, setShowChangelog] = useState(false)
+  const [changelogData, setChangelogData] = useState<ChangelogData | null>(null)
+  const pollingRef = useRef<NodeJS.Timeout | null>(null)
+  const changelogRef = useRef<ChangelogData | null>(null)
+
+  // Poll for server reconnection after update
+  const pollForReconnection = useCallback(() => {
+    let attempts = 0
+    const maxAttempts = 60 // Poll for up to 60 seconds
+
+    pollingRef.current = setInterval(async () => {
+      attempts++
+
+      try {
+        // Try to fetch version info - if this succeeds, server is back
+        const versionInfo = await api.getLatestVersion()
+
+        // Server is back online
+        if (pollingRef.current) {
+          clearInterval(pollingRef.current)
+          pollingRef.current = null
+        }
+
+        // Show changelog dialog if we have release notes
+        if (versionInfo?.body) {
+          const latestRelease = {
+            version: versionInfo.tag_name,
+            body: versionInfo.body
+          }
+          setChangelogData(latestRelease)
+          changelogRef.current = latestRelease
+          setShowChangelog(true)
+        } else if (changelogRef.current) {
+          setChangelogData(changelogRef.current)
+          setShowChangelog(true)
+        } else {
+          toast.success("Update completed successfully!")
+          // Reload to update service worker cache
+          setTimeout(() => {
+            window.location.reload()
+          }, 1000)
+        }
+      } catch {
+        // Server not ready yet
+        if (attempts >= maxAttempts) {
+          if (pollingRef.current) {
+            clearInterval(pollingRef.current)
+            pollingRef.current = null
+          }
+          toast.info("Update completed. Please refresh the page.")
+        }
+      }
+    }, 1000) // Poll every second
+  }, [])
+
+  const handleCloseChangelog = useCallback(() => {
+    setShowChangelog(false)
+    // Reload page to update service worker cache after user reads changelog
+    setTimeout(() => {
+      window.location.reload()
+    }, 200)
+  }, [])
+
+  // Clean up changelog by removing commit hashes
+  const cleanChangelog = useCallback((markdown: string) => {
+    // Remove commit hashes (40 hex chars followed by ": ") from list items
+    // Example: "* a7e79d862928c1bf8838b1a30678bdb3844d3315: feat(backups)..." -> "* feat(backups)..."
+    return markdown.replace(/^(\s*[*-]\s+)([a-f0-9]{40}):\s+/gm, "$1")
+  }, [])
+
+  // Store changelog data for after reconnection
+  const storeChangelog = useCallback((version: string, body: string) => {
+    changelogRef.current = { version, body }
+  }, [])
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (pollingRef.current) {
+        clearInterval(pollingRef.current)
+        pollingRef.current = null
+      }
+    }
+  }, [])
+
+  // Render the changelog dialog
+  const ChangelogDialog = useCallback(() => (
+    <Dialog open={showChangelog} onOpenChange={(open) => !open && handleCloseChangelog()}>
+      <DialogContent className="max-w-[90vw] w-auto max-h-[85vh] overflow-hidden flex flex-col">
+        <DialogHeader>
+          <DialogTitle>Update Completed - Version {changelogData?.version}</DialogTitle>
+          <DialogDescription>
+            qui has been successfully updated. Here's what's new:
+          </DialogDescription>
+        </DialogHeader>
+        <div className="overflow-y-auto flex-1 pr-2">
+          <div className="prose dark:prose-invert max-w-none prose-headings:mb-3 prose-headings:mt-6 prose-p:my-2 prose-ul:my-2 prose-li:my-1">
+            {changelogData?.body && (
+              <ReactMarkdown
+                components={{
+                  h1: ({ children }) => <h2 className="text-xl font-bold mt-6 mb-3">{children}</h2>,
+                  h2: ({ children }) => <h3 className="text-lg font-semibold mt-5 mb-2">{children}</h3>,
+                  h3: ({ children }) => <h4 className="text-base font-semibold mt-4 mb-2">{children}</h4>,
+                  ul: ({ children }) => <ul className="list-disc pl-5 space-y-1">{children}</ul>,
+                  li: ({ children }) => <li className="text-sm leading-relaxed break-words">{children}</li>,
+                  p: ({ children }) => <p className="text-sm my-2 break-words">{children}</p>,
+                  code: ({ children }) => <code className="text-xs bg-muted px-1.5 py-0.5 rounded break-all">{children}</code>,
+                  a: ({ href, children }) => (
+                    <a href={href} target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
+                      {children}
+                    </a>
+                  ),
+                }}
+              >
+                {cleanChangelog(changelogData.body)}
+              </ReactMarkdown>
+            )}
+          </div>
+        </div>
+        <div className="flex justify-end pt-4 border-t">
+          <Button onClick={handleCloseChangelog}>
+            Reload
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  ), [showChangelog, changelogData, handleCloseChangelog, cleanChangelog])
+
+  return {
+    pollForReconnection,
+    storeChangelog,
+    ChangelogDialog,
+  }
+}

--- a/web/src/hooks/useServerReconnect.tsx
+++ b/web/src/hooks/useServerReconnect.tsx
@@ -59,7 +59,7 @@ export function useServerReconnect() {
         // Show changelog dialog if we have release notes
         if (versionInfo?.body) {
           const latestRelease = {
-            version: versionInfo.tag_name,
+            version: versionInfo.tag_name ?? "Unknown",
             body: versionInfo.body
           }
           setChangelogData(latestRelease)

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -795,6 +795,7 @@ class ApiClient {
     name?: string
     html_url: string
     published_at: string
+    self_update_supported: boolean
   } | null> {
     try {
       const response = await this.request<{
@@ -802,6 +803,7 @@ class ApiClient {
         name?: string
         html_url: string
         published_at: string
+        self_update_supported: boolean
       } | null>("/version/latest")
 
       // Treat empty responses as no update available
@@ -810,6 +812,12 @@ class ApiClient {
       // Return null if no update available (204 status) or any error
       return null
     }
+  }
+
+  async triggerSelfUpdate(): Promise<{ message: string }> {
+    return this.request<{ message: string }>("/version/self-update", {
+      method: "POST",
+    })
   }
 
   async getTrackerIcons(): Promise<Record<string, string>> {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -793,6 +793,7 @@ class ApiClient {
   async getLatestVersion(): Promise<{
     tag_name: string
     name?: string
+    body?: string
     html_url: string
     published_at: string
     self_update_supported: boolean
@@ -801,6 +802,7 @@ class ApiClient {
       const response = await this.request<{
         tag_name: string
         name?: string
+        body?: string
         html_url: string
         published_at: string
         self_update_supported: boolean

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -816,8 +816,8 @@ class ApiClient {
     }
   }
 
-  async triggerSelfUpdate(): Promise<{ message: string }> {
-    return this.request<{ message: string }>("/version/self-update", {
+  async triggerSelfUpdate(): Promise<{ message: string; restart_pending: boolean }> {
+    return this.request<{ message: string; restart_pending: boolean }>("/version/self-update", {
       method: "POST",
     })
   }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { defineConfig } from "vite"
-import react from "@vitejs/plugin-react"
 import tailwindcss from "@tailwindcss/vite"
-import { VitePWA } from "vite-plugin-pwa"
-import { nodePolyfills } from "vite-plugin-node-polyfills"
+import react from "@vitejs/plugin-react"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
+import { defineConfig } from "vite"
+import { nodePolyfills } from "vite-plugin-node-polyfills"
+import { VitePWA } from "vite-plugin-pwa"
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -35,7 +35,7 @@ export default defineConfig(() => ({
       },
       workbox: {
         globPatterns: ["**/*.{js,css,html,ico,png,svg,webp}"],
-        maximumFileSizeToCacheInBytes: 3 * 1024 * 1024, // Allow larger bundles to be precached
+        maximumFileSizeToCacheInBytes: 5 * 1024 * 1024, // Allow larger bundles to be precached
         sourcemap: true,
         // Avoid serving the SPA shell for backend proxy routes (also under custom base URLs)
         navigateFallbackDenylist: [/^\/api/, /\/proxy(?:\/|$)/],


### PR DESCRIPTION
We need to do the same as Sonarr does in swizzin to make it work there. Using /opt.

> Sonarr works because Swizzin installs it in a user-owned location, so the daemon can overwrite itself. The Sonarr installer (scripts/install/sonarr.sh:1-108) pulls the tarball into /opt/Sonarr, then chown -R "${user}": "$app_dir" so the same account that systemd runs (User=${user} in the generated unit) owns the entire tree. Sonarr’s built-in updater therefore has write access to /opt/Sonarr and can drop new binaries in place.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-app self-update: “Update & Restart” action in header, footer and banner with API trigger, restart feedback, and server reconnection polling.
  * Release notes rendered as Markdown in a Changelog dialog after updates.

* **Bug Fixes / UX**
  * Clear message when no update is available: “Already running the latest version.”
  * Improved path normalization for linked files to reduce edge-case failures.

* **Chores**
  * Increased service worker cache size and added Markdown rendering dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->