### PR TITLE
feat(qbittorrent): Add ability to move torrents between instances

### DIFF
--- a/documentation/static/openapi.yaml
+++ b/documentation/static/openapi.yaml
@@ -1584,6 +1584,34 @@ paths:
         '500':
           description: Failed to get web seeds
 
+  /api/instances/{instanceID}/torrents/{hash}/pieces:
+    get:
+      tags:
+        - Torrent Details
+      summary: Get torrent piece states
+      description: |
+        Get download state of each piece for a torrent.
+        States: 0 = not downloaded, 1 = downloading, 2 = downloaded
+      parameters:
+        - $ref: '#/components/parameters/instanceID'
+        - $ref: '#/components/parameters/hash'
+      responses:
+        '200':
+          description: Array of piece states
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: integer
+                  minimum: 0
+                  maximum: 2
+                  description: 'Piece state: 0 = not downloaded, 1 = downloading, 2 = downloaded'
+        '400':
+          description: Invalid request
+        '500':
+          description: Failed to get piece states
+
   /api/instances/{instanceID}/torrents/{hash}/files:
     get:
       tags:
@@ -3906,8 +3934,24 @@ paths:
           description: Filter by source or target instance ID
         - name: states
           in: query
+          style: form
+          explode: false
           schema:
-            type: string
+            type: array
+            items:
+              type: string
+              enum:
+                - pending
+                - preparing
+                - links_creating
+                - links_created
+                - adding_torrent
+                - torrent_added
+                - deleting_source
+                - completed
+                - failed
+                - rolled_back
+                - cancelled
           description: Comma-separated list of states to filter by
       responses:
         '200':
@@ -5735,6 +5779,7 @@ components:
         linkMode:
           type: string
           enum: ["hardlink", "reflink", "direct"]
+          description: Link mode used for the transfer. "hardlink" creates hard links, "reflink" uses copy-on-write (CoW), "direct" uses the files directly without linking.
         deleteFromSource:
           type: boolean
         preserveCategory:
@@ -5751,12 +5796,14 @@ components:
           type: object
           additionalProperties:
             type: string
+          default: { }
         filesTotal:
           type: integer
         filesLinked:
           type: integer
         error:
           type: string
+          nullable: true
         createdAt:
           type: string
           format: date-time
@@ -5788,6 +5835,7 @@ components:
           type: object
           additionalProperties:
             type: string
+          default: { }
           description: Optional path prefix mappings from source to target
         deleteFromSource:
           type: boolean
@@ -5814,6 +5862,7 @@ components:
           type: object
           additionalProperties:
             type: string
+          default: { }
           description: Optional path prefix mappings from source to target
         deleteFromSource:
           type: boolean

--- a/documentation/static/openapi.yaml
+++ b/documentation/static/openapi.yaml
@@ -760,6 +760,12 @@ paths:
                   type: string
                   enum: [flat, by-tracker, by-instance]
                   description: Directory organization preset for hardlink mode.
+                useReflinks:
+                  type: boolean
+                  description: Enable reflink (copy-on-write) mode for cross-seed operations. Mutually exclusive with hardlink mode.
+                fallbackToRegularMode:
+                  type: boolean
+                  description: Fall back to regular mode if reflink/hardlink fails (e.g., cross-filesystem).
       responses:
         '201':
           description: Instance created
@@ -853,6 +859,12 @@ paths:
                   type: string
                   enum: [flat, by-tracker, by-instance]
                   description: Directory organization preset for hardlink mode.
+                useReflinks:
+                  type: boolean
+                  description: Enable reflink (copy-on-write) mode for cross-seed operations. Mutually exclusive with hardlink mode.
+                fallbackToRegularMode:
+                  type: boolean
+                  description: Fall back to regular mode if reflink/hardlink fails (e.g., cross-filesystem).
       responses:
         '200':
           description: Instance updated
@@ -1774,6 +1786,33 @@ paths:
                     relevance:
                       type: number
 
+  /api/instances/{instanceID}/torrents/{hash}/move:
+    post:
+      tags:
+        - Transfers
+      summary: Move torrent to another instance
+      description: Queue a transfer to move this torrent to another qBittorrent instance
+      parameters:
+        - $ref: '#/components/parameters/instanceID'
+        - $ref: '#/components/parameters/hash'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MoveRequest'
+      responses:
+        '202':
+          description: Transfer queued successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Transfer'
+        '400':
+          description: Invalid request or target instance ID required
+        '409':
+          description: Transfer already exists for this torrent
+
   /api/instances/{instanceID}/torrents/add-peers:
     post:
       tags:
@@ -2687,6 +2726,18 @@ paths:
         '500':
           description: Failed to trigger automation run
 
+  /api/cross-seed/run/cancel:
+    post:
+      tags:
+        - Cross-Seed
+      summary: Cancel RSS automation run
+      description: Stops the currently running RSS automation run, if any.
+      responses:
+        '204':
+          description: RSS automation run cancelled successfully
+        '409':
+          description: No automation run is currently active
+
   /api/cross-seed/search/settings:
     get:
       tags:
@@ -3022,10 +3073,6 @@ paths:
                   type: array
                   items:
                     type: string
-                ignorePatterns:
-                  type: array
-                  items:
-                    type: string
                 startPaused:
                   type: boolean
                 skipIfExists:
@@ -3151,6 +3198,41 @@ paths:
           description: Invalid request body
         '500':
           description: Failed to add torrents
+
+  /api/cross-seed/torrents/{instanceID}/{hash}/local-matches:
+    get:
+      tags:
+        - Cross-Seed
+      summary: Find local cross-seed matches
+      description: Find torrents across all qBittorrent instances that match the specified torrent (by content path, name, or release metadata)
+      parameters:
+        - $ref: '#/components/parameters/instanceID'
+        - $ref: '#/components/parameters/hash'
+        - name: strict
+          in: query
+          description: When true, fail if file overlap checks cannot complete (use for delete dialogs to avoid false negatives)
+          required: false
+          schema:
+            type: boolean
+            default: false
+      responses:
+        '200':
+          description: List of matching torrents
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  matches:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/LocalCrossSeedMatch'
+                required:
+                  - matches
+        '400':
+          description: Invalid parameters
+        '500':
+          description: Failed to find matches
 
   /api/log-settings:
     get:
@@ -3775,6 +3857,119 @@ paths:
         '200':
           description: Service is alive
 
+  # Transfer API endpoints
+  /api/transfers:
+    post:
+      tags:
+        - Transfers
+      summary: Create transfer
+      description: Queue a new torrent transfer between instances
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TransferRequest'
+      responses:
+        '201':
+          description: Transfer queued successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Transfer'
+        '400':
+          description: Invalid request
+        '409':
+          description: Transfer already exists for this torrent
+    get:
+      tags:
+        - Transfers
+      summary: List transfers
+      description: Get list of transfers with optional filtering
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 50
+          description: Maximum number of transfers to return
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            default: 0
+          description: Number of transfers to skip
+        - name: instanceId
+          in: query
+          schema:
+            type: integer
+          description: Filter by source or target instance ID
+        - name: states
+          in: query
+          schema:
+            type: string
+          description: Comma-separated list of states to filter by
+      responses:
+        '200':
+          description: List of transfers
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Transfer'
+
+  /api/transfers/{id}:
+    get:
+      tags:
+        - Transfers
+      summary: Get transfer
+      description: Get details of a specific transfer
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+          description: Transfer ID
+      responses:
+        '200':
+          description: Transfer details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Transfer'
+        '404':
+          description: Transfer not found
+    delete:
+      tags:
+        - Transfers
+      summary: Cancel transfer
+      description: Cancel a pending transfer
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+          description: Transfer ID
+      responses:
+        '200':
+          description: Transfer cancelled
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: cancelled
+        '400':
+          description: Invalid transfer ID
+        '409':
+          description: Cannot cancel transfer in current state
 
 components:
   securitySchemes:
@@ -3999,6 +4194,12 @@ components:
           type: string
           enum: [flat, by-tracker, by-instance]
           description: Directory organization preset for hardlink mode.
+        useReflinks:
+          type: boolean
+          description: When true, cross-seed operations use reflink (copy-on-write) mode for this instance. Mutually exclusive with hardlink mode.
+        fallbackToRegularMode:
+          type: boolean
+          description: When true, cross-seed falls back to regular mode if reflink/hardlink fails (e.g., cross-filesystem).
         sortOrder:
           type: integer
           description: Display order preference for the instance.
@@ -4522,10 +4723,6 @@ components:
           type: array
           items:
             type: string
-        ignorePatterns:
-          type: array
-          items:
-            type: string
         targetInstanceIds:
           type: array
           items:
@@ -4579,7 +4776,7 @@ components:
           description: Skip torrents with any of these tags when processing webhook requests
         skipRecheck:
           type: boolean
-          description: Skip cross-seed matches that would require a manual recheck
+          description: Skip cross-seed matches that would require a manual recheck (alignment, extra files, or disc layouts like BDMV/VIDEO_TS)
         useHardlinks:
           type: boolean
           description: Enable hardlink mode for cross-seeding (creates hardlinked file trees)
@@ -4607,10 +4804,6 @@ components:
           type: array
           items:
             type: string
-        ignorePatterns:
-          type: array
-          items:
-            type: string
         targetInstanceIds:
           type: array
           items:
@@ -4664,7 +4857,7 @@ components:
           description: Skip torrents with any of these tags when processing webhook requests
         skipRecheck:
           type: boolean
-          description: Skip cross-seed matches that would require a manual recheck
+          description: Skip cross-seed matches that would require a manual recheck (alignment, extra files, or disc layouts like BDMV/VIDEO_TS)
         useHardlinks:
           type: boolean
           description: Enable hardlink mode for cross-seeding (creates hardlinked file trees)
@@ -4821,6 +5014,12 @@ components:
         content_filtering_completed:
           type: boolean
           nullable: true
+        disc_layout:
+          type: boolean
+          description: True if this torrent contains disc-based media (Blu-ray/DVD)
+        disc_marker:
+          type: string
+          description: The marker directory name (e.g., "BDMV" or "VIDEO_TS") if disc_layout is true
 
     AsyncIndexerFilteringState:
       type: object
@@ -4996,6 +5195,57 @@ components:
           items:
             $ref: '#/components/schemas/CrossSeedApplyResult'
 
+    LocalCrossSeedMatch:
+      type: object
+      description: A torrent that matches another torrent for cross-seeding purposes
+      properties:
+        instanceId:
+          type: integer
+          description: The qBittorrent instance ID containing this torrent
+        instanceName:
+          type: string
+          description: The name of the qBittorrent instance
+        hash:
+          type: string
+          description: Torrent info hash
+        name:
+          type: string
+          description: Torrent name
+        size:
+          type: integer
+          format: int64
+          description: Total size in bytes
+        progress:
+          type: number
+          format: float
+          description: Download progress (0-1)
+        savePath:
+          type: string
+          description: Save path on disk
+        contentPath:
+          type: string
+          description: Content path on disk
+        category:
+          type: string
+          description: Torrent category
+        tags:
+          type: string
+          description: Comma-separated torrent tags
+        state:
+          type: string
+          description: Torrent state
+        tracker:
+          type: string
+          description: Primary tracker URL
+        trackerHealth:
+          type: string
+          enum: [unregistered, tracker_down]
+          description: Tracker health status (only present if unhealthy)
+        matchType:
+          type: string
+          enum: [content_path, name, release]
+          description: How this torrent was matched
+
     CrossInstanceFilterOptions:
       type: object
       description: Filter options for cross-instance torrent filtering
@@ -5137,6 +5387,10 @@ components:
         scanIntervalHours:
           type: integer
           description: Hours between scheduled scans
+        previewSort:
+          type: string
+          description: Sorting applied to the orphan preview list
+          enum: ["size_desc", "directory_size_desc"]
         maxFilesPerRun:
           type: integer
           description: Maximum orphan files to record per run (prevents DB bloat)
@@ -5162,6 +5416,9 @@ components:
         scanIntervalHours:
           type: integer
           minimum: 1
+        previewSort:
+          type: string
+          enum: ["size_desc", "directory_size_desc"]
         maxFilesPerRun:
           type: integer
           minimum: 1
@@ -5442,6 +5699,135 @@ components:
           type: string
           nullable: true
 
