### PR TITLE
Add (puid) and group (pgid) to Unraid installation instructions

### DIFF
--- a/documentation/docs/getting-started/docker.md
+++ b/documentation/docs/getting-started/docker.md
@@ -46,8 +46,9 @@ Our release workflow builds multi-architecture images (`linux/amd64`, `linux/arm
 7. Enable **Advanced View** (top right)
 8. Set **Icon URL** to `https://raw.githubusercontent.com/autobrr/qui/main/web/public/icon.png`
 9. Set **WebUI** to `http://[IP]:[PORT:7476]`
-10. (Optional) add environment variables for advanced settings (e.g., `QUI__BASE_URL`, `QUI__LOG_LEVEL`, `TZ`)
-11. Click **Apply** to pull the image and start the container
+10. Set **Extra Parameters** to `--user="99:100"` (if you ran qui without this before you will need to change the ownership for the config and hardlink folders to `nobody`)
+11. (Optional) add environment variables for advanced settings (e.g., `QUI__BASE_URL`, `QUI__LOG_LEVEL`, `TZ`)
+12. Click **Apply** to pull the image and start the container
 
 The `/config` mount stores `config.toml`, the SQLite database, and logs. Point it at your preferred appdata share so settings persist across upgrades.
 


### PR DESCRIPTION
Add (puid) and group (pgid) to Unraid installation instructions to prevent permission issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Enhanced Unraid deployment guide with new configuration step for setting Extra Parameters to ensure proper user ownership for config and hardlink folders
- Added clarification on container logs location and stdout behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->