### PR TITLE
fix(orphanscan): ignore .parts files from qBittorrent partial downloads

### DIFF
--- a/documentation/docs/_partials/_orphan-scan-default-ignores.mdx
+++ b/documentation/docs/_partials/_orphan-scan-default-ignores.mdx
@@ -17,6 +17,9 @@ Orphan Scan skips common OS/NAS metadata, recycle bin, snapshot, and Kubernetes 
 - `.#*`
 - `~$*`
 
+**Ignored files (name suffixes)**
+- `*.parts` (qBittorrent partial download files)
+
 **Ignored directories (exact names)**
 - `.AppleDB`
 - `.AppleDouble`

--- a/internal/services/orphanscan/walker.go
+++ b/internal/services/orphanscan/walker.go
@@ -34,6 +34,12 @@ var ignoredOrphanFileNamePrefixes = []string{
 	"~$",
 }
 
+// ignoredOrphanFileNameSuffixes are filename (not path) suffixes that are commonly created by
+// torrent clients and should not be treated as orphan content (e.g. "*.parts" from qBittorrent).
+var ignoredOrphanFileNameSuffixes = []string{
+	".parts",
+}
+
 // ignoredOrphanDirNames are directory names that should be skipped entirely during scanning.
 // These are typically system metadata/recycle bins/snapshot internals, not real content.
 var ignoredOrphanDirNames = []string{
@@ -595,6 +601,11 @@ func isIgnoredOrphanFileName(name string) bool {
 			return true
 		}
 	}
+	for _, suffix := range ignoredOrphanFileNameSuffixes {
+		if hasSuffixFold(name, suffix) {
+			return true
+		}
+	}
 	return false
 }
 
@@ -617,6 +628,13 @@ func hasPrefixFold(s, prefix string) bool {
 		return false
 	}
 	return strings.EqualFold(s[:len(prefix)], prefix)
+}
+
+func hasSuffixFold(s, suffix string) bool {
+	if len(s) < len(suffix) {
+		return false
+	}
+	return strings.EqualFold(s[len(s)-len(suffix):], suffix)
 }
 
 // isPathProtectedByIgnorePaths checks if a path should not be deleted because:


### PR DESCRIPTION
qBittorrent leaves .parts files when downloading partial torrents. These
should not be treated as orphans.

Adds a new suffix ignore pattern for *.parts files to the default ignore
list, alongside the existing prefix patterns for FUSE/NFS hidden files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Orphan scan now ignores qBittorrent partial download files (*.parts)

## Documentation
* Added documentation for ignored file patterns

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->