### PR TITLE
fix(crossseed): execute external program reliably after injection

### DIFF
--- a/internal/externalprograms/args.go
+++ b/internal/externalprograms/args.go
@@ -1,0 +1,102 @@
+package externalprograms
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/autobrr/qui/internal/models"
+)
+
+// SplitArgs splits a command line string into arguments, respecting quoted strings.
+// It strips surrounding single/double quotes from quoted segments.
+func SplitArgs(s string) []string {
+	var args []string
+	var current strings.Builder
+	inQuote := false
+	quoteChar := rune(0)
+
+	for _, r := range s {
+		switch {
+		case r == '"' || r == '\'':
+			switch {
+			case !inQuote:
+				inQuote = true
+				quoteChar = r
+			case r == quoteChar:
+				inQuote = false
+				quoteChar = 0
+			default:
+				current.WriteRune(r)
+			}
+		case r == ' ' && !inQuote:
+			if current.Len() > 0 {
+				args = append(args, current.String())
+				current.Reset()
+			}
+		default:
+			current.WriteRune(r)
+		}
+	}
+
+	if current.Len() > 0 {
+		args = append(args, current.String())
+	}
+
+	return args
+}
+
+// BuildArguments substitutes variables in the args template with torrent data.
+// Returns arguments as an array suitable for exec.Command (no manual quoting needed).
+func BuildArguments(template string, torrentData map[string]string) []string {
+	if template == "" {
+		return []string{}
+	}
+
+	args := SplitArgs(template)
+	for i := range args {
+		for key, value := range torrentData {
+			placeholder := "{" + key + "}"
+			args[i] = strings.ReplaceAll(args[i], placeholder, value)
+		}
+	}
+
+	return args
+}
+
+// ApplyPathMappings applies configured path mappings to convert remote paths to local paths.
+//
+// Mappings are matched longest-prefix-first to handle overlapping prefixes correctly.
+// Prefix matching requires a path separator boundary (/ or \) to avoid false matches
+// like "/data" matching "/data-backup".
+func ApplyPathMappings(path string, mappings []models.PathMapping) string {
+	if len(mappings) == 0 {
+		return path
+	}
+
+	sortedMappings := make([]models.PathMapping, len(mappings))
+	copy(sortedMappings, mappings)
+	sort.Slice(sortedMappings, func(i, j int) bool {
+		return len(sortedMappings[i].From) > len(sortedMappings[j].From)
+	})
+
+	for _, mapping := range sortedMappings {
+		if mapping.From == "" || mapping.To == "" {
+			continue
+		}
+		if strings.HasPrefix(path, mapping.From) {
+			// Ensure we match at a path boundary, not mid-component.
+			// E.g., From="/data" should match "/data/foo" but not "/data-backup".
+			remainder := path[len(mapping.From):]
+			// Boundary match if:
+			// - exact match (remainder empty)
+			// - From ends with separator (e.g., "/data/" or "C:\data\")
+			// - remainder starts with separator
+			fromEndsWithSep := strings.HasSuffix(mapping.From, "/") || strings.HasSuffix(mapping.From, "\\")
+			if remainder == "" || fromEndsWithSep || remainder[0] == '/' || remainder[0] == '\\' {
+				return mapping.To + remainder
+			}
+		}
+	}
+
+	return path
+}

