### PR TITLE
fix(web): sort trackers by display name in filter sidebar

### DIFF
--- a/web/src/components/torrents/FilterSidebar.tsx
+++ b/web/src/components/torrents/FilterSidebar.tsx
@@ -719,6 +719,9 @@ const FilterSidebarComponent = ({
       }
     }
 
+    // Sort by display name (case-insensitive) for consistent alphabetical ordering
+    processed.sort((a, b) => a.displayName.localeCompare(b.displayName, undefined, { sensitivity: 'base' }))
+
     return processed
   }, [trackers, trackerCustomizationMaps])
 


### PR DESCRIPTION
Sort trackers alphabetically by their display name instead of the
underlying domain name for better user experience when custom
tracker names are configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tracker groups in the filter sidebar now display in consistent alphabetical order, improving usability and making trackers easier to locate.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->