### PR TITLE
fix(automations): respect remove-only tag conditions

### DIFF
--- a/internal/models/automation.go
+++ b/internal/models/automation.go
@@ -29,7 +29,7 @@ const (
 const (
 	TagModeFull   = "full"   // Add to matches, remove from non-matches
 	TagModeAdd    = "add"    // Only add to matches
-	TagModeRemove = "remove" // Only remove from non-matches
+	TagModeRemove = "remove" // Only remove from matches
 )
 
 // FreeSpaceSourceType defines the source for free space checks in workflows.


### PR DESCRIPTION
Fix tag action mode "remove" to remove tags when the condition matches (not when it fails).

Repro from discussion: https://github.com/autobrr/qui/discussions/1377

Adds regression test covering `Private EQUALS false` + `Remove only` behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected conditional tag removal behavior to properly match intended outcomes

* **Improvements**
  * Refactored automation tag handling with explicit mode switching for Add, Remove, and Default operations

* **Documentation**
  * Updated tag mode descriptions for accuracy

* **Tests**
  * Added test coverage for tag removal under specific conditions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->