### PR TITLE
feat(web): add logs nav

### DIFF
--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -39,7 +39,7 @@ import { cn } from "@/lib/utils"
 import type { InstanceCapabilities } from "@/types"
 import { useQuery } from "@tanstack/react-query"
 import { Link, useNavigate, useSearch } from "@tanstack/react-router"
-import { Archive, ChevronsUpDown, Cog, Download, FileEdit, FunnelPlus, FunnelX, GitBranch, HardDrive, Home, Info, ListTodo, Loader2, LogOut, Menu, Plus, Rss, Search, SearchCode, Server, Settings, X, Zap } from "lucide-react"
+import { Archive, ChevronsUpDown, Cog, Download, FileEdit, FileText, FunnelPlus, FunnelX, GitBranch, HardDrive, Home, Info, ListTodo, Loader2, LogOut, Menu, Plus, Rss, Search, SearchCode, Server, Settings, X, Zap } from "lucide-react"
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useHotkeys } from "react-hotkeys-hook"
 
@@ -582,6 +582,16 @@ export function Header({
                 >
                   <Server className="mr-2 h-4 w-4" />
                   Instances
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <Link
+                  to="/settings"
+                  search={{ tab: "logs" }}
+                  className="flex cursor-pointer"
+                >
+                  <FileText className="mr-2 h-4 w-4" />
+                  Logs
                 </Link>
               </DropdownMenuItem>
               {activeInstances.length > 0 && (

--- a/web/src/components/layout/MobileFooterNav.tsx
+++ b/web/src/components/layout/MobileFooterNav.tsx
@@ -46,6 +46,7 @@ import {
   Copyright,
   CornerDownRight,
   Download,
+  FileText,
   GitBranch,
   Github,
   HardDrive,
@@ -450,6 +451,16 @@ export function MobileFooterNav() {
               >
                 <Server className="h-4 w-4" />
                 Manage Instances
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link
+                to="/settings"
+                search={{ tab: "logs" }}
+                className="flex items-center gap-2"
+              >
+                <FileText className="h-4 w-4" />
+                Logs
               </Link>
             </DropdownMenuItem>
             <DropdownMenuItem onClick={() => setShowThemeDialog(true)}>

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -17,10 +17,11 @@ import { api } from "@/lib/api"
 import { getAppVersion } from "@/lib/build-info"
 import { cn } from "@/lib/utils"
 import { useQuery } from "@tanstack/react-query"
-import { Link, useLocation } from "@tanstack/react-router"
+import { Link, useLocation, useSearch } from "@tanstack/react-router"
 import {
   Archive,
   Copyright,
+  FileText,
   GitBranch,
   Github,
   HardDrive,
@@ -35,53 +36,73 @@ import {
 } from "lucide-react"
 
 interface NavItem {
+  id: string
   title: string
   href: string
   icon: React.ComponentType<{ className?: string }>
   params?: Record<string, string>
+  search?: Record<string, unknown>
+  isActive?: (pathname: string, search: Record<string, unknown> | undefined) => boolean
 }
 
 const navigation: NavItem[] = [
   {
+    id: "dashboard",
     title: "Dashboard",
     href: "/dashboard",
     icon: Home,
   },
   {
+    id: "search",
     title: "Search",
     href: "/search",
     icon: Search,
   },
   {
+    id: "cross-seed",
     title: "Cross-Seed",
     href: "/cross-seed",
     icon: GitBranch,
     params: {},
   },
   {
+    id: "automations",
     title: "Automations",
     href: "/automations",
     icon: Zap,
   },
   {
+    id: "backups",
     title: "Backups",
     href: "/backups",
     icon: Archive,
   },
   {
+    id: "rss",
     title: "RSS",
     href: "/rss",
     icon: Rss,
   },
   {
+    id: "settings",
     title: "Settings",
     href: "/settings",
     icon: Settings,
+    isActive: (pathname, search) => pathname === "/settings" && search?.tab !== "logs",
+  },
+  {
+    id: "logs",
+    title: "Logs",
+    href: "/settings",
+    icon: FileText,
+    search: { tab: "logs" },
+    isActive: (pathname, search) => pathname === "/settings" && search?.tab === "logs",
   },
 ]
 
 export function Sidebar() {
   const location = useLocation()
+  const routeSearch = useSearch({ strict: false }) as Record<string, unknown> | undefined
   const { logout } = useAuth()
   const { theme } = useTheme()
 
@@ -115,13 +136,16 @@ export function Sidebar() {
         <div className="space-y-1">
           {navigation.map((item) => {
             const Icon = item.icon
-            const isActive = location.pathname === item.href
+            const isActive = item.isActive
+              ? item.isActive(location.pathname, routeSearch)
+              : location.pathname === item.href
 
             return (
               <Link
-                key={item.href}
+                key={item.id}
                 to={item.href}
                 params={item.params}
+                search={item.search}
                 className={cn(
                   "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-all duration-200 ease-out",
                   isActive? "bg-sidebar-primary text-sidebar-primary-foreground": "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"


### PR DESCRIPTION
Add Logs link to sidebar, header menu, and mobile settings dropdown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Logs" menu item to the settings navigation across the header, sidebar, and mobile footer. Users can now easily access their logs from these navigation areas, routing directly to the Logs tab in Settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->