### PR TITLE
fix: normalize DD+ and DDP file keys

### DIFF
--- a/internal/services/crossseed/align.go
+++ b/internal/services/crossseed/align.go
@@ -496,11 +496,16 @@ func normalizeFileKey(path string) string {
 
 	// Normalize Unicode characters (Shōgun → Shogun, etc.)
 	base = stringutils.NormalizeUnicode(base)
+	base = strings.ToLower(base)
+
+	// Dolby Digital Plus commonly appears as either DDP or DD+ depending on indexer naming.
+	// Normalize to the same token so equivalent files match by key.
+	base = strings.ReplaceAll(base, "dd+", "ddp")
 
 	var b strings.Builder
 	for _, r := range base {
 		if unicode.IsLetter(r) || unicode.IsDigit(r) {
-			b.WriteRune(unicode.ToLower(r))
+			b.WriteRune(r)
 		}
 	}
 

--- a/internal/services/crossseed/align_test.go
+++ b/internal/services/crossseed/align_test.go
@@ -651,6 +651,13 @@ func TestNormalizeFileKey_UnicodeMatching(t *testing.T) {
 	}
 }
 
+func TestNormalizeFileKey_AudioAliasMatching(t *testing.T) {
+	// DD+ and DDP represent the same Dolby Digital Plus codec and should normalize the same.
+	normDDPlus := normalizeFileKey("Example.Show.S03.720p.AMZN.WEB-DL.DD+5.1.H.264-GRP.mkv")
+	normDDP := normalizeFileKey("Example.Show.S03.720p.AMZN.WEB-DL.DDP5.1.H.264-GRP.mkv")
+	require.Equal(t, normDDP, normDDPlus)
+}
+
 func TestHasContentFileSizeMismatch(t *testing.T) {
 	normalizer := stringutils.NewDefaultNormalizer()
 


### PR DESCRIPTION
Normalize file-key generation to treat Dolby Digital Plus aliases (DD+ and DDP) as equivalent.

Fixes false mismatches that caused valid cross-seed candidates to be skipped/recheck-gated when tracker naming differed.