### PR TITLE
fix(tracker-icons): improve fetch reliability and icon resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ backups/*
 .golangci-cache/*
 torrentfiles/*
 analyses/*
+.envrc

--- a/internal/api/handlers/tracker_icons.go
+++ b/internal/api/handlers/tracker_icons.go
@@ -38,7 +38,9 @@ func (h *TrackerIconHandler) GetTrackerIcons(w http.ResponseWriter, r *http.Requ
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Cache-Control", "public, max-age=3600")
+	// The icon map is dynamic (files can be added/updated at runtime), so avoid
+	// browser/proxy caching that can cause stale/missing icons in the UI.
+	w.Header().Set("Cache-Control", "no-store")
 
 	if err := json.NewEncoder(w).Encode(icons); err != nil {
 		http.Error(w, "failed to encode response", http.StatusInternalServerError)

--- a/internal/api/handlers/tracker_icons_test.go
+++ b/internal/api/handlers/tracker_icons_test.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type fakeTrackerIconProvider struct {
+	icons map[string]string
+}
+
+func (f fakeTrackerIconProvider) GetIcon(_ context.Context, _, _ string) (string, error) {
+	return "", nil
+}
+
+func (f fakeTrackerIconProvider) ListIcons(_ context.Context) (map[string]string, error) {
+	return f.icons, nil
+}
+
+func TestTrackerIconHandler_GetTrackerIcons_NoStoreCaching(t *testing.T) {
+	t.Parallel()
+
+	h := NewTrackerIconHandler(fakeTrackerIconProvider{
+		icons: map[string]string{"example.org": "data:image/png;base64,AAA"},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/tracker-icons", nil)
+	rr := httptest.NewRecorder()
+	h.GetTrackerIcons(rr, req)
+
+	res := rr.Result()
+	defer res.Body.Close()
+
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Equal(t, "application/json", res.Header.Get("Content-Type"))
+	require.Equal(t, "no-store", res.Header.Get("Cache-Control"))
+}

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -456,6 +456,13 @@ func (sm *SyncManager) refreshTrackerHealthCounts(ctx context.Context, instanceI
 
 	sm.setValidatedTrackerMapping(instanceID, mapping)
 
+	// Queue icon fetches for discovered tracker domains. We do this here (in the
+	// background refresh) so icons get fetched even when API requests use the
+	// validated mapping path (which doesn't walk MainData.Trackers).
+	for domain := range mapping.DomainToHashes {
+		trackericons.QueueFetch(domain, "")
+	}
+
 	log.Debug().
 		Int("instanceID", instanceID).
 		Int("unregistered", counts.Unregistered).

--- a/internal/services/trackericons/service.go
+++ b/internal/services/trackericons/service.go
@@ -40,6 +40,7 @@ const (
 	maxIconBytes int64 = 1 << 20 // 1 MiB
 
 	fetchTimeout    = 15 * time.Second
+	requestTimeout  = 5 * time.Second
 	failureCooldown = 30 * time.Minute
 )
 
@@ -170,6 +171,10 @@ func QueueFetch(host, trackerURL string) {
 
 // ListIcons returns all cached tracker icons as base64-encoded data URLs.
 func (s *Service) ListIcons(ctx context.Context) (map[string]string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	entries, err := os.ReadDir(s.iconDir)
 	if err != nil {
 		return nil, fmt.Errorf("read icon directory: %w", err)
@@ -177,28 +182,46 @@ func (s *Service) ListIcons(ctx context.Context) (map[string]string, error) {
 
 	icons := make(map[string]string)
 	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".png") {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		if entry.IsDir() {
 			continue
 		}
 
-		iconPath := filepath.Join(s.iconDir, entry.Name())
+		name := entry.Name()
+		ext := filepath.Ext(name)
+		if strings.ToLower(ext) != ".png" {
+			continue
+		}
+
+		// Extract tracker host from filename (strip extension, normalise casing).
+		host := sanitizeHost(strings.TrimSuffix(name, ext))
+		if host == "" {
+			continue
+		}
+
+		iconPath := filepath.Join(s.iconDir, name)
 		data, err := os.ReadFile(iconPath)
 		if err != nil {
 			continue
 		}
 
-		// Extract tracker name from filename (remove .png extension)
-		trackerName := strings.TrimSuffix(entry.Name(), ".png")
 		encoded := base64.StdEncoding.EncodeToString(data)
 		dataURL := "data:image/png;base64," + encoded
-		icons[trackerName] = dataURL
-		if after, ok := strings.CutPrefix(trackerName, "www."); ok {
-			trimmed := after
-			if trimmed != "" {
-				if _, exists := icons[trimmed]; !exists {
-					icons[trimmed] = dataURL
-				}
-			}
+		icons[host] = dataURL
+
+		// Mirror common www/bare hostname variants so icons resolve regardless of
+		// which variant the torrent client reports.
+		var alias string
+		if bare, ok := strings.CutPrefix(host, "www."); ok && bare != "" {
+			alias = bare
+		} else {
+			alias = "www." + host
+		}
+		if _, exists := icons[alias]; !exists {
+			icons[alias] = dataURL
 		}
 	}
 
@@ -233,10 +256,15 @@ func (s *Service) GetIcon(ctx context.Context, host, trackerURL string) (string,
 
 		err := s.fetchAndStoreIcon(ctx, sanitized, trackerURL)
 		if err != nil {
-			if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			shouldRecordFailure := !errors.Is(err, context.Canceled)
+			if errors.Is(err, context.DeadlineExceeded) && ctx != nil && ctx.Err() == context.DeadlineExceeded {
+				shouldRecordFailure = false
+			}
+			if shouldRecordFailure {
 				s.recordFailure(sanitized)
 			}
 			if errors.Is(err, ErrIconNotFound) {
+				log.Trace().Str("host", sanitized).Err(err).Msg("Tracker icon fetch failed")
 				return "", ErrIconNotFound
 			}
 			return "", fmt.Errorf("fetch tracker icon: %w", err)
@@ -274,6 +302,7 @@ func (s *Service) fetchAndStoreIcon(ctx context.Context, host, trackerURL string
 
 	iconPath := s.iconPath(host)
 	attempted := make(map[string]struct{})
+	var lastErr error
 	hostCandidates := generateHostCandidates(host)
 	if len(hostCandidates) == 0 {
 		hostCandidates = []string{sanitizeHost(host)}
@@ -308,12 +337,18 @@ func (s *Service) fetchAndStoreIcon(ctx context.Context, host, trackerURL string
 				}
 			}
 
-			fallback := baseURL.ResolveReference(&url.URL{Path: "/favicon.ico"}).String()
-			if _, ok := attempted[fallback]; !ok {
-				if _, seen := localSeen[fallback]; !seen {
-					localSeen[fallback] = struct{}{}
-					iconURLs = append(iconURLs, fallback)
+			// Common fallbacks for sites that don't advertise <link rel="icon"> or
+			// don't serve /favicon.ico.
+			for _, fallbackPath := range []string{"/favicon.ico", "/favicon.png", "/apple-touch-icon.png"} {
+				fallback := baseURL.ResolveReference(&url.URL{Path: fallbackPath}).String()
+				if _, ok := attempted[fallback]; ok {
+					continue
 				}
+				if _, seen := localSeen[fallback]; seen {
+					continue
+				}
+				localSeen[fallback] = struct{}{}
+				iconURLs = append(iconURLs, fallback)
 			}
 		}
 
@@ -322,11 +357,16 @@ func (s *Service) fetchAndStoreIcon(ctx context.Context, host, trackerURL string
 
 			data, contentType, err := s.fetchIconBytes(ctx, iconURL)
 			if err != nil {
+				// Prefer retaining more specific errors over generic timeouts.
+				if lastErr == nil || !errors.Is(err, context.DeadlineExceeded) {
+					lastErr = err
+				}
 				continue
 			}
 
 			img, err := decodeImage(data, contentType, iconURL)
 			if err != nil {
+				lastErr = err
 				continue
 			}
 
@@ -339,11 +379,17 @@ func (s *Service) fetchAndStoreIcon(ctx context.Context, host, trackerURL string
 		}
 	}
 
+	if lastErr != nil {
+		return fmt.Errorf("%w: %w", ErrIconNotFound, lastErr)
+	}
 	return ErrIconNotFound
 }
 
 func (s *Service) discoverIcons(ctx context.Context, baseURL *url.URL) ([]string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL.String(), nil)
+	reqCtx, cancel := context.WithTimeout(ctx, requestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, baseURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -408,7 +454,10 @@ func (s *Service) fetchIconBytes(ctx context.Context, iconURL string) ([]byte, s
 		return parseDataURI(iconURL)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, iconURL, nil)
+	reqCtx, cancel := context.WithTimeout(ctx, requestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, iconURL, nil)
 	if err != nil {
 		return nil, "", err
 	}
@@ -482,6 +531,17 @@ func (s *Service) buildBaseCandidates(host, trackerURL string) []*url.URL {
 		return nil
 	}
 
+	// Avoid probing http:// unless the announce URL is explicitly http://.
+	// In some environments outbound port 80 is blocked/blackholed, which causes
+	// repeated context deadline exceeded errors and prevents successful https
+	// candidates from being attempted.
+	allowHTTP := false
+	if trackerURL != "" {
+		if u, err := url.Parse(trackerURL); err == nil && strings.EqualFold(u.Scheme, "http") {
+			allowHTTP = true
+		}
+	}
+
 	seen := make(map[string]struct{})
 	var ordered []string
 	add := func(raw string) {
@@ -508,14 +568,18 @@ func (s *Service) buildBaseCandidates(host, trackerURL string) []*url.URL {
 			default:
 				if u.Host != "" {
 					add((&url.URL{Scheme: "https", Host: u.Host}).String())
-					add((&url.URL{Scheme: "http", Host: u.Host}).String())
+					if allowHTTP {
+						add((&url.URL{Scheme: "http", Host: u.Host}).String())
+					}
 				}
 			}
 		}
 	}
 
 	add((&url.URL{Scheme: "https", Host: host}).String())
-	add((&url.URL{Scheme: "http", Host: host}).String())
+	if allowHTTP {
+		add((&url.URL{Scheme: "http", Host: host}).String())
+	}
 
 	var urls []*url.URL
 	for _, raw := range ordered {
@@ -631,7 +695,15 @@ func generateHostCandidates(host string) []string {
 		candidates = append(candidates, candidate)
 	}
 
-	add(sanitized)
+	addWithWWW := func(candidate string) {
+		add(candidate)
+		// Also try the www alias for base domains (e.g. example.org -> www.example.org).
+		if !strings.HasPrefix(candidate, "www.") && strings.Count(candidate, ".") == 1 {
+			add("www." + candidate)
+		}
+	}
+
+	addWithWWW(sanitized)
 
 	current := sanitized
 	for {
@@ -642,15 +714,11 @@ func generateHostCandidates(host string) []string {
 		if strings.Count(next, ".") == 0 {
 			break
 		}
-		add(next)
+		addWithWWW(next)
 		current = next
 		if strings.Count(current, ".") == 1 {
 			break
 		}
-	}
-
-	if !strings.HasPrefix(sanitized, "www.") && strings.Count(sanitized, ".") == 1 {
-		add("www." + sanitized)
 	}
 
 	return candidates

--- a/internal/services/trackericons/service_test.go
+++ b/internal/services/trackericons/service_test.go
@@ -4,82 +4,60 @@
 package trackericons
 
 import (
-	"strings"
+	"bytes"
+	"context"
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestServiceBuildBaseCandidatesOrder(t *testing.T) {
+func testPNG(t *testing.T) []byte {
+	t.Helper()
+	img := image.NewNRGBA(image.Rect(0, 0, 1, 1))
+	img.Set(0, 0, color.NRGBA{R: 255, A: 255})
+	var buf bytes.Buffer
+	require.NoError(t, png.Encode(&buf, img))
+	return buf.Bytes()
+}
+
+func TestService_ListIcons_NormalizesFilenamesAndAddsWWWAlias(t *testing.T) {
 	t.Parallel()
 
-	type testCase struct {
-		name        string
-		host        string
-		trackerURL  string
-		wantFirst   string
-		requireBoth bool
-	}
+	dataDir := t.TempDir()
+	svc, err := NewService(dataDir, "qui-test")
+	require.NoError(t, err)
 
-	tests := []testCase{
-		{
-			name:        "no tracker URL defaults to https first",
-			host:        "tracker.example",
-			trackerURL:  "",
-			wantFirst:   "https://tracker.example/",
-			requireBoth: true,
-		},
-		{
-			name:        "https tracker preserves scheme priority",
-			host:        "tracker.example",
-			trackerURL:  "https://tracker.example/announce",
-			wantFirst:   "https://tracker.example/",
-			requireBoth: true,
-		},
-		{
-			name:        "http tracker stays first",
-			host:        "tracker.example",
-			trackerURL:  "http://tracker.example/announce",
-			wantFirst:   "http://tracker.example/",
-			requireBoth: true,
-		},
-		{
-			name:        "non http tracker falls back to https first",
-			host:        "tracker.example",
-			trackerURL:  "udp://tracker.example:1337/announce",
-			wantFirst:   "https://tracker.example:1337/",
-			requireBoth: true,
-		},
-	}
+	iconPath := filepath.Join(dataDir, iconDirName, "MyTracker.COM.PNG")
+	require.NoError(t, os.WriteFile(iconPath, testPNG(t), 0o600))
 
-	for i := range tests {
-		tc := tests[i]
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
+	icons, err := svc.ListIcons(context.Background())
+	require.NoError(t, err)
 
-			svc := &Service{}
-			var got []string
+	require.Contains(t, icons, "mytracker.com")
+	require.Contains(t, icons, "www.mytracker.com")
+	require.NotEmpty(t, icons["mytracker.com"])
+	require.Equal(t, icons["mytracker.com"], icons["www.mytracker.com"])
+}
 
-			for _, u := range svc.buildBaseCandidates(tc.host, tc.trackerURL) {
-				got = append(got, u.String())
-			}
+func TestService_ListIcons_StripsWWWPrefixAlias(t *testing.T) {
+	t.Parallel()
 
-			require.NotEmpty(t, got, "no base candidates returned")
-			require.Equal(t, tc.wantFirst, got[0], "unexpected first candidate: full=%v", got)
+	dataDir := t.TempDir()
+	svc, err := NewService(dataDir, "qui-test")
+	require.NoError(t, err)
 
-			if tc.requireBoth {
-				var hasHTTP, hasHTTPS bool
-				for _, candidate := range got {
-					if strings.HasPrefix(candidate, "http://") {
-						hasHTTP = true
-					}
-					if strings.HasPrefix(candidate, "https://") {
-						hasHTTPS = true
-					}
-				}
+	iconPath := filepath.Join(dataDir, iconDirName, "www.Example.ORG.png")
+	require.NoError(t, os.WriteFile(iconPath, testPNG(t), 0o600))
 
-				require.True(t, hasHTTP && hasHTTPS, "expected both http and https candidates, got %v", got)
-			}
-		})
-	}
+	icons, err := svc.ListIcons(context.Background())
+	require.NoError(t, err)
+
+	require.Contains(t, icons, "www.example.org")
+	require.Contains(t, icons, "example.org")
+	require.Equal(t, icons["www.example.org"], icons["example.org"])
 }

--- a/web/src/components/instances/preferences/TrackerReannounceForm.tsx
+++ b/web/src/components/instances/preferences/TrackerReannounceForm.tsx
@@ -23,6 +23,7 @@ import { useInstanceTrackers } from "@/hooks/useInstanceTrackers"
 import { buildTrackerCustomizationMaps, useTrackerCustomizations } from "@/hooks/useTrackerCustomizations"
 import { useTrackerIcons } from "@/hooks/useTrackerIcons"
 import { api } from "@/lib/api"
+import { pickTrackerIconDomain } from "@/lib/tracker-icons"
 import { cn, copyTextToClipboard, formatErrorReason, normalizeTrackerDomains } from "@/lib/utils"
 import { REANNOUNCE_CONSTRAINTS, type InstanceFormData, type InstanceReannounceActivity, type InstanceReannounceSettings } from "@/types"
 import { useQuery } from "@tanstack/react-query"
@@ -119,11 +120,11 @@ export function TrackerReannounceForm({ instanceId, onInstanceChange, onSuccess,
         if (seenDisplayNames.has(displayKey)) continue
         seenDisplayNames.add(displayKey)
 
-        const primaryDomain = customization.domains[0]
+        const iconDomain = pickTrackerIconDomain(trackerIcons, customization.domains)
         processed.push({
           label: customization.displayName,
           value: customization.domains.join(","),
-          icon: <TrackerIconImage tracker={primaryDomain} trackerIcons={trackerIcons} />,
+          icon: <TrackerIconImage tracker={iconDomain} trackerIcons={trackerIcons} />,
         })
       } else {
         if (seenDisplayNames.has(lowerTracker)) continue

--- a/web/src/components/instances/preferences/WorkflowDialog.tsx
+++ b/web/src/components/instances/preferences/WorkflowDialog.tsx
@@ -47,6 +47,7 @@ import { useTrackerIcons } from "@/hooks/useTrackerIcons"
 import { api } from "@/lib/api"
 import { buildCategorySelectOptions } from "@/lib/category-utils"
 import { type CsvColumn, downloadBlob, toCsv } from "@/lib/csv-export"
+import { pickTrackerIconDomain } from "@/lib/tracker-icons"
 import { cn, formatBytes, normalizeTrackerDomains, parseTrackerDomains } from "@/lib/utils"
 import type {
   ActionConditions,
@@ -350,11 +351,11 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
         seenDisplayNames.add(displayKey)
         seenValues.add(mergedValue)
 
-        const primaryDomain = customization.domains[0]
+        const iconDomain = pickTrackerIconDomain(trackerIcons, customization.domains)
         processed.push({
           label: customization.displayName,
           value: mergedValue,
-          icon: <TrackerIconImage tracker={primaryDomain} trackerIcons={trackerIcons} />,
+          icon: <TrackerIconImage tracker={iconDomain} trackerIcons={trackerIcons} />,
         })
       } else {
         if (seenDisplayNames.has(lowerTracker) || seenValues.has(tracker)) return

--- a/web/src/components/instances/preferences/WorkflowsOverview.tsx
+++ b/web/src/components/instances/preferences/WorkflowsOverview.tsx
@@ -49,6 +49,7 @@ import { useTrackerCustomizations } from "@/hooks/useTrackerCustomizations"
 import { useTrackerIcons } from "@/hooks/useTrackerIcons"
 import { api } from "@/lib/api"
 import { type CsvColumn, downloadBlob, toCsv } from "@/lib/csv-export"
+import { pickTrackerIconDomain } from "@/lib/tracker-icons"
 import { cn, copyTextToClipboard, formatBytes, formatRelativeTime, parseTrackerDomains } from "@/lib/utils"
 import {
   fromImportFormat,
@@ -349,7 +350,7 @@ export function WorkflowsOverview({
     if (customization) {
       return {
         displayName: customization.displayName,
-        iconDomain: customization.domains[0],
+        iconDomain: pickTrackerIconDomain(trackerIcons, customization.domains, domain),
         isCustomized: true,
       }
     }
@@ -358,7 +359,7 @@ export function WorkflowsOverview({
       iconDomain: domain,
       isCustomized: false,
     }
-  }, [domainToCustomization])
+  }, [domainToCustomization, trackerIcons])
 
   const deleteRule = useMutation({
     mutationFn: ({ instanceId, ruleId }: { instanceId: number; ruleId: number }) =>

--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -36,6 +36,7 @@ import { useTorrentsList } from "@/hooks/useTorrentsList"
 import { useTrackerCustomizations } from "@/hooks/useTrackerCustomizations"
 import { useTrackerIcons } from "@/hooks/useTrackerIcons"
 import { buildTrackerCustomizationLookup, extractTrackerHost, getTrackerCustomizationsCacheKey, resolveTrackerDisplay, type TrackerCustomizationLookup } from "@/lib/tracker-customizations"
+import { resolveTrackerIconSrc } from "@/lib/tracker-icons"
 import { useNavigate, useSearch } from "@tanstack/react-router"
 import { useVirtualizer } from "@tanstack/react-virtual"
 import {
@@ -592,7 +593,7 @@ function SwipeableCard({
   }, [trackerMeta.host, trackerCustomizationLookup])
   // Use primary domain for icon lookup (so merged trackers share icons)
   const iconDomain = trackerDisplayInfo.primaryDomain || trackerMeta.host
-  const trackerIconSrc = iconDomain ? trackerIcons?.[iconDomain] ?? null : null
+  const trackerIconSrc = resolveTrackerIconSrc(trackerIcons, iconDomain, trackerMeta.host)
   // Display name is either custom name or hostname
   const trackerDisplayName = trackerDisplayInfo.displayName || trackerMeta.title
 

--- a/web/src/components/torrents/TorrentTableColumns.tsx
+++ b/web/src/components/torrents/TorrentTableColumns.tsx
@@ -27,8 +27,9 @@ import {
   resolveTrackerDisplay,
   type TrackerCustomizationLookup
 } from "@/lib/tracker-customizations"
+import { resolveTrackerIconSrc } from "@/lib/tracker-icons"
 import { cn, formatBytes, formatDuration, getRatioColor } from "@/lib/utils"
-import type { AppPreferences, Torrent } from "@/types"
+import type { AppPreferences, CrossInstanceTorrent, Torrent } from "@/types"
 import type { ColumnDef } from "@tanstack/react-table"
 import {
   AlertCircle,
@@ -402,6 +403,23 @@ export const createColumns = (
   // Badge padding classes based on view mode
   const badgePadding = viewMode === "dense" ? "px-1.5 py-0" : ""
 
+  const instanceColumn: ColumnDef<Torrent> = {
+    id: "instance",
+    accessorKey: "instanceName",
+    header: "Instance",
+    cell: ({ row }) => {
+      const instanceName = (row.original as CrossInstanceTorrent).instanceName ?? ""
+      return (
+        <div className="overflow-hidden whitespace-nowrap text-sm font-medium" title={instanceName}>
+          <Badge variant="outline" className="text-xs">
+            {instanceName}
+          </Badge>
+        </div>
+      )
+    },
+    size: calculateMinWidth("Instance"),
+  }
+
   return [
     {
       id: "select",
@@ -553,22 +571,7 @@ export const createColumns = (
       },
       size: 200,
     },
-    ...(showInstanceColumn ? [{
-      id: "instance",
-      accessorKey: "instanceName",
-      header: "Instance",
-      cell: ({ row }: { row: any }) => {
-        const instanceName = row.original.instanceName || ""
-        return (
-          <div className="overflow-hidden whitespace-nowrap text-sm font-medium" title={instanceName}>
-            <Badge variant="outline" className="text-xs">
-              {instanceName}
-            </Badge>
-          </div>
-        )
-      },
-      size: calculateMinWidth("Instance"),
-    }] : []),
+    ...(showInstanceColumn ? [instanceColumn] : []),
     {
       accessorKey: "size",
       header: "Size",
@@ -847,7 +850,7 @@ export const createColumns = (
         // Use primary domain from customization for icon lookup (if customized)
         const trackerDisplayInfo = trackerCustomizationLookup ? resolveTrackerDisplay(host, trackerCustomizationLookup) : null
         const iconDomain = trackerDisplayInfo?.primaryDomain || host
-        const iconSrc = iconDomain ? trackerIcons?.[iconDomain] ?? null : null
+        const iconSrc = resolveTrackerIconSrc(trackerIcons, iconDomain, host)
 
         return (
           <TrackerIconCell

--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -20,6 +20,7 @@ import { useTrackerCustomizations } from "@/hooks/useTrackerCustomizations"
 import { useTrackerIcons } from "@/hooks/useTrackerIcons"
 import { columnFiltersToExpr } from "@/lib/column-filter-utils"
 import { buildTrackerCustomizationLookup, extractTrackerHost, getTrackerCustomizationsCacheKey, resolveTrackerDisplay, type TrackerCustomizationLookup } from "@/lib/tracker-customizations"
+import { resolveTrackerIconSrc } from "@/lib/tracker-icons"
 import { formatBytes, getRatioColor } from "@/lib/utils"
 import {
   DndContext,
@@ -383,8 +384,7 @@ const CompactRow = memo(({
     [trackerHost, trackerCustomizationLookup]
   )
   const trackerLabel = trackerDisplayInfo.displayName || ""
-  const trackerIconKey = trackerDisplayInfo.primaryDomain || trackerHost
-  const trackerIconSrc = trackerIconKey ? trackerIcons?.[trackerIconKey] ?? null : null
+  const trackerIconSrc = resolveTrackerIconSrc(trackerIcons, trackerDisplayInfo.primaryDomain, trackerHost)
   const trackerTitle = trackerDisplayInfo.isCustomized ? `${trackerDisplayInfo.displayName} (${trackerHost})` : trackerHost
 
   // Compact view

--- a/web/src/components/ui/tracker-icon.tsx
+++ b/web/src/components/ui/tracker-icon.tsx
@@ -4,6 +4,7 @@
  */
 
 import { memo, useEffect, useState } from "react"
