### PR TITLE
fix(web): use fixed for scroll-to-top

### DIFF
--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -2510,7 +2510,7 @@ export function TorrentCardsMobile({
       <div className="sm:hidden">
         <ScrollToTopButton
           scrollContainerRef={parentRef}
-          className="right-4 z-[60] bottom-[calc(3rem+env(safe-area-inset-bottom))]"
+          className="right-8 z-[60] bottom-[calc(8.5rem+env(safe-area-inset-bottom))]"
         />
       </div>
     </div>

--- a/web/src/components/ui/scroll-to-top-button.tsx
+++ b/web/src/components/ui/scroll-to-top-button.tsx
@@ -59,7 +59,7 @@ export function ScrollToTopButton({
       variant="outline"
       size="icon"
       className={cn(
-        "absolute z-10 shadow-lg bg-background/80 backdrop-blur-sm transition-all duration-200",
+        "fixed z-10 shadow-lg bg-background/80 backdrop-blur-sm transition-all duration-200",
         isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2 pointer-events-none",
         className
       )}


### PR DESCRIPTION
didnt check android on my previous fix

# develop
## ios | android
<img width="400" alt="Develop" src="https://github.com/user-attachments/assets/b8f78a60-522b-4fa1-bde9-5e051e50ab45" /><img width="400" alt="Develop" src="https://github.com/user-attachments/assets/0fc32d26-2ae3-44dc-8091-872800caf0c1" /> 

# v1.12.0
## ios | android
<img width="400" height="439" alt="v1 12 0" src="https://github.com/user-attachments/assets/7ebeb27a-77d6-4bf8-9b93-29ce3e0e51f4" /><img width="400" height="439" alt="v1 12 0" src="https://github.com/user-attachments/assets/0d02d480-c930-43e2-bfb3-599940e77864" />

# This PR
## ios | android
<img width="400" height="439" alt="v1 12 0" src="https://github.com/user-attachments/assets/d56250ec-2552-44a9-a11d-c644af4af6f6" /><img width="400" height="439" alt="v1 12 0" src="https://github.com/user-attachments/assets/baf4ad21-b488-428e-a811-5ae7defa357d" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted scroll-to-top button positioning and spacing for improved layout on mobile devices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->