+    # Transfer schemas
+    Transfer:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        sourceInstanceId:
+          type: integer
+        targetInstanceId:
+          type: integer
+        torrentHash:
+          type: string
+        torrentName:
+          type: string
+        state:
+          type: string
+          enum:
+            - pending
+            - preparing
+            - links_creating
+            - links_created
+            - adding_torrent
+            - torrent_added
+            - deleting_source
+            - completed
+            - failed
+            - rolled_back
+            - cancelled
+        sourceSavePath:
+          type: string
+        targetSavePath:
+          type: string
+        linkMode:
+          type: string
+          enum: ["hardlink", "reflink", "direct"]
+        deleteFromSource:
+          type: boolean
+        preserveCategory:
+          type: boolean
+        preserveTags:
+          type: boolean
+        targetCategory:
+          type: string
+        targetTags:
+          type: array
+          items:
+            type: string
+        pathMappings:
+          type: object
+          additionalProperties:
+            type: string
+        filesTotal:
+          type: integer
+        filesLinked:
+          type: integer
+        error:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        completedAt:
+          type: string
+          format: date-time
+          nullable: true
+
+    TransferRequest:
+      type: object
+      required:
+        - sourceInstanceId
+        - targetInstanceId
+        - torrentHash
+      properties:
+        sourceInstanceId:
+          type: integer
+          description: ID of the source qBittorrent instance
+        targetInstanceId:
+          type: integer
+          description: ID of the target qBittorrent instance
+        torrentHash:
+          type: string
+          description: Hash of the torrent to transfer
+        pathMappings:
+          type: object
+          additionalProperties:
+            type: string
+          description: Optional path prefix mappings from source to target
+        deleteFromSource:
+          type: boolean
+          default: true
+          description: Whether to delete the torrent from source after transfer
+        preserveCategory:
+          type: boolean
+          default: true
+          description: Whether to preserve the torrent's category
+        preserveTags:
+          type: boolean
+          default: true
+          description: Whether to preserve the torrent's tags
+
+    MoveRequest:
+      type: object
+      required:
+        - targetInstanceId
+      properties:
+        targetInstanceId:
+          type: integer
+          description: ID of the target qBittorrent instance
+        pathMappings:
+          type: object
+          additionalProperties:
+            type: string
+          description: Optional path prefix mappings from source to target
+        deleteFromSource:
+          type: boolean
+          default: true
+          description: Whether to delete the torrent from source after transfer
+        preserveCategory:
+          type: boolean
+          default: true
+          description: Whether to preserve the torrent's category
+        preserveTags:
+          type: boolean
+          default: true
+          description: Whether to preserve the torrent's tags
+
 tags:
   - name: Authentication
     description: User authentication and session management
@@ -5467,5 +5853,7 @@ tags:
     description: Cross-seeding operations for finding and adding duplicate torrents
   - name: Orphan Scan
     description: Orphan file scanning and cleanup (files on disk not associated with any torrent)
+  - name: Transfers
+    description: Move torrents between qBittorrent instances with hardlink/reflink support
   - name: Theme Licenses
     description: Theme license management (optional feature)

--- a/internal/api/handlers/transfers.go
+++ b/internal/api/handlers/transfers.go
@@ -1,0 +1,288 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/rs/zerolog/log"
+
+	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/services/transfer"
+)
+
+// TransfersHandler handles transfer API endpoints
+type TransfersHandler struct {
+	service *transfer.Service
+}
+
+// NewTransfersHandler creates a new TransfersHandler
+func NewTransfersHandler(service *transfer.Service) *TransfersHandler {
+	return &TransfersHandler{service: service}
+}
+
+// CreateTransferPayload is the request body for creating a transfer
+type CreateTransferPayload struct {
+	SourceInstanceID int               `json:"sourceInstanceId"`
+	TargetInstanceID int               `json:"targetInstanceId"`
+	TorrentHash      string            `json:"torrentHash"`
+	PathMappings     map[string]string `json:"pathMappings,omitempty"`
+	DeleteFromSource *bool             `json:"deleteFromSource,omitempty"`
+	PreserveCategory *bool             `json:"preserveCategory,omitempty"`
+	PreserveTags     *bool             `json:"preserveTags,omitempty"`
+}
+
+// MovePayload is the request body for the move convenience endpoint
+type MovePayload struct {
+	TargetInstanceID int               `json:"targetInstanceId"`
+	PathMappings     map[string]string `json:"pathMappings,omitempty"`
+	DeleteFromSource *bool             `json:"deleteFromSource,omitempty"`
+	PreserveCategory *bool             `json:"preserveCategory,omitempty"`
+	PreserveTags     *bool             `json:"preserveTags,omitempty"`
+}
+
+// Create handles POST /api/transfers
+func (h *TransfersHandler) Create(w http.ResponseWriter, r *http.Request) {
+	var payload CreateTransferPayload
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		log.Warn().Err(err).Msg("transfers: failed to decode create payload")
+		RespondError(w, http.StatusBadRequest, "Invalid request payload")
+		return
+	}
+
+	// Apply defaults
+	deleteFromSource := true
+	if payload.DeleteFromSource != nil {
+		deleteFromSource = *payload.DeleteFromSource
+	}
+	preserveCategory := true
+	if payload.PreserveCategory != nil {
+		preserveCategory = *payload.PreserveCategory
+	}
+	preserveTags := true
+	if payload.PreserveTags != nil {
+		preserveTags = *payload.PreserveTags
+	}
+
+	req := &transfer.TransferRequest{
+		SourceInstanceID: payload.SourceInstanceID,
+		TargetInstanceID: payload.TargetInstanceID,
+		TorrentHash:      payload.TorrentHash,
+		PathMappings:     payload.PathMappings,
+		DeleteFromSource: deleteFromSource,
+		PreserveCategory: preserveCategory,
+		PreserveTags:     preserveTags,
+	}
+
+	t, err := h.service.QueueTransfer(r.Context(), req)
+	if err != nil {
+		if errors.Is(err, transfer.ErrTransferAlreadyExists) {
+			RespondError(w, http.StatusConflict, "Transfer already exists for this torrent")
+			return
+		}
+		log.Error().Err(err).Msg("failed to create transfer")
+		RespondError(w, http.StatusInternalServerError, "Failed to create transfer")
+		return
+	}
+
+	RespondJSON(w, http.StatusCreated, t)
+}
+
+// List handles GET /api/transfers
+func (h *TransfersHandler) List(w http.ResponseWriter, r *http.Request) {
+	opts := transfer.ListOptions{
+		Limit:  50,
+		Offset: 0,
+	}
+
+	// Parse query parameters
+	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
+		if limit, err := strconv.Atoi(limitStr); err == nil && limit > 0 {
+			opts.Limit = limit
+		}
+	}
+	if offsetStr := r.URL.Query().Get("offset"); offsetStr != "" {
+		if offset, err := strconv.Atoi(offsetStr); err == nil && offset >= 0 {
+			opts.Offset = offset
+		}
+	}
+	if instanceIDStr := r.URL.Query().Get("instanceId"); instanceIDStr != "" {
+		if instanceID, err := strconv.Atoi(instanceIDStr); err == nil && instanceID > 0 {
+			opts.InstanceID = &instanceID
+		}
+	}
+	if statesStr := r.URL.Query().Get("states"); statesStr != "" {
+		// Parse comma-separated states
+		var states []models.TransferState
+		for _, s := range splitAndTrim(statesStr, ",") {
+			states = append(states, models.TransferState(s))
+		}
+		opts.States = states
+	}
+
+	transfers, err := h.service.ListTransfers(r.Context(), opts)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to list transfers")
+		RespondError(w, http.StatusInternalServerError, "Failed to list transfers")
+		return
+	}
+
+	RespondJSON(w, http.StatusOK, transfers)
+}
+
+// Get handles GET /api/transfers/{id}
+func (h *TransfersHandler) Get(w http.ResponseWriter, r *http.Request) {
+	idStr := chi.URLParam(r, "id")
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil || id <= 0 {
+		RespondError(w, http.StatusBadRequest, "Invalid transfer ID")
+		return
+	}
+
+	t, err := h.service.GetTransfer(r.Context(), id)
+	if err != nil {
+		log.Error().Err(err).Int64("id", id).Msg("failed to get transfer")
+		RespondError(w, http.StatusNotFound, "Transfer not found")
+		return
+	}
+
+	RespondJSON(w, http.StatusOK, t)
+}
+
+// Cancel handles DELETE /api/transfers/{id}
+func (h *TransfersHandler) Cancel(w http.ResponseWriter, r *http.Request) {
+	idStr := chi.URLParam(r, "id")
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil || id <= 0 {
+		RespondError(w, http.StatusBadRequest, "Invalid transfer ID")
+		return
+	}
+
+	if err := h.service.CancelTransfer(r.Context(), id); err != nil {
+		if errors.Is(err, transfer.ErrCannotCancel) {
+			RespondError(w, http.StatusConflict, "Cannot cancel transfer in current state")
+			return
+		}
+		log.Error().Err(err).Int64("id", id).Msg("failed to cancel transfer")
+		RespondError(w, http.StatusInternalServerError, "Failed to cancel transfer")
+		return
+	}
+
+	RespondJSON(w, http.StatusOK, map[string]string{"status": "cancelled"})
+}
+
+// MoveTorrent handles POST /api/instances/{instanceID}/torrents/{hash}/move
+// This is a convenience endpoint that creates a transfer from the given instance
+func (h *TransfersHandler) MoveTorrent(w http.ResponseWriter, r *http.Request) {
+	sourceInstanceID, err := parseInstanceID(w, r)
+	if err != nil {
+		return
+	}
+
+	hash := chi.URLParam(r, "hash")
+	if hash == "" {
+		RespondError(w, http.StatusBadRequest, "Torrent hash is required")
+		return
+	}
+
+	var payload MovePayload
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		log.Warn().Err(err).Msg("transfers: failed to decode move payload")
+		RespondError(w, http.StatusBadRequest, "Invalid request payload")
+		return
+	}
+
+	if payload.TargetInstanceID == 0 {
+		RespondError(w, http.StatusBadRequest, "Target instance ID is required")
+		return
+	}
+
+	// Apply defaults
+	deleteFromSource := true
+	if payload.DeleteFromSource != nil {
+		deleteFromSource = *payload.DeleteFromSource
+	}
+	preserveCategory := true
+	if payload.PreserveCategory != nil {
+		preserveCategory = *payload.PreserveCategory
+	}
+	preserveTags := true
+	if payload.PreserveTags != nil {
+		preserveTags = *payload.PreserveTags
+	}
+
+	req := &transfer.MoveRequest{
+		SourceInstanceID: sourceInstanceID,
+		TargetInstanceID: payload.TargetInstanceID,
+		Hash:             hash,
+		PathMappings:     payload.PathMappings,
+		DeleteFromSource: deleteFromSource,
+		PreserveCategory: preserveCategory,
+		PreserveTags:     preserveTags,
+	}
+
+	t, err := h.service.MoveTorrent(r.Context(), req)
+	if err != nil {
+		if errors.Is(err, transfer.ErrTransferAlreadyExists) {
+			RespondError(w, http.StatusConflict, "Transfer already exists for this torrent")
+			return
+		}
+		log.Error().Err(err).
+			Int("sourceInstance", sourceInstanceID).
+			Str("hash", hash).
+			Msg("failed to move torrent")
+		RespondError(w, http.StatusInternalServerError, "Failed to queue move")
+		return
+	}
+
+	RespondJSON(w, http.StatusAccepted, t)
+}
+
+// splitAndTrim splits a string by separator and trims whitespace
+func splitAndTrim(s, sep string) []string {
+	if s == "" {
+		return nil
+	}
+	var parts []string
+	for _, p := range splitString(s, sep) {
+		p = trimSpace(p)
+		if p != "" {
+			parts = append(parts, p)
+		}
+	}
+	return parts
+}
+
+func splitString(s, sep string) []string {
+	if sep == "" {
+		return []string{s}
+	}
+	var parts []string
+	start := 0
+	for i := 0; i <= len(s)-len(sep); i++ {
+		if s[i:i+len(sep)] == sep {
+			parts = append(parts, s[start:i])
+			start = i + len(sep)
+			i += len(sep) - 1
+		}
+	}
+	parts = append(parts, s[start:])
+	return parts
+}
+
+func trimSpace(s string) string {
+	start := 0
+	end := len(s)
+	for start < end && (s[start] == ' ' || s[start] == '\t' || s[start] == '\n' || s[start] == '\r') {
+		start++
+	}
+	for end > start && (s[end-1] == ' ' || s[end-1] == '\t' || s[end-1] == '\n' || s[end-1] == '\r') {
+		end--
+	}
+	return s[start:end]
+}

