### PR TITLE
fix(web): only show selection checkbox on normal view

### DIFF
--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -615,8 +615,8 @@ function SwipeableCard({
       {isSelected && (
         <div className="absolute inset-0 rounded-lg ring-2 ring-primary ring-inset pointer-events-none" />
       )}
-      {/* Selection checkbox - visible in selection mode */}
-      {selectionMode && (
+      {/* Selection checkbox - visible in normal view selection mode */}
+      {selectionMode && viewMode === "normal" && (
         <div className="absolute top-2 right-2 z-10">
           <Checkbox
             checked={isSelected}


### PR DESCRIPTION
<img width="400" height="1278" alt="Screenshot 2025-12-19 at 12 37 16 PM" src="https://github.com/user-attachments/assets/ae6f5975-72c5-4919-8f17-eaecbea5de3c" /> <img width="400" height="1278" alt="Screenshot 2025-12-19 at 12 38 22 PM" src="https://github.com/user-attachments/assets/ca48658a-d7d0-4230-81fc-023eafe1b91a" />
not sure if fix or feat

think border is enough for compact and ultra
can refactor to move badge if you want to keep the checkbox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed selection checkbox visibility to display only in normal view mode when selection is enabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->