### PR TITLE
Format IPv6 address for display in PeersTable

### DIFF
--- a/web/src/components/torrents/details/PeersTable.tsx
+++ b/web/src/components/torrents/details/PeersTable.tsx
@@ -202,7 +202,7 @@ export const PeersTable = memo(function PeersTable({
 
   const handleCopyIp = (peer: SortedPeer) => {
     if (incognitoMode) return
-    copyTextToClipboard(`${peer.ip}:${peer.port}`)
+    copyTextToClipboard(`${peer.ip}`)
     toast.success("IP address copied to clipboard")
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * IPv6 addresses in the peers table are now shown with square brackets for correct formatting; IPv4 unchanged.  
  * Copy-to-clipboard now copies only the IP (not IP:port) in non-incognito mode; copying remains disabled in incognito.  
  * Port visibility unchanged: shown in non-incognito, hidden in incognito.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->