### PR TITLE
fix(web): sort Peers column by total peers instead of connected

### DIFF
--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -943,7 +943,7 @@ export function TorrentCardsMobile({
   const sortOrder = sortState.order
 
   // Map sort field to backend field name (e.g., num_seeds -> num_complete)
-  const backendSortField = sortField === "num_seeds" ? "num_complete" : sortField
+  const backendSortField = sortField === "num_seeds" ? "num_complete" : sortField === "num_leechs" ? "num_incomplete" : sortField
 
   const currentSortOption = useMemo(() => {
     return TORRENT_SORT_OPTIONS.find(option => option.value === sortField) ?? TORRENT_SORT_OPTIONS[0]

--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -971,6 +971,8 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
         return "state"
       case "num_seeds":
         return "num_complete" // Sort by total seeds, not connected
+      case "num_leechs":
+        return "num_incomplete" // Sort by total peers, not connected
       default:
         return columnId
     }


### PR DESCRIPTION
## Summary
- Maps `num_leechs` → `num_incomplete` when sorting by Peers column
- Matches the Seeds fix from #747 (`num_seeds` → `num_complete`)
- Now sorting uses total peers in swarm instead of currently connected peers

Fixes #750

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected torrent sorting by seed and leech counts to ensure accurate result ordering in torrent list views.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->