### PR TITLE
docs: clarify autobrr filter + apply troubleshooting

### DIFF
--- a/documentation/docs/features/cross-seed/autobrr.md
+++ b/documentation/docs/features/cross-seed/autobrr.md
@@ -29,19 +29,36 @@ qui integrates with autobrr through webhook endpoints, enabling real-time cross-
 
 ### 2. Configure autobrr External Filter
 
-In your autobrr filter, go to **External** tab → **Add new**:
+:::important
+Create a **new autobrr filter dedicated to qui**.
+:::
 
-| Field | Value |
-|-------|-------|
-| Type | `Webhook` |
-| Name | `qui` |
-| On Error | `Reject` |
-| Endpoint | `http://localhost:7476/api/cross-seed/webhook/check` |
-| HTTP Method | `POST` |
-| HTTP Request Headers | `X-API-Key=YOUR_QUI_API_KEY` |
-| Expected HTTP Status Code | `200` |
+:::note
+The **External** webhook (`/api/cross-seed/webhook/check`) only answers: "is this ready to cross-seed?" It does **not** add a torrent to qBittorrent.
+
+You must also set up the **Action** in [Apply Endpoint](#apply-endpoint).
+:::
+
+:::tip
+**Docker Compose:** if autobrr and qui are both containers, `localhost` inside autobrr is the autobrr container, not qui.
+
+Use your qui container hostname instead (often the Compose service name), for example: `http://qui:7476/api/cross-seed/webhook/check`.
+:::
+
+In your new autobrr filter, go to **External** tab → **Add new**:
+
+| Field                     | Value                                                |
+| ------------------------- | ---------------------------------------------------- |
+| Type                      | `Webhook`                                            |
+| Name                      | `qui`                                                |
+| On Error                  | `Reject`                                             |
+| Endpoint                  | `http://localhost:7476/api/cross-seed/webhook/check` |
+| HTTP Method               | `POST`                                               |
+| HTTP Request Headers      | `X-API-Key=YOUR_QUI_API_KEY`                         |
+| Expected HTTP Status Code | `200`                                                |
 
 **Data (JSON):**
+
 ```json
 {
   "torrentName": {{ toRawJson .TorrentName }},
@@ -50,6 +67,7 @@ In your autobrr filter, go to **External** tab → **Add new**:
 ```
 
 To search all instances, omit `instanceIds`:
+
 ```json
 {
   "torrentName": {{ toRawJson .TorrentName }}
@@ -57,6 +75,7 @@ To search all instances, omit `instanceIds`:
 ```
 
 **Field descriptions:**
+
 - `torrentName` (required): The release name as announced
 - `instanceIds` (optional): qBittorrent instance IDs to scan. Omit to search all instances.
 - `findIndividualEpisodes` (optional): Override the global episode matching setting
@@ -75,13 +94,14 @@ When `/check` returns `200 OK`, send the torrent to `/api/cross-seed/apply`:
 
 **Action setup in autobrr:**
 
-| Field | Value |
-|-------|-------|
-| Action Type | `Webhook` |
-| Name | `qui cross-seed` |
-| Endpoint | `http://localhost:7476/api/cross-seed/apply?apikey=YOUR_QUI_API_KEY` |
+| Field       | Value                                                                |
+| ----------- | -------------------------------------------------------------------- |
+| Action Type | `Webhook`                                                            |
+| Name        | `qui cross-seed`                                                     |
+| Endpoint    | `http://localhost:7476/api/cross-seed/apply?apikey=YOUR_QUI_API_KEY` |
 
 **Payload (JSON):**
+
 ```json
 {
   "torrentData": "{{ .TorrentDataRawBytes | toString | b64enc }}",
@@ -91,6 +111,7 @@ When `/check` returns `200 OK`, send the torrent to `/api/cross-seed/apply`:
 ```
 
 **Field descriptions:**
+
 - `torrentData` (required) - Base64-encoded torrent file bytes
 - `instanceIds` (optional) - Target instances (omit to apply to any matching instance)
 - `indexerName` (optional) - Indexer display name (e.g., "TorrentDB"). Only used when "Use indexer name as category" mode is enabled; ignored otherwise
@@ -102,6 +123,26 @@ When `/check` returns `200 OK`, send the torrent to `/api/cross-seed/apply`:
 
 Cross-seeded torrents are added paused with `skip_checking=true`. qui polls the torrent state and auto-resumes if progress meets the size tolerance threshold. If progress is too low, it remains paused for manual review.
 
+### Troubleshooting: autobrr matches, but nothing gets added to qBittorrent
+
+Use this when autobrr shows the filter accepted the release (or your Discord notification fires), but you never see a new torrent in qBittorrent.
+
+1. **Confirm you added the `/apply` Action**
+   - The External webhook (`/check`) does not add torrents.
+   - You need an autobrr **Action** (Webhook) that calls `/api/cross-seed/apply` (above).
+2. **Fix Docker networking if you're using containers**
+   - `http://localhost:7476/...` only works if autobrr can reach qui on its own `localhost`.
+   - In Docker Compose, use the qui service hostname (example): `http://qui:7476/api/cross-seed/apply?apikey=...`.
+3. **Double-check auth**
+   - `/check`: header `X-API-Key=...`
+   - `/apply`: query string `?apikey=...` (as shown in this guide)
+4. **Verify qui can talk to qBittorrent**
+   - qui UI: **Settings → Instances → Test Connection**
+5. **Check paused torrents**
+   - Cross-seeds are often added **paused**. Look in qBittorrent's paused list (and any cross-seed tag/category you configured).
+
+If you still can't see why, jump to [Cross-Seed Troubleshooting](troubleshooting).
+
 ## Webhook Source Filters
 
 By default, the webhook endpoint scans **all** torrents on your instances when looking for matches. You can configure filters to exclude certain categories or tags from being matched:
@@ -112,6 +153,7 @@ By default, the webhook endpoint scans **all** torrents on your instances when l
 - **Include Tags:** Only match against torrents with these tags (leave empty for all)
 
 This is useful when:
+
 - You have a legacy cross-seed category that shouldn't be re-matched
 - Certain content types should never be considered for cross-seeding
 - You want to exclude torrents with specific metadata tags


### PR DESCRIPTION
Fix FAQ #9: users wire /check (External) + Discord action and expect qBittorrent add; nothing happens until /apply Action exists.

Changes
- Step 2: explicit new filter requirement + ELI5 /check vs /apply
- Docker Compose note: localhost vs service hostname
- Apply section: short checklist for 'matched but not added' + link to Cross-Seed Troubleshooting

Refs: ze0s note (asked almost daily).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Autobrr integration guide with expanded configuration examples and Docker networking clarification for container setups.
  * Added troubleshooting section addressing common integration issues and validation steps.
  * Improved field descriptions for External Filter and Apply Endpoint payloads.
  * Reworked webhook source filters documentation with detailed include/exclude filtering options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->