### PR TITLE
fix(deps): update rls to recognize IP as iPlayer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	modernc.org/sqlite v1.40.1
 )
 
-replace github.com/moistari/rls => github.com/autobrr/rls v0.7.1-0.20251216090501-a93fa08d24d2
+replace github.com/moistari/rls => github.com/autobrr/rls v0.7.1-0.20260101090144-934fa1613435
 
 require (
 	code.gitea.io/sdk/gitea v0.22.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/autobrr/autobrr v1.70.0 h1:N3NxMuiu6uQ500N9nPxDWXlBtlQx2QlkkGnU/JPcLw
 github.com/autobrr/autobrr v1.70.0/go.mod h1:sCMO8xAaZLLA4H1qbKRiSTZnPsY/stvTngHF9o2F8pI=
 github.com/autobrr/go-qbittorrent v1.15.0-rc1.0.20251209201933-62cc902b8602 h1:RyJtQJGklw0kJ3Ec5kHakQArHXuXb7EodudkUVGwsDk=
 github.com/autobrr/go-qbittorrent v1.15.0-rc1.0.20251209201933-62cc902b8602/go.mod h1:mGH+UlSzkZOpTx9hezpL9dnKakskLzOsNfngl2E1ZE0=
-github.com/autobrr/rls v0.7.1-0.20251216090501-a93fa08d24d2 h1:BKYdKcK64fnbm8EoTsWcBOXU/syjVJap6eOD2NUa3b8=
-github.com/autobrr/rls v0.7.1-0.20251216090501-a93fa08d24d2/go.mod h1:11YJWgNe5H+UQrfFaNGjnkEy0OEsMFnmV4IL2tRKpPk=
+github.com/autobrr/rls v0.7.1-0.20260101090144-934fa1613435 h1:8b1Ht/OBqgtO2IjqkxOj+uz2an0aARa06m4uKwVFfEE=
+github.com/autobrr/rls v0.7.1-0.20260101090144-934fa1613435/go.mod h1:11YJWgNe5H+UQrfFaNGjnkEy0OEsMFnmV4IL2tRKpPk=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/benbjohnson/immutable v0.2.0/go.mod h1:uc6OHo6PN2++n98KHLxW8ef4W42ylHiQSENghE1ezxI=


### PR DESCRIPTION
## Summary
- Update rls dependency to include fix for recognizing `IP` (all caps) as iPlayer streaming service

The rls parser only recognized `iP` (mixed case) as iPlayer but not `IP` (all caps) which is used by some indexers. This caused cross-seed matching to fail when the Collection field didn't match (`"iPlayer"` vs `""`).

## Test plan
- [x] rls tests pass
- [x] Verified parsing works for both `iP` and `IP` variants

Closes #920

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated module dependency to the latest commit.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->