### PR TITLE
feat(ui): Use 4 column grid for dashboard instances on 2xl screens

### DIFF
--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -2331,7 +2331,7 @@ export function Dashboard() {
                     return (
                       <div key={sectionId}>
                         {/* Responsive layout so each instance mounts once */}
-                        <div className="flex flex-col gap-4 sm:grid sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                        <div className="flex flex-col gap-4 sm:grid sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
                           {statsData.map(instanceData => (
                             <InstanceCard
                               key={instanceData.instance.id}


### PR DESCRIPTION
Tested with both `xl:grid-cols-4` and `2xl:grid-cols-4`, but found that 4 columns can be too small on the lower end of `xl` sizes.

Before
<img width="2559" height="1322" alt="firefox_v7l5EK2oY8" src="https://github.com/user-attachments/assets/9793e49c-6a8d-41c9-830a-3b72ef56af8b" />

After

<img width="2560" height="1327" alt="riUZkQug7W" src="https://github.com/user-attachments/assets/5dad8bbc-6b82-4707-baba-9a670d4b4892" />

<img width="1515" height="990" alt="firefox_A543w7Af6J" src="https://github.com/user-attachments/assets/be7481de-887c-4c2b-83c8-2c5910acee14" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved Instance grid responsiveness with an additional breakpoint for very large screens, now displaying four columns instead of three on extra-wide displays.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->