### PR TITLE
fix(db): resolve cross-seed settings mutual exclusivity lockout

### DIFF
--- a/internal/database/migrations/028_fix_cross_seed_mutual_exclusivity.sql
+++ b/internal/database/migrations/028_fix_cross_seed_mutual_exclusivity.sql
@@ -1,0 +1,11 @@
+-- Fix lockout for users who had use_category_from_indexer enabled before migration 023.
+-- Migration 023 added use_cross_category_suffix with DEFAULT TRUE, which caused both
+-- settings to be enabled simultaneously. Since these settings are mutually exclusive
+-- in the UI, users became locked out of both toggles.
+--
+-- Resolution: Preserve the user's original choice (use_category_from_indexer) and
+-- disable the new setting that was auto-enabled by the migration default.
+
+UPDATE cross_seed_settings
+SET use_cross_category_suffix = 0
+WHERE use_category_from_indexer = 1;


### PR DESCRIPTION
Migration 023 added use_cross_category_suffix with DEFAULT TRUE, which caused users who previously had use_category_from_indexer enabled to have both settings enabled. Since these are mutually exclusive in the UI, both toggles became locked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a configuration issue where conflicting UI toggle settings were both simultaneously enabled. Settings will now function as mutually exclusive.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->