--- a/internal/externalprograms/args_test.go
+++ b/internal/externalprograms/args_test.go
@@ -1,0 +1,162 @@
+package externalprograms
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/autobrr/qui/internal/models"
+)
+
+func TestSplitArgs(t *testing.T) {
+	t.Parallel()
+
+	in := `-s --form-string "token=abc" --form-string 'user=def' --form-string "message=Cross-Seed added {name}" https://api.example.com/1/messages.json`
+	want := []string{
+		"-s",
+		"--form-string",
+		"token=abc",
+		"--form-string",
+		"user=def",
+		"--form-string",
+		"message=Cross-Seed added {name}",
+		"https://api.example.com/1/messages.json",
+	}
+
+	got := SplitArgs(in)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("SplitArgs() mismatch\nwant: %#v\ngot:  %#v", want, got)
+	}
+}
+
+func TestBuildArguments_Substitution(t *testing.T) {
+	t.Parallel()
+
+	template := `--form-string "message=Cross-Seed added {name}"`
+	data := map[string]string{
+		"name": "Some Torrent Name",
+	}
+
+	want := []string{"--form-string", "message=Cross-Seed added Some Torrent Name"}
+	got := BuildArguments(template, data)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("BuildArguments() mismatch\nwant: %#v\ngot:  %#v", want, got)
+	}
+}
+
+func TestApplyPathMappings_LongestPrefixWins(t *testing.T) {
+	t.Parallel()
+
+	mappings := []models.PathMapping{
+		{From: "/data", To: "/mnt/data"},
+		{From: "/data/torrents", To: "/mnt/torrents"},
+	}
+
+	got := ApplyPathMappings("/data/torrents/movies", mappings)
+	want := "/mnt/torrents/movies"
+	if got != want {
+		t.Fatalf("ApplyPathMappings() mismatch\nwant: %q\ngot:  %q", want, got)
+	}
+}
+
+func TestApplyPathMappings_PrefixBoundary(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		path     string
+		mappings []models.PathMapping
+		want     string
+	}{
+		{
+			name: "unix: should not match similar prefix",
+			path: "/data-backup/file.txt",
+			mappings: []models.PathMapping{
+				{From: "/data", To: "/mnt/data"},
+			},
+			want: "/data-backup/file.txt", // unchanged
+		},
+		{
+			name: "unix: should match exact prefix with subpath",
+			path: "/data/backup/file.txt",
+			mappings: []models.PathMapping{
+				{From: "/data", To: "/mnt/data"},
+			},
+			want: "/mnt/data/backup/file.txt",
+		},
+		{
+			name: "unix: should match exact prefix only",
+			path: "/data",
+			mappings: []models.PathMapping{
+				{From: "/data", To: "/mnt/data"},
+			},
+			want: "/mnt/data",
+		},
+		{
+			name: "windows: should not match similar prefix",
+			path: `C:\data-backup\file.txt`,
+			mappings: []models.PathMapping{
+				{From: `C:\data`, To: `D:\data`},
+			},
+			want: `C:\data-backup\file.txt`, // unchanged
+		},
+		{
+			name: "windows: should match exact prefix with subpath",
+			path: `C:\data\backup\file.txt`,
+			mappings: []models.PathMapping{
+				{From: `C:\data`, To: `D:\data`},
+			},
+			want: `D:\data\backup\file.txt`,
+		},
+		// Trailing separator cases
+		{
+			name: "unix: From with trailing slash should match",
+			path: "/data/torrents/file.txt",
+			mappings: []models.PathMapping{
+				{From: "/data/", To: "/mnt/data/"},
+			},
+			want: "/mnt/data/torrents/file.txt",
+		},
+		{
+			name: "unix: From with trailing slash should not match similar prefix",
+			path: "/data-backup/file.txt",
+			mappings: []models.PathMapping{
+				{From: "/data/", To: "/mnt/data/"},
+			},
+			want: "/data-backup/file.txt", // unchanged - doesn't start with "/data/"
+		},
+		{
+			name: "unix: root mapping should work",
+			path: "/torrents/file.txt",
+			mappings: []models.PathMapping{
+				{From: "/", To: "/mnt/"},
+			},
+			want: "/mnt/torrents/file.txt",
+		},
+		{
+			name: "windows: From with trailing backslash should match",
+			path: `C:\data\torrents\file.txt`,
+			mappings: []models.PathMapping{
+				{From: `C:\data\`, To: `D:\data\`},
+			},
+			want: `D:\data\torrents\file.txt`,
+		},
+		{
+			name: "windows: From with trailing backslash should not match similar prefix",
+			path: `C:\data-backup\file.txt`,
+			mappings: []models.PathMapping{
+				{From: `C:\data\`, To: `D:\data\`},
+			},
+			want: `C:\data-backup\file.txt`, // unchanged
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := ApplyPathMappings(tc.path, tc.mappings)
+			if got != tc.want {
+				t.Errorf("ApplyPathMappings(%q) = %q, want %q", tc.path, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Cross-seed injection now executes configured external programs using the same quote-aware argument parsing as the manual UI path, fixing cases where templates with quoted values (e.g. curl `--form-string "message=... {name}"`) were split incorrectly and silently failed.

Also hardens path mapping prefix matching to avoid accidental partial-prefix replacements (e.g. `/data` no longer matches `/data-backup`), reduces copying by passing torrents by pointer, and improves Windows reporting so `cmd.exe start` is treated as “launched (outcome unknown)” instead of “executed successfully”.

Closes #1082

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of external program execution with more robust path mapping logic, including stricter boundary checks and cross-platform support, and better distinction between launch failures and execution outcomes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->