### PR TITLE
fix(crossseed): tighten TV title matching

### DIFF
--- a/internal/services/crossseed/matching_title_test.go
+++ b/internal/services/crossseed/matching_title_test.go
@@ -313,3 +313,20 @@ func TestReleasesMatch_PunctuationVariations(t *testing.T) {
 		})
 	}
 }
+
+func TestReleasesMatch_TVTitleMustNotUseSubstringMatching(t *testing.T) {
+	s := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
+
+	// Regression: different shows that share a common prefix should not match.
+	// Example: "FBI" vs "FBI Most Wanted".
+	fbi := rls.ParseString("FBI.S03.720p.AMZN.WEB-DL.DDP5.1.H.264-NTb")
+	fbiMostWanted := rls.ParseString("FBI.Most.Wanted.S03.720p.AMZN.WEB-DL.DDP5.1.H.264-NTb")
+	require.False(t, s.releasesMatch(&fbi, &fbiMostWanted, false))
+	require.False(t, s.releasesMatch(&fbiMostWanted, &fbi, false), "match should be symmetric")
+
+	// Another common case: main series vs spinoff where the spinoff embeds the parent title.
+	sao := rls.ParseString("Sword.Art.Online.S01.1080p.BluRay.REMUX.AVC.Dual-Audio.FLAC.2.0-NAN0")
+	ggo := rls.ParseString("Sword.Art.Online.Alternative.Gun.Gale.Online.S01.1080p.BluRay.REMUX.AVC.Dual-Audio.FLAC.2.0-NAN0")
+	require.False(t, s.releasesMatch(&sao, &ggo, false))
+	require.False(t, s.releasesMatch(&ggo, &sao, false), "match should be symmetric")
+}


### PR DESCRIPTION
Fix cross-seed local matching false-positives between related TV titles (e.g. 'FBI' vs 'FBI Most Wanted') by removing substring-based title matching and requiring exact normalized title equality. Adds regression test covering FBI + SAO spinoff cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced title matching logic to enforce exact matches after normalization
  * Reduces false positive matches between content with similar titles across all content types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->