### PR TITLE
feat(automations): Add the ability to define the move automation with a templated path

### DIFF
--- a/documentation/docs/features/automations.md
+++ b/documentation/docs/features/automations.md
@@ -241,6 +241,34 @@ Move torrents to a different path on disk. This is needed to move the contents i
 Options:
 - **Skip if cross-seeds don't match the rule's conditions** - Skip the move if the torrent has cross-seeds that don't match the rule's conditions
 
+#### Move path templates
+
+The move path is evaluated as a **Go template** for each torrent. You can use a fixed path (e.g. `/data/archive`) or template actions to build paths from torrent properties.
+
+**Available template variables:**
+
+| Variable | Description |
+|----------|-------------|
+| `.Name` | Torrent display name |
+| `.Hash` | Info hash |
+| `.Category` | qBittorrent category |
+| `.IsolationFolderName` | Filesystem-safe folder name (hash or sanitized name) |
+| `.Tracker` | Tracker display name (when available from instance config) |
+
+**Template function:**
+
+| Function | Description |
+|----------|-------------|
+| `sanitize` | Makes a string safe for use as a path segment (removes invalid characters). Use for user-controlled values like names, e.g. `{{ sanitize .Name }}`. |
+
+**Examples:**
+
+- Fixed path (no template actions): `/data/archive`
+- By category: `/data/{{.Category}}` → e.g. `/data/movies`
+- By name (safe for paths): `/data/{{ sanitize .Name }}`
+- By isolation folder: `/data/{{.IsolationFolderName}}`
+- By tracker: `/data/{{.Tracker}}` (when tracker display name is configured)
+
 ## Cross-Seed Awareness
 
 Automations detect cross-seeded torrents (same content/files) and can handle them specially:

--- a/documentation/docs/features/automations.md
+++ b/documentation/docs/features/automations.md
@@ -253,7 +253,7 @@ The move path is evaluated as a **Go template** for each torrent. You can use a 
 | `.Hash` | Info hash |
 | `.Category` | qBittorrent category |
 | `.IsolationFolderName` | Filesystem-safe folder name (hash or sanitized name) |
-| `.Tracker` | Tracker display name (when available from instance config) |
+| `.Tracker` | Tracker display name (when available from instance config), otherwise the tracker domain |
 
 **Template function:**
 

--- a/internal/services/automations/processor.go
+++ b/internal/services/automations/processor.go
@@ -429,21 +429,6 @@ func inSavePath(torrent qbt.Torrent, savePath string) bool {
 	return normalizePath(torrent.SavePath) == normalizePath(savePath)
 }
 
-// truncate returns the first n characters of a string.
-func truncate(str string, n int) string {
-	// Convert the string to a slice of runes.
-	// This ensures proper handling of multi-byte characters (Unicode).
-	runes := []rune(str)
-
-	// Check if n is greater than or equal to the actual number of characters.
-	if n >= len(runes) {
-		return str
-	}
-
-	// Slice the rune slice and convert it back to a string.
-	return string(runes[:n])
-}
-
 // resolveMovePath returns the path to use for a move. The path is executed as a
 // Go template with data; paths with no template actions are unchanged. sanitize
 // is available in templates for safe path segments (e.g. {{ sanitize .Name }}).

--- a/internal/services/automations/processor.go
+++ b/internal/services/automations/processor.go
@@ -455,7 +455,7 @@ func resolveMovePath(path string, torrent qbt.Torrent, state *torrentDesiredStat
 	}
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, data); err != nil {
-		// Log template parse error for debugging
+		// Log template execution error for debugging
 		log.Error().Err(err).Str("path", path).Msg("failed to execute move path template")
 		return "", false
 	}

--- a/internal/services/automations/processor.go
+++ b/internal/services/automations/processor.go
@@ -441,7 +441,7 @@ func resolveMovePath(path string, torrent qbt.Torrent, state *torrentDesiredStat
 		"IsolationFolderName": pathutil.IsolationFolderName(torrent.Hash, torrent.Name),
 	}
 
