### PR TITLE
fix(crossseed): handle V1/V2 hash visibility in alignment

### DIFF
--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -3632,7 +3632,10 @@ func (s *Service) processCrossSeedCandidate(
 	}
 
 	// Attempt to align the new torrent's naming and file layout with the matched torrent
-	alignmentSucceeded := s.alignCrossSeedContentPaths(ctx, candidate.InstanceID, torrentHash, torrentHashV2, torrentName, matchedTorrent, sourceFiles, candidateFiles)
+	alignmentSucceeded, activeHash := s.alignCrossSeedContentPaths(ctx, candidate.InstanceID, torrentHash, torrentHashV2, torrentName, matchedTorrent, sourceFiles, candidateFiles)
+	if activeHash == "" {
+		activeHash = torrentHash
+	}
 
 	// Determine if we need to wait for verification and resume at threshold:
 	// - requiresAlignment: we used skip_checking but need to recheck after renaming paths
@@ -3680,9 +3683,9 @@ func (s *Service) processCrossSeedCandidate(
 				Msg("Queuing torrent for recheck resume")
 			queueErr := error(nil)
 			if addPolicy.DiscLayout {
-				queueErr = s.queueRecheckResumeWithThreshold(ctx, candidate.InstanceID, torrentHash, 1.0)
+				queueErr = s.queueRecheckResumeWithThreshold(ctx, candidate.InstanceID, activeHash, 1.0)
 			} else {
-				queueErr = s.queueRecheckResume(ctx, candidate.InstanceID, torrentHash)
+				queueErr = s.queueRecheckResume(ctx, candidate.InstanceID, activeHash)
 			}
 			if queueErr != nil {
 				result.Message += " - auto-resume queue full, manual resume required"
@@ -3705,7 +3708,7 @@ func (s *Service) processCrossSeedCandidate(
 			result.Message += " - auto-resume skipped per settings"
 		} else {
 			// Resume immediately since there's nothing to wait for
-			if err := s.syncManager.BulkAction(ctx, candidate.InstanceID, []string{torrentHash}, "resume"); err != nil {
+			if err := s.syncManager.BulkAction(ctx, candidate.InstanceID, []string{activeHash}, "resume"); err != nil {
 				log.Warn().
 					Err(err).
 					Int("instanceID", candidate.InstanceID).
@@ -3719,7 +3722,7 @@ func (s *Service) processCrossSeedCandidate(
 		// Alignment failed - pause torrent to prevent unwanted downloads
 		if !startPaused {
 			// Torrent was added running - need to actually pause it
-			if err := s.syncManager.BulkAction(ctx, candidate.InstanceID, []string{torrentHash}, "pause"); err != nil {
+			if err := s.syncManager.BulkAction(ctx, candidate.InstanceID, []string{activeHash}, "pause"); err != nil {
 				log.Warn().
 					Err(err).
 					Int("instanceID", candidate.InstanceID).


### PR DESCRIPTION
## Summary
Fixes regression where torrents were added **STOPPED** due to hash visibility timeouts during alignment (reported in #1333).

## Problem
1. When a torrent is added, `alignCrossSeedContentPaths` waits for the torrent to appear in qBittorrent.
2. It previously only waited for the V1 hash. 
3. If qBittorrent indexed the torrent by its V2 hash (common in hybrid torrents on qBt v5.0+), the wait timed out.
4. Alignment was marked as **failed**, triggering a safety **forced pause** to prevent downloads of misaligned data.

## Fix
- Modified `waitForTorrentAvailability` to accept multiple hashes and return the hash that actually appeared.
- Alignment now uses this returned "active" hash for all subsequent rename and file fetch operations.
- Updated all catch-all pause/resume/recheck logic to operate on both hash variants consistently.

## Related
- Closes #1333
- Follow-up to V2 hash support in 1.13.0

/cc @s0up4200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-seed reliability by correctly selecting the active torrent when multiple identifiers exist, ensuring renames and syncs target the visible torrent.

* **Improvements**
  * Enhanced availability polling to wait across multiple torrent identifiers and propagate the chosen active identifier to subsequent fetch, rename, and alignment operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->