### PR TITLE
fix(web): mobile card spacing

### DIFF
--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -2510,7 +2510,7 @@ export function TorrentCardsMobile({
       <div className="sm:hidden">
         <ScrollToTopButton
           scrollContainerRef={parentRef}
-          className="right-4 z-[60] bottom-[calc(8rem+env(safe-area-inset-bottom))]"
+          className="right-4 z-[60] bottom-[calc(3rem+env(safe-area-inset-bottom))]"
         />
       </div>
     </div>


### PR DESCRIPTION
# Before
<img width="452" height="436" alt="image" src="https://github.com/user-attachments/assets/bdfd0fae-472e-454c-97b2-3c4eac419b5f" />

# After
<img width="449" height="476" alt="image" src="https://github.com/user-attachments/assets/9b2a0a9f-4658-4b74-a4ce-bc7c3b494b4c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted torrent card dimensions and spacing in mobile view
  * Repositioned scroll-to-top button in mobile layout for improved visibility

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->