### PR TITLE
fix(web): column filter status now matches all states in category

### DIFF
--- a/web/src/components/torrents/ColumnFilterPopover.tsx
+++ b/web/src/components/torrents/ColumnFilterPopover.tsx
@@ -71,28 +71,21 @@ const DURATION_UNITS: { value: DurationUnit; label: string }[] = [
   { value: "days", label: "Days" },
 ]
 
+// Grouped torrent states matching FilterSidebar categories
+// These are expanded to individual qBittorrent states in columnFilterToExpr
 const TORRENT_STATES: { value: string; label: string }[] = [
   { value: "downloading", label: "Downloading" },
   { value: "uploading", label: "Seeding" },
-  { value: "forcedUP", label: "Forced (UP)" },
-  { value: "forcedDL", label: "Forced (DL)" },
-  { value: "pausedUP", label: "Paused (UP)" },
-  { value: "pausedDL", label: "Paused (DL)" },
-  { value: "stoppedUP", label: "Stopped (UP)" },
-  { value: "stoppedDL", label: "Stopped (DL)" },
-  { value: "queuedUP", label: "Queued (UP)" },
-  { value: "queuedDL", label: "Queued (DL)" },
-  { value: "stalledUP", label: "Stalled (UP)" },
-  { value: "stalledDL", label: "Stalled (DL)" },
-  { value: "error", label: "Error" },
-  { value: "missingFiles", label: "Missing Files" },
-  { value: "checkingUP", label: "Checking (UP)" },
-  { value: "checkingDL", label: "Checking (DL)" },
+  { value: "completed", label: "Completed" },
+  { value: "stopped", label: "Stopped" },
+  { value: "paused", label: "Paused" },
+  { value: "active", label: "Active" },
+  { value: "stalled", label: "Stalled" },
+  { value: "stalled_uploading", label: "Stalled (Up)" },
+  { value: "stalled_downloading", label: "Stalled (Down)" },
+  { value: "errored", label: "Error" },
+  { value: "checking", label: "Checking" },
   { value: "moving", label: "Moving" },
-  { value: "checkingResumeData", label: "Checking Resume Data" },
-  { value: "allocating", label: "Allocating" },
-  { value: "metaDL", label: "Fetching Metadata" },
-  { value: "unknown", label: "Unknown" },
 ]
 
 interface ValueInputProps {

--- a/web/src/lib/column-filter-utils.ts
+++ b/web/src/lib/column-filter-utils.ts
@@ -77,6 +77,30 @@ const COLUMN_TO_QB_FIELD: Partial<Record<keyof (Torrent & CrossInstanceTorrent),
   instanceName: "InstanceName", // Cross-seed filtering instance column
 }
 
