### PR TITLE
fix(web): handle SSO session expiry behind Cloudflare Access and other proxies

### DIFF
--- a/documentation/docs/advanced/sso-proxy-cors.md
+++ b/documentation/docs/advanced/sso-proxy-cors.md
@@ -1,0 +1,21 @@
+---
+sidebar_position: 50
+title: SSO Proxies and CORS
+---
+
+# SSO Proxies and CORS
+
+When qui is behind an SSO proxy (Cloudflare Access, Pangolin, etc.), expired sessions can redirect API `fetch()` calls to the proxy's auth origin. Browsers block cross-origin redirects unless the **proxy** sends CORS headers, so you may see errors like "CORS request did not succeed" or "NetworkError". In normal same-origin setups, qui does not need any CORS configuration.
+
+## What qui does
+
+- Detects likely SSO/CORS failures on `/api/*` requests.
+- Performs a single top-level navigation so the SSO login can complete.
+
+## What you must configure
+
+- Keep the auth flow same-origin if possible.
+- Configure CORS **on the SSO proxy** (not in qui) for the auth endpoints.
+- Allow credentials and handle `OPTIONS` preflight when required.
+
+If you still hit CORS errors after proxy configuration, capture the browser console error and open an issue.

--- a/documentation/docs/configuration/oidc.md
+++ b/documentation/docs/configuration/oidc.md
@@ -30,6 +30,8 @@ When reverse proxying, include your base URL:
 https://host/qui/api/auth/oidc/callback
 ```
 
+If you run OIDC behind an SSO proxy (Cloudflare Access, Pangolin, etc.), review [SSO proxies and CORS](../advanced/sso-proxy-cors) for browser fetch behavior and proxy-side configuration.
+
 ## Example Configuration
 
 ```bash

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -299,11 +299,12 @@ function attemptSSORecoveryNavigation(options?: { bypassGuard?: boolean; target?
   }
   sessionStorage.setItem(SSO_RECOVERY_GUARD_KEY, "1")
   const target = options?.target ?? withBasePath("/")
-  if (window.location.href === target) {
+  const targetUrl = new URL(target, window.location.origin)
+  if (window.location.href === targetUrl.href) {
     window.location.reload()
     return
   }
-  window.location.assign(target)
+  window.location.assign(targetUrl.href)
 }
 
 /** Clear the SSO recovery guard after a successful request. */

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -45,6 +45,13 @@ export function Login() {
   })
 
   useEffect(() => {
+    if (sessionStorage.getItem("qui_sso_recovered")) {
+      sessionStorage.removeItem("qui_sso_recovered")
+      toast.info("SSO session refreshed. Please sign in again.")
+    }
+  }, [])
+
+  useEffect(() => {
     // Redirect to homepage if user is already authenticated
     if (isAuthenticated && !isLoading) {
       navigate({ to: "/dashboard" })

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -47,8 +47,10 @@ export default defineConfig(() => ({
         // VitePWA defaults to 2 MiB; our main bundle can exceed that, which breaks CI builds.
         maximumFileSizeToCacheInBytes: 3 * 1024 * 1024,
         sourcemap: true,
-        // Avoid serving the SPA shell for backend proxy routes (also under custom base URLs)
-        navigateFallbackDenylist: [/\/api(?:\/|$)/, /\/proxy(?:\/|$)/],
+        // Avoid serving the SPA shell for backend proxy routes and SSO callback paths
+        // (also under custom base URLs). /cdn-cgi/ is used by Cloudflare Access for its
+        // auth callback (/cdn-cgi/access/authorized); intercepting it breaks the SSO flow.
+        navigateFallbackDenylist: [/\/api(?:\/|$)/, /\/proxy(?:\/|$)/, /\/cdn-cgi(?:\/|$)/, /\/\.well-known(?:\/|$)/],
         // Some deployments sit behind Basic Auth; skip assets that tend to 401 (e.g. manifest, source maps)
         manifestTransforms: [
           async (entries) => {


### PR DESCRIPTION
Builds on #1380

## Summary

Testing PR #1380 behind a Cloudflare Access tunnel (`qui2.nitrobass24.com`) confirmed the Firefox network error detection works, but revealed additional issues specifically when Cloudflare Access returns `401` responses with `Content-Type: text/html` instead of blocking at the network level. This required several incremental fixes:

### 1. HTML response recovery for login requests
Extended `ssoSafeFetch` to also trigger SSO recovery on HTML responses (not just network errors), with `bypassGuard` for `/api/auth/login` so the first login attempt always triggers recovery instead of being blocked by a stale guard.

### 2. Timestamp-based guard cooldown
The `sessionStorage` recovery guard persisted across page loads, blocking recovery after SSO re-authentication completed. Added a 10-second timestamp cooldown that auto-clears the guard on fresh page loads while still preventing rapid navigation loops.

### 3. Service worker cache clearing
The PWA service worker serves the cached SPA shell for navigation requests, bypassing the SSO proxy entirely. Before recovery navigation, all SW caches are now cleared so the request falls through to the network. (Unregistering the SW entirely was tried but broke Cloudflare Access's auth flow.)

### 4. Service worker navigateFallbackDenylist
The root cause of the final issue: Cloudflare Access redirects to `/cdn-cgi/access/authorized?nonce=...` after authentication, but the SW intercepted this path and failed with `FetchEvent.respondWith received an error: TypeError: Load failed`. Added `/cdn-cgi/` and `/.well-known/` to the denylist so SSO callback paths bypass the service worker.

### 5. SSO recovery toast
With stacked auth (SSO + app login), the first login attempt is consumed by SSO re-authentication. A toast ("SSO session refreshed. Please sign in again.") now appears on the login page after recovery so users understand why they need to enter credentials again.

## Test plan
- [x] Tested end-to-end behind Cloudflare Access tunnel with expired sessions in Safari
- [ ] Verify behavior with Pangolin SSO proxy
- [ ] Verify no regression for non-SSO deployments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on SSO proxy and CORS configuration for API requests
  * Added OIDC configuration recommendations for SSO proxy environments

* **Bug Fixes**
  * Enhanced authentication error detection and recovery mechanisms
  * Improved handling of network and CORS failures during login flows

* **New Features**
  * Added user notification when SSO session recovery completes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->