### PR TITLE
feat(public-trackers): add bulk tracker management for public torrents

### DIFF
--- a/cmd/qui/main.go
+++ b/cmd/qui/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/autobrr/qui/internal/services/jackett"
 	"github.com/autobrr/qui/internal/services/license"
 	"github.com/autobrr/qui/internal/services/orphanscan"
+	"github.com/autobrr/qui/internal/services/publictrackers"
 	"github.com/autobrr/qui/internal/services/reannounce"
 	"github.com/autobrr/qui/internal/services/trackericons"
 	"github.com/autobrr/qui/internal/update"
@@ -488,6 +489,7 @@ func (app *Application) runServer() {
 	trackerCustomizationStore := models.NewTrackerCustomizationStore(db)
 	dashboardSettingsStore := models.NewDashboardSettingsStore(db)
 	logExclusionsStore := models.NewLogExclusionsStore(db)
+	publicTrackerSettingsStore := models.NewPublicTrackerSettingsStore(db)
 
 	clientAPIKeyStore := models.NewClientAPIKeyStore(db)
 	externalProgramStore := models.NewExternalProgramStore(db)
@@ -573,6 +575,8 @@ func (app *Application) runServer() {
 
 	orphanScanStore := models.NewOrphanScanStore(db)
 	orphanScanService := orphanscan.NewService(orphanscan.DefaultConfig(), instanceStore, orphanScanStore, syncManager)
+
+	publicTrackersService := publictrackers.NewService(publicTrackerSettingsStore, syncManager)
 
 	syncManager.SetTorrentCompletionHandler(crossSeedService.HandleTorrentCompletion)
 
@@ -688,6 +692,7 @@ func (app *Application) runServer() {
 		OrphanScanService:                orphanScanService,
 		ArrInstanceStore:                 arrInstanceStore,
 		ArrService:                       arrService,
+		PublicTrackersService:            publicTrackersService,
 	})
 
 	errorChannel := make(chan error)

--- a/internal/api/handlers/public_trackers.go
+++ b/internal/api/handlers/public_trackers.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/rs/zerolog/log"
+
+	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/services/publictrackers"
+)
+
+type PublicTrackersHandler struct {
+	service *publictrackers.Service
+}
+
+func NewPublicTrackersHandler(service *publictrackers.Service) *PublicTrackersHandler {
+	return &PublicTrackersHandler{
+		service: service,
+	}
+}
+
+// GetSettings returns the current public tracker settings
+func (h *PublicTrackersHandler) GetSettings(w http.ResponseWriter, r *http.Request) {
+	settings, err := h.service.GetSettings(r.Context())
+	if err != nil {
+		log.Error().Err(err).Msg("failed to get public tracker settings")
+		RespondError(w, http.StatusInternalServerError, "Failed to load public tracker settings")
+		return
+	}
+
+	RespondJSON(w, http.StatusOK, settings)
+}
+
+// UpdateSettings updates the public tracker settings
+func (h *PublicTrackersHandler) UpdateSettings(w http.ResponseWriter, r *http.Request) {
+	var input models.PublicTrackerSettingsInput
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		log.Warn().Err(err).Msg("failed to decode public tracker settings request")
+		RespondError(w, http.StatusBadRequest, "Invalid request payload")
+		return
+	}
+
+	settings, err := h.service.UpdateSettings(r.Context(), &input)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to update public tracker settings")
+		RespondError(w, http.StatusInternalServerError, "Failed to update public tracker settings")
+		return
+	}
+
+	RespondJSON(w, http.StatusOK, settings)
+}
+
+// RefreshTrackerList fetches the tracker list from the configured URL
+func (h *PublicTrackersHandler) RefreshTrackerList(w http.ResponseWriter, r *http.Request) {
+	settings, err := h.service.RefreshTrackerList(r.Context())
+	if err != nil {
+		log.Error().Err(err).Msg("failed to refresh public tracker list")
+		RespondError(w, http.StatusInternalServerError, "Failed to refresh tracker list: "+err.Error())
+		return
+	}
+
+	RespondJSON(w, http.StatusOK, settings)
+}
+
+// ExecuteActionRequest represents the request body for executing a public tracker action
+type ExecuteActionRequest struct {
+	Hashes    []string                 `json:"hashes"`
+	PruneMode publictrackers.PruneMode `json:"pruneMode"`
+}
+
+// ExecuteAction performs a public tracker action on the specified torrents
+func (h *PublicTrackersHandler) ExecuteAction(w http.ResponseWriter, r *http.Request) {
+	instanceID, err := strconv.Atoi(chi.URLParam(r, "instanceID"))
+	if err != nil || instanceID <= 0 {
+		RespondError(w, http.StatusBadRequest, "Invalid instance ID")
+		return
+	}
+
+	var req ExecuteActionRequest
+	if decodeErr := json.NewDecoder(r.Body).Decode(&req); decodeErr != nil {
+		log.Warn().Err(decodeErr).Msg("failed to decode public tracker action request")
+		RespondError(w, http.StatusBadRequest, "Invalid request payload")
+		return
+	}
+
+	if len(req.Hashes) == 0 {
+		RespondError(w, http.StatusBadRequest, "No torrent hashes provided")
+		return
+	}
+
+	// Validate prune mode
+	switch req.PruneMode {
+	case publictrackers.PruneModeAll, publictrackers.PruneModeDead, publictrackers.PruneModeNone:
+		// Valid
+	default:
+		RespondError(w, http.StatusBadRequest, "Invalid prune mode. Must be 'all', 'dead', or 'none'")
+		return
+	}
+
+	result, err := h.service.ExecuteAction(r.Context(), instanceID, req.Hashes, req.PruneMode)
+	if err != nil {
+		log.Error().Err(err).Int("instanceID", instanceID).Msg("failed to execute public tracker action")
+		RespondError(w, http.StatusInternalServerError, "Failed to execute action: "+err.Error())
+		return
+	}
+
+	log.Info().
+		Int("instanceID", instanceID).
+		Int("totalTorrents", result.TotalTorrents).
+		Int("processedCount", result.ProcessedCount).
+		Int("skippedPrivate", result.SkippedPrivate).
+		Int("trackersAdded", result.TrackersAdded).
+		Int("trackersRemoved", result.TrackersRemoved).
+		Msg("public tracker action completed")
+
+	RespondJSON(w, http.StatusOK, result)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/autobrr/qui/internal/services/jackett"
 	"github.com/autobrr/qui/internal/services/license"
 	"github.com/autobrr/qui/internal/services/orphanscan"
+	"github.com/autobrr/qui/internal/services/publictrackers"
 	"github.com/autobrr/qui/internal/services/reannounce"
 	"github.com/autobrr/qui/internal/services/trackericons"
 	"github.com/autobrr/qui/internal/update"
@@ -77,6 +78,7 @@ type Server struct {
 	orphanScanService                *orphanscan.Service
 	arrInstanceStore                 *models.ArrInstanceStore
 	arrService                       *arr.Service
+	publicTrackersService            *publictrackers.Service
 }
 
 type Dependencies struct {
@@ -112,6 +114,7 @@ type Dependencies struct {
 	OrphanScanService                *orphanscan.Service
 	ArrInstanceStore                 *models.ArrInstanceStore
 	ArrService                       *arr.Service
+	PublicTrackersService            *publictrackers.Service
 }
 
 func NewServer(deps *Dependencies) *Server {
@@ -154,6 +157,7 @@ func NewServer(deps *Dependencies) *Server {
 		orphanScanService:                deps.OrphanScanService,
 		arrInstanceStore:                 deps.ArrInstanceStore,
 		arrService:                       deps.ArrService,
+		publicTrackersService:            deps.PublicTrackersService,
 	}
 
 	return &s
@@ -295,6 +299,7 @@ func (s *Server) Handler() (*chi.Mux, error) {
 	trackerCustomizationHandler := handlers.NewTrackerCustomizationHandler(s.trackerCustomizationStore)
 	dashboardSettingsHandler := handlers.NewDashboardSettingsHandler(s.dashboardSettingsStore)
 	logExclusionsHandler := handlers.NewLogExclusionsHandler(s.logExclusionsStore)
+	publicTrackersHandler := handlers.NewPublicTrackersHandler(s.publicTrackersService)
 	logsHandler := handlers.NewLogsHandler(s.config)
 
 	// Torznab/Jackett handler
@@ -396,6 +401,13 @@ func (s *Server) Handler() (*chi.Mux, error) {
 			r.Get("/dashboard-settings", dashboardSettingsHandler.Get)
 			r.Put("/dashboard-settings", dashboardSettingsHandler.Update)
 
+			// Public trackers management
+			r.Route("/public-trackers", func(r chi.Router) {
+				r.Get("/settings", publicTrackersHandler.GetSettings)
+				r.Patch("/settings", publicTrackersHandler.UpdateSettings)
+				r.Post("/refresh", publicTrackersHandler.RefreshTrackerList)
+			})
+
 			// Log exclusions (muted log message patterns)
 			r.Get("/log-exclusions", logExclusionsHandler.Get)
 			r.Put("/log-exclusions", logExclusionsHandler.Update)
@@ -426,6 +438,7 @@ func (s *Server) Handler() (*chi.Mux, error) {
 						r.Post("/bulk-action", torrentsHandler.BulkAction)
 						r.Post("/add-peers", torrentsHandler.AddPeers)
 						r.Post("/ban-peers", torrentsHandler.BanPeers)
+						r.Post("/public-tracker-action", publicTrackersHandler.ExecuteAction)
 
 						r.Route("/{hash}", func(r chi.Router) {
 							// Torrent details

--- a/internal/database/migrations/048_add_public_tracker_settings.sql
+++ b/internal/database/migrations/048_add_public_tracker_settings.sql
@@ -1,0 +1,12 @@
+-- Public tracker management settings (singleton table)
+CREATE TABLE IF NOT EXISTS public_tracker_settings (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    tracker_list_url TEXT NOT NULL DEFAULT '',
+    cached_trackers TEXT NOT NULL DEFAULT '[]',
+    last_fetched_at TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Insert default row
+INSERT OR IGNORE INTO public_tracker_settings (id) VALUES (1);

--- a/internal/models/public_tracker_settings.go
+++ b/internal/models/public_tracker_settings.go
@@ -1,0 +1,157 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package models
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/autobrr/qui/internal/dbinterface"
+)
+
+type PublicTrackerSettings struct {
+	ID             int        `json:"id"`
+	TrackerListURL string     `json:"trackerListUrl"`
+	CachedTrackers []string   `json:"cachedTrackers"`
+	LastFetchedAt  *time.Time `json:"lastFetchedAt,omitempty"`
+	CreatedAt      time.Time  `json:"createdAt"`
+	UpdatedAt      time.Time  `json:"updatedAt"`
+}
+
+type PublicTrackerSettingsInput struct {
+	TrackerListURL *string  `json:"trackerListUrl,omitempty"`
+	CachedTrackers []string `json:"cachedTrackers,omitempty"`
+}
+
+type PublicTrackerSettingsStore struct {
+	db dbinterface.Querier
+}
+
+func NewPublicTrackerSettingsStore(db dbinterface.Querier) *PublicTrackerSettingsStore {
+	return &PublicTrackerSettingsStore{db: db}
+}
+
+// Get returns the singleton public tracker settings
+func (s *PublicTrackerSettingsStore) Get(ctx context.Context) (*PublicTrackerSettings, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, tracker_list_url, cached_trackers, last_fetched_at, created_at, updated_at
+		FROM public_tracker_settings
+		WHERE id = 1
+	`)
+
+	var pts PublicTrackerSettings
+	var trackersJSON string
+	var lastFetchedAt sql.NullTime
+
+	err := row.Scan(
+		&pts.ID, &pts.TrackerListURL, &trackersJSON, &lastFetchedAt, &pts.CreatedAt, &pts.UpdatedAt,
+	)
+
+	if errors.Is(err, sql.ErrNoRows) {
+		// This shouldn't happen since migration inserts default row, but handle gracefully
+		return s.createDefault(ctx)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("scan public tracker settings: %w", err)
+	}
+
+	// Parse cached trackers JSON
+	if trackersJSON != "" && trackersJSON != "[]" {
+		if err := json.Unmarshal([]byte(trackersJSON), &pts.CachedTrackers); err != nil {
+			pts.CachedTrackers = []string{}
+		}
+	} else {
+		pts.CachedTrackers = []string{}
+	}
+
+	if lastFetchedAt.Valid {
+		pts.LastFetchedAt = &lastFetchedAt.Time
+	}
+
+	return &pts, nil
+}
+
+// Update updates the public tracker settings (partial update)
+func (s *PublicTrackerSettingsStore) Update(ctx context.Context, input *PublicTrackerSettingsInput) (*PublicTrackerSettings, error) {
+	if input == nil {
+		return nil, errors.New("input is nil")
+	}
+
+	// Get existing settings
+	existing, err := s.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Merge input with existing
+	if input.TrackerListURL != nil {
+		existing.TrackerListURL = *input.TrackerListURL
+	}
+	if input.CachedTrackers != nil {
+		existing.CachedTrackers = input.CachedTrackers
+	}
+
+	// Serialize cached trackers
+	trackersJSON, err := json.Marshal(existing.CachedTrackers)
+	if err != nil {
+		return nil, fmt.Errorf("marshal cached trackers: %w", err)
+	}
+
+	// Update in database
+	_, err = s.db.ExecContext(ctx, `
+		UPDATE public_tracker_settings
+		SET tracker_list_url = ?,
+		    cached_trackers = ?,
+		    updated_at = CURRENT_TIMESTAMP
+		WHERE id = 1
+	`, existing.TrackerListURL, string(trackersJSON))
+	if err != nil {
+		return nil, fmt.Errorf("update public tracker settings: %w", err)
+	}
+
+	return s.Get(ctx)
+}
+
+// UpdateCachedTrackers updates just the cached trackers and last_fetched_at timestamp
+func (s *PublicTrackerSettingsStore) UpdateCachedTrackers(ctx context.Context, trackers []string) error {
+	trackersJSON, err := json.Marshal(trackers)
+	if err != nil {
+		return fmt.Errorf("marshal trackers: %w", err)
+	}
+
+	_, err = s.db.ExecContext(ctx, `
+		UPDATE public_tracker_settings
+		SET cached_trackers = ?,
+		    last_fetched_at = CURRENT_TIMESTAMP,
+		    updated_at = CURRENT_TIMESTAMP
+		WHERE id = 1
+	`, string(trackersJSON))
+	if err != nil {
+		return fmt.Errorf("update cached trackers: %w", err)
+	}
+	return nil
+}
+
+// createDefault creates the default settings row (should only be called if migration didn't run)
+func (s *PublicTrackerSettingsStore) createDefault(ctx context.Context) (*PublicTrackerSettings, error) {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT OR IGNORE INTO public_tracker_settings (id, tracker_list_url, cached_trackers)
+		VALUES (1, '', '[]')
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("create default public tracker settings: %w", err)
+	}
+
+	return &PublicTrackerSettings{
+		ID:             1,
+		TrackerListURL: "",
+		CachedTrackers: []string{},
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}, nil
+}

--- a/internal/services/publictrackers/service.go
+++ b/internal/services/publictrackers/service.go
@@ -1,0 +1,292 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package publictrackers
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/rs/zerolog/log"
+
+	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/qbittorrent"
+	"github.com/autobrr/qui/pkg/httphelpers"
+)
+
+const (
+	fetchTimeout    = 30 * time.Second
+	maxResponseSize = 1 << 20 // 1 MiB
+)
+
+// PruneMode defines how existing trackers should be handled
+type PruneMode string
+
+const (
+	PruneModeAll  PruneMode = "all"  // Remove all existing trackers
+	PruneModeDead PruneMode = "dead" // Remove only dead/erroring trackers
+	PruneModeNone PruneMode = "none" // Keep all existing trackers
+)
+
+// ActionResult contains the result of a public tracker action
+type ActionResult struct {
+	TotalTorrents   int      `json:"totalTorrents"`
+	ProcessedCount  int      `json:"processedCount"`
+	SkippedPrivate  int      `json:"skippedPrivate"`
+	TrackersAdded   int      `json:"trackersAdded"`
+	TrackersRemoved int      `json:"trackersRemoved"`
+	Errors          []string `json:"errors,omitempty"`
+}
+
+// Service handles public tracker management
+type Service struct {
+	store       *models.PublicTrackerSettingsStore
+	syncManager *qbittorrent.SyncManager
+	httpClient  *http.Client
+}
+
+// NewService creates a new public tracker service
+func NewService(store *models.PublicTrackerSettingsStore, syncManager *qbittorrent.SyncManager) *Service {
+	return &Service{
+		store:       store,
+		syncManager: syncManager,
+		httpClient:  &http.Client{Timeout: fetchTimeout},
+	}
+}
+
+// GetSettings returns the current public tracker settings
+func (s *Service) GetSettings(ctx context.Context) (*models.PublicTrackerSettings, error) {
+	settings, err := s.store.Get(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get public tracker settings: %w", err)
+	}
+	return settings, nil
+}
+
+// UpdateSettings updates the public tracker settings
+func (s *Service) UpdateSettings(ctx context.Context, input *models.PublicTrackerSettingsInput) (*models.PublicTrackerSettings, error) {
+	settings, err := s.store.Update(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("update public tracker settings: %w", err)
+	}
+	return settings, nil
+}
+
+// RefreshTrackerList fetches the tracker list from the configured URL and caches it
+func (s *Service) RefreshTrackerList(ctx context.Context) (*models.PublicTrackerSettings, error) {
+	settings, err := s.store.Get(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get settings: %w", err)
+	}
+
+	if settings.TrackerListURL == "" {
+		return nil, errors.New("no tracker list URL configured")
+	}
+
+	trackers, err := s.fetchTrackersFromURL(ctx, settings.TrackerListURL)
+	if err != nil {
+		return nil, fmt.Errorf("fetch trackers: %w", err)
+	}
+
+	err = s.store.UpdateCachedTrackers(ctx, trackers)
+	if err != nil {
+		return nil, fmt.Errorf("update cached trackers: %w", err)
+	}
+
+	log.Info().Int("count", len(trackers)).Str("url", settings.TrackerListURL).Msg("Refreshed public tracker list")
+
+	updatedSettings, err := s.store.Get(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get updated settings: %w", err)
+	}
+	return updatedSettings, nil
+}
+
+// fetchTrackersFromURL fetches and parses a tracker list from a URL
+func (s *Service) fetchTrackersFromURL(ctx context.Context, url string) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	req.Header.Set("User-Agent", "qui/1.0")
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch url: %w", err)
+	}
+	defer resp.Body.Close()
+	defer httphelpers.DrainAndClose(resp)
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	// Limit response size
+	limitedReader := io.LimitReader(resp.Body, maxResponseSize)
+
+	var trackers []string
+	scanner := bufio.NewScanner(limitedReader)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		// Skip empty lines and comments
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		// Basic validation - tracker URLs should start with a scheme
+		if strings.HasPrefix(line, "http://") || strings.HasPrefix(line, "https://") ||
+			strings.HasPrefix(line, "udp://") || strings.HasPrefix(line, "wss://") {
+			trackers = append(trackers, line)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	return trackers, nil
+}
+
+// ExecuteAction performs a public tracker action on the specified torrents
+func (s *Service) ExecuteAction(ctx context.Context, instanceID int, hashes []string, pruneMode PruneMode) (*ActionResult, error) {
+	settings, err := s.store.Get(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get settings: %w", err)
+	}
+
+	// Ensure we have cached trackers
+	if len(settings.CachedTrackers) == 0 {
+		// Try to refresh
+		settings, err = s.RefreshTrackerList(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("no cached trackers and refresh failed: %w", err)
+		}
+		if len(settings.CachedTrackers) == 0 {
+			return nil, errors.New("no trackers available from URL")
+		}
+	}
+
+	result := &ActionResult{
+		TotalTorrents: len(hashes),
+	}
+
+	// Filter out private torrents
+	publicHashes, skippedCount := s.filterPublicTorrents(ctx, instanceID, hashes)
+	result.SkippedPrivate = skippedCount
+
+	if len(publicHashes) == 0 {
+		return result, nil
+	}
+
+	// Handle pruning based on mode
+	if pruneMode == PruneModeAll || pruneMode == PruneModeDead {
+		removed, errs := s.pruneTrackers(ctx, instanceID, publicHashes, pruneMode)
+		result.TrackersRemoved = removed
+		result.Errors = append(result.Errors, errs...)
+	}
+
+	// Add new trackers
+	trackersToAdd := strings.Join(settings.CachedTrackers, "\n")
+	if err := s.syncManager.BulkAddTrackers(ctx, instanceID, publicHashes, trackersToAdd); err != nil {
+		result.Errors = append(result.Errors, fmt.Sprintf("add trackers: %v", err))
+	} else {
+		result.TrackersAdded = len(settings.CachedTrackers)
+		result.ProcessedCount = len(publicHashes)
+	}
+
+	return result, nil
+}
+
+// filterPublicTorrents returns only public (non-private) torrent hashes
+func (s *Service) filterPublicTorrents(ctx context.Context, instanceID int, hashes []string) (publicHashes []string, skipped int) {
+	publicHashes = make([]string, 0, len(hashes))
+
+	for _, hash := range hashes {
+		props, err := s.syncManager.GetTorrentProperties(ctx, instanceID, hash)
+		if err != nil {
+			// If we can't get the torrent properties, skip it
+			skipped++
+			continue
+		}
+
+		// Check if torrent is private
+		if props.IsPrivate {
+			skipped++
+			continue
+		}
+
+		publicHashes = append(publicHashes, hash)
+	}
+
+	return publicHashes, skipped
+}
+
+// shouldRemoveTracker determines if a tracker should be removed based on prune mode
+func shouldRemoveTracker(tracker qbt.TorrentTracker, mode PruneMode) bool {
+	// Skip DHT, PeX, LSD (status 0 = disabled for these)
+	if tracker.Status == 0 || tracker.Url == "" {
+		return false
+	}
+
+	switch mode {
+	case PruneModeAll:
+		return true
+	case PruneModeDead:
+		// Check if tracker is dead/erroring (status 4 = NotWorking)
+		if tracker.Status == 4 {
+			return true
+		}
+		return qbittorrent.TrackerMessageMatchesDown(tracker.Message) ||
+			qbittorrent.TrackerMessageMatchesUnregistered(tracker.Message)
+	case PruneModeNone:
+		return false
+	default:
+		return false
+	}
+}
+
+// pruneTrackers removes trackers based on the prune mode
+func (s *Service) pruneTrackers(ctx context.Context, instanceID int, hashes []string, mode PruneMode) (totalRemoved int, errs []string) {
+	for _, hash := range hashes {
+		removed, err := s.pruneTrackersForHash(ctx, instanceID, hash, mode)
+		if err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+		totalRemoved += removed
+	}
+	return totalRemoved, errs
+}
+
+// pruneTrackersForHash removes trackers for a single torrent
+func (s *Service) pruneTrackersForHash(ctx context.Context, instanceID int, hash string, mode PruneMode) (int, error) {
+	trackers, err := s.syncManager.GetTorrentTrackers(ctx, instanceID, hash)
+	if err != nil {
+		return 0, fmt.Errorf("get trackers for %s: %w", hash[:8], err)
+	}
+
+	var urlsToRemove []string
+	for _, tracker := range trackers {
+		if shouldRemoveTracker(tracker, mode) {
+			urlsToRemove = append(urlsToRemove, tracker.Url)
+		}
+	}
+
+	if len(urlsToRemove) == 0 {
+		return 0, nil
+	}
+
+	urlsStr := strings.Join(urlsToRemove, "\n")
+	if err := s.syncManager.BulkRemoveTrackers(ctx, instanceID, []string{hash}, urlsStr); err != nil {
+		return 0, fmt.Errorf("remove trackers from %s: %w", hash[:8], err)
+	}
+
+	return len(urlsToRemove), nil
+}

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -3729,6 +3729,110 @@ paths:
         '404':
           description: Run not found
 
+  /api/public-trackers/settings:
+    get:
+      tags:
+        - Public Trackers
+      summary: Get public tracker settings
+      description: Get the current public tracker settings including cached tracker list
+      responses:
+        '200':
+          description: Public tracker settings
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublicTrackerSettings'
+        '500':
+          description: Failed to get settings
+    patch:
+      tags:
+        - Public Trackers
+      summary: Update public tracker settings
+      description: Update the public tracker list URL
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                trackerListUrl:
+                  type: string
+                  format: uri
+                  description: URL to fetch tracker list from
+      responses:
+        '200':
+          description: Settings updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublicTrackerSettings'
+        '400':
+          description: Invalid request
+        '500':
+          description: Failed to update settings
+
+  /api/public-trackers/refresh:
+    post:
+      tags:
+        - Public Trackers
+      summary: Refresh public tracker list
+      description: Fetch and cache the tracker list from the configured URL
+      responses:
+        '200':
+          description: Tracker list refreshed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublicTrackerSettings'
+        '500':
+          description: Failed to refresh tracker list
+
+  /api/instances/{instanceID}/torrents/public-tracker-action:
+    post:
+      tags:
+        - Public Trackers
+        - Torrents
+      summary: Execute public tracker action
+      description: Add public trackers to selected torrents with optional pruning
+      parameters:
+        - name: instanceID
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Instance ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - hashes
+                - pruneMode
+              properties:
+                hashes:
+                  type: array
+                  items:
+                    type: string
+                  description: Torrent hashes to process
+                pruneMode:
+                  type: string
+                  enum: [all, dead, none]
+                  description: How to handle existing trackers
+      responses:
+        '200':
+          description: Action completed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublicTrackerActionResult'
+        '400':
+          description: Invalid request
+        '500':
+          description: Failed to execute action
+
   /health:
     get:
       tags:
@@ -5439,6 +5543,47 @@ components:
           type: string
           nullable: true
 
+    PublicTrackerSettings:
+      type: object
+      properties:
+        id:
+          type: integer
+        trackerListUrl:
+          type: string
+          format: uri
+        cachedTrackers:
+          type: array
+          items:
+            type: string
+        lastFetchedAt:
+          type: string
+          format: date-time
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    PublicTrackerActionResult:
+      type: object
+      properties:
+        totalTorrents:
+          type: integer
+        processedCount:
+          type: integer
+        skippedPrivate:
+          type: integer
+        trackersAdded:
+          type: integer
+        trackersRemoved:
+          type: integer
+        errors:
+          type: array
+          items:
+            type: string
+
 tags:
   - name: Authentication
     description: User authentication and session management
@@ -5466,3 +5611,7 @@ tags:
     description: Orphan file scanning and cleanup (files on disk not associated with any torrent)
   - name: Theme Licenses
     description: Theme license management (optional feature)
+  - name: Public Trackers
+    description: Public tracker list management for enhancing public torrent connectivity
+  - name: System
+    description: System health and status endpoints

--- a/web/src/components/torrents/PublicTrackerActionDialog.tsx
+++ b/web/src/components/torrents/PublicTrackerActionDialog.tsx
@@ -52,9 +52,11 @@ export function PublicTrackerActionDialog({
       const result = await actionMutation.mutateAsync({ hashes, pruneMode })
 
       if (result.processedCount > 0) {
+        const added = result.trackersAdded > 0 ? `added ${result.trackersAdded} trackers` : ""
+        const removed = result.trackersRemoved > 0 ? `removed ${result.trackersRemoved} dead trackers` : ""
+        const actions = [added, removed].filter(Boolean).join(", ")
         toast.success(
-          `Updated ${result.processedCount} torrent(s): added ${result.trackersAdded} trackers` +
-          (result.trackersRemoved > 0 ? `, removed ${result.trackersRemoved} trackers` : "")
+          `Updated ${result.processedCount} torrent(s)` + (actions ? `: ${actions}` : "")
         )
       }
 

--- a/web/src/components/torrents/PublicTrackerActionDialog.tsx
+++ b/web/src/components/torrents/PublicTrackerActionDialog.tsx
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { Label } from "@/components/ui/label"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import { usePublicTrackerAction, usePublicTrackerSettings, useRefreshPublicTrackerList } from "@/hooks/usePublicTrackers"
+import type { PruneMode, Torrent } from "@/types"
+import { AlertCircle, RefreshCw } from "lucide-react"
+import { useState } from "react"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+
+interface PublicTrackerActionDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  instanceId: number
+  hashes: string[]
+  torrents: Torrent[]
+}
+
+export function PublicTrackerActionDialog({
+  open,
+  onOpenChange,
+  instanceId,
+  hashes,
+  torrents,
+}: PublicTrackerActionDialogProps) {
+  const [pruneMode, setPruneMode] = useState<PruneMode>("dead")
+
+  const { data: settings, isLoading: settingsLoading } = usePublicTrackerSettings()
+  const refreshMutation = useRefreshPublicTrackerList()
+  const actionMutation = usePublicTrackerAction(instanceId)
+
+  // Check how many torrents are private (will be skipped)
+  const privateCount = torrents.filter(t => t.private).length
+  const publicCount = torrents.length - privateCount
+
+  const handleExecute = async () => {
+    try {
+      const result = await actionMutation.mutateAsync({ hashes, pruneMode })
+
+      if (result.processedCount > 0) {
+        toast.success(
+          `Updated ${result.processedCount} torrent(s): added ${result.trackersAdded} trackers` +
+          (result.trackersRemoved > 0 ? `, removed ${result.trackersRemoved} trackers` : "")
+        )
+      }
+
+      if (result.skippedPrivate > 0) {
+        toast.info(`Skipped ${result.skippedPrivate} private torrent(s)`)
+      }
+
+      if (result.errors && result.errors.length > 0) {
+        toast.warning(`${result.errors.length} error(s) occurred during processing`)
+      }
+
+      onOpenChange(false)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error"
+      toast.error(`Failed to execute action: ${message}`)
+    }
+  }
+
+  const handleRefresh = async () => {
+    try {
+      await refreshMutation.mutateAsync()
+      toast.success("Tracker list refreshed")
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error"
+      toast.error(`Failed to refresh tracker list: ${message}`)
+    }
+  }
+
+  const trackerCount = settings?.cachedTrackers?.length ?? 0
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent className="!max-w-2xl">
+        <AlertDialogHeader>
+          <AlertDialogTitle>Manage Public Trackers</AlertDialogTitle>
+          <AlertDialogDescription>
+            Add reliable public trackers from a curated list to {hashes.length} selected torrent(s).
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        {privateCount > 0 && (
+          <div className="flex items-start gap-2 p-3 bg-yellow-500/10 border border-yellow-500/20 rounded-md">
+            <AlertCircle className="h-4 w-4 text-yellow-500 mt-0.5 shrink-0" />
+            <div className="text-sm">
+              <span className="font-medium text-yellow-600 dark:text-yellow-400">
+                {privateCount} private torrent(s) will be skipped
+              </span>
+              <p className="text-muted-foreground mt-1">
+                Private torrents cannot have trackers modified. Only {publicCount} public torrent(s) will be processed.
+              </p>
+            </div>
+          </div>
+        )}
+
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium">Tracker List</p>
+              {settingsLoading ? (
+                <p className="text-xs text-muted-foreground">Loading...</p>
+              ) : (
+                <p className="text-xs text-muted-foreground">
+                  {trackerCount} tracker(s) available
+                  {settings?.lastFetchedAt && (
+                    <span className="ml-2">
+                      (last updated: {new Date(settings.lastFetchedAt).toLocaleDateString()})
+                    </span>
+                  )}
+                </p>
+              )}
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleRefresh}
+              disabled={refreshMutation.isPending}
+            >
+              <RefreshCw className={`h-4 w-4 mr-2 ${refreshMutation.isPending ? "animate-spin" : ""}`} />
+              Refresh
+            </Button>
+          </div>
+
+          <div className="space-y-3">
+            <p className="text-sm font-medium">Prune Mode</p>
+            <RadioGroup
+              value={pruneMode}
+              onValueChange={(value) => setPruneMode(value as PruneMode)}
+              className="space-y-2"
+            >
+              <div className="flex items-start space-x-3">
+                <RadioGroupItem value="dead" id="prune-dead" />
+                <Label htmlFor="prune-dead" className="cursor-pointer">
+                  <span className="font-medium">Remove Dead, Add New</span>
+                  <p className="text-xs text-muted-foreground">
+                    Remove only dead/erroring trackers, keep working ones, add new trackers
+                  </p>
+                </Label>
+              </div>
+              <div className="flex items-start space-x-3">
+                <RadioGroupItem value="all" id="prune-all" />
+                <Label htmlFor="prune-all" className="cursor-pointer">
+                  <span className="font-medium">Replace All Trackers</span>
+                  <p className="text-xs text-muted-foreground">
+                    Remove all existing trackers and replace with the curated list
+                  </p>
+                </Label>
+              </div>
+              <div className="flex items-start space-x-3">
+                <RadioGroupItem value="none" id="prune-none" />
+                <Label htmlFor="prune-none" className="cursor-pointer">
+                  <span className="font-medium">Add Missing Trackers</span>
+                  <p className="text-xs text-muted-foreground">
+                    Keep all existing trackers, only add new ones from the list
+                  </p>
+                </Label>
+              </div>
+            </RadioGroup>
+          </div>
+        </div>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleExecute}
+            disabled={actionMutation.isPending || publicCount === 0 || trackerCount === 0}
+          >
+            {actionMutation.isPending ? "Processing..." : "Execute"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/web/src/components/torrents/TorrentContextMenu.tsx
+++ b/web/src/components/torrents/TorrentContextMenu.tsx
@@ -31,6 +31,7 @@ import {
   FolderOpen,
   Gauge,
   GitBranch,
+  ListFilter,
   Pause,
   Play,
   Radio,
@@ -83,6 +84,7 @@ interface TorrentContextMenuProps {
   onCrossSeedSearch?: (torrent: Torrent) => void
   isCrossSeedSearching?: boolean
   onFilterChange?: (filters: TorrentFilters) => void
+  onPreparePublicTrackerAction?: (hashes: string[], torrents: Torrent[]) => void
 }
 
 export const TorrentContextMenu = memo(function TorrentContextMenu({
@@ -118,6 +120,7 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
   onCrossSeedSearch,
   isCrossSeedSearching = false,
   onFilterChange,
+  onPreparePublicTrackerAction,
 }: TorrentContextMenuProps) {
   const [incognitoMode] = useIncognitoMode()
 
@@ -336,6 +339,15 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
           <Radio className="mr-2 h-4 w-4" />
           Reannounce {count > 1 ? `(${count})` : ""}
         </ContextMenuItem>
+        {onPreparePublicTrackerAction && (
+          <ContextMenuItem
+            onClick={() => onPreparePublicTrackerAction(hashes, torrents)}
+            disabled={isPending}
+          >
+            <ListFilter className="mr-2 h-4 w-4" />
+            Manage Public Trackers {count > 1 ? `(${count})` : ""}
+          </ContextMenuItem>
+        )}
         {seqDlMixed ? (
           <>
             <ContextMenuItem

--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -124,6 +124,7 @@ import {
 } from "./TorrentDialogs"
 import { TorrentDropZone } from "./TorrentDropZone"
 import { createColumns, type TableViewMode } from "./TorrentTableColumns"
+import { PublicTrackerActionDialog } from "./PublicTrackerActionDialog"
 
 const TABLE_ALLOWED_VIEW_MODES = ["normal", "dense", "compact"] as const
 
@@ -758,6 +759,8 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
     pendingTmmEnable,
     showLocationWarningDialog,
     setShowLocationWarningDialog,
+    showPublicTrackerDialog,
+    setShowPublicTrackerDialog,
     contextHashes,
     contextTorrents,
     isPending,
@@ -790,6 +793,7 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
     prepareRecheckAction,
     prepareReannounceAction,
     prepareTmmAction,
+    preparePublicTrackerAction,
   } = useTorrentActions({
     instanceId,
     onActionComplete: (action) => {
@@ -2481,6 +2485,7 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
                         onPrepareRecheck={prepareRecheckAction}
                         onPrepareReannounce={prepareReannounceAction}
                         onPrepareTmm={prepareTmmAction}
+                        onPreparePublicTrackerAction={preparePublicTrackerAction}
                         availableCategories={availableCategories}
                         onSetCategory={handleSetCategoryDirect}
                         isPending={isPending}
@@ -2593,6 +2598,7 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
                       onPrepareRecheck={prepareRecheckAction}
                       onPrepareReannounce={prepareReannounceAction}
                       onPrepareTmm={prepareTmmAction}
+                      onPreparePublicTrackerAction={preparePublicTrackerAction}
                       availableCategories={availableCategories}
                       onSetCategory={handleSetCategoryDirect}
                       isPending={isPending}
@@ -2898,6 +2904,15 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
           count={isAllSelected ? effectiveSelectionCount : contextHashes.length}
           onConfirm={proceedToLocationDialog}
           isPending={isPending}
+        />
+
+        {/* Public Tracker Action Dialog */}
+        <PublicTrackerActionDialog
+          open={showPublicTrackerDialog}
+          onOpenChange={setShowPublicTrackerDialog}
+          instanceId={instanceId}
+          hashes={contextHashes}
+          torrents={contextTorrents}
         />
 
         {/* Instance Preferences Dialog */}

--- a/web/src/hooks/usePublicTrackers.ts
+++ b/web/src/hooks/usePublicTrackers.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { api } from "@/lib/api"
+import type { PruneMode, PublicTrackerSettings, PublicTrackerSettingsInput } from "@/types"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+const QUERY_KEY = ["public-tracker-settings"]
+
+/**
+ * Hook for fetching public tracker settings
+ */
+export function usePublicTrackerSettings() {
+  return useQuery<PublicTrackerSettings>({
+    queryKey: QUERY_KEY,
+    queryFn: () => api.getPublicTrackerSettings(),
+    staleTime: 60000, // 1 minute
+    gcTime: 300000, // 5 minutes
+  })
+}
+
+/**
+ * Hook for updating public tracker settings
+ */
+export function useUpdatePublicTrackerSettings() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: PublicTrackerSettingsInput) => api.updatePublicTrackerSettings(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY })
+    },
+  })
+}
+
+/**
+ * Hook for refreshing the public tracker list from the configured URL
+ */
+export function useRefreshPublicTrackerList() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: () => api.refreshPublicTrackerList(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY })
+    },
+  })
+}
+
+/**
+ * Hook for executing a public tracker action on selected torrents
+ */
+export function usePublicTrackerAction(instanceId: number) {
+  return useMutation({
+    mutationFn: ({ hashes, pruneMode }: { hashes: string[]; pruneMode: PruneMode }) =>
+      api.executePublicTrackerAction(instanceId, hashes, pruneMode),
+  })
+}

--- a/web/src/hooks/useTorrentActions.ts
+++ b/web/src/hooks/useTorrentActions.ts
@@ -103,6 +103,7 @@ export function useTorrentActions({ instanceId, onActionComplete }: UseTorrentAc
   const [showTmmDialog, setShowTmmDialog] = useState(false)
   const [pendingTmmEnable, setPendingTmmEnable] = useState(false)
   const [showLocationWarningDialog, setShowLocationWarningDialog] = useState(false)
+  const [showPublicTrackerDialog, setShowPublicTrackerDialog] = useState(false)
 
   // Context state for dialogs
   const [contextHashes, setContextHashes] = useState<string[]>([])
@@ -861,6 +862,13 @@ export function useTorrentActions({ instanceId, onActionComplete }: UseTorrentAc
     setShowRenameFolderDialog(true)
   }, [])
 
+  const preparePublicTrackerAction = useCallback((hashes: string[], torrents?: Torrent[]) => {
+    if (hashes.length === 0) return
+    setContextHashes(hashes)
+    if (torrents) setContextTorrents(torrents)
+    setShowPublicTrackerDialog(true)
+  }, [])
+
   const isPending = mutation.isPending || renameTorrentMutation.isPending || renameFileMutation.isPending || renameFolderMutation.isPending
 
 
@@ -906,6 +914,8 @@ export function useTorrentActions({ instanceId, onActionComplete }: UseTorrentAc
     pendingTmmEnable,
     showLocationWarningDialog,
     setShowLocationWarningDialog,
+    showPublicTrackerDialog,
+    setShowPublicTrackerDialog,
     contextHashes,
     contextTorrents,
 
@@ -944,6 +954,7 @@ export function useTorrentActions({ instanceId, onActionComplete }: UseTorrentAc
     prepareTmmAction,
     handleTmmConfirm,
     proceedToLocationDialog,
+    preparePublicTrackerAction,
   }
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -54,6 +54,10 @@ import type {
   LogSettings,
   LogSettingsUpdate,
   OrphanScanRun,
+  PruneMode,
+  PublicTrackerActionResult,
+  PublicTrackerSettings,
+  PublicTrackerSettingsInput,
   OrphanScanRunWithFiles,
   OrphanScanSettings,
   OrphanScanSettingsUpdate,
@@ -1602,6 +1606,31 @@ class ApiClient {
     return this.request<DashboardSettings>("/dashboard-settings", {
       method: "PUT",
       body: JSON.stringify(data),
+    })
+  }
+
+  // Public Trackers endpoints
+  async getPublicTrackerSettings(): Promise<PublicTrackerSettings> {
+    return this.request<PublicTrackerSettings>("/public-trackers/settings")
+  }
+
+  async updatePublicTrackerSettings(data: PublicTrackerSettingsInput): Promise<PublicTrackerSettings> {
+    return this.request<PublicTrackerSettings>("/public-trackers/settings", {
+      method: "PATCH",
+      body: JSON.stringify(data),
+    })
+  }
+
+  async refreshPublicTrackerList(): Promise<PublicTrackerSettings> {
+    return this.request<PublicTrackerSettings>("/public-trackers/refresh", {
+      method: "POST",
+    })
+  }
+
+  async executePublicTrackerAction(instanceId: number, hashes: string[], pruneMode: PruneMode): Promise<PublicTrackerActionResult> {
+    return this.request<PublicTrackerActionResult>(`/instances/${instanceId}/torrents/public-tracker-action`, {
+      method: "POST",
+      body: JSON.stringify({ hashes, pruneMode }),
     })
   }
 

--- a/web/src/routes/_authenticated/settings.tsx
+++ b/web/src/routes/_authenticated/settings.tsx
@@ -16,6 +16,7 @@ const settingsSearchSchema = z.object({
     "client-api",
     "api",
     "external-programs",
+    "public-trackers",
     "datetime",
     "themes",
     "security",

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -1893,3 +1893,34 @@ export interface LogSettingsUpdate {
   maxSize?: number
   maxBackups?: number
 }
+
+// Public Tracker Settings Types
+export interface PublicTrackerSettings {
+  id: number
+  trackerListUrl: string
+  cachedTrackers: string[]
+  lastFetchedAt?: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface PublicTrackerSettingsInput {
+  trackerListUrl?: string
+  cachedTrackers?: string[]
+}
+
+export type PruneMode = "all" | "dead" | "none"
+
+export interface PublicTrackerActionRequest {
+  hashes: string[]
+  pruneMode: PruneMode
+}
+
+export interface PublicTrackerActionResult {
+  totalTorrents: number
+  processedCount: number
+  skippedPrivate: number
+  trackersAdded: number
+  trackersRemoved: number
+  errors?: string[]
+}


### PR DESCRIPTION
## Summary

Add a new feature to manage trackers on public torrents:

- Fetch tracker lists from a configurable remote URL (e.g., trackerslist)
- Three prune modes via context menu:
  - **Replace All Trackers** - Remove all existing, add from list
  - **Remove Dead, Add New** - Remove only dead/erroring trackers, add from list
  - **Add Missing Trackers** - Keep existing, add from list
- Automatic filtering of private torrents (skipped with count shown)
- Settings page under Settings > Public Trackers for URL configuration
- Manual refresh button to update cached tracker list

## Test plan

- [ ] Configure a tracker list URL in Settings > Public Trackers
- [ ] Click Refresh to fetch the list
- [ ] Select public torrents, right-click > Manage Public Trackers
- [ ] Test each prune mode
- [ ] Verify private torrents are skipped
- [ ] Verify error handling when URL is not configured

Closes #917