### PR TITLE
feat(web): add torrent table selection quick wins

### DIFF
--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -1901,7 +1901,7 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
   useEffect(() => {
     const handleDeleteHotkey = (event: KeyboardEvent) => {
       const isDeleteKey = event.key === "Delete"
-      const isBackspaceDelete = event.key === "Backspace" && !event.metaKey && !event.ctrlKey && !event.altKey
+      const isBackspaceDelete = isMac && event.key === "Backspace" && !event.metaKey && !event.ctrlKey && !event.altKey
 
       // Mac keyboards commonly emit Backspace for the key labeled Delete.
       if (!isDeleteKey && !isBackspaceDelete) {
@@ -1939,6 +1939,7 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
     }
   }, [
     effectiveSelectionCount,
+    isMac,
     isPending,
     prepareDeleteAction,
     selectedHashes,


### PR DESCRIPTION
## Summary
- add Delete/Backspace shortcut to open delete dialog for selected torrents
- clear selection when clicking empty table space
- re-click selected row now clears row selection and closes details panel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Delete/Backspace hotkey to open the delete dialog for the current selection, with safeguards to avoid triggering in input contexts or when deletion is pending.
  * Clicking empty table space clears the current selection.
  * Re-clicking a selected row toggles selection/details appropriately, with distinct behavior when "select all" is active.
  * Consistent selection and interaction behavior across compact and normal table views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->