### PR TITLE
fix(crossseed): normalize parsed hashes

### DIFF
--- a/internal/services/crossseed/parsing.go
+++ b/internal/services/crossseed/parsing.go
@@ -523,11 +523,11 @@ func ParseTorrentMetadataWithInfo(torrentBytes []byte) (TorrentMetadata, error) 
 	}
 
 	name := infoVal.Name
-	hashV1 := strings.ToUpper(mi.HashInfoBytes().HexString())
+	hashV1 := strings.ToLower(mi.HashInfoBytes().HexString())
 	var hashV2 string
 	if infoVal.HasV2() {
 		h := infohash_v2.HashBytes([]byte(mi.InfoBytes))
-		hashV2 = strings.ToUpper(h.HexString())
+		hashV2 = strings.ToLower(h.HexString())
 	}
 
 	if name == "" {


### PR DESCRIPTION
## Summary
- normalize parsed v1/v2 infohashes to lowercase so qBittorrent hash filters match
- prevent uppercase hashes from breaking GetTorrents hash lookups during alignment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Normalized torrent hash representations to use lowercase formatting for consistent display across the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->