### PR TITLE
feat(web): add Size default sort option to Tracker Breakdown table settings

### DIFF
--- a/web/src/components/dashboard-settings-dialog.tsx
+++ b/web/src/components/dashboard-settings-dialog.tsx
@@ -41,7 +41,7 @@ const SORT_COLUMN_LABELS: Record<string, string> = {
   "ratio": "Ratio",
   "buffer": "Buffer",
   "count": "Torrents",
-  "sort": "Sort",
+  "size": "Size",
   "performance": "Seeded",
 }
 


### PR DESCRIPTION
From https://github.com/autobrr/qui/pull/770 , the size option wasn't added to the dashboard settings default sort.

This is all I changed was adding the option.

Picture showing the option is added and working.

<img width="1512" height="787" alt="SortDefaultOption" src="https://github.com/user-attachments/assets/adf73461-ad89-47c1-80db-f48ec6f90c7d" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added size as a new sorting option for Tracker Breakdown Defaults in dashboard settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->