### PR TITLE
feat(torrents): add "não registrado" to unregistered status

### DIFF
--- a/internal/qbittorrent/tracker_statuses.go
+++ b/internal/qbittorrent/tracker_statuses.go
@@ -34,6 +34,7 @@ var defaultUnregisteredStatuses = []string{
 	"trump",
 	"unknown",
 	"unregistered",
+	"não registrado",
 	"upgraded",
 	"uploaded",
 }


### PR DESCRIPTION
~~"postponed" is from unit3d~~
"não registrado" is translation for unregistered (BJ uses it)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of tracker status messages (including localized wording), so certain trackers are now correctly identified as unregistered — enhancing tracker display accuracy.
  * Minor clarity improvements to status handling to reduce false positives in tracker reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->