### PR TITLE
fix(proxy): inject base tag in client proxy resource links

### DIFF
--- a/documentation/docs/features/reverse-proxy.md
+++ b/documentation/docs/features/reverse-proxy.md
@@ -121,3 +121,14 @@ These endpoints proxy to qBittorrent and update qui's local state:
 | `/api/v2/torrents/delete` | Forwards to qBittorrent, invalidates file cache |
 
 All other endpoints are forwarded transparently to qBittorrent.
+
+## HTML Resources and Base URL Injection
+
+When accessing the qBittorrent web UI through the client proxy (e.g., opening the proxy URL in a browser), qui automatically injects a `<base>` tag into HTML responses. This ensures that relative resource URLs (like images, scripts, and stylesheets) resolve correctly under the proxy path.
+
+**Example:**
+- Proxy URL: `http://localhost:7476/proxy/abc123/`
+- qui injects: `<base href="/proxy/abc123/">`
+- Relative URLs like `images/qbittorrent32.png` correctly resolve to `/proxy/abc123/images/qbittorrent32.png`
+
+This feature is automatic and requires no configuration. Non-HTML content (JSON API responses, images, scripts, etc.) is proxied without modification.

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,6 @@ github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUS
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/autobrr/autobrr v1.71.0 h1:5QZU/i/lsS9qraoWtlW3kMXL0shy+jWhXp3vQX/QiGo=
 github.com/autobrr/autobrr v1.71.0/go.mod h1:N0+9Y2cJaOHq/MtyRbeWZQHyDnHypTCaajGheRl7Cs0=
-github.com/autobrr/go-qbittorrent v1.15.0-rc1.0.20251209201933-62cc902b8602 h1:RyJtQJGklw0kJ3Ec5kHakQArHXuXb7EodudkUVGwsDk=
-github.com/autobrr/go-qbittorrent v1.15.0-rc1.0.20251209201933-62cc902b8602/go.mod h1:mGH+UlSzkZOpTx9hezpL9dnKakskLzOsNfngl2E1ZE0=
 github.com/autobrr/go-qbittorrent v1.15.0-rc1.0.20260121130753-8741290569bc h1:iSDMPD1K6H71WSCR6iv6HY+01uBKEeHXEF2MAvP/S/A=
 github.com/autobrr/go-qbittorrent v1.15.0-rc1.0.20260121130753-8741290569bc/go.mod h1:16BG5dqbTh9kaV6bZru4AeW2/o80TDwGBMDyj5Kj3zI=
 github.com/autobrr/rls v0.7.1-0.20260101090144-934fa1613435 h1:8b1Ht/OBqgtO2IjqkxOj+uz2an0aARa06m4uKwVFfEE=

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -92,10 +92,11 @@ func NewHandler(clientPool *qbittorrent.ClientPool, clientAPIKeyStore *models.Cl
 		return proxyCtx.httpClient.Transport
 	})
 	h.proxy = &httputil.ReverseProxy{
-		Rewrite:      h.rewriteRequest,
-		BufferPool:   bufferPool,
-		ErrorHandler: h.errorHandler,
-		Transport:    retryTransport,
+		Rewrite:        h.rewriteRequest,
+		ModifyResponse: h.modifyResponse,
+		BufferPool:     bufferPool,
+		ErrorHandler:   h.errorHandler,
+		Transport:      retryTransport,
 	}
 
 	return h
@@ -200,6 +201,98 @@ func (h *Handler) stripProxyPrefix(path, apiKey string) string {
 		return after
 	}
 	return path
