### PR TITLE
Make progress bars tint only the completed portion (leave incomplete portion untinted)

### DIFF
--- a/web/src/components/ui/progress.tsx
+++ b/web/src/components/ui/progress.tsx
@@ -17,7 +17,7 @@ function Progress({
     <ProgressPrimitive.Root
       data-slot="progress"
       className={cn(
-        "bg-primary/20 relative h-2 w-full overflow-hidden rounded-full",
+        "bg-muted relative h-2 w-full overflow-hidden rounded-full",
         className
       )}
       {...props}


### PR DESCRIPTION
**Problem:**
In Qui, the “incomplete” portion of the progress bar uses the same color as the completed portion, just at 20% opacity. When a torrent is stuck at 0%, stalled torrents are easy to miss at a glance in a UI that de-emphasizes brightness differences (alternating row colors + selected row coloration). I've been using torrent clients for many years, and this is the first time I've had trouble picking up on torrents that are just stalled at zero percent at a glance, and I believe it's because the incomplete portion of the bar is tinted.

<img width="2996" height="1633" alt="image" src="https://github.com/user-attachments/assets/9a38b0e9-92c7-40b1-a5b6-824848b80402" />

A 0% progress bar is only distinguished by subtle brightness variance whilst keeping the tint, which is easy to overlook in my experience. I often glance at my Qui instance and my brain doesn't pick up on the fact that some torrents are stuck at 0%. I am making this PR in case this isn't just a deficiency in my brain/eyes, but something that others would benefit from also. 

**Comparison:**
qBittorrent Desktop (and many other clients) only colors the completed portion of the progress bar, making 0% immediately obvious.

<img width="426" height="181" alt="image" src="https://github.com/user-attachments/assets/5486c96e-7d4a-4d4f-ad20-4b1c78a3fabe" />

<img width="267" height="344" alt="image" src="https://github.com/user-attachments/assets/b2594a69-3026-4cdc-b72b-76354a08bbd5" />

<img width="388" height="358" alt="image" src="https://github.com/user-attachments/assets/23ba53e2-120a-4575-a5ba-5b4cf4a1708c" />

**Solution:**
match the desktop qbittorrent behavior: only color the completed portion of the progress bar, and leave the incomplete portion neutral/transparent.

before
<img width="1732" height="397" alt="image" src="https://github.com/user-attachments/assets/9498b4f3-1223-46f9-abd0-a3c9ad922ad8" />

after
<img width="1740" height="399" alt="image" src="https://github.com/user-attachments/assets/59cc93fc-e217-4935-b7c7-29bd46495ad4" />


Alternate approach: instead of bg-muted, just use no color at all, and let the bg be visible behind the progress bar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Progress component's background styling for improved visual appearance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->