### PR TITLE
fix(web): make Add Instance dialog scrollable on small viewports

### DIFF
--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -517,8 +517,8 @@ function InstancesManager({ search, onSearchChange }: InstancesManagerProps) {
       </div>
 
       <Dialog open={isDialogOpen} onOpenChange={(open) => open ? handleOpenDialog() : handleCloseDialog()}>
-        <DialogContent className="sm:max-w-[425px]">
-          <DialogHeader>
+        <DialogContent className="sm:max-w-[425px] max-h-[90dvh] flex flex-col">
+          <DialogHeader className="flex-shrink-0">
             <DialogTitle>
               {editingInstance ? "Edit Instance" : "Add Instance"}
             </DialogTitle>
@@ -526,11 +526,13 @@ function InstancesManager({ search, onSearchChange }: InstancesManagerProps) {
               {editingInstance? "Update your qBittorrent instance configuration": "Add a new qBittorrent instance to manage"}
             </DialogDescription>
           </DialogHeader>
-          <InstanceForm
-            instance={editingInstance}
-            onSuccess={handleCloseDialog}
-            onCancel={handleCloseDialog}
-          />
+          <div className="flex-1 overflow-y-auto min-h-0">
+            <InstanceForm
+              instance={editingInstance}
+              onSuccess={handleCloseDialog}
+              onCancel={handleCloseDialog}
+            />
+          </div>
         </DialogContent>
       </Dialog>
     </div>


### PR DESCRIPTION
## Summary
- Add `max-h-[90dvh] flex flex-col` to DialogContent to constrain height and enable flex layout
- Add `flex-shrink-0` to DialogHeader to keep it always visible
- Wrap InstanceForm in scrollable container with `flex-1 overflow-y-auto min-h-0`

Fixes #1231

## Test plan
- [x] Open Settings > Instances > Add Instance
- [x] Enable HTTP Basic Auth to expand the form
- [x] Shrink browser window height
- [x] Verify modal content scrolls and buttons remain accessible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the layout and scrolling behavior of the Settings dialog to better accommodate longer forms and content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->