### PR TITLE
fix(web): toast message when searching then adding cross-seeds

### DIFF
--- a/web/src/components/torrents/CrossSeedDialog.tsx
+++ b/web/src/components/torrents/CrossSeedDialog.tsx
@@ -545,6 +545,10 @@ function getInstanceStatusDisplay(status: string, success: boolean): { text: str
   switch (status) {
     case "added":
       return { text: "Added", variant: "success" }
+    case "added_hardlink":
+      return { text: "Added (hardlink)", variant: "success" }
+    case "added_reflink":
+      return { text: "Added (reflink)", variant: "success" }
     case "exists":
       return { text: "Already exists", variant: "warning" }
     case "no_match":

--- a/web/src/hooks/useCrossSeedSearch.tsx
+++ b/web/src/hooks/useCrossSeedSearch.tsx
@@ -411,7 +411,7 @@ export function useCrossSeedSearch(instanceId: number) {
         const instanceResults = result.instanceResults ?? []
         if (instanceResults.length > 0) {
           for (const ir of instanceResults) {
-            if (ir.status === "added") {
+            if (ir.status === "added" || ir.status === "added_hardlink" || ir.status === "added_reflink") {
               addedCount++
             } else if (!ir.success) {
               failedCount++


### PR DESCRIPTION
Currently the frontend ignores `added_hardlink` and `added_reflink`, which makes it show an error message when it succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed cross-seed operations to properly recognize hardlink and reflink file additions as successful, ensuring accurate result reporting and feedback in the UI.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->