### PR TITLE
fix(web): harden SSO fetch detection for Firefox

### DIFF
--- a/documentation/docs/advanced/sso-proxy-cors.md
+++ b/documentation/docs/advanced/sso-proxy-cors.md
@@ -1,0 +1,21 @@
+---
+sidebar_position: 50
+title: SSO Proxies and CORS
+---
+
+# SSO Proxies and CORS
+
+When qui is behind an SSO proxy (Cloudflare Access, Pangolin, etc.), expired sessions can redirect API `fetch()` calls to the proxy's auth origin. Browsers block cross-origin redirects unless the **proxy** sends CORS headers, so you may see errors like "CORS request did not succeed" or "NetworkError". In normal same-origin setups, qui does not need any CORS configuration.
+
+## What qui does
+
+- Detects likely SSO/CORS failures on `/api/*` requests.
+- Performs a single top-level navigation so the SSO login can complete.
+
+## What you must configure
+
+- Keep the auth flow same-origin if possible.
+- Configure CORS **on the SSO proxy** (not in qui) for the auth endpoints.
+- Allow credentials and handle `OPTIONS` preflight when required.
+
+If you still hit CORS errors after proxy configuration, capture the browser console error and open an issue.

--- a/documentation/docs/configuration/oidc.md
+++ b/documentation/docs/configuration/oidc.md
@@ -30,6 +30,8 @@ When reverse proxying, include your base URL:
 https://host/qui/api/auth/oidc/callback
 ```
 
+If you run OIDC behind an SSO proxy (Cloudflare Access, Pangolin, etc.), review [SSO proxies and CORS](../advanced/sso-proxy-cors) for browser fetch behavior and proxy-side configuration.
+
 ## Example Configuration
 
 ```bash

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -299,11 +299,12 @@ function attemptSSORecoveryNavigation(options?: { bypassGuard?: boolean; target?
   }
   sessionStorage.setItem(SSO_RECOVERY_GUARD_KEY, "1")
   const target = options?.target ?? withBasePath("/")
-  if (window.location.href === target) {
+  const targetUrl = new URL(target, window.location.origin)
+  if (window.location.href === targetUrl.href) {
     window.location.reload()
     return
   }
-  window.location.assign(target)
+  window.location.assign(targetUrl.href)
 }
 
 /** Clear the SSO recovery guard after a successful request. */


### PR DESCRIPTION
Fixes #1105

When running behind SSO proxies (Pangolin, Cloudflare Access), Firefox can throw `DOMException` with `name: NetworkError` instead of `TypeError` when fetch fails due to CORS-blocked redirects. The existing detection only matched `TypeError` with specific English messages, missing Firefox's error patterns.

**Changes:**
- Broaden `isSSONetworkError()` to catch `DOMException` and locale-agnostic error strings
- Add `isLikelySSOHTMLResponse()` async helper that sniffs HTML when content-type is missing (with size guards to avoid reading large/binary responses)
- Hard-navigate to base path on `/api/*` fetch rejections so SSO proxies can complete top-level auth
- Bypass the recovery guard for `/api/auth/login` to avoid getting stuck after session expiry

**Testing:**
- `make test` passes
- `make lint` skipped Go (no Go changes)
- Frontend lint has pre-existing failures unrelated to this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Recovery now uses top-level navigation (instead of forcing a full reload) when SSO/session expiry is detected, preserving user context.
  * Broader detection of network/CORS/DOM network errors to trigger recovery more reliably.
  * Improved heuristics to distinguish HTML SSO responses from API errors, reducing false-positive interruptions.
  * Recovery guard state is cleared appropriately after successful requests.

* **Documentation**
  * New guidance on SSO proxy and CORS interactions for browser fetches and an OIDC redirect-note advising proxy-side configuration.

* **Chores**
  * Minor wording and comment updates; no public API signature changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
