### PR TITLE
feat(tracker): add per-domain stats inclusion toggle for merged trackers

### DIFF
--- a/internal/database/migrations/034_add_tracker_customization_included_stats.sql
+++ b/internal/database/migrations/034_add_tracker_customization_included_stats.sql
@@ -1,0 +1,7 @@
+-- Copyright (c) 2025, s0up and the autobrr contributors.
+-- SPDX-License-Identifier: GPL-2.0-or-later
+
+-- Add included_in_stats column to tracker_customizations
+-- Stores comma-separated list of secondary domains whose stats SHOULD be included in combined totals
+-- Empty = only primary domain stats shown (backwards compatible with pre-feature behavior)
+ALTER TABLE tracker_customizations ADD COLUMN included_in_stats TEXT DEFAULT '';

--- a/web/src/hooks/useTrackerCustomizations.ts
+++ b/web/src/hooks/useTrackerCustomizations.ts
@@ -6,6 +6,7 @@
 import { api } from "@/lib/api"
 import type { TrackerCustomization, TrackerCustomizationInput } from "@/types"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
 
 const QUERY_KEY = ["tracker-customizations"]
 
@@ -34,6 +35,7 @@ export function useCreateTrackerCustomization() {
     },
     onError: (error) => {
       console.error("[TrackerCustomization] Create failed:", error)
+      toast.error("Failed to create tracker customization")
     },
   })
 }
@@ -52,6 +54,7 @@ export function useUpdateTrackerCustomization() {
     },
     onError: (error) => {
       console.error("[TrackerCustomization] Update failed:", error)
+      toast.error("Failed to update tracker customization")
     },
   })
 }
@@ -69,6 +72,7 @@ export function useDeleteTrackerCustomization() {
     },
     onError: (error) => {
       console.error("[TrackerCustomization] Delete failed:", error)
+      toast.error("Failed to delete tracker customization")
     },
   })
 }

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -321,6 +321,7 @@ export interface TrackerCustomization {
   id: number
   displayName: string
   domains: string[]
+  includedInStats?: string[]
   createdAt: string
   updatedAt: string
 }
@@ -328,6 +329,7 @@ export interface TrackerCustomization {
 export interface TrackerCustomizationInput {
   displayName: string
   domains: string[]
+  includedInStats?: string[]
 }
 
 export interface DashboardSettings {


### PR DESCRIPTION
## Summary
- Add per-domain checkbox to control which domains contribute to combined stats when merging trackers
- Add ScrollArea for scrollable domain list when many domains are merged
- Add X button to remove domains from within the customize dialog
- Add toast notifications for mutation failures

This addresses the use case where:
- Same tracker with multiple URLs (e.g., TorrentLeech): should NOT sum stats (would double-count)
- Different trackers grouped together (e.g., Public Trackers): may want to sum stats

Primary domain is always included. Secondary domains are only included if explicitly checked.

Empty `includedInStats` means only primary domain stats shown, which is backwards compatible with existing customizations.

## Test plan
- [ ] Create new tracker customization with multiple domains, verify checkbox behavior
- [ ] Edit existing customization, verify includedInStats persists correctly
- [ ] Verify stats calculation changes based on checkbox state
- [ ] Test import/export includes includedInStats field
- [ ] Verify existing customizations continue to work (only primary stats shown)
- [ ] Verify toast appears on mutation failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to selectively include secondary domains in tracker statistics. Users can now configure which secondary domains' data contributes to combined stat totals through domain inclusion toggles.

* **Improvements**
  * Enhanced error notifications for tracker customization operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->