### PR TITLE
docs: Update README to remove size field description

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,7 +525,6 @@ To search all instances, omit `instanceIds`:
 **Field descriptions:**
 - `torrentName` (required): The release name as announced
 - `instanceIds` (optional): qBittorrent instance IDs to scan. Omit to search all instances.
-- `size` (optional): Torrent size in bytes for size validation
 - `findIndividualEpisodes` (optional): Override the global episode matching setting
 
 **3. Configure Retry Handling**


### PR DESCRIPTION
Removed 'size' field description from README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated webhook payload documentation by removing the size field description.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->