### PR TITLE
feat(settings): add TMM relocation behavior settings

### DIFF
--- a/web/src/components/instances/preferences/FileManagementForm.tsx
+++ b/web/src/components/instances/preferences/FileManagementForm.tsx
@@ -59,6 +59,9 @@ export function FileManagementForm({ instanceId, onSuccess }: FileManagementForm
   const form = useForm({
     defaultValues: {
       auto_tmm_enabled: false,
+      torrent_changed_tmm_enabled: true,
+      save_path_changed_tmm_enabled: true,
+      category_changed_tmm_enabled: true,
       start_paused_enabled: false,
       use_subcategories: false,
       save_path: "",
@@ -75,6 +78,9 @@ export function FileManagementForm({ instanceId, onSuccess }: FileManagementForm
         // Update other preferences to qBittorrent (excluding start_paused_enabled)
         const qbittorrentPrefs: Record<string, unknown> = {
           auto_tmm_enabled: value.auto_tmm_enabled,
+          torrent_changed_tmm_enabled: value.torrent_changed_tmm_enabled,
+          save_path_changed_tmm_enabled: value.save_path_changed_tmm_enabled,
+          category_changed_tmm_enabled: value.category_changed_tmm_enabled,
           save_path: value.save_path,
           temp_path_enabled: value.temp_path_enabled,
           temp_path: value.temp_path,
@@ -96,6 +102,9 @@ export function FileManagementForm({ instanceId, onSuccess }: FileManagementForm
   React.useEffect(() => {
     if (preferences) {
       form.setFieldValue("auto_tmm_enabled", preferences.auto_tmm_enabled)
+      form.setFieldValue("torrent_changed_tmm_enabled", preferences.torrent_changed_tmm_enabled ?? true)
+      form.setFieldValue("save_path_changed_tmm_enabled", preferences.save_path_changed_tmm_enabled ?? true)
+      form.setFieldValue("category_changed_tmm_enabled", preferences.category_changed_tmm_enabled ?? true)
       if (supportsSubcategories) {
         form.setFieldValue("use_subcategories", Boolean(preferences.use_subcategories))
       } else {
@@ -148,6 +157,47 @@ export function FileManagementForm({ instanceId, onSuccess }: FileManagementForm
             />
           )}
         </form.Field>
+
+        <form.Subscribe selector={(state) => state.values.auto_tmm_enabled}>
+          {(autoTmmEnabled) =>
+            autoTmmEnabled && (
+              <div className="ml-6 pl-4 border-l-2 border-muted space-y-4">
+                <form.Field name="torrent_changed_tmm_enabled">
+                  {(field) => (
+                    <SwitchSetting
+                      label="Relocate on Category Change"
+                      checked={field.state.value as boolean}
+                      onCheckedChange={field.handleChange}
+                      description="Relocate torrent when its category changes (disable to switch to Manual Mode instead)"
+                    />
+                  )}
+                </form.Field>
+
+                <form.Field name="save_path_changed_tmm_enabled">
+                  {(field) => (
+                    <SwitchSetting
+                      label="Relocate on Default Save Path Change"
+                      checked={field.state.value as boolean}
+                      onCheckedChange={field.handleChange}
+                      description="Relocate affected torrents when default save path changes (disable to switch to Manual Mode instead)"
+                    />
+                  )}
+                </form.Field>
+
+                <form.Field name="category_changed_tmm_enabled">
+                  {(field) => (
+                    <SwitchSetting
+                      label="Relocate on Category Save Path Change"
+                      checked={field.state.value as boolean}
+                      onCheckedChange={field.handleChange}
+                      description="Relocate affected torrents when category save path changes (disable to switch to Manual Mode instead)"
+                    />
+                  )}
+                </form.Field>
+              </div>
+            )
+          }
+        </form.Subscribe>
 
         {supportsSubcategories && (
           <form.Field name="use_subcategories">


### PR DESCRIPTION
<img width="1414" height="874" alt="CleanShot 2025-12-01 at 23 02 55@2x" src="https://github.com/user-attachments/assets/9b2af3a3-e9bb-41d7-9e03-839115fbb47f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new settings for automatic torrent management behavior:
    * Relocate on Category Change
    * Relocate on Default Save Path Change
    * Relocate on Category Save Path Change
  * Settings appear when automatic torrent management is enabled and are enabled by default.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->