+import { resolveTrackerIconSrc } from "@/lib/tracker-icons"
 
 interface TrackerIconImageProps {
   tracker: string
@@ -19,7 +20,7 @@ export const TrackerIconImage = memo(({ tracker, trackerIcons }: TrackerIconImag
 
   const trimmed = tracker.trim()
   const fallbackLetter = trimmed ? trimmed.charAt(0).toUpperCase() : "#"
-  const src = trackerIcons?.[trimmed] ?? null
+  const src = resolveTrackerIconSrc(trackerIcons, trimmed)
 
   return (
     <div className="flex h-4 w-4 items-center justify-center rounded-sm border border-border/40 bg-muted text-[10px] font-medium uppercase leading-none shrink-0">

--- a/web/src/lib/tracker-icons.ts
+++ b/web/src/lib/tracker-icons.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { extractTrackerHost } from "@/lib/tracker-customizations"
+
+export function resolveTrackerIconSrc(
+  trackerIcons: Record<string, string> | undefined,
+  ...candidates: Array<string | undefined | null>
+): string | null {
+  if (!trackerIcons) {
+    return null
+  }
+
+  for (const candidate of candidates) {
+    if (!candidate) {
+      continue
+    }
+
+    const key = extractTrackerHost(candidate)
+    if (!key) {
+      continue
+    }
+
+    if (trackerIcons[key]) {
+      return trackerIcons[key]
+    }
+
+    // Try the www/bare hostname variant as a fallback.
+    const alias = key.startsWith("www.") ? key.slice(4) : `www.${key}`
+    if (trackerIcons[alias]) {
+      return trackerIcons[alias]
+    }
+  }
+
+  return null
+}
+
+export function pickTrackerIconDomain(
+  trackerIcons: Record<string, string> | undefined,
+  domains: string[],
+  fallback?: string
+): string {
+  const candidates = [...domains, fallback].filter(Boolean) as string[]
+  if (candidates.length === 0) {
+    return ""
+  }
+
+  for (const candidate of candidates) {
+    if (resolveTrackerIconSrc(trackerIcons, candidate)) {
+      return extractTrackerHost(candidate)
+    }
+  }
+
+  // Fall back to the first parseable host/domain.
+  for (const candidate of candidates) {
+    const key = extractTrackerHost(candidate)
+    if (key) {
+      return key
+    }
+  }
+
+  return ""
+}


### PR DESCRIPTION
- Fix cases where icons “sometimes work” by disabling caching for `/api/tracker-icons`, normalizing icon filenames/keys, and mirroring `www.`/bare host aliases.
- Ensure tracker-domain refresh queues icon fetches even when using validated tracker mappings.
- Improve remote fetching: prefer https unless announce is http, add per-request timeouts and more fallback paths (`/favicon.png`, `/apple-touch-icon.png`), and generate better host candidates (`www` for base domains).
- Prevent repeated timeout retries/log spam by recording timeouts into the existing per-host cooldown.
- Add tests for cache headers and icon listing normalization/aliasing; add a shared frontend resolver so customized tracker domains don’t accidentally hide icons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added instance column to torrent display tables for cross-instance torrent tracking.
  * Enhanced tracker icon resolution with improved fallback discovery and alias variants.

* **Bug Fixes**
  * Fixed stale tracker icons in UI by disabling caching and ensuring dynamic icon updates.
  * Improved tracker icon availability through expanded fallback options and hostname normalization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->