### PR TITLE
refactor(web): use TanStack Query for path autocomplete

### DIFF
--- a/web/src/hooks/useDirectoryContent.ts
+++ b/web/src/hooks/useDirectoryContent.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { useQuery } from "@tanstack/react-query"
+
+import { api } from "@/lib/api"
+
+type UseDirectoryContentOptions = {
+  enabled?: boolean
+  staleTimeMs?: number
+}
+
+export function useDirectoryContent(
+  instanceId: number,
+  dirPath: string,
+  options: UseDirectoryContentOptions = {}
+) {
+  const { enabled = true, staleTimeMs = 30000 } = options
+
+  // Normalize the path for consistent cache keys
+  const normalizedPath = dirPath
+    ? (dirPath.startsWith("/") ? dirPath : `/${dirPath}`).replace(/\/*$/, "/")
+    : ""
+
+  return useQuery<string[]>({
+    queryKey: ["directory-content", instanceId, normalizedPath],
+    queryFn: () => api.getDirectoryContent(instanceId, normalizedPath),
+    staleTime: staleTimeMs,
+    enabled: Boolean(enabled && instanceId && normalizedPath),
+  })
+}


### PR DESCRIPTION
## Summary

Refactors `usePathAutocomplete` to use ApiClient + TanStack Query instead of manual `fetch()` with `useRef` caching.

## Changes

- Add `useDirectoryContent` hook using TanStack Query
- Remove manual cache (`useRef<Map>`), abort controller, and timeout handling
- TanStack Query handles caching, deduplication, and request cancellation

## Benefits

- Consistent with codebase patterns
- Prevents baseUrl bugs like #798
- Less code to maintain (-44 lines)

## Files Modified

1. `web/src/hooks/useDirectoryContent.ts` - New hook
2. `web/src/hooks/usePathAutocomplete.ts` - Refactored to use new hook

No breaking changes to `usePathAutocomplete`'s public API.

Closes #803

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved path autocomplete feature by optimizing directory content retrieval and enhancing caching mechanisms, resulting in faster and more responsive suggestions when entering file paths
  * Streamlined internal data management processes to ensure more consistent and reliable autocomplete behavior during path input operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->