### PR TITLE
Removed: Content-Type=application/json from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ In your autobrr filter, go to **External** tab → **Add new**:
 | On Error | `Reject` |
 | Endpoint | `http://localhost:7476/api/cross-seed/webhook/check` |
 | HTTP Method | `POST` |
-| HTTP Request Headers | `X-API-Key=YOUR_QUI_API_KEY,Content-Type=application/json` |
+| HTTP Request Headers | `X-API-Key=YOUR_QUI_API_KEY` |
 | Expected HTTP Status Code | `200` |
 
 **Data (JSON):**


### PR DESCRIPTION
It was confirmed by me and couple of other people that you get `Unauthorized` when `Content-Type` is in the headers. This is incorrectly shown in the documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated webhook configuration headers in the Cross-Seed example.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->