### PR TITLE
fix(qbittorrent): ignore pseudo tracker labels in domain parsing

### DIFF
--- a/internal/qbittorrent/integration_test.go
+++ b/internal/qbittorrent/integration_test.go
@@ -1016,12 +1016,49 @@ func TestSyncManager_GetDomainsForTorrent(t *testing.T) {
 				"tracker.example.com": {},
 			},
 		},
+		{
+			name: "Pseudo trackers are filtered out",
+			torrent: &qbt.Torrent{
+				Hash: "hash7",
+				Trackers: []qbt.TorrentTracker{
+					{Url: "** [DHT] **"},
+					{Url: "[PeX]"},
+					{Url: " [LSD] "},
+					{Url: "https://valid.tracker.com/announce"},
+				},
+			},
+			expected: map[string]struct{}{
+				"valid.tracker.com": {},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			result := sm.getDomainsForTorrent(tc.torrent)
 			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestSyncManager_ExtractDomainFromURL_IgnoresPseudoTrackers(t *testing.T) {
+	sm := &SyncManager{}
+
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{input: "[DHT]", expected: ""},
+		{input: "** [dht] **", expected: ""},
+		{input: "[PeX]", expected: ""},
+		{input: " [LSD] ", expected: ""},
+		{input: "dht://", expected: ""},
+		{input: "https://tracker.example.com/announce", expected: "tracker.example.com"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			assert.Equal(t, tc.expected, sm.ExtractDomainFromURL(tc.input))
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- filter qBittorrent pseudo tracker labels (`[DHT]`, `[PeX]`, `[LSD]`) in `ExtractDomainFromURL`
- prevent pseudo labels from entering tracker counts and sidebar filter lists
- add regression coverage for pseudo tracker filtering in tracker-domain extraction tests

## Validation
- go test -race -count=3 ./internal/qbittorrent
- make test
- make build
- make lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed domain extraction to filter out pseudo tracker labels (DHT, PeX, LSD) ensuring only authentic tracker domains are returned.
* Enhanced domain validation to prevent pseudo-tracker placeholders from contaminating cached results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->