### PR TITLE
fix(orphanscan): ignore OS/NAS/k8s artifacts

### DIFF
--- a/documentation/docs/_partials/_orphan-scan-default-ignores.mdx
+++ b/documentation/docs/_partials/_orphan-scan-default-ignores.mdx
@@ -1,0 +1,39 @@
+import Details from "@theme/Details";
+
+<Details summary="Default ignores">
+Orphan Scan skips common OS/NAS metadata, recycle bin, snapshot, and Kubernetes volume-internal entries automatically (case-insensitive).
+
+**Ignored files (exact names)**
+- `.DS_Store`
+- `.directory`
+- `desktop.ini`
+- `Thumbs.db`
+
+**Ignored files (name prefixes)**
+- `.fuse*` (e.g. `.fuse_hidden*`)
+- `.nfs*`
+- `._*`
+- `.goutputstream-*`
+- `.#*`
+- `~$*`
+
+**Ignored directories (exact names)**
+- `.AppleDB`
+- `.AppleDouble`
+- `.TemporaryItems`
+- `.Trashes`
+- `.Recycle.Bin`
+- `.recycle`
+- `.snapshot`
+- `.snapshots`
+- `.zfs`
+- `@eaDir`
+- `$RECYCLE.BIN`
+- `#recycle`
+- `lost+found`
+- `System Volume Information`
+
+**Ignored directories (name prefixes)**
+- `.Trash-*`
+- `..*` (Kubernetes internals like `..data` and timestamp dirs)
+</Details>

--- a/documentation/docs/features/orphan-scan.md
+++ b/documentation/docs/features/orphan-scan.md
@@ -5,6 +5,7 @@ description: Find and remove files not associated with any torrent.
 ---
 
 import LocalFilesystemDocker from '@site/docs/_partials/_local-filesystem-docker.mdx';
+import OrphanScanDefaultIgnores from '@site/docs/_partials/_orphan-scan-default-ignores.mdx';
 
 # Orphan Scan
 
@@ -39,6 +40,8 @@ Directories are only scanned if at least one torrent points to them. If you dele
 | Max files per run | Limit results to prevent overwhelming large scans | 1,000 |
 | Auto-cleanup | Automatically delete orphans from scheduled scans | Disabled |
 | Auto-cleanup max files | Only auto-delete if orphan count is at or below this threshold | 100 |
+
+<OrphanScanDefaultIgnores />
 
 ## Workflow
 

