### PR TITLE
fix(api): add webhook source filter fields to PATCH settings endpoint

### DIFF
--- a/internal/api/handlers/crossseed.go
+++ b/internal/api/handlers/crossseed.go
@@ -54,11 +54,16 @@ type automationSettingsPatchRequest struct {
 	TargetIndexerIDs   *[]int         `json:"targetIndexerIds,omitempty"`
 	MaxResultsPerRun   *int           `json:"maxResultsPerRun,omitempty"` // Deprecated: automation now processes full feeds and ignores this value
 	// RSS source filtering: filter which local torrents to search when checking RSS feeds
-	RSSSourceCategories          *[]string   `json:"rssSourceCategories,omitempty"`
-	RSSSourceTags                *[]string   `json:"rssSourceTags,omitempty"`
-	RSSSourceExcludeCategories   *[]string   `json:"rssSourceExcludeCategories,omitempty"`
-	RSSSourceExcludeTags         *[]string   `json:"rssSourceExcludeTags,omitempty"`
-	FindIndividualEpisodes       *bool       `json:"findIndividualEpisodes,omitempty"`
+	RSSSourceCategories        *[]string `json:"rssSourceCategories,omitempty"`
+	RSSSourceTags              *[]string `json:"rssSourceTags,omitempty"`
+	RSSSourceExcludeCategories *[]string `json:"rssSourceExcludeCategories,omitempty"`
+	RSSSourceExcludeTags       *[]string `json:"rssSourceExcludeTags,omitempty"`
+	// Webhook source filtering: filter which local torrents to search when checking webhook requests
+	WebhookSourceCategories        *[]string `json:"webhookSourceCategories,omitempty"`
+	WebhookSourceTags              *[]string `json:"webhookSourceTags,omitempty"`
+	WebhookSourceExcludeCategories *[]string `json:"webhookSourceExcludeCategories,omitempty"`
+	WebhookSourceExcludeTags       *[]string `json:"webhookSourceExcludeTags,omitempty"`
+	FindIndividualEpisodes         *bool     `json:"findIndividualEpisodes,omitempty"`
 	SizeMismatchTolerancePercent *float64    `json:"sizeMismatchTolerancePercent,omitempty"`
 	UseCategoryFromIndexer       *bool       `json:"useCategoryFromIndexer,omitempty"`
 	UseCrossCategorySuffix       *bool       `json:"useCrossCategorySuffix,omitempty"`
@@ -145,6 +150,10 @@ func (r automationSettingsPatchRequest) isEmpty() bool {
 		r.RSSSourceTags == nil &&
 		r.RSSSourceExcludeCategories == nil &&
 		r.RSSSourceExcludeTags == nil &&
+		r.WebhookSourceCategories == nil &&
+		r.WebhookSourceTags == nil &&
+		r.WebhookSourceExcludeCategories == nil &&
+		r.WebhookSourceExcludeTags == nil &&
 		r.FindIndividualEpisodes == nil &&
 		r.SizeMismatchTolerancePercent == nil &&
 		r.UseCategoryFromIndexer == nil &&
@@ -207,6 +216,19 @@ func applyAutomationSettingsPatch(settings *models.CrossSeedAutomationSettings, 
 	}
 	if patch.RSSSourceExcludeTags != nil {
 		settings.RSSSourceExcludeTags = *patch.RSSSourceExcludeTags
+	}
+	// Webhook source filtering
+	if patch.WebhookSourceCategories != nil {
+		settings.WebhookSourceCategories = *patch.WebhookSourceCategories
+	}
+	if patch.WebhookSourceTags != nil {
+		settings.WebhookSourceTags = *patch.WebhookSourceTags
+	}
+	if patch.WebhookSourceExcludeCategories != nil {
+		settings.WebhookSourceExcludeCategories = *patch.WebhookSourceExcludeCategories
+	}
+	if patch.WebhookSourceExcludeTags != nil {
+		settings.WebhookSourceExcludeTags = *patch.WebhookSourceExcludeTags
 	}
 	if patch.FindIndividualEpisodes != nil {
 		settings.FindIndividualEpisodes = *patch.FindIndividualEpisodes


### PR DESCRIPTION
The webhook source filter fields (webhookSourceCategories,
webhookSourceTags, webhookSourceExcludeCategories,
webhookSourceExcludeTags) were present in the model and database but
missing from the API patch request struct. This caused the frontend
to send these values but they were silently ignored and never
persisted.

Added the four webhook source filter fields to:
- automationSettingsPatchRequest struct
- isEmpty() validation check
- applyAutomationSettingsPatch() to apply values to settings

Fixes webhook source filters not persisting in CrossSeedPage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced webhook-based source filtering for automation settings, supporting filtering by categories, tags, and exclusions.

* **Breaking Changes**
  * Removed RSS-based source filtering configuration from automation settings. Users relying on this feature should migrate to webhook-based filtering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->