### PR TITLE
fix: disable update indicators when update checks are off

### DIFF
--- a/documentation/docs/configuration/environment.md
+++ b/documentation/docs/configuration/environment.md
@@ -45,6 +45,12 @@ QUI__DATA_DIR=...        # Optional: custom data directory (default: next to con
 QUI__TRACKER_ICONS_FETCH_ENABLED=false  # Optional: set to false to disable remote tracker icon fetching (default: true)
 ```
 
+## Updates
+
+```bash
+QUI__CHECK_FOR_UPDATES=false  # Optional: disable update checks and UI indicators (default: true)
+```
+
 ## Metrics
 
 ```bash

--- a/internal/update/service.go
+++ b/internal/update/service.go
@@ -126,4 +126,11 @@ func (s *Service) CheckUpdateAvailable(ctx context.Context) (*version.Release, e
 // SetEnabled toggles whether periodic update checks should run.
 func (s *Service) SetEnabled(enabled bool) {
 	s.isEnabled = enabled
+	if !enabled {
+		s.mu.Lock()
+		s.latestRelease = nil
+		s.lastTag = ""
+		s.lastChecked = time.Time{}
+		s.mu.Unlock()
+	}
 }


### PR DESCRIPTION
### Motivation
- Allow disabling update checks (and the related UI indicator) for environments like distro packages by ensuring cached update state is removed when checks are turned off.

### Description
- When `SetEnabled(false)` is called on `update.Service`, clear cached update state by setting `latestRelease` to `nil`, `lastTag` to `""`, and `lastChecked` to a zero `time.Time` so the UI stops showing an available update.
- Document the `QUI__CHECK_FOR_UPDATES` environment variable in `documentation/docs/configuration/environment.md` to make disabling update checks available via environment configuration.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c644a5f8c83219bf54e47616a206f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added configuration documentation for the environment variable to control automatic update checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->