### PR TITLE
feat(automations): same content counts

### DIFF
--- a/internal/models/automation.go
+++ b/internal/models/automation.go
@@ -414,6 +414,12 @@ const (
 	OperatorBetween            ConditionOperator = "BETWEEN"
 	OperatorMatches            ConditionOperator = "MATCHES" // regex
 
+	// Percentage operators (for content count fields)
+	OperatorGreaterThanPercent        ConditionOperator = "GREATER_THAN_PERCENT"
+	OperatorGreaterThanOrEqualPercent ConditionOperator = "GREATER_THAN_OR_EQUAL_PERCENT"
+	OperatorLessThanPercent           ConditionOperator = "LESS_THAN_PERCENT"
+	OperatorLessThanOrEqualPercent    ConditionOperator = "LESS_THAN_OR_EQUAL_PERCENT"
+
 	// Cross-category lookup operators (NAME field only)
 	OperatorExistsIn   ConditionOperator = "EXISTS_IN"   // exact name match in target category
 	OperatorContainsIn ConditionOperator = "CONTAINS_IN" // partial name match in target category

--- a/internal/models/automation.go
+++ b/internal/models/automation.go
@@ -430,6 +430,12 @@ type RuleCondition struct {
 	Negate     bool              `json:"negate,omitempty"`
 	Conditions []*RuleCondition  `json:"conditions,omitempty"`
 	Compiled   *regexp.Regexp    `json:"-"` // compiled regex, not serialized
+
+	// IncludeCrossSeeds extends content count fields (SAME_CONTENT_COUNT, UNREGISTERED_SAME_CONTENT_COUNT,
+	// REGISTERED_SAME_CONTENT_COUNT) to also count cross-seeds that share the same SavePath but may have
+	// different ContentPath. This is useful when cross-seeded torrents from different trackers have
+	// different naming conventions but point to the same files.
+	IncludeCrossSeeds bool `json:"includeCrossSeeds,omitempty"`
 }
 
 // IsGroup returns true if this condition is an AND/OR group containing child conditions.

--- a/internal/models/automation.go
+++ b/internal/models/automation.go
@@ -421,21 +421,16 @@ const (
 
 // RuleCondition represents a condition or group of conditions for filtering torrents.
 type RuleCondition struct {
-	Field      ConditionField    `json:"field,omitempty"`
-	Operator   ConditionOperator `json:"operator"`
-	Value      string            `json:"value,omitempty"`
-	MinValue   *float64          `json:"minValue,omitempty"`
-	MaxValue   *float64          `json:"maxValue,omitempty"`
-	Regex      bool              `json:"regex,omitempty"`
-	Negate     bool              `json:"negate,omitempty"`
-	Conditions []*RuleCondition  `json:"conditions,omitempty"`
-	Compiled   *regexp.Regexp    `json:"-"` // compiled regex, not serialized
-
-	// IncludeCrossSeeds extends content count fields (SAME_CONTENT_COUNT, UNREGISTERED_SAME_CONTENT_COUNT,
-	// REGISTERED_SAME_CONTENT_COUNT) to also count cross-seeds that share the same SavePath but may have
-	// different ContentPath. This is useful when cross-seeded torrents from different trackers have
-	// different naming conventions but point to the same files.
-	IncludeCrossSeeds bool `json:"includeCrossSeeds,omitempty"`
+	Field             ConditionField    `json:"field,omitempty"`
+	Operator          ConditionOperator `json:"operator"`
+	Value             string            `json:"value,omitempty"`
+	MinValue          *float64          `json:"minValue,omitempty"`
+	MaxValue          *float64          `json:"maxValue,omitempty"`
+	Regex             bool              `json:"regex,omitempty"`
+	Negate            bool              `json:"negate,omitempty"`
+	Conditions        []*RuleCondition  `json:"conditions,omitempty"`
+	Compiled          *regexp.Regexp    `json:"-"`                           // compiled regex, not serialized
+	IncludeCrossSeeds bool              `json:"includeCrossSeeds,omitempty"` // For *_SAME_CONTENT_COUNT: also match by content basename (folder/file name)
 }
 
 // IsGroup returns true if this condition is an AND/OR group containing child conditions.

--- a/internal/models/automation.go
+++ b/internal/models/automation.go
@@ -372,6 +372,11 @@ const (
 	FieldNumIncomplete ConditionField = "NUM_INCOMPLETE"
 	FieldTrackersCount ConditionField = "TRACKERS_COUNT"
 
+	// Cross-seed count fields (counts of torrents sharing same ContentPath)
+	FieldSameContentCount             ConditionField = "SAME_CONTENT_COUNT"              // Total torrents with same content (including self)
+	FieldUnregisteredSameContentCount ConditionField = "UNREGISTERED_SAME_CONTENT_COUNT" // Unregistered torrents with same content (excluding self)
+	FieldRegisteredSameContentCount   ConditionField = "REGISTERED_SAME_CONTENT_COUNT"   // Registered torrents with same content (excluding self)
+
 	// Boolean fields
 	FieldPrivate        ConditionField = "PRIVATE"
 	FieldIsUnregistered ConditionField = "IS_UNREGISTERED"
@@ -482,7 +487,7 @@ type PauseAction struct {
 // DeleteAction configures deletion with mode and conditions.
 type DeleteAction struct {
 	Enabled          bool           `json:"enabled"`
-	Mode             string         `json:"mode"` // "delete", "deleteWithFiles", "deleteWithFilesPreserveCrossSeeds", "deleteWithFilesIncludeCrossSeeds"
+	Mode             string         `json:"mode"`                       // "delete", "deleteWithFiles", "deleteWithFilesPreserveCrossSeeds", "deleteWithFilesIncludeCrossSeeds"
 	IncludeHardlinks bool           `json:"includeHardlinks,omitempty"` // Only valid when mode is "deleteWithFilesIncludeCrossSeeds" and instance has local filesystem access
 	Condition        *RuleCondition `json:"condition,omitempty"`
 }

--- a/internal/services/automations/condition.go
+++ b/internal/services/automations/condition.go
@@ -109,6 +109,12 @@ const (
 	OperatorBetween            = models.OperatorBetween
 	OperatorMatches            = models.OperatorMatches
 
+	// Percentage operators (for content count fields)
+	OperatorGreaterThanPercent        = models.OperatorGreaterThanPercent
+	OperatorGreaterThanOrEqualPercent = models.OperatorGreaterThanOrEqualPercent
+	OperatorLessThanPercent           = models.OperatorLessThanPercent
+	OperatorLessThanOrEqualPercent    = models.OperatorLessThanOrEqualPercent
+
 	// Cross-category lookup operators (NAME field only)
 	OperatorExistsIn   = models.OperatorExistsIn
 	OperatorContainsIn = models.OperatorContainsIn

--- a/internal/services/automations/condition.go
+++ b/internal/services/automations/condition.go
@@ -69,6 +69,11 @@ const (
 	FieldNumIncomplete = models.FieldNumIncomplete
 	FieldTrackersCount = models.FieldTrackersCount
 
+	// Cross-seed count fields
+	FieldSameContentCount             = models.FieldSameContentCount
+	FieldUnregisteredSameContentCount = models.FieldUnregisteredSameContentCount
+	FieldRegisteredSameContentCount   = models.FieldRegisteredSameContentCount
+
 	// Boolean fields
 	FieldPrivate        = models.FieldPrivate
 	FieldIsUnregistered = models.FieldIsUnregistered

--- a/internal/services/automations/evaluator.go
+++ b/internal/services/automations/evaluator.go
@@ -133,7 +133,7 @@ func BuildContentGroupIndex(torrents []qbt.Torrent) map[string][]string {
 	// First pass: group torrents by normalized ContentPath
 	byContentPath := make(map[string][]string) // normalized path → list of hashes
 	for _, t := range torrents {
-		normalizedPath := normalizeContentPath(t.ContentPath)
+		normalizedPath := normalizePath(t.ContentPath)
 		if normalizedPath == "" {
 			continue // Skip torrents without ContentPath
 		}
@@ -155,23 +155,11 @@ func BuildContentGroupIndex(torrents []qbt.Torrent) map[string][]string {
 	return result
 }
 
-// normalizeContentPath standardizes a content path for comparison.
-// Lowercases, normalizes path separators, and removes trailing slashes.
-func normalizeContentPath(p string) string {
-	if p == "" {
-		return ""
-	}
-	p = strings.ToLower(p)
-	p = strings.ReplaceAll(p, "\\", "/")
-	p = strings.TrimSuffix(p, "/")
-	return p
-}
-
 // getContentBasename extracts just the folder/file name from a content path.
 // For "D:\Movies\Some.Movie.2024" returns "some.movie.2024" (lowercased).
 // This allows matching cross-seeds that have the same content but different parent directories.
 func getContentBasename(contentPath string) string {
-	normalized := normalizeContentPath(contentPath)
+	normalized := normalizePath(contentPath)
 	if normalized == "" {
 		return ""
 	}

--- a/internal/services/automations/evaluator.go
+++ b/internal/services/automations/evaluator.go
@@ -200,6 +200,16 @@ func BuildBasenameGroupIndex(torrents []qbt.Torrent) map[string][]string {
 		byBasename[basename] = append(byBasename[basename], t.Hash)
 	}
 
+	// Debug: log groups with many members
+	for basename, hashes := range byBasename {
+		if len(hashes) >= 5 {
+			log.Trace().
+				Str("basename", basename).
+				Int("count", len(hashes)).
+				Msg("automations: basename group with 5+ members")
+		}
+	}
+
 	// Second pass: build hash → group mapping (only for groups with 2+ torrents)
 	result := make(map[string][]string)
 	for _, hashes := range byBasename {

--- a/internal/services/automations/evaluator_test.go
+++ b/internal/services/automations/evaluator_test.go
@@ -1102,7 +1102,7 @@ func TestBuildBasenameGroupIndex_CrossSeedPaths(t *testing.T) {
 		{Hash: "ulcx-hash", ContentPath: "D:\\UA_Linked\\ULCX\\Code.3.2025.2160p.AMZN.WEBRip.FAN.GRADE.HDR10.DoVi.x265.DDP5.1-RANSOM.mkv"},
 		{Hash: "aither-hash", ContentPath: "D:\\UA_Linked\\AITHER\\Code.3.2025.2160p.AMZN.WEBRip.FAN.GRADE.HDR10.DoVi.x265.DDP5.1-RANSOM.mkv"},
 		{Hash: "movies-hash", ContentPath: "D:\\Movies\\Code.3.2025.2160p.AMZN.WEBRip.FAN.GRADE.HDR10.DoVi.x265.DDP5.1-RANSOM.mkv"}, // Original in different dir
-		{Hash: "other-hash", ContentPath: "D:\\Movies\\Different.Movie.2024.mkv"}, // Different movie
+		{Hash: "other-hash", ContentPath: "D:\\Movies\\Different.Movie.2024.mkv"},                                                   // Different movie
 	}
 
 	basenameGroupByHash := BuildBasenameGroupIndex(torrents)

--- a/internal/services/automations/service.go
+++ b/internal/services/automations/service.go
@@ -290,10 +290,13 @@ func buildPreviewTorrent(torrent qbt.Torrent, tracker string, evalCtx *EvalConte
 		if evalCtx.HardlinkScopeByHash != nil {
 			pt.HardlinkScope = evalCtx.HardlinkScopeByHash[torrent.Hash]
 		}
-		// Add content count fields for debugging (using ContentPath matching, not basename)
-		pt.SameContentCount = getSameContentCount(torrent.Hash, false, evalCtx)
-		pt.UnregisteredSameContentCount = getUnregisteredSameContentCount(torrent.Hash, false, evalCtx)
-		pt.RegisteredSameContentCount = getRegisteredSameContentCount(torrent.Hash, false, evalCtx)
+		// Add content count fields for debugging
+		// When basename index is available (IncludeCrossSeeds used), show basename-based counts
+		// Otherwise show ContentPath-based counts
+		useBasename := evalCtx.BasenameGroupByHash != nil
+		pt.SameContentCount = getSameContentCount(torrent.Hash, useBasename, evalCtx)
+		pt.UnregisteredSameContentCount = getUnregisteredSameContentCount(torrent.Hash, useBasename, evalCtx)
+		pt.RegisteredSameContentCount = getRegisteredSameContentCount(torrent.Hash, useBasename, evalCtx)
 	}
 
 	return pt

--- a/web/src/components/query-builder/LeafCondition.tsx
+++ b/web/src/components/query-builder/LeafCondition.tsx
@@ -605,12 +605,16 @@ export function LeafCondition({
       ) : (
         <div className="flex items-center gap-1">
           <Input
-            type={isNumericType(fieldType) ? "number" : "text"}
+            type={isNumericType(fieldType) || isPercentOperator(condition.operator) ? "number" : "text"}
             className="h-8 w-32 flex-1"
             value={condition.value ?? ""}
             onChange={(e) => handleValueChange(e.target.value)}
-            placeholder={getPlaceholder(fieldType)}
+            placeholder={isPercentOperator(condition.operator) ? "0-100" : getPlaceholder(fieldType)}
           />
+          {/* Show % indicator for percentage operators */}
+          {isPercentOperator(condition.operator) && (
+            <span className="text-muted-foreground text-sm">%</span>
+          )}
           {/* Regex toggle for string fields - hide for EXISTS_IN/CONTAINS_IN */}
           {fieldType === "string" &&
             condition.operator !== "MATCHES" &&
@@ -688,6 +692,10 @@ export function LeafCondition({
 
 function isNumericType(type: string): boolean {
   return ["bytes", "duration", "float", "speed", "integer"].includes(type);
+}
+
+function isPercentOperator(operator: string | undefined): boolean {
+  return operator?.includes("PERCENT") ?? false;
 }
 
 function getPlaceholder(type: string): string {

--- a/web/src/components/query-builder/LeafCondition.tsx
+++ b/web/src/components/query-builder/LeafCondition.tsx
@@ -16,7 +16,7 @@ import { cn } from "@/lib/utils";
 import type { ConditionField, ConditionOperator, RuleCondition } from "@/types";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { GripVertical, ToggleLeft, ToggleRight, X } from "lucide-react";
+import { GripVertical, GitMerge, ToggleLeft, ToggleRight, X } from "lucide-react";
 import { useState } from "react";
 import {
   getFieldType,
@@ -208,6 +208,17 @@ export function LeafCondition({
   const toggleRegex = () => {
     onChange({ ...condition, regex: !condition.regex });
   };
+
+  const toggleIncludeCrossSeeds = () => {
+    onChange({ ...condition, includeCrossSeeds: !condition.includeCrossSeeds });
+  };
+
+  // Check if field is a content count field that supports includeCrossSeeds
+  const isContentCountField = condition.field && [
+    "SAME_CONTENT_COUNT",
+    "UNREGISTERED_SAME_CONTENT_COUNT",
+    "REGISTERED_SAME_CONTENT_COUNT"
+  ].includes(condition.field);
 
   // Duration handling - parse seconds to display value using tracked unit
   const getDurationDisplay = (): { value: string; unit: number } => {
@@ -634,6 +645,30 @@ export function LeafCondition({
               </TooltipTrigger>
               <TooltipContent>
                 {condition.regex ? "Regex enabled" : "Enable regex"}
+              </TooltipContent>
+            </Tooltip>
+          )}
+          {/* Include cross-seeds toggle for content count fields */}
+          {isContentCountField && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className={cn(
+                    "h-7 px-2",
+                    condition.includeCrossSeeds && "bg-primary/10 text-primary"
+                  )}
+                  onClick={toggleIncludeCrossSeeds}
+                >
+                  <GitMerge className="size-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {condition.includeCrossSeeds 
+                  ? "Including cross-seeds (matching by SavePath)" 
+                  : "Click to include cross-seeds (match by SavePath in addition to ContentPath)"}
               </TooltipContent>
             </Tooltip>
           )}

--- a/web/src/components/query-builder/LeafCondition.tsx
+++ b/web/src/components/query-builder/LeafCondition.tsx
@@ -16,7 +16,7 @@ import { cn } from "@/lib/utils";
 import type { ConditionField, ConditionOperator, RuleCondition } from "@/types";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { GripVertical, GitMerge, ToggleLeft, ToggleRight, X } from "lucide-react";
+import { GitMerge, GripVertical, ToggleLeft, ToggleRight, X } from "lucide-react";
 import { useState } from "react";
 import {
   getFieldType,
@@ -212,13 +212,6 @@ export function LeafCondition({
   const toggleIncludeCrossSeeds = () => {
     onChange({ ...condition, includeCrossSeeds: !condition.includeCrossSeeds });
   };
-
-  // Check if field is a content count field that supports includeCrossSeeds
-  const isContentCountField = condition.field && [
-    "SAME_CONTENT_COUNT",
-    "UNREGISTERED_SAME_CONTENT_COUNT",
-    "REGISTERED_SAME_CONTENT_COUNT"
-  ].includes(condition.field);
 
   // Duration handling - parse seconds to display value using tracked unit
   const getDurationDisplay = (): { value: string; unit: number } => {
@@ -648,31 +641,34 @@ export function LeafCondition({
               </TooltipContent>
             </Tooltip>
           )}
-          {/* Include cross-seeds toggle for content count fields */}
-          {isContentCountField && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  className={cn(
-                    "h-7 px-2",
-                    condition.includeCrossSeeds && "bg-primary/10 text-primary"
-                  )}
-                  onClick={toggleIncludeCrossSeeds}
-                >
-                  <GitMerge className="size-4" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                {condition.includeCrossSeeds 
-                  ? "Including cross-seeds (matching by SavePath)" 
-                  : "Click to include cross-seeds (match by SavePath in addition to ContentPath)"}
-              </TooltipContent>
-            </Tooltip>
-          )}
         </div>
+      )}
+
+      {/* Include cross-seeds toggle (for content count fields) */}
+      {(condition.field === "SAME_CONTENT_COUNT" ||
+        condition.field === "UNREGISTERED_SAME_CONTENT_COUNT" ||
+        condition.field === "REGISTERED_SAME_CONTENT_COUNT") && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className={cn(
+                "h-7 px-2",
+                condition.includeCrossSeeds && "bg-primary/10 text-primary"
+              )}
+              onClick={toggleIncludeCrossSeeds}
+            >
+              <GitMerge className="size-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            {condition.includeCrossSeeds
+              ? "Cross-seeds included (matching by content folder name)"
+              : "Click to include cross-seeds with same folder name"}
+          </TooltipContent>
+        </Tooltip>
       )}
 
       {/* Remove button */}

--- a/web/src/components/query-builder/constants.ts
+++ b/web/src/components/query-builder/constants.ts
@@ -220,6 +220,17 @@ export const NAME_SPECIAL_OPERATORS = [
   { value: "CONTAINS_IN", label: "similar exists in" },
 ];
 
+// Percentage operators for content count fields (UNREGISTERED_SAME_CONTENT_COUNT, REGISTERED_SAME_CONTENT_COUNT)
+export const PERCENT_OPERATORS = [
+  { value: "GREATER_THAN_PERCENT", label: "> %" },
+  { value: "GREATER_THAN_OR_EQUAL_PERCENT", label: ">= %" },
+  { value: "LESS_THAN_PERCENT", label: "< %" },
+  { value: "LESS_THAN_OR_EQUAL_PERCENT", label: "<= %" },
+];
+
+// Fields that support percentage operators (comparing count as % of total)
+const PERCENT_ENABLED_FIELDS = ["UNREGISTERED_SAME_CONTENT_COUNT", "REGISTERED_SAME_CONTENT_COUNT"];
+
 // Helper to get operators for a field
 export function getOperatorsForField(field: string) {
   const type = getFieldType(field);
@@ -228,6 +239,11 @@ export function getOperatorsForField(field: string) {
   // Add special cross-category operators for NAME field only
   if (field === "NAME") {
     return [...baseOperators, ...NAME_SPECIAL_OPERATORS];
+  }
+
+  // Add percentage operators for content count fields
+  if (PERCENT_ENABLED_FIELDS.includes(field)) {
+    return [...baseOperators, ...PERCENT_OPERATORS];
   }
 
   return baseOperators;

--- a/web/src/components/query-builder/constants.ts
+++ b/web/src/components/query-builder/constants.ts
@@ -42,6 +42,11 @@ export const CONDITION_FIELDS = {
   NUM_INCOMPLETE: { label: "Total Leechers", type: "integer" as const, description: "Total leechers in swarm (tracker-reported)" },
   TRACKERS_COUNT: { label: "Trackers", type: "integer" as const, description: "Number of trackers" },
 
+  // Cross-seed count fields
+  SAME_CONTENT_COUNT: { label: "Same Content Count", type: "integer" as const, description: "Total torrents sharing the same content (including self)" },
+  UNREGISTERED_SAME_CONTENT_COUNT: { label: "Unregistered Same Content", type: "integer" as const, description: "Other unregistered torrents sharing the same content" },
+  REGISTERED_SAME_CONTENT_COUNT: { label: "Registered Same Content", type: "integer" as const, description: "Other registered torrents sharing the same content" },
+
   // Boolean fields
   PRIVATE: { label: "Private", type: "boolean" as const, description: "Private tracker torrent" },
   IS_UNREGISTERED: { label: "Unregistered", type: "boolean" as const, description: "Tracker reports torrent as unregistered" },
@@ -192,6 +197,10 @@ export const FIELD_GROUPS = [
   {
     label: "Tracker",
     fields: ["TRACKER", "TRACKERS_COUNT", "PRIVATE", "IS_UNREGISTERED", "COMMENT"],
+  },
+  {
+    label: "Cross-Seeds",
+    fields: ["SAME_CONTENT_COUNT", "UNREGISTERED_SAME_CONTENT_COUNT", "REGISTERED_SAME_CONTENT_COUNT"],
   },
   {
     label: "Files",

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -226,6 +226,8 @@ export interface RuleCondition {
   maxValue?: number
   regex?: boolean
   negate?: boolean
+  /** Include cross-seeds that share the same SavePath (for content count fields) */
+  includeCrossSeeds?: boolean
   conditions?: RuleCondition[]
 }
 

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -212,6 +212,11 @@ export type ConditionOperator =
   | "LESS_THAN_OR_EQUAL"
   | "BETWEEN"
   | "MATCHES"
+  // Percentage operators (for content count fields)
+  | "GREATER_THAN_PERCENT"
+  | "GREATER_THAN_OR_EQUAL_PERCENT"
+  | "LESS_THAN_PERCENT"
+  | "LESS_THAN_OR_EQUAL_PERCENT"
   // Cross-category lookup operators (NAME field only)
   | "EXISTS_IN"
   | "CONTAINS_IN"

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -226,9 +226,9 @@ export interface RuleCondition {
   maxValue?: number
   regex?: boolean
   negate?: boolean
-  /** Include cross-seeds that share the same SavePath (for content count fields) */
-  includeCrossSeeds?: boolean
   conditions?: RuleCondition[]
+  /** For *_SAME_CONTENT_COUNT fields: also match by content basename (folder/file name) for cross-seed detection */
+  includeCrossSeeds?: boolean
 }
 
 export interface SpeedLimitAction {

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -185,6 +185,10 @@ export type ConditionField =
   | "NUM_COMPLETE"
   | "NUM_INCOMPLETE"
   | "TRACKERS_COUNT"
+  // Cross-seed count fields
+  | "SAME_CONTENT_COUNT"
+  | "UNREGISTERED_SAME_CONTENT_COUNT"
+  | "REGISTERED_SAME_CONTENT_COUNT"
   // Boolean fields
   | "PRIVATE"
   | "IS_UNREGISTERED"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three content-sharing metrics for automation rules: Same Content Count, Unregistered Same Content, and Registered Same Content.
  * Introduced percentage-based comparison operators for these content-count fields and a UI toggle to include cross-seed (basename) matching.
  * Preview and rule previews now surface content-count and save-path info for debugging.

* **Tests**
  * Added comprehensive tests for content grouping, basename normalization, and content-count evaluation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->