+}
+
+// modifyResponse injects a <base> tag into HTML responses to fix relative resource URLs
+func (h *Handler) modifyResponse(resp *http.Response) error {
+	// Only process HTML responses
+	contentType := resp.Header.Get("Content-Type")
+	if !strings.Contains(strings.ToLower(contentType), "text/html") {
+		return nil
+	}
+
+	// Get the original request from the response
+	req := resp.Request
+	if req == nil {
+		return nil
+	}
+
+	// Extract the API key from the original request to construct the base URL
+	apiKey := chi.URLParam(req, "api-key")
+	if apiKey == "" {
+		// Try to extract from URL path as fallback
+		pathParts := strings.Split(strings.TrimPrefix(req.URL.Path, h.basePath), "/")
+		if len(pathParts) >= 2 && pathParts[0] == "proxy" {
+			apiKey = pathParts[1]
+		}
+	}
+
+	if apiKey == "" {
+		log.Debug().Msg("Cannot inject base tag: API key not found in request")
+		return nil
+	}
+
+	// Construct the base URL (the proxy path with trailing slash)
+	// This should be the URL path that the client used to access the proxy
+	baseURL := httphelpers.JoinBasePath(h.basePath, "/proxy/"+apiKey+"/")
+
+	// Read the response body
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+	resp.Body.Close()
+
+	// Inject the base tag into the HTML
+	modifiedBody := injectBaseTag(bodyBytes, baseURL)
+
+	// Update the response body and content length
+	resp.Body = io.NopCloser(bytes.NewReader(modifiedBody))
+	resp.ContentLength = int64(len(modifiedBody))
+	resp.Header.Set("Content-Length", strconv.FormatInt(int64(len(modifiedBody)), 10))
+
+	log.Debug().
+		Str("baseURL", baseURL).
+		Int("originalSize", len(bodyBytes)).
+		Int("modifiedSize", len(modifiedBody)).
+		Msg("Injected base tag into HTML response")
+
+	return nil
+}
+
+// injectBaseTag inserts a <base href="..."> tag into the HTML <head> section
+func injectBaseTag(html []byte, baseURL string) []byte {
+	htmlStr := string(html)
+	htmlLower := strings.ToLower(htmlStr)
+
+	// Check if a base tag already exists
+	if strings.Contains(htmlLower, "<base") {
+		log.Debug().Msg("Base tag already exists, skipping injection")
+		return html
+	}
+
+	// Find the <head> tag (case-insensitive)
+	headStart := strings.Index(htmlLower, "<head")
+	if headStart == -1 {
+		log.Debug().Msg("No <head> tag found, skipping base tag injection")
+		return html
+	}
+
+	// Find the end of the <head> opening tag
+	headEnd := strings.Index(htmlStr[headStart:], ">")
+	if headEnd == -1 {
+		log.Debug().Msg("Malformed <head> tag, skipping base tag injection")
+		return html
+	}
+	insertPos := headStart + headEnd + 1
+
+	// Construct the base tag
+	baseTag := fmt.Sprintf("<base href=\"%s\">", baseURL)
+
+	// Insert the base tag right after the <head> opening tag
+	result := htmlStr[:insertPos] + baseTag + htmlStr[insertPos:]
+
+	return []byte(result)
 }
 
 func combineInstanceAndRequestPath(instanceBasePath, strippedPath string) string {

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -268,6 +268,18 @@ func TestInjectBaseTag(t *testing.T) {
 			baseURL:  "/qui/proxy/test123/",
 			expected: "<html><Head><base href=\"/qui/proxy/test123/\"><title>Test</title></Head><body></body></html>",
 		},
+		{
+			name:     "HTML with self-closing head tag",
+			html:     "<html><head/><body></body></html>",
+			baseURL:  "/proxy/abc123/",
+			expected: "<html><head/><body></body></html>", // Should not inject
+		},
+		{
+			name:     "HTML with word containing 'base' should not be detected",
+			html:     "<html><head><title>Database Test</title></head><body></body></html>",
+			baseURL:  "/proxy/abc123/",
+			expected: "<html><head><base href=\"/proxy/abc123/\"><title>Database Test</title></head><body></body></html>",
+		},
 	}
 
 	for _, tt := range tests {
@@ -406,4 +418,3 @@ func TestModifyResponse_WithCustomBasePath(t *testing.T) {
 	// Should contain the base tag with the custom base path
 	require.Contains(t, string(bodyBytes), "<base href=\"/qui/proxy/test123/\">")
 }
-


### PR DESCRIPTION
In Client Proxy entries, we add an HTML `<base href>` tag, that will have the path of the proxy URL.

This fixes qBittorrent relative links to be processed from the proxy auth URL `/proxy/token-string/`, rather than from `/proxy`, and makes the qBittorrent UI elements usable (if for some reason you use the proxy link with your web-browser).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reverse proxy now automatically injects a base URL tag into HTML responses, ensuring correct resolution of relative URLs when accessing the web UI through the proxy path.

* **Documentation**
  * Added documentation section explaining automatic base URL injection for HTML resources in reverse proxy configuration.

* **Tests**
  * Added comprehensive test coverage for base tag injection and HTML response modification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->