### PR TITLE
fix(web): truncate file progress percentage instead of rounding

### DIFF
--- a/web/src/components/torrents/details/TorrentFileTable.tsx
+++ b/web/src/components/torrents/details/TorrentFileTable.tsx
@@ -400,7 +400,7 @@ export const TorrentFileTable = memo(function TorrentFileTable({
                       <div className="flex items-center gap-2">
                         <Progress value={progress} className="h-1.5 w-16" />
                         <span className="tabular-nums text-[10px] text-muted-foreground w-10">
-                          {progress.toFixed(1)}%
+                          {(Math.floor(progress * 10) / 10).toFixed(1)}%
                         </span>
                       </div>
                     </td>


### PR DESCRIPTION
## Summary
- Fixes file progress percentage display to truncate instead of round
- Prevents files at 99.95%+ from showing as "100.0%" when incomplete
- Only truly complete files now display 100.0%

## Test plan
- [ ] View a torrent with files still downloading
- [ ] Verify files near completion (99.9x%) don't show as 100.0%
- [ ] Verify fully complete files still show 100.0%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the torrent file progress percentage display by modifying how values are rendered to the user, switching from standard rounding to floor-truncation methodology. This ensures progress percentages are consistently displayed to one decimal place with improved accuracy and visual consistency when tracking torrent download and upload file transfer progress.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->