### PR TITLE
fix(web): hide redundant actions dropdown

### DIFF
--- a/web/src/components/instances/preferences/WorkflowDialog.tsx
+++ b/web/src/components/instances/preferences/WorkflowDialog.tsx
@@ -1227,8 +1227,8 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
                 <div className="space-y-3">
                   <div className="flex items-center justify-between">
                     <Label>Action</Label>
-                    {/* Add action dropdown - only show if Delete is not enabled and there are available actions */}
-                    {!formState.deleteEnabled && (() => {
+                    {/* Add action dropdown - only show if Delete is not enabled, at least one action exists, and there are available actions to add */}
+                    {!formState.deleteEnabled && enabledActionsCount > 0 && (() => {
                       const enabledActions = getEnabledActions(formState)
                       const availableActions = COMBINABLE_ACTIONS.filter(a => !enabledActions.includes(a))
                       if (availableActions.length === 0) return null


### PR DESCRIPTION
# Before
<img width="805" height="318" alt="image" src="https://github.com/user-attachments/assets/bbcef49a-7fea-427d-8232-eb7d04aef9a4" />

# After
<img width="807" height="303" alt="image" src="https://github.com/user-attachments/assets/9a8f1190-f1d1-4e4c-aaa2-dc6972bd854c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved "Add action" dropdown behavior in workflow preferences—now displays only when at least one action is already enabled and Delete is not enabled, preventing unnecessary interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->