### PR TITLE
fix(web,workflows) add import button to empty workflows state

### DIFF
--- a/web/src/components/instances/preferences/WorkflowsOverview.tsx
+++ b/web/src/components/instances/preferences/WorkflowsOverview.tsx
@@ -824,14 +824,24 @@ export function WorkflowsOverview({
                         <p className="text-sm text-muted-foreground">
                           No automations configured yet.
                         </p>
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          onClick={() => openCreateDialog(instance.id)}
-                        >
-                          <Plus className="h-4 w-4 mr-2" />
-                          Add your first rule
-                        </Button>
+                        <div className="flex flex-wrap items-center justify-center gap-2">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => openCreateDialog(instance.id)}
+                          >
+                            <Plus className="h-4 w-4 mr-2" />
+                            Add your first rule
+                          </Button>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => openImportDialog(instance.id)}
+                          >
+                            <Upload className="h-4 w-4 mr-2" />
+                            Import
+                          </Button>
+                        </div>
                       </div>
                     ) : (
                       <div className="space-y-2">


### PR DESCRIPTION
### Motivation
- The empty workflows state only exposed the "Add your first rule" action, preventing users from importing existing workflows from that view.
- Users should be able to import workflows immediately without first creating a rule.

### Description
- Updated `web/src/components/instances/preferences/WorkflowsOverview.tsx` to show an `Import` button alongside the `Add your first rule` button in the empty rules state. 
- The new button invokes `openImportDialog(instance.id)` and is rendered in a `flex` wrapper next to the `openCreateDialog(instance.id)` action.
- Adjusted the layout to use `flex-wrap` and a `gap-2` to keep the buttons neatly aligned in the empty state.

### Testing
- No automated tests were run for this change.
- Manual UI verification was not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69640eff35b48321b1b8238a40d75bcf)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the empty workflows view to display both "Add your first rule" and "Import" action buttons side by side, giving users direct access to import existing automations or create new ones from the initial setup screen.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->