### PR TITLE
feat(web): improve torrent selection UX with unified click and escape behavior

### DIFF
--- a/web/src/components/torrents/TorrentDetailsPanel.tsx
+++ b/web/src/components/torrents/TorrentDetailsPanel.tsx
@@ -86,23 +86,8 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
     }
   }, [initialTab, onInitialTabConsumed, setActiveTab])
 
-  // Escape key handler to close the panel
-  useEffect(() => {
-    if (!onClose) return
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && !e.defaultPrevented) {
-        // Don't close if a dialog/modal is open
-        const hasOpenDialog = document.querySelector("[role=\"dialog\"]")
-        if (!hasOpenDialog) {
-          onClose()
-        }
-      }
-    }
-
-    window.addEventListener("keydown", handleKeyDown)
-    return () => window.removeEventListener("keydown", handleKeyDown)
-  }, [onClose])
+  // Note: Escape key handling is now unified in Torrents.tsx
+  // to close panel and clear selection atomically
 
   const [showAddPeersDialog, setShowAddPeersDialog] = useState(false)
   const { formatTimestamp } = useDateTimeFormatters()

--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -1912,12 +1912,7 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
     }
   }, [filters, effectiveSearch, instanceId, virtualizer, sortedTorrents.length, lastUserAction, resetSelectionState])
 
-  // Clear selection handler for keyboard navigation
-  const clearSelection = useCallback(() => {
-    resetSelectionState()
-  }, [resetSelectionState])
-
-  // Set up keyboard navigation with selection clearing
+  // Set up keyboard navigation (PageUp/Down, Home/End)
   useKeyboardNavigation({
     parentRef,
     virtualizer,
@@ -1926,8 +1921,6 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
     isLoadingMore,
     loadMore,
     estimatedRowHeight,
-    onClearSelection: clearSelection,
-    hasSelection: isAllSelected || selectedRowIds.length > 0,
   })
 
   // Apply Ctrl/Cmd+A shortcut to select all torrents
@@ -2609,6 +2602,17 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
                             handleRowSelection(torrent.hash, !isRowSelected, row.id)
                             lastSelectedIndexRef.current = currentIndex
                           } else {
+                            // Plain click - open details panel
+                            // If row is already selected, keep selection intact
+                            // Otherwise, select only this torrent (replace selection)
+                            if (!isRowSelected) {
+                              const allRows = table.getRowModel().rows
+                              const currentIndex = allRows.findIndex(r => r.id === row.id)
+                              setIsAllSelected(false)
+                              setExcludedFromSelectAll(new Set())
+                              setRowSelection({ [row.id]: true })
+                              lastSelectedIndexRef.current = currentIndex
+                            }
                             onTorrentSelect?.(torrent)
                           }
                         }}
@@ -2722,7 +2726,17 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
                             handleRowSelection(torrent.hash, !isRowSelected, row.id)
                             lastSelectedIndexRef.current = currentIndex
                           } else {
-                            // Plain click - open details without changing checkbox selection state
+                            // Plain click - open details panel
+                            // If row is already selected, keep selection intact
+                            // Otherwise, select only this torrent (replace selection)
+                            if (!isRowSelected) {
+                              const allRows = table.getRowModel().rows
+                              const currentIndex = allRows.findIndex(r => r.id === row.id)
+                              setIsAllSelected(false)
+                              setExcludedFromSelectAll(new Set())
+                              setRowSelection({ [row.id]: true })
+                              lastSelectedIndexRef.current = currentIndex
+                            }
                             onTorrentSelect?.(torrent)
                           }
                         }

--- a/web/src/hooks/useKeyboardNavigation.ts
+++ b/web/src/hooks/useKeyboardNavigation.ts
@@ -17,9 +17,6 @@ interface UseKeyboardNavigationProps {
   isLoadingMore: boolean
   loadMore: () => void
   estimatedRowHeight?: number
-  // Selection handling props (optional)
-  onClearSelection?: () => void
-  hasSelection?: boolean
 }
 
 export function useKeyboardNavigation({
@@ -30,8 +27,6 @@ export function useKeyboardNavigation({
   isLoadingMore,
   loadMore,
   estimatedRowHeight = 40,
-  onClearSelection,
-  hasSelection = false,
 }: UseKeyboardNavigationProps) {
 
   // Set up keyboard event listeners
@@ -54,12 +49,8 @@ export function useKeyboardNavigation({
 
       if (!container) return
 
-      // Handle Escape key for clearing selection
-      if (key === "Escape" && onClearSelection && hasSelection) {
-        event.preventDefault()
-        onClearSelection()
-        return
-      }
+      // Note: Escape key handling is now unified in Torrents.tsx
+      // to close panel and clear selection atomically
 
       // Only handle standard navigation keys
       const navigationKeys = ["PageUp", "PageDown", "Home", "End"]
@@ -157,5 +148,5 @@ export function useKeyboardNavigation({
     return () => {
       window.removeEventListener("keydown", handleKeyDown)
     }
-  }, [virtualizer, safeLoadedRows, hasLoadedAll, isLoadingMore, loadMore, estimatedRowHeight, parentRef, onClearSelection, hasSelection])
+  }, [virtualizer, safeLoadedRows, hasLoadedAll, isLoadingMore, loadMore, estimatedRowHeight, parentRef])
 }


### PR DESCRIPTION
## Summary

- Plain click on row now selects torrent and opens detail panel
- Clicking already-selected row opens panel without changing selection (preserves multi-select)
- Cmd/Ctrl+click toggles selection without changing panel
- Single Escape press closes panel and clears all selection atomically

## Test plan

- [ ] Click row → Panel opens, only that torrent selected
- [ ] Click different row → Panel switches, selection replaces to new torrent
- [ ] Cmd+click multiple rows → Multiple selected, panel unchanged
- [ ] Click one of the selected rows → Panel shows that torrent, all remain selected
- [ ] Checkbox click → Selection toggles, panel unchanged
- [ ] Escape with panel open + selection → Both cleared in one press
- [ ] Escape with dialog open → Nothing happens
- [ ] Shift+click → Range selection still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified Escape key handling to close the details panel and clear torrent selection atomically.
  * Simplified row click behavior for more consistent selection interactions across different layouts.
  * Streamlined keyboard navigation by removing redundant selection management callbacks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->