### PR TITLE
fix(crossseed): reduce false negatives for anime matching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ tracker-icons/*
 backups/*
 .gocache/*
 torrentfiles/*
+analyses/*

--- a/internal/services/crossseed/matching.go
+++ b/internal/services/crossseed/matching.go
@@ -238,13 +238,13 @@ func (s *Service) releasesMatch(source, candidate *rls.Release, findIndividualEp
 
 	// Site field is used by anime releases where group is in brackets like [SubsPlease].
 	// rls parses these as Site rather than Group. Different fansub groups can never
-	// cross-seed, so enforce strict matching like Group.
+	// cross-seed, but many indexer titles omit the site tag entirely. Treat mismatched
+	// non-empty site tags as incompatible, but don't reject candidates that simply
+	// lack this metadata.
 	sourceSite := s.stringNormalizer.Normalize(source.Site)
 	candidateSite := s.stringNormalizer.Normalize(candidate.Site)
-	if sourceSite != "" {
-		if candidateSite == "" || sourceSite != candidateSite {
-			return false
-		}
+	if sourceSite != "" && candidateSite != "" && sourceSite != candidateSite {
+		return false
 	}
 
 	// Sum field contains the CRC32 checksum for anime releases like [32ECE75A].
@@ -489,9 +489,15 @@ func joinNormalizedCodecSlice(slice []string) string {
 	if len(slice) == 0 {
 		return ""
 	}
-	normalized := make([]string, len(slice))
-	for i, s := range slice {
-		normalized[i] = normalizeVideoCodec(s)
+	seen := make(map[string]struct{}, len(slice))
+	normalized := make([]string, 0, len(slice))
+	for _, codec := range slice {
+		n := normalizeVideoCodec(codec)
+		if _, ok := seen[n]; ok {
+			continue
+		}
+		seen[n] = struct{}{}
+		normalized = append(normalized, n)
 	}
 	sort.Strings(normalized)
 	return strings.Join(normalized, " ")

--- a/internal/services/crossseed/matching_anime_test.go
+++ b/internal/services/crossseed/matching_anime_test.go
@@ -54,7 +54,7 @@ func TestReleasesMatch_SiteMustMatch(t *testing.T) {
 			description: "same fansub group should match",
 		},
 		{
-			name: "source has site, candidate does not - should not match",
+			name: "source has site, candidate does not - should match",
 			source: rls.Release{
 				Title:   "Kingdom",
 				Series:  6,
@@ -66,8 +66,8 @@ func TestReleasesMatch_SiteMustMatch(t *testing.T) {
 				Series:  6,
 				Episode: 11,
 			},
-			wantMatch:   false,
-			description: "candidate must have matching site when source has one",
+			wantMatch:   true,
+			description: "missing site metadata should not block a match",
 		},
 		{
 			name: "candidate has site, source does not - should match",

--- a/internal/services/crossseed/matching_codec_test.go
+++ b/internal/services/crossseed/matching_codec_test.go
@@ -60,6 +60,8 @@ func TestJoinNormalizedCodecSlice(t *testing.T) {
 		{"x265 alone", []string{"x265"}, "HEVC"},
 		{"H.265 alone", []string{"H.265"}, "HEVC"},
 		{"multiple codecs sorted", []string{"HEVC", "AVC"}, "AVC HEVC"},
+		{"dedupe hevc aliases", []string{"HEVC", "x265"}, "HEVC"},
+		{"dedupe avc aliases", []string{"x264", "H.264"}, "AVC"},
 		{"passthrough codec", []string{"VP9"}, "VP9"},
 	}
 

--- a/internal/services/crossseed/source_release_inference.go
+++ b/internal/services/crossseed/source_release_inference.go
@@ -1,0 +1,107 @@
+package crossseed
+
+import (
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/moistari/rls"
+
+	"github.com/autobrr/qui/pkg/stringutils"
+)
+
+// deriveSourceReleaseForSearch enhances parsed torrent metadata with information inferred
+// from actual files, primarily to recover season/episode structure when the torrent name
+// doesn't include it (common for anime season packs).
+func (s *Service) deriveSourceReleaseForSearch(sourceRelease *rls.Release, files qbt.TorrentFiles) *rls.Release {
+	if sourceRelease == nil || len(files) == 0 || s == nil || s.releaseCache == nil {
+		return sourceRelease
+	}
+
+	inferredSeries, inferredEpisode, inferredIsPack, ok := s.inferTVSeriesEpisodeFromFiles(sourceRelease, files)
+	if !ok {
+		return sourceRelease
+	}
+
+	derived := *sourceRelease
+	if derived.Series == 0 && inferredSeries > 0 {
+		derived.Series = inferredSeries
+	}
+
+	// Trust file structure when it indicates a season pack.
+	if inferredIsPack && derived.Series > 0 {
+		derived.Episode = 0
+		return &derived
+	}
+
+	if derived.Series > 0 && derived.Episode == 0 && inferredEpisode > 0 {
+		derived.Episode = inferredEpisode
+	}
+
+	return &derived
+}
+
+func (s *Service) inferTVSeriesEpisodeFromFiles(torrentRelease *rls.Release, files qbt.TorrentFiles) (series, episode int, isPack, ok bool) {
+	normalizer := s.stringNormalizer
+	if normalizer == nil {
+		normalizer = stringutils.NewDefaultNormalizer()
+	}
+
+	type seriesInfo struct {
+		filesSeen int
+		episodes  map[int]struct{}
+	}
+
+	bySeries := make(map[int]*seriesInfo)
+	for _, file := range files {
+		if shouldIgnoreFile(file.Name, normalizer) {
+			continue
+		}
+
+		fileRelease := s.releaseCache.Parse(file.Name)
+		fileRelease = enrichReleaseFromTorrent(fileRelease, torrentRelease)
+		if fileRelease.Series <= 0 {
+			continue
+		}
+
+		info := bySeries[fileRelease.Series]
+		if info == nil {
+			info = &seriesInfo{episodes: make(map[int]struct{})}
+			bySeries[fileRelease.Series] = info
+		}
+		info.filesSeen++
+		if fileRelease.Episode > 0 {
+			info.episodes[fileRelease.Episode] = struct{}{}
+		}
+	}
+
+	bestSeries := 0
+	bestEpisodeCount := 0
+	bestFileCount := 0
+	for sNum, info := range bySeries {
+		epCount := len(info.episodes)
+		if epCount > bestEpisodeCount || (epCount == bestEpisodeCount && info.filesSeen > bestFileCount) {
+			bestSeries = sNum
+			bestEpisodeCount = epCount
+			bestFileCount = info.filesSeen
+		}
+	}
+
+	if bestSeries == 0 {
+		return 0, 0, false, false
+	}
+
+	switch {
+	case bestEpisodeCount >= 2:
+		return bestSeries, 0, true, true
+	case bestEpisodeCount == 1:
+		for ep := range bySeries[bestSeries].episodes {
+			return bestSeries, ep, false, true
+		}
+	}
+
+	// If rls detected a season but couldn't extract episode numbers, treat multiple
+	// relevant files as a season pack.
+	if bestFileCount >= 2 {
+		return bestSeries, 0, true, true
+	}
+
+	return bestSeries, 0, false, true
+}

--- a/internal/services/crossseed/source_release_inference_test.go
+++ b/internal/services/crossseed/source_release_inference_test.go
@@ -1,0 +1,74 @@
+package crossseed
+
+import (
+	"testing"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/pkg/stringutils"
+)
+
+func TestDeriveSourceReleaseForSearch_InferSeasonPackFromFiles(t *testing.T) {
+	svc := &Service{
+		releaseCache:                  NewReleaseCache(),
+		stringNormalizer:              stringutils.NewDefaultNormalizer(),
+		recoverErroredTorrentsEnabled: false,
+	}
+
+	source := svc.releaseCache.Parse("Frieren Beyond Journey's End (BD Remux 1080p AVC FLAC AAC) [Dual Audio] [PMR]")
+	require.NotNil(t, source)
+	require.Equal(t, 0, source.Series)
+	require.Equal(t, 0, source.Episode)
+
+	files := qbt.TorrentFiles{
+		{Name: "Frieren Beyond Journey's End - S01E01 (BD Remux 1080p AVC FLAC AAC) [Dual Audio] [PMR].mkv", Size: 1},
+		{Name: "Frieren Beyond Journey's End - S01E02 (BD Remux 1080p AVC FLAC AAC) [Dual Audio] [PMR].mkv", Size: 1},
+		{Name: "Frieren Beyond Journey's End - S01E01.nfo", Size: 1},
+	}
+
+	derived := svc.deriveSourceReleaseForSearch(source, files)
+	require.Equal(t, 1, derived.Series)
+	require.Equal(t, 0, derived.Episode)
+}
+
+func TestDeriveSourceReleaseForSearch_InferSingleEpisodeFromFiles(t *testing.T) {
+	svc := &Service{
+		releaseCache:     NewReleaseCache(),
+		stringNormalizer: stringutils.NewDefaultNormalizer(),
+	}
+
+	source := svc.releaseCache.Parse("Some Anime Title (WEB 1080p) [Group]")
+	require.NotNil(t, source)
+	require.Equal(t, 0, source.Series)
+	require.Equal(t, 0, source.Episode)
+
+	files := qbt.TorrentFiles{
+		{Name: "Some Anime Title - S01E03 (WEB 1080p) [Group].mkv", Size: 1},
+	}
+
+	derived := svc.deriveSourceReleaseForSearch(source, files)
+	require.Equal(t, 1, derived.Series)
+	require.Equal(t, 3, derived.Episode)
+}
+
+func TestDeriveSourceReleaseForSearch_FileStructureOverridesEpisodeForPacks(t *testing.T) {
+	svc := &Service{
+		releaseCache:     NewReleaseCache(),
+		stringNormalizer: stringutils.NewDefaultNormalizer(),
+	}
+
+	source := svc.releaseCache.Parse("Some.Show.S01E01.1080p.WEB-DL.x264-GROUP")
+	require.NotNil(t, source)
+	require.Equal(t, 1, source.Series)
+	require.Equal(t, 1, source.Episode)
+
+	files := qbt.TorrentFiles{
+		{Name: "Some Show - S01E01 (1080p WEB-DL x264) [GROUP].mkv", Size: 1},
+		{Name: "Some Show - S01E02 (1080p WEB-DL x264) [GROUP].mkv", Size: 1},
+	}
+
+	derived := svc.deriveSourceReleaseForSearch(source, files)
+	require.Equal(t, 1, derived.Series)
+	require.Equal(t, 0, derived.Episode)
+}


### PR DESCRIPTION
- Deduplicate normalized codec list (e.g. HEVC+x265 vs H.265)
- Relax anime Site matching (only enforce when both present)
- Infer season/episode/pack from torrent files when name lacks Sxx/Exx
- Update/add tests for codec, site, and inference
- Tests: go test -race -count=3 ./internal/services/crossseed