### PR TITLE
fix(web): use absolute for scroll-to-top on desktop

### DIFF
--- a/web/src/components/ui/scroll-to-top-button.tsx
+++ b/web/src/components/ui/scroll-to-top-button.tsx
@@ -59,7 +59,7 @@ export function ScrollToTopButton({
       variant="outline"
       size="icon"
       className={cn(
-        "fixed z-10 shadow-lg bg-background/80 backdrop-blur-sm transition-all duration-200",
+        "fixed lg:absolute z-10 shadow-lg bg-background/80 backdrop-blur-sm transition-all duration-200",
         isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2 pointer-events-none",
         className
       )}


### PR DESCRIPTION
use absolute on desktop to reposition when the torrent panel is visible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated scroll-to-top button positioning behavior to improve layout compatibility on large screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->