### PR TITLE
fix(web): sort Seeds column by total seeds instead of connected

### DIFF
--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -942,6 +942,9 @@ export function TorrentCardsMobile({
   const sortField = sortState.field
   const sortOrder = sortState.order
 
+  // Map sort field to backend field name (e.g., num_seeds -> num_complete)
+  const backendSortField = sortField === "num_seeds" ? "num_complete" : sortField
+
   const currentSortOption = useMemo(() => {
     return TORRENT_SORT_OPTIONS.find(option => option.value === sortField) ?? TORRENT_SORT_OPTIONS[0]
   }, [sortField])
@@ -1190,7 +1193,7 @@ export function TorrentCardsMobile({
   } = useTorrentsList(instanceId, {
     search: effectiveSearch,
     filters: effectiveFilters,
-    sort: sortField,
+    sort: backendSortField,
     order: sortOrder,
   })
 

--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -969,6 +969,8 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
     switch (columnId) {
       case "status_icon":
         return "state"
+      case "num_seeds":
+        return "num_complete" // Sort by total seeds, not connected
       default:
         return columnId
     }


### PR DESCRIPTION
The Seeds column was sorting by num_seeds (connected seeders) instead of num_complete (total seeders in swarm). Users expect sorting by total count.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sorting functionality in torrent list views to correctly map user-selected sort options to the appropriate backend data fields, ensuring accurate and consistent sorting results across all torrent displays.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->