### PR TITLE
fix: glob pattern formatting in tooltip content

### DIFF
--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -417,7 +417,7 @@ export function Header({
                     <div className="space-y-2 text-xs">
                       <p className="font-semibold">Smart Search Features:</p>
                       <ul className="space-y-1 ml-2">
-                        <li>• <strong>Glob patterns:</strong> *.mkv, *1080p*, S??E??</li>
+                        <li>• <strong>Glob patterns:</strong> *.mkv, *1080p*, *S??E??*</li>
                         <li>• <strong>Fuzzy matching:</strong> "breaking bad" finds "Breaking.Bad"</li>
                         <li>• Handles dots, underscores, and brackets</li>
                         <li>• Searches name, category, and tags</li>


### PR DESCRIPTION
`S??E??` by itself returns nothing, let's give the users the better example to use `*S??E??*` instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the glob pattern example in Smart Search Features tooltip to include a trailing asterisk for improved pattern consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->