### PR TITLE
fix(ui): torrents with no creation metadata don't display 1969

### DIFF
--- a/web/src/components/torrents/TorrentDetailsPanel.tsx
+++ b/web/src/components/torrents/TorrentDetailsPanel.tsx
@@ -1031,10 +1031,12 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
                                 <p className="text-sm">{formatTimestamp(properties.completion_date)}</p>
                               </div>
                             )}
-                            <div className="space-y-1">
-                              <p className="text-xs text-muted-foreground">Created</p>
-                              <p className="text-sm">{formatTimestamp(properties.creation_date)}</p>
-                            </div>
+                            {properties.creation_date && properties.creation_date !== -1 && (
+                              <div className="space-y-1">
+                                <p className="text-xs text-muted-foreground">Created</p>
+                                <p className="text-sm">{formatTimestamp(properties.creation_date)}</p>
+                              </div>
+                            )}
                           </div>
                         </div>
                       </div>

--- a/web/src/components/torrents/details/GeneralTabHorizontal.tsx
+++ b/web/src/components/torrents/details/GeneralTabHorizontal.tsx
@@ -300,7 +300,9 @@ export const GeneralTabHorizontal = memo(function GeneralTabHorizontal({
             {properties.completion_date && properties.completion_date !== -1 && (
               <StatRow label="Completed" value={formatTimestamp(properties.completion_date)} />
             )}
-            <StatRow label="Created" value={formatTimestamp(properties.creation_date)} />
+            {properties.creation_date && properties.creation_date !== -1 && (
+              <StatRow label="Created" value={formatTimestamp(properties.creation_date)} />
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
This is effectively the same bug I fixed in #851, but impacts a different field. Unlike the completion timestamp, there's no option to display the torrent creation timestamp in the table view, so this is a bit simpler.

## Before

### Compact
<img width="547" height="241" alt="Screenshot 2025-12-27 at 2 08 51 PM" src="https://github.com/user-attachments/assets/f6dbdfb6-c650-4620-83bd-63153768e7b0" />

### General
<img width="215" height="141" alt="Screenshot 2025-12-27 at 2 09 05 PM" src="https://github.com/user-attachments/assets/b7e22182-a5f8-4096-94c5-73bde0c58e77" />

## After

### Compact
<img width="539" height="186" alt="Screenshot 2025-12-27 at 2 08 41 PM" src="https://github.com/user-attachments/assets/021c805b-b762-4bdd-ab7e-a1927432c0f7" />

### General
<img width="215" height="123" alt="Screenshot 2025-12-27 at 2 10 26 PM" src="https://github.com/user-attachments/assets/ea7b6661-dcee-4524-9cf7-ba8c91805af8" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Torrent creation dates now display only when valid data is available, preventing empty or invalid date entries from appearing in torrent details.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->