### PR TITLE
fix(peers): format IPv6 display and copy IP only

### DIFF
--- a/web/src/components/torrents/details/PeersTable.tsx
+++ b/web/src/components/torrents/details/PeersTable.tsx
@@ -202,7 +202,7 @@ export const PeersTable = memo(function PeersTable({
 
   const handleCopyIp = (peer: SortedPeer) => {
     if (incognitoMode) return
-    copyTextToClipboard(`${peer.ip}:${peer.port}`)
+    copyTextToClipboard(`${peer.ip}`)
     toast.success("IP address copied to clipboard")
   }
 


### PR DESCRIPTION
fix handle copy ip address

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * IPv6 addresses in the peers table now display properly with brackets.
  * Copying an IP address now copies only the IP, excluding the port information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->