### PR TITLE
feat(external): add instance placeholders

### DIFF
--- a/internal/api/handlers/EXTERNAL_PROGRAMS.md
+++ b/internal/api/handlers/EXTERNAL_PROGRAMS.md
@@ -42,6 +42,10 @@ Arguments are parsed with shell-style quoting and each placeholder is replaced w
 | `{state}` | qBittorrent torrent state string. |
 | `{size}` | Size in bytes. |
 | `{progress}` | Progress value between 0 and 1 rounded to two decimal places. |
+| `{instance_name}` | Name of the qBittorrent instance. |
+| `{instance_id}` | ID of the qBittorrent instance. |
+| `{instance_qbit_url}` | qBittorrent instance URL (host). |
+| `{instance_external_ipv4}` | External IPv4 address reported by qBittorrent (may be empty if not available). |
 
 Example arguments:
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -204,7 +204,7 @@ func (s *Server) Handler() (*chi.Mux, error) {
 	torrentsHandler := handlers.NewTorrentsHandler(s.syncManager)
 	preferencesHandler := handlers.NewPreferencesHandler(s.syncManager)
 	clientAPIKeysHandler := handlers.NewClientAPIKeysHandler(s.clientAPIKeyStore, s.instanceStore, s.config.Config.BaseURL)
-	externalProgramsHandler := handlers.NewExternalProgramsHandler(s.externalProgramStore, s.clientPool, s.config.Config)
+	externalProgramsHandler := handlers.NewExternalProgramsHandler(s.externalProgramStore, s.instanceStore, s.clientPool, s.config.Config)
 	versionHandler := handlers.NewVersionHandler(s.updateService)
 	qbittorrentInfoHandler := handlers.NewQBittorrentInfoHandler(s.clientPool)
 	backupsHandler := handlers.NewBackupsHandler(s.backupService)

--- a/web/src/components/settings/ExternalProgramsManager.tsx
+++ b/web/src/components/settings/ExternalProgramsManager.tsx
@@ -152,7 +152,7 @@ export function ExternalProgramsManager() {
                     </div>
                     <CardDescription className="text-xs">
                       Created {formatDate(new Date(program.created_at))}
-                      {program.updated_at !== program.created_at && 
+                      {program.updated_at !== program.created_at &&
                         ` • Updated ${formatDate(new Date(program.updated_at))}`}
                     </CardDescription>
                   </div>
@@ -330,6 +330,10 @@ function ProgramForm({ program, onSubmit, onCancel, isPending }: ProgramFormProp
             <li><code className="bg-muted px-1 rounded">{"{state}"}</code> - Torrent state</li>
             <li><code className="bg-muted px-1 rounded">{"{size}"}</code> - Size in bytes</li>
             <li><code className="bg-muted px-1 rounded">{"{progress}"}</code> - Progress (0-1)</li>
+            <li><code className="bg-muted px-1 rounded">{"{instance_name}"}</code> - Instance name</li>
+            <li><code className="bg-muted px-1 rounded">{"{instance_id}"}</code> - Instance ID</li>
+            <li><code className="bg-muted px-1 rounded">{"{instance_qbit_url}"}</code> - qBittorrent URL</li>
+            <li><code className="bg-muted px-1 rounded">{"{instance_external_ipv4}"}</code> - External IPv4 address</li>
           </ul>
         </div>
       </div>
@@ -388,7 +392,7 @@ function ProgramForm({ program, onSubmit, onCancel, isPending }: ProgramFormProp
           </Button>
         </div>
         <p className="text-xs text-muted-foreground">
-          Path mappings convert remote paths to local mount points. Useful when running external programs on a local qui server while qBittorrent is remote. 
+          Path mappings convert remote paths to local mount points. Useful when running external programs on a local qui server while qBittorrent is remote.
           Paths are matched by longest prefix first. Use the same path separator style as the remote qBittorrent instance (/ for Linux, \ for Windows).
         </p>
       </div>


### PR DESCRIPTION
#### What is the relevant ticket?
* #558 

#### What’s this PR do?
##### Add
* `{instance_name}` - The name of the qBittorrent instance
* `{instance_id}` - The ID of the qBittorrent instance
* `{instance_qbit_url}` - The qBittorrent instance host + port
* `{instance_external_ipv4}` - The external IPv4 address reported by qBittorrent (may be empty if not available)
* `instanceStore` to `ExternalProgramsHandler` struct and constructor
##### Change
* `ExecuteExternalProgram` to fetch instance information and server state (for external IPv4)
* `executeForHash` to accept instance data and add the new placeholders to the `torrentData` map
* `server.go` to pass `instanceStore` when creating the handler
* `ExternalProgramsManager.tsx` to display the four new placeholders in the arguments template help text

#### Where should the reviewer start?
* `internal/api/server.go`
* `internal/api/handlers/external_programs.go`
* `web/src/components/settings/ExternalProgramsManager.tsx`
* `internal/api/handlers/EXTERNAL_PROGRAMS.md`

#### How should this be manually tested?
1. Build and run this branch: `cd web; pnpm run build` & `cd ..; go run cmd/qui/main.go`
2. Create an external program: `/usr/bin/echo "{instance_name}" "{instance_id}" "{instance_qbit_url}" "{instance_external_ipv4}"`
3. Right-click on the item and select run this external program
4. Output should look something like: `seedbox 1 http://192.168.1.2:8080/ 123.222.321.123`

#### Risk involved?
* N/A

#### Screenshots (if appropriate):

<img width="647" height="891" alt="Screenshot from 2025-11-12 16-05-50" src="https://github.com/user-attachments/assets/1ef5f717-27e6-4445-be77-3ed3a5e22cab" />


#### Does the documentation or dependencies need an update?
* `EXTERNAL_PROGRAMS.md` to document the new placeholders in the placeholder table


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * External programs now support four new placeholders for instance metadata: `{instance_name}`, `{instance_id}`, `{instance_qbit_url}`, and `{instance_external_ipv4}`.

* **Documentation**
  * Updated external program configuration guide to document newly available instance-level placeholders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->