### PR TITLE
fix(web): restore piece size display in torrent details panel

### DIFF
--- a/web/src/components/torrents/details/GeneralTabHorizontal.tsx
+++ b/web/src/components/torrents/details/GeneralTabHorizontal.tsx
@@ -228,8 +228,7 @@ export const GeneralTabHorizontal = memo(function GeneralTabHorizontal({
             />
             <StatRow
               label="Pieces"
-              value={`${properties.pieces_have || 0} / ${properties.pieces_num || 0}`}
-              tooltip={`${formatBytes(properties.piece_size || 0)} each`}
+              value={`${properties.pieces_have || 0} / ${properties.pieces_num || 0} (${formatBytes(properties.piece_size || 0)} each)`}
             />
             {queueingEnabled && (
               <StatRow


### PR DESCRIPTION
## Summary
- Show piece size inline (e.g., "1160 / 1160 (512 KiB each)") instead of hiding it in a tooltip
- Restores the v1.09 behavior where piece size was always visible

Fixes #787

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved torrent details view by displaying piece size information inline with piece count, eliminating the need for a separate tooltip for better accessibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->