### PR TITLE
feat(crossseed): add source aliasing for WEB/WEB-DL/WEBRip precheck matching

### DIFF
--- a/internal/services/crossseed/matching.go
+++ b/internal/services/crossseed/matching.go
@@ -226,10 +226,13 @@ func (s *Service) releasesMatch(source, candidate *rls.Release, findIndividualEp
 		}
 	}
 
-	// Source must match if both are present (WEB-DL vs BluRay produce different files)
-	sourceSource := s.stringNormalizer.Normalize((source.Source))
-	candidateSource := s.stringNormalizer.Normalize((candidate.Source))
-	if sourceSource != "" && candidateSource != "" && sourceSource != candidateSource {
+	// Source must be compatible if both are present.
+	// WEB is ambiguous and matches both WEB-DL and WEBRip.
+	// WEB-DL and WEBRip are explicitly different and do not match.
+	// Other sources (BluRay, HDTV, etc.) must match exactly.
+	sourceSource := normalizeSource(source.Source)
+	candidateSource := normalizeSource(candidate.Source)
+	if !sourcesCompatible(sourceSource, candidateSource) {
 		return false
 	}
 
@@ -395,6 +398,58 @@ func normalizeVideoCodec(codec string) string {
 		return canonical
 	}
 	return upper
+}
+
+// sourceAliases maps source names to a canonical form for comparison.
+// WEB-DL variants normalize to WEBDL, WEBRip variants to WEBRIP.
+// Plain "WEB" stays as "WEB" and is treated as ambiguous (matches both).
+var sourceAliases = map[string]string{
+	"WEB-DL": "WEBDL",
+	"WEBDL":  "WEBDL",
+	"WEBRIP": "WEBRIP",
+	"WEB":    "WEB",
+}
+
+// normalizeSource converts a source string to its canonical form.
+// Returns the original (uppercased) string if no alias mapping exists.
+func normalizeSource(source string) string {
+	upper := strings.ToUpper(strings.TrimSpace(source))
+	if canonical, ok := sourceAliases[upper]; ok {
+		return canonical
+	}
+	return upper
+}
+
+// sourcesCompatible checks if two sources are compatible for cross-seed precheck.
+// Plain "WEB" is ambiguous and matches both WEBDL and WEBRIP.
+// WEBDL and WEBRIP are explicitly different and do not match each other.
+// The final apply stage trusts file verification, so this is just for precheck gating.
+func sourcesCompatible(source, candidate string) bool {
+	if source == "" || candidate == "" {
+		return true
+	}
+	if source == candidate {
+		return true
+	}
+
+	// WEB is ambiguous: treat it as compatible with both WEBDL and WEBRIP.
+	// It must not match non-web sources (BLURAY, HDTV, etc.).
+	isWebSource := func(s string) bool {
+		switch s {
+		case "WEB", "WEBDL", "WEBRIP":
+			return true
+		default:
+			return false
+		}
+	}
+
+	if !isWebSource(source) || !isWebSource(candidate) {
+		return false
+	}
+
+	// At this point both are web sources, but they differ.
+	// WEBDL and WEBRIP are explicitly different and do not match each other.
+	return source == "WEB" || candidate == "WEB"
 }
 
 // joinNormalizedCodecSlice converts a codec slice to a normalized string for comparison.

