### PR TITLE
docs(readme): Clarify ignore pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ Configure tags applied to cross-seed torrents based on how they were discovered:
 
 #### Ignore Patterns
 
-File patterns to skip when comparing torrents. Useful for excluding sidecar files like `.nfo`, `.srr`, or sample folders.
+File patterns to skip when comparing torrents. Useful for excluding sidecar files like `.nfo`, `.srr`, or sample folders. This means torrents including those files will be skipped by default. If you want those to be grabbed, add the files to the ignore pattern.
 
 - Plain strings match any path ending in the text (e.g., `.nfo` ignores all `.nfo` files)
 - Glob patterns treat `/` as a folder separator (e.g., `*/sample/*` ignores sample folders)


### PR DESCRIPTION
This adds a small context to the usage of the ignore patterns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Ignore Patterns behavior: torrents containing ignored files are skipped by default, and modifying the ignore pattern is required to include them in grabs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->