### PR TITLE
feat(torrents): add "torrent introuvable" to unregistered status

### DIFF
--- a/internal/qbittorrent/tracker_statuses.go
+++ b/internal/qbittorrent/tracker_statuses.go
@@ -26,6 +26,7 @@ var defaultUnregisteredStatuses = []string{
 	"torrent existiert nicht",
 	"torrent has been deleted",
 	"torrent has been nuked",
+	"torrent introuvable",
 	"torrent is not authorized for use on this tracker",
 	"torrent is not found",
 	"torrent nicht gefunden",


### PR DESCRIPTION
"torrent introuvable" is french translation for unregistered (used by Sharewood)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced tracker status detection to recognize additional unregistered torrent messages, improving accuracy of torrent availability tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->