### PR TITLE
fix(api): respect baseURL for path autocompletion cap

### DIFF
--- a/web/src/hooks/usePathAutocomplete.ts
+++ b/web/src/hooks/usePathAutocomplete.ts
@@ -1,4 +1,7 @@
 import { useCallback, useDeferredValue, useEffect, useRef, useState } from "react";
+import { getApiBaseUrl } from "../lib/base-url";
+
+const API_BASE = getApiBaseUrl();
 
 export function usePathAutocomplete(
   onSuggestionSelect: (path: string) => void,
@@ -51,7 +54,7 @@ export function usePathAutocomplete(
 
       try {
         const response = await fetch(
-          `/api/instances/${instanceId}/getDirectoryContent?dirPath=${encodeURIComponent(key)}`,
+          `${API_BASE}/instances/${instanceId}/getDirectoryContent?dirPath=${encodeURIComponent(key)}`,
           { signal: controller.signal }
         );
 


### PR DESCRIPTION
I think I have found out why I was getting 404 with the api call for the path autocompletion. I had `baseUrl = "/qui/"` set in the config.toml but the base URL wasn't used for the requests. So the requests where still sent to `http://127.0.0.1:7476/api/instances/1/getDirectoryContent` instead of `http://127.0.0.1:7476/qui/api/instances/1/getDirectoryContent`. With this pull request I'm trying to fix this, so that the baseURL gets respected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal API configuration handling for path autocomplete functionality, ensuring consistent API endpoint usage across the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->