### PR TITLE
fix(crossseed): support game scene releases with RAR files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,8 @@ require (
 	modernc.org/sqlite v1.40.1
 )
 
+replace github.com/moistari/rls => github.com/autobrr/rls v0.7.0
+
 require (
 	code.gitea.io/sdk/gitea v0.22.0 // indirect
 	github.com/42wim/httpsig v1.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/autobrr/autobrr v1.70.0 h1:N3NxMuiu6uQ500N9nPxDWXlBtlQx2QlkkGnU/JPcLw
 github.com/autobrr/autobrr v1.70.0/go.mod h1:sCMO8xAaZLLA4H1qbKRiSTZnPsY/stvTngHF9o2F8pI=
 github.com/autobrr/go-qbittorrent v1.15.0-rc1.0.20251209201933-62cc902b8602 h1:RyJtQJGklw0kJ3Ec5kHakQArHXuXb7EodudkUVGwsDk=
 github.com/autobrr/go-qbittorrent v1.15.0-rc1.0.20251209201933-62cc902b8602/go.mod h1:mGH+UlSzkZOpTx9hezpL9dnKakskLzOsNfngl2E1ZE0=
+github.com/autobrr/rls v0.7.0 h1:Wzu6f6qMN1D+3QQSDJ6EqwdjOqBPutrz2aa2SXE3Zlo=
+github.com/autobrr/rls v0.7.0/go.mod h1:11YJWgNe5H+UQrfFaNGjnkEy0OEsMFnmV4IL2tRKpPk=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/benbjohnson/immutable v0.2.0/go.mod h1:uc6OHo6PN2++n98KHLxW8ef4W42ylHiQSENghE1ezxI=
@@ -234,8 +236,6 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/moistari/rls v0.6.0 h1:9AWzsLaTN2zMTdUBkljQsUr5YlXxCQuHMhhoqBYUo5A=
-github.com/moistari/rls v0.6.0/go.mod h1:11YJWgNe5H+UQrfFaNGjnkEy0OEsMFnmV4IL2tRKpPk=
 github.com/mr-tron/base58 v1.2.0 h1:T/HDJBh4ZCPbU39/+c3rRvE0uKBQlU27+QI8LJ4t64o=
 github.com/mr-tron/base58 v1.2.0/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
 github.com/mschoch/smat v0.0.0-20160514031455-90eadee771ae/go.mod h1:qAyveg+e4CE+eKJXWVjKXM4ck2QobLqTDytGJbLLhJg=

--- a/internal/services/crossseed/matching.go
+++ b/internal/services/crossseed/matching.go
@@ -427,18 +427,14 @@ func (s *Service) getMatchTypeFromTitle(targetName, candidateName string, target
 		// key matches the target's release key. This prevents unrelated torrents
 		// with generic filenames from matching purely because rls could parse
 		// something from their names.
-		if len(candidateReleases) > 0 {
-			targetKey := makeReleaseKey(targetRelease)
-			if targetKey == (releaseKey{}) {
-				// No usable metadata from the target; be conservative and avoid
-				// treating non-episodic candidates as matches in this pre-filter.
-				return ""
-			}
+		targetKey := makeReleaseKey(targetRelease)
 
+		if len(candidateReleases) > 0 {
 			if _, exists := candidateReleases[targetKey]; exists {
 				return "partial-in-pack"
 			}
 		}
+
 	}
 
 	// Fallback: rls couldn't derive usable release keys from the files, but the titles match and
@@ -471,15 +467,22 @@ func (s *Service) getMatchTypeFromTitle(targetName, candidateName string, target
 			targetEp := extractEpisode(targetName)
 			candidateEp := extractEpisode(candidateName)
 
-			if targetEp == "" || candidateEp == "" || targetEp != candidateEp {
-				return ""
+			// If episode numbers match (anime fallback), accept the match
+			if targetEp != "" && candidateEp != "" && targetEp == candidateEp {
+				log.Debug().
+					Str("title", targetRelease.Title).
+					Str("episode", targetEp).
+					Msg("Falling back to title+episode candidate match")
+				return "partial-in-pack"
 			}
 
-			log.Debug().
-				Str("title", targetRelease.Title).
-				Str("episode", targetEp).
-				Msg("Falling back to title+episode candidate match")
-			return "partial-in-pack"
+			// For content without usable file-level metadata (games, apps, scene releases
+			// with RAR files), trust the torrent-level releasesMatch check that got us here
+			// when no episode pattern exists in the names.
+			targetKey := makeReleaseKey(targetRelease)
+			if targetKey == (releaseKey{}) && targetEp == "" && candidateEp == "" {
+				return "release-match"
+			}
 		}
 	}
 

--- a/internal/services/crossseed/matching_layout_test.go
+++ b/internal/services/crossseed/matching_layout_test.go
@@ -277,6 +277,43 @@ func TestGetMatchTypeFromTitle_NonEpisodicWithMatchingReleaseKey(t *testing.T) {
 	require.Equal(t, "partial-in-pack", match, "non-episodic candidates with matching release keys should match")
 }
 
+func TestGetMatchTypeFromTitle_GameSceneReleasesWithRARFiles(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{
+		releaseCache:     releases.NewDefaultParser(),
+		stringNormalizer: stringutils.NewDefaultNormalizer(),
+	}
+
+	// Game scene releases have RAR files with group prefixes, no year, no episode info.
+	// These should match based on title alone when the titles match.
+	targetName := "Oddsparks.An.Automation.Adventure.Coaster.Rush-RUNE"
+	targetRelease := rls.Release{
+		Title: "Oddsparks An Automation Adventure Coaster Rush",
+		Group: "RUNE",
+		Type:  rls.Game,
+	}
+
+	candidateName := "Oddsparks.An.Automation.Adventure.Coaster.Rush-RUNE"
+	candidateRelease := rls.Release{
+		Title: "Oddsparks An Automation Adventure Coaster Rush",
+		Group: "RUNE",
+		Type:  rls.Game,
+	}
+
+	// RAR files don't produce usable release keys when parsed
+	candidateFiles := qbt.TorrentFiles{
+		{Name: "rune-oddsparks.rar", Size: 100 << 20},
+		{Name: "rune-oddsparks.r00", Size: 100 << 20},
+		{Name: "rune-oddsparks.r01", Size: 100 << 20},
+		{Name: "rune-oddsparks.sfv", Size: 1024},
+		{Name: "rune-oddsparks.nfo", Size: 4096},
+	}
+
+	match := svc.getMatchTypeFromTitle(targetName, candidateName, &targetRelease, &candidateRelease, candidateFiles, nil)
+	require.Equal(t, "release-match", match, "game scene releases with RAR files should match when titles match")
+}
+
 func TestGetMatchType_FileNameFallback(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/crossseed/parsing_test.go
+++ b/internal/services/crossseed/parsing_test.go
@@ -288,3 +288,55 @@ func TestDetermineContentType(t *testing.T) {
 		})
 	}
 }
