### PR TITLE
fix(crossseed): normalize ampersand to "and" for title matching

### DIFF
--- a/pkg/stringutils/unicode.go
+++ b/pkg/stringutils/unicode.go
@@ -51,6 +51,7 @@ func NormalizeUnicode(s string) string {
 //   - Lowercase
 //   - Strip apostrophes (including Unicode variants)
 //   - Strip colons
+//   - Convert ampersand to "and"
 //   - Convert hyphens to spaces
 //   - Collapse multiple spaces to single space
 //
@@ -59,6 +60,7 @@ func NormalizeUnicode(s string) string {
 //   - "Bob's Burgers" → "bobs burgers"
 //   - "CSI: Miami" → "csi miami"
 //   - "Spider-Man" → "spider man"
+//   - "His & Hers" → "his and hers"
 func NormalizeForMatching(s string) string {
 	// First apply unicode normalization
 	s = NormalizeUnicode(s)
@@ -74,6 +76,10 @@ func NormalizeForMatching(s string) string {
 
 	// Remove colons - "csi: miami" → "csi miami"
 	s = strings.ReplaceAll(s, ":", "")
+
+	// Normalize ampersand to "and" - "His & Hers" → "His and Hers"
+	// Some trackers use & while others use "and" in release names
+	s = strings.ReplaceAll(s, "&", " and ")
 
 	// Normalize hyphens to spaces - "Spider-Man" → "spider man"
 	s = strings.ReplaceAll(s, "-", " ")

--- a/pkg/stringutils/unicode_test.go
+++ b/pkg/stringutils/unicode_test.go
@@ -95,6 +95,11 @@ func TestNormalizeForMatching(t *testing.T) {
 		{"hyphen", "Spider-Man", "spider man"},
 		{"multiple hyphens", "X-Men: Days of Future Past", "x men days of future past"},
 
+		// Ampersand handling
+		{"ampersand", "His & Hers", "his and hers"},
+		{"ampersand no spaces", "Law&Order", "law and order"},
+		{"ampersand with spaces", "Will & Grace", "will and grace"},
+
 		// Combined
 		{"all punctuation", "Bob's Place: Spider-Man", "bobs place spider man"},
 		{"unicode and punctuation", "Shōgun: The Warrior's Way", "shogun the warriors way"},
@@ -200,6 +205,16 @@ func TestNormalizeForMatching_RealWorldPairs(t *testing.T) {
 			"curly vs straight apostrophe",
 			"It's Always Sunny",
 			"It's Always Sunny",
+		},
+		{
+			"ampersand vs and",
+			"His & Hers S01",
+			"His and Hers S01",
+		},
+		{
+			"ampersand law and order",
+			"Law & Order SVU",
+			"Law and Order SVU",
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Add ampersand (`&`) to `and` normalization in `NormalizeForMatching`
- Some trackers use `&` while others use `and` in release names for the same content
- This caused cross-seed matching to fail when titles differed only by `&` vs `and`

## Test plan
- [x] Added unit tests for ampersand handling in `TestNormalizeForMatching`
- [x] Added real-world pair tests verifying `&` and `and` variants normalize identically
- [x] All existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved string normalization to convert ampersands ("&") to "and" for more accurate text matching results.

* **Tests**
  * Added test cases to verify ampersand conversion across various text formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->