### PR TITLE
fix(crossseed): add partial-contains to match type priority

### DIFF
--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -4093,10 +4093,14 @@ func matchTypePriority(matchType string) int {
 		return 3
 	case "partial-in-pack":
 		return 2
+	case "partial-contains":
+		// Allows cross-seeding when folder structures differ but content matches
+		// (e.g., /movie1/movie1.mkv vs /movie1.mkv)
+		return 1
 	case "size":
 		return 1
 	default:
-		// Unknown/unsupported match types (e.g. "release-match", "partial-contains")
+		// Unknown/unsupported match types (e.g. "release-match")
 		// intentionally receive priority 0 so callers treat them as unusable unless
 		// explicitly handled above. Add new match types here when they become valid.
 		return 0


### PR DESCRIPTION
## Summary
Fixes regression introduced in f7dced60 (#1250) where `partial-contains` matches were rejected due to missing priority entry.

## Problem
When folder structures differ but content matches (e.g., `/movie1/movie1.mkv` vs `/movie1.mkv`):
1. Exact match fails (paths differ)
2. Match type swap correctly labels this as `partial-contains`
3. But `matchTypePriority()` returned 0 → candidate rejected
4. "No matching torrents found with required files"

This broke the v1.12.0 behavior where alignment could handle folder structure differences.

## Fix
Add `partial-contains` to `matchTypePriority()` with priority 1 (same as `size` match).

## Related
- Regression from: #1250 (f7dced60)
- Reported in: #1332

/cc @s0up4200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal improvements to content matching logic within the cross-seed system to better handle additional matching scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->