+
+// TestGameSceneGroupDetection verifies that releases from known game scene groups
+// are correctly detected as games via the rls library's group detection.
+func TestGameSceneGroupDetection(t *testing.T) {
+	tests := []struct {
+		name     string
+		release  string
+		wantType string
+		wantCats []int
+	}{
+		{
+			name:     "RUNE game release",
+			release:  "Oddsparks.An.Automation.Adventure.Coaster.Rush-RUNE",
+			wantType: "game",
+			wantCats: []int{4000},
+		},
+		{
+			name:     "CODEX game release",
+			release:  "Some.Game.v1.0-CODEX",
+			wantType: "game",
+			wantCats: []int{4000},
+		},
+		{
+			name:     "SKIDROW game release",
+			release:  "Another.Game-SKIDROW",
+			wantType: "game",
+			wantCats: []int{4000},
+		},
+		{
+			name:     "PLAZA game release",
+			release:  "Game.Update.v1.2-PLAZA",
+			wantType: "game",
+			wantCats: []int{4000},
+		},
+		{
+			name:     "Movie release unchanged",
+			release:  "Random.Movie.2024.1080p.BluRay.x264-GROUP",
+			wantType: "movie",
+			wantCats: []int{2000},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed := rls.ParseString(tt.release)
+			result := DetermineContentType(&parsed)
+
+			assert.Equal(t, tt.wantType, result.ContentType, "content type mismatch for %s", tt.release)
+			assert.Equal(t, tt.wantCats, result.Categories, "categories mismatch for %s", tt.release)
+		})
+	}
+}


### PR DESCRIPTION
Game scene releases use RAR archives with group-prefixed filenames that don't contain year/episode metadata. Previously, cross-seed matching would fail with "No matching torrents found" because makeReleaseKey() returned empty keys for these files.

Changes:
- Add fallback in getMatchTypeFromTitle() that returns "release-match" for content without usable file-level metadata when titles match
- Only triggers when no episode patterns exist (preserves anime fallback)
- Switch to autobrr/rls fork (v0.7.0) with game scene group detection
- Add test for game scene releases with RAR files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined release matching for titles with missing or ambiguous metadata
  * Improved game-scene release detection for special archive formats

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->