### PR TITLE
fix(trackericons): apply failure cooldown on timeouts

### DIFF
--- a/internal/services/trackericons/service.go
+++ b/internal/services/trackericons/service.go
@@ -254,10 +254,11 @@ func (s *Service) GetIcon(ctx context.Context, host, trackerURL string) (string,
 			return "", ErrIconNotFound
 		}
 
+		ctxWasDone := ctx != nil && ctx.Err() != nil
 		err := s.fetchAndStoreIcon(ctx, sanitized, trackerURL)
 		if err != nil {
 			shouldRecordFailure := !errors.Is(err, context.Canceled)
-			if errors.Is(err, context.DeadlineExceeded) && ctx != nil && ctx.Err() == context.DeadlineExceeded {
+			if ctxWasDone && errors.Is(err, context.DeadlineExceeded) {
 				shouldRecordFailure = false
 			}
 			if shouldRecordFailure {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of timeout scenarios during icon fetches to prevent unnecessary retry attempts.

* **Tests**
  * Added test coverage for icon fetch behavior under timeout conditions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->