### PR TITLE
feat(web): Torrent list details bar shows free space

### DIFF
--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -2805,19 +2805,6 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
           </div>
 
           <div className="flex flex-wrap items-center justify-end gap-2 text-xs">
-            {effectiveServerState?.free_space_on_disk !== undefined && effectiveServerState.free_space_on_disk > 0 && (
-              <div className="flex items-center gap-2 pr-2 border-r last:border-r-0 last:pr-0">
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="flex items-center h-6 px-2 text-xs text-muted-foreground">
-                      <HardDrive  aria-hidden="true" className="h-3 w-3 mr-1"/>
-                      <span className="ml-auto font-medium truncate">{formatBytes(effectiveServerState.free_space_on_disk)}</span>
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent>Free Space</TooltipContent>
-                </Tooltip>
-              </div>
-            )}
             <div className="flex items-center gap-2 pr-2 border-r last:border-r-0 last:pr-0">
               <ChevronDown className="h-3 w-3 text-muted-foreground"/>
               <span className="font-medium">{formatSpeedWithUnit(stats?.totalDownloadSpeed ?? 0, speedUnit)}</span>
@@ -2925,6 +2912,19 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
                 </span>
               </Button>
             </div>
+            {effectiveServerState?.free_space_on_disk !== undefined && effectiveServerState.free_space_on_disk > 0 && (
+              <div className="flex items-center gap-2 pr-2 border-r last:border-r-0 last:pr-0">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="flex items-center h-6 px-2 text-xs text-muted-foreground">
+                      <HardDrive  aria-hidden="true" className="h-3 w-3 mr-1"/>
+                      <span className="ml-auto font-medium truncate">{formatBytes(effectiveServerState.free_space_on_disk)}</span>
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>Free Space</TooltipContent>
+                </Tooltip>
+              </div>
+            )}
             <div className="flex items-center gap-2">
               <ExternalIPAddress
                 address={effectiveServerState?.last_external_address_v4}


### PR DESCRIPTION
This addresses #676

<img width="615" height="80" alt="Screenshot 2025-12-04 at 1 37 07 PM" src="https://github.com/user-attachments/assets/492e8807-3844-4d5d-a354-67ce648b609d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a free disk space indicator in the torrent table header/footer showing available storage with a hard drive icon and a "Free Space" tooltip.
* **Bug Fixes**
  * External IPv4/IPv6 addresses now reflect the computed server state so displayed addresses match the current server status.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->