### PR TITLE
docs: add Windows installation guide

### DIFF
--- a/documentation/docs/getting-started/windows.md
+++ b/documentation/docs/getting-started/windows.md
@@ -36,13 +36,7 @@ Avoid placing qui in `C:\Program Files` — it can cause permission issues with 
 
 ### Configuration
 
-qui stores its configuration and database in `%APPDATA%\qui\` by default. You can override this with the `--config-dir` flag:
-
-```powershell
-.\qui.exe serve --config-dir "C:\qui\config"
-```
-
-For more details, see the [Configuration](/docs/configuration/environment) section.
+qui stores its configuration and database in `%APPDATA%\qui\` by default. For more details, see the [Configuration](/docs/configuration/environment) section.
 
 ## Create a Windows Task
 


### PR DESCRIPTION
Adds Windows installation instructions to the docs, covering:

- Downloading and extracting the release
- Initial setup and first run
- Creating a Windows Task Scheduler service for background operation
- Updating, reverse proxy notes, and finishing up

Follows the same structure as the [autobrr Windows guide](https://autobrr.com/installation/windows), adapted for qui (port 7476, config path, etc.).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Windows setup guide with step-by-step instructions to download and extract the release, perform initial configuration and account setup, set the app directory, and run the app as a background service using Task Scheduler (task properties, startup behavior, and privileges). Includes start/restart/update procedures (stop task before updating), optional reverse-proxy tips, updater notes, and verification steps for localhost access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->