### PR TITLE
fix(crossseed): restore reuse matched category option

### DIFF
--- a/web/src/pages/CrossSeedPage.tsx
+++ b/web/src/pages/CrossSeedPage.tsx
@@ -1024,9 +1024,12 @@ export function CrossSeedPage({ activeTab, onTabChange }: CrossSeedPageProps) {
   }
 
   const handleSaveGlobal = () => {
+    // Clear prior validation errors
+    setValidationErrors(prev => ({ ...prev, customCategory: "" }))
+
     // Validate custom category mode has a category specified
     if (globalSettings.useCustomCategory && !globalSettings.customCategory.trim()) {
-      toast.error("Custom category mode requires a category name")
+      setValidationErrors(prev => ({ ...prev, customCategory: "Custom category mode requires a category name" }))
       return
     }
 
@@ -2410,15 +2413,26 @@ export function CrossSeedPage({ activeTab, onTabChange }: CrossSeedPageProps) {
                       </div>
                       <p className="text-xs text-muted-foreground">Use a fixed category name for all cross-seeds.</p>
                       {globalSettings.useCustomCategory && (
-                        <MultiSelect
-                          options={customCategorySelectOptions}
-                          selected={globalSettings.customCategory ? [globalSettings.customCategory] : []}
-                          onChange={values => setGlobalSettings(prev => ({ ...prev, customCategory: values[0] ?? "" }))}
-                          placeholder="Select or type a category..."
-                          className="mt-2 max-w-xs"
-                          creatable
-                          onCreateOption={value => setGlobalSettings(prev => ({ ...prev, customCategory: value }))}
-                        />
+                        <>
+                          <MultiSelect
+                            options={customCategorySelectOptions}
+                            selected={globalSettings.customCategory ? [globalSettings.customCategory] : []}
+                            onChange={values => {
+                              setGlobalSettings(prev => ({ ...prev, customCategory: values[0] ?? "" }))
+                              setValidationErrors(prev => ({ ...prev, customCategory: "" }))
+                            }}
+                            placeholder="Select or type a category..."
+                            className={`mt-2 max-w-xs ${validationErrors.customCategory ? "border-destructive" : ""}`}
+                            creatable
+                            onCreateOption={value => {
+                              setGlobalSettings(prev => ({ ...prev, customCategory: value }))
+                              setValidationErrors(prev => ({ ...prev, customCategory: "" }))
+                            }}
+                          />
+                          {validationErrors.customCategory && (
+                            <p className="text-sm text-destructive">{validationErrors.customCategory}</p>
+                          )}
+                        </>
                       )}
                     </div>
                   </div>


### PR DESCRIPTION
Cross-seed category settings in `web/src/pages/CrossSeedPage.tsx` switched to radio buttons, which removed the ability to reuse the matched torrent’s existing qBittorrent category (needed for non-hardlink/reflink mode).

- Add an explicit **Reuse matched torrent category** mode.
- Normalize category-mode booleans (custom > indexer > suffix > reuse) so legacy/invalid combinations collapse deterministically.
- Preserve historical default to `.cross` suffix when the backend omits `useCrossCategorySuffix`.
- Validate custom-category mode requires a non-empty category before saving.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Reuse matched torrent category" option in Cross-Seed Rules to reuse categories from matched torrents.
  * Custom category editor now supports selecting or creating categories with inline validation and clears errors on change.

* **Bug Fixes / Validation**
  * Save is blocked and an error shown if custom category mode is enabled but no category is provided.
  * Category selection precedence and fallback behavior improved to ensure stable settings and legacy compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->