### PR TITLE
fix(ui): update placeholder text in ArrInstanceForm based on instance type

### DIFF
--- a/web/src/components/settings/ArrInstancesManager.tsx
+++ b/web/src/components/settings/ArrInstancesManager.tsx
@@ -426,7 +426,7 @@ function ArrInstanceForm({ instance, onSubmit, onCancel, isPending }: ArrInstanc
           id="name"
           value={name}
           onChange={(e) => setName(e.target.value)}
-          placeholder="My Sonarr"
+          placeholder={`My ${type === "sonarr" ? "Sonarr" : "Radarr"}`}
           required
         />
       </div>
@@ -437,7 +437,7 @@ function ArrInstanceForm({ instance, onSubmit, onCancel, isPending }: ArrInstanc
           id="baseUrl"
           value={baseUrl}
           onChange={(e) => setBaseUrl(e.target.value)}
-          placeholder="http://localhost:8989"
+          placeholder={`http://localhost:${type === "sonarr" ? "8989" : "7878"}`}
           required
         />
         <p className="text-xs text-muted-foreground">


### PR DESCRIPTION
Tiny starter pr for something thats annoyed me for a while now.
Replaces "My Sonarr" helper text with a variable text depending on selected instance type
Also uses default interface for sonarr and radarr respectively 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Form field placeholders now dynamically update based on the selected instance type, with type-specific names and default port numbers to provide clearer guidance when configuring your instances.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->