### PR TITLE
fix(api): tighten CORS/auth routing and base URL joins

### DIFF
--- a/internal/api/ctxkeys/ctxkeys.go
+++ b/internal/api/ctxkeys/ctxkeys.go
@@ -1,0 +1,11 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package ctxkeys
+
+// Key is a typed context key to avoid collisions across packages.
+type Key int
+
+const (
+	Username Key = iota
+)

--- a/internal/api/handlers/crossseed.go
+++ b/internal/api/handlers/crossseed.go
@@ -331,28 +331,32 @@ func NewCrossSeedHandler(service *crossseed.Service, completionStore *models.Ins
 	}
 }
 
-// Routes registers the cross-seed routes
-func (h *CrossSeedHandler) Routes(r chi.Router) {
+// Routes registers the cross-seed routes with explicit middleware ordering.
+func (h *CrossSeedHandler) Routes(r chi.Router, authMiddleware func(http.Handler) http.Handler, apiKeyQueryMiddleware func(http.Handler) http.Handler) {
 	// Register instance-scoped route at top level
-	r.Get("/instances/{instanceID}/cross-seed/status", h.GetCrossSeedStatus)
+	r.With(authMiddleware).Get("/instances/{instanceID}/cross-seed/status", h.GetCrossSeedStatus)
 
 	r.Route("/cross-seed", func(r chi.Router) {
-		r.Post("/apply", h.AutobrrApply)
-		r.Route("/torrents", func(r chi.Router) {
+		r.With(apiKeyQueryMiddleware, authMiddleware).Post("/apply", h.AutobrrApply)
+		r.Route("/webhook", func(r chi.Router) {
+			r.With(apiKeyQueryMiddleware, authMiddleware).Post("/check", h.WebhookCheck)
+		})
+
+		r.With(authMiddleware).Route("/torrents", func(r chi.Router) {
 			r.Get("/{instanceID}/{hash}/analyze", h.AnalyzeTorrentForSearch)
 			r.Get("/{instanceID}/{hash}/async-status", h.GetAsyncFilteringStatus)
 			r.Get("/{instanceID}/{hash}/local-matches", h.GetLocalMatches)
 			r.Post("/{instanceID}/{hash}/search", h.SearchTorrentMatches)
 			r.Post("/{instanceID}/{hash}/apply", h.ApplyTorrentSearchResults)
 		})
-		r.Get("/settings", h.GetAutomationSettings)
-		r.Patch("/settings", h.PatchAutomationSettings)
-		r.Put("/settings", h.UpdateAutomationSettings)
-		r.Get("/status", h.GetAutomationStatus)
-		r.Get("/runs", h.ListAutomationRuns)
-		r.Post("/run", h.TriggerAutomationRun)
-		r.Post("/run/cancel", h.CancelAutomationRun)
-		r.Route("/search", func(r chi.Router) {
+		r.With(authMiddleware).Get("/settings", h.GetAutomationSettings)
+		r.With(authMiddleware).Patch("/settings", h.PatchAutomationSettings)
+		r.With(authMiddleware).Put("/settings", h.UpdateAutomationSettings)
+		r.With(authMiddleware).Get("/status", h.GetAutomationStatus)
+		r.With(authMiddleware).Get("/runs", h.ListAutomationRuns)
+		r.With(authMiddleware).Post("/run", h.TriggerAutomationRun)
+		r.With(authMiddleware).Post("/run/cancel", h.CancelAutomationRun)
+		r.With(authMiddleware).Route("/search", func(r chi.Router) {
 			r.Get("/settings", h.GetSearchSettings)
 			r.Patch("/settings", h.PatchSearchSettings)
 			r.Get("/status", h.GetSearchRunStatus)
@@ -360,12 +364,9 @@ func (h *CrossSeedHandler) Routes(r chi.Router) {
 			r.Post("/run/cancel", h.CancelSearchRun)
 			r.Get("/runs", h.ListSearchRunHistory)
 		})
-		r.Route("/completion", func(r chi.Router) {
+		r.With(authMiddleware).Route("/completion", func(r chi.Router) {
 			r.Get("/{instanceID}", h.GetInstanceCompletionSettings)
 			r.Put("/{instanceID}", h.UpdateInstanceCompletionSettings)
-		})
-		r.Route("/webhook", func(r chi.Router) {
-			r.Post("/check", h.WebhookCheck)
 		})
 	})
 }

--- a/internal/api/handlers/licenses.go
+++ b/internal/api/handlers/licenses.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/rs/zerolog/log"
 
+	"github.com/autobrr/qui/internal/api/ctxkeys"
 	"github.com/autobrr/qui/internal/services/license"
 )
 
@@ -97,8 +98,8 @@ func (h *LicenseHandler) ActivateLicense(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	username := r.Context().Value("username")
-	if username == "" || username == nil {
+	username, ok := r.Context().Value(ctxkeys.Username).(string)
+	if !ok || username == "" {
 		RespondJSON(w, http.StatusBadRequest, ActivateLicenseResponse{
 			Valid: false,
 			Error: "Username not found in context",
@@ -107,7 +108,7 @@ func (h *LicenseHandler) ActivateLicense(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Activate and store license
-	licenseResp, err := h.licenseService.ActivateAndStoreLicense(r.Context(), req.LicenseKey, username.(string))
+	licenseResp, err := h.licenseService.ActivateAndStoreLicense(r.Context(), req.LicenseKey, username)
 	if err != nil {
 		log.Error().
 			Err(err).
@@ -154,8 +155,8 @@ func (h *LicenseHandler) ValidateLicense(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	username := r.Context().Value("username")
-	if username == "" || username == nil {
+	username, ok := r.Context().Value(ctxkeys.Username).(string)
+	if !ok || username == "" {
 		RespondJSON(w, http.StatusBadRequest, ActivateLicenseResponse{
 			Valid: false,
 			Error: "Username not found in context",
@@ -164,7 +165,7 @@ func (h *LicenseHandler) ValidateLicense(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Validate and store license
-	licenseResp, err := h.licenseService.ValidateAndStoreLicense(r.Context(), req.LicenseKey, username.(string))
+	licenseResp, err := h.licenseService.ValidateAndStoreLicense(r.Context(), req.LicenseKey, username)
 	if err != nil {
 		log.Error().
 			Err(err).

--- a/internal/api/handlers/oidc.go
+++ b/internal/api/handlers/oidc.go
@@ -373,7 +373,11 @@ func (h *OIDCHandler) handleCallback(w http.ResponseWriter, r *http.Request) {
 		}
 	} else if h.config.BaseURL != "" && h.config.BaseURL != "/" {
 		// Use configured base URL
-		frontendURL = h.config.BaseURL + "/dashboard"
+		base := strings.TrimSuffix(h.config.BaseURL, "/")
+		if base == "" {
+			base = "/"
+		}
+		frontendURL = base + "/dashboard"
 	}
 
 	log.Trace().

--- a/internal/api/middleware/apikey_query.go
+++ b/internal/api/middleware/apikey_query.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package middleware
+
+import "net/http"
+
+// APIKeyFromQuery promotes an API key query param into the X-API-Key header.
+// Use this only on routes that explicitly allow query param auth.
+func APIKeyFromQuery(param string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("X-API-Key") == "" {
+				if apiKey := r.URL.Query().Get(param); apiKey != "" {
+					r.Header.Set("X-API-Key", apiKey)
+				}
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/api/middleware/apikey_query_test.go
+++ b/internal/api/middleware/apikey_query_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/alexedwards/scs/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/auth"
+	"github.com/autobrr/qui/internal/database"
+)
+
+func TestAPIKeyFromQuery_AllowsQueryParam(t *testing.T) {
+	ctx := t.Context()
+
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	db, err := database.New(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	authService := auth.NewService(db)
+	sessionManager := scs.New()
+
+	apiKeyValue, _, err := authService.CreateAPIKey(ctx, "test-key")
+	require.NoError(t, err)
+
+	okHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	authMiddleware := IsAuthenticated(authService, sessionManager)
+	handler := sessionManager.LoadAndSave(APIKeyFromQuery("apikey")(authMiddleware(okHandler)))
+
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/api/cross-seed/apply?apikey="+apiKeyValue, nil)
+	resp := httptest.NewRecorder()
+
+	handler.ServeHTTP(resp, req)
+
+	require.Equal(t, http.StatusOK, resp.Code)
+}

--- a/internal/api/middleware/auth_test.go
+++ b/internal/api/middleware/auth_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/autobrr/qui/internal/database"
 )
 
-func TestIsAuthenticated_APIKeyQueryParam_CustomBaseURL(t *testing.T) {
+func TestIsAuthenticated_APIKeyHeaderAndUnauthorized(t *testing.T) {
 	ctx := t.Context()
 
 	dbPath := filepath.Join(t.TempDir(), "test.db")
@@ -51,57 +51,27 @@ func TestIsAuthenticated_APIKeyQueryParam_CustomBaseURL(t *testing.T) {
 		expectedStatus int
 	}{
 		{
-			name:           "apply endpoint with apikey query param (no base URL)",
+			name:           "endpoint with X-API-Key header",
 			path:           "/api/cross-seed/apply",
-			apiKeyQuery:    apiKeyValue,
-			expectedStatus: http.StatusOK,
-		},
-		{
-			name:           "apply endpoint with apikey query param (custom base URL /qui/)",
-			path:           "/qui/api/cross-seed/apply",
-			apiKeyQuery:    apiKeyValue,
-			expectedStatus: http.StatusOK,
-		},
-		{
-			name:           "apply endpoint with apikey query param (custom base URL /foo/bar/)",
-			path:           "/foo/bar/api/cross-seed/apply",
-			apiKeyQuery:    apiKeyValue,
-			expectedStatus: http.StatusOK,
-		},
-		{
-			name:           "webhook check with apikey query param (no base URL)",
-			path:           "/api/cross-seed/webhook/check",
-			apiKeyQuery:    apiKeyValue,
-			expectedStatus: http.StatusOK,
-		},
-		{
-			name:           "webhook check with apikey query param (custom base URL /qui/)",
-			path:           "/qui/api/cross-seed/webhook/check",
-			apiKeyQuery:    apiKeyValue,
-			expectedStatus: http.StatusOK,
-		},
-		{
-			name:           "apply endpoint with X-API-Key header",
-			path:           "/qui/api/cross-seed/apply",
 			apiKeyHeader:   apiKeyValue,
 			expectedStatus: http.StatusOK,
 		},
 		{
-			name:           "apply endpoint without auth",
-			path:           "/qui/api/cross-seed/apply",
-			expectedStatus: http.StatusForbidden,
+			name:           "endpoint without auth",
+			path:           "/api/cross-seed/apply",
+			expectedStatus: http.StatusUnauthorized,
 		},
 		{
-			name:           "apply endpoint with invalid apikey",
-			path:           "/qui/api/cross-seed/apply",
+			name:           "endpoint with invalid apikey",
+			path:           "/api/cross-seed/apply",
 			apiKeyQuery:    "invalid-key",
 			expectedStatus: http.StatusUnauthorized,
 		},
 		{
-			name:           "non-webhook endpoint should not accept apikey query param",
+			name:           "query param without middleware is rejected",
 			path:           "/api/torrents",
 			apiKeyQuery:    apiKeyValue,
-			expectedStatus: http.StatusForbidden,
+			expectedStatus: http.StatusUnauthorized,
 		},
 	}
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -338,9 +338,14 @@ func (s *Server) Handler() (*chi.Mux, error) {
 			}
 		})
 
-		// Protected routes
+		apiKeyQueryMiddleware := middleware.APIKeyFromQuery("apikey")
+		authMiddleware := middleware.IsAuthenticated(s.authService, s.sessionManager)
+
+		// Cross-seed routes (query param auth for select endpoints)
+		crossSeedHandler.Routes(r, authMiddleware, apiKeyQueryMiddleware)
+
 		r.Group(func(r chi.Router) {
-			r.Use(middleware.IsAuthenticated(s.authService, s.sessionManager))
+			r.Use(authMiddleware)
 
 			r.Get("/tracker-icons", trackerIconHandler.GetTrackerIcons)
 
@@ -350,9 +355,6 @@ func (s *Server) Handler() (*chi.Mux, error) {
 			r.Put("/auth/change-password", authHandler.ChangePassword)
 
 			r.Route("/license", licenseHandler.Routes)
-
-			// Cross-seed routes
-			crossSeedHandler.Routes(r)
 
 			// Jackett routes (if configured)
 			if jackettHandler != nil {
@@ -601,7 +603,11 @@ func (s *Server) Handler() (*chi.Mux, error) {
 	r.Get("/healthz/readiness", healthHandler.HandleReady)
 	r.Get("/healthz/liveness", healthHandler.HandleLiveness)
 
-	r.Mount(baseURL+"api", apiRouter)
+	apiMount := "/api"
+	if baseURL != "/" {
+		apiMount = strings.TrimSuffix(baseURL, "/") + "/api"
+	}
+	r.Mount(apiMount, apiRouter)
 
 	// Initialize web handler (for embedded frontend)
 	// This MUST be registered AFTER API routes to avoid catch-all intercepting /api/* paths


### PR DESCRIPTION
## Summary
- normalize base URL joins for API mount and OIDC dashboard redirect
- scope apikey query param support to cross-seed apply/webhook with explicit middleware ordering
- switch unauthenticated responses to 401 and use typed context keys for username
- add/adjust tests for CORS base URL and apikey middleware behavior

## Testing
- make test
- make lint (fails in web/ due to pre-existing frontend lint errors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for passing API keys via query parameters in addition to headers.

* **Bug Fixes**
  * Fixed OIDC redirect URL handling to properly handle custom base URLs without duplicate slashes.
  * Corrected authentication error responses to use 401 Unauthorized status code instead of 403 Forbidden.

* **Tests**
  * Added comprehensive test coverage for API key and authentication flows.
  * Added CORS preflight validation test with custom base URL support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->