### PR TITLE
fix(web): redirect already authenticated users to dashboard

### DIFF
--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -24,7 +24,7 @@ import { toast } from "sonner"
 
 export function Login() {
   const navigate = useNavigate()
-  const { login, isLoggingIn, loginError, setIsAuthenticated } = useAuth()
+  const { login, isLoggingIn, loginError, setIsAuthenticated, isAuthenticated, isLoading } = useAuth()
 
   // Query to check if setup is required
   const { data: setupRequired } = useQuery({
@@ -45,6 +45,12 @@ export function Login() {
   })
 
   useEffect(() => {
+    // Redirect to homepage if user is already authenticated
+    if (isAuthenticated && !isLoading) {
+      navigate({ to: "/dashboard" })
+      return
+    }
+
     // Redirect to setup if required
     if (setupRequired) {
       navigate({ to: "/setup" })
@@ -67,7 +73,7 @@ export function Login() {
         toast.error(error.message || "OIDC authentication failed")
       })
     }
-  }, [setupRequired, navigate, setIsAuthenticated])
+  }, [setupRequired, navigate, setIsAuthenticated, isAuthenticated, isLoading])
 
   const form = useForm({
     defaultValues: {


### PR DESCRIPTION
The `/login` page should just redirect to the home page (`/dashboard`) if the user is already authenticated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed login flow to automatically redirect already-authenticated users directly to the dashboard, preventing unnecessary access to the login page.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->