### PR TITLE
feat(crossseed): only poll status endpoints when features are enabled

### DIFF
--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -169,7 +169,7 @@ export function Header({
 
   const supportsTorrentCreation = instanceCapabilities?.supportsTorrentCreation ?? true
 
-  const crossSeedInstanceState = useCrossSeedInstanceState()
+  const { state: crossSeedInstanceState } = useCrossSeedInstanceState()
 
   // Dense mode uses reduced header height
   const headerHeight = viewMode === "dense" ? "lg:h-12" : "lg:h-16"

--- a/web/src/components/layout/MobileFooterNav.tsx
+++ b/web/src/components/layout/MobileFooterNav.tsx
@@ -119,7 +119,7 @@ export function MobileFooterNav() {
     return instances.filter(instance => instance.isActive)
   }, [instances])
 
-  const crossSeedInstanceState = useCrossSeedInstanceState()
+  const { state: crossSeedInstanceState } = useCrossSeedInstanceState()
   const isOnInstancePage = location.pathname.startsWith("/instances/")
   const hasMultipleActiveInstances = activeInstances.length > 1
   const singleActiveInstance = activeInstances.length === 1 ? activeInstances[0] : null

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -87,7 +87,7 @@ export function Sidebar() {
   const activeInstances = instances?.filter(instance => instance.isActive) ?? []
   const hasConfiguredInstances = (instances?.length ?? 0) > 0
 
-  const crossSeedInstanceState = useCrossSeedInstanceState()
+  const { state: crossSeedInstanceState } = useCrossSeedInstanceState()
 
   const appVersion = getAppVersion()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Polling now respects RSS enablement and reduces unnecessary requests when disabled.
  * Search-status polling dynamically increases during active searches and slows when idle for efficiency.
  * Instance state now exposes loading, error and status indicators so UI shows current fetch state more reliably.
  * UI layout components updated to consume the consolidated instance state shape.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->