### PR TITLE
feat(web): add color-coded status badges for torrents

### DIFF
--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -80,7 +80,7 @@ import { usePersistedCompactViewState, type ViewMode } from "@/hooks/usePersiste
 import { api } from "@/lib/api"
 import { getLinuxCategory, getLinuxIsoName, getLinuxRatio, getLinuxTags, getLinuxTracker, useIncognitoMode } from "@/lib/incognito"
 import { formatSpeedWithUnit, useSpeedUnits, type SpeedUnit } from "@/lib/speedUnits"
-import { getStateLabel } from "@/lib/torrent-state-utils"
+import { getStatusBadgeMeta } from "@/lib/torrent-state-utils"
 import { getCommonCategory, getCommonSavePath, getCommonTags } from "@/lib/torrent-utils"
 import { cn, formatBytes } from "@/lib/utils"
 import type { Category, Torrent, TorrentCounts, TorrentFilters } from "@/types"
@@ -334,53 +334,6 @@ function formatEta(seconds: number): string {
   return `${minutes}m`
 }
 
-function getStatusBadgeVariant(state: string): "default" | "secondary" | "destructive" | "outline" {
-  switch (state) {
-    case "downloading":
-      return "default"
-    case "stalledDL":
-      return "secondary"
-    case "uploading":
-      return "default"
-    case "stalledUP":
-      return "secondary"
-    case "pausedDL":
-    case "pausedUP":
-      return "secondary"
-    case "error":
-    case "missingFiles":
-      return "destructive"
-    default:
-      return "outline"
-  }
-}
-
-function getStatusBadgeProps(torrent: Torrent, supportsTrackerHealth: boolean): {
-  variant: "default" | "secondary" | "destructive" | "outline"
-  label: string
-  className: string
-} {
-  const baseVariant = getStatusBadgeVariant(torrent.state)
-  let variant = baseVariant
-  let label = getStateLabel(torrent.state)
-  let className = ""
-
-  if (supportsTrackerHealth) {
-    const trackerHealth = torrent.tracker_health ?? null
-    if (trackerHealth === "tracker_down") {
-      label = "Tracker Down"
-      variant = "outline"
-      className = "text-yellow-500 border-yellow-500/40 bg-yellow-500/10"
-    } else if (trackerHealth === "unregistered") {
-      label = "Unregistered"
-      variant = "outline"
-      className = "text-destructive border-destructive/40 bg-destructive/10"
-    }
-  }
-
-  return { variant, label, className }
-}
-
 function shallowEqualTrackerIcons(
   prev?: Record<string, string>,
   next?: Record<string, string>
@@ -584,8 +537,8 @@ function SwipeableCard({
   const displayTags = incognitoMode ? getLinuxTags(torrent.hash) : torrent.tags
   const displayRatio = incognitoMode ? getLinuxRatio(torrent.hash) : torrent.ratio
   const { variant: statusBadgeVariant, label: statusBadgeLabel, className: statusBadgeClass } = useMemo(
-    () => getStatusBadgeProps(torrent, supportsTrackerHealth),
-    [torrent, supportsTrackerHealth]
+    () => getStatusBadgeMeta(torrent.state, torrent.tracker_health, supportsTrackerHealth),
+    [torrent.state, torrent.tracker_health, supportsTrackerHealth]
   )
   const trackerValue = incognitoMode ? getLinuxTracker(torrent.hash) : torrent.tracker
   const trackerMeta = useMemo(() => getTrackerDisplayMeta(trackerValue), [trackerValue])

--- a/web/src/components/torrents/TorrentDetailsPanel.tsx
+++ b/web/src/components/torrents/TorrentDetailsPanel.tsx
@@ -25,7 +25,7 @@ import { getLinuxCategory, getLinuxComment, getLinuxCreatedBy, getLinuxFileName,
 import { renderTextWithLinks } from "@/lib/linkUtils"
 import { formatSpeedWithUnit, useSpeedUnits } from "@/lib/speedUnits"
 import { getPeerFlagDetails } from "@/lib/torrent-peer-flags"
-import { getStateLabel } from "@/lib/torrent-state-utils"
+import { getStatusBadgeMeta } from "@/lib/torrent-state-utils"
 import { resolveTorrentHashes } from "@/lib/torrent-utils"
 import { cn, copyTextToClipboard, formatBytes, formatDuration } from "@/lib/utils"
 import type { SortedPeersResponse, Torrent, TorrentFile, TorrentPeer } from "@/types"
@@ -1616,37 +1616,7 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
                           }
 
                           // Get enriched status (tracker-aware)
-                          const trackerHealth = match.tracker_health ?? null
-                          let statusLabel = getStateLabel(match.state)
-                          let statusVariant: "default" | "secondary" | "destructive" | "outline" = "outline"
-                          let statusClass = ""
-
-                          // Check tracker health first (if supported)
-                          if (trackerHealth === "unregistered") {
-                            statusLabel = "Unregistered"
-                            statusVariant = "outline"
-                            statusClass = "text-destructive border-destructive/40 bg-destructive/10"
-                          } else if (trackerHealth === "tracker_down") {
-                            statusLabel = "Tracker Down"
-                            statusVariant = "outline"
-                            statusClass = "text-yellow-500 border-yellow-500/40 bg-yellow-500/10"
-                          } else {
-                            // Normal state-based styling
-                            if (match.state === "downloading" || match.state === "uploading") {
-                              statusVariant = "default"
-                            } else if (
-                              match.state === "stalledDL" ||
-                              match.state === "stalledUP" ||
-                              match.state === "pausedDL" ||
-                              match.state === "pausedUP" ||
-                              match.state === "queuedDL" ||
-                              match.state === "queuedUP"
-                            ) {
-                              statusVariant = "secondary"
-                            } else if (match.state === "error" || match.state === "missingFiles") {
-                              statusVariant = "destructive"
-                            }
-                          }
+                          const { label: statusLabel, variant: statusVariant, className: statusClass } = getStatusBadgeMeta(match.state, match.tracker_health)
 
                           // Match type display
                           const matchType = match.matchType as 'infohash' | 'content_path' | 'save_path' | 'name'

--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -80,7 +80,7 @@ import { useInstances } from "@/hooks/useInstances"
 import { api } from "@/lib/api"
 import { getLinuxCategory, getLinuxIsoName, getLinuxRatio, getLinuxTags, getLinuxTracker, useIncognitoMode } from "@/lib/incognito"
 import { formatSpeedWithUnit, useSpeedUnits } from "@/lib/speedUnits"
-import { getStateLabel } from "@/lib/torrent-state-utils"
+import { getStatusBadgeMeta } from "@/lib/torrent-state-utils"
 import { getCommonCategory, getCommonSavePath, getCommonTags, getTotalSize } from "@/lib/torrent-utils"
 import { cn } from "@/lib/utils"
 import type {
@@ -226,53 +226,6 @@ function getRowBackgroundClass(isRowSelected: boolean, isSelected: boolean, rowI
   return ""
 }
 
-function getStatusBadgeVariant(state: string): "default" | "secondary" | "destructive" | "outline" {
-  switch (state) {
-    case "downloading":
-      return "default"
-    case "stalledDL":
-      return "secondary"
-    case "uploading":
-      return "default"
-    case "stalledUP":
-      return "secondary"
-    case "pausedDL":
-    case "pausedUP":
-      return "secondary"
-    case "error":
-    case "missingFiles":
-      return "destructive"
-    default:
-      return "outline"
-  }
-}
-
-function getStatusBadgeProps(torrent: Torrent, supportsTrackerHealth: boolean): {
-  variant: "default" | "secondary" | "destructive" | "outline"
-  label: string
-  className: string
-} {
-  const baseVariant = getStatusBadgeVariant(torrent.state)
-  let variant = baseVariant
-  let label = getStateLabel(torrent.state)
-  let className = ""
-
-  if (supportsTrackerHealth) {
-    const trackerHealth = torrent.tracker_health ?? null
-    if (trackerHealth === "tracker_down") {
-      label = "Tracker Down"
-      variant = "outline"
-      className = "text-yellow-500 border-yellow-500/40 bg-yellow-500/10"
-    } else if (trackerHealth === "unregistered") {
-      label = "Unregistered"
-      variant = "outline"
-      className = "text-destructive border-destructive/40 bg-destructive/10"
-    }
-  }
-
-  return { variant, label, className }
-}
-
 const trackerIconSizeClasses = {
   xs: "h-3 w-3 text-[8px]",
   sm: "h-[14px] w-[14px] text-[9px]",
@@ -396,8 +349,8 @@ const CompactRow = memo(({
   const displayRatio = incognitoMode ? getLinuxRatio(torrent.hash) : torrent.ratio
 
   const { variant: statusBadgeVariant, label: statusBadgeLabel, className: statusBadgeClass } = useMemo(
-    () => getStatusBadgeProps(torrent, supportsTrackerHealth),
-    [torrent, supportsTrackerHealth]
+    () => getStatusBadgeMeta(torrent.state, torrent.tracker_health, supportsTrackerHealth),
+    [torrent.state, torrent.tracker_health, supportsTrackerHealth]
   )
 
   const trackerValue = incognitoMode ? getLinuxTracker(torrent.hash) : torrent.tracker

--- a/web/src/components/torrents/details/CrossSeedTable.tsx
+++ b/web/src/components/torrents/details/CrossSeedTable.tsx
@@ -15,7 +15,7 @@ import { useTrackerIcons } from "@/hooks/useTrackerIcons"
 import type { CrossSeedTorrent } from "@/lib/cross-seed-utils"
 import { getLinuxFileName, getLinuxTracker } from "@/lib/incognito"
 import { formatSpeedWithUnit, type SpeedUnit } from "@/lib/speedUnits"
-import { getStateLabel } from "@/lib/torrent-state-utils"
+import { getStatusBadgeMeta } from "@/lib/torrent-state-utils"
 import { cn, formatBytes } from "@/lib/utils"
 import {
   createColumnHelper,
@@ -43,36 +43,6 @@ interface CrossSeedTableProps {
 }
 
 const columnHelper = createColumnHelper<CrossSeedTorrent>()
-
-function getStatusInfo(match: CrossSeedTorrent): { label: string; variant: "default" | "secondary" | "destructive" | "outline"; className: string } {
-  const trackerHealth = match.tracker_health ?? null
-  let label = getStateLabel(match.state)
-  let variant: "default" | "secondary" | "destructive" | "outline" = "outline"
-  let className = ""
-
-  if (trackerHealth === "unregistered") {
-    return { label: "Unregistered", variant: "outline", className: "text-destructive border-destructive/40 bg-destructive/10" }
-  } else if (trackerHealth === "tracker_down") {
-    return { label: "Tracker Down", variant: "outline", className: "text-yellow-500 border-yellow-500/40 bg-yellow-500/10" }
-  }
-
-  if (match.state === "downloading" || match.state === "uploading") {
-    variant = "default"
-  } else if (
-    match.state === "stalledDL" ||
-    match.state === "stalledUP" ||
-    match.state === "pausedDL" ||
-    match.state === "pausedUP" ||
-    match.state === "queuedDL" ||
-    match.state === "queuedUP"
-  ) {
-    variant = "secondary"
-  } else if (match.state === "error" || match.state === "missingFiles") {
-    variant = "destructive"
-  }
-
-  return { label, variant, className }
-}
 
 function getMatchTypeLabel(matchType: string): { label: string; description: string } {
   switch (matchType) {
@@ -215,7 +185,8 @@ export const CrossSeedTable = memo(function CrossSeedTable({
     columnHelper.accessor("state", {
       header: "Status",
       cell: (info) => {
-        const { label, variant, className } = getStatusInfo(info.row.original)
+        const match = info.row.original
+        const { label, variant, className } = getStatusBadgeMeta(match.state, match.tracker_health)
         return (
           <Badge variant={variant} className={cn("text-[10px] px-1.5 py-0", className)}>
             {label}

--- a/web/src/lib/torrent-state-utils.ts
+++ b/web/src/lib/torrent-state-utils.ts
@@ -38,5 +38,97 @@ export function getStateLabel(state: string): string {
   return TORRENT_STATE_LABELS[state] ?? state
 }
 
+export type StatusBadgeVariant = "default" | "secondary" | "destructive" | "outline"
 
+export interface StatusBadgeMeta {
+  label: string
+  variant: StatusBadgeVariant
+  className: string
+  iconClass: string
+}
+
+/**
+ * Returns status badge styling based on torrent state and tracker health.
+ * Centralizes all status color logic for consistency across views.
+ */
+export function getStatusBadgeMeta(
+  state: string,
+  trackerHealth?: string | null,
+  supportsTrackerHealth: boolean = true
+): StatusBadgeMeta {
+  let label = getStateLabel(state)
+  let variant: StatusBadgeVariant = "outline"
+  let className = ""
+  let iconClass = "text-muted-foreground"
+
+  // Tracker health takes priority
+  if (supportsTrackerHealth && trackerHealth) {
+    if (trackerHealth === "tracker_down") {
+      return {
+        label: "Tracker Down",
+        variant: "outline",
+        className: "text-yellow-500 border-yellow-500/40 bg-yellow-500/10",
+        iconClass: "text-yellow-500",
+      }
+    }
+    if (trackerHealth === "unregistered") {
+      return {
+        label: "Unregistered",
+        variant: "outline",
+        className: "text-destructive border-destructive/40 bg-destructive/10",
+        iconClass: "text-destructive",
+      }
+    }
+  }
+
+  // Apply semantic status colors based on state
+  switch (state) {
+    // Downloading states - green
+    case "downloading":
+    case "metaDL":
+    case "forcedDL":
+    case "allocating":
+    case "checkingDL":
+      variant = "default"
+      className = "text-green-400 border-green-400/40 bg-green-400/10"
+      iconClass = "text-green-400"
+      break
+    // Uploading/seeding states - blue
+    case "uploading":
+    case "forcedUP":
+      variant = "default"
+      className = "text-blue-400 border-blue-400/40 bg-blue-400/10"
+      iconClass = "text-blue-400"
+      break
+    // Stalled states
+    case "stalledDL":
+    case "stalledUP":
+      variant = "secondary"
+      iconClass = "text-secondary-foreground"
+      break
+    // Error states
+    case "error":
+    case "missingFiles":
+      variant = "destructive"
+      iconClass = "text-destructive"
+      break
+    // Queued/paused states
+    case "pausedDL":
+    case "pausedUP":
+    case "stoppedDL":
+    case "stoppedUP":
+    case "queuedDL":
+    case "queuedUP":
+      variant = "secondary"
+      iconClass = "text-secondary-foreground"
+      break
+    // Other states (checking, moving, etc.)
+    default:
+      variant = "outline"
+      iconClass = "text-muted-foreground"
+      break
+  }
+
+  return { label, variant, className, iconClass }
+}
 


### PR DESCRIPTION
Add semantic coloring to torrent status badges across all views:
- Downloading states: green
- Uploading/seeding states: blue
- Error states: red (destructive)
- Other states: default theme styling

Centralized status color logic in getStatusBadgeMeta()

Ideally we go through every theme and do custom per theme. Optionally make this opt-out using the db.

This is a work in progress.

Closes #819