### PR TITLE
fix(cross-seed): fix cache functioning with partial results

### DIFF
--- a/internal/pkg/timeouts/timeouts.go
+++ b/internal/pkg/timeouts/timeouts.go
@@ -1,0 +1,46 @@
+package timeouts
+
+import (
+	"context"
+	"time"
+)
+
+const (
+	// DefaultSearchTimeout matches both Jackett and cross-seed automation base timeout.
+	DefaultSearchTimeout = 9 * time.Second
+	// MaxSearchTimeout caps how far we extend the adaptive timeout budget.
+	MaxSearchTimeout = 45 * time.Second
+	// PerIndexerSearchTimeout is the additional budget granted per indexer; keep in sync with automation scheduler assumptions.
+	PerIndexerSearchTimeout = 1 * time.Second
+)
+
+// AdaptiveSearchTimeout scales the timeout linearly per indexer (starting from DefaultSearchTimeout)
+// and caps the total budget at MaxSearchTimeout.
+func AdaptiveSearchTimeout(indexerCount int) time.Duration {
+	if indexerCount <= 1 {
+		return DefaultSearchTimeout
+	}
+	extra := time.Duration(indexerCount-1) * PerIndexerSearchTimeout
+	if extra < 0 {
+		extra = 0
+	}
+	timeout := DefaultSearchTimeout + extra
+	if timeout > MaxSearchTimeout {
+		return MaxSearchTimeout
+	}
+	return timeout
+}
+
+// WithSearchTimeout enforces a timeout only when the parent context lacks a deadline.
+func WithSearchTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if timeout <= 0 {
+		timeout = DefaultSearchTimeout
+	}
+	if ctx == nil {
+		return context.WithTimeout(context.Background(), timeout)
+	}
+	if _, hasDeadline := ctx.Deadline(); hasDeadline {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, timeout)
+}

--- a/internal/services/crossseed/service_search_test.go
+++ b/internal/services/crossseed/service_search_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/autobrr/qui/internal/database"
 	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/pkg/timeouts"
 	internalqb "github.com/autobrr/qui/internal/qbittorrent"
 )
 
@@ -24,10 +25,10 @@ func TestComputeAutomationSearchTimeout(t *testing.T) {
 		indexers     int
 		expectedTime time.Duration
 	}{
-		{name: "no indexers uses base", indexers: 0, expectedTime: automationSearchTimeout},
-		{name: "single indexer", indexers: 1, expectedTime: automationSearchTimeout},
-		{name: "grows with indexers", indexers: 4, expectedTime: automationSearchTimeout + 3*automationTimeoutPerIndexer},
-		{name: "caps at max", indexers: 100, expectedTime: maxAutomationSearchTimeout},
+		{name: "no indexers uses base", indexers: 0, expectedTime: timeouts.DefaultSearchTimeout},
+		{name: "single indexer", indexers: 1, expectedTime: timeouts.DefaultSearchTimeout},
+		{name: "grows with indexers", indexers: 4, expectedTime: timeouts.DefaultSearchTimeout + 3*timeouts.PerIndexerSearchTimeout},
+		{name: "caps at max", indexers: 100, expectedTime: timeouts.MaxSearchTimeout},
 	}
 
 	for _, tt := range tests {

--- a/internal/services/jackett/service_test.go
+++ b/internal/services/jackett/service_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/pkg/timeouts"
 )
 
 func TestDetectContentType(t *testing.T) {
@@ -311,16 +312,16 @@ func TestAdaptiveSearchTimeoutScalesWithIndexerCount(t *testing.T) {
 		indexerCount  int
 		expectedLimit time.Duration
 	}{
-		{name: "zero indexers uses default", indexerCount: 0, expectedLimit: defaultSearchTimeout},
-		{name: "single indexer uses default", indexerCount: 1, expectedLimit: defaultSearchTimeout},
-		{name: "adds budget per indexer", indexerCount: 5, expectedLimit: defaultSearchTimeout + 4*perIndexerSearchTimeout},
-		{name: "clamps to max", indexerCount: 500, expectedLimit: maxSearchTimeout},
+		{name: "zero indexers uses default", indexerCount: 0, expectedLimit: timeouts.DefaultSearchTimeout},
+		{name: "single indexer uses default", indexerCount: 1, expectedLimit: timeouts.DefaultSearchTimeout},
+		{name: "adds budget per indexer", indexerCount: 5, expectedLimit: timeouts.DefaultSearchTimeout + 4*timeouts.PerIndexerSearchTimeout},
+		{name: "clamps to max", indexerCount: 500, expectedLimit: timeouts.MaxSearchTimeout},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := adaptiveSearchTimeout(tt.indexerCount); got != tt.expectedLimit {
-				t.Fatalf("adaptiveSearchTimeout(%d) = %s, want %s", tt.indexerCount, got, tt.expectedLimit)
+			if got := timeouts.AdaptiveSearchTimeout(tt.indexerCount); got != tt.expectedLimit {
+				t.Fatalf("AdaptiveSearchTimeout(%d) = %s, want %s", tt.indexerCount, got, tt.expectedLimit)
 			}
 		})
 	}


### PR DESCRIPTION
With the addition of `automationSearchTimeout` to prevent context deadline exceed catastrophic failures, the cache handling was not correctly updated to manage partial results, resulting in a severe lack of cache.

Cache will now store successful indexer results, using a hybrid mode, allowing previously successful indexers to be cache queried, and previously non-successful indexers to be http queried.

Adjusted `automationSearchTimeout` to scale with indexer count.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search timeouts now dynamically scale based on the number of indexers searched, with configurable budgets.
  * Implemented hybrid caching that combines cached results with fresh live search results for improved coverage.
  * Enhanced result deduplication and sorting to ensure consistent pagination across cached and live data.

* **Tests**
  * Added comprehensive test coverage for adaptive timeout logic and cache-aware search scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->