### PR TITLE
fix(torznab): respect per-indexer caps limits

### DIFF
--- a/internal/database/migrations/052_add_indexer_limits.sql
+++ b/internal/database/migrations/052_add_indexer_limits.sql
@@ -1,0 +1,34 @@
+-- Copyright (c) 2025, s0up and the autobrr contributors.
+-- SPDX-License-Identifier: GPL-2.0-or-later
+
+-- Add limit columns to torznab_indexers (sensible default is 100)
+ALTER TABLE torznab_indexers ADD COLUMN limit_default INTEGER NOT NULL DEFAULT 100;
+ALTER TABLE torznab_indexers ADD COLUMN limit_max INTEGER NOT NULL DEFAULT 100;
+
+UPDATE torznab_indexers SET limit_default = 100 WHERE limit_default <= 0;
+UPDATE torznab_indexers SET limit_max = 100 WHERE limit_max <= 0;
+
+-- Recreate the view to expose new columns
+DROP VIEW IF EXISTS torznab_indexers_view;
+CREATE VIEW torznab_indexers_view AS
+SELECT
+    ti.id,
+    sp_name.value AS name,
+    sp_base_url.value AS base_url,
+    sp_indexer_id.value AS indexer_id,
+    ti.backend,
+    ti.api_key_encrypted,
+    ti.enabled,
+    ti.priority,
+    ti.timeout_seconds,
+    ti.limit_default,
+    ti.limit_max,
+    ti.last_test_at,
+    ti.last_test_status,
+    ti.last_test_error,
+    ti.created_at,
+    ti.updated_at
+FROM torznab_indexers ti
+INNER JOIN string_pool sp_name ON ti.name_id = sp_name.id
+INNER JOIN string_pool sp_base_url ON ti.base_url_id = sp_base_url.id
+LEFT JOIN string_pool sp_indexer_id ON ti.indexer_id_string_id = sp_indexer_id.id;

