### PR TITLE
feat(torrents): add clear filters action for empty filtered state

### DIFF
--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -1063,9 +1063,19 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
     )
   }, [filters])
 
-  const hasActiveFilters = useMemo(() => {
+  const hasSearchQuery = Boolean(effectiveSearch)
+  const hasFilterControls = useMemo(() => {
     return hasSidebarFilters || columnFilters.length > 0
   }, [hasSidebarFilters, columnFilters])
+  const emptyStateMessage = useMemo(() => {
+    if (hasFilterControls) {
+      return "No torrents match the current filters"
+    }
+    if (hasSearchQuery) {
+      return "No torrents match the current search"
+    }
+    return "No torrents found"
+  }, [hasFilterControls, hasSearchQuery])
 
   // Call the callback when filtered data updates
   useEffect(() => {
@@ -2356,12 +2366,12 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
             <div
               className={cn(
                 "absolute inset-0 flex items-center justify-center z-40 animate-in fade-in duration-300",
-                !hasActiveFilters && "pointer-events-none"
+                !hasFilterControls && "pointer-events-none"
               )}
             >
               <div className="text-center animate-in zoom-in-95 duration-300 text-muted-foreground space-y-3">
-                <p>{hasActiveFilters ? "No torrents match the current filters" : "No torrents found"}</p>
-                {hasActiveFilters && (
+                <p>{emptyStateMessage}</p>
+                {hasFilterControls && (
                   <Button
                     size="sm"
                     variant="outline"
@@ -2718,7 +2728,7 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
                 Loading torrents...
               </>
             ) : totalCount === 0 ? (
-              hasActiveFilters ? "No torrents match the current filters" : "No torrents found"
+              emptyStateMessage
             ) : (
               <>
                 {hasLoadedAll ? (


### PR DESCRIPTION
<img width="2696" height="1858" alt="CleanShot 2025-11-21 at 22 50 49@2x" src="https://github.com/user-attachments/assets/341da3c1-6182-4bbb-95af-cebfca556179" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Clear filters" button appears in the empty state when any filters are active, letting users reset all filters at once.
  * UI now detects active filter and search states to adjust empty-state behavior.

* **Style**
  * Contextual empty-state messages: "No torrents match the current filters", "No torrents match the current search", or "No torrents found".
  * Empty-state area styling updated (including disabled pointer interactions when appropriate) for clearer UX.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->