### PR TITLE
Show "Free space" when disk is full

### DIFF
--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -2912,7 +2912,7 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
                 </span>
               </Button>
             </div>
-            {effectiveServerState?.free_space_on_disk !== undefined && effectiveServerState.free_space_on_disk > 0 && (
+            {effectiveServerState?.free_space_on_disk !== undefined && (
               <div className="flex items-center gap-2 pr-2 border-r last:border-r-0 last:pr-0">
                 <Tooltip>
                   <TooltipTrigger asChild>

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -375,7 +375,7 @@ function InstanceCard({
                 </div>
               </div>
 
-              {serverState?.free_space_on_disk !== undefined && serverState.free_space_on_disk > 0 && (
+              {serverState?.free_space_on_disk !== undefined && (
                 <div className="flex items-center gap-2 text-xs mt-1 sm:mt-2">
                   <HardDrive className="h-3 w-3 text-muted-foreground flex-shrink-0" />
                   <span className="text-muted-foreground">Free Space</span>


### PR DESCRIPTION
Related to https://github.com/autobrr/qui/issues/676

Does not hide free space info when the disk is full, as `0` is a valid response from the qBit API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Free Space display to show whenever storage data is available, including cases with zero free space, ensuring more complete visibility of disk status information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->