### PR TITLE
feat(web): qBittorrent autorun preferences

### DIFF
--- a/web/src/components/instances/preferences/FileManagementForm.tsx
+++ b/web/src/components/instances/preferences/FileManagementForm.tsx
@@ -193,9 +193,9 @@ export function FileManagementForm({ instanceId, onSuccess }: FileManagementForm
       form.setFieldValue("temp_path_enabled", preferences.temp_path_enabled)
       form.setFieldValue("temp_path", preferences.temp_path)
       form.setFieldValue("torrent_content_layout", preferences.torrent_content_layout ?? "Original")
-      form.setFieldValue("autorun_on_torrent_added_enabled", preferences.autorun_on_torrent_added_enabled)
+      form.setFieldValue("autorun_on_torrent_added_enabled", preferences.autorun_on_torrent_added_enabled ?? false)
       form.setFieldValue("autorun_on_torrent_added_program", preferences.autorun_on_torrent_added_program ?? "")
-      form.setFieldValue("autorun_enabled", preferences.autorun_enabled)
+      form.setFieldValue("autorun_enabled", preferences.autorun_enabled ?? false)
       form.setFieldValue("autorun_program", preferences.autorun_program ?? "")
     }
   }, [preferences, form, supportsSubcategories])


### PR DESCRIPTION
Expose qBittorrent "Run external program" preferences in Instance Settings (finished + added, gated by WebAPI >= 2.8.18).

<img width="2226" height="1302" alt="CleanShot 2026-02-08 at 20 17 12@2x" src="https://github.com/user-attachments/assets/2ddd5576-c60b-4c3b-9c78-8df81f1f832a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Run External Program: Configure automatic execution of external scripts when torrents finish or are added, with version-aware controls and clear compatibility messaging.
  * Improved UI: New grouped controls and placeholders to guide command entry for both "on finished" and "on added" flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->