### PR TITLE
feat(automations): make conditions optional for non-delete rules and add drag reorder

### DIFF
--- a/internal/api/handlers/automations.go
+++ b/internal/api/handlers/automations.go
@@ -282,6 +282,9 @@ func (h *AutomationHandler) validatePayload(ctx context.Context, instanceID int,
 	// Validate delete is standalone - it cannot be combined with any other action
 	hasDelete := payload.Conditions.Delete != nil && payload.Conditions.Delete.Enabled
 	if hasDelete {
+		if payload.Conditions.Delete.Condition == nil {
+			return http.StatusBadRequest, "Delete action requires at least one condition", errors.New("delete condition required")
+		}
 		hasOtherAction := (payload.Conditions.SpeedLimits != nil && payload.Conditions.SpeedLimits.Enabled) ||
 			(payload.Conditions.ShareLimits != nil && payload.Conditions.ShareLimits.Enabled) ||
 			(payload.Conditions.Pause != nil && payload.Conditions.Pause.Enabled) ||

--- a/internal/services/automations/processor.go
+++ b/internal/services/automations/processor.go
@@ -262,23 +262,28 @@ func processRuleForTorrent(rule *models.Automation, torrent qbt.Torrent, state *
 
 	// Delete
 	if conditions.Delete != nil && conditions.Delete.Enabled {
-		shouldApply := conditions.Delete.Condition == nil ||
-			EvaluateConditionWithContext(conditions.Delete.Condition, torrent, evalCtx, 0)
-
-		if shouldApply {
+		// Safety: delete must always have an explicit condition.
+		if conditions.Delete.Condition == nil {
 			if stats != nil {
-				stats.DeleteApplied++
+				stats.DeleteConditionNotMet++
 			}
-			state.shouldDelete = true
-			state.deleteMode = conditions.Delete.Mode
-			if state.deleteMode == "" {
-				state.deleteMode = DeleteModeKeepFiles
+		} else {
+			shouldApply := EvaluateConditionWithContext(conditions.Delete.Condition, torrent, evalCtx, 0)
+			if shouldApply {
+				if stats != nil {
+					stats.DeleteApplied++
+				}
+				state.shouldDelete = true
+				state.deleteMode = conditions.Delete.Mode
+				if state.deleteMode == "" {
+					state.deleteMode = DeleteModeKeepFiles
+				}
+				state.deleteRuleID = rule.ID
+				state.deleteRuleName = rule.Name
+				state.deleteReason = "condition matched"
+			} else if stats != nil {
+				stats.DeleteConditionNotMet++
 			}
-			state.deleteRuleID = rule.ID
-			state.deleteRuleName = rule.Name
-			state.deleteReason = "condition matched"
-		} else if stats != nil {
-			stats.DeleteConditionNotMet++
 		}
 	}
 }

--- a/web/src/components/instances/preferences/WorkflowDialog.tsx
+++ b/web/src/components/instances/preferences/WorkflowDialog.tsx
@@ -616,6 +616,10 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
         return
       }
     }
+    if (formState.deleteEnabled && !formState.actionCondition) {
+      toast.error("Delete requires at least one condition")
+      return
+    }
 
     // Validate regex patterns before saving (only if enabling the workflow)
     const payload = buildPayload(formState)
@@ -706,17 +710,23 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
               <div className="space-y-3">
                 {/* Query Builder */}
                 <div className="space-y-1.5">
-                  <Label>When conditions match</Label>
+                  <Label>Conditions (optional)</Label>
                   <QueryBuilder
                     condition={formState.actionCondition}
                     onChange={(condition) => {
                       setFormState(prev => ({ ...prev, actionCondition: condition }))
                       setRegexErrors([]) // Clear errors when condition changes
                     }}
+                    allowEmpty
                     categoryOptions={categoryOptions}
                     hiddenFields={supportsTrackerHealth ? [] : ["IS_UNREGISTERED"]}
                     hiddenStateValues={supportsTrackerHealth ? [] : ["tracker_down"]}
                   />
+                  {formState.deleteEnabled && !formState.actionCondition && (
+                    <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm">
+                      <p className="font-medium text-destructive">Delete requires at least one condition.</p>
+                    </div>
+                  )}
                   {regexErrors.length > 0 && (
                     <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm">
                       <p className="font-medium text-destructive mb-1">Invalid regex pattern</p>
@@ -1200,6 +1210,10 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
                     id="rule-enabled"
                     checked={formState.enabled}
                     onCheckedChange={(checked) => {
+                      if (checked && isDeleteRule && !formState.actionCondition) {
+                        toast.error("Delete requires at least one condition")
+                        return
+                      }
                       // When enabling a delete or category rule, show preview first
                       if (checked && (isDeleteRule || isCategoryRule)) {
                         setEnabledBeforePreview(formState.enabled)

--- a/web/src/components/query-builder/ConditionGroup.tsx
+++ b/web/src/components/query-builder/ConditionGroup.tsx
@@ -1,12 +1,12 @@
-import { useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { ConditionOperator, RuleCondition } from "@/types";
 import {
   SortableContext,
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { Plus, X } from "lucide-react";
-import { cn } from "@/lib/utils";
-import { Button } from "@/components/ui/button";
-import type { RuleCondition, ConditionOperator } from "@/types";
+import { useCallback } from "react";
 import { LeafCondition } from "./LeafCondition";
 
 interface ConditionGroupProps {
@@ -99,9 +99,14 @@ export function ConditionGroup({
       // If removing leaves only one child in a non-root group, replace group with child
       if (!isRoot && newChildren.length === 1) {
         onChange(newChildren[0]);
-      } else if (newChildren.length === 0 && !isRoot) {
-        // Remove empty group
-        onRemove?.();
+      } else if (newChildren.length === 0) {
+        // Remove empty group (or clear root when allowEmpty)
+        if (onRemove) {
+          onRemove();
+        } else {
+          // Root without onRemove: update with empty children (handleChange normalizes to null)
+          onChange({ ...condition, conditions: newChildren });
+        }
       } else {
         onChange({
           ...condition,
@@ -203,7 +208,7 @@ export function ConditionGroup({
                 condition={child}
                 onChange={(updated) => updateChild(index, updated)}
                 onRemove={() => removeChild(index)}
-                isOnly={children.length === 1 && isRoot}
+                isOnly={children.length === 1 && isRoot && !onRemove}
                 categoryOptions={categoryOptions}
                 hiddenFields={hiddenFields}
                 hiddenStateValues={hiddenStateValues}


### PR DESCRIPTION
## Summary

- **Optional conditions for workflows**: Workflow rules no longer require conditions for most actions (speed limits, share limits, pause, tag, category). Rules without conditions will match all torrents for the selected trackers.
- **Delete safety requirement**: Delete actions still require an explicit condition to prevent accidental mass deletion.
- **Drag-and-drop reordering**: Workflows can now be reordered via drag handles in the UI.
- **"All torrents" badge**: Workflows without conditions now display an "All torrents" badge for clarity.

## Changes

**Backend:**
- Added validation requiring delete actions to have at least one condition
- Updated processor to treat missing delete condition as "condition not met"

**Frontend:**
- Added `allowEmpty` prop to QueryBuilder allowing null condition state
- Updated WorkflowDialog to support optional conditions with delete safety warnings
- Added drag-and-drop reordering using @dnd-kit in WorkflowsOverview
- Added "All torrents" badge for workflows without explicit conditions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Drag-and-drop reordering of workflow rules with visual feedback during dragging.
  * Optional conditions support with new "Conditions (optional)" label in rule configuration.

* **Bug Fixes**
  * Delete actions now require at least one condition to be configured.
  * Delete conditions must be satisfied before deletion is applied.

* **UI/UX Improvements**
  * Inline warning banner displays when Delete is enabled without a condition.
  * Enhanced condition handling flow for better rule validation and preview.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->