### PR TITLE
fix(ui): hide unified entry when one instance is active

### DIFF
--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -126,9 +126,7 @@ export function Header({
   }, [activeInstanceIds, isAllInstancesRoute, navigate, routeSearch])
   const toggleUnifiedScopeInstance = useCallback((instanceId: number) => {
     const currentlySelected = effectiveUnifiedInstanceIds.includes(instanceId)
-    const nextIds = currentlySelected
-      ? effectiveUnifiedInstanceIds.filter(id => id !== instanceId)
-      : [...effectiveUnifiedInstanceIds, instanceId]
+    const nextIds = currentlySelected? effectiveUnifiedInstanceIds.filter(id => id !== instanceId): [...effectiveUnifiedInstanceIds, instanceId]
 
     if (nextIds.length === 0) {
       return
@@ -145,8 +143,8 @@ export function Header({
     if (!isInstanceRoute || selectedInstanceId === null || selectedInstanceId <= 0) return undefined
     return instances?.find(i => i.id === selectedInstanceId)
   }, [isInstanceRoute, instances, selectedInstanceId])
-  const instanceName = isAllInstancesRoute ? "Unified" : (currentInstance?.name ?? null)
   const hasMultipleActiveInstances = activeInstances.length > 1
+  const instanceName = isAllInstancesRoute? (hasMultipleActiveInstances ? "Unified" : (activeInstances[0]?.name ?? null)): (currentInstance?.name ?? null)
 
   // Keep local state in sync with URL when navigating between instances/routes
   useEffect(() => {
@@ -278,29 +276,29 @@ export function Header({
                 Switch Scope
               </DropdownMenuLabel>
               <DropdownMenuSeparator />
-              <DropdownMenuItem asChild>
-                <Link
-                  to="/instances"
-                  search={hasCustomUnifiedScope ? { [UNIFIED_INSTANCE_IDS_SEARCH_PARAM]: encodeUnifiedInstanceIds(normalizedUnifiedInstanceIds) } : undefined}
-                  className={cn(
-                    "flex items-center gap-2 cursor-pointer rounded-sm px-2 py-1.5 text-sm focus-visible:outline-none",
-                    isAllInstancesRoute ? "bg-accent text-accent-foreground font-medium" : "hover:bg-accent/80 data-[highlighted]:bg-accent/80 text-foreground"
-                  )}
-                >
-                  <HardDrive className="h-4 w-4 flex-shrink-0" />
-                  <span className="flex-1 truncate">Unified</span>
-                  <span className="rounded border px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground">
-                    {activeInstances.length} active
-                  </span>
-                  {hasCustomUnifiedScope && (
-                    <span className="rounded border border-primary/40 px-1.5 py-0.5 text-[10px] font-medium leading-none text-primary">
-                      {unifiedScopeSummary}
-                    </span>
-                  )}
-                </Link>
-              </DropdownMenuItem>
-              {activeInstances.length > 1 && (
+              {hasMultipleActiveInstances && (
                 <>
+                  <DropdownMenuItem asChild>
+                    <Link
+                      to="/instances"
+                      search={hasCustomUnifiedScope ? { [UNIFIED_INSTANCE_IDS_SEARCH_PARAM]: encodeUnifiedInstanceIds(normalizedUnifiedInstanceIds) } : undefined}
+                      className={cn(
+                        "flex items-center gap-2 cursor-pointer rounded-sm px-2 py-1.5 text-sm focus-visible:outline-none",
+                        isAllInstancesRoute ? "bg-accent text-accent-foreground font-medium" : "hover:bg-accent/80 data-[highlighted]:bg-accent/80 text-foreground"
+                      )}
+                    >
+                      <HardDrive className="h-4 w-4 flex-shrink-0" />
+                      <span className="flex-1 truncate">Unified</span>
+                      <span className="rounded border px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground">
+                        {activeInstances.length} active
+                      </span>
+                      {hasCustomUnifiedScope && (
+                        <span className="rounded border border-primary/40 px-1.5 py-0.5 text-[10px] font-medium leading-none text-primary">
+                          {unifiedScopeSummary}
+                        </span>
+                      )}
+                    </Link>
+                  </DropdownMenuItem>
                   <DropdownMenuSeparator />
                   <DropdownMenuLabel className="text-xs text-muted-foreground uppercase tracking-wide">
                     Unified Scope
@@ -339,9 +337,9 @@ export function Header({
                       </DropdownMenuCheckboxItem>
                     )
                   })}
+                  <DropdownMenuSeparator />
                 </>
               )}
-              <DropdownMenuSeparator />
               <div className="max-h-64 overflow-y-auto space-y-1">
                 {activeInstances.length > 0 ? (
                   activeInstances.map((instance) => (
@@ -722,30 +720,30 @@ export function Header({
                   Logs
                 </Link>
               </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem asChild>
-                <Link
-                  to="/instances"
-                  search={hasCustomUnifiedScope ? { [UNIFIED_INSTANCE_IDS_SEARCH_PARAM]: encodeUnifiedInstanceIds(normalizedUnifiedInstanceIds) } : undefined}
-                  className={cn(
-                    "flex cursor-pointer",
-                    isAllInstancesRoute && "bg-accent text-accent-foreground font-medium"
-                  )}
-                >
-                  <HardDrive className="mr-2 h-4 w-4" />
-                  <span className="truncate">Unified</span>
-                  <span className="ml-auto rounded border px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground">
-                    {activeInstances.length} active
-                  </span>
-                  {hasCustomUnifiedScope && (
-                    <span className="rounded border border-primary/40 px-1.5 py-0.5 text-[10px] font-medium leading-none text-primary">
-                      {unifiedScopeSummary}
-                    </span>
-                  )}
-                </Link>
-              </DropdownMenuItem>
-              {activeInstances.length > 1 && (
+              {hasMultipleActiveInstances && (
                 <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem asChild>
+                    <Link
+                      to="/instances"
+                      search={hasCustomUnifiedScope ? { [UNIFIED_INSTANCE_IDS_SEARCH_PARAM]: encodeUnifiedInstanceIds(normalizedUnifiedInstanceIds) } : undefined}
+                      className={cn(
+                        "flex cursor-pointer",
+                        isAllInstancesRoute && "bg-accent text-accent-foreground font-medium"
+                      )}
+                    >
+                      <HardDrive className="mr-2 h-4 w-4" />
+                      <span className="truncate">Unified</span>
+                      <span className="ml-auto rounded border px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground">
+                        {activeInstances.length} active
+                      </span>
+                      {hasCustomUnifiedScope && (
+                        <span className="rounded border border-primary/40 px-1.5 py-0.5 text-[10px] font-medium leading-none text-primary">
+                          {unifiedScopeSummary}
+                        </span>
+                      )}
+                    </Link>
+                  </DropdownMenuItem>
                   <DropdownMenuSeparator />
                   <DropdownMenuLabel className="text-xs text-muted-foreground uppercase tracking-wide">
                     Unified Scope
@@ -784,9 +782,9 @@ export function Header({
                       </DropdownMenuCheckboxItem>
                     )
                   })}
+                  <DropdownMenuSeparator />
                 </>
               )}
-              <DropdownMenuSeparator />
               {activeInstances.length > 0 ? (
                 activeInstances.map((instance) => {
                   const csState = crossSeedInstanceState[instance.id]

--- a/web/src/components/layout/MobileFooterNav.tsx
+++ b/web/src/components/layout/MobileFooterNav.tsx
@@ -148,6 +148,7 @@ export function MobileFooterNav() {
   )
   const hasCustomUnifiedScope = normalizedUnifiedInstanceIds.length > 0
   const unifiedScopeSummary = `${effectiveUnifiedInstanceIds.length}/${activeInstances.length}`
+  const hasMultipleActiveInstances = activeInstances.length > 1
   const applyUnifiedScope = useCallback((nextIds: number[]) => {
     const normalizedIds = normalizeUnifiedInstanceIds(nextIds, activeInstanceIds)
     const nextSearch: Record<string, unknown> = isOnAllInstancesPage ? { ...(routeSearch || {}) } : {}
@@ -167,9 +168,7 @@ export function MobileFooterNav() {
   }, [activeInstanceIds, isOnAllInstancesPage, navigate, routeSearch])
   const toggleUnifiedScopeInstance = useCallback((instanceId: number) => {
     const currentlySelected = effectiveUnifiedInstanceIds.includes(instanceId)
-    const nextIds = currentlySelected
-      ? effectiveUnifiedInstanceIds.filter(id => id !== instanceId)
-      : [...effectiveUnifiedInstanceIds, instanceId]
+    const nextIds = currentlySelected? effectiveUnifiedInstanceIds.filter(id => id !== instanceId): [...effectiveUnifiedInstanceIds, instanceId]
 
     if (nextIds.length === 0) {
       return
@@ -181,9 +180,7 @@ export function MobileFooterNav() {
   const hasClientScopeEntry = isOnAllInstancesPage || hasActiveInstances
   const currentInstanceId = !isOnAllInstancesPage && location.pathname.startsWith("/instances/") ? location.pathname.split("/")[2] : null
   const currentInstance = instances?.find(i => i.id.toString() === currentInstanceId)
-  const currentInstanceLabel = isOnAllInstancesPage
-    ? "Unified"
-    : (currentInstance && currentInstance.isActive ? currentInstance.name : null)
+  const currentInstanceLabel = isOnAllInstancesPage? (hasMultipleActiveInstances ? "Unified" : (activeInstances[0]?.name ?? null)): (currentInstance && currentInstance.isActive ? currentInstance.name : null)
   const activeInstancesSummary = `${activeInstances.length} active instance${activeInstances.length === 1 ? "" : "s"}`
 
   const handleModeSelect = useCallback(async (mode: ThemeMode) => {
@@ -292,26 +289,26 @@ export function MobileFooterNav() {
             <DropdownMenuContent align="center" side="top" className="w-56 mb-2">
               <DropdownMenuLabel>qBittorrent Clients</DropdownMenuLabel>
               <DropdownMenuSeparator />
-              <DropdownMenuItem asChild>
-                <Link
-                  to="/instances"
-                  search={hasCustomUnifiedScope ? { [UNIFIED_INSTANCE_IDS_SEARCH_PARAM]: encodeUnifiedInstanceIds(normalizedUnifiedInstanceIds) } : undefined}
-                  className="flex items-center gap-2 min-w-0"
-                >
-                  <HardDrive className="h-4 w-4" />
-                  <span className="flex-1 min-w-0 truncate font-medium">Unified</span>
-                  <span className="rounded border px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground">
-                    {activeInstancesSummary}
-                  </span>
-                  {hasCustomUnifiedScope && (
-                    <span className="rounded border border-primary/40 px-1.5 py-0.5 text-[10px] font-medium leading-none text-primary">
-                      {unifiedScopeSummary}
-                    </span>
-                  )}
-                </Link>
-              </DropdownMenuItem>
-              {activeInstances.length > 1 && (
+              {hasMultipleActiveInstances && (
                 <>
+                  <DropdownMenuItem asChild>
+                    <Link
+                      to="/instances"
+                      search={hasCustomUnifiedScope ? { [UNIFIED_INSTANCE_IDS_SEARCH_PARAM]: encodeUnifiedInstanceIds(normalizedUnifiedInstanceIds) } : undefined}
+                      className="flex items-center gap-2 min-w-0"
+                    >
+                      <HardDrive className="h-4 w-4" />
+                      <span className="flex-1 min-w-0 truncate font-medium">Unified</span>
+                      <span className="rounded border px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground">
+                        {activeInstancesSummary}
+                      </span>
+                      {hasCustomUnifiedScope && (
+                        <span className="rounded border border-primary/40 px-1.5 py-0.5 text-[10px] font-medium leading-none text-primary">
+                          {unifiedScopeSummary}
+                        </span>
+                      )}
+                    </Link>
+                  </DropdownMenuItem>
                   <DropdownMenuSeparator />
                   <DropdownMenuLabel className="text-xs uppercase tracking-wide text-muted-foreground">
                     Unified Scope
@@ -350,9 +347,9 @@ export function MobileFooterNav() {
                       </DropdownMenuCheckboxItem>
                     )
                   })}
+                  <DropdownMenuSeparator />
                 </>
               )}
-              <DropdownMenuSeparator />
               {activeInstances.length > 0 ? (
                 activeInstances.map((instance) => {
                   const csState = crossSeedInstanceState[instance.id]
@@ -730,9 +727,7 @@ export function MobileFooterNav() {
                                       }}
                                       className={cn(
                                         "w-8 h-8 rounded-full transition-all cursor-pointer",
-                                        isSelected
-                                          ? "ring-2 ring-black dark:ring-white"
-                                          : "ring-1 ring-black/10 dark:ring-white/10"
+                                        isSelected? "ring-2 ring-black dark:ring-white": "ring-1 ring-black/10 dark:ring-white/10"
                                       )}
                                       style={{
                                         backgroundColor: variation.color,

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -147,6 +147,7 @@ export function Sidebar() {
   const isAllInstancesActive = location.pathname === "/instances" || location.pathname === "/instances/"
   const hasCustomUnifiedScope = normalizedUnifiedInstanceIds.length > 0
   const unifiedScopeSummary = `${effectiveUnifiedInstanceIds.length}/${activeInstances.length}`
+  const hasMultipleActiveInstances = activeInstances.length > 1
   const applyUnifiedScope = useCallback((nextIds: number[]) => {
     const normalizedIds = normalizeUnifiedInstanceIds(nextIds, activeInstanceIds)
     const nextSearch: Record<string, unknown> = isAllInstancesActive ? { ...(routeSearch || {}) } : {}
@@ -166,9 +167,7 @@ export function Sidebar() {
   }, [activeInstanceIds, isAllInstancesActive, navigate, routeSearch])
   const toggleUnifiedScopeInstance = useCallback((instanceId: number) => {
     const currentlySelected = effectiveUnifiedInstanceIds.includes(instanceId)
-    const nextIds = currentlySelected
-      ? effectiveUnifiedInstanceIds.filter(id => id !== instanceId)
-      : [...effectiveUnifiedInstanceIds, instanceId]
+    const nextIds = currentlySelected? effectiveUnifiedInstanceIds.filter(id => id !== instanceId): [...effectiveUnifiedInstanceIds, instanceId]
 
     if (nextIds.length === 0) {
       return
@@ -201,9 +200,7 @@ export function Sidebar() {
         <div className="space-y-1">
           {navigation.map((item) => {
             const Icon = item.icon
-            const isActive = item.isActive
-              ? item.isActive(location.pathname, routeSearch)
-              : location.pathname === item.href
+            const isActive = item.isActive? item.isActive(location.pathname, routeSearch): location.pathname === item.href
 
             return (
               <Link
@@ -231,96 +228,98 @@ export function Sidebar() {
               Instances
             </p>
             <div className="mt-1 flex-1 overflow-y-auto space-y-1 pr-1">
-              <Link
-                to="/instances"
-                search={hasCustomUnifiedScope ? { [UNIFIED_INSTANCE_IDS_SEARCH_PARAM]: encodeUnifiedInstanceIds(normalizedUnifiedInstanceIds) } : undefined}
-                className={cn(
-                  "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-all duration-200 ease-out",
-                  isAllInstancesActive ? "bg-sidebar-primary text-sidebar-primary-foreground" : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
-                )}
-              >
-                <HardDrive className="h-4 w-4 flex-shrink-0" />
-                <span className="truncate max-w-36">Unified</span>
-                <span
-                  className={cn(
-                    "ml-auto rounded border px-1.5 py-0.5 text-[10px] font-medium leading-none flex-shrink-0",
-                    isAllInstancesActive ? "border-sidebar-primary-foreground/35 text-sidebar-primary-foreground/90" : "border-sidebar-border text-sidebar-foreground/70"
-                  )}
-                >
-                  {activeInstances.length} active
-                </span>
-                {hasCustomUnifiedScope && (
-                  <span
+              {hasMultipleActiveInstances && (
+                <>
+                  <Link
+                    to="/instances"
+                    search={hasCustomUnifiedScope ? { [UNIFIED_INSTANCE_IDS_SEARCH_PARAM]: encodeUnifiedInstanceIds(normalizedUnifiedInstanceIds) } : undefined}
                     className={cn(
-                      "rounded border px-1.5 py-0.5 text-[10px] font-medium leading-none flex-shrink-0",
-                      isAllInstancesActive ? "border-sidebar-primary-foreground/35 text-sidebar-primary-foreground/90" : "border-sidebar-border text-sidebar-foreground/70"
+                      "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-all duration-200 ease-out",
+                      isAllInstancesActive ? "bg-sidebar-primary text-sidebar-primary-foreground" : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
                     )}
                   >
-                    {unifiedScopeSummary}
-                  </span>
-                )}
-              </Link>
-              {activeInstances.length > 1 && (
-                <div className="px-3">
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <button
-                        type="button"
+                    <HardDrive className="h-4 w-4 flex-shrink-0" />
+                    <span className="truncate max-w-36">Unified</span>
+                    <span
+                      className={cn(
+                        "ml-auto rounded border px-1.5 py-0.5 text-[10px] font-medium leading-none flex-shrink-0",
+                        isAllInstancesActive ? "border-sidebar-primary-foreground/35 text-sidebar-primary-foreground/90" : "border-sidebar-border text-sidebar-foreground/70"
+                      )}
+                    >
+                      {activeInstances.length} active
+                    </span>
+                    {hasCustomUnifiedScope && (
+                      <span
                         className={cn(
-                          "mt-1 w-full rounded-md border border-sidebar-border/70 px-2 py-1 text-xs",
-                          "text-sidebar-foreground/80 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
-                          "inline-flex items-center gap-1.5"
+                          "rounded border px-1.5 py-0.5 text-[10px] font-medium leading-none flex-shrink-0",
+                          isAllInstancesActive ? "border-sidebar-primary-foreground/35 text-sidebar-primary-foreground/90" : "border-sidebar-border text-sidebar-foreground/70"
                         )}
                       >
-                        <SlidersHorizontal className="h-3 w-3" />
-                        Scope
-                      </button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent side="right" align="start" className="w-56">
-                      <DropdownMenuLabel className="text-xs uppercase tracking-wide text-muted-foreground">
-                        Unified Scope
-                      </DropdownMenuLabel>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem
-                        onSelect={(event) => {
-                          event.preventDefault()
-                          applyUnifiedScope(activeInstanceIds)
-                        }}
-                        className="cursor-pointer text-xs"
-                      >
-                        All active ({activeInstances.length})
-                      </DropdownMenuItem>
-                      <DropdownMenuSeparator />
-                      {activeInstances.map((instance) => {
-                        const checked = effectiveUnifiedInstanceIds.includes(instance.id)
-                        return (
-                          <DropdownMenuCheckboxItem
-                            key={`sidebar-scope-${instance.id}`}
-                            checked={checked}
-                            onSelect={(event) => {
-                              event.preventDefault()
-                              toggleUnifiedScopeInstance(instance.id)
-                            }}
-                            className="cursor-pointer"
-                          >
-                            <span className="flex w-full items-center justify-between gap-2">
-                              <span className="truncate">{instance.name}</span>
-                              <span
-                                className={cn(
-                                  "h-2 w-2 rounded-full flex-shrink-0",
-                                  instance.connected ? "bg-green-500" : "bg-red-500"
-                                )}
-                                aria-hidden="true"
-                              />
-                            </span>
-                          </DropdownMenuCheckboxItem>
-                        )
-                      })}
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </div>
+                        {unifiedScopeSummary}
+                      </span>
+                    )}
+                  </Link>
+                  <div className="px-3">
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <button
+                          type="button"
+                          className={cn(
+                            "mt-1 w-full rounded-md border border-sidebar-border/70 px-2 py-1 text-xs",
+                            "text-sidebar-foreground/80 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+                            "inline-flex items-center gap-1.5"
+                          )}
+                        >
+                          <SlidersHorizontal className="h-3 w-3" />
+                          Scope
+                        </button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent side="right" align="start" className="w-56">
+                        <DropdownMenuLabel className="text-xs uppercase tracking-wide text-muted-foreground">
+                          Unified Scope
+                        </DropdownMenuLabel>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          onSelect={(event) => {
+                            event.preventDefault()
+                            applyUnifiedScope(activeInstanceIds)
+                          }}
+                          className="cursor-pointer text-xs"
+                        >
+                          All active ({activeInstances.length})
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                        {activeInstances.map((instance) => {
+                          const checked = effectiveUnifiedInstanceIds.includes(instance.id)
+                          return (
+                            <DropdownMenuCheckboxItem
+                              key={`sidebar-scope-${instance.id}`}
+                              checked={checked}
+                              onSelect={(event) => {
+                                event.preventDefault()
+                                toggleUnifiedScopeInstance(instance.id)
+                              }}
+                              className="cursor-pointer"
+                            >
+                              <span className="flex w-full items-center justify-between gap-2">
+                                <span className="truncate">{instance.name}</span>
+                                <span
+                                  className={cn(
+                                    "h-2 w-2 rounded-full flex-shrink-0",
+                                    instance.connected ? "bg-green-500" : "bg-red-500"
+                                  )}
+                                  aria-hidden="true"
+                                />
+                              </span>
+                            </DropdownMenuCheckboxItem>
+                          )
+                        })}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
+                  <Separator className="my-2" />
+                </>
               )}
-              <Separator className="my-2" />
               {activeInstances.map((instance) => {
                 const instancePath = `/instances/${instance.id}`
                 const isActive = location.pathname === instancePath || location.pathname.startsWith(`${instancePath}/`)


### PR DESCRIPTION
## Summary
- hide the Unified entry and scope controls in sidebar/header/mobile client switchers when there is only one active instance
- keep Unified behavior unchanged when two or more instances are active
- show the single active instance name (instead of Unified) on all-instances route labels to avoid duplicate-looking controls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified scope UI now appears only when multiple active instances exist, reducing visual clutter
  * Instance display logic updated: shows "Unified" label conditionally based on active instance count
  * Navigation layout refined across header, mobile footer, and sidebar for improved consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->