-	if displayName, ok := getTrackerDisplayName(state.trackerDomains, evalCtx); ok {
+	if displayName, found := getTrackerDisplayName(state.trackerDomains, evalCtx); found {
 		data["Tracker"] = displayName
 	}
 
@@ -584,7 +584,7 @@ func getTrackerDisplayName(domains []string, evalCtx *EvalContext) (displayName 
 	}
 
 	for _, domain := range domains {
-		if displayName, ok := evalCtx.TrackerDisplayNameByDomain[strings.ToLower(domain)]; ok {
+		if displayName, found := evalCtx.TrackerDisplayNameByDomain[strings.ToLower(domain)]; found {
 			return displayName, true
 		}
 	}

--- a/internal/services/automations/processor.go
+++ b/internal/services/automations/processor.go
@@ -10,6 +10,7 @@ import (
 	"text/template"
 
 	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/rs/zerolog/log"
 
 	"github.com/autobrr/qui/internal/models"
 	"github.com/autobrr/qui/internal/qbittorrent"

--- a/internal/services/automations/processor.go
+++ b/internal/services/automations/processor.go
@@ -448,10 +448,14 @@ func resolveMovePath(path string, torrent qbt.Torrent, state *torrentDesiredStat
 		"sanitize":  pathutil.SanitizePathSegment,
 	}).Parse(path)
 	if err != nil {
+		// Log template parse error for debugging
+		log.Error().Err(err).Str("path", path).Msg("failed to parse move path template")
 		return "", false
 	}
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, data); err != nil {
+		// Log template parse error for debugging
+		log.Error().Err(err).Str("path", path).Msg("failed to execute move path template")
 		return "", false
 	}
 

--- a/internal/services/automations/processor.go
+++ b/internal/services/automations/processor.go
@@ -439,6 +439,7 @@ func resolveMovePath(path string, torrent qbt.Torrent, state *torrentDesiredStat
 		"Hash":                torrent.Hash,
 		"Category":            torrent.Category,
 		"IsolationFolderName": pathutil.IsolationFolderName(torrent.Hash, torrent.Name),
+		"Tracker":             "",
 	}
 
 	if displayName, found := getTrackerDisplayName(state.trackerDomains, evalCtx); found {

--- a/internal/services/automations/processor.go
+++ b/internal/services/automations/processor.go
@@ -573,7 +573,7 @@ func selectTrackerTag(domains []string, useDisplayName bool, evalCtx *EvalContex
 }
 
 // getTrackerDisplayName picks the best tracker display name available.
-func getTrackerDisplayName(domains []string, evalCtx *EvalContext) string, bool {
+func getTrackerDisplayName(domains []string, evalCtx *EvalContext) (displayName string, ok bool) {
 	if evalCtx == nil {
 		return "", false
 	}

--- a/internal/services/automations/processor.go
+++ b/internal/services/automations/processor.go
@@ -442,13 +442,18 @@ func resolveMovePath(path string, torrent qbt.Torrent, state *torrentDesiredStat
 		"Tracker":             "",
 	}
 
-	if displayName, found := getTrackerDisplayName(state.trackerDomains, evalCtx); found {
-		data["Tracker"] = displayName
+	if state != nil {
+		if displayName, found := getTrackerDisplayName(state.trackerDomains, evalCtx); found {
+			data["Tracker"] = displayName
+		}
 	}
 
-	tmpl, err := template.New("movePath").Funcs(template.FuncMap{
-		"sanitize":  pathutil.SanitizePathSegment,
-	}).Parse(path)
+	tmpl, err := template.New("movePath").
+		Option("missingkey=error").
+		Funcs(template.FuncMap{
+			"sanitize": pathutil.SanitizePathSegment,
+		}).
+		Parse(path)
 	if err != nil {
 		// Log template parse error for debugging
 		log.Error().Err(err).Str("path", path).Msg("failed to parse move path template")
@@ -589,7 +594,7 @@ func getTrackerDisplayName(domains []string, evalCtx *EvalContext) (displayName 
 			return displayName, true
 		}
 	}
-	
+
 	return "", false
 }
 

--- a/internal/services/automations/processor_test.go
+++ b/internal/services/automations/processor_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/autobrr/qui/internal/models"
 	"github.com/autobrr/qui/internal/qbittorrent"
+	"github.com/autobrr/qui/pkg/pathutil"
 )
 
 func TestProcessTorrents_CategoryBlockedByCrossSeedCategory(t *testing.T) {
@@ -446,7 +447,8 @@ func TestResolveMovePath_TemplateWithSanitize(t *testing.T) {
 	}
 	resolved, ok := resolveMovePath("/data/{{ sanitize .Name }}", torrent, nil, nil)
 	require.True(t, ok)
-	require.Equal(t, "/data/" + pathutil.SanitizePathSegment(data["Name"]), resolved)
+	expectedName := pathutil.SanitizePathSegment(torrent.Name)
+	require.Equal(t, "/data/"+expectedName, resolved)
 }
 
 func TestMoveAction_WithTemplatePath(t *testing.T) {

--- a/internal/services/automations/processor_test.go
+++ b/internal/services/automations/processor_test.go
@@ -451,6 +451,20 @@ func TestResolveMovePath_TemplateWithSanitize(t *testing.T) {
 	require.Equal(t, "/data/"+expectedName, resolved)
 }
 
+func TestResolveMovePath_TrackerFallback(t *testing.T) {
+	torrent := qbt.Torrent{
+		Hash:     "abc",
+		Name:     "Show.S01",
+		Category: "tv",
+	}
+	state := &torrentDesiredState{
+		trackerDomains: []string{"tracker.example.com"},
+	}
+	resolved, ok := resolveMovePath("/data/{{.Tracker}}", torrent, state, nil)
+	require.True(t, ok)
+	require.Equal(t, "/data/tracker.example.com", resolved)
+}
+
 func TestMoveAction_WithTemplatePath(t *testing.T) {
 	sm := qbittorrent.NewSyncManager(nil, nil)
 	torrent := qbt.Torrent{

--- a/internal/services/automations/processor_test.go
+++ b/internal/services/automations/processor_test.go
@@ -419,9 +419,9 @@ func TestMoveWithConditionAndCrossSeedBlock(t *testing.T) {
 
 func TestResolveMovePath_Literal(t *testing.T) {
 	torrent := qbt.Torrent{
-		Hash:        "abc",
-		Name:        "Show.S01",
-		Category:    "tv",
+		Hash:     "abc",
+		Name:     "Show.S01",
+		Category: "tv",
 	}
 	resolved, ok := resolveMovePath("/data/archive", torrent, nil, nil)
 	require.True(t, ok)
@@ -430,9 +430,9 @@ func TestResolveMovePath_Literal(t *testing.T) {
 
 func TestResolveMovePath_Template(t *testing.T) {
 	torrent := qbt.Torrent{
-		Hash:        "abc",
-		Name:        "Movie.2024",
-		Category:    "movies",
+		Hash:     "abc",
+		Name:     "Movie.2024",
+		Category: "movies",
 	}
 	resolved, ok := resolveMovePath("/data/{{.Category}}", torrent, nil, nil)
 	require.True(t, ok)
@@ -441,9 +441,9 @@ func TestResolveMovePath_Template(t *testing.T) {
 
 func TestResolveMovePath_TemplateWithSanitize(t *testing.T) {
 	torrent := qbt.Torrent{
-		Hash:        "abc",
-		Name:        "Movie/2024:Bad*Name",
-		Category:    "movies",
+		Hash:     "abc",
+		Name:     "Movie/2024:Bad*Name",
+		Category: "movies",
 	}
 	resolved, ok := resolveMovePath("/data/{{ sanitize .Name }}", torrent, nil, nil)
 	require.True(t, ok)
@@ -458,14 +458,14 @@ func TestMoveAction_WithTemplatePath(t *testing.T) {
 		Name:        "Show.S01",
 		Category:    "tv",
 		SavePath:    "/incoming",
-		ContentPath:  "/incoming/Show.S01",
+		ContentPath: "/incoming/Show.S01",
 	}
 	rules := []*models.Automation{{
-		ID:              1,
-		Name:            "move-by-category",
-		Enabled:         true,
-		TrackerPattern:  "*",
-		Conditions:      &models.ActionConditions{Move: &models.MoveAction{Enabled: true, Path: "/archive/{{.Category}}"}},
+		ID:             1,
+		Name:           "move-by-category",
+		Enabled:        true,
+		TrackerPattern: "*",
+		Conditions:     &models.ActionConditions{Move: &models.MoveAction{Enabled: true, Path: "/archive/{{.Category}}"}},
 	}}
 	states := processTorrents([]qbt.Torrent{torrent}, rules, nil, sm, nil, nil)
 	state, ok := states["abc"]

--- a/internal/services/automations/processor_test.go
+++ b/internal/services/automations/processor_test.go
@@ -417,22 +417,34 @@ func TestMoveWithConditionAndCrossSeedBlock(t *testing.T) {
 }
 
 func TestResolveMovePath_Literal(t *testing.T) {
-	data := map[string]any{"Name": "Movie.2024", "Category": "movies"}
-	resolved, ok := resolveMovePath("/data/archive", data)
+	torrent := qbt.Torrent{
+		Hash:        "abc",
+		Name:        "Show.S01",
+		Category:    "tv",
+	}
+	resolved, ok := resolveMovePath("/data/archive", torrent, nil, nil)
 	require.True(t, ok)
 	require.Equal(t, "/data/archive", resolved)
 }
 
 func TestResolveMovePath_Template(t *testing.T) {
-	data := map[string]any{"Name": "Movie.2024", "Category": "movies"}
-	resolved, ok := resolveMovePath("/data/{{.Category}}", data)
+	torrent := qbt.Torrent{
+		Hash:        "abc",
+		Name:        "Movie.2024",
+		Category:    "movies",
+	}
+	resolved, ok := resolveMovePath("/data/{{.Category}}", torrent, nil, nil)
 	require.True(t, ok)
 	require.Equal(t, "/data/movies", resolved)
 }
 
 func TestResolveMovePath_TemplateWithSanitize(t *testing.T) {
-	data := map[string]any{"Name": "Movie/2024:Bad*Name"}
-	resolved, ok := resolveMovePath("/data/{{ sanitize .Name }}", data)
+	torrent := qbt.Torrent{
+		Hash:        "abc",
+		Name:        "Movie/2024:Bad*Name",
+		Category:    "movies",
+	}
+	resolved, ok := resolveMovePath("/data/{{ sanitize .Name }}", torrent, nil, nil)
 	require.True(t, ok)
 	require.Equal(t, "/data/" + pathutil.SanitizePathSegment(data["Name"]), resolved)
 }


### PR DESCRIPTION
Allows to use "templated paths" when using the move action.

For example the move automation with the path `/data/{{.Category}}` for a torrent with the category `movies` will use the path `/data/movies`.

This adds a few functions out of the box:

- `.Name`: Name of the torrent
- `.Hash`: Hash of the torrent
- `.Category`: Current category of the torrent
- `.IsolationFolderName`: Folder name used by qui to ensure isolation between torrents
- `.Tracker`: DisplayName of the tracker in use
- `sanitize`: function that removes special characters you might not want in a path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Move actions can use templated destination paths using torrent metadata and optional tracker display names; templates are rendered, trimmed, validated, and path segments sanitized. Resolved paths are used for destination checks and state updates.

* **Refactor**
  * Tracker display-name lookup consolidated behind a helper and integrated into move/tag logic.

* **Tests**
  * Added tests covering path templating, sanitization, tracker display-name handling, and resolved move behavior.

* **Documentation**
  * Added guidance and examples for configuring move path templates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->