### PR TITLE
fix(web): speed limit input reformatting during typing

### DIFF
--- a/web/src/components/instances/preferences/SpeedLimitsForm.tsx
+++ b/web/src/components/instances/preferences/SpeedLimitsForm.tsx
@@ -80,14 +80,7 @@ function SpeedLimitInput({
               onChange(mibToBytes(mibValue))
             }
           }}
-          onBlur={() => {
-            setIsFocused(false)
-            // Reformat on blur
-            const mibValue = localValue === "" ? 0 : parseFloat(localValue)
-            if (!isNaN(mibValue) && mibValue >= 0) {
-              setLocalValue(mibValue === 0 ? "" : mibValue.toFixed(1))
-            }
-          }}
+          onBlur={() => setIsFocused(false)}
           placeholder="0 (Unlimited)"
           className="flex-1"
         />


### PR DESCRIPTION
## Summary

- Fix Alternative Download/Upload Limit input fields reformatting values during typing
- Use local state to track raw input while focused, only reformat with `.toFixed(1)` on blur
- Prevents typing "35" from showing "3.1" instead of "35"

Fixes #813

## Test plan

- [x] Go to Instance Preferences → Speed tab
- [x] Click on Alternative Download Limit or Alternative Upload Limit field
- [x] Type a two-digit number like "35"
- [x] Verify it shows "35" while typing, then "35.0" after clicking away

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Refined speed limit input behavior: preserves in-field edits, formats value to one decimal when leaving the field, treats zero as empty, and updates underlying value on change.
  * Improved focus handling so editing is more predictable and display formatting is applied only on focus transitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->