### PR TITLE
fix(web): add height constraint to filter sidebar wrapper for proper scrolling

### DIFF
--- a/web/src/pages/Torrents.tsx
+++ b/web/src/pages/Torrents.tsx
@@ -265,7 +265,7 @@ export function Torrents({ instanceId, search, onSearchChange }: TorrentsProps) 
       >
         <div
           className={cn(
-            "overflow-hidden transition-[transform,opacity,width] duration-300 ease-in-out",
+            "h-full overflow-hidden transition-[transform,opacity,width] duration-300 ease-in-out",
             filterSidebarCollapsed ? "-translate-x-full opacity-0 pointer-events-none" : "translate-x-0 opacity-100"
           )}
           style={{ width: sidebarWidth }}


### PR DESCRIPTION
The inner wrapper div was missing h-full, causing the FilterSidebar's
ScrollArea to not have a defined height context. This resulted in content
being clipped instead of scrolling in dense layout mode.

Fixes #777

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Desktop sidebar now extends fully to fill available vertical space, providing improved visual balance and layout consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->