### PR TITLE
fix(qbittorrent): force sync+retry in BulkAction

### DIFF
--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -1397,6 +1397,7 @@ func (sm *SyncManager) BulkAction(ctx context.Context, instanceID int, hashes []
 
 		// Retry loop: qBittorrent may need a moment to register the new torrent.
 		const maxAttempts = 3
+	retryLoop:
 		for attempt := 1; attempt <= maxAttempts; attempt++ {
 			if syncErr := syncManager.Sync(syncCtx); syncErr != nil {
 				log.Debug().Err(syncErr).Int("instanceID", instanceID).Str("action", action).
@@ -1410,7 +1411,7 @@ func (sm *SyncManager) BulkAction(ctx context.Context, instanceID int, hashes []
 			if attempt < maxAttempts {
 				select {
 				case <-syncCtx.Done():
-					break
+					break retryLoop
 				case <-time.After(150 * time.Millisecond):
 				}
 			}


### PR DESCRIPTION
### Problem
Cross-seed in reflink/hardlink mode can add torrents and immediately call `BulkAction(..., "recheck")`. Right after `AddTorrent()`, qui’s qBittorrent sync cache may not include the newly-added torrent yet, causing `BulkAction()` to fail with `no sync data available`, which prevents the recheck and leaves the torrent paused.

### Change
- Update `internal/qbittorrent/sync_manager.go` `BulkAction()` to handle an initial empty `GetTorrentMap()` result by forcing a short qBittorrent sync and retrying the map lookup (bounded attempts within a 3s timeout), then only returning `no sync data available` if still missing.
- Use a detached context for the forced sync (`context.Background()` with timeout) so request cancellation doesn’t abort the critical post-add sync.

### Outcome
Hardlink/reflink cross-seeds with extra files reliably trigger recheck immediately after add, enabling threshold-based resume behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bulk action reliability by adding automatic, time-limited retry attempts when torrent data is temporarily unavailable, improving handling of recently added torrents.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->