--- a/internal/models/torznab_indexer.go
+++ b/internal/models/torznab_indexer.go
@@ -71,6 +71,8 @@ type TorznabIndexer struct {
 	Enabled         bool                     `json:"enabled"`
 	Priority        int                      `json:"priority"`
 	TimeoutSeconds  int                      `json:"timeout_seconds"`
+	LimitDefault    int                      `json:"limit_default"`
+	LimitMax        int                      `json:"limit_max"`
 	Capabilities    []string                 `json:"capabilities"`
 	Categories      []TorznabIndexerCategory `json:"categories"`
 	LastTestAt      *time.Time               `json:"last_test_at,omitempty"`
@@ -267,6 +269,8 @@ func (s *TorznabIndexerStore) CreateWithIndexerID(ctx context.Context, name, bas
 	if timeoutSeconds <= 0 {
 		timeoutSeconds = 30
 	}
+	limitDefault := 100
+	limitMax := 100
 
 	// Begin transaction for string interning and insert
 	tx, err := s.db.BeginTx(ctx, nil)
@@ -293,11 +297,11 @@ func (s *TorznabIndexerStore) CreateWithIndexerID(ctx context.Context, name, bas
 	}
 
 	query := `
-		INSERT INTO torznab_indexers (name_id, base_url_id, indexer_id_string_id, backend, api_key_encrypted, enabled, priority, timeout_seconds)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO torznab_indexers (name_id, base_url_id, indexer_id_string_id, backend, api_key_encrypted, enabled, priority, timeout_seconds, limit_default, limit_max)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
 
-	result, err := tx.ExecContext(ctx, query, nameID, baseURLID, indexerIDStringID, backend, encryptedAPIKey, enabled, priority, timeoutSeconds)
+	result, err := tx.ExecContext(ctx, query, nameID, baseURLID, indexerIDStringID, backend, encryptedAPIKey, enabled, priority, timeoutSeconds, limitDefault, limitMax)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create torznab indexer: %w", err)
 	}
@@ -317,7 +321,7 @@ func (s *TorznabIndexerStore) CreateWithIndexerID(ctx context.Context, name, bas
 // Get retrieves a Torznab indexer by ID using the view
 func (s *TorznabIndexerStore) Get(ctx context.Context, id int) (*TorznabIndexer, error) {
 	query := `
-		SELECT id, name, base_url, indexer_id, backend, api_key_encrypted, enabled, priority, timeout_seconds, last_test_at, last_test_status, last_test_error, created_at, updated_at
+		SELECT id, name, base_url, indexer_id, backend, api_key_encrypted, enabled, priority, timeout_seconds, limit_default, limit_max, last_test_at, last_test_status, last_test_error, created_at, updated_at
 		FROM torznab_indexers_view
 		WHERE id = ?
 	`
@@ -335,6 +339,8 @@ func (s *TorznabIndexerStore) Get(ctx context.Context, id int) (*TorznabIndexer,
 		&indexer.Enabled,
 		&indexer.Priority,
 		&indexer.TimeoutSeconds,
+		&indexer.LimitDefault,
+		&indexer.LimitMax,
 		&indexer.LastTestAt,
 		&indexer.LastTestStatus,
 		&indexer.LastTestError,
@@ -381,7 +387,7 @@ func (s *TorznabIndexerStore) Get(ctx context.Context, id int) (*TorznabIndexer,
 // List retrieves all Torznab indexers using the view, ordered by priority (descending) and name
 func (s *TorznabIndexerStore) List(ctx context.Context) ([]*TorznabIndexer, error) {
 	query := `
-		SELECT id, name, base_url, indexer_id, backend, api_key_encrypted, enabled, priority, timeout_seconds, last_test_at, last_test_status, last_test_error, created_at, updated_at
+		SELECT id, name, base_url, indexer_id, backend, api_key_encrypted, enabled, priority, timeout_seconds, limit_default, limit_max, last_test_at, last_test_status, last_test_error, created_at, updated_at
 		FROM torznab_indexers_view
 		ORDER BY priority DESC, name ASC
 	`
@@ -407,6 +413,8 @@ func (s *TorznabIndexerStore) List(ctx context.Context) ([]*TorznabIndexer, erro
 			&indexer.Enabled,
 			&indexer.Priority,
 			&indexer.TimeoutSeconds,
+			&indexer.LimitDefault,
+			&indexer.LimitMax,
 			&indexer.LastTestAt,
 			&indexer.LastTestStatus,
 			&indexer.LastTestError,
@@ -456,7 +464,7 @@ func (s *TorznabIndexerStore) List(ctx context.Context) ([]*TorznabIndexer, erro
 // ListEnabled retrieves all enabled Torznab indexers using the view, ordered by priority
 func (s *TorznabIndexerStore) ListEnabled(ctx context.Context) ([]*TorznabIndexer, error) {
 	query := `
-		SELECT id, name, base_url, indexer_id, backend, api_key_encrypted, enabled, priority, timeout_seconds, last_test_at, last_test_status, last_test_error, created_at, updated_at
+		SELECT id, name, base_url, indexer_id, backend, api_key_encrypted, enabled, priority, timeout_seconds, limit_default, limit_max, last_test_at, last_test_status, last_test_error, created_at, updated_at
 		FROM torznab_indexers_view
 		WHERE enabled = 1
 		ORDER BY priority DESC, name ASC
@@ -483,6 +491,8 @@ func (s *TorznabIndexerStore) ListEnabled(ctx context.Context) ([]*TorznabIndexe
 			&indexer.Enabled,
 			&indexer.Priority,
 			&indexer.TimeoutSeconds,
+			&indexer.LimitDefault,
+			&indexer.LimitMax,
 			&indexer.LastTestAt,
 			&indexer.LastTestStatus,
 			&indexer.LastTestError,
@@ -899,6 +909,31 @@ func (s *TorznabIndexerStore) SetCategories(ctx context.Context, indexerID int, 
 
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return nil
+}
+
+// SetLimits updates the limit_default and limit_max values for an indexer
+func (s *TorznabIndexerStore) SetLimits(ctx context.Context, indexerID, limitDefault, limitMax int) error {
+	query := `
+		UPDATE torznab_indexers
+		SET limit_default = ?, limit_max = ?
+		WHERE id = ?
+	`
+
+	result, err := s.db.ExecContext(ctx, query, limitDefault, limitMax, indexerID)
+	if err != nil {
+		return fmt.Errorf("failed to update indexer limits: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return ErrTorznabIndexerNotFound
 	}
 
 	return nil

--- a/internal/services/jackett/caps_test.go
+++ b/internal/services/jackett/caps_test.go
@@ -1,0 +1,218 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package jackett
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseTorznabCaps_Limits(t *testing.T) {
+	tests := []struct {
+		name        string
+		xml         string
+		wantDefault int
+		wantMax     int
+	}{
+		{
+			name: "limits present with both values",
+			xml: `<?xml version="1.0" encoding="UTF-8"?>
+<caps>
+	<limits default="50" max="100"/>
+	<searching>
+		<search available="yes" supportedParams="q"/>
+	</searching>
+	<categories></categories>
+</caps>`,
+			wantDefault: 50,
+			wantMax:     100,
+		},
+		{
+			name: "limits missing",
+			xml: `<?xml version="1.0" encoding="UTF-8"?>
+<caps>
+	<searching>
+		<search available="yes" supportedParams="q"/>
+	</searching>
+	<categories></categories>
+</caps>`,
+			wantDefault: 100,
+			wantMax:     100,
+		},
+		{
+			name: "limits with invalid values",
+			xml: `<?xml version="1.0" encoding="UTF-8"?>
+<caps>
+	<limits default="abc" max="xyz"/>
+	<searching>
+		<search available="yes" supportedParams="q"/>
+	</searching>
+	<categories></categories>
+</caps>`,
+			wantDefault: 100,
+			wantMax:     100,
+		},
+		{
+			name: "only max present",
+			xml: `<?xml version="1.0" encoding="UTF-8"?>
+<caps>
+	<limits max="100"/>
+	<searching>
+		<search available="yes" supportedParams="q"/>
+	</searching>
+	<categories></categories>
+</caps>`,
+			wantDefault: 100,
+			wantMax:     100,
+		},
+		{
+			name: "only default present",
+			xml: `<?xml version="1.0" encoding="UTF-8"?>
+<caps>
+	<limits default="50"/>
+	<searching>
+		<search available="yes" supportedParams="q"/>
+	</searching>
+	<categories></categories>
+</caps>`,
+			wantDefault: 50,
+			wantMax:     100,
+		},
+		{
+			name: "limits with zero values",
+			xml: `<?xml version="1.0" encoding="UTF-8"?>
+<caps>
+	<limits default="0" max="0"/>
+	<searching>
+		<search available="yes" supportedParams="q"/>
+	</searching>
+	<categories></categories>
+</caps>`,
+			wantDefault: 100,
+			wantMax:     100,
+		},
+		{
+			name: "limits with negative values",
+			xml: `<?xml version="1.0" encoding="UTF-8"?>
+<caps>
+	<limits default="-10" max="-5"/>
+	<searching>
+		<search available="yes" supportedParams="q"/>
+	</searching>
+	<categories></categories>
+</caps>`,
+			wantDefault: 100,
+			wantMax:     100,
+		},
+		{
+			name: "real-world MTV example",
+			xml: `<?xml version="1.0" encoding="UTF-8"?>
+<caps>
+	<limits default="50" max="100"/>
+	<searching>
+		<search available="yes" supportedParams="q,imdbid"/>
+		<tv-search available="yes" supportedParams="q,tvdbid,imdbid,season,ep"/>
+		<movie-search available="yes" supportedParams="q,imdbid"/>
+	</searching>
+	<categories>
+		<category id="2000" name="Movies">
+			<subcat id="2010" name="Foreign"/>
+			<subcat id="2020" name="Other"/>
+		</category>
+	</categories>
+</caps>`,
+			wantDefault: 50,
+			wantMax:     100,
+		},
+		{
+			name: "limits with large values",
+			xml: `<?xml version="1.0" encoding="UTF-8"?>
+<caps>
+	<limits default="500" max="1000"/>
+	<searching>
+		<search available="yes" supportedParams="q"/>
+	</searching>
+	<categories></categories>
+</caps>`,
+			wantDefault: 500,
+			wantMax:     1000,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			caps, err := parseTorznabCaps(strings.NewReader(tt.xml))
+			if err != nil {
+				t.Fatalf("parseTorznabCaps() error = %v", err)
+			}
+
+			if caps.LimitDefault != tt.wantDefault {
+				t.Errorf("LimitDefault = %d, want %d", caps.LimitDefault, tt.wantDefault)
+			}
+			if caps.LimitMax != tt.wantMax {
+				t.Errorf("LimitMax = %d, want %d", caps.LimitMax, tt.wantMax)
+			}
+		})
+	}
+}
+
+func TestParseTorznabCaps_FullParsing(t *testing.T) {
+	// Test that limits parsing doesn't interfere with other cap parsing
+	xml := `<?xml version="1.0" encoding="UTF-8"?>
+<caps>
+	<limits default="50" max="100"/>
+	<searching>
+		<search available="yes" supportedParams="q,imdbid"/>
+		<tv-search available="yes" supportedParams="q,tvdbid,season,ep"/>
+		<movie-search available="no"/>
+	</searching>
+	<categories>
+		<category id="2000" name="Movies">
+			<subcat id="2010" name="Foreign"/>
+		</category>
+		<category id="5000" name="TV"/>
+	</categories>
+</caps>`
+
+	caps, err := parseTorznabCaps(strings.NewReader(xml))
+	if err != nil {
+		t.Fatalf("parseTorznabCaps() error = %v", err)
+	}
+
+	// Check limits
+	if caps.LimitDefault != 50 {
+		t.Errorf("LimitDefault = %d, want 50", caps.LimitDefault)
+	}
+	if caps.LimitMax != 100 {
+		t.Errorf("LimitMax = %d, want 100", caps.LimitMax)
+	}
+
+	// Check capabilities are still parsed correctly
+	expectedCaps := map[string]bool{
+		"search":           true,
+		"search-q":         true,
+		"search-imdbid":    true,
+		"tv-search":        true,
+		"tv-search-q":      true,
+		"tv-search-tvdbid": true,
+		"tv-search-season": true,
+		"tv-search-ep":     true,
+	}
+
+	for _, cap := range caps.Capabilities {
+		if !expectedCaps[cap] {
+			t.Errorf("unexpected capability: %s", cap)
+		}
+		delete(expectedCaps, cap)
+	}
+
+	for cap := range expectedCaps {
+		t.Errorf("missing expected capability: %s", cap)
+	}
+
+	// Check categories are still parsed correctly
+	if len(caps.Categories) != 3 { // 2 parents + 1 subcat
+		t.Errorf("expected 3 categories, got %d", len(caps.Categories))
+	}
+}

--- a/internal/services/jackett/service_test.go
+++ b/internal/services/jackett/service_test.go
@@ -1471,6 +1471,10 @@ func (m *mockTorznabIndexerStore) SetCategories(ctx context.Context, indexerID i
 	return nil
 }
 
+func (m *mockTorznabIndexerStore) SetLimits(ctx context.Context, indexerID, limitDefault, limitMax int) error {
+	return nil
+}
+
 func (m *mockTorznabIndexerStore) RecordLatency(ctx context.Context, indexerID int, operationType string, latencyMs int, success bool) error {
 	return nil
 }
@@ -1612,6 +1616,21 @@ func TestProwlarrYearParameterWorkaround(t *testing.T) {
 				// year parameter should be removed
 			},
 			description: "Prowlarr indexer should use year as query when original query is empty",
+		},
+		{
+			name:    "prowlarr with year parameter and ids present",
+			backend: models.TorznabBackendProwlarr,
+			inputParams: map[string]string{
+				"t":      "movie",
+				"year":   "1999",
+				"imdbid": "0133093",
+			},
+			expected: map[string]string{
+				"t":      "movie",
+				"imdbid": "0133093",
+				// year parameter should be removed
+			},
+			description: "Prowlarr indexer should drop year when doing ID-driven search",
 		},
 		{
 			name:    "jackett with year parameter",
@@ -2302,6 +2321,26 @@ func TestApplyCapabilitySpecificParams(t *testing.T) {
 			},
 			wantParams:  map[string]string{},
 			description: "No query restored when original query is empty",
+		},
+		{
+			name: "all IDs pruned - restores release name when original query empty",
+			indexer: &models.TorznabIndexer{
+				ID:           12,
+				Name:         "NoIDsIndexer",
+				Capabilities: []string{"movie-search"},
+			},
+			meta: &searchContext{
+				searchMode:    "movie",
+				originalQuery: "",
+				releaseName:   "The Matrix (1999)",
+			},
+			inputParams: map[string]string{
+				"imdbid": "tt0133093",
+			},
+			wantParams: map[string]string{
+				"q": "The Matrix (1999)",
+			},
+			description: "Release name restored when all IDs are pruned and original query is empty",
 		},
 		{
 			name: "case-insensitive capability matching",


### PR DESCRIPTION
qui previously sent a hard-coded limit (e.g. 120) to every Torznab indexer. Some indexers (e.g. MTV) cap limit at 100 via their caps endpoint, causing 429s and indexers getting disabled in qui/Prowlarr.

Changes:
- Parse <limits default/max> from caps with sane fallback (100)
- Persist limit_default/limit_max on caps sync and on indexer creation
- Add DB migration to store limits and expose them via torznab_indexers_view
- Clamp outgoing search limit per indexer to its caps max
- When ID params are pruned per-indexer, restore a usable text query (original query or release name) and avoid year-only searches
- Apply the Prowlarr year workaround after pruning/restoring, and drop year for ID-driven searches

This prevents over-limit requests and improves fallback behavior for indexers without IMDb/TMDb support.

Closes #1263

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-indexer result limit configuration with configurable default and maximum thresholds
  * Limit settings are automatically synchronized from indexer capabilities
  * Search requests now respect indexer-specified limits to optimize result retrieval

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->