### PR TITLE
fix(database): remove noisy stmt cache promotion log

### DIFF
--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -277,9 +277,7 @@ func (t *Tx) promoteStatementsToCache() {
 		stmt, err := conn.PrepareContext(ctx, query)
 		if err != nil {
 			t.db.stmtMu.RUnlock()
-			// Log but don't fail - caching is an optimization
-			log.Debug().Err(err).Str("query", query).Msg("failed to promote transaction statement to cache")
-			continue
+			continue // silently skip - caching is best-effort
 		}
 
 		stmts.Set(query, stmt, ttlcache.DefaultTTL)


### PR DESCRIPTION
Queries referencing temp tables always fail PrepareContext outside their transaction, spamming debug logs. Statement caching is best-effort; silently skip failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved database statement caching robustness by refining error handling during cache promotion operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->