--- a/internal/services/crossseed/matching_source_test.go
+++ b/internal/services/crossseed/matching_source_test.go
@@ -1,0 +1,240 @@
+package crossseed
+
+import (
+	"testing"
+
+	"github.com/moistari/rls"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/pkg/stringutils"
+)
+
+func TestNormalizeSource(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		// WEB-DL variants normalize to WEBDL
+		{"WEB-DL uppercase", "WEB-DL", "WEBDL"},
+		{"web-dl lowercase", "web-dl", "WEBDL"},
+		{"WEBDL no hyphen", "WEBDL", "WEBDL"},
+
+		// WEBRip variants normalize to WEBRIP
+		{"WEBRIP uppercase", "WEBRIP", "WEBRIP"},
+		{"WEBRip mixed", "WEBRip", "WEBRIP"},
+		{"webrip lowercase", "webrip", "WEBRIP"},
+
+		// Plain WEB stays as WEB (ambiguous)
+		{"WEB uppercase", "WEB", "WEB"},
+		{"web lowercase", "web", "WEB"},
+
+		// Non-web sources pass through uppercased
+		{"BluRay passthrough", "BluRay", "BLURAY"},
+		{"HDTV passthrough", "HDTV", "HDTV"},
+		{"DVDRip passthrough", "DVDRip", "DVDRIP"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeSource(tt.input)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSourcesCompatible(t *testing.T) {
+	tests := []struct {
+		name       string
+		source     string
+		candidate  string
+		compatible bool
+	}{
+		// Empty sources are always compatible
+		{"both empty", "", "", true},
+		{"source empty", "", "WEBDL", true},
+		{"candidate empty", "WEBDL", "", true},
+
+		// Identical sources are compatible
+		{"both WEBDL", "WEBDL", "WEBDL", true},
+		{"both WEBRIP", "WEBRIP", "WEBRIP", true},
+		{"both WEB", "WEB", "WEB", true},
+		{"both BLURAY", "BLURAY", "BLURAY", true},
+
+		// WEB is ambiguous - matches both WEBDL and WEBRIP
+		{"WEB matches WEBDL", "WEB", "WEBDL", true},
+		{"WEBDL matches WEB", "WEBDL", "WEB", true},
+		{"WEB matches WEBRIP", "WEB", "WEBRIP", true},
+		{"WEBRIP matches WEB", "WEBRIP", "WEB", true},
+
+		// WEBDL and WEBRIP are explicitly different
+		{"WEBDL vs WEBRIP", "WEBDL", "WEBRIP", false},
+		{"WEBRIP vs WEBDL", "WEBRIP", "WEBDL", false},
+
+		// Other sources must match exactly
+		{"BLURAY vs HDTV", "BLURAY", "HDTV", false},
+		{"WEBDL vs BLURAY", "WEBDL", "BLURAY", false},
+		{"WEB does not match BLURAY", "WEB", "BLURAY", false},
+		{"BLURAY does not match WEB", "BLURAY", "WEB", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sourcesCompatible(tt.source, tt.candidate)
+			require.Equal(t, tt.compatible, result)
+		})
+	}
+}
+
+func TestReleasesMatch_SourceCompatibility(t *testing.T) {
+	s := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
+
+	tests := []struct {
+		name        string
+		source      rls.Release
+		candidate   rls.Release
+		shouldMatch bool
+		description string
+	}{
+		{
+			name: "WEB matches WEB-DL",
+			source: rls.Release{
+				Title:      "Movie",
+				Year:       2025,
+				Source:     "WEB",
+				Resolution: "2160p",
+				Group:      "GROUP",
+			},
+			candidate: rls.Release{
+				Title:      "Movie",
+				Year:       2025,
+				Source:     "WEB-DL",
+				Resolution: "2160p",
+				Group:      "GROUP",
+			},
+			shouldMatch: true,
+			description: "WEB is ambiguous and should match WEB-DL for precheck",
+		},
+		{
+			name: "WEB-DL matches WEB",
+			source: rls.Release{
+				Title:      "Movie",
+				Year:       2025,
+				Source:     "WEB-DL",
+				Resolution: "2160p",
+				Group:      "GROUP",
+			},
+			candidate: rls.Release{
+				Title:      "Movie",
+				Year:       2025,
+				Source:     "WEB",
+				Resolution: "2160p",
+				Group:      "GROUP",
+			},
+			shouldMatch: true,
+			description: "WEB-DL should match ambiguous WEB for precheck",
+		},
+		{
+			name: "WEB matches WEBRip",
+			source: rls.Release{
+				Title:      "Movie",
+				Year:       2025,
+				Source:     "WEB",
+				Resolution: "1080p",
+				Group:      "GROUP",
+			},
+			candidate: rls.Release{
+				Title:      "Movie",
+				Year:       2025,
+				Source:     "WEBRip",
+				Resolution: "1080p",
+				Group:      "GROUP",
+			},
+			shouldMatch: true,
+			description: "WEB is ambiguous and should match WEBRip for precheck",
+		},
+		{
+			name: "WEB-DL does not match WEBRip",
+			source: rls.Release{
+				Title:      "Movie",
+				Year:       2025,
+				Source:     "WEB-DL",
+				Resolution: "1080p",
+				Group:      "GROUP",
+			},
+			candidate: rls.Release{
+				Title:      "Movie",
+				Year:       2025,
+				Source:     "WEBRip",
+				Resolution: "1080p",
+				Group:      "GROUP",
+			},
+			shouldMatch: false,
+			description: "WEB-DL and WEBRip are explicitly different sources",
+		},
+		{
+			name: "WEBRip does not match WEB-DL",
+			source: rls.Release{
+				Title:      "Movie",
+				Year:       2025,
+				Source:     "WEBRip",
+				Resolution: "1080p",
+				Group:      "GROUP",
+			},
+			candidate: rls.Release{
+				Title:      "Movie",
+				Year:       2025,
+				Source:     "WEB-DL",
+				Resolution: "1080p",
+				Group:      "GROUP",
+			},
+			shouldMatch: false,
+			description: "WEBRip and WEB-DL are explicitly different sources",
+		},
+		{
+			name: "BluRay does not match WEB-DL",
+			source: rls.Release{
+				Title:      "Movie",
+				Year:       2025,
+				Source:     "BluRay",
+				Resolution: "1080p",
+				Group:      "GROUP",
+			},
+			candidate: rls.Release{
+				Title:      "Movie",
+				Year:       2025,
+				Source:     "WEB-DL",
+				Resolution: "1080p",
+				Group:      "GROUP",
+			},
+			shouldMatch: false,
+			description: "Different source types should not match",
+		},
+		{
+			name: "WEB does not match BluRay",
+			source: rls.Release{
+				Title:      "Movie",
+				Year:       2025,
+				Source:     "WEB",
+				Resolution: "1080p",
+				Group:      "GROUP",
+			},
+			candidate: rls.Release{
+				Title:      "Movie",
+				Year:       2025,
+				Source:     "BluRay",
+				Resolution: "1080p",
+				Group:      "GROUP",
+			},
+			shouldMatch: false,
+			description: "Ambiguous WEB should not match non-web sources",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := s.releasesMatch(&tt.source, &tt.candidate, false)
+			require.Equalf(t, tt.shouldMatch, result, tt.description)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add source normalization (`WEB-DL` → `WEBDL`, `WEBRip` → `WEBRIP`, `WEB` → `WEB`)
- Add `sourcesCompatible()` function for flexible web source matching
- Update `releasesMatch()` to use new source compatibility logic

**Matching behavior:**
- `WEB` ↔ `WEB-DL` ✓ (WEB is ambiguous)
- `WEB` ↔ `WEBRip` ✓ (WEB is ambiguous)
- `WEB-DL` ↔ `WEBRip` ✗ (explicitly different)
- `WEB` ↔ `BluRay` ✗ (non-web sources don't match)

This only affects the precheck gate (webhook `/check`). The final apply stage trusts file verification (size check + qBittorrent recheck) to catch real mismatches.

## Test plan
- [x] Added unit tests for `normalizeSource()`
- [x] Added unit tests for `sourcesCompatible()`
- [x] Added integration tests for `releasesMatch()` with source compatibility
- [x] All existing crossseed tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-seed source compatibility detection for web-based releases. Web sources (WEB, WEBDL, WEBRIP) now intelligently match based on compatibility rules, enabling more effective cross-seeding scenarios.

* **Tests**
  * Added comprehensive test coverage for source normalization and compatibility logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->