### PR TITLE
fix(db): drop legacy hardlink columns from cross_seed_settings

### DIFF
--- a/internal/database/migrations/047_drop_legacy_hardlink_columns.sql
+++ b/internal/database/migrations/047_drop_legacy_hardlink_columns.sql
@@ -1,0 +1,10 @@
+-- Copyright (c) 2025, s0up and the autobrr contributors.
+-- SPDX-License-Identifier: GPL-2.0-or-later
+
+-- Remove legacy hardlink columns from cross_seed_settings.
+-- These were moved to the instances table in migration 040.
+-- Migration 040 noted that cleanup would happen in a later migration - this is it.
+
+ALTER TABLE cross_seed_settings DROP COLUMN use_hardlinks;
+ALTER TABLE cross_seed_settings DROP COLUMN hardlink_base_dir;
+ALTER TABLE cross_seed_settings DROP COLUMN hardlink_dir_preset;


### PR DESCRIPTION
## Summary

- Add migration 047 to drop orphaned `use_hardlinks`, `hardlink_base_dir`, and `hardlink_dir_preset` columns from `cross_seed_settings`
- Remove dummy variable shims from `crossseed.go` queries that were absorbing these unused columns

## Context

Migration 040 moved hardlink settings to the instances table but left orphaned columns in `cross_seed_settings`. The code was also still querying these columns with dummy variables "for backwards compatibility" even though they were never shipped to users. This cleanup was promised in migration 040's comments but never done.

## Test plan

- [ ] Run app and verify cross-seed settings load correctly after migration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed legacy hardlink configuration settings that were previously consolidated into instance-level settings, streamlining the database schema and simplifying configuration management.
  * Cleaned up related obsolete fields and data handling to reduce redundancy and improve consistency between settings and instances.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->