### PR TITLE
fix(web): raise instance preferences max value from 999 to 99999

### DIFF
--- a/web/src/components/instances/preferences/QueueManagementForm.tsx
+++ b/web/src/components/instances/preferences/QueueManagementForm.tsx
@@ -139,7 +139,7 @@ export function QueueManagementForm({ instanceId, onSuccess }: QueueManagementFo
                   label="Max Active Downloads"
                   value={(field.state.value as number) ?? 3}
                   onChange={field.handleChange}
-                  max={999}
+                  max={99999}
                   description="Maximum number of downloading torrents"
                   allowUnlimited={true}
                 />
@@ -167,7 +167,7 @@ export function QueueManagementForm({ instanceId, onSuccess }: QueueManagementFo
                   label="Max Active Uploads"
                   value={(field.state.value as number) ?? 3}
                   onChange={field.handleChange}
-                  max={999}
+                  max={99999}
                   description="Maximum number of uploading torrents"
                   allowUnlimited={true}
                 />
@@ -195,7 +195,7 @@ export function QueueManagementForm({ instanceId, onSuccess }: QueueManagementFo
                   label="Max Active Torrents"
                   value={(field.state.value as number) ?? 5}
                   onChange={field.handleChange}
-                  max={999}
+                  max={99999}
                   description="Total maximum active torrents"
                   allowUnlimited={true}
                 />
@@ -212,7 +212,7 @@ export function QueueManagementForm({ instanceId, onSuccess }: QueueManagementFo
                 label="Max Checking Torrents"
                 value={(field.state.value as number) ?? 1}
                 onChange={field.handleChange}
-                max={999}
+                max={99999}
                 description="Maximum torrents checking simultaneously"
                 allowUnlimited={true}
               />


### PR DESCRIPTION
## Summary

Users with qBittorrent settings >999 (e.g., max_active_uploads = 2000) were unable to save changes in qui. The value would revert to 999, blocking all preference updates.

## Changes

Raised the `max` prop from `999` to `99999` for:
- Max Active Downloads
- Max Active Uploads  
- Max Active Torrents
- Max Checking Torrents

## Root Cause

The `NumberInputWithUnlimited` component was given an arbitrary `max={999}` that didn't match qBittorrent's actual limits.

Fixes #1310
Converted from discussion #1269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Increased maximum queue management limits from 999 to 99999 for Max Active Downloads, Max Active Uploads, Max Active Torrents, and Max Checking Torrents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->