### PR TITLE
fix(automations): make managed full tag sync idempotent

### DIFF
--- a/documentation/docs/features/automations.md
+++ b/documentation/docs/features/automations.md
@@ -468,11 +468,28 @@ Manage tags on torrents. You can add multiple Tag actions in one workflow.
 `mode: remove` removes tags from torrents that match the tag action condition. It does not remove from non-matches.
 :::
 
+`mode: full` is evaluated within the rule's scope for that run (enabled rule, tracker pattern match, and run eligibility). It is not a client-wide sweep by itself.
+
 Options:
 
-- **Managed / Replace in Client** - `Managed` (default) keeps tag set in sync without hard-resetting client tags. `Replace in client` deletes managed tags from qBittorrent first, then reapplies to current matches.
+- **Managed / Replace in Client** - `Managed` (default) applies per-torrent add/remove diffs only. `Replace in client` deletes managed tags from qBittorrent first, then reapplies to current matches.
 - **Use Tracker as Tag** - Derive tag from tracker domain
 - **Use Display Name** - Use tracker customization display name instead of raw domain
+
+Behavior reference:
+
+| Configuration                  | Behavior |
+| ----------------------------- | -------- |
+| `mode: full` + `Managed`      | Adds/removes tag for torrents this rule evaluates. No client-wide reset. |
+| `mode: full` + `Replace in client` | Deletes selected tag(s) client-wide first, then re-adds only current matches. |
+
+If you see repeated activity like `+tag=696` every run, that usually means **Replace in client** is enabled for that tag action.
+
+Quick troubleshooting:
+
+1. Check logs for `automations: deleted managed tags from client before retagging`.
+2. In Automations UI, open enabled rules and verify whether "Replace in client" is enabled on any tag action.
+3. Confirm the activity entry's rule list matches the rule you expect.
 
 ### Category
 

--- a/internal/services/automations/processor_test.go
+++ b/internal/services/automations/processor_test.go
@@ -1934,7 +1934,7 @@ func TestProcessTorrents_Tag_DeleteFromClient_ReaddsForMatchingTorrents(t *testi
 	require.Equal(t, "add", action, "expected managed tag to be re-added after client reset")
 }
 
