### PR TITLE
fix(automations): handle -1 value for incomplete torrent completion_on

### DIFF
--- a/internal/services/automations/evaluator.go
+++ b/internal/services/automations/evaluator.go
@@ -338,8 +338,9 @@ func evaluateLeaf(cond *RuleCondition, torrent qbt.Torrent, ctx *EvalContext) bo
 	case FieldAddedOnAge:
 		return compareAge(torrent.AddedOn, cond, ctx)
 	case FieldCompletionOnAge:
-		// If completion_on is 0 (never completed), don't match
-		if torrent.CompletionOn == 0 {
+		// If completion_on is 0 or -1 (never completed), don't match
+		// qBittorrent uses -1 for incomplete torrents
+		if torrent.CompletionOn <= 0 {
 			return false
 		}
 		return compareAge(torrent.CompletionOn, cond, ctx)

--- a/internal/services/automations/evaluator_test.go
+++ b/internal/services/automations/evaluator_test.go
@@ -1293,6 +1293,17 @@ func TestEvaluateCondition_AgeFields(t *testing.T) {
 			expected: false,
 		},
 		{
+			name: "completion_on_age unset (-1 qBittorrent) - does not match",
+			cond: &RuleCondition{
+				Field:    FieldCompletionOnAge,
+				Operator: OperatorGreaterThanOrEqual,
+				Value:    "86400", // 1 day
+			},
+			torrent:  qbt.Torrent{CompletionOn: -1}, // qBittorrent uses -1 for incomplete torrents
+			ctx:      &EvalContext{NowUnix: nowUnix},
+			expected: false,
+		},
+		{
 			name: "completion_on_age between - matches",
 			cond: &RuleCondition{
 				Field:    FieldCompletionOnAge,


### PR DESCRIPTION
## Summary

Fixes #1179 - "Completion Age >= x" automation rules were triggering instantly for torrents that hadn't finished downloading.

## Problem

When a torrent hasn't completed downloading, qBittorrent returns `-1` for the `completion_on` field (not `0`). The existing code only checked for `== 0`, so incomplete torrents with `completion_on: -1` would pass through and trigger the automation rule immediately.

This was verified by checking qBittorrent's source code at `src/base/utils/datetime.cpp`:
```cpp
qint64 Utils::DateTime::toSecsSinceEpoch(const QDateTime &dateTime)
{
    return dateTime.isValid() ? dateTime.toSecsSinceEpoch() : -1;
}
```

## Changes

- **`internal/services/automations/evaluator.go`**: Changed the completion check from `== 0` to `<= 0` to handle both `0` and `-1` values for incomplete torrents
- **`internal/services/automations/evaluator_test.go`**: Added test case specifically for `CompletionOn == -1` to ensure qBittorrent's incomplete torrent behavior is properly handled

## Test Plan

- [x] Existing tests pass
- [x] New test case `completion_on_age unset (-1 qBittorrent) - does not match` passes
- [ ] Manual testing with qBittorrent to verify incomplete torrents no longer trigger completion age rules

---

This PR was written using [Vibe Kanban](https://vibekanban.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed age-based automation conditions to properly exclude incomplete items from matching criteria.

* **Tests**
  * Added test case validating correct handling of incomplete items in age-based condition evaluation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->