### PR TITLE
fix(auth): avoid chromium basic auth resets on expired qui sessions

### DIFF
--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -46,7 +46,9 @@ func IsAuthenticated(authService *auth.Service, sessionManager *scs.SessionManag
 
 			// Check session using SCS
 			if !sessionManager.GetBool(r.Context(), "authenticated") {
-				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				// Use 403 to avoid Chromium resetting upstream Basic Auth creds when
+				// qui is behind a reverse proxy (e.g. Swizzin nginx auth_basic).
+				http.Error(w, "Unauthorized", http.StatusForbidden)
 				return
 			}
 

--- a/internal/api/middleware/auth_test.go
+++ b/internal/api/middleware/auth_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/autobrr/qui/internal/domain"
 )
 
-func TestIsAuthenticated_APIKeyHeaderAndUnauthorized(t *testing.T) {
+func TestIsAuthenticated_APIKeyHeaderAndSessionForbidden(t *testing.T) {
 	ctx := t.Context()
 
 	dbPath := filepath.Join(t.TempDir(), "test.db")
@@ -59,21 +59,27 @@ func TestIsAuthenticated_APIKeyHeaderAndUnauthorized(t *testing.T) {
 			expectedStatus: http.StatusOK,
 		},
 		{
+			name:           "endpoint with invalid X-API-Key header",
+			path:           "/api/cross-seed/apply",
+			apiKeyHeader:   "invalid-key",
+			expectedStatus: http.StatusUnauthorized,
+		},
+		{
 			name:           "endpoint without auth",
 			path:           "/api/cross-seed/apply",
-			expectedStatus: http.StatusUnauthorized,
+			expectedStatus: http.StatusForbidden,
 		},
 		{
 			name:           "endpoint with invalid apikey",
 			path:           "/api/cross-seed/apply",
 			apiKeyQuery:    "invalid-key",
-			expectedStatus: http.StatusUnauthorized,
+			expectedStatus: http.StatusForbidden,
 		},
 		{
 			name:           "query param without middleware is rejected",
 			path:           "/api/torrents",
 			apiKeyQuery:    apiKeyValue,
-			expectedStatus: http.StatusUnauthorized,
+			expectedStatus: http.StatusForbidden,
 		},
 	}
 
@@ -158,5 +164,5 @@ func TestIsAuthenticated_AuthDisabledWithoutConfirmation(t *testing.T) {
 	resp := httptest.NewRecorder()
 	handler.ServeHTTP(resp, req)
 
-	assert.Equal(t, http.StatusUnauthorized, resp.Code)
+	assert.Equal(t, http.StatusForbidden, resp.Code)
 }


### PR DESCRIPTION
## Summary
- return 403 Forbidden (instead of 401 Unauthorized) when a request has no valid qui session
- keep invalid X-API-Key behavior as 401 Unauthorized
- add regression coverage to lock session-missing responses to 403 while preserving 401 for invalid API key headers
- restores the reverse-proxy behavior expected after #468 for setups like Swizzin

Validation run: go test -race -count=3 ./internal/api/middleware, make test, make build, make lint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated authentication failure responses to return Forbidden (403) instead of Unauthorized (401) in specific scenarios for improved reverse proxy compatibility with upstream authentication systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->