### PR TITLE
docs(readme): add banner linking to stable docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # qui
 
+> [!WARNING]
+> **You're viewing the development branch — documentation here may describe unreleased features.**
+>
+> [![Stable Docs](https://img.shields.io/github/v/release/autobrr/qui?label=stable%20docs&style=for-the-badge)](https://github.com/autobrr/qui/blob/v1.11.0/README.md)
+
 A fast, modern web interface for qBittorrent. Supports managing multiple qBittorrent instances from a single, lightweight application.
 
 <div align="center">


### PR DESCRIPTION
## Summary
- Add a warning banner at the top of the README indicating users are viewing the development branch
- Include a dynamic shields.io badge that auto-updates to show the latest release version
- Badge links to the tagged README for stable documentation

The badge version updates automatically; only the link URL needs manual update each release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a prominent development-branch warning banner at the top of the documentation to indicate unreleased features and development status.
  * Added a stable documentation reference badge directing readers to the released documentation for stable, production-ready information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->