### PR TITLE
docs: update contributing.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -29,14 +29,16 @@ Make sure you have the following dependencies installed before setting up your d
 
 ## How to contribute
 
-- **Fork and Clone:** [Fork the qui repository](https://github.com/autobrr/qui/fork) and clone it to start working on your changes.
+- **Pull request access:** This repo restricts pull request creation to **collaborators only**.
+  - If you are **not** a collaborator: start with an issue/discussion (or Discord) and include a patch (`git diff`) or link to your fork/branch so a maintainer can apply it.
+- **Clone:** Clone the repository to start working on your changes. If you are not a collaborator, you can still work from a [fork](https://github.com/autobrr/qui/fork) and share a patch/link (see above).
 - **Branching:** Create a new branch for your changes. Use a descriptive name for easy understanding.
   - Checkout a new branch for your fix or feature `git checkout -b fix/torrent-actions-issue`
 - **Coding:** Ensure your code is well-commented for clarity. With go use `go fmt`
 - **Commit Guidelines:** We appreciate the use of [Conventional Commit Guidelines](https://www.conventionalcommits.org/en/v1.0.0/#summary) when writing your commits.
   - Examples: `fix(qbittorrent): improve connection pooling`, `feat(torrent): add bulk actions`
   - There is no need for force pushing or rebasing. We squash commits on merge to keep the history clean and manageable.
-- **Pull Requests:** Submit a pull request from your Fork with a clear description of your changes. Reference any related issues.
+- **Pull Requests:** Open a pull request with a clear description of your changes. Reference any related issues.
   - Mark it as Draft if it's still in progress.
 - **Code Review:** Be open to feedback during the code review process.
 

--- a/.github/DISCUSSION_TEMPLATE/issue-triage.yml
+++ b/.github/DISCUSSION_TEMPLATE/issue-triage.yml
@@ -5,6 +5,8 @@ body:
       value: |
         > [!IMPORTANT]
         > Before opening a discussion, please check the [documentation](https://qui.autobrr.com) and search existing [Discussions](https://github.com/autobrr/qui/discussions) and [Issues](https://github.com/autobrr/qui/issues).
+        >
+        > Code contributions: PR creation is restricted to collaborators only, so start here (or open an Issue) to coordinate changes.
 
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: false
 contact_links:
   - name: Features, Bug Reports, Questions
     url: https://github.com/autobrr/qui/discussions/new/choose
-    about: Our preferred starting point if you have any questions or suggestions about issues, features or behavior.
+    about: Our preferred starting point for questions/suggestions (and contributions; PR creation is collaborators-only).

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Thank you for your support ❤️
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request.
+Contributions are welcome. Note: this repo restricts pull request creation to **collaborators only**. Please start with a Discussion/Issue (or Discord) so we can coordinate changes.
 
 ## License
 


### PR DESCRIPTION
update contributing.md to route non-collabs to Discussion/Issue/Discord\n\nAlso aligns README + issue/discussion templates with the new PR-creation restriction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines to clarify that pull request creation is restricted to collaborators.
  * Added guidance for non-collaborators to open issues or discussions to coordinate contributions and share patches.
  * Streamlined contribution information across project documentation for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->