### PR TITLE
fix(crossseed): normalize punctuation in title matching

### DIFF
--- a/internal/services/crossseed/matching.go
+++ b/internal/services/crossseed/matching.go
@@ -84,6 +84,31 @@ func (k releaseKey) String() string {
 	return fmt.Sprintf("%d|%d|%d|%d|%d", k.series, k.episode, k.year, k.month, k.day)
 }
 
+// normalizeTitleForComparison normalizes a title for fuzzy comparison.
+// Strips punctuation that commonly differs between space-separated and
+// dot-separated release name formats (e.g., "Bob's Burgers" vs "Bobs.Burgers").
+func normalizeTitleForComparison(title string) string {
+	title = strings.ToLower(strings.TrimSpace(title))
+
+	// Remove apostrophes - "Bob's" → "Bobs"
+	title = strings.ReplaceAll(title, "'", "")
+	title = strings.ReplaceAll(title, "'", "") // Unicode right single quote U+2019
+	title = strings.ReplaceAll(title, "'", "") // Unicode left single quote U+2018
+	title = strings.ReplaceAll(title, "`", "") // Backtick
+
+	// Remove colons - "CSI: Miami" → "CSI Miami"
+	title = strings.ReplaceAll(title, ":", "")
+
+	// Normalize hyphens to spaces - "Spider-Man" → "spider man"
+	// This handles cases where hyphens are dropped in dot notation
+	title = strings.ReplaceAll(title, "-", " ")
+
+	// Collapse multiple spaces to single space
+	title = strings.Join(strings.Fields(title), " ")
+
+	return title
+}
+
 // releasesMatch checks if two releases are related using fuzzy matching.
 // This allows matching similar content that isn't exactly the same.
 func (s *Service) releasesMatch(source, candidate *rls.Release, findIndividualEpisodes bool) bool {
@@ -92,10 +117,12 @@ func (s *Service) releasesMatch(source, candidate *rls.Release, findIndividualEp
 	}
 
 	// Title should match closely but not necessarily exactly.
-	sourceTitleLower := s.stringNormalizer.Normalize(source.Title)
-	candidateTitleLower := s.stringNormalizer.Normalize(candidate.Title)
+	// Use punctuation-stripping normalization to handle differences like
+	// "Bob's Burgers" vs "Bobs.Burgers" (apostrophes lost in dot notation).
+	sourceTitleNorm := normalizeTitleForComparison(source.Title)
+	candidateTitleNorm := normalizeTitleForComparison(candidate.Title)
 
-	if sourceTitleLower == "" || candidateTitleLower == "" {
+	if sourceTitleNorm == "" || candidateTitleNorm == "" {
 		return false
 	}
 
@@ -104,9 +131,9 @@ func (s *Service) releasesMatch(source, candidate *rls.Release, findIndividualEp
 	if isTV {
 		// For TV, allow a bit of fuzziness in the title (e.g. different punctuation)
 		// while still requiring the titles to be closely related.
-		if sourceTitleLower != candidateTitleLower &&
-			!strings.Contains(sourceTitleLower, candidateTitleLower) &&
-			!strings.Contains(candidateTitleLower, sourceTitleLower) {
+		if sourceTitleNorm != candidateTitleNorm &&
+			!strings.Contains(sourceTitleNorm, candidateTitleNorm) &&
+			!strings.Contains(candidateTitleNorm, sourceTitleNorm) {
 			// Title mismatches are expected for most candidates - don't log to avoid noise
 			return false
 		}
@@ -114,7 +141,7 @@ func (s *Service) releasesMatch(source, candidate *rls.Release, findIndividualEp
 		// For non-TV content (movies, music, audiobooks, etc.), require exact title
 		// match after normalization. This avoids very loose substring matches across
 		// unrelated content types.
-		if sourceTitleLower != candidateTitleLower {
+		if sourceTitleNorm != candidateTitleNorm {
 			// Title mismatches are expected for most candidates - don't log to avoid noise
 			return false
 		}
@@ -404,8 +431,8 @@ func (s *Service) getMatchTypeFromTitle(targetName, candidateName string, target
 	// the episode number encoded in the raw torrent names also matches (e.g. anime releases where
 	// rls fails to parse " - 1150 " as an episode).
 	if len(candidateReleases) == 0 {
-		targetTitle := s.stringNormalizer.Normalize(targetRelease.Title)
-		candidateTitle := s.stringNormalizer.Normalize(candidateRelease.Title)
+		targetTitle := normalizeTitleForComparison(targetRelease.Title)
+		candidateTitle := normalizeTitleForComparison(candidateRelease.Title)
 		if targetTitle != "" && targetTitle == candidateTitle {
 			// Extract simple episode number from torrent names of the form "... - 1150 (...)".
 			extractEpisode := func(name string) string {

--- a/internal/services/crossseed/matching_title_test.go
+++ b/internal/services/crossseed/matching_title_test.go
@@ -159,3 +159,154 @@ func TestReleasesMatch_DateBasedReleasesRequireExactDate(t *testing.T) {
 	require.True(t, s.releasesMatch(&yearOnly, &anotherYearOnly, false),
 		"year-only releases should match when year is same")
 }
+
+func TestNormalizeTitleForComparison(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"lowercase", "MIKE'S TACOS", "mikes tacos"},
+		{"apostrophe", "Mike's Tacos", "mikes tacos"},
+		{"curly apostrophe right", "Don't Stop", "dont stop"},
+		{"curly apostrophe left", "It's Fine", "its fine"},
+		{"backtick", "Rock`n Roll", "rockn roll"},
+		{"colon", "City: Downtown", "city downtown"},
+		{"hyphen to space", "Laser-Cat", "laser cat"},
+		{"multiple hyphens", "Up-And-Away", "up and away"},
+		{"mixed punctuation", "Jake's Place: Season 1", "jakes place season 1"},
+		{"extra spaces collapsed", "The   Show", "the show"},
+		{"trim whitespace", "  Trimmed  ", "trimmed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeTitleForComparison(tt.input)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestReleasesMatch_PunctuationVariations(t *testing.T) {
+	s := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
+
+	tests := []struct {
+		name        string
+		source      rls.Release
+		candidate   rls.Release
+		wantMatch   bool
+		description string
+	}{
+		{
+			name: "apostrophe vs no apostrophe TV",
+			source: rls.Release{
+				Title:  "Mike's Tacos",
+				Series: 1,
+				Source: "WEB-DL",
+				Group:  "GROUP",
+			},
+			candidate: rls.Release{
+				Title:  "Mikes Tacos",
+				Series: 1,
+				Source: "WEB-DL",
+				Group:  "GROUP",
+			},
+			wantMatch:   true,
+			description: "apostrophe should be stripped - 'Mike's' matches 'Mikes'",
+		},
+		{
+			name: "colon vs no colon TV",
+			source: rls.Release{
+				Title:  "City: Downtown",
+				Series: 1,
+				Source: "WEB-DL",
+				Group:  "GROUP",
+			},
+			candidate: rls.Release{
+				Title:  "City Downtown",
+				Series: 1,
+				Source: "WEB-DL",
+				Group:  "GROUP",
+			},
+			wantMatch:   true,
+			description: "colon should be stripped - 'City: Downtown' matches 'City Downtown'",
+		},
+		{
+			name: "hyphen vs space TV",
+			source: rls.Release{
+				Title:  "Laser-Cat",
+				Series: 1,
+				Source: "WEB-DL",
+				Group:  "GROUP",
+			},
+			candidate: rls.Release{
+				Title:  "Laser Cat",
+				Series: 1,
+				Source: "WEB-DL",
+				Group:  "GROUP",
+			},
+			wantMatch:   true,
+			description: "hyphen should become space - 'Laser-Cat' matches 'Laser Cat'",
+		},
+		{
+			name: "unicode curly apostrophe TV",
+			source: rls.Release{
+				Title:  "Can't Stop Now",
+				Series: 1,
+				Source: "WEB-DL",
+				Group:  "GROUP",
+			},
+			candidate: rls.Release{
+				Title:  "Cant Stop Now",
+				Series: 1,
+				Source: "WEB-DL",
+				Group:  "GROUP",
+			},
+			wantMatch:   true,
+			description: "curly apostrophe should be stripped",
+		},
+		{
+			name: "apostrophe vs no apostrophe non-TV movie",
+			source: rls.Release{
+				Title: "Jake's Adventure",
+				Year:  2024,
+				Type:  rls.Movie,
+				Group: "GROUP",
+			},
+			candidate: rls.Release{
+				Title: "Jakes Adventure",
+				Year:  2024,
+				Type:  rls.Movie,
+				Group: "GROUP",
+			},
+			wantMatch:   true,
+			description: "non-TV should also match with punctuation normalization",
+		},
+		{
+			name: "completely different titles should not match",
+			source: rls.Release{
+				Title:  "Space Adventures",
+				Series: 1,
+				Group:  "GROUP",
+			},
+			candidate: rls.Release{
+				Title:  "Ocean Mysteries",
+				Series: 1,
+				Group:  "GROUP",
+			},
+			wantMatch:   false,
+			description: "different titles should still not match",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := s.releasesMatch(&tt.source, &tt.candidate, false)
+			if tt.wantMatch {
+				require.True(t, result, tt.description)
+			} else {
+				require.False(t, result, tt.description)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Titles with apostrophes, colons, or hyphens now match their dot-separated equivalents where punctuation gets lost during parsing.

For example, "Bob's Burgers" from a space-separated release name now matches "Bobs Burgers" parsed from "Bobs.Burgers.S01...".

- Add normalizeTitleForComparison() helper that strips apostrophes (including unicode variants), colons, and converts hyphens to spaces
- Update releasesMatch() and getMatchTypeFromTitle() to use new normalizer
- Add comprehensive tests for punctuation variations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release title matching to handle punctuation variations (apostrophes, colons, hyphens) and spacing differences, reducing false negatives in comparisons.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->