--- a/internal/database/migrations/052_add_transfers.sql
+++ b/internal/database/migrations/052_add_transfers.sql
@@ -1,0 +1,57 @@
+-- Copyright (c) 2025, s0up and the autobrr contributors.
+-- SPDX-License-Identifier: GPL-2.0-or-later
+
+-- Create transfers table for tracking torrent moves between instances
+CREATE TABLE IF NOT EXISTS transfers (
+    id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+
+    -- Source and target
+    source_instance_id   INTEGER NOT NULL,
+    target_instance_id   INTEGER NOT NULL,
+    torrent_hash         TEXT NOT NULL,
+    torrent_name         TEXT NOT NULL,
+
+    -- State machine
+    state                TEXT NOT NULL DEFAULT 'pending',
+
+    -- Persisted configuration for recovery
+    source_save_path     TEXT,
+    target_save_path     TEXT,
+    link_mode            TEXT,  -- 'hardlink', 'reflink', 'direct'
+
+    -- Options
+    delete_from_source   INTEGER NOT NULL DEFAULT 1,
+    preserve_category    INTEGER NOT NULL DEFAULT 1,
+    preserve_tags        INTEGER NOT NULL DEFAULT 1,
+    target_category      TEXT,
+    target_tags          TEXT,  -- JSON array
+    path_mappings        TEXT,  -- JSON object
+
+    -- Progress tracking
+    files_total          INTEGER NOT NULL DEFAULT 0,
+    files_linked         INTEGER NOT NULL DEFAULT 0,
+
+    -- Error info
+    error                TEXT,
+
+    -- Timestamps
+    created_at           DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at           DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    completed_at         DATETIME,
+
+    FOREIGN KEY (source_instance_id) REFERENCES instances(id) ON DELETE CASCADE,
+    FOREIGN KEY (target_instance_id) REFERENCES instances(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_transfers_state ON transfers(state);
+CREATE INDEX IF NOT EXISTS idx_transfers_source ON transfers(source_instance_id, state);
+CREATE INDEX IF NOT EXISTS idx_transfers_target ON transfers(target_instance_id, state);
+CREATE INDEX IF NOT EXISTS idx_transfers_hash ON transfers(torrent_hash);
+
+CREATE TRIGGER IF NOT EXISTS trg_transfers_updated
+AFTER UPDATE ON transfers
+BEGIN
+    UPDATE transfers
+    SET updated_at = CURRENT_TIMESTAMP
+    WHERE id = NEW.id;
+END;

--- a/internal/models/automation.go
+++ b/internal/models/automation.go
@@ -505,13 +505,23 @@ func (c *RuleCondition) CompileRegex() error {
 // ActionConditions holds per-action conditions with action configuration.
 // This is the top-level structure stored in the `conditions` JSON column.
 type ActionConditions struct {
-	SchemaVersion string             `json:"schemaVersion"`
-	SpeedLimits   *SpeedLimitAction  `json:"speedLimits,omitempty"`
-	ShareLimits   *ShareLimitsAction `json:"shareLimits,omitempty"`
-	Pause         *PauseAction       `json:"pause,omitempty"`
-	Delete        *DeleteAction      `json:"delete,omitempty"`
-	Tag           *TagAction         `json:"tag,omitempty"`
-	Category      *CategoryAction    `json:"category,omitempty"`
+	SchemaVersion string               `json:"schemaVersion"`
+	SpeedLimits   *SpeedLimitAction    `json:"speedLimits,omitempty"`
+	ShareLimits   *ShareLimitsAction   `json:"shareLimits,omitempty"`
+	Pause         *PauseAction         `json:"pause,omitempty"`
+	Delete        *DeleteAction        `json:"delete,omitempty"`
+	Tag           *TagAction           `json:"tag,omitempty"`
+	Category      *CategoryAction      `json:"category,omitempty"`
+	MoveInstance  *MoveInstanceAction  `json:"moveInstance,omitempty"`
+}
+
+// MoveInstanceAction configures moving torrents to another qBittorrent instance.
+type MoveInstanceAction struct {
+	Enabled          bool              `json:"enabled"`
+	TargetInstanceID int               `json:"targetInstanceId"`
+	PathMappings     map[string]string `json:"pathMappings,omitempty"`
+	DeleteFromSource bool              `json:"deleteFromSource"`
+	Condition        *RuleCondition    `json:"condition,omitempty"`
 }
 
 // SpeedLimitAction configures speed limit application with optional conditions.
@@ -570,5 +580,5 @@ func (ac *ActionConditions) IsEmpty() bool {
 	if ac == nil {
 		return true
 	}
-	return ac.SpeedLimits == nil && ac.ShareLimits == nil && ac.Pause == nil && ac.Delete == nil && ac.Tag == nil && ac.Category == nil
+	return ac.SpeedLimits == nil && ac.ShareLimits == nil && ac.Pause == nil && ac.Delete == nil && ac.Tag == nil && ac.Category == nil && ac.MoveInstance == nil
 }

--- a/internal/models/transfer.go
+++ b/internal/models/transfer.go
@@ -1,0 +1,476 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package models
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/autobrr/qui/internal/dbinterface"
+)
+
+// TransferState represents the current state of a transfer operation
+type TransferState string
+
+const (
+	TransferStatePending        TransferState = "pending"
+	TransferStatePreparing      TransferState = "preparing"
+	TransferStateLinksCreating  TransferState = "links_creating"
+	TransferStateLinksCreated   TransferState = "links_created"
+	TransferStateAddingTorrent  TransferState = "adding_torrent"
+	TransferStateTorrentAdded   TransferState = "torrent_added"
+	TransferStateDeletingSource TransferState = "deleting_source"
+	TransferStateCompleted      TransferState = "completed"
+	TransferStateFailed         TransferState = "failed"
+	TransferStateRolledBack     TransferState = "rolled_back"
+	TransferStateCancelled      TransferState = "cancelled"
+)
+
+// IsTerminal returns true if the state is a terminal state (no further transitions)
+func (s TransferState) IsTerminal() bool {
+	switch s {
+	case TransferStateCompleted, TransferStateFailed, TransferStateRolledBack, TransferStateCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+// Transfer represents a torrent transfer between instances
+type Transfer struct {
+	ID               int64         `json:"id"`
+	SourceInstanceID int           `json:"sourceInstanceId"`
+	TargetInstanceID int           `json:"targetInstanceId"`
+	TorrentHash      string        `json:"torrentHash"`
+	TorrentName      string        `json:"torrentName"`
+	State            TransferState `json:"state"`
+
+	// Persisted for recovery
+	SourceSavePath string `json:"sourceSavePath,omitempty"`
+	TargetSavePath string `json:"targetSavePath,omitempty"`
+	LinkMode       string `json:"linkMode,omitempty"` // "hardlink", "reflink", "direct"
+
+	// Options
+	DeleteFromSource bool              `json:"deleteFromSource"`
+	PreserveCategory bool              `json:"preserveCategory"`
+	PreserveTags     bool              `json:"preserveTags"`
+	TargetCategory   string            `json:"targetCategory,omitempty"`
+	TargetTags       []string          `json:"targetTags,omitempty"`
+	PathMappings     map[string]string `json:"pathMappings,omitempty"`
+
+	// Progress
+	FilesTotal  int `json:"filesTotal"`
+	FilesLinked int `json:"filesLinked"`
+
+	// Error info
+	Error string `json:"error,omitempty"`
+
+	// Timestamps
+	CreatedAt   time.Time  `json:"createdAt"`
+	UpdatedAt   time.Time  `json:"updatedAt"`
+	CompletedAt *time.Time `json:"completedAt,omitempty"`
+}
+
+// TransferStore handles database operations for transfers
+type TransferStore struct {
+	db dbinterface.Querier
+}
+
+// NewTransferStore creates a new TransferStore
+func NewTransferStore(db dbinterface.Querier) *TransferStore {
+	return &TransferStore{db: db}
+}
+
+// Create inserts a new transfer record
+func (s *TransferStore) Create(ctx context.Context, t *Transfer) (*Transfer, error) {
+	if t == nil {
+		return nil, errors.New("transfer is nil")
+	}
+	if t.SourceInstanceID == 0 {
+		return nil, errors.New("source instance ID is required")
+	}
+	if t.TargetInstanceID == 0 {
+		return nil, errors.New("target instance ID is required")
+	}
+	if t.TorrentHash == "" {
+		return nil, errors.New("torrent hash is required")
+	}
+
+	var targetTagsJSON sql.NullString
+	if len(t.TargetTags) > 0 {
+		data, err := json.Marshal(t.TargetTags)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal target_tags: %w", err)
+		}
+		targetTagsJSON = sql.NullString{String: string(data), Valid: true}
+	}
+
+	var pathMappingsJSON sql.NullString
+	if len(t.PathMappings) > 0 {
+		data, err := json.Marshal(t.PathMappings)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal path_mappings: %w", err)
+		}
+		pathMappingsJSON = sql.NullString{String: string(data), Valid: true}
+	}
+
+	res, err := s.db.ExecContext(ctx, `
+		INSERT INTO transfers (
+			source_instance_id, target_instance_id, torrent_hash, torrent_name,
+			state, source_save_path, target_save_path, link_mode,
+			delete_from_source, preserve_category, preserve_tags,
+			target_category, target_tags, path_mappings,
+			files_total, files_linked, error
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		t.SourceInstanceID, t.TargetInstanceID, t.TorrentHash, t.TorrentName,
+		t.State, nullString(t.SourceSavePath), nullString(t.TargetSavePath), nullString(t.LinkMode),
+		boolToInt(t.DeleteFromSource), boolToInt(t.PreserveCategory), boolToInt(t.PreserveTags),
+		nullString(t.TargetCategory), targetTagsJSON, pathMappingsJSON,
+		t.FilesTotal, t.FilesLinked, nullString(t.Error),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to insert transfer: %w", err)
+	}
+
+	id, err := res.LastInsertId()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get last insert id: %w", err)
+	}
+
+	return s.Get(ctx, id)
+}
+
+// Get retrieves a transfer by ID
+func (s *TransferStore) Get(ctx context.Context, id int64) (*Transfer, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, source_instance_id, target_instance_id, torrent_hash, torrent_name,
+			state, source_save_path, target_save_path, link_mode,
+			delete_from_source, preserve_category, preserve_tags,
+			target_category, target_tags, path_mappings,
+			files_total, files_linked, error,
+			created_at, updated_at, completed_at
+		FROM transfers
+		WHERE id = ?
+	`, id)
+
+	return s.scanTransfer(row)
+}
+
+// GetByHash retrieves a non-terminal transfer by torrent hash
+func (s *TransferStore) GetByHash(ctx context.Context, hash string) (*Transfer, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, source_instance_id, target_instance_id, torrent_hash, torrent_name,
+			state, source_save_path, target_save_path, link_mode,
+			delete_from_source, preserve_category, preserve_tags,
+			target_category, target_tags, path_mappings,
+			files_total, files_linked, error,
+			created_at, updated_at, completed_at
+		FROM transfers
+		WHERE torrent_hash = ? AND state NOT IN ('completed', 'failed', 'rolled_back', 'cancelled')
+		ORDER BY created_at DESC
+		LIMIT 1
+	`, hash)
+
+	return s.scanTransfer(row)
+}
+
+// Update updates a transfer record
+func (s *TransferStore) Update(ctx context.Context, t *Transfer) error {
+	if t == nil {
+		return errors.New("transfer is nil")
+	}
+
+	var targetTagsJSON sql.NullString
+	if len(t.TargetTags) > 0 {
+		data, err := json.Marshal(t.TargetTags)
+		if err != nil {
+			return fmt.Errorf("failed to marshal target_tags: %w", err)
+		}
+		targetTagsJSON = sql.NullString{String: string(data), Valid: true}
+	}
+
+	var pathMappingsJSON sql.NullString
+	if len(t.PathMappings) > 0 {
+		data, err := json.Marshal(t.PathMappings)
+		if err != nil {
+			return fmt.Errorf("failed to marshal path_mappings: %w", err)
+		}
+		pathMappingsJSON = sql.NullString{String: string(data), Valid: true}
+	}
+
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE transfers SET
+			torrent_name = ?, state = ?,
+			source_save_path = ?, target_save_path = ?, link_mode = ?,
+			delete_from_source = ?, preserve_category = ?, preserve_tags = ?,
+			target_category = ?, target_tags = ?, path_mappings = ?,
+			files_total = ?, files_linked = ?, error = ?, completed_at = ?
+		WHERE id = ?
+	`,
+		t.TorrentName, t.State,
+		nullString(t.SourceSavePath), nullString(t.TargetSavePath), nullString(t.LinkMode),
+		boolToInt(t.DeleteFromSource), boolToInt(t.PreserveCategory), boolToInt(t.PreserveTags),
+		nullString(t.TargetCategory), targetTagsJSON, pathMappingsJSON,
+		t.FilesTotal, t.FilesLinked, nullString(t.Error), nullTime(t.CompletedAt),
+		t.ID,
+	)
+	return err
+}
+
+// UpdateState updates just the state and optional error message
+func (s *TransferStore) UpdateState(ctx context.Context, id int64, state TransferState, errorMsg string) error {
+	var completedAt sql.NullTime
+	if state.IsTerminal() {
+		completedAt = sql.NullTime{Time: time.Now().UTC(), Valid: true}
+	}
+
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE transfers SET state = ?, error = ?, completed_at = ?
+		WHERE id = ?
+	`, state, nullString(errorMsg), completedAt, id)
+	return err
+}
+
+// UpdateProgress updates files_linked count
+func (s *TransferStore) UpdateProgress(ctx context.Context, id int64, filesLinked int) error {
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE transfers SET files_linked = ?
+		WHERE id = ?
+	`, filesLinked, id)
+	return err
+}
+
+// ListByStates returns transfers in any of the given states
+func (s *TransferStore) ListByStates(ctx context.Context, states []TransferState) ([]*Transfer, error) {
+	if len(states) == 0 {
+		return nil, nil
+	}
+
+	query := `
+		SELECT id, source_instance_id, target_instance_id, torrent_hash, torrent_name,
+			state, source_save_path, target_save_path, link_mode,
+			delete_from_source, preserve_category, preserve_tags,
+			target_category, target_tags, path_mappings,
+			files_total, files_linked, error,
+			created_at, updated_at, completed_at
+		FROM transfers
+		WHERE state IN (`
+
+	args := make([]any, len(states))
+	for i, state := range states {
+		if i > 0 {
+			query += ", "
+		}
+		query += "?"
+		args[i] = state
+	}
+	query += `) ORDER BY created_at ASC`
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	return s.scanTransfers(rows)
+}
+
+// ListByInstance returns transfers for a given source or target instance
+func (s *TransferStore) ListByInstance(ctx context.Context, instanceID int, limit, offset int) ([]*Transfer, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, source_instance_id, target_instance_id, torrent_hash, torrent_name,
+			state, source_save_path, target_save_path, link_mode,
+			delete_from_source, preserve_category, preserve_tags,
+			target_category, target_tags, path_mappings,
+			files_total, files_linked, error,
+			created_at, updated_at, completed_at
+		FROM transfers
+		WHERE source_instance_id = ? OR target_instance_id = ?
+		ORDER BY created_at DESC
+		LIMIT ? OFFSET ?
+	`, instanceID, instanceID, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	return s.scanTransfers(rows)
+}
+
+// ListRecent returns recent transfers across all instances
+func (s *TransferStore) ListRecent(ctx context.Context, limit, offset int) ([]*Transfer, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, source_instance_id, target_instance_id, torrent_hash, torrent_name,
+			state, source_save_path, target_save_path, link_mode,
+			delete_from_source, preserve_category, preserve_tags,
+			target_category, target_tags, path_mappings,
+			files_total, files_linked, error,
+			created_at, updated_at, completed_at
+		FROM transfers
+		ORDER BY created_at DESC
+		LIMIT ? OFFSET ?
+	`, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	return s.scanTransfers(rows)
+}
+
+// Delete removes a transfer record
+func (s *TransferStore) Delete(ctx context.Context, id int64) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM transfers WHERE id = ?`, id)
+	return err
+}
+
+// MarkInterrupted marks in-progress transfers as failed (for recovery)
+func (s *TransferStore) MarkInterrupted(ctx context.Context, states []TransferState, errorMsg string) (int64, error) {
+	if len(states) == 0 {
+		return 0, nil
+	}
+
+	query := `UPDATE transfers SET state = ?, error = ?, completed_at = ? WHERE state IN (`
+	now := time.Now().UTC()
+	args := []any{TransferStateFailed, errorMsg, now}
+
+	for i, state := range states {
+		if i > 0 {
+			query += ", "
+		}
+		query += "?"
+		args = append(args, state)
+	}
+	query += ")"
+
+	res, err := s.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return 0, err
+	}
+
+	return res.RowsAffected()
+}
+
+// scanTransfer scans a single transfer row
+func (s *TransferStore) scanTransfer(row *sql.Row) (*Transfer, error) {
+	var t Transfer
+	var sourceSavePath, targetSavePath, linkMode sql.NullString
+	var targetCategory sql.NullString
+	var targetTagsJSON, pathMappingsJSON sql.NullString
+	var errorStr sql.NullString
+	var completedAt sql.NullTime
+
+	err := row.Scan(
+		&t.ID, &t.SourceInstanceID, &t.TargetInstanceID, &t.TorrentHash, &t.TorrentName,
+		&t.State, &sourceSavePath, &targetSavePath, &linkMode,
+		&t.DeleteFromSource, &t.PreserveCategory, &t.PreserveTags,
+		&targetCategory, &targetTagsJSON, &pathMappingsJSON,
+		&t.FilesTotal, &t.FilesLinked, &errorStr,
+		&t.CreatedAt, &t.UpdatedAt, &completedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	t.SourceSavePath = sourceSavePath.String
+	t.TargetSavePath = targetSavePath.String
+	t.LinkMode = linkMode.String
+	t.TargetCategory = targetCategory.String
+	t.Error = errorStr.String
+
+	if completedAt.Valid {
+		t.CompletedAt = &completedAt.Time
+	}
+
+	if targetTagsJSON.Valid && targetTagsJSON.String != "" {
+		if err := json.Unmarshal([]byte(targetTagsJSON.String), &t.TargetTags); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal target_tags: %w", err)
+		}
+	}
+
+	if pathMappingsJSON.Valid && pathMappingsJSON.String != "" {
+		if err := json.Unmarshal([]byte(pathMappingsJSON.String), &t.PathMappings); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal path_mappings: %w", err)
+		}
+	}
+
+	return &t, nil
+}
+
+// scanTransfers scans multiple transfer rows
+func (s *TransferStore) scanTransfers(rows *sql.Rows) ([]*Transfer, error) {
+	var transfers []*Transfer
+
+	for rows.Next() {
+		var t Transfer
+		var sourceSavePath, targetSavePath, linkMode sql.NullString
+		var targetCategory sql.NullString
+		var targetTagsJSON, pathMappingsJSON sql.NullString
+		var errorStr sql.NullString
+		var completedAt sql.NullTime
+
+		err := rows.Scan(
+			&t.ID, &t.SourceInstanceID, &t.TargetInstanceID, &t.TorrentHash, &t.TorrentName,
+			&t.State, &sourceSavePath, &targetSavePath, &linkMode,
+			&t.DeleteFromSource, &t.PreserveCategory, &t.PreserveTags,
+			&targetCategory, &targetTagsJSON, &pathMappingsJSON,
+			&t.FilesTotal, &t.FilesLinked, &errorStr,
+			&t.CreatedAt, &t.UpdatedAt, &completedAt,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		t.SourceSavePath = sourceSavePath.String
+		t.TargetSavePath = targetSavePath.String
+		t.LinkMode = linkMode.String
+		t.TargetCategory = targetCategory.String
+		t.Error = errorStr.String
+
+		if completedAt.Valid {
+			t.CompletedAt = &completedAt.Time
+		}
+
+		if targetTagsJSON.Valid && targetTagsJSON.String != "" {
+			if err := json.Unmarshal([]byte(targetTagsJSON.String), &t.TargetTags); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal target_tags for transfer %d: %w", t.ID, err)
+			}
+		}
+
+		if pathMappingsJSON.Valid && pathMappingsJSON.String != "" {
+			if err := json.Unmarshal([]byte(pathMappingsJSON.String), &t.PathMappings); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal path_mappings for transfer %d: %w", t.ID, err)
+			}
+		}
+
+		transfers = append(transfers, &t)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return transfers, nil
+}
+
+// nullString converts a string to sql.NullString
+func nullString(s string) sql.NullString {
+	if s == "" {
+		return sql.NullString{}
+	}
+	return sql.NullString{String: s, Valid: true}
+}
+
+// nullTime converts a *time.Time to sql.NullTime
+func nullTime(t *time.Time) sql.NullTime {
+	if t == nil {
+		return sql.NullTime{}
+	}
+	return sql.NullTime{Time: *t, Valid: true}
+}

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -1599,6 +1599,15 @@ func (sm *SyncManager) BulkAction(ctx context.Context, instanceID int, hashes []
 	return err
 }
 
+// DeleteTorrents deletes torrents from the instance
+func (sm *SyncManager) DeleteTorrents(ctx context.Context, instanceID int, hashes []string, deleteFiles bool) error {
+	action := "delete"
+	if deleteFiles {
+		action = "deleteWithFiles"
+	}
+	return sm.BulkAction(ctx, instanceID, hashes, action)
+}
+
 // AddTorrent adds a new torrent from file content
 func (sm *SyncManager) AddTorrent(ctx context.Context, instanceID int, fileContent []byte, options map[string]string) error {
 	// Get client and sync manager

--- a/internal/services/transfer/operations.go
+++ b/internal/services/transfer/operations.go
@@ -1,0 +1,499 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package transfer
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/rs/zerolog/log"
+
+	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/pkg/hardlinktree"
+	"github.com/autobrr/qui/pkg/reflinktree"
+)
+
+// doPrepare gathers source torrent info and prepares for transfer
+func (s *Service) doPrepare(ctx context.Context, t *models.Transfer) {
+	s.updateState(ctx, t, models.TransferStatePreparing, "")
+
+	// 1. Validate source instance
+	sourceInstance, err := s.instanceStore.Get(ctx, t.SourceInstanceID)
+	if err != nil {
+		s.fail(ctx, t, fmt.Sprintf("failed to get source instance: %v", err))
+		return
+	}
+	if !sourceInstance.HasLocalFilesystemAccess {
+		s.fail(ctx, t, "source instance lacks local filesystem access")
+		return
+	}
+
+	// 2. Validate target instance
+	targetInstance, err := s.instanceStore.Get(ctx, t.TargetInstanceID)
+	if err != nil {
+		s.fail(ctx, t, fmt.Sprintf("failed to get target instance: %v", err))
+		return
+	}
+	if !targetInstance.HasLocalFilesystemAccess {
+		s.fail(ctx, t, "target instance lacks local filesystem access")
+		return
+	}
+
+	// 3. Get source torrent info
+	torrents, err := s.syncManager.GetTorrents(ctx, t.SourceInstanceID,
+		qbt.TorrentFilterOptions{Hashes: []string{t.TorrentHash}})
+	if err != nil {
+		s.fail(ctx, t, fmt.Sprintf("failed to get source torrent: %v", err))
+		return
+	}
+	if len(torrents) == 0 {
+		s.fail(ctx, t, "torrent not found on source instance")
+		return
+	}
+	sourceTorrent := torrents[0]
+
+	// 4. Get source files
+	files, err := s.syncManager.GetTorrentFiles(ctx, t.SourceInstanceID, t.TorrentHash)
+	if err != nil {
+		s.fail(ctx, t, fmt.Sprintf("failed to get source files: %v", err))
+		return
+	}
+
+	// 5. Get properties (save path)
+	props, err := s.syncManager.GetTorrentProperties(ctx, t.SourceInstanceID, t.TorrentHash)
+	if err != nil {
+		s.fail(ctx, t, fmt.Sprintf("failed to get source properties: %v", err))
+		return
+	}
+
+	// 6. Check torrent is complete
+	if sourceTorrent.Progress < 1.0 {
+		s.fail(ctx, t, fmt.Sprintf("torrent is not complete (%.1f%%)", sourceTorrent.Progress*100))
+		return
+	}
+
+	// 7. Update transfer with gathered info
+	t.TorrentName = sourceTorrent.Name
+	t.SourceSavePath = props.SavePath
+	t.FilesTotal = len(*files)
+
+	if t.PreserveCategory {
+		t.TargetCategory = sourceTorrent.Category
+	}
+	if t.PreserveTags && sourceTorrent.Tags != "" {
+		t.TargetTags = strings.Split(sourceTorrent.Tags, ",")
+		for i := range t.TargetTags {
+			t.TargetTags[i] = strings.TrimSpace(t.TargetTags[i])
+		}
+	}
+
+	// 8. Compute target save path
+	t.TargetSavePath = s.computeTargetPath(t.SourceSavePath, targetInstance, t.PathMappings)
+
+	// 9. Determine link mode
+	t.LinkMode = s.determineLinkMode(targetInstance, t.SourceSavePath, t.TargetSavePath)
+
+	log.Info().
+		Int64("id", t.ID).
+		Str("name", t.TorrentName).
+		Str("sourcePath", t.SourceSavePath).
+		Str("targetPath", t.TargetSavePath).
+		Str("linkMode", t.LinkMode).
+		Int("files", t.FilesTotal).
+		Msg("[TRANSFER] Prepared transfer")
+
+	// 10. Save and continue
+	if err := s.store.Update(ctx, t); err != nil {
+		s.fail(ctx, t, fmt.Sprintf("failed to save transfer: %v", err))
+		return
+	}
+
+	s.doCreateLinks(ctx, t)
+}
+
+// doCreateLinks creates hardlinks or reflinks for the torrent files
+func (s *Service) doCreateLinks(ctx context.Context, t *models.Transfer) {
+	s.updateState(ctx, t, models.TransferStateLinksCreating, "")
+
+	// Direct mode - skip link creation
+	if t.LinkMode == "direct" {
+		log.Debug().Int64("id", t.ID).Msg("[TRANSFER] Direct mode - skipping link creation")
+		s.updateState(ctx, t, models.TransferStateLinksCreated, "")
+		s.doAddTorrent(ctx, t)
+		return
+	}
+
+	// Get target instance for settings
+	targetInstance, err := s.instanceStore.Get(ctx, t.TargetInstanceID)
+	if err != nil {
+		s.fail(ctx, t, fmt.Sprintf("failed to get target instance: %v", err))
+		return
+	}
+
+	// Get source files
+	files, err := s.syncManager.GetTorrentFiles(ctx, t.SourceInstanceID, t.TorrentHash)
+	if err != nil {
+		s.fail(ctx, t, fmt.Sprintf("failed to get source files: %v", err))
+		return
+	}
+
+	// Build file list for linking
+	sourceFiles := make([]hardlinktree.TorrentFile, 0, len(*files))
+	for _, f := range *files {
+		sourceFiles = append(sourceFiles, hardlinktree.TorrentFile{
+			Path: f.Name,
+			Size: f.Size,
+		})
+	}
+
+	// Build existing files list (source locations)
+	existingFiles := make([]hardlinktree.ExistingFile, 0, len(*files))
+	for _, f := range *files {
+		existingFiles = append(existingFiles, hardlinktree.ExistingFile{
+			AbsPath: filepath.Join(t.SourceSavePath, f.Name),
+			RelPath: f.Name,
+			Size:    f.Size,
+		})
+	}
+
+	// Build destination directory
+	destDir := s.buildDestDir(t, targetInstance)
+
+	// Ensure destination directory exists
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		s.fail(ctx, t, fmt.Sprintf("failed to create destination directory: %v", err))
+		return
+	}
+
+	// Build plan
+	plan, err := hardlinktree.BuildPlan(sourceFiles, existingFiles, hardlinktree.LayoutOriginal, t.TorrentName, destDir)
+	if err != nil {
+		s.fail(ctx, t, fmt.Sprintf("failed to build link plan: %v", err))
+		return
+	}
+
+	// Store plan info for potential rollback
+	t.TargetSavePath = plan.RootDir
+
+	// Execute based on link mode
+	switch t.LinkMode {
+	case "hardlink":
+		if err := hardlinktree.Create(plan); err != nil {
+			s.fail(ctx, t, fmt.Sprintf("failed to create hardlinks: %v", err))
+			return
+		}
+	case "reflink":
+		if err := reflinktree.Create(plan); err != nil {
+			// Check if we should fall back
+			if targetInstance.FallbackToRegularMode {
+				log.Warn().
+					Err(err).
+					Int64("id", t.ID).
+					Msg("[TRANSFER] Reflink failed, falling back to copy")
+				// For now, fail - copy mode not implemented
+				s.fail(ctx, t, fmt.Sprintf("reflink failed and copy fallback not implemented: %v", err))
+				return
+			}
+			s.fail(ctx, t, fmt.Sprintf("failed to create reflinks: %v", err))
+			return
+		}
+	}
+
+	t.FilesLinked = len(plan.Files)
+	if err := s.store.Update(ctx, t); err != nil {
+		log.Warn().Err(err).Int64("id", t.ID).Msg("[TRANSFER] Failed to update progress")
+	}
+
+	log.Info().
+		Int64("id", t.ID).
+		Int("files", len(plan.Files)).
+		Str("destDir", destDir).
+		Msg("[TRANSFER] Created file links")
+
+	s.updateState(ctx, t, models.TransferStateLinksCreated, "")
+	s.doAddTorrent(ctx, t)
+}
+
+// doAddTorrent adds the torrent to the target instance
+func (s *Service) doAddTorrent(ctx context.Context, t *models.Transfer) {
+	s.updateState(ctx, t, models.TransferStateAddingTorrent, "")
+
+	// Export torrent from source
+	torrentBytes, _, _, err := s.syncManager.ExportTorrent(ctx, t.SourceInstanceID, t.TorrentHash)
+	if err != nil {
+		s.rollbackLinks(ctx, t)
+		s.fail(ctx, t, fmt.Sprintf("failed to export torrent: %v", err))
+		return
+	}
+
+	// Ensure category exists on target
+	if t.TargetCategory != "" {
+		if err := s.ensureCategory(ctx, t.TargetInstanceID, t.TargetCategory, t.TargetSavePath); err != nil {
+			log.Warn().
+				Err(err).
+				Int64("id", t.ID).
+				Str("category", t.TargetCategory).
+				Msg("[TRANSFER] Failed to create category, continuing without")
+			t.TargetCategory = ""
+		}
+	}
+
+	// Build add options
+	options := map[string]string{
+		"autoTMM":       "false",
+		"savepath":      t.TargetSavePath,
+		"skip_checking": "true", // Files already exist via links
+	}
+
+	if t.LinkMode != "direct" {
+		options["contentLayout"] = "Original"
+	}
+
+	if t.TargetCategory != "" {
+		options["category"] = t.TargetCategory
+	}
+
+	if len(t.TargetTags) > 0 {
+		options["tags"] = strings.Join(t.TargetTags, ",")
+	}
+
+	// Start paused to verify before resuming
+	options["paused"] = "true"
+	options["stopped"] = "true"
+
+	// Add torrent to target
+	if err := s.syncManager.AddTorrent(ctx, t.TargetInstanceID, torrentBytes, options); err != nil {
+		s.rollbackLinks(ctx, t)
+		s.fail(ctx, t, fmt.Sprintf("failed to add torrent to target: %v", err))
+		return
+	}
+
+	log.Info().
+		Int64("id", t.ID).
+		Str("hash", t.TorrentHash).
+		Int("targetInstance", t.TargetInstanceID).
+		Msg("[TRANSFER] Added torrent to target instance")
+
+	// Wait for torrent to be visible, then resume
+	if s.waitForTorrent(ctx, t.TargetInstanceID, t.TorrentHash, 15*time.Second) {
+		// Trigger recheck and resume
+		if err := s.syncManager.BulkAction(ctx, t.TargetInstanceID, []string{t.TorrentHash}, "recheck"); err != nil {
+			log.Warn().Err(err).Int64("id", t.ID).Msg("[TRANSFER] Failed to trigger recheck")
+		}
+		// Resume after a brief delay for recheck to start
+		time.Sleep(2 * time.Second)
+		if err := s.syncManager.BulkAction(ctx, t.TargetInstanceID, []string{t.TorrentHash}, "resume"); err != nil {
+			log.Warn().Err(err).Int64("id", t.ID).Msg("[TRANSFER] Failed to resume torrent")
+		}
+	}
+
+	s.updateState(ctx, t, models.TransferStateTorrentAdded, "")
+
+	if t.DeleteFromSource {
+		s.doDeleteSource(ctx, t)
+	} else {
+		s.markCompleted(ctx, t)
+	}
+}
+
+// doDeleteSource removes the torrent from the source instance
+func (s *Service) doDeleteSource(ctx context.Context, t *models.Transfer) {
+	s.updateState(ctx, t, models.TransferStateDeletingSource, "")
+
+	// Delete torrent from source (keep files - they're hardlinked)
+	if err := s.syncManager.DeleteTorrents(ctx, t.SourceInstanceID, []string{t.TorrentHash}, false); err != nil {
+		// Don't fail the whole transfer for this - log and complete
+		log.Warn().
+			Err(err).
+			Int64("id", t.ID).
+			Msg("[TRANSFER] Failed to delete from source, completing anyway")
+	} else {
+		log.Info().
+			Int64("id", t.ID).
+			Int("sourceInstance", t.SourceInstanceID).
+			Msg("[TRANSFER] Deleted torrent from source instance")
+	}
+
+	s.markCompleted(ctx, t)
+}
+
+// Helper methods
+
+func (s *Service) updateState(ctx context.Context, t *models.Transfer, state models.TransferState, errorMsg string) {
+	t.State = state
+	t.Error = errorMsg
+	if err := s.store.UpdateState(ctx, t.ID, state, errorMsg); err != nil {
+		log.Error().Err(err).Int64("id", t.ID).Str("state", string(state)).Msg("[TRANSFER] Failed to update state")
+	}
+}
+
+func (s *Service) fail(ctx context.Context, t *models.Transfer, errorMsg string) {
+	log.Error().Int64("id", t.ID).Str("error", errorMsg).Msg("[TRANSFER] Transfer failed")
+	s.updateState(ctx, t, models.TransferStateFailed, errorMsg)
+}
+
+func (s *Service) markCompleted(ctx context.Context, t *models.Transfer) {
+	now := time.Now().UTC()
+	t.CompletedAt = &now
+	t.State = models.TransferStateCompleted
+	if err := s.store.Update(ctx, t); err != nil {
+		log.Error().Err(err).Int64("id", t.ID).Msg("[TRANSFER] Failed to mark completed")
+		return
+	}
+	log.Info().
+		Int64("id", t.ID).
+		Str("name", t.TorrentName).
+		Msg("[TRANSFER] Transfer completed successfully")
+}
+
+func (s *Service) checkTorrentExists(ctx context.Context, instanceID int, hash string) bool {
+	_, exists, err := s.syncManager.HasTorrentByAnyHash(ctx, instanceID, []string{hash})
+	if err != nil {
+		return false
+	}
+	return exists
+}
+
+func (s *Service) waitForTorrent(ctx context.Context, instanceID int, hash string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if s.checkTorrentExists(ctx, instanceID, hash) {
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+	return false
+}
+
+func (s *Service) rollbackLinks(ctx context.Context, t *models.Transfer) {
+	if t.LinkMode == "direct" || t.TargetSavePath == "" {
+		return
+	}
+
+	log.Debug().Int64("id", t.ID).Str("path", t.TargetSavePath).Msg("[TRANSFER] Rolling back links")
+
+	// Get source files to build rollback plan
+	files, err := s.syncManager.GetTorrentFiles(ctx, t.SourceInstanceID, t.TorrentHash)
+	if err != nil {
+		log.Warn().Err(err).Int64("id", t.ID).Msg("[TRANSFER] Failed to get files for rollback")
+		return
+	}
+
+	// Build plan just for rollback
+	sourceFiles := make([]hardlinktree.TorrentFile, 0, len(*files))
+	for _, f := range *files {
+		sourceFiles = append(sourceFiles, hardlinktree.TorrentFile{
+			Path: f.Name,
+			Size: f.Size,
+		})
+	}
+
+	plan := &hardlinktree.TreePlan{
+		RootDir: t.TargetSavePath,
+		Files:   make([]hardlinktree.FilePlan, 0, len(sourceFiles)),
+	}
+	for _, f := range sourceFiles {
+		plan.Files = append(plan.Files, hardlinktree.FilePlan{
+			TargetPath: filepath.Join(t.TargetSavePath, f.Path),
+		})
+	}
+
+	if err := hardlinktree.Rollback(plan); err != nil {
+		log.Warn().Err(err).Int64("id", t.ID).Msg("[TRANSFER] Rollback failed")
+	}
+}
+
+func (s *Service) buildDestDir(t *models.Transfer, instance *models.Instance) string {
+	baseDir := t.TargetSavePath
+	if instance.HardlinkBaseDir != "" {
+		baseDir = instance.HardlinkBaseDir
+	}
+
+	// Use preset if configured
+	switch instance.HardlinkDirPreset {
+	case "flat":
+		// All torrents in base dir with isolation folder
+		shortHash := t.TorrentHash
+		if len(shortHash) > 8 {
+			shortHash = shortHash[:8]
+		}
+		return filepath.Join(baseDir, fmt.Sprintf("%s--%s", sanitizeName(t.TorrentName), shortHash))
+	case "by-instance":
+		return filepath.Join(baseDir, fmt.Sprintf("instance-%d", t.SourceInstanceID))
+	default:
+		return baseDir
+	}
+}
+
+func (s *Service) ensureCategory(ctx context.Context, instanceID int, category, savePath string) error {
+	if category == "" {
+		return nil
+	}
+
+	key := fmt.Sprintf("%d:%s", instanceID, category)
+
+	// Fast path: already created in this session
+	if _, ok := s.createdCategories.Load(key); ok {
+		return nil
+	}
+
+	// Use singleflight to deduplicate concurrent calls
+	_, err, _ := s.categoryCreationGroup.Do(key, func() (any, error) {
+		// Double-check
+		if _, ok := s.createdCategories.Load(key); ok {
+			return nil, nil
+		}
+
+		// Check if exists
+		categories, err := s.syncManager.GetCategories(ctx, instanceID)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, exists := categories[category]; exists {
+			s.createdCategories.Store(key, true)
+			return nil, nil
+		}
+
+		// Create category
+		if err := s.syncManager.CreateCategory(ctx, instanceID, category, savePath); err != nil {
+			return nil, err
+		}
+
+		s.createdCategories.Store(key, true)
+		log.Debug().
+			Int("instanceID", instanceID).
+			Str("category", category).
+			Msg("[TRANSFER] Created category")
+
+		return nil, nil
+	})
+
+	return err
+}
+
+func sanitizeName(name string) string {
+	// Replace characters that might cause issues in paths
+	replacer := strings.NewReplacer(
+		"/", "_",
+		"\\", "_",
+		":", "_",
+		"*", "_",
+		"?", "_",
+		"\"", "_",
+		"<", "_",
+		">", "_",
+		"|", "_",
+	)
+	return replacer.Replace(name)
+}

--- a/internal/services/transfer/path.go
+++ b/internal/services/transfer/path.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package transfer
+
+import (
+	"strings"
+
+	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/pkg/fsutil"
+)
+
+// computeTargetPath determines where files should be placed on target
+func (s *Service) computeTargetPath(
+	sourcePath string,
+	targetInstance *models.Instance,
+	mappings map[string]string,
+) string {
+	// 1. Check explicit path mappings first (longest prefix match)
+	if len(mappings) > 0 {
+		var bestMatch string
+		var bestReplacement string
+		for oldPrefix, newPrefix := range mappings {
+			if strings.HasPrefix(sourcePath, oldPrefix) {
+				if len(oldPrefix) > len(bestMatch) {
+					bestMatch = oldPrefix
+					bestReplacement = newPrefix
+				}
+			}
+		}
+		if bestMatch != "" {
+			return strings.Replace(sourcePath, bestMatch, bestReplacement, 1)
+		}
+	}
+
+	// 2. Use target instance's HardlinkBaseDir if configured
+	if targetInstance.HardlinkBaseDir != "" {
+		return targetInstance.HardlinkBaseDir
+	}
+
+	// 3. Same path (same server, shared storage)
+	return sourcePath
+}
+
+// determineLinkMode decides whether to use hardlinks, reflinks, or direct add
+func (s *Service) determineLinkMode(
+	targetInstance *models.Instance,
+	sourcePath, targetPath string,
+) string {
+	// Check hardlinks first (preferred - instant, no extra space)
+	if targetInstance.UseHardlinks {
+		sameFS, err := fsutil.SameFilesystem(sourcePath, targetPath)
+		if err == nil && sameFS {
+			return "hardlink"
+		}
+		// Different filesystem - fall back to reflink if enabled and fallback allowed
+		if targetInstance.UseReflinks && targetInstance.FallbackToRegularMode {
+			return "reflink"
+		}
+	}
+
+	// Check reflinks (copy-on-write)
+	if targetInstance.UseReflinks {
+		return "reflink"
+	}
+
+	// Direct add (no file linking - assumes shared storage or same paths)
+	return "direct"
+}

--- a/internal/services/transfer/recovery.go
+++ b/internal/services/transfer/recovery.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package transfer
+
+import (
+	"context"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/autobrr/qui/internal/models"
+)
+
+// recoverInterrupted handles transfers that were in progress when the app stopped
+func (s *Service) recoverInterrupted() {
+	ctx := context.Background()
+
+	// Get all in-progress transfers
+	states := []models.TransferState{
+		models.TransferStatePending,
+		models.TransferStatePreparing,
+		models.TransferStateLinksCreating,
+		models.TransferStateLinksCreated,
+		models.TransferStateAddingTorrent,
+		models.TransferStateTorrentAdded,
+		models.TransferStateDeletingSource,
+	}
+
+	transfers, err := s.store.ListByStates(ctx, states)
+	if err != nil {
+		log.Error().Err(err).Msg("[TRANSFER] Failed to list interrupted transfers")
+		return
+	}
+
+	if len(transfers) == 0 {
+		return
+	}
+
+	log.Info().Int("count", len(transfers)).Msg("[TRANSFER] Recovering interrupted transfers")
+
+	for _, t := range transfers {
+		s.recoverTransfer(ctx, t)
+	}
+}
+
+// recoverTransfer handles recovery for a single interrupted transfer
+func (s *Service) recoverTransfer(ctx context.Context, t *models.Transfer) {
+	log.Debug().
+		Int64("id", t.ID).
+		Str("state", string(t.State)).
+		Str("hash", t.TorrentHash).
+		Msg("[TRANSFER] Recovering transfer")
+
+	switch t.State {
+	case models.TransferStatePending:
+		// Safe to restart
+		s.queue <- t.ID
+
+	case models.TransferStatePreparing:
+		// Safe to restart from beginning
+		s.updateState(ctx, t, models.TransferStatePending, "")
+		s.queue <- t.ID
+
+	case models.TransferStateLinksCreating:
+		// Links may be partial - attempt rollback and restart
+		s.rollbackLinks(ctx, t)
+		s.updateState(ctx, t, models.TransferStatePending, "")
+		s.queue <- t.ID
+
+	case models.TransferStateLinksCreated:
+		// Links are done, continue with add
+		s.queue <- t.ID
+
+	case models.TransferStateAddingTorrent:
+		// Check if torrent was actually added
+		exists := s.checkTorrentExists(ctx, t.TargetInstanceID, t.TorrentHash)
+		if exists {
+			// Torrent was added - continue
+			s.updateState(ctx, t, models.TransferStateTorrentAdded, "")
+			s.queue <- t.ID
+		} else {
+			// Torrent wasn't added - rollback links and restart
+			s.rollbackLinks(ctx, t)
+			s.updateState(ctx, t, models.TransferStatePending, "")
+			s.queue <- t.ID
+		}
+
+	case models.TransferStateTorrentAdded:
+		// Torrent is on target - continue to delete source if needed
+		s.queue <- t.ID
+
+	case models.TransferStateDeletingSource:
+		// Check if source still has torrent
+		exists := s.checkTorrentExists(ctx, t.SourceInstanceID, t.TorrentHash)
+		if exists {
+			// Still there - continue deletion
+			s.queue <- t.ID
+		} else {
+			// Already deleted - mark complete
+			s.markCompleted(ctx, t)
+		}
+	}
+}
+
+// ReconcileInterruptedTransfers marks stale in-progress transfers as failed
+// Called during startup to clean up any truly stuck transfers
+func (s *Service) ReconcileInterruptedTransfers(ctx context.Context) (int64, error) {
+	// Mark very old in-progress transfers as failed
+	// This is a safety net for transfers that got stuck
+	stuckStates := []models.TransferState{
+		models.TransferStateLinksCreating,
+		models.TransferStateAddingTorrent,
+	}
+
+	count, err := s.store.MarkInterrupted(ctx, stuckStates, "transfer interrupted (application restarted)")
+	if err != nil {
+		return 0, err
+	}
+
+	if count > 0 {
+		log.Info().Int64("count", count).Msg("[TRANSFER] Reconciled stuck transfers")
+	}
+
+	return count, nil
+}

--- a/internal/services/transfer/requests.go
+++ b/internal/services/transfer/requests.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package transfer
+
+import (
+	"errors"
+
+	"github.com/autobrr/qui/internal/models"
+)
+
+// Errors
+var (
+	ErrTransferAlreadyExists = errors.New("transfer already exists for this torrent")
+	ErrCannotCancel          = errors.New("cannot cancel transfer in current state")
+	ErrSourceNotAccessible   = errors.New("source instance not accessible or lacks local filesystem access")
+	ErrTargetNotAccessible   = errors.New("target instance not accessible or lacks local filesystem access")
+	ErrTorrentNotFound       = errors.New("torrent not found on source instance")
+	ErrNoLinkModeAvailable   = errors.New("no link mode available (hardlink/reflink not enabled and different filesystems)")
+)
+
+// TransferRequest is the request to queue a new transfer
+type TransferRequest struct {
+	SourceInstanceID int               `json:"sourceInstanceId"`
+	TargetInstanceID int               `json:"targetInstanceId"`
+	TorrentHash      string            `json:"torrentHash"`
+	PathMappings     map[string]string `json:"pathMappings,omitempty"`
+	DeleteFromSource bool              `json:"deleteFromSource"`
+	PreserveCategory bool              `json:"preserveCategory"`
+	PreserveTags     bool              `json:"preserveTags"`
+}
+
+// Validate validates the transfer request
+func (r *TransferRequest) Validate() error {
+	if r.SourceInstanceID == 0 {
+		return errors.New("source instance ID is required")
+	}
+	if r.TargetInstanceID == 0 {
+		return errors.New("target instance ID is required")
+	}
+	if r.SourceInstanceID == r.TargetInstanceID {
+		return errors.New("source and target instance must be different")
+	}
+	if r.TorrentHash == "" {
+		return errors.New("torrent hash is required")
+	}
+	return nil
+}
+
+// MoveRequest is a convenience wrapper for common move operations
+type MoveRequest struct {
+	SourceInstanceID int               `json:"sourceInstanceId"`
+	TargetInstanceID int               `json:"targetInstanceId"`
+	Hash             string            `json:"hash"`
+	PathMappings     map[string]string `json:"pathMappings,omitempty"`
+	DeleteFromSource bool              `json:"deleteFromSource"` // Default: true
+	PreserveCategory bool              `json:"preserveCategory"` // Default: true
+	PreserveTags     bool              `json:"preserveTags"`     // Default: true
+}
+
+// ListOptions for filtering transfer list
+type ListOptions struct {
+	InstanceID *int                    // Filter by source or target instance
+	States     []models.TransferState  // Filter by states
+	Limit      int
+	Offset     int
+}

--- a/internal/services/transfer/requests.go
+++ b/internal/services/transfer/requests.go
@@ -13,6 +13,10 @@ import (
 var (
 	ErrTransferAlreadyExists = errors.New("transfer already exists for this torrent")
 	ErrCannotCancel          = errors.New("cannot cancel transfer in current state")
+	ErrMissingSourceID       = errors.New("source instance ID is required")
+	ErrMissingTargetID       = errors.New("target instance ID is required")
+	ErrSourceTargetSame      = errors.New("source and target instance must be different")
+	ErrMissingTorrentHash    = errors.New("torrent hash is required")
 	ErrSourceNotAccessible   = errors.New("source instance not accessible or lacks local filesystem access")
 	ErrTargetNotAccessible   = errors.New("target instance not accessible or lacks local filesystem access")
 	ErrTorrentNotFound       = errors.New("torrent not found on source instance")
@@ -33,16 +37,16 @@ type TransferRequest struct {
 // Validate validates the transfer request
 func (r *TransferRequest) Validate() error {
 	if r.SourceInstanceID == 0 {
-		return errors.New("source instance ID is required")
+		return ErrMissingSourceID
 	}
 	if r.TargetInstanceID == 0 {
-		return errors.New("target instance ID is required")
+		return ErrMissingTargetID
 	}
 	if r.SourceInstanceID == r.TargetInstanceID {
-		return errors.New("source and target instance must be different")
+		return ErrSourceTargetSame
 	}
 	if r.TorrentHash == "" {
-		return errors.New("torrent hash is required")
+		return ErrMissingTorrentHash
 	}
 	return nil
 }
@@ -53,15 +57,31 @@ type MoveRequest struct {
 	TargetInstanceID int               `json:"targetInstanceId"`
 	Hash             string            `json:"hash"`
 	PathMappings     map[string]string `json:"pathMappings,omitempty"`
-	DeleteFromSource bool              `json:"deleteFromSource"` // Default: true
-	PreserveCategory bool              `json:"preserveCategory"` // Default: true
-	PreserveTags     bool              `json:"preserveTags"`     // Default: true
+	DeleteFromSource bool              `json:"deleteFromSource"`
+	PreserveCategory bool              `json:"preserveCategory"`
+	PreserveTags     bool              `json:"preserveTags"`
+}
+
+func (r *MoveRequest) Validate() error {
+	if r.SourceInstanceID == 0 {
+		return ErrMissingSourceID
+	}
+	if r.TargetInstanceID == 0 {
+		return ErrMissingTargetID
+	}
+	if r.SourceInstanceID == r.TargetInstanceID {
+		return ErrSourceTargetSame
+	}
+	if r.Hash == "" {
+		return ErrMissingTorrentHash
+	}
+	return nil
 }
 
 // ListOptions for filtering transfer list
 type ListOptions struct {
-	InstanceID *int                    // Filter by source or target instance
-	States     []models.TransferState  // Filter by states
+	InstanceID *int                   // Filter by source or target instance
+	States     []models.TransferState // Filter by states
 	Limit      int
 	Offset     int
 }

--- a/internal/services/transfer/service.go
+++ b/internal/services/transfer/service.go
@@ -1,0 +1,192 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package transfer
+
+import (
+	"context"
+	"sync"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/rs/zerolog/log"
+	"golang.org/x/sync/singleflight"
+
+	"github.com/autobrr/qui/internal/models"
+)
+
+// InstanceProvider abstracts instance store access
+type InstanceProvider interface {
+	Get(ctx context.Context, id int) (*models.Instance, error)
+}
+
+// SyncManager abstracts qBittorrent operations
+type SyncManager interface {
+	GetTorrents(ctx context.Context, instanceID int, filter qbt.TorrentFilterOptions) ([]qbt.Torrent, error)
+	GetTorrentFiles(ctx context.Context, instanceID int, hash string) (*qbt.TorrentFiles, error)
+	GetTorrentProperties(ctx context.Context, instanceID int, hash string) (*qbt.TorrentProperties, error)
+	ExportTorrent(ctx context.Context, instanceID int, hash string) ([]byte, string, string, error)
+	AddTorrent(ctx context.Context, instanceID int, fileContent []byte, options map[string]string) error
+	BulkAction(ctx context.Context, instanceID int, hashes []string, action string) error
+	DeleteTorrents(ctx context.Context, instanceID int, hashes []string, deleteFiles bool) error
+	GetCategories(ctx context.Context, instanceID int) (map[string]qbt.Category, error)
+	CreateCategory(ctx context.Context, instanceID int, name, path string) error
+	HasTorrentByAnyHash(ctx context.Context, instanceID int, hashes []string) (*qbt.Torrent, bool, error)
+}
+
+// Service handles torrent transfers between instances
+type Service struct {
+	store         *models.TransferStore
+	instanceStore InstanceProvider
+	syncManager   SyncManager
+
+	// Background worker
+	workerCtx    context.Context
+	workerCancel context.CancelFunc
+	workerWg     sync.WaitGroup
+	queue        chan int64
+
+	// Category creation deduplication
+	createdCategories     sync.Map
+	categoryCreationGroup singleflight.Group
+
+	// Configuration
+	workerCount int
+}
+
+// New creates a new transfer service
+func New(
+	store *models.TransferStore,
+	instanceStore InstanceProvider,
+	syncManager SyncManager,
+) *Service {
+	return &Service{
+		store:         store,
+		instanceStore: instanceStore,
+		syncManager:   syncManager,
+		queue:         make(chan int64, 100),
+		workerCount:   2,
+	}
+}
+
+// Start initializes the service and recovers interrupted transfers
+func (s *Service) Start(ctx context.Context) {
+	s.workerCtx, s.workerCancel = context.WithCancel(ctx)
+
+	// Recover interrupted transfers
+	s.recoverInterrupted()
+
+	// Start worker goroutines
+	for i := 0; i < s.workerCount; i++ {
+		s.workerWg.Add(1)
+		go s.worker(i)
+	}
+
+	log.Info().Int("workers", s.workerCount).Msg("[TRANSFER] Service started")
+}
+
+// Stop gracefully shuts down the service
+func (s *Service) Stop() {
+	if s.workerCancel != nil {
+		s.workerCancel()
+	}
+	s.workerWg.Wait()
+	log.Info().Msg("[TRANSFER] Service stopped")
+}
+
+// QueueTransfer creates a new transfer and queues it for processing
+func (s *Service) QueueTransfer(ctx context.Context, req *TransferRequest) (*models.Transfer, error) {
+	// Validate request
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Check for existing non-terminal transfer for this hash
+	existing, err := s.store.GetByHash(ctx, req.TorrentHash)
+	if err == nil && existing != nil {
+		return nil, ErrTransferAlreadyExists
+	}
+
+	// Create transfer record
+	t := &models.Transfer{
+		SourceInstanceID: req.SourceInstanceID,
+		TargetInstanceID: req.TargetInstanceID,
+		TorrentHash:      req.TorrentHash,
+		TorrentName:      req.TorrentHash, // Will be updated during prepare
+		State:            models.TransferStatePending,
+		DeleteFromSource: req.DeleteFromSource,
+		PreserveCategory: req.PreserveCategory,
+		PreserveTags:     req.PreserveTags,
+		PathMappings:     req.PathMappings,
+	}
+
+	created, err := s.store.Create(ctx, t)
+	if err != nil {
+		return nil, err
+	}
+
+	// Queue for processing
+	select {
+	case s.queue <- created.ID:
+		log.Debug().
+			Int64("id", created.ID).
+			Str("hash", created.TorrentHash).
+			Msg("[TRANSFER] Queued transfer")
+	default:
+		// Queue full - worker will pick up from DB on next cycle
+		log.Warn().
+			Int64("id", created.ID).
+			Msg("[TRANSFER] Queue full, transfer will be picked up later")
+	}
+
+	return created, nil
+}
+
+// MoveTorrent is a convenience method for moving a torrent between instances
+func (s *Service) MoveTorrent(ctx context.Context, req *MoveRequest) (*models.Transfer, error) {
+	return s.QueueTransfer(ctx, &TransferRequest{
+		SourceInstanceID: req.SourceInstanceID,
+		TargetInstanceID: req.TargetInstanceID,
+		TorrentHash:      req.Hash,
+		PathMappings:     req.PathMappings,
+		DeleteFromSource: req.DeleteFromSource,
+		PreserveCategory: req.PreserveCategory,
+		PreserveTags:     req.PreserveTags,
+	})
+}
+
+// GetTransfer retrieves a transfer by ID
+func (s *Service) GetTransfer(ctx context.Context, id int64) (*models.Transfer, error) {
+	return s.store.Get(ctx, id)
+}
+
+// CancelTransfer attempts to cancel a pending or in-progress transfer
+func (s *Service) CancelTransfer(ctx context.Context, id int64) error {
+	t, err := s.store.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	// Only pending transfers can be cancelled
+	if t.State != models.TransferStatePending {
+		return ErrCannotCancel
+	}
+
+	return s.store.UpdateState(ctx, id, models.TransferStateCancelled, "cancelled by user")
+}
+
+// ListTransfers returns transfers with optional filtering
+func (s *Service) ListTransfers(ctx context.Context, opts ListOptions) ([]*models.Transfer, error) {
+	if opts.Limit == 0 {
+		opts.Limit = 50
+	}
+
+	if len(opts.States) > 0 {
+		return s.store.ListByStates(ctx, opts.States)
+	}
+
+	if opts.InstanceID != nil {
+		return s.store.ListByInstance(ctx, *opts.InstanceID, opts.Limit, opts.Offset)
+	}
+
+	return s.store.ListRecent(ctx, opts.Limit, opts.Offset)
+}

--- a/internal/services/transfer/worker.go
+++ b/internal/services/transfer/worker.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package transfer
+
+import (
+	"context"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/autobrr/qui/internal/models"
+)
+
+// worker processes transfers from the queue
+func (s *Service) worker(id int) {
+	defer s.workerWg.Done()
+
+	log.Debug().Int("workerID", id).Msg("[TRANSFER] Worker started")
+
+	for {
+		select {
+		case <-s.workerCtx.Done():
+			log.Debug().Int("workerID", id).Msg("[TRANSFER] Worker stopping")
+			return
+		case transferID := <-s.queue:
+			s.processTransfer(transferID)
+		}
+	}
+}
+
+// processTransfer executes the state machine for a single transfer
+func (s *Service) processTransfer(id int64) {
+	ctx := s.workerCtx
+
+	t, err := s.store.Get(ctx, id)
+	if err != nil {
+		log.Error().Err(err).Int64("transferID", id).Msg("[TRANSFER] Failed to load transfer")
+		return
+	}
+
+	// Skip if already in terminal state
+	if t.State.IsTerminal() {
+		log.Debug().
+			Int64("id", t.ID).
+			Str("state", string(t.State)).
+			Msg("[TRANSFER] Skipping terminal transfer")
+		return
+	}
+
+	log.Debug().
+		Int64("id", t.ID).
+		Str("hash", t.TorrentHash).
+		Str("state", string(t.State)).
+		Msg("[TRANSFER] Processing transfer")
+
+	// State machine
+	switch t.State {
+	case models.TransferStatePending:
+		s.doPrepare(ctx, t)
+
+	case models.TransferStatePreparing:
+		// If we're still in preparing state, it means prepare was interrupted
+		// Restart from pending
+		s.updateState(ctx, t, models.TransferStatePending, "")
+		s.doPrepare(ctx, t)
+
+	case models.TransferStateLinksCreating:
+		// Links may be partial - attempt rollback and restart
+		s.rollbackLinks(ctx, t)
+		s.updateState(ctx, t, models.TransferStatePending, "")
+		s.doPrepare(ctx, t)
+
+	case models.TransferStateLinksCreated:
+		s.doAddTorrent(ctx, t)
+
+	case models.TransferStateAddingTorrent:
+		// Check if torrent was actually added
+		exists := s.checkTorrentExists(ctx, t.TargetInstanceID, t.TorrentHash)
+		if exists {
+			s.updateState(ctx, t, models.TransferStateTorrentAdded, "")
+			s.continueAfterAdd(ctx, t)
+		} else {
+			// Torrent wasn't added - rollback and fail
+			s.rollbackLinks(ctx, t)
+			s.fail(ctx, t, "interrupted during add - rolled back")
+		}
+
+	case models.TransferStateTorrentAdded:
+		s.continueAfterAdd(ctx, t)
+
+	case models.TransferStateDeletingSource:
+		s.doDeleteSource(ctx, t)
+	}
+}
+
+// continueAfterAdd handles post-add logic
+func (s *Service) continueAfterAdd(ctx context.Context, t *models.Transfer) {
+	if t.DeleteFromSource {
+		s.doDeleteSource(ctx, t)
+	} else {
+		s.markCompleted(ctx, t)
+	}
+}
+
+// requeueTransfer puts a transfer back in the queue for processing
+func (s *Service) requeueTransfer(t *models.Transfer) {
+	select {
+	case s.queue <- t.ID:
+		log.Debug().Int64("id", t.ID).Msg("[TRANSFER] Requeued transfer")
+	default:
+		log.Warn().Int64("id", t.ID).Msg("[TRANSFER] Queue full, transfer will be picked up on next recovery")
+	}
+}

--- a/internal/services/transfer/worker.go
+++ b/internal/services/transfer/worker.go
@@ -13,8 +13,6 @@ import (
 
 // worker processes transfers from the queue
 func (s *Service) worker(id int) {
-	defer s.workerWg.Done()
-
 	log.Debug().Int("workerID", id).Msg("[TRANSFER] Worker started")
 
 	for {

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -1814,6 +1814,33 @@ paths:
                     relevance:
                       type: number
 
+  /api/instances/{instanceID}/torrents/{hash}/move:
+    post:
+      tags:
+        - Transfers
+      summary: Move torrent to another instance
+      description: Queue a transfer to move this torrent to another qBittorrent instance
+      parameters:
+        - $ref: '#/components/parameters/instanceID'
+        - $ref: '#/components/parameters/hash'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MoveRequest'
+      responses:
+        '202':
+          description: Transfer queued successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Transfer'
+        '400':
+          description: Invalid request or target instance ID required
+        '409':
+          description: Transfer already exists for this torrent
+
   /api/instances/{instanceID}/torrents/add-peers:
     post:
       tags:
@@ -4159,6 +4186,119 @@ paths:
         '200':
           description: Service is alive
 
+  # Transfer API endpoints
+  /api/transfers:
+    post:
+      tags:
+        - Transfers
+      summary: Create transfer
+      description: Queue a new torrent transfer between instances
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TransferRequest'
+      responses:
+        '201':
+          description: Transfer queued successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Transfer'
+        '400':
+          description: Invalid request
+        '409':
+          description: Transfer already exists for this torrent
+    get:
+      tags:
+        - Transfers
+      summary: List transfers
+      description: Get list of transfers with optional filtering
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 50
+          description: Maximum number of transfers to return
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            default: 0
+          description: Number of transfers to skip
+        - name: instanceId
+          in: query
+          schema:
+            type: integer
+          description: Filter by source or target instance ID
+        - name: states
+          in: query
+          schema:
+            type: string
+          description: Comma-separated list of states to filter by
+      responses:
+        '200':
+          description: List of transfers
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Transfer'
+
+  /api/transfers/{id}:
+    get:
+      tags:
+        - Transfers
+      summary: Get transfer
+      description: Get details of a specific transfer
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+          description: Transfer ID
+      responses:
+        '200':
+          description: Transfer details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Transfer'
+        '404':
+          description: Transfer not found
+    delete:
+      tags:
+        - Transfers
+      summary: Cancel transfer
+      description: Cancel a pending transfer
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+          description: Transfer ID
+      responses:
+        '200':
+          description: Transfer cancelled
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: cancelled
+        '400':
+          description: Invalid transfer ID
+        '409':
+          description: Cannot cancel transfer in current state
 
 components:
   securitySchemes:
@@ -6256,6 +6396,135 @@ components:
       required:
         - status
 
+    # Transfer schemas
+    Transfer:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        sourceInstanceId:
+          type: integer
+        targetInstanceId:
+          type: integer
+        torrentHash:
+          type: string
+        torrentName:
+          type: string
+        state:
+          type: string
+          enum:
+            - pending
+            - preparing
+            - links_creating
+            - links_created
+            - adding_torrent
+            - torrent_added
+            - deleting_source
+            - completed
+            - failed
+            - rolled_back
+            - cancelled
+        sourceSavePath:
+          type: string
+        targetSavePath:
+          type: string
+        linkMode:
+          type: string
+          enum: ["hardlink", "reflink", "direct"]
+        deleteFromSource:
+          type: boolean
+        preserveCategory:
+          type: boolean
+        preserveTags:
+          type: boolean
+        targetCategory:
+          type: string
+        targetTags:
+          type: array
+          items:
+            type: string
+        pathMappings:
+          type: object
+          additionalProperties:
+            type: string
+        filesTotal:
+          type: integer
+        filesLinked:
+          type: integer
+        error:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        completedAt:
+          type: string
+          format: date-time
+          nullable: true
+
+    TransferRequest:
+      type: object
+      required:
+        - sourceInstanceId
+        - targetInstanceId
+        - torrentHash
+      properties:
+        sourceInstanceId:
+          type: integer
+          description: ID of the source qBittorrent instance
+        targetInstanceId:
+          type: integer
+          description: ID of the target qBittorrent instance
+        torrentHash:
+          type: string
+          description: Hash of the torrent to transfer
+        pathMappings:
+          type: object
+          additionalProperties:
+            type: string
+          description: Optional path prefix mappings from source to target
+        deleteFromSource:
+          type: boolean
+          default: true
+          description: Whether to delete the torrent from source after transfer
+        preserveCategory:
+          type: boolean
+          default: true
+          description: Whether to preserve the torrent's category
+        preserveTags:
+          type: boolean
+          default: true
+          description: Whether to preserve the torrent's tags
+
+    MoveRequest:
+      type: object
+      required:
+        - targetInstanceId
+      properties:
+        targetInstanceId:
+          type: integer
+          description: ID of the target qBittorrent instance
+        pathMappings:
+          type: object
+          additionalProperties:
+            type: string
+          description: Optional path prefix mappings from source to target
+        deleteFromSource:
+          type: boolean
+          default: true
+          description: Whether to delete the torrent from source after transfer
+        preserveCategory:
+          type: boolean
+          default: true
+          description: Whether to preserve the torrent's category
+        preserveTags:
+          type: boolean
+          default: true
+          description: Whether to preserve the torrent's tags
+
 tags:
   - name: Authentication
     description: User authentication and session management
@@ -6283,5 +6552,7 @@ tags:
     description: Directory scanner operations for data-based matching and injection
   - name: Orphan Scan
     description: Orphan file scanning and cleanup (files on disk not associated with any torrent)
+  - name: Transfers
+    description: Move torrents between qBittorrent instances with hardlink/reflink support
   - name: Theme Licenses
     description: Theme license management (optional feature)

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -4235,8 +4235,24 @@ paths:
           description: Filter by source or target instance ID
         - name: states
           in: query
+          style: form
+          explode: false
           schema:
-            type: string
+            type: array
+            items:
+              type: string
+              enum:
+                - pending
+                - preparing
+                - links_creating
+                - links_created
+                - adding_torrent
+                - torrent_added
+                - deleting_source
+                - completed
+                - failed
+                - rolled_back
+                - cancelled
           description: Comma-separated list of states to filter by
       responses:
         '200':
@@ -4297,6 +4313,8 @@ paths:
                     example: cancelled
         '400':
           description: Invalid transfer ID
+        '404':
+          description: Transfer not found
         '409':
           description: Cannot cancel transfer in current state
 
@@ -6432,6 +6450,7 @@ components:
         linkMode:
           type: string
           enum: ["hardlink", "reflink", "direct"]
+          description: Link mode used for the transfer. "hardlink" creates hard links, "reflink" uses copy-on-write (CoW), "direct" uses the files directly without linking.
         deleteFromSource:
           type: boolean
         preserveCategory:
@@ -6448,12 +6467,14 @@ components:
           type: object
           additionalProperties:
             type: string
+          default: { }
         filesTotal:
           type: integer
         filesLinked:
           type: integer
         error:
           type: string
+          nullable: true
         createdAt:
           type: string
           format: date-time
@@ -6485,6 +6506,7 @@ components:
           type: object
           additionalProperties:
             type: string
+          default: { }
           description: Optional path prefix mappings from source to target
         deleteFromSource:
           type: boolean
@@ -6511,6 +6533,7 @@ components:
           type: object
           additionalProperties:
             type: string
+          default: { }
           description: Optional path prefix mappings from source to target
         deleteFromSource:
           type: boolean

--- a/web/src/components/torrents/TorrentContextMenu.tsx
+++ b/web/src/components/torrents/TorrentContextMenu.tsx
@@ -23,6 +23,7 @@ import { copyTextToClipboard } from "@/lib/utils"
 import type { Category, ExternalProgram, InstanceCapabilities, Torrent, TorrentFilters } from "@/types"
 import { useMutation, useQuery } from "@tanstack/react-query"
 import {
+  ArrowRightLeft,
   Blocks,
   CheckCircle,
   Copy,
@@ -44,6 +45,7 @@ import {
 } from "lucide-react"
 import { memo, useCallback, useMemo } from "react"
 import { toast } from "sonner"
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import { CategorySubmenu } from "./CategorySubmenu"
 import { QueueSubmenu } from "./QueueSubmenu"
 import { RenameSubmenu } from "./RenameSubmenu"
@@ -72,6 +74,9 @@ interface TorrentContextMenuProps {
   onPrepareRenameTorrent: (hashes: string[], torrents?: Torrent[]) => void
   onPrepareRenameFile: (hashes: string[], torrents?: Torrent[]) => void
   onPrepareRenameFolder: (hashes: string[], torrents?: Torrent[]) => void
+  onPrepareMoveToInstance?: (hashes: string[], torrents?: Torrent[]) => void
+  canMoveToInstance?: boolean
+  moveToInstanceDisabledReason?: string
   availableCategories?: Record<string, Category>
   onSetCategory?: (category: string, hashes: string[]) => void
   isPending?: boolean
@@ -106,6 +111,9 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
   onPrepareRenameTorrent,
   onPrepareRenameFile: _onPrepareRenameFile,
   onPrepareRenameFolder: _onPrepareRenameFolder,
+  onPrepareMoveToInstance,
+  canMoveToInstance = false,
+  moveToInstanceDisabledReason,
   onPrepareTmm,
   availableCategories = {},
   onSetCategory,
@@ -497,6 +505,29 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
             <Download className="mr-2 h-4 w-4" />
             {count > 1 ? `Export Torrents (${count})` : "Export Torrent"}
           </ContextMenuItem>
+        )}
+        {onPrepareMoveToInstance && (
+          <TooltipProvider delayDuration={300}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div>
+                  <ContextMenuItem
+                    onClick={() => canMoveToInstance && onPrepareMoveToInstance(hashes, torrents)}
+                    disabled={isPending || !canMoveToInstance}
+                    className={!canMoveToInstance ? "opacity-50" : ""}
+                  >
+                    <ArrowRightLeft className="mr-2 h-4 w-4" />
+                    Move to Instance {count > 1 ? `(${count})` : ""}
+                  </ContextMenuItem>
+                </div>
+              </TooltipTrigger>
+              {!canMoveToInstance && moveToInstanceDisabledReason && (
+                <TooltipContent side="left">
+                  <p>{moveToInstanceDisabledReason}</p>
+                </TooltipContent>
+              )}
+            </Tooltip>
+          </TooltipProvider>
         )}
         <ContextMenuSub>
           <ContextMenuSubTrigger>

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -269,6 +269,14 @@ export interface CategoryAction {
   condition?: RuleCondition
 }
 
+export interface MoveInstanceAction {
+  enabled: boolean
+  targetInstanceId: number
+  pathMappings?: Record<string, string>
+  deleteFromSource: boolean
+  condition?: RuleCondition
+}
+
 export interface ActionConditions {
   schemaVersion: string
   speedLimits?: SpeedLimitAction
@@ -277,6 +285,7 @@ export interface ActionConditions {
   delete?: DeleteAction
   tag?: TagAction
   category?: CategoryAction
+  moveInstance?: MoveInstanceAction
 }
 
 export type FreeSpaceSource =
@@ -1921,6 +1930,59 @@ export interface OrphanScanFile {
 
 export interface OrphanScanRunWithFiles extends OrphanScanRun {
   files: OrphanScanFile[]
+}
+
+// Transfer Types (for moving torrents between instances)
+export type TransferState =
+  | "pending"
+  | "preparing"
+  | "links_creating"
+  | "links_created"
+  | "adding_torrent"
+  | "torrent_added"
+  | "deleting_source"
+  | "completed"
+  | "failed"
+  | "rolled_back"
+  | "cancelled"
+
+export interface Transfer {
+  id: number
+  sourceInstanceId: number
+  targetInstanceId: number
+  torrentHash: string
+  torrentName: string
+  state: TransferState
+  sourceSavePath?: string
+  targetSavePath?: string
+  linkMode?: "hardlink" | "reflink" | "direct"
+  deleteFromSource: boolean
+  preserveCategory: boolean
+  preserveTags: boolean
+  targetCategory?: string
+  targetTags?: string[]
+  pathMappings?: Record<string, string>
+  filesTotal: number
+  filesLinked: number
+  error?: string
+  createdAt: string
+  updatedAt: string
+  completedAt?: string
+}
+
+export interface MovePayload {
+  targetInstanceId: number
+  pathMappings?: Record<string, string>
+  deleteFromSource?: boolean
+  preserveCategory?: boolean
+  preserveTags?: boolean
+}
+
+export interface TransferListOptions {
+  limit?: number
+  offset?: number
+  instanceId?: number
+  states?: TransferState[]
 }
 
 // Log Settings Types


### PR DESCRIPTION
## Summary
  - Adds functionality to move/migrate torrents between qBittorrent instances
  - Full backend transfer service with recovery handling
  - Frontend UI for initiating moves from context menu and management bar

  ## Changes
  ### Backend
  - New `transfer` service (`operations.go`, `worker.go`, `recovery.go`, `service.go`)
  - New transfer models and database migration
  - API handlers and OpenAPI spec for transfer endpoints

  ### Frontend
  - Move buttons in torrent context menu and management bar
  - New `TorrentDialogs.tsx` for move confirmation
  - Extended `useTorrentActions` hook with move functionality
  - API client methods for transfer operations

  ## Test plan
  - [ ] Move single torrent between two qBittorrent instances
  - [ ] Bulk move multiple torrents
  - [ ] Verify torrent data integrity after move
  - [ ] Test recovery if move fails mid-operation
  - [ ] Confirm UI updates correctly after move completes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transfer system: queue and process torrent moves between instances with background workers, progress, cancel/rollback, restart recovery, and optional source deletion
  * Move-to-instance UI & workflow: context menu, toolbar button, dialog, bulk-move flow and automation action with path-mapping and preserve options

* **Documentation**
  * API docs updated with Transfers and Move endpoints and new Transfer schemas

* **Enhancements**
  * Instance settings extended for reflink/hardlink fallback behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->