-func TestProcessTorrents_Tag_FullMode_ReaddsForMatchingTorrents(t *testing.T) {
+func TestProcessTorrents_Tag_FullMode_NoOpForAlreadyMatchingTag(t *testing.T) {
 	sm := qbittorrent.NewSyncManager(nil, nil)
 
 	torrents := []qbt.Torrent{
@@ -1966,12 +1966,8 @@ func TestProcessTorrents_Tag_FullMode_ReaddsForMatchingTorrents(t *testing.T) {
 	}
 
 	states := processTorrents(torrents, []*models.Automation{rule}, nil, sm, nil, nil)
-	state, ok := states["abc123"]
-	require.True(t, ok, "expected state to be recorded for torrent")
-
-	action, hasTag := state.tagActions["managed"]
-	require.True(t, hasTag, "expected tag action to be recorded")
-	require.Equal(t, "add", action, "expected full mode managed tag to be re-added after client reset")
+	_, ok := states["abc123"]
+	require.False(t, ok, "expected no state changes when managed full mode tag already matches")
 }
 
 func TestProcessTorrents_ExternalProgram_CombinedWithOtherActions(t *testing.T) {

--- a/internal/services/automations/service.go
+++ b/internal/services/automations/service.go
@@ -5219,7 +5219,7 @@ func collectManagedTagsForClientReset(rules []*models.Automation) []string {
 
 	unique := make(map[string]struct{})
 	for _, rule := range rules {
-		if rule == nil || rule.Conditions == nil {
+		if rule == nil || !rule.Enabled || rule.Conditions == nil {
 			continue
 		}
 		for _, action := range rule.Conditions.TagActions() {

--- a/internal/services/automations/service_test.go
+++ b/internal/services/automations/service_test.go
@@ -411,6 +411,7 @@ func TestApplyRuleDryRun_NoServiceOrRule(t *testing.T) {
 func TestCollectManagedTagsForClientReset(t *testing.T) {
 	rules := []*models.Automation{
 		{
+			Enabled: true,
 			Conditions: &models.ActionConditions{
 				Tag: &models.TagAction{
 					Enabled: true,
@@ -420,6 +421,7 @@ func TestCollectManagedTagsForClientReset(t *testing.T) {
 			},
 		},
 		{
+			Enabled: true,
 			Conditions: &models.ActionConditions{
 				Tag: &models.TagAction{
 					Enabled:          true,
@@ -430,6 +432,7 @@ func TestCollectManagedTagsForClientReset(t *testing.T) {
 			},
 		},
 		{
+			Enabled: true,
 			Conditions: &models.ActionConditions{
 				Tag: &models.TagAction{
 					Enabled:          false,
@@ -439,6 +442,7 @@ func TestCollectManagedTagsForClientReset(t *testing.T) {
 			},
 		},
 		{
+			Enabled: true,
 			Conditions: &models.ActionConditions{
 				Tag: &models.TagAction{
 					Enabled: true,
@@ -448,11 +452,22 @@ func TestCollectManagedTagsForClientReset(t *testing.T) {
 			},
 		},
 		{
+			Enabled: true,
 			Conditions: &models.ActionConditions{
 				Tag: &models.TagAction{
 					Enabled:          true,
 					DeleteFromClient: true,
 					Tags:             []string{"managed"},
+				},
+			},
+		},
+		{
+			Enabled: false,
+			Conditions: &models.ActionConditions{
+				Tag: &models.TagAction{
+					Enabled:          true,
+					DeleteFromClient: true,
+					Tags:             []string{"disabled-rule"},
 				},
 			},
 		},

--- a/internal/services/automations/service_test.go
+++ b/internal/services/automations/service_test.go
@@ -459,7 +459,7 @@ func TestCollectManagedTagsForClientReset(t *testing.T) {
 	}
 
 	got := collectManagedTagsForClientReset(rules)
-	require.Equal(t, []string{"managed", "stale"}, got)
+	require.Equal(t, []string{"managed"}, got)
 }
 
 // -----------------------------------------------------------------------------

--- a/internal/services/automations/tag_reset.go
+++ b/internal/services/automations/tag_reset.go
@@ -4,8 +4,6 @@
 package automations
 
 import (
-	"strings"
-
 	"github.com/autobrr/qui/internal/models"
 )
 
@@ -18,10 +16,5 @@ func shouldResetTagActionInClient(action *models.TagAction) bool {
 		return false
 	}
 
-	mode := strings.ToLower(strings.TrimSpace(action.Mode))
-	if mode == "" {
-		mode = models.TagModeFull
-	}
-
-	return action.DeleteFromClient || mode == models.TagModeFull
+	return action.DeleteFromClient
 }

--- a/web/src/components/instances/preferences/WorkflowDialog.tsx
+++ b/web/src/components/instances/preferences/WorkflowDialog.tsx
@@ -2540,7 +2540,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
                                 </div>
                               ) : (
                                 <div className="text-xs text-muted-foreground">
-                                  Managed mode keeps tags accurate; with Full sync it resets selected tags and re-adds only current matches.
+                                  Managed mode keeps tags accurate with diff-based updates; Full sync adds tags to matches and removes them from non-matches.
                                 </div>
                               )}
                               <div className="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4">


### PR DESCRIPTION
## Summary
- make tag reset-in-client behavior opt-in: only `deleteFromClient: true` triggers reset
- keep managed `full` mode diff-based and idempotent for already-correct tags
- update automations tests to lock new managed vs replace semantics
- align workflow dialog copy with runtime behavior

## Validation
- make lint
- make test
- make build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified tag management text to distinguish Managed (diff-based add/remove per item) and Full sync (adds tags to matches, removes from non-matches); added behavior reference and troubleshooting steps.
* **Behavior Change**
  * Client-side tag reset now only occurs when the action explicitly requests deletion; disabled rules are ignored when collecting managed tags.
* **Tests**
  * Updated tests to match the adjusted tag-reset and rule-collection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->