+// State categories: maps filter value to all qBittorrent states in that category
+// Must match the backend's torrentStateCategories in sync_manager.go
+const STATE_CATEGORY_MAP: Record<string, string[]> = {
+  // Seeding states (uploading category)
+  uploading: ["uploading", "stalledUP", "queuedUP", "checkingUP", "forcedUP"],
+  // Downloading states
+  downloading: ["downloading", "stalledDL", "metaDL", "queuedDL", "allocating", "checkingDL", "forcedDL"],
+  // Stalled states
+  stalled: ["stalledDL", "stalledUP"],
+  stalled_uploading: ["stalledUP"],
+  stalled_downloading: ["stalledDL"],
+  // Checking states
+  checking: ["checkingDL", "checkingUP", "checkingResumeData"],
+  // Error states
+  errored: ["error", "missingFiles"],
+  // Paused/stopped states
+  paused: ["pausedDL", "pausedUP", "stoppedDL", "stoppedUP"],
+  stopped: ["stoppedDL", "stoppedUP"],
+  // Active states (downloading or uploading actively)
+  active: ["downloading", "uploading", "forcedDL", "forcedUP"],
+  // Moving state
+  moving: ["moving"],
+}
+
 // Remap column IDs for filtering to use total counts instead of connected counts
 // This matches the sorting behavior in TorrentTableOptimized.tsx (lines 972-976)
 const FILTER_COLUMN_REMAP: Record<string, string> = {
@@ -151,9 +175,20 @@ function convertDurationToSeconds(value: number, unit: DurationUnit): number {
  * Examples:
  * - { columnId: "ratio", operation: "gt", value: "2" } => "Ratio > 2"
  * - { columnId: "name", operation: "contains", value: "linux" } => "Name contains \"linux\""
- * - { columnId: "state", operation: "eq", value: "downloading" } => "State == \"downloading\""
  * - { columnId: "size", operation: "gt", value: "10", sizeUnit: "GiB" } => "Size > 10737418240"
  * - { columnId: "added_on", operation: "gt", value: "2024-01-01" } => "AddedOn > 1704067200"
+ *
+ * State filters use category expansion (matching FilterSidebar behavior):
+ * - "uploading" (Seeding) expands to: uploading, stalledUP, queuedUP, checkingUP, forcedUP
+ * - "downloading" expands to: downloading, stalledDL, metaDL, queuedDL, allocating, checkingDL, forcedDL
+ * - "completed" uses progress-based filtering: Progress == 1
+ *
+ * Example expansions:
+ * - { columnId: "state", operation: "eq", value: "uploading" } =>
+ *   "(string(State) == \"uploading\" || string(State) == \"stalledUP\" || ...)"
+ * - { columnId: "state", operation: "ne", value: "uploading" } =>
+ *   "(string(State) != \"uploading\" && string(State) != \"stalledUP\" && ...)"
+ * - { columnId: "state", operation: "eq", value: "completed" } => "Progress == 1"
  */
 export function columnFilterToExpr(filter: ColumnFilter): string | null {
   // Apply column remapping for filtering (use total counts instead of connected)
@@ -298,6 +333,36 @@ export function columnFilterToExpr(filter: ColumnFilter): string | null {
     }
     const fractionValue = numericValue / 100
     return `${fieldName} ${operator} ${fractionValue}`
+  }
+
+  // Handle state column with category expansion
+  // When filtering by a state category (e.g., "uploading" which means "Seeding"),
+  // expand it to match all qBittorrent states in that category
+  if (filter.columnId === "state" && (filter.operation === "eq" || filter.operation === "ne")) {
+    // Special case: "completed" uses progress-based filtering, not state
+    if (filter.value === "completed") {
+      if (filter.operation === "eq") {
+        return "Progress == 1"
+      } else {
+        return "Progress != 1"
+      }
+    }
+
+    const stateCategory = STATE_CATEGORY_MAP[filter.value]
+    if (stateCategory && stateCategory.length >= 1) {
+      // Generate combined expression for all states in the category
+      const stateExpressions = stateCategory.map(state =>
+        `string(${fieldName}) ${operator} "${escapeExprValue(state)}"`
+      )
+      if (filter.operation === "eq") {
+        // "eq" (equals): any state in category matches -> OR logic
+        return `(${stateExpressions.join(" || ")})`
+      } else {
+        // "ne" (not equals): exclude all states in category -> AND logic
+        return `(${stateExpressions.join(" && ")})`
+      }
+    }
+    // Unknown state: fall through to default handling
   }
 
   const needsQuotes = isNaN(Number(filter.value)) ||


### PR DESCRIPTION
## Summary
- Fixes column filter status not properly filtering all states in a category
- Consolidates status options between ColumnFilterPopover and FilterSidebar
- Expands state categories to match all constituent qBittorrent states

## Problem
When using the column filter to select "Is not" + "Seeding", the filter only generated:
```
string(State) != "uploading"
```

This only excluded torrents with the exact `uploading` state. Torrents in related seeding states (`stalledUP`, `queuedUP`, `checkingUP`, `forcedUP`) were still shown.

## Solution
- Replace individual qBittorrent states in ColumnFilterPopover with grouped categories matching FilterSidebar
- Add `STATE_CATEGORY_MAP` that maps each category to its constituent states
- Modify `columnFilterToExpr` to expand categories when generating filter expressions

Now "Is not Seeding" generates:
```
(string(State) != "uploading" && string(State) != "stalledUP" && string(State) != "queuedUP" && string(State) != "checkingUP" && string(State) != "forcedUP")
```

## Test plan
- [x] Apply column filter with "Is" + "Seeding" - should show all seeding torrents
- [x] Apply column filter with "Is not" + "Seeding" - should hide all seeding torrents (including stalled, queued, etc.)
- [x] Verify "Completed" filter works (uses Progress == 1)
- [x] Verify other status categories filter correctly

Fixes #824

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Simplified torrent state filtering options with consolidated state groupings for clearer categorization.
  * Enhanced state filtering logic to properly handle grouped states and special conditions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->