--- a/internal/services/orphanscan/walker_test.go
+++ b/internal/services/orphanscan/walker_test.go
@@ -7,9 +7,12 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
+
+const orphanFileName = "orphan.txt"
 
 func TestWalkScanRoot_CollapsesDiscLayoutIntoSingleOrphanUnit(t *testing.T) {
 	t.Parallel()
@@ -213,6 +216,151 @@ func TestWalkScanRoot_DiscUnitFallsBackToMarkerDirWhenSiblingContentInUse(t *tes
 	}
 	if filepath.Clean(orphans[0].Path) != filepath.Clean(bdmvDir) {
 		t.Fatalf("expected orphan unit path %q, got %q", bdmvDir, orphans[0].Path)
+	}
+}
+
+func TestWalkScanRoot_IgnoresFuseHiddenFiles(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+
+	fuseHidden := filepath.Join(root, ".fuse_hidden0005c2cb00000025")
+	if err := os.WriteFile(fuseHidden, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	normal := filepath.Join(root, orphanFileName)
+	if err := os.WriteFile(normal, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	old := time.Now().Add(-2 * time.Hour)
+	_ = os.Chtimes(fuseHidden, old, old)
+	_ = os.Chtimes(normal, old, old)
+
+	tfm := NewTorrentFileMap()
+	orphans, truncated, err := walkScanRoot(context.Background(), root, tfm, nil, 0, 100)
+	if err != nil {
+		t.Fatalf("walkScanRoot: %v", err)
+	}
+	if truncated {
+		t.Fatalf("expected not truncated")
+	}
+
+	paths := make([]string, 0, len(orphans))
+	for _, o := range orphans {
+		paths = append(paths, filepath.Base(o.Path))
+	}
+	for _, p := range paths {
+		if strings.HasPrefix(p, ".fuse") {
+			t.Fatalf("expected .fuse* to be ignored, got orphan %q", p)
+		}
+	}
+	foundNormal := false
+	for _, p := range paths {
+		if p == orphanFileName {
+			foundNormal = true
+		}
+	}
+	if !foundNormal {
+		t.Fatalf("expected orphan.txt to be included, got %v", paths)
+	}
+}
+
+func writeOldFile(t *testing.T, path string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	old := time.Now().Add(-2 * time.Hour)
+	_ = os.Chtimes(path, old, old)
+}
+
+func orphanPaths(orphans []OrphanFile) []string {
+	paths := make([]string, 0, len(orphans))
+	for _, o := range orphans {
+		paths = append(paths, normalizePath(o.Path))
+	}
+	return paths
+}
+
+func TestWalkScanRoot_IgnoresTrashDirs(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+
+	inTrash := filepath.Join(root, ".Trash-1000", "trash.txt")
+	writeOldFile(t, inTrash)
+
+	normal := filepath.Join(root, orphanFileName)
+	writeOldFile(t, normal)
+
+	tfm := NewTorrentFileMap()
+	orphans, truncated, err := walkScanRoot(context.Background(), root, tfm, nil, 0, 100)
+	if err != nil {
+		t.Fatalf("walkScanRoot: %v", err)
+	}
+	if truncated {
+		t.Fatalf("expected not truncated")
+	}
+
+	paths := orphanPaths(orphans)
+	for _, p := range paths {
+		if strings.Contains(p, normalizePath(filepath.Join(root, ".Trash-1000"))) {
+			t.Fatalf("expected .Trash-* to be ignored, got orphan %q", p)
+		}
+	}
+
+	foundNormal := false
+	for _, p := range paths {
+		if filepath.Base(p) == orphanFileName {
+			foundNormal = true
+		}
+	}
+	if !foundNormal {
+		t.Fatalf("expected orphan.txt to be included, got %v", paths)
+	}
+}
+
+func TestWalkScanRoot_IgnoresKubernetesInternalDirs(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+
+	inKube := filepath.Join(root, "..data", "kube.txt")
+	writeOldFile(t, inKube)
+
+	normal := filepath.Join(root, orphanFileName)
+	writeOldFile(t, normal)
+
+	tfm := NewTorrentFileMap()
+	orphans, truncated, err := walkScanRoot(context.Background(), root, tfm, nil, 0, 100)
+	if err != nil {
+		t.Fatalf("walkScanRoot: %v", err)
+	}
+	if truncated {
+		t.Fatalf("expected not truncated")
+	}
+
+	paths := orphanPaths(orphans)
+	for _, p := range paths {
+		if strings.Contains(p, normalizePath(filepath.Join(root, "..data"))) {
+			t.Fatalf("expected k8s internal dirs to be ignored, got orphan %q", p)
+		}
+	}
+
+	foundNormal := false
+	for _, p := range paths {
+		if filepath.Base(p) == orphanFileName {
+			foundNormal = true
+		}
+	}
+	if !foundNormal {
+		t.Fatalf("expected orphan.txt to be included, got %v", paths)
 	}
 }
 


### PR DESCRIPTION
Orphan Scan no longer flags common filesystem artifacts as orphans (e.g. Unraid .fuse_hidden*, NFS .nfs*, macOS/Windows metadata, recycle bins, snapshot dirs, and Kubernetes volume internals like ..data).

This reduces false positives on Unraid/Proxmox/NAS hosts while keeping real orphan content visible. Documentation now lists the default ignored entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Orphan Scan now skips predefined files and directories by default, including hidden files, trash directories, and Kubernetes internal directories.

* **Documentation**
  * Added collapsible reference section documenting all default ignored files and directories in the Orphan Scan feature documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->