### PR TITLE
feat(crossseed): add custom category prefix toggle

### DIFF
--- a/internal/api/handlers/crossseed.go
+++ b/internal/api/handlers/crossseed.go
@@ -43,6 +43,7 @@ type automationSettingsRequest struct {
 	UseCrossCategorySuffix       bool     `json:"useCrossCategorySuffix"`
 	UseCustomCategory            bool     `json:"useCustomCategory"`
 	CustomCategory               string   `json:"customCategory"`
+	PrefixOriginalCategory       bool     `json:"prefixOriginalCategory"`
 	RunExternalProgramID         *int     `json:"runExternalProgramId"`
 	SkipRecheck                  bool     `json:"skipRecheck"`
 }
@@ -72,6 +73,7 @@ type automationSettingsPatchRequest struct {
 	UseCrossCategorySuffix         *bool       `json:"useCrossCategorySuffix,omitempty"`
 	UseCustomCategory              *bool       `json:"useCustomCategory,omitempty"`
 	CustomCategory                 *string     `json:"customCategory,omitempty"`
+	PrefixOriginalCategory         *bool       `json:"prefixOriginalCategory,omitempty"`
 	RunExternalProgramID           optionalInt `json:"runExternalProgramId"`
 	// Source-specific tagging
 	RSSAutomationTags    *[]string `json:"rssAutomationTags,omitempty"`
@@ -167,6 +169,7 @@ func (r automationSettingsPatchRequest) isEmpty() bool {
 		r.UseCrossCategorySuffix == nil &&
 		r.UseCustomCategory == nil &&
 		r.CustomCategory == nil &&
+		r.PrefixOriginalCategory == nil &&
 		!r.RunExternalProgramID.Set &&
 		r.RSSAutomationTags == nil &&
 		r.SeededSearchTags == nil &&
@@ -258,6 +261,9 @@ func applyAutomationSettingsPatch(settings *models.CrossSeedAutomationSettings, 
 	}
 	if patch.CustomCategory != nil {
 		settings.CustomCategory = *patch.CustomCategory
+	}
+	if patch.PrefixOriginalCategory != nil {
+		settings.PrefixOriginalCategory = *patch.PrefixOriginalCategory
 	}
 	if patch.RunExternalProgramID.Set {
 		settings.RunExternalProgramID = patch.RunExternalProgramID.Value
@@ -686,6 +692,7 @@ func (h *CrossSeedHandler) UpdateAutomationSettings(w http.ResponseWriter, r *ht
 		UseCrossCategorySuffix:       req.UseCrossCategorySuffix,
 		UseCustomCategory:            req.UseCustomCategory,
 		CustomCategory:               req.CustomCategory,
+		PrefixOriginalCategory:       req.PrefixOriginalCategory,
 		RunExternalProgramID:         req.RunExternalProgramID,
 		SkipRecheck:                  req.SkipRecheck,
 	}

--- a/internal/api/handlers/crossseed_patch_test.go
+++ b/internal/api/handlers/crossseed_patch_test.go
@@ -147,6 +147,7 @@ func TestApplyAutomationSettingsPatch_CustomCategory(t *testing.T) {
 		UseCategoryFromIndexer: false,
 		UseCustomCategory:      false,
 		CustomCategory:         "",
+		PrefixOriginalCategory: false,
 	}
 
 	customCat := "cross-seed"
@@ -154,6 +155,7 @@ func TestApplyAutomationSettingsPatch_CustomCategory(t *testing.T) {
 		UseCrossCategorySuffix: ptrBool(false),
 		UseCustomCategory:      ptrBool(true),
 		CustomCategory:         &customCat,
+		PrefixOriginalCategory: ptrBool(true),
 	}
 
 	applyAutomationSettingsPatch(&existing, patch)
@@ -166,5 +168,8 @@ func TestApplyAutomationSettingsPatch_CustomCategory(t *testing.T) {
 	}
 	if existing.CustomCategory != "cross-seed" {
 		t.Fatalf("expected customCategory to be 'cross-seed', got %q", existing.CustomCategory)
+	}
+	if !existing.PrefixOriginalCategory {
+		t.Fatalf("expected prefixOriginalCategory to be true")
 	}
 }

--- a/internal/database/migrations/048_add_custom_category_prefix_original.sql
+++ b/internal/database/migrations/048_add_custom_category_prefix_original.sql
@@ -1,0 +1,5 @@
+-- Add option to prefix custom category to original torrent category
+-- When prefix_original_category is TRUE and use_custom_category is TRUE,
+-- the cross-seed category becomes: {custom_category}/{original_category}
+
+ALTER TABLE cross_seed_settings ADD COLUMN prefix_original_category BOOLEAN NOT NULL DEFAULT 0;

--- a/internal/models/crossseed.go
+++ b/internal/models/crossseed.go
@@ -62,6 +62,7 @@ type CrossSeedAutomationSettings struct {
 	// Custom category: use exact user-specified category without any suffixing
 	UseCustomCategory bool   `json:"useCustomCategory"` // Use custom category instead of suffix or indexer name
 	CustomCategory    string `json:"customCategory"`    // Custom category name when UseCustomCategory is true
+	PrefixOriginalCategory bool   `json:"prefixOriginalCategory"` // Prepend custom category to original category (e.g., "Cross-Seed/Movies")
 
 	// Skip auto-resume settings per source mode.
 	// When enabled, torrents remain paused after hash check instead of auto-resuming.
@@ -122,6 +123,7 @@ func DefaultCrossSeedAutomationSettings() *CrossSeedAutomationSettings {
 		// Custom category - default to false (use suffix mode by default)
 		UseCustomCategory: false,
 		CustomCategory:    "",
+		PrefixOriginalCategory: false,
 		// Skip auto-resume - default to false to preserve existing behavior
 		SkipAutoResumeRSS:            false,
 		SkipAutoResumeSeededSearch:   false,
@@ -306,7 +308,7 @@ func (s *CrossSeedStore) GetSettings(ctx context.Context) (*CrossSeedAutomationS
 		       use_category_from_indexer, run_external_program_id,
 		       rss_automation_tags, seeded_search_tags, completion_search_tags,
 		       webhook_tags, inherit_source_tags, use_cross_category_suffix,
-		       use_custom_category, custom_category,
+		       use_custom_category, custom_category, prefix_original_category,
 		       skip_auto_resume_rss, skip_auto_resume_seeded_search,
 		       skip_auto_resume_completion, skip_auto_resume_webhook,
 		       skip_recheck, skip_piece_boundary_safety_check,
@@ -355,6 +357,7 @@ func (s *CrossSeedStore) GetSettings(ctx context.Context) (*CrossSeedAutomationS
 		&settings.UseCrossCategorySuffix,
 		&settings.UseCustomCategory,
 		&settings.CustomCategory,
+		&settings.PrefixOriginalCategory,
 		&settings.SkipAutoResumeRSS,
 		&settings.SkipAutoResumeSeededSearch,
 		&settings.SkipAutoResumeCompletion,
@@ -529,12 +532,12 @@ func (s *CrossSeedStore) UpsertSettings(ctx context.Context, settings *CrossSeed
 			use_category_from_indexer, run_external_program_id,
 			rss_automation_tags, seeded_search_tags, completion_search_tags,
 			webhook_tags, inherit_source_tags, use_cross_category_suffix,
-			use_custom_category, custom_category,
+			use_custom_category, custom_category, prefix_original_category,
 			skip_auto_resume_rss, skip_auto_resume_seeded_search,
 			skip_auto_resume_completion, skip_auto_resume_webhook,
 			skip_recheck, skip_piece_boundary_safety_check
 		) VALUES (
-			?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+			?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 		)
 		ON CONFLICT(id) DO UPDATE SET
 			enabled = excluded.enabled,
@@ -565,6 +568,7 @@ func (s *CrossSeedStore) UpsertSettings(ctx context.Context, settings *CrossSeed
 			use_cross_category_suffix = excluded.use_cross_category_suffix,
 			use_custom_category = excluded.use_custom_category,
 			custom_category = excluded.custom_category,
+			prefix_original_category = excluded.prefix_original_category,
 			skip_auto_resume_rss = excluded.skip_auto_resume_rss,
 			skip_auto_resume_seeded_search = excluded.skip_auto_resume_seeded_search,
 			skip_auto_resume_completion = excluded.skip_auto_resume_completion,
@@ -614,6 +618,7 @@ func (s *CrossSeedStore) UpsertSettings(ctx context.Context, settings *CrossSeed
 		settings.UseCrossCategorySuffix,
 		settings.UseCustomCategory,
 		settings.CustomCategory,
+		settings.PrefixOriginalCategory,
 		settings.SkipAutoResumeRSS,
 		settings.SkipAutoResumeSeededSearch,
 		settings.SkipAutoResumeCompletion,

--- a/internal/services/crossseed/crossseed_test.go
+++ b/internal/services/crossseed/crossseed_test.go
@@ -1469,6 +1469,86 @@ func TestCrossSeed_CategoryAndTagPreservation(t *testing.T) {
 			expectedCrossCategory: "movies.cross",
 			expectedTags:          []string{},
 		},
+		{
+			name: "custom category with prefix prepends to original category",
+			request: &CrossSeedRequest{
+				Category: "",
+				Tags:     []string{},
+			},
+			matched: qbt.Torrent{
+				Category: "movies",
+				Tags:     "",
+			},
+			settings: &models.CrossSeedAutomationSettings{
+				UseCustomCategory:      true,
+				CustomCategory:         "cross-seed",
+				PrefixOriginalCategory: true,
+			},
+			inheritSourceTags:     false,
+			expectedBaseCategory:  "cross-seed",
+			expectedCrossCategory: "cross-seed/movies",
+			expectedTags:          []string{},
+		},
+		{
+			name: "custom category with prefix and nested original category",
+			request: &CrossSeedRequest{
+				Category: "",
+				Tags:     []string{},
+			},
+			matched: qbt.Torrent{
+				Category: "movies/1080p",
+				Tags:     "",
+			},
+			settings: &models.CrossSeedAutomationSettings{
+				UseCustomCategory:      true,
+				CustomCategory:         "cross-seed",
+				PrefixOriginalCategory: true,
+			},
+			inheritSourceTags:     false,
+			expectedBaseCategory:  "cross-seed",
+			expectedCrossCategory: "cross-seed/movies/1080p",
+			expectedTags:          []string{},
+		},
+		{
+			name: "custom category with prefix and empty original category",
+			request: &CrossSeedRequest{
+				Category: "",
+				Tags:     []string{},
+			},
+			matched: qbt.Torrent{
+				Category: "",
+				Tags:     "",
+			},
+			settings: &models.CrossSeedAutomationSettings{
+				UseCustomCategory:      true,
+				CustomCategory:         "cross-seed",
+				PrefixOriginalCategory: true,
+			},
+			inheritSourceTags:     false,
+			expectedBaseCategory:  "cross-seed",
+			expectedCrossCategory: "cross-seed",
+			expectedTags:          []string{},
+		},
+		{
+			name: "no double prefix for already prefixed category",
+			request: &CrossSeedRequest{
+				Category: "",
+				Tags:     []string{},
+			},
+			matched: qbt.Torrent{
+				Category: "cross-seed/movies",
+				Tags:     "",
+			},
+			settings: &models.CrossSeedAutomationSettings{
+				UseCustomCategory:      true,
+				CustomCategory:         "cross-seed",
+				PrefixOriginalCategory: true,
+			},
+			inheritSourceTags:     false,
+			expectedBaseCategory:  "cross-seed",
+			expectedCrossCategory: "cross-seed/movies",
+			expectedTags:          []string{},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -7242,6 +7242,22 @@ func appendCrossSuffix(category string) string {
 	return category + ".cross"
 }
 
+// prependCustomCategoryPrefix prepends a custom category prefix to a category name.
+// Returns empty string if both are empty, just the prefix if category is empty and avoids double-prefixing.
+func prependCustomCategoryPrefix(prefix, category string) string {
+	if prefix == "" {
+		return category
+	}
+	if category == "" {
+		return prefix
+	}
+	expectedPrefix := prefix + "/"
+	if strings.HasPrefix(category, expectedPrefix) || category == prefix {
+		return category
+	}
+	return prefix + "/" + category
+}
+
 // ensureCrossCategory ensures a .cross suffixed category exists with the correct save_path.
 // If the category already exists, it verifies the save_path matches (logs warning if different).
 // If it doesn't exist, it creates it with the provided save_path.
@@ -7324,6 +7340,10 @@ func (s *Service) determineCrossSeedCategory(ctx context.Context, req *CrossSeed
 
 	// Custom category takes priority - use exact category without any suffix
 	if settings != nil && settings.UseCustomCategory && settings.CustomCategory != "" {
+		if settings.PrefixOriginalCategory {
+			// Prepend custom category to matched torrents category
+			return settings.CustomCategory, prependCustomCategoryPrefix(settings.CustomCategory, matchedCategory)
+		}
 		return settings.CustomCategory, settings.CustomCategory
 	}
 

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -4551,6 +4551,9 @@ components:
         customCategory:
           type: string
           description: Custom category name when useCustomCategory is true
+        prefixOriginalCategory:
+          type: boolean
+          description: Prepend custom category to original category (e.g., cross-seed/movies)
         runExternalProgramId:
           type: integer
           nullable: true
@@ -4636,6 +4639,9 @@ components:
         customCategory:
           type: string
           description: Custom category name when useCustomCategory is true
+        prefixOriginalCategory:
+          type: boolean
+          description: Prepend custom category to original category (e.g., cross-seed/movies)
         runExternalProgramId:
           type: integer
           nullable: true

--- a/web/src/pages/CrossSeedPage.tsx
+++ b/web/src/pages/CrossSeedPage.tsx
@@ -76,6 +76,7 @@ interface GlobalCrossSeedSettings {
   useCrossCategorySuffix: boolean
   useCustomCategory: boolean
   customCategory: string
+  prefixOriginalCategory: boolean
   runExternalProgramId?: number | null
   ignorePatterns: string
   // Source-specific tagging
@@ -127,6 +128,7 @@ const DEFAULT_GLOBAL_SETTINGS: GlobalCrossSeedSettings = {
   useCrossCategorySuffix: true,
   useCustomCategory: false,
   customCategory: "",
+  prefixOriginalCategory: false,
   runExternalProgramId: null,
   ignorePatterns: "",
   // Source-specific tagging defaults
@@ -728,6 +730,7 @@ export function CrossSeedPage({ activeTab, onTabChange }: CrossSeedPageProps) {
         useCrossCategorySuffix: settings.useCrossCategorySuffix ?? true,
         useCustomCategory: settings.useCustomCategory ?? false,
         customCategory: settings.customCategory ?? "",
+        prefixOriginalCategory: settings.prefixOriginalCategory ?? false,
         runExternalProgramId: settings.runExternalProgramId ?? null,
         ignorePatterns: Array.isArray(settings.ignorePatterns)
           ? settings.ignorePatterns.join("\n")
@@ -832,6 +835,7 @@ export function CrossSeedPage({ activeTab, onTabChange }: CrossSeedPageProps) {
         useCrossCategorySuffix: settings.useCrossCategorySuffix ?? true,
         useCustomCategory: settings.useCustomCategory ?? false,
         customCategory: settings.customCategory ?? "",
+        prefixOriginalCategory: settings.prefixOriginalCategory ?? false,
         runExternalProgramId: settings.runExternalProgramId ?? null,
         ignorePatterns: ignorePatterns.length > 0 ? ignorePatterns.join(", ") : "",
         rssAutomationTags: settings.rssAutomationTags ?? ["cross-seed"],
@@ -859,6 +863,7 @@ export function CrossSeedPage({ activeTab, onTabChange }: CrossSeedPageProps) {
       useCrossCategorySuffix: globalSource.useCrossCategorySuffix,
       useCustomCategory: globalSource.useCustomCategory,
       customCategory: globalSource.customCategory,
+      prefixOriginalCategory: globalSource.prefixOriginalCategory,
       runExternalProgramId: globalSource.runExternalProgramId,
       ignorePatterns: normalizeIgnorePatterns(globalSource.ignorePatterns),
       // Source-specific tagging
@@ -2418,15 +2423,39 @@ export function CrossSeedPage({ activeTab, onTabChange }: CrossSeedPageProps) {
                       </div>
                       <p className="text-xs text-muted-foreground">Use a fixed category name for all cross-seeds.</p>
                       {globalSettings.useCustomCategory && (
-                        <MultiSelect
-                          options={customCategorySelectOptions}
-                          selected={globalSettings.customCategory ? [globalSettings.customCategory] : []}
-                          onChange={values => setGlobalSettings(prev => ({ ...prev, customCategory: values[0] ?? "" }))}
-                          placeholder="Select or type a category..."
-                          className="mt-2 max-w-xs"
-                          creatable
-                          onCreateOption={value => setGlobalSettings(prev => ({ ...prev, customCategory: value }))}
-                        />
+                        <>
+                          <MultiSelect
+                            options={customCategorySelectOptions}
+                            selected={globalSettings.customCategory ? [globalSettings.customCategory] : []}
+                            onChange={values => setGlobalSettings(prev => ({ ...prev, customCategory: values[0] ?? "" }))}
+                            placeholder="Select or type a category..."
+                            className="mt-2 max-w-xs"
+                            creatable
+                            onCreateOption={value => setGlobalSettings(prev => ({ ...prev, customCategory: value }))}
+                          />
+                          <div className="flex items-center gap-2 mt-3">
+                            <Switch
+                              id="prefix-original-category"
+                              checked={globalSettings.prefixOriginalCategory}
+                              onCheckedChange={value => setGlobalSettings(prev => ({ ...prev, prefixOriginalCategory: !!value }))}
+                            />
+                            <div className="flex items-center gap-1.5">
+                              <Label htmlFor="prefix-original-category" className="cursor-pointer">
+                                Include original category
+                              </Label>
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <button type="button" className="text-muted-foreground hover:text-foreground" aria-label="Include original category help">
+                                    <Info className="h-3.5 w-3.5" />
+                                  </button>
+                                </TooltipTrigger>
+                                <TooltipContent align="start" className="max-w-sm text-xs">
+                                  All cross-seeds will be placed in a subcategory using the original torrents category. For example, if the custom category is "cross-seed" and the original torrent is in "movies", the cross-seed will be placed in "cross-seed/movies". Also works with nested categories like "movies/1080p" to "cross-seed/movies/1080p".
+                                </TooltipContent>
+                              </Tooltip>
+                            </div>
+                          </div>
+                        </>
                       )}
                     </div>
                   </div>

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -1666,6 +1666,7 @@ export interface CrossSeedAutomationSettings {
   useCrossCategorySuffix: boolean
   useCustomCategory: boolean
   customCategory: string
+  prefixOriginalCategory: boolean
   runExternalProgramId?: number | null
   // Source-specific tagging
   rssAutomationTags: string[]
@@ -1712,6 +1713,7 @@ export interface CrossSeedAutomationSettingsPatch {
   useCrossCategorySuffix?: boolean
   useCustomCategory?: boolean
   customCategory?: string
+  prefixOriginalCategory?: boolean
   runExternalProgramId?: number | null
   // Source-specific tagging
   rssAutomationTags?: string[]


### PR DESCRIPTION
let me know 👍

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new configuration option to Cross Seed automation settings that allows prefixing the original category when using custom categories. When enabled, categories are formatted as "{custom_category}/{original_category}", providing more granular organization.

* **Chores**
  * Updated database schema, API definitions, and web interface components to support the new category prefixing configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->