### PR TITLE
feat(web): share tracker customizations with filtersidebar

### DIFF
--- a/web/src/components/torrents/FilterSidebar.tsx
+++ b/web/src/components/torrents/FilterSidebar.tsx
@@ -1077,7 +1077,7 @@ const FilterSidebarComponent = ({
     const anyExcluded = domains.some(d => excludeTrackerSet.has(d))
 
     switch (state) {
-      case "include":
+      case "include": {
         // Add all domains to include, remove from exclude
         if (anyExcluded) {
           nextExcluded = nextExcluded.filter(t => !domains.includes(t))
@@ -1088,7 +1088,8 @@ const FilterSidebarComponent = ({
           nextIncluded = [...nextIncluded, ...toAdd]
         }
         break
-      case "exclude":
+      }
+      case "exclude": {
         // Remove all domains from include, add to exclude
         if (anyIncluded) {
           nextIncluded = nextIncluded.filter(t => !domains.includes(t))
@@ -1099,7 +1100,8 @@ const FilterSidebarComponent = ({
           nextExcluded = [...nextExcluded, ...toExclude]
         }
         break
-      case "neutral":
+      }
+      case "neutral": {
         // Remove all domains from both include and exclude
         if (anyIncluded) {
           nextIncluded = nextIncluded.filter(t => !domains.includes(t))
@@ -1108,6 +1110,7 @@ const FilterSidebarComponent = ({
           nextExcluded = nextExcluded.filter(t => !domains.includes(t))
         }
         break
+      }
     }
 
     if (nextIncluded === selectedFilters.trackers && nextExcluded === selectedFilters.excludeTrackers) {


### PR DESCRIPTION
- Display tracker nicknames from Dashboard customizations in FilterSidebar
- Merge tracker domains into groups with aggregated torrent counts
- Filter by all domains when selecting a merged tracker group
- Show submenu for editing tracker URLs on merged trackers
- Search works on both display names and raw domains

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tracker customization with nicknames and custom display names for clearer identification
  * Introduced tracker grouping to merge related domains and derive group-level icons and counts
  * Enhanced context menus and interactions to support group-level editing, inclusive/exclusive toggles, long-press and modifier behaviors

* **Refactor**
  * Filtering and rendering updated to operate on grouped tracker representations for consistent UI behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->