### PR TITLE
feat: add option to disable built-in authentication

### DIFF
--- a/cmd/qui/main.go
+++ b/cmd/qui/main.go
@@ -447,7 +447,10 @@ func (app *Application) runServer() {
 
 	switch {
 	case cfg.Config.IsAuthDisabled():
-		log.Warn().Msg("Authentication is disabled via QUI__AUTH_DISABLED. All endpoints are publicly accessible. Make sure qui is behind a reverse proxy with its own authentication.")
+		if err := cfg.Config.ValidateAuthDisabledConfig(); err != nil {
+			log.Fatal().Err(err).Msg("Authentication is disabled but authDisabledAllowedCIDRs is invalid or empty")
+		}
+		log.Warn().Strs("authDisabledAllowedCIDRs", cfg.Config.AuthDisabledAllowedCIDRs).Msg("Authentication is disabled via QUI__AUTH_DISABLED. Access is restricted to authDisabledAllowedCIDRs. Make sure qui is behind a reverse proxy with its own authentication.")
 	case cfg.Config.AuthDisabled != cfg.Config.IfIGetBannedItsMyFault:
 		log.Warn().Msg("Only one of QUI__AUTH_DISABLED and QUI__IF_I_GET_BANNED_ITS_MY_FAULT is set. Authentication remains enabled. Set both to disable authentication.")
 	}

--- a/cmd/qui/main.go
+++ b/cmd/qui/main.go
@@ -445,6 +445,13 @@ func (app *Application) runServer() {
 
 	log.Info().Str("version", buildinfo.Version).Msg("Starting qui")
 
+	switch {
+	case cfg.Config.IsAuthDisabled():
+		log.Warn().Msg("Authentication is disabled via QUI__AUTH_DISABLED. All endpoints are publicly accessible. Make sure qui is behind a reverse proxy with its own authentication.")
+	case cfg.Config.AuthDisabled != cfg.Config.IfIGetBannedItsMyFault:
+		log.Warn().Msg("Only one of QUI__AUTH_DISABLED and QUI__IF_I_GET_BANNED_ITS_MY_FAULT is set. Authentication remains enabled. Set both to disable authentication.")
+	}
+
 	trackerIconService, err := trackericons.NewService(cfg.GetDataDir(), buildinfo.UserAgent)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to prepare tracker icon cache")

--- a/cmd/qui/main.go
+++ b/cmd/qui/main.go
@@ -451,8 +451,8 @@ func (app *Application) runServer() {
 			log.Fatal().Err(err).Msg("Authentication is disabled but authDisabledAllowedCIDRs is invalid or empty")
 		}
 		log.Warn().Strs("authDisabledAllowedCIDRs", cfg.Config.AuthDisabledAllowedCIDRs).Msg("Authentication is disabled via QUI__AUTH_DISABLED. Access is restricted to authDisabledAllowedCIDRs. Make sure qui is behind a reverse proxy with its own authentication.")
-	case cfg.Config.AuthDisabled != cfg.Config.IfIGetBannedItsMyFault:
-		log.Warn().Msg("Only one of QUI__AUTH_DISABLED and QUI__IF_I_GET_BANNED_ITS_MY_FAULT is set. Authentication remains enabled. Set both to disable authentication.")
+	case cfg.Config.AuthDisabled != cfg.Config.IAcknowledgeThisIsABadIdea:
+		log.Warn().Msg("Only one of QUI__AUTH_DISABLED and QUI__I_ACKNOWLEDGE_THIS_IS_A_BAD_IDEA is set. Authentication remains enabled. Set both to disable authentication.")
 	}
 
 	trackerIconService, err := trackericons.NewService(cfg.GetDataDir(), buildinfo.UserAgent)

--- a/documentation/docs/configuration/environment.md
+++ b/documentation/docs/configuration/environment.md
@@ -79,9 +79,18 @@ QUI__METRICS_BASIC_AUTH_USERS=user:hash  # Optional: basic auth for metrics (bcr
 ```bash
 QUI__AUTH_DISABLED=true                 # Optional: disable built-in auth (default: false)
 QUI__IF_I_GET_BANNED_ITS_MY_FAULT=true  # Required confirmation to actually disable auth
+QUI__AUTH_DISABLED_ALLOWED_CIDRS=127.0.0.1/32,192.168.1.0/24  # Required when auth is disabled (IPs or CIDRs)
 ```
 
-**Both** variables must be `true` to disable authentication. The second variable exists as an explicit acknowledgement that running without authentication can lead to unauthorized access to your torrent clients and potential bans from private trackers.
+Built-in authentication is disabled only when:
+
+- `QUI__AUTH_DISABLED=true`
+- `QUI__IF_I_GET_BANNED_ITS_MY_FAULT=true`
+- `QUI__AUTH_DISABLED_ALLOWED_CIDRS` is set to one or more allowed IPs/CIDR ranges
+
+If auth is disabled and `QUI__AUTH_DISABLED_ALLOWED_CIDRS` is missing or invalid, qui refuses to start.
+
+`QUI__AUTH_DISABLED_ALLOWED_CIDRS` accepts comma-separated entries. Each entry may be a CIDR (`192.168.1.0/24`) or a single IP (`10.0.0.5`, treated as `/32` or `/128`).
 
 Only use this when qui runs behind a reverse proxy that already handles authentication (e.g., Authelia, Authentik, Caddy with forward_auth). See the [Configuration Reference](./reference#authentication) for a full explanation of the risks.
 

--- a/documentation/docs/configuration/environment.md
+++ b/documentation/docs/configuration/environment.md
@@ -74,6 +74,17 @@ QUI__METRICS_PORT=9074         # Optional: metrics server port (default: 9074)
 QUI__METRICS_BASIC_AUTH_USERS=user:hash  # Optional: basic auth for metrics (bcrypt hashed)
 ```
 
+## Authentication
+
+```bash
+QUI__AUTH_DISABLED=true                 # Optional: disable built-in auth (default: false)
+QUI__IF_I_GET_BANNED_ITS_MY_FAULT=true  # Required confirmation to actually disable auth
+```
+
+**Both** variables must be `true` to disable authentication. The second variable exists as an explicit acknowledgement that running without authentication can lead to unauthorized access to your torrent clients and potential bans from private trackers.
+
+Only use this when qui runs behind a reverse proxy that already handles authentication (e.g., Authelia, Authentik, Caddy with forward_auth). See the [Configuration Reference](./reference#authentication) for a full explanation of the risks.
+
 ## External Programs
 
 Configure the allow list from `config.toml`; there is no environment override to keep it read-only from the UI.

--- a/documentation/docs/configuration/environment.md
+++ b/documentation/docs/configuration/environment.md
@@ -78,14 +78,14 @@ QUI__METRICS_BASIC_AUTH_USERS=user:hash  # Optional: basic auth for metrics (bcr
 
 ```bash
 QUI__AUTH_DISABLED=true                 # Optional: disable built-in auth (default: false)
-QUI__IF_I_GET_BANNED_ITS_MY_FAULT=true  # Required confirmation to actually disable auth
+QUI__I_ACKNOWLEDGE_THIS_IS_A_BAD_IDEA=true  # Required confirmation to actually disable auth
 QUI__AUTH_DISABLED_ALLOWED_CIDRS=127.0.0.1/32,192.168.1.0/24  # Required when auth is disabled (IPs or CIDRs)
 ```
 
 Built-in authentication is disabled only when:
 
 - `QUI__AUTH_DISABLED=true`
-- `QUI__IF_I_GET_BANNED_ITS_MY_FAULT=true`
+- `QUI__I_ACKNOWLEDGE_THIS_IS_A_BAD_IDEA=true`
 - `QUI__AUTH_DISABLED_ALLOWED_CIDRS` is set to one or more allowed IPs/CIDR ranges
 
 If auth is disabled and `QUI__AUTH_DISABLED_ALLOWED_CIDRS` is missing or invalid, qui refuses to start.

--- a/documentation/docs/configuration/environment.md
+++ b/documentation/docs/configuration/environment.md
@@ -88,9 +88,13 @@ Built-in authentication is disabled only when:
 - `QUI__I_ACKNOWLEDGE_THIS_IS_A_BAD_IDEA=true`
 - `QUI__AUTH_DISABLED_ALLOWED_CIDRS` is set to one or more allowed IPs/CIDR ranges
 
-If auth is disabled and `QUI__AUTH_DISABLED_ALLOWED_CIDRS` is missing or invalid, qui refuses to start.
+If auth is disabled and `QUI__AUTH_DISABLED_ALLOWED_CIDRS` is missing or invalid, qui refuses to start and rejects invalid live reloads.
 
-`QUI__AUTH_DISABLED_ALLOWED_CIDRS` accepts comma-separated entries. Each entry may be a CIDR (`192.168.1.0/24`) or a single IP (`10.0.0.5`, treated as `/32` or `/128`).
+`QUI__AUTH_DISABLED_ALLOWED_CIDRS` accepts comma-separated entries. Each entry may be a canonical CIDR (`192.168.1.0/24`) or a single IP (`10.0.0.5`, treated as `/32` or `/128`).
+
+Non-canonical CIDRs with host bits set (for example `10.0.0.5/8`) are rejected.
+
+`QUI__OIDC_ENABLED=true` cannot be combined with auth-disabled mode.
 
 Only use this when qui runs behind a reverse proxy that already handles authentication (e.g., Authelia, Authentik, Caddy with forward_auth). See the [Configuration Reference](./reference#authentication) for a full explanation of the risks.
 

--- a/documentation/docs/configuration/reference.md
+++ b/documentation/docs/configuration/reference.md
@@ -59,8 +59,8 @@ qui watches `config.toml` for changes. Some settings are applied immediately (fo
 | `metricsPort` | `QUI__METRICS_PORT` | int | `9074` | Metrics server port. Restart required. |
 | `metricsBasicAuthUsers` | `QUI__METRICS_BASIC_AUTH_USERS` | string | empty | Optional basic auth: `user:bcrypt_hash` or `user1:hash1,user2:hash2`. Restart required. |
 | `externalProgramAllowList` | (none) | string[] | empty list | Restricts which executables can be launched from the UI. Only configurable via `config.toml` (no env override). |
-| `authDisabled` | `QUI__AUTH_DISABLED` | bool | `false` | Disable all built-in authentication. **Both** this and `ifIGetBannedItsMyFault` must be `true` for auth to be disabled. See [Authentication](#authentication) below. Restart required. |
-| `ifIGetBannedItsMyFault` | `QUI__IF_I_GET_BANNED_ITS_MY_FAULT` | bool | `false` | Required confirmation for `authDisabled`. Acknowledges that running without authentication can lead to unauthorized access to your torrent clients and potential bans from private trackers. Restart required. |
+| `authDisabled` | `QUI__AUTH_DISABLED` | bool | `false` | Disable all built-in authentication. **Both** this and `I_ACKNOWLEDGE_THIS_IS_A_BAD_IDEA` must be `true` for auth to be disabled. See [Authentication](#authentication) below. Restart required. |
+| `I_ACKNOWLEDGE_THIS_IS_A_BAD_IDEA` | `QUI__I_ACKNOWLEDGE_THIS_IS_A_BAD_IDEA` | bool | `false` | Required confirmation for `authDisabled`. Acknowledges that running without authentication can lead to unauthorized access to your torrent clients and potential bans from private trackers. Restart required. |
 | `authDisabledAllowedCIDRs` | `QUI__AUTH_DISABLED_ALLOWED_CIDRS` | string[] | empty list | Required when auth is disabled. Restricts access to specific client IPs/CIDRs. Entries may be CIDRs or single IPs. Restart required. |
 | `oidcEnabled` | `QUI__OIDC_ENABLED` | bool | `false` | Enable OpenID Connect authentication. Restart required. |
 | `oidcIssuer` | `QUI__OIDC_ISSUER` | string | empty | OIDC issuer URL. Restart required. |
@@ -75,7 +75,7 @@ To disable qui's built-in authentication, all of the following are required:
 
 ```bash
 QUI__AUTH_DISABLED=true
-QUI__IF_I_GET_BANNED_ITS_MY_FAULT=true
+QUI__I_ACKNOWLEDGE_THIS_IS_A_BAD_IDEA=true
 QUI__AUTH_DISABLED_ALLOWED_CIDRS=127.0.0.1/32,192.168.1.0/24
 ```
 
@@ -101,7 +101,7 @@ When authentication is disabled:
 If you use private trackers, running qui without authentication is especially dangerous. Anyone with network access can control your torrent clients — adding, removing, or modifying torrents. Actions performed by unauthorized users (hit-and-runs, ratio manipulation, uploading unwanted content) can get your accounts permanently banned from private trackers, with no way to recover.
 :::
 
-If `QUI__AUTH_DISABLED` is set without `QUI__IF_I_GET_BANNED_ITS_MY_FAULT`, qui will log a warning and keep authentication enabled.
+If `QUI__AUTH_DISABLED` is set without `QUI__I_ACKNOWLEDGE_THIS_IS_A_BAD_IDEA`, qui will log a warning and keep authentication enabled.
 
 ## Example `config.toml`
 

--- a/documentation/docs/configuration/reference.md
+++ b/documentation/docs/configuration/reference.md
@@ -35,7 +35,7 @@ Override with `--config-dir`:
 
 ## Notes On Reloading
 
-qui watches `config.toml` for changes. Some settings are applied immediately (for example logging and tracker icon fetching). For anything else, restart qui after changes to be safe.
+qui watches `config.toml` for changes. Some settings are applied immediately (for example logging, tracker icon fetching, and auth-disabled settings). For anything else, restart qui after changes to be safe.
 
 ## Settings
 
@@ -59,9 +59,9 @@ qui watches `config.toml` for changes. Some settings are applied immediately (fo
 | `metricsPort` | `QUI__METRICS_PORT` | int | `9074` | Metrics server port. Restart required. |
 | `metricsBasicAuthUsers` | `QUI__METRICS_BASIC_AUTH_USERS` | string | empty | Optional basic auth: `user:bcrypt_hash` or `user1:hash1,user2:hash2`. Restart required. |
 | `externalProgramAllowList` | (none) | string[] | empty list | Restricts which executables can be launched from the UI. Only configurable via `config.toml` (no env override). |
-| `authDisabled` | `QUI__AUTH_DISABLED` | bool | `false` | Disable all built-in authentication. **Both** this and `I_ACKNOWLEDGE_THIS_IS_A_BAD_IDEA` must be `true` for auth to be disabled. See [Authentication](#authentication) below. Restart required. |
-| `I_ACKNOWLEDGE_THIS_IS_A_BAD_IDEA` | `QUI__I_ACKNOWLEDGE_THIS_IS_A_BAD_IDEA` | bool | `false` | Required confirmation for `authDisabled`. Acknowledges that running without authentication can lead to unauthorized access to your torrent clients and potential bans from private trackers. Restart required. |
-| `authDisabledAllowedCIDRs` | `QUI__AUTH_DISABLED_ALLOWED_CIDRS` | string[] | empty list | Required when auth is disabled. Restricts access to specific client IPs/CIDRs. Entries may be CIDRs or single IPs. Restart required. |
+| `authDisabled` | `QUI__AUTH_DISABLED` | bool | `false` | Disable all built-in authentication. **Both** this and `I_ACKNOWLEDGE_THIS_IS_A_BAD_IDEA` must be `true` for auth to be disabled. See [Authentication](#authentication) below. Applied on config reload. |
+| `I_ACKNOWLEDGE_THIS_IS_A_BAD_IDEA` | `QUI__I_ACKNOWLEDGE_THIS_IS_A_BAD_IDEA` | bool | `false` | Required confirmation for `authDisabled`. Acknowledges that running without authentication can lead to unauthorized access to your torrent clients and potential bans from private trackers. Applied on config reload. |
+| `authDisabledAllowedCIDRs` | `QUI__AUTH_DISABLED_ALLOWED_CIDRS` | string[] | empty list | Required when auth is disabled. Restricts access to specific client IPs/CIDRs. Entries may be canonical CIDRs or single IPs. Applied on config reload. |
 | `oidcEnabled` | `QUI__OIDC_ENABLED` | bool | `false` | Enable OpenID Connect authentication. Restart required. |
 | `oidcIssuer` | `QUI__OIDC_ISSUER` | string | empty | OIDC issuer URL. Restart required. |
 | `oidcClientId` | `QUI__OIDC_CLIENT_ID` | string | empty | OIDC client ID. Restart required. |
@@ -81,12 +81,16 @@ QUI__AUTH_DISABLED_ALLOWED_CIDRS=127.0.0.1/32,192.168.1.0/24
 
 The second variable exists as an explicit acknowledgement of the risks.
 
-`QUI__AUTH_DISABLED_ALLOWED_CIDRS` is mandatory and acts as a hard IP allowlist. If auth is disabled and the value is missing/invalid, qui will refuse to start.
+`QUI__AUTH_DISABLED_ALLOWED_CIDRS` is mandatory and acts as a hard IP allowlist. If auth is disabled and the value is missing/invalid, qui will refuse to start and reject invalid live reloads.
 
 Entries can be:
 
-- CIDR ranges (`192.168.1.0/24`)
+- Canonical CIDR ranges (`192.168.1.0/24`)
 - Single IPs (`10.0.0.5`), automatically treated as `/32` (IPv4) or `/128` (IPv6)
+
+Non-canonical CIDRs with host bits set (for example `10.0.0.5/8`) are rejected.
+
+`oidcEnabled` and auth-disabled mode cannot be enabled at the same time.
 
 When authentication is disabled:
 

--- a/documentation/docs/configuration/reference.md
+++ b/documentation/docs/configuration/reference.md
@@ -95,8 +95,8 @@ Non-canonical CIDRs with host bits set (for example `10.0.0.5/8`) are rejected.
 When authentication is disabled:
 
 - Requests are allowed only if the direct client IP matches `authDisabledAllowedCIDRs`.
-- `/auth/me` returns a synthetic `admin` user so the frontend works without login.
-- `/auth/validate` returns a synthetic `admin` user so callback/session checks work without login.
+- `/api/auth/me` returns a synthetic `admin` user so the frontend works without login.
+- `/api/auth/validate` returns a synthetic `admin` user so callback/session checks work without login.
 - The setup screen is skipped entirely.
 
 **Only use this if qui is behind a reverse proxy that already handles authentication** (e.g., Authelia, Authentik, Caddy with forward_auth).

--- a/documentation/docs/configuration/reference.md
+++ b/documentation/docs/configuration/reference.md
@@ -59,12 +59,37 @@ qui watches `config.toml` for changes. Some settings are applied immediately (fo
 | `metricsPort` | `QUI__METRICS_PORT` | int | `9074` | Metrics server port. Restart required. |
 | `metricsBasicAuthUsers` | `QUI__METRICS_BASIC_AUTH_USERS` | string | empty | Optional basic auth: `user:bcrypt_hash` or `user1:hash1,user2:hash2`. Restart required. |
 | `externalProgramAllowList` | (none) | string[] | empty list | Restricts which executables can be launched from the UI. Only configurable via `config.toml` (no env override). |
+| `authDisabled` | `QUI__AUTH_DISABLED` | bool | `false` | Disable all built-in authentication. **Both** this and `ifIGetBannedItsMyFault` must be `true` for auth to be disabled. See [Authentication](#authentication) below. Restart required. |
+| `ifIGetBannedItsMyFault` | `QUI__IF_I_GET_BANNED_ITS_MY_FAULT` | bool | `false` | Required confirmation for `authDisabled`. Acknowledges that running without authentication can lead to unauthorized access to your torrent clients and potential bans from private trackers. Restart required. |
 | `oidcEnabled` | `QUI__OIDC_ENABLED` | bool | `false` | Enable OpenID Connect authentication. Restart required. |
 | `oidcIssuer` | `QUI__OIDC_ISSUER` | string | empty | OIDC issuer URL. Restart required. |
 | `oidcClientId` | `QUI__OIDC_CLIENT_ID` | string | empty | OIDC client ID. Restart required. |
 | `oidcClientSecret` | `QUI__OIDC_CLIENT_SECRET` / `QUI__OIDC_CLIENT_SECRET_FILE` | string | empty | OIDC client secret. Restart required. |
 | `oidcRedirectUrl` | `QUI__OIDC_REDIRECT_URL` | string | empty | Must match the provider redirect URI (include `baseUrl` when reverse proxying). Restart required. |
 | `oidcDisableBuiltInLogin` | `QUI__OIDC_DISABLE_BUILT_IN_LOGIN` | bool | `false` | Hide local username/password form when OIDC is enabled. Restart required. |
+
+## Authentication
+
+To disable qui's built-in authentication, **both** environment variables must be set:
+
+```bash
+QUI__AUTH_DISABLED=true
+QUI__IF_I_GET_BANNED_ITS_MY_FAULT=true
+```
+
+The second variable exists as an explicit acknowledgement of the risks. When authentication is disabled:
+
+- **All API endpoints are publicly accessible** to anyone who can reach qui over the network.
+- `/auth/me` returns a synthetic `admin` user so the frontend works without login.
+- The setup screen is skipped entirely.
+
+**Only use this if qui is behind a reverse proxy that already handles authentication** (e.g., Authelia, Authentik, Caddy with forward_auth).
+
+:::danger Private tracker risks
+If you use private trackers, running qui without authentication is especially dangerous. Anyone with network access can control your torrent clients — adding, removing, or modifying torrents. Actions performed by unauthorized users (hit-and-runs, ratio manipulation, uploading unwanted content) can get your accounts permanently banned from private trackers, with no way to recover.
+:::
+
+If `QUI__AUTH_DISABLED` is set without `QUI__IF_I_GET_BANNED_ITS_MY_FAULT`, qui will log a warning and keep authentication enabled.
 
 ## Example `config.toml`
 

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -65,6 +65,16 @@ func (h *AuthHandler) GetOIDCHandler() *OIDCHandler {
 	return h.oidcHandler
 }
 
+// rejectIfAuthDisabled returns true (and writes a 403 response) when
+// authentication is disabled, signalling the caller to return early.
+func (h *AuthHandler) rejectIfAuthDisabled(w http.ResponseWriter) bool {
+	if h.config != nil && h.config.IsAuthDisabled() {
+		RespondError(w, http.StatusForbidden, "Endpoint disabled when authentication is disabled")
+		return true
+	}
+	return false
+}
+
 // SetupRequest represents the initial setup request
 type SetupRequest struct {
 	Username string `json:"username"`
@@ -86,6 +96,10 @@ type ChangePasswordRequest struct {
 
 // Setup handles initial user setup
 func (h *AuthHandler) Setup(w http.ResponseWriter, r *http.Request) {
+	if h.rejectIfAuthDisabled(w) {
+		return
+	}
+
 	if h.config != nil && h.config.OIDCEnabled {
 		RespondError(w, http.StatusForbidden, "Setup is disabled when OIDC is enabled")
 		return
@@ -226,6 +240,10 @@ func (h *AuthHandler) warmSession(ctx context.Context) {
 
 // Login handles user login
 func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
+	if h.rejectIfAuthDisabled(w) {
+		return
+	}
+
 	var req LoginRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		RespondError(w, http.StatusBadRequest, "Invalid request body")
@@ -277,6 +295,10 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 
 // Logout handles user logout
 func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
+	if h.rejectIfAuthDisabled(w) {
+		return
+	}
+
 	// Destroy the session
 	if err := h.sessionManager.Destroy(r.Context()); err != nil {
 		log.Error().Err(err).Msg("Failed to destroy session")
@@ -291,6 +313,15 @@ func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
 
 // GetCurrentUser returns the current user information
 func (h *AuthHandler) GetCurrentUser(w http.ResponseWriter, r *http.Request) {
+	// When auth is disabled, return a synthetic user
+	if h.config != nil && h.config.IsAuthDisabled() {
+		RespondJSON(w, http.StatusOK, map[string]any{
+			"username":    "admin",
+			"auth_method": "none",
+		})
+		return
+	}
+
 	// Check if the session is authenticated (works for both regular and OIDC auth)
 	authenticated := h.sessionManager.GetBool(r.Context(), "authenticated")
 	if !authenticated {
@@ -346,6 +377,13 @@ func (h *AuthHandler) Validate(w http.ResponseWriter, r *http.Request) {
 
 // CheckSetupRequired checks if initial setup is required
 func (h *AuthHandler) CheckSetupRequired(w http.ResponseWriter, r *http.Request) {
+	if h.config != nil && h.config.IsAuthDisabled() {
+		RespondJSON(w, http.StatusOK, map[string]any{
+			"setupRequired": false,
+		})
+		return
+	}
+
 	if h.config != nil && h.config.OIDCEnabled {
 		RespondJSON(w, http.StatusOK, map[string]any{
 			"setupRequired": false,
@@ -367,6 +405,10 @@ func (h *AuthHandler) CheckSetupRequired(w http.ResponseWriter, r *http.Request)
 
 // ChangePassword handles password change requests
 func (h *AuthHandler) ChangePassword(w http.ResponseWriter, r *http.Request) {
+	if h.rejectIfAuthDisabled(w) {
+		return
+	}
+
 	var req ChangePasswordRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		RespondError(w, http.StatusBadRequest, "Invalid request body")
@@ -398,6 +440,10 @@ type CreateAPIKeyRequest struct {
 
 // CreateAPIKey creates a new API key
 func (h *AuthHandler) CreateAPIKey(w http.ResponseWriter, r *http.Request) {
+	if h.rejectIfAuthDisabled(w) {
+		return
+	}
+
 	var req CreateAPIKeyRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		RespondError(w, http.StatusBadRequest, "Invalid request body")
@@ -428,6 +474,10 @@ func (h *AuthHandler) CreateAPIKey(w http.ResponseWriter, r *http.Request) {
 
 // ListAPIKeys returns all API keys
 func (h *AuthHandler) ListAPIKeys(w http.ResponseWriter, r *http.Request) {
+	if h.rejectIfAuthDisabled(w) {
+		return
+	}
+
 	keys, err := h.authService.ListAPIKeys(r.Context())
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to list API keys")
@@ -440,6 +490,10 @@ func (h *AuthHandler) ListAPIKeys(w http.ResponseWriter, r *http.Request) {
 
 // DeleteAPIKey deletes an API key
 func (h *AuthHandler) DeleteAPIKey(w http.ResponseWriter, r *http.Request) {
+	if h.rejectIfAuthDisabled(w) {
+		return
+	}
+
 	// Get API key ID from URL parameter
 	idStr := chi.URLParam(r, "id")
 	if idStr == "" {

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -386,14 +386,7 @@ func (h *AuthHandler) Validate(w http.ResponseWriter, r *http.Request) {
 
 // CheckSetupRequired checks if initial setup is required
 func (h *AuthHandler) CheckSetupRequired(w http.ResponseWriter, r *http.Request) {
-	if h.config != nil && h.config.IsAuthDisabled() {
-		RespondJSON(w, http.StatusOK, map[string]any{
-			"setupRequired": false,
-		})
-		return
-	}
-
-	if h.config != nil && h.config.OIDCEnabled {
+	if h.config != nil && (h.config.IsAuthDisabled() || h.config.OIDCEnabled) {
 		RespondJSON(w, http.StatusOK, map[string]any{
 			"setupRequired": false,
 		})

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -358,6 +358,14 @@ func (h *AuthHandler) GetCurrentUser(w http.ResponseWriter, r *http.Request) {
 
 // Validate checks if the user has a valid session (used for OIDC callback)
 func (h *AuthHandler) Validate(w http.ResponseWriter, r *http.Request) {
+	if h.config != nil && h.config.IsAuthDisabled() {
+		RespondJSON(w, http.StatusOK, map[string]any{
+			"username":    "admin",
+			"auth_method": "none",
+		})
+		return
+	}
+
 	authenticated := h.sessionManager.GetBool(r.Context(), "authenticated")
 	if !authenticated {
 		RespondError(w, http.StatusUnauthorized, "Not authenticated")

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -311,14 +311,18 @@ func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func syntheticAdminResponse() map[string]any {
+	return map[string]any{
+		"username":    "admin",
+		"auth_method": "none",
+	}
+}
+
 // GetCurrentUser returns the current user information
 func (h *AuthHandler) GetCurrentUser(w http.ResponseWriter, r *http.Request) {
 	// When auth is disabled, return a synthetic user
 	if h.config != nil && h.config.IsAuthDisabled() {
-		RespondJSON(w, http.StatusOK, map[string]any{
-			"username":    "admin",
-			"auth_method": "none",
-		})
+		RespondJSON(w, http.StatusOK, syntheticAdminResponse())
 		return
 	}
 
@@ -359,10 +363,7 @@ func (h *AuthHandler) GetCurrentUser(w http.ResponseWriter, r *http.Request) {
 // Validate checks if the user has a valid session (used for OIDC callback)
 func (h *AuthHandler) Validate(w http.ResponseWriter, r *http.Request) {
 	if h.config != nil && h.config.IsAuthDisabled() {
-		RespondJSON(w, http.StatusOK, map[string]any{
-			"username":    "admin",
-			"auth_method": "none",
-		})
+		RespondJSON(w, http.StatusOK, syntheticAdminResponse())
 		return
 	}
 

--- a/internal/api/handlers/auth_setup_test.go
+++ b/internal/api/handlers/auth_setup_test.go
@@ -72,8 +72,8 @@ func TestValidateReturnsSyntheticUserWhenAuthDisabled(t *testing.T) {
 	handler := &AuthHandler{
 		sessionManager: scs.New(),
 		config: &domain.Config{
-			AuthDisabled:           true,
-			IfIGetBannedItsMyFault: true,
+			AuthDisabled:               true,
+			IAcknowledgeThisIsABadIdea: true,
 		},
 	}
 

--- a/internal/api/handlers/auth_setup_test.go
+++ b/internal/api/handlers/auth_setup_test.go
@@ -77,7 +77,7 @@ func TestValidateReturnsSyntheticUserWhenAuthDisabled(t *testing.T) {
 		},
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/api/auth/validate", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/auth/validate", nil)
 	resp := httptest.NewRecorder()
 
 	handler.Validate(resp, req)

--- a/internal/api/middleware/apikey_query_test.go
+++ b/internal/api/middleware/apikey_query_test.go
@@ -36,7 +36,7 @@ func TestAPIKeyFromQuery_AllowsQueryParam(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	authMiddleware := IsAuthenticated(authService, sessionManager)
+	authMiddleware := IsAuthenticated(authService, sessionManager, nil)
 	handler := sessionManager.LoadAndSave(APIKeyFromQuery("apikey")(authMiddleware(okHandler)))
 
 	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/api/cross-seed/apply?apikey="+apiKeyValue, nil)

--- a/internal/api/middleware/auth_disabled_ip_allowlist.go
+++ b/internal/api/middleware/auth_disabled_ip_allowlist.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package middleware
+
+import (
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/autobrr/qui/internal/domain"
+)
+
+// RequireAuthDisabledIPAllowlist enforces authDisabledAllowedCIDRs when
+// built-in authentication is disabled.
+func RequireAuthDisabledIPAllowlist(cfg *domain.Config) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if cfg == nil || !cfg.IsAuthDisabled() {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			prefixes, err := cfg.ParseAuthDisabledAllowedCIDRs()
+			if err != nil || len(prefixes) == 0 {
+				log.Error().Err(err).Msg("auth-disabled mode is misconfigured: authDisabledAllowedCIDRs is invalid or empty")
+				http.Error(w, "Forbidden", http.StatusForbidden)
+				return
+			}
+
+			addr, err := parseRemoteAddrIP(r.RemoteAddr)
+			if err != nil {
+				log.Warn().Err(err).Str("remote_addr", r.RemoteAddr).Msg("Failed to parse remote address for auth-disabled allowlist")
+				http.Error(w, "Forbidden", http.StatusForbidden)
+				return
+			}
+
+			for _, prefix := range prefixes {
+				if prefix.Contains(addr) {
+					next.ServeHTTP(w, r)
+					return
+				}
+			}
+
+			log.Warn().
+				Str("remote_addr", r.RemoteAddr).
+				Str("ip", addr.String()).
+				Msg("Blocked request in auth-disabled mode: client IP not in authDisabledAllowedCIDRs")
+			http.Error(w, "Forbidden", http.StatusForbidden)
+		})
+	}
+}
+
+func parseRemoteAddrIP(remoteAddr string) (netip.Addr, error) {
+	trimmed := strings.TrimSpace(remoteAddr)
+	if addr, err := netip.ParseAddr(strings.Trim(trimmed, "[]")); err == nil {
+		return addr.Unmap(), nil
+	}
+
+	host, _, err := net.SplitHostPort(trimmed)
+	if err != nil {
+		return netip.Addr{}, err
+	}
+
+	addr, err := netip.ParseAddr(strings.Trim(host, "[]"))
+	if err != nil {
+		return netip.Addr{}, err
+	}
+
+	return addr.Unmap(), nil
+}

--- a/internal/api/middleware/auth_disabled_ip_allowlist_test.go
+++ b/internal/api/middleware/auth_disabled_ip_allowlist_test.go
@@ -32,9 +32,9 @@ func TestRequireAuthDisabledIPAllowlist(t *testing.T) {
 
 	t.Run("allows request from configured CIDR", func(t *testing.T) {
 		cfg := &domain.Config{
-			AuthDisabled:             true,
-			IfIGetBannedItsMyFault:   true,
-			AuthDisabledAllowedCIDRs: []string{"127.0.0.1/32"},
+			AuthDisabled:               true,
+			IAcknowledgeThisIsABadIdea: true,
+			AuthDisabledAllowedCIDRs:   []string{"127.0.0.1/32"},
 		}
 		handler := RequireAuthDisabledIPAllowlist(cfg)(inner)
 
@@ -48,9 +48,9 @@ func TestRequireAuthDisabledIPAllowlist(t *testing.T) {
 
 	t.Run("blocks request outside CIDR", func(t *testing.T) {
 		cfg := &domain.Config{
-			AuthDisabled:             true,
-			IfIGetBannedItsMyFault:   true,
-			AuthDisabledAllowedCIDRs: []string{"127.0.0.1/32"},
+			AuthDisabled:               true,
+			IAcknowledgeThisIsABadIdea: true,
+			AuthDisabledAllowedCIDRs:   []string{"127.0.0.1/32"},
 		}
 		handler := RequireAuthDisabledIPAllowlist(cfg)(inner)
 
@@ -64,9 +64,9 @@ func TestRequireAuthDisabledIPAllowlist(t *testing.T) {
 
 	t.Run("blocks when configured list is invalid", func(t *testing.T) {
 		cfg := &domain.Config{
-			AuthDisabled:             true,
-			IfIGetBannedItsMyFault:   true,
-			AuthDisabledAllowedCIDRs: []string{"invalid-cidr"},
+			AuthDisabled:               true,
+			IAcknowledgeThisIsABadIdea: true,
+			AuthDisabledAllowedCIDRs:   []string{"invalid-cidr"},
 		}
 		handler := RequireAuthDisabledIPAllowlist(cfg)(inner)
 

--- a/internal/api/middleware/auth_disabled_ip_allowlist_test.go
+++ b/internal/api/middleware/auth_disabled_ip_allowlist_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/autobrr/qui/internal/domain"
+)
+
+func TestRequireAuthDisabledIPAllowlist(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	t.Run("passes when auth-disabled mode is off", func(t *testing.T) {
+		cfg := &domain.Config{}
+		handler := RequireAuthDisabledIPAllowlist(cfg)(inner)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/instances", nil)
+		req.RemoteAddr = "203.0.113.10:12345"
+		resp := httptest.NewRecorder()
+
+		handler.ServeHTTP(resp, req)
+		assert.Equal(t, http.StatusOK, resp.Code)
+	})
+
+	t.Run("allows request from configured CIDR", func(t *testing.T) {
+		cfg := &domain.Config{
+			AuthDisabled:             true,
+			IfIGetBannedItsMyFault:   true,
+			AuthDisabledAllowedCIDRs: []string{"127.0.0.1/32"},
+		}
+		handler := RequireAuthDisabledIPAllowlist(cfg)(inner)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/instances", nil)
+		req.RemoteAddr = "127.0.0.1:54321"
+		resp := httptest.NewRecorder()
+
+		handler.ServeHTTP(resp, req)
+		assert.Equal(t, http.StatusOK, resp.Code)
+	})
+
+	t.Run("blocks request outside CIDR", func(t *testing.T) {
+		cfg := &domain.Config{
+			AuthDisabled:             true,
+			IfIGetBannedItsMyFault:   true,
+			AuthDisabledAllowedCIDRs: []string{"127.0.0.1/32"},
+		}
+		handler := RequireAuthDisabledIPAllowlist(cfg)(inner)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/instances", nil)
+		req.RemoteAddr = "203.0.113.10:54321"
+		resp := httptest.NewRecorder()
+
+		handler.ServeHTTP(resp, req)
+		assert.Equal(t, http.StatusForbidden, resp.Code)
+	})
+
+	t.Run("blocks when configured list is invalid", func(t *testing.T) {
+		cfg := &domain.Config{
+			AuthDisabled:             true,
+			IfIGetBannedItsMyFault:   true,
+			AuthDisabledAllowedCIDRs: []string{"invalid-cidr"},
+		}
+		handler := RequireAuthDisabledIPAllowlist(cfg)(inner)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/instances", nil)
+		req.RemoteAddr = "127.0.0.1:54321"
+		resp := httptest.NewRecorder()
+
+		handler.ServeHTTP(resp, req)
+		assert.Equal(t, http.StatusForbidden, resp.Code)
+	})
+}

--- a/internal/api/middleware/auth_disabled_ip_allowlist_test.go
+++ b/internal/api/middleware/auth_disabled_ip_allowlist_test.go
@@ -66,6 +66,26 @@ func TestRequireAuthDisabledIPAllowlist(t *testing.T) {
 			remoteAddr: "127.0.0.1:54321",
 			wantStatus: http.StatusForbidden,
 		},
+		{
+			name: "blocks when allowlist is empty in auth-disabled mode",
+			cfg: &domain.Config{
+				AuthDisabled:               true,
+				IAcknowledgeThisIsABadIdea: true,
+				AuthDisabledAllowedCIDRs:   []string{},
+			},
+			remoteAddr: "127.0.0.1:54321",
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name: "blocks when remote address is malformed",
+			cfg: &domain.Config{
+				AuthDisabled:               true,
+				IAcknowledgeThisIsABadIdea: true,
+				AuthDisabledAllowedCIDRs:   []string{"127.0.0.1/32"},
+			},
+			remoteAddr: "not-an-address",
+			wantStatus: http.StatusForbidden,
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/api/middleware/auth_test.go
+++ b/internal/api/middleware/auth_test.go
@@ -13,8 +13,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/autobrr/qui/internal/api/ctxkeys"
 	"github.com/autobrr/qui/internal/auth"
 	"github.com/autobrr/qui/internal/database"
+	"github.com/autobrr/qui/internal/domain"
 )
 
 func TestIsAuthenticated_APIKeyHeaderAndUnauthorized(t *testing.T) {
@@ -39,7 +41,7 @@ func TestIsAuthenticated_APIKeyHeaderAndUnauthorized(t *testing.T) {
 		w.Write([]byte("OK"))
 	})
 
-	authMiddleware := IsAuthenticated(authService, sessionManager)
+	authMiddleware := IsAuthenticated(authService, sessionManager, nil)
 	// Wrap with session middleware to avoid panic when session is checked
 	handler := sessionManager.LoadAndSave(authMiddleware(okHandler))
 
@@ -93,4 +95,68 @@ func TestIsAuthenticated_APIKeyHeaderAndUnauthorized(t *testing.T) {
 			assert.Equal(t, tt.expectedStatus, resp.Code, "unexpected status for %s", tt.name)
 		})
 	}
+}
+
+func TestIsAuthenticated_AuthDisabled(t *testing.T) {
+	cfg := &domain.Config{AuthDisabled: true, IfIGetBannedItsMyFault: true}
+
+	var capturedUsername string
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedUsername, _ = r.Context().Value(ctxkeys.Username).(string)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := IsAuthenticated(nil, nil, cfg)(inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/instances", nil)
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, "admin", capturedUsername)
+}
+
+func TestRequireSetup_AuthDisabled(t *testing.T) {
+	cfg := &domain.Config{AuthDisabled: true, IfIGetBannedItsMyFault: true}
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	})
+
+	handler := RequireSetup(nil, cfg)(inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/instances", nil)
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, "OK", resp.Body.String())
+}
+
+func TestIsAuthenticated_AuthDisabledWithoutConfirmation(t *testing.T) {
+	// AuthDisabled alone without IfIGetBannedItsMyFault should NOT bypass auth
+	cfg := &domain.Config{AuthDisabled: true, IfIGetBannedItsMyFault: false}
+
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	db, err := database.New(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	authService := auth.NewService(db)
+	sessionManager := scs.New()
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := sessionManager.LoadAndSave(IsAuthenticated(authService, sessionManager, cfg)(inner))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/instances", nil)
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+
+	assert.Equal(t, http.StatusUnauthorized, resp.Code)
 }

--- a/internal/api/middleware/auth_test.go
+++ b/internal/api/middleware/auth_test.go
@@ -98,7 +98,7 @@ func TestIsAuthenticated_APIKeyHeaderAndUnauthorized(t *testing.T) {
 }
 
 func TestIsAuthenticated_AuthDisabled(t *testing.T) {
-	cfg := &domain.Config{AuthDisabled: true, IfIGetBannedItsMyFault: true}
+	cfg := &domain.Config{AuthDisabled: true, IAcknowledgeThisIsABadIdea: true}
 
 	var capturedUsername string
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -117,7 +117,7 @@ func TestIsAuthenticated_AuthDisabled(t *testing.T) {
 }
 
 func TestRequireSetup_AuthDisabled(t *testing.T) {
-	cfg := &domain.Config{AuthDisabled: true, IfIGetBannedItsMyFault: true}
+	cfg := &domain.Config{AuthDisabled: true, IAcknowledgeThisIsABadIdea: true}
 
 	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -135,8 +135,8 @@ func TestRequireSetup_AuthDisabled(t *testing.T) {
 }
 
 func TestIsAuthenticated_AuthDisabledWithoutConfirmation(t *testing.T) {
-	// AuthDisabled alone without IfIGetBannedItsMyFault should NOT bypass auth
-	cfg := &domain.Config{AuthDisabled: true, IfIGetBannedItsMyFault: false}
+	// AuthDisabled alone without IAcknowledgeThisIsABadIdea should NOT bypass auth
+	cfg := &domain.Config{AuthDisabled: true, IAcknowledgeThisIsABadIdea: false}
 
 	dbPath := filepath.Join(t.TempDir(), "test.db")
 	db, err := database.New(dbPath)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -343,7 +343,7 @@ func (s *Server) Handler() (*chi.Mux, error) {
 		})
 
 		apiKeyQueryMiddleware := middleware.APIKeyFromQuery("apikey")
-		authMiddleware := middleware.IsAuthenticated(s.authService, s.sessionManager)
+		authMiddleware := middleware.IsAuthenticated(s.authService, s.sessionManager, s.config.Config)
 
 		// Cross-seed routes (query param auth for select endpoints)
 		crossSeedHandler.Routes(r, authMiddleware, apiKeyQueryMiddleware)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -250,6 +250,9 @@ func (s *Server) Handler() (*chi.Mux, error) {
 	r.Use(middleware.RequestID) // Must be before logger to capture request ID
 	// r.Use(middleware.Logger(s.logger))
 	r.Use(middleware.Recoverer)
+	// Enforce auth-disabled IP allowlist against the direct TCP peer.
+	// This runs before RealIP so forwarded headers cannot bypass restrictions.
+	r.Use(middleware.RequireAuthDisabledIPAllowlist(s.config.Config))
 	r.Use(middleware.RealIP)
 
 	// HTTP compression - handles gzip, brotli, zstd, deflate automatically

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -116,6 +116,10 @@ func (c *AppConfig) defaults() {
 	c.viper.SetDefault("metricsBasicAuthUsers", "")
 	c.viper.SetDefault("externalProgramAllowList", []string{})
 
+	// Auth disabled
+	c.viper.SetDefault("authDisabled", false)
+	c.viper.SetDefault("ifIGetBannedItsMyFault", false)
+
 	// OIDC defaults
 	c.viper.SetDefault("oidcEnabled", false)
 	c.viper.SetDefault("oidcIssuer", "")
@@ -200,6 +204,9 @@ func (c *AppConfig) loadFromEnv() {
 	c.viper.BindEnv("metricsPort", envPrefix+"METRICS_PORT")
 	c.viper.BindEnv("metricsBasicAuthUsers", envPrefix+"METRICS_BASIC_AUTH_USERS")
 
+	c.viper.BindEnv("authDisabled", envPrefix+"AUTH_DISABLED")
+	c.viper.BindEnv("ifIGetBannedItsMyFault", envPrefix+"IF_I_GET_BANNED_ITS_MY_FAULT")
+
 	// OIDC environment variables
 	c.viper.BindEnv("oidcEnabled", envPrefix+"OIDC_ENABLED")
 	c.viper.BindEnv("oidcIssuer", envPrefix+"OIDC_ISSUER")
@@ -261,6 +268,9 @@ func (c *AppConfig) hydrateConfigFromViper() {
 	c.Config.MetricsBasicAuthUsers = c.viper.GetString("metricsBasicAuthUsers")
 
 	c.Config.ExternalProgramAllowList = c.viper.GetStringSlice("externalProgramAllowList")
+
+	c.Config.AuthDisabled = c.viper.GetBool("authDisabled")
+	c.Config.IfIGetBannedItsMyFault = c.viper.GetBool("ifIGetBannedItsMyFault")
 
 	c.Config.OIDCEnabled = c.viper.GetBool("oidcEnabled")
 	c.Config.OIDCIssuer = c.viper.GetString("oidcIssuer")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -119,6 +119,7 @@ func (c *AppConfig) defaults() {
 	// Auth disabled
 	c.viper.SetDefault("authDisabled", false)
 	c.viper.SetDefault("ifIGetBannedItsMyFault", false)
+	c.viper.SetDefault("authDisabledAllowedCIDRs", []string{})
 
 	// OIDC defaults
 	c.viper.SetDefault("oidcEnabled", false)
@@ -206,6 +207,7 @@ func (c *AppConfig) loadFromEnv() {
 
 	c.viper.BindEnv("authDisabled", envPrefix+"AUTH_DISABLED")
 	c.viper.BindEnv("ifIGetBannedItsMyFault", envPrefix+"IF_I_GET_BANNED_ITS_MY_FAULT")
+	c.viper.BindEnv("authDisabledAllowedCIDRs", envPrefix+"AUTH_DISABLED_ALLOWED_CIDRS")
 
 	// OIDC environment variables
 	c.viper.BindEnv("oidcEnabled", envPrefix+"OIDC_ENABLED")
@@ -271,6 +273,7 @@ func (c *AppConfig) hydrateConfigFromViper() {
 
 	c.Config.AuthDisabled = c.viper.GetBool("authDisabled")
 	c.Config.IfIGetBannedItsMyFault = c.viper.GetBool("ifIGetBannedItsMyFault")
+	c.Config.AuthDisabledAllowedCIDRs = c.viper.GetStringSlice("authDisabledAllowedCIDRs")
 
 	c.Config.OIDCEnabled = c.viper.GetBool("oidcEnabled")
 	c.Config.OIDCIssuer = c.viper.GetString("oidcIssuer")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -118,7 +118,7 @@ func (c *AppConfig) defaults() {
 
 	// Auth disabled
 	c.viper.SetDefault("authDisabled", false)
-	c.viper.SetDefault("ifIGetBannedItsMyFault", false)
+	c.viper.SetDefault("I_ACKNOWLEDGE_THIS_IS_A_BAD_IDEA", false)
 	c.viper.SetDefault("authDisabledAllowedCIDRs", []string{})
 
 	// OIDC defaults
@@ -206,7 +206,7 @@ func (c *AppConfig) loadFromEnv() {
 	c.viper.BindEnv("metricsBasicAuthUsers", envPrefix+"METRICS_BASIC_AUTH_USERS")
 
 	c.viper.BindEnv("authDisabled", envPrefix+"AUTH_DISABLED")
-	c.viper.BindEnv("ifIGetBannedItsMyFault", envPrefix+"IF_I_GET_BANNED_ITS_MY_FAULT")
+	c.viper.BindEnv("I_ACKNOWLEDGE_THIS_IS_A_BAD_IDEA", envPrefix+"I_ACKNOWLEDGE_THIS_IS_A_BAD_IDEA")
 	c.viper.BindEnv("authDisabledAllowedCIDRs", envPrefix+"AUTH_DISABLED_ALLOWED_CIDRS")
 
 	// OIDC environment variables
@@ -272,7 +272,7 @@ func (c *AppConfig) hydrateConfigFromViper() {
 	c.Config.ExternalProgramAllowList = c.viper.GetStringSlice("externalProgramAllowList")
 
 	c.Config.AuthDisabled = c.viper.GetBool("authDisabled")
-	c.Config.IfIGetBannedItsMyFault = c.viper.GetBool("ifIGetBannedItsMyFault")
+	c.Config.IAcknowledgeThisIsABadIdea = c.viper.GetBool("I_ACKNOWLEDGE_THIS_IS_A_BAD_IDEA")
 	c.Config.AuthDisabledAllowedCIDRs = c.viper.GetStringSlice("authDisabledAllowedCIDRs")
 
 	c.Config.OIDCEnabled = c.viper.GetBool("oidcEnabled")

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -39,11 +39,11 @@ type Config struct {
 	CrossSeedRecoverErroredTorrents bool `toml:"crossSeedRecoverErroredTorrents" mapstructure:"crossSeedRecoverErroredTorrents"`
 
 	// AuthDisabled disables all authentication when both QUI__AUTH_DISABLED=true and
-	// QUI__IF_I_GET_BANNED_ITS_MY_FAULT=true are set. Intended for deployments behind
+	// QUI__I_ACKNOWLEDGE_THIS_IS_A_BAD_IDEA=true are set. Intended for deployments behind
 	// a reverse proxy that handles authentication. Use IsAuthDisabled() to check.
-	AuthDisabled             bool     `toml:"authDisabled" mapstructure:"authDisabled"`
-	IfIGetBannedItsMyFault   bool     `toml:"ifIGetBannedItsMyFault" mapstructure:"ifIGetBannedItsMyFault"`
-	AuthDisabledAllowedCIDRs []string `toml:"authDisabledAllowedCIDRs" mapstructure:"authDisabledAllowedCIDRs"`
+	AuthDisabled               bool     `toml:"authDisabled" mapstructure:"authDisabled"`
+	IAcknowledgeThisIsABadIdea bool     `toml:"I_ACKNOWLEDGE_THIS_IS_A_BAD_IDEA" mapstructure:"I_ACKNOWLEDGE_THIS_IS_A_BAD_IDEA"`
+	AuthDisabledAllowedCIDRs   []string `toml:"authDisabledAllowedCIDRs" mapstructure:"authDisabledAllowedCIDRs"`
 
 	// OIDC Configuration
 	OIDCEnabled             bool   `toml:"oidcEnabled" mapstructure:"oidcEnabled"`
@@ -55,10 +55,10 @@ type Config struct {
 }
 
 // IsAuthDisabled returns true only when both AuthDisabled and
-// IfIGetBannedItsMyFault are set, requiring the operator to explicitly
+// IAcknowledgeThisIsABadIdea are set, requiring the operator to explicitly
 // acknowledge the risks of running without authentication.
 func (c *Config) IsAuthDisabled() bool {
-	return c.AuthDisabled && c.IfIGetBannedItsMyFault
+	return c.AuthDisabled && c.IAcknowledgeThisIsABadIdea
 }
 
 // ParseAuthDisabledAllowedCIDRs parses configured auth-disabled IP ranges.

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -3,6 +3,13 @@
 
 package domain
 
+import (
+	"errors"
+	"fmt"
+	"net/netip"
+	"strings"
+)
+
 // Config represents the application configuration
 type Config struct {
 	Version                  string
@@ -34,8 +41,9 @@ type Config struct {
 	// AuthDisabled disables all authentication when both QUI__AUTH_DISABLED=true and
 	// QUI__IF_I_GET_BANNED_ITS_MY_FAULT=true are set. Intended for deployments behind
 	// a reverse proxy that handles authentication. Use IsAuthDisabled() to check.
-	AuthDisabled           bool `toml:"authDisabled" mapstructure:"authDisabled"`
-	IfIGetBannedItsMyFault bool `toml:"ifIGetBannedItsMyFault" mapstructure:"ifIGetBannedItsMyFault"`
+	AuthDisabled             bool     `toml:"authDisabled" mapstructure:"authDisabled"`
+	IfIGetBannedItsMyFault   bool     `toml:"ifIGetBannedItsMyFault" mapstructure:"ifIGetBannedItsMyFault"`
+	AuthDisabledAllowedCIDRs []string `toml:"authDisabledAllowedCIDRs" mapstructure:"authDisabledAllowedCIDRs"`
 
 	// OIDC Configuration
 	OIDCEnabled             bool   `toml:"oidcEnabled" mapstructure:"oidcEnabled"`
@@ -51,4 +59,52 @@ type Config struct {
 // acknowledge the risks of running without authentication.
 func (c *Config) IsAuthDisabled() bool {
 	return c.AuthDisabled && c.IfIGetBannedItsMyFault
+}
+
+// ParseAuthDisabledAllowedCIDRs parses configured auth-disabled IP ranges.
+// Entries can be either CIDR (for example 192.168.1.0/24) or a single IP
+// (for example 192.168.1.10, which is treated as /32 or /128).
+func (c *Config) ParseAuthDisabledAllowedCIDRs() ([]netip.Prefix, error) {
+	prefixes := make([]netip.Prefix, 0, len(c.AuthDisabledAllowedCIDRs))
+
+	for _, raw := range c.AuthDisabledAllowedCIDRs {
+		entry := strings.TrimSpace(raw)
+		if entry == "" {
+			continue
+		}
+
+		if strings.Contains(entry, "/") {
+			prefix, err := netip.ParsePrefix(entry)
+			if err != nil {
+				return nil, fmt.Errorf("invalid authDisabledAllowedCIDRs entry %q: %w", entry, err)
+			}
+			prefixes = append(prefixes, prefix.Masked())
+			continue
+		}
+
+		addr, err := netip.ParseAddr(entry)
+		if err != nil {
+			return nil, fmt.Errorf("invalid authDisabledAllowedCIDRs entry %q: %w", entry, err)
+		}
+		prefixes = append(prefixes, netip.PrefixFrom(addr, addr.BitLen()))
+	}
+
+	return prefixes, nil
+}
+
+// ValidateAuthDisabledConfig validates required settings for auth-disabled mode.
+func (c *Config) ValidateAuthDisabledConfig() error {
+	if !c.IsAuthDisabled() {
+		return nil
+	}
+
+	prefixes, err := c.ParseAuthDisabledAllowedCIDRs()
+	if err != nil {
+		return err
+	}
+	if len(prefixes) == 0 {
+		return errors.New("authDisabledAllowedCIDRs is required when authentication is disabled")
+	}
+
+	return nil
 }

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -31,6 +31,12 @@ type Config struct {
 	// When disabled (default), errored torrents are simply excluded from candidate selection.
 	CrossSeedRecoverErroredTorrents bool `toml:"crossSeedRecoverErroredTorrents" mapstructure:"crossSeedRecoverErroredTorrents"`
 
+	// AuthDisabled disables all authentication when both QUI__AUTH_DISABLED=true and
+	// QUI__IF_I_GET_BANNED_ITS_MY_FAULT=true are set. Intended for deployments behind
+	// a reverse proxy that handles authentication. Use IsAuthDisabled() to check.
+	AuthDisabled           bool `toml:"authDisabled" mapstructure:"authDisabled"`
+	IfIGetBannedItsMyFault bool `toml:"ifIGetBannedItsMyFault" mapstructure:"ifIGetBannedItsMyFault"`
+
 	// OIDC Configuration
 	OIDCEnabled             bool   `toml:"oidcEnabled" mapstructure:"oidcEnabled"`
 	OIDCIssuer              string `toml:"oidcIssuer" mapstructure:"oidcIssuer"`
@@ -38,4 +44,11 @@ type Config struct {
 	OIDCClientSecret        string `toml:"oidcClientSecret" mapstructure:"oidcClientSecret"`
 	OIDCRedirectURL         string `toml:"oidcRedirectUrl" mapstructure:"oidcRedirectUrl"`
 	OIDCDisableBuiltInLogin bool   `toml:"oidcDisableBuiltInLogin" mapstructure:"oidcDisableBuiltInLogin"`
+}
+
+// IsAuthDisabled returns true only when both AuthDisabled and
+// IfIGetBannedItsMyFault are set, requiring the operator to explicitly
+// acknowledge the risks of running without authentication.
+func (c *Config) IsAuthDisabled() bool {
+	return c.AuthDisabled && c.IfIGetBannedItsMyFault
 }

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -78,7 +78,10 @@ func (c *Config) ParseAuthDisabledAllowedCIDRs() ([]netip.Prefix, error) {
 			if err != nil {
 				return nil, fmt.Errorf("invalid authDisabledAllowedCIDRs entry %q: %w", entry, err)
 			}
-			prefixes = append(prefixes, prefix.Masked())
+			if prefix != prefix.Masked() {
+				return nil, fmt.Errorf("invalid authDisabledAllowedCIDRs entry %q: host bits must be zero for CIDR entries", entry)
+			}
+			prefixes = append(prefixes, prefix)
 			continue
 		}
 
@@ -96,6 +99,9 @@ func (c *Config) ParseAuthDisabledAllowedCIDRs() ([]netip.Prefix, error) {
 func (c *Config) ValidateAuthDisabledConfig() error {
 	if !c.IsAuthDisabled() {
 		return nil
+	}
+	if c.OIDCEnabled {
+		return errors.New("OIDC cannot be enabled when authentication is disabled")
 	}
 
 	prefixes, err := c.ParseAuthDisabledAllowedCIDRs()

--- a/internal/domain/config_test.go
+++ b/internal/domain/config_test.go
@@ -11,56 +11,101 @@ import (
 )
 
 func TestValidateAuthDisabledConfig(t *testing.T) {
-	t.Run("does nothing when auth is enabled", func(t *testing.T) {
-		cfg := &Config{
-			AuthDisabled:               true,
-			IAcknowledgeThisIsABadIdea: false,
-		}
-
-		require.NoError(t, cfg.ValidateAuthDisabledConfig())
-	})
-
-	t.Run("fails when allowlist is missing", func(t *testing.T) {
-		cfg := &Config{
-			AuthDisabled:               true,
-			IAcknowledgeThisIsABadIdea: true,
-		}
-
-		err := cfg.ValidateAuthDisabledConfig()
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "authDisabledAllowedCIDRs")
-	})
-
-	t.Run("fails on invalid entry", func(t *testing.T) {
-		cfg := &Config{
-			AuthDisabled:               true,
-			IAcknowledgeThisIsABadIdea: true,
-			AuthDisabledAllowedCIDRs:   []string{"nope"},
-		}
-
-		err := cfg.ValidateAuthDisabledConfig()
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid authDisabledAllowedCIDRs entry")
-	})
-
-	t.Run("accepts CIDR and single IP entries", func(t *testing.T) {
-		cfg := &Config{
-			AuthDisabled:               true,
-			IAcknowledgeThisIsABadIdea: true,
-			AuthDisabledAllowedCIDRs: []string{
-				"192.168.1.0/24",
-				"10.0.0.5",
-				"::1",
+	tests := []struct {
+		name         string
+		cfg          *Config
+		wantErr      bool
+		wantErrSub   string
+		wantPrefixes []string
+	}{
+		{
+			name: "no-op when only AuthDisabled is set",
+			cfg: &Config{
+				AuthDisabled:               true,
+				IAcknowledgeThisIsABadIdea: false,
 			},
-		}
+		},
+		{
+			name: "fails when OIDC is also enabled",
+			cfg: &Config{
+				AuthDisabled:               true,
+				IAcknowledgeThisIsABadIdea: true,
+				OIDCEnabled:                true,
+				AuthDisabledAllowedCIDRs:   []string{"127.0.0.1/32"},
+			},
+			wantErr:    true,
+			wantErrSub: "OIDC cannot be enabled",
+		},
+		{
+			name: "fails when allowlist is missing",
+			cfg: &Config{
+				AuthDisabled:               true,
+				IAcknowledgeThisIsABadIdea: true,
+			},
+			wantErr:    true,
+			wantErrSub: "authDisabledAllowedCIDRs",
+		},
+		{
+			name: "fails on invalid entry",
+			cfg: &Config{
+				AuthDisabled:               true,
+				IAcknowledgeThisIsABadIdea: true,
+				AuthDisabledAllowedCIDRs:   []string{"nope"},
+			},
+			wantErr:    true,
+			wantErrSub: "invalid authDisabledAllowedCIDRs entry",
+		},
+		{
+			name: "fails on non-canonical CIDR entry",
+			cfg: &Config{
+				AuthDisabled:               true,
+				IAcknowledgeThisIsABadIdea: true,
+				AuthDisabledAllowedCIDRs:   []string{"10.0.0.5/8"},
+			},
+			wantErr:    true,
+			wantErrSub: "host bits must be zero",
+		},
+		{
+			name: "accepts CIDR and single IP entries",
+			cfg: &Config{
+				AuthDisabled:               true,
+				IAcknowledgeThisIsABadIdea: true,
+				AuthDisabledAllowedCIDRs: []string{
+					"192.168.1.0/24",
+					"10.0.0.5",
+					"::1",
+				},
+			},
+			wantPrefixes: []string{
+				"192.168.1.0/24",
+				"10.0.0.5/32",
+				"::1/128",
+			},
+		},
+	}
 
-		require.NoError(t, cfg.ValidateAuthDisabledConfig())
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.ValidateAuthDisabledConfig()
+			if tc.wantErr {
+				require.Error(t, err)
+				if tc.wantErrSub != "" {
+					assert.Contains(t, err.Error(), tc.wantErrSub)
+				}
+				return
+			}
 
-		prefixes, err := cfg.ParseAuthDisabledAllowedCIDRs()
-		require.NoError(t, err)
-		require.Len(t, prefixes, 3)
-		assert.Equal(t, "192.168.1.0/24", prefixes[0].String())
-		assert.Equal(t, "10.0.0.5/32", prefixes[1].String())
-		assert.Equal(t, "::1/128", prefixes[2].String())
-	})
+			require.NoError(t, err)
+			if len(tc.wantPrefixes) == 0 {
+				return
+			}
+
+			prefixes, parseErr := tc.cfg.ParseAuthDisabledAllowedCIDRs()
+			require.NoError(t, parseErr)
+			require.Len(t, prefixes, len(tc.wantPrefixes))
+			for i, want := range tc.wantPrefixes {
+				assert.Equal(t, want, prefixes[i].String())
+			}
+		})
+	}
 }

--- a/internal/domain/config_test.go
+++ b/internal/domain/config_test.go
@@ -13,8 +13,8 @@ import (
 func TestValidateAuthDisabledConfig(t *testing.T) {
 	t.Run("does nothing when auth is enabled", func(t *testing.T) {
 		cfg := &Config{
-			AuthDisabled:           true,
-			IfIGetBannedItsMyFault: false,
+			AuthDisabled:               true,
+			IAcknowledgeThisIsABadIdea: false,
 		}
 
 		require.NoError(t, cfg.ValidateAuthDisabledConfig())
@@ -22,8 +22,8 @@ func TestValidateAuthDisabledConfig(t *testing.T) {
 
 	t.Run("fails when allowlist is missing", func(t *testing.T) {
 		cfg := &Config{
-			AuthDisabled:           true,
-			IfIGetBannedItsMyFault: true,
+			AuthDisabled:               true,
+			IAcknowledgeThisIsABadIdea: true,
 		}
 
 		err := cfg.ValidateAuthDisabledConfig()
@@ -33,9 +33,9 @@ func TestValidateAuthDisabledConfig(t *testing.T) {
 
 	t.Run("fails on invalid entry", func(t *testing.T) {
 		cfg := &Config{
-			AuthDisabled:             true,
-			IfIGetBannedItsMyFault:   true,
-			AuthDisabledAllowedCIDRs: []string{"nope"},
+			AuthDisabled:               true,
+			IAcknowledgeThisIsABadIdea: true,
+			AuthDisabledAllowedCIDRs:   []string{"nope"},
 		}
 
 		err := cfg.ValidateAuthDisabledConfig()
@@ -45,8 +45,8 @@ func TestValidateAuthDisabledConfig(t *testing.T) {
 
 	t.Run("accepts CIDR and single IP entries", func(t *testing.T) {
 		cfg := &Config{
-			AuthDisabled:           true,
-			IfIGetBannedItsMyFault: true,
+			AuthDisabled:               true,
+			IAcknowledgeThisIsABadIdea: true,
 			AuthDisabledAllowedCIDRs: []string{
 				"192.168.1.0/24",
 				"10.0.0.5",

--- a/internal/domain/config_test.go
+++ b/internal/domain/config_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateAuthDisabledConfig(t *testing.T) {
+	t.Run("does nothing when auth is enabled", func(t *testing.T) {
+		cfg := &Config{
+			AuthDisabled:           true,
+			IfIGetBannedItsMyFault: false,
+		}
+
+		require.NoError(t, cfg.ValidateAuthDisabledConfig())
+	})
+
+	t.Run("fails when allowlist is missing", func(t *testing.T) {
+		cfg := &Config{
+			AuthDisabled:           true,
+			IfIGetBannedItsMyFault: true,
+		}
+
+		err := cfg.ValidateAuthDisabledConfig()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "authDisabledAllowedCIDRs")
+	})
+
+	t.Run("fails on invalid entry", func(t *testing.T) {
+		cfg := &Config{
+			AuthDisabled:             true,
+			IfIGetBannedItsMyFault:   true,
+			AuthDisabledAllowedCIDRs: []string{"nope"},
+		}
+
+		err := cfg.ValidateAuthDisabledConfig()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid authDisabledAllowedCIDRs entry")
+	})
+
+	t.Run("accepts CIDR and single IP entries", func(t *testing.T) {
+		cfg := &Config{
+			AuthDisabled:           true,
+			IfIGetBannedItsMyFault: true,
+			AuthDisabledAllowedCIDRs: []string{
+				"192.168.1.0/24",
+				"10.0.0.5",
+				"::1",
+			},
+		}
+
+		require.NoError(t, cfg.ValidateAuthDisabledConfig())
+
+		prefixes, err := cfg.ParseAuthDisabledAllowedCIDRs()
+		require.NoError(t, err)
+		require.Len(t, prefixes, 3)
+		assert.Equal(t, "192.168.1.0/24", prefixes[0].String())
+		assert.Equal(t, "10.0.0.5/32", prefixes[1].String())
+		assert.Equal(t, "::1/128", prefixes[2].String())
+	})
+}


### PR DESCRIPTION
## Summary

- Add two env vars to disable qui's built-in authentication: `QUI__AUTH_DISABLED=true` **and** `QUI__IF_I_GET_BANNED_ITS_MY_FAULT=true` (both required)
- The second variable forces operators to explicitly acknowledge the risks — especially around private tracker bans from unauthorized torrent client access
- If only one of the two is set, a warning is logged and authentication remains enabled
- Intended for users running qui behind a reverse proxy that already handles auth (Authelia, Authentik, Caddy with forward_auth, etc.)

When both are set:
- All API endpoints are publicly accessible, `/auth/me` returns a synthetic `admin` user, and the setup screen is skipped — so the frontend works without any login flow
- Auth-specific endpoints (Login, Logout, ChangePassword, API key management, Setup) return `403 Forbidden` to prevent confusing errors and accidental DB mutations
- A warning is logged at startup

Also configurable via `config.toml` (`authDisabled` + `ifIGetBannedItsMyFault`).

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./internal/api/middleware/...` — all pass, including new tests:
  - `TestIsAuthenticated_AuthDisabled` — verifies bypass with synthetic username
  - `TestRequireSetup_AuthDisabled` — verifies setup check is skipped
  - `TestIsAuthenticated_AuthDisabledWithoutConfirmation` — verifies auth stays on when only one var is set
- [x] Docker: both env vars set — startup warning logged, `/api/auth/check-setup` returns `setupRequired: false`, `/api/auth/me` returns synthetic admin, `/api/instances` accessible without auth
- [x] `golangci-lint run --new-from-rev=origin/develop` — 0 issues

Fixes #951

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional built-in authentication disablement with a synthetic admin identity and setup skip when fully enabled.
  * IP/CIDR allowlist enforcement required when auth is disabled.

* **Behavior Changes**
  * Startup and config reload now validate auth-disable settings, emit warnings, and refuse invalid configurations.

* **Documentation**
  * Expanded guidance, examples, CIDR/IP formats, validation rules, and reverse-proxy safety advice.

* **Tests**
  * Added unit and integration tests covering auth-disabled validation, allowlist behavior, and reload handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->