### PR TITLE
fix(web) add missing ratio colors in TorrentCardsMobile

### DIFF
--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -82,7 +82,7 @@ import { getLinuxCategory, getLinuxIsoName, getLinuxRatio, getLinuxTags, getLinu
 import { formatSpeedWithUnit, useSpeedUnits, type SpeedUnit } from "@/lib/speedUnits"
 import { getStateLabel } from "@/lib/torrent-state-utils"
 import { getCommonCategory, getCommonSavePath, getCommonTags } from "@/lib/torrent-utils"
-import { cn, formatBytes } from "@/lib/utils"
+import { cn, formatBytes, getRatioColor } from "@/lib/utils"
 import type { Category, Torrent, TorrentCounts, TorrentFilters } from "@/types"
 import { useQuery } from "@tanstack/react-query"
 import { getDefaultSortOrder, TORRENT_SORT_OPTIONS, type TorrentSortOptionValue } from "./torrentSortOptions"
@@ -718,10 +718,10 @@ function SwipeableCard({
             </span>
             <div className="flex items-center gap-1">
               <span className="text-muted-foreground">Ratio:</span>
-              <span className={cn(
-                "font-medium",
-                displayRatio >= 1 ? "[color:var(--chart-3)]" : "[color:var(--chart-4)]"
-              )}>
+              <span
+                className="font-medium"
+                style={{ color: getRatioColor(displayRatio) }}
+              >
                 {displayRatio === -1 ? "∞" : displayRatio.toFixed(2)}
               </span>
             </div>
@@ -787,10 +787,10 @@ function SwipeableCard({
               {/* Ratio on the left */}
               <div className="flex items-center gap-1">
                 <span className="text-muted-foreground">Ratio:</span>
-                <span className={cn(
-                  "font-medium",
-                  displayRatio >= 1 ? "[color:var(--chart-3)]" : "[color:var(--chart-4)]"
-                )}>
+                <span
+                  className="font-medium"
+                  style={{ color: getRatioColor(displayRatio) }}
+                >
                   {displayRatio === -1 ? "∞" : displayRatio.toFixed(2)}
                 </span>
               </div>

--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -18,7 +18,7 @@ import { useTorrentExporter } from "@/hooks/useTorrentExporter"
 import { useTorrentsList } from "@/hooks/useTorrentsList"
 import { useTrackerIcons } from "@/hooks/useTrackerIcons"
 import { columnFiltersToExpr } from "@/lib/column-filter-utils"
-import { formatBytes } from "@/lib/utils"
+import { formatBytes, getRatioColor } from "@/lib/utils"
 import {
   DndContext,
   MouseSensor,
@@ -465,10 +465,10 @@ const CompactRow = memo(({
         </span>
         <div className="flex items-center gap-1">
           <span className="text-muted-foreground">Ratio:</span>
-          <span className={cn(
-            "font-medium",
-            displayRatio >= 1 ? "[color:var(--chart-3)]" : "[color:var(--chart-4)]"
-          )}>
+          <span
+            className="font-medium"
+            style={{ color: getRatioColor(displayRatio) }}
+          >
             {displayRatio === -1 ? "∞" : displayRatio.toFixed(2)}
           </span>
         </div>


### PR DESCRIPTION
TorrentCardsMobile and TorrentTableOptimized CompactRow were using a simplified 2-color ratio logic instead of the 5-tier getRatioColor function used in TorrentTableColumns. This caused inconsistent color display across different views.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated ratio text color styling in torrent components to use a computed inline style approach instead of CSS class-based coloring. The visual appearance and functionality remain consistent.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->