### PR TITLE
feat(web): compact torrent details panel

### DIFF
--- a/web/src/components/torrents/TorrentDetailsPanel.tsx
+++ b/web/src/components/torrents/TorrentDetailsPanel.tsx
@@ -669,35 +669,6 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
 
   return (
     <div className="h-full flex flex-col">
-      <div className="flex items-center gap-2 px-4 py-1 sm:px-6 border-b bg-muted/30">
-        <div className="flex items-center gap-1 min-w-0 flex-1">
-          <h3 className="text-sm font-semibold truncate" title={displayName}>
-            {displayName}
-          </h3>
-          {displayName && (
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-5 w-5 shrink-0"
-              onClick={() => copyToClipboard(displayName, "Torrent name")}
-            >
-              <Copy className="h-3 w-3" />
-            </Button>
-          )}
-        </div>
-        {onClose && (
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-5 w-5 shrink-0"
-            onClick={onClose}
-            aria-label="Close details panel"
-          >
-            <X className="h-3 w-3" />
-          </Button>
-        )}
-      </div>
-
       <Tabs value={activeTab} onValueChange={handleTabChange} className="flex-1 flex flex-col overflow-hidden">
         <TabsList className="w-full justify-start rounded-none border-b h-8 bg-background px-4 sm:px-6 py-0">
           <TabsTrigger
@@ -738,7 +709,19 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
           >
             Cross-Seed
           </TabsTrigger>
+          {onClose && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-5 w-10 shrink-0"
+              onClick={onClose}
+              aria-label="Close details panel"
+            >
+              <X className="h-3 w-3" />
+            </Button>
+          )}
         </TabsList>
+
 
         <div className="flex-1 min-h-0 overflow-hidden">
           <TabsContent value="general" className="m-0 h-full">
@@ -750,6 +733,7 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
                 speedUnit={speedUnit}
                 downloadLimit={properties?.dl_limit ?? torrent.dl_limit ?? 0}
                 uploadLimit={properties?.up_limit ?? torrent.up_limit ?? 0}
+                displayName={displayName}
                 displaySavePath={displaySavePath || ""}
                 displayTempPath={displayTempPath}
                 tempPathEnabled={tempPathEnabled}

--- a/web/src/components/torrents/details/GeneralTabHorizontal.tsx
+++ b/web/src/components/torrents/details/GeneralTabHorizontal.tsx
@@ -23,6 +23,7 @@ interface GeneralTabHorizontalProps {
   speedUnit: SpeedUnit
   downloadLimit: number
   uploadLimit: number
+  displayName?: string
   displaySavePath: string
   displayTempPath?: string
   tempPathEnabled: boolean
@@ -43,6 +44,7 @@ export const GeneralTabHorizontal = memo(function GeneralTabHorizontal({
   speedUnit,
   downloadLimit,
   uploadLimit,
+  displayName,
   displaySavePath,
   displayTempPath,
   tempPathEnabled,
@@ -91,11 +93,29 @@ export const GeneralTabHorizontal = memo(function GeneralTabHorizontal({
 
   return (
     <ScrollArea className="h-full">
-      <div className="p-3 space-y-3">
-        {/* Row 1: Save Path + Hash (most used) */}
-        <div className="space-y-2">
-          <div className="flex items-center gap-2">
-            <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground shrink-0 w-16">
+      <div className="p-3">
+        {/* Row 1: Name + Save Path */}
+        <div className="flex gap-6 h-5">
+          {displayName && (
+            <div className="flex items-center gap-2 flex-1">
+              <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground shrink-0 w-20">
+                Name:
+              </span>
+              <code className="text-xs font-mono text-muted-foreground truncate" title={displayName}>
+                {displayName}
+              </code>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-5 w-5 shrink-0"
+                onClick={() => copyToClipboard(displayName, "Torrent name")}
+              >
+                <Copy className="h-4 w-4" />
+              </Button>
+            </div>
+          )}
+          <div className="flex items-center gap-2 flex-1">
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground shrink-0 w-20">
               Save Path:
             </span>
             <code className="text-xs font-mono text-muted-foreground truncate">
@@ -105,17 +125,21 @@ export const GeneralTabHorizontal = memo(function GeneralTabHorizontal({
               <Button
                 variant="ghost"
                 size="icon"
-                className="h-6 w-6 shrink-0"
+                className="h-5 w-5 shrink-0"
                 onClick={() => copyToClipboard(displaySavePath, "Save path")}
               >
-                <Copy className="h-3 w-3" />
+                <Copy className="h-4 w-4" />
               </Button>
             )}
           </div>
+        </div>
 
-          {tempPathEnabled && displayTempPath && (
-            <div className="flex items-center gap-2">
-              <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground shrink-0 w-16">
+        {/* Row 2: Temp Path (if enabled) */}
+        {tempPathEnabled && displayTempPath && (
+          <div className="flex gap-6 h-5">
+            {displayName && <div className="flex-1" />}
+            <div className="flex items-center gap-2 flex-1">
+              <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground shrink-0 w-20">
                 Temp Path:
               </span>
               <code className="text-xs font-mono text-muted-foreground truncate">
@@ -124,16 +148,19 @@ export const GeneralTabHorizontal = memo(function GeneralTabHorizontal({
               <Button
                 variant="ghost"
                 size="icon"
-                className="h-6 w-6 shrink-0"
+                className="h-5 w-5 shrink-0"
                 onClick={() => copyToClipboard(displayTempPath, "Temp path")}
               >
-                <Copy className="h-3 w-3" />
+                <Copy className="h-4 w-4" />
               </Button>
             </div>
-          )}
+          </div>
+        )}
 
-          <div className="flex items-center gap-2">
-            <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground shrink-0 w-16">
+        {/* Row 3: Hashes */}
+        <div className="flex gap-6 h-5">
+          <div className="flex items-center gap-2 flex-1">
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground shrink-0 w-20">
               Hash v1:
             </span>
             <code className="text-xs font-mono text-muted-foreground truncate">
@@ -143,17 +170,16 @@ export const GeneralTabHorizontal = memo(function GeneralTabHorizontal({
               <Button
                 variant="ghost"
                 size="icon"
-                className="h-6 w-6 shrink-0"
+                className="h-5 w-5 shrink-0"
                 onClick={() => copyToClipboard(displayInfohashV1, "Info Hash v1")}
               >
-                <Copy className="h-3 w-3" />
+                <Copy className="h-4 w-4" />
               </Button>
             )}
           </div>
-
           {displayInfohashV2 && (
-            <div className="flex items-center gap-2">
-              <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground shrink-0 w-16">
+            <div className="flex items-center gap-2 flex-1">
+              <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground shrink-0 w-20">
                 Hash v2:
               </span>
               <code className="text-xs font-mono text-muted-foreground truncate">
@@ -162,19 +188,46 @@ export const GeneralTabHorizontal = memo(function GeneralTabHorizontal({
               <Button
                 variant="ghost"
                 size="icon"
-                className="h-6 w-6 shrink-0"
+                className="h-5 w-5 shrink-0"
                 onClick={() => copyToClipboard(displayInfohashV2, "Info Hash v2")}
               >
-                <Copy className="h-3 w-3" />
+                <Copy className="h-4 w-4" />
               </Button>
             </div>
           )}
         </div>
 
-        <Separator className="opacity-30" />
 
-        {/* Row 2: Transfer Stats + Speed + Network + Time */}
-        <div className="grid grid-cols-2 lg:grid-cols-4 gap-x-6 gap-y-2">
+        {/* Row 4: Additional Info (if present) */}
+        {(displayComment || displayCreatedBy) && (
+          <div className="flex gap-6 h-5">
+            {displayCreatedBy && (
+              <div className="flex items-center gap-2 flex-1">
+                <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground shrink-0 w-20 whitespace-nowrap">
+                  Created By:
+                </span>
+                <span className="text-xs text-muted-foreground truncate" title={displayCreatedBy}>
+                  {renderTextWithLinks(displayCreatedBy)}
+                </span>
+              </div>
+            )}
+            {displayComment && (
+              <div className="flex items-center gap-2 flex-1">
+                <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground shrink-0 w-20">
+                  Comment:
+                </span>
+                <span className="text-xs text-muted-foreground truncate" title={displayComment}>
+                  {renderTextWithLinks(displayComment)}
+                </span>
+              </div>
+            )}
+          </div>
+        )}
+
+        <Separator className="opacity-30 mt-2" />
+
+        {/* Row 5: Transfer Stats + Speed + Network + Time */}
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-x-6 m-0 mt-2">
           {/* Transfer Stats */}
           <div className="space-y-1">
             <h4 className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground mb-1.5">Transfer</h4>
@@ -248,33 +301,6 @@ export const GeneralTabHorizontal = memo(function GeneralTabHorizontal({
             <StatRow label="Created" value={formatTimestamp(properties.creation_date)} />
           </div>
         </div>
-
-        {/* Row 3: Additional Info (if present) */}
-        {(displayComment || displayCreatedBy) && (
-          <>
-            <Separator className="opacity-30" />
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-2 text-xs">
-              {displayCreatedBy && (
-                <div className="flex items-start gap-2">
-                  <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground shrink-0">
-                    Created By:
-                  </span>
-                  <span className="text-muted-foreground truncate">{renderTextWithLinks(displayCreatedBy)}</span>
-                </div>
-              )}
-              {displayComment && (
-                <div className="flex items-start gap-2">
-                  <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground shrink-0">
-                    Comment:
-                  </span>
-                  <span className="text-muted-foreground truncate" title={displayComment}>
-                    {renderTextWithLinks(displayComment)}
-                  </span>
-                </div>
-              )}
-            </div>
-          </>
-        )}
 
         {/* Queue Management (if enabled) */}
         {queueingEnabled && (maxActiveDownloads || maxActiveUploads || maxActiveTorrents) && (


### PR DESCRIPTION
This PR compacts the view of the torrent details panel.
The name has been moved into the grid of the panel and the close button into the div of the tabs.
A lot of whitespace has been removed by moving the 
name, (temp) save path, hashes, created by and comment to the top in a 2 column grid.

Disclaimer: This PR has been created with the help of Ai.

Old:
<img width="2560" height="442" alt="image" src="https://github.com/user-attachments/assets/9e172ffd-b5c8-46c6-b21b-bc8b7e1072f8" />

New:
<img width="2558" height="365" alt="image" src="https://github.com/user-attachments/assets/a71a81b8-12b6-4125-ad6e-3a8e87f7afc0" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **UI/UX Improvements**
  * Reorganized torrent details panel layout with improved information hierarchy and structured rows
  * Moved close button from header to tab bar for better accessibility
  * Enhanced copy-to-clipboard controls with improved affordances across torrent information fields
  * Improved spacing and alignment consistency throughout details view

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->