### PR TITLE
fix(crossseed): avoid webhook notification spam on pending matches

### DIFF
--- a/internal/services/crossseed/crossseed_test.go
+++ b/internal/services/crossseed/crossseed_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/autobrr/qui/internal/models"
 	internalqb "github.com/autobrr/qui/internal/qbittorrent"
 	"github.com/autobrr/qui/internal/services/jackett"
+	"github.com/autobrr/qui/internal/services/notifications"
 	"github.com/autobrr/qui/pkg/releases"
 	"github.com/autobrr/qui/pkg/stringutils"
 )
@@ -2274,6 +2275,68 @@ func TestCheckWebhook_AutobrrPayload(t *testing.T) {
 	}
 }
 
+func TestCheckWebhook_NotificationRequiresCompleteMatch(t *testing.T) {
+	t.Parallel()
+
+	instance := &models.Instance{
+		ID:   1,
+		Name: "Test Instance",
+	}
+	store := &fakeInstanceStore{
+		instances: map[int]*models.Instance{
+			instance.ID: instance,
+		},
+	}
+
+	tests := []struct {
+		name              string
+		progress          float64
+		wantCanCrossSeed  bool
+		wantNotificationN int
+	}{
+		{
+			name:              "pending-only match does not notify",
+			progress:          0.5,
+			wantCanCrossSeed:  false,
+			wantNotificationN: 0,
+		},
+		{
+			name:              "complete match notifies once",
+			progress:          1.0,
+			wantCanCrossSeed:  true,
+			wantNotificationN: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			notifier := &recordingNotifier{}
+			svc := &Service{
+				instanceStore:    store,
+				syncManager:      newFakeSyncManager(instance, []qbt.Torrent{{Hash: "abc123", Name: "Notify.Test.2025.1080p.BluRay.x264-GRP", Progress: tt.progress}}, nil),
+				releaseCache:     NewReleaseCache(),
+				stringNormalizer: stringutils.NewDefaultNormalizer(),
+				notifier:         notifier,
+			}
+
+			resp, err := svc.CheckWebhook(context.Background(), &WebhookCheckRequest{
+				InstanceIDs: []int{instance.ID},
+				TorrentName: "Notify.Test.2025.1080p.BluRay.x264-GRP",
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			assert.Equal(t, tt.wantCanCrossSeed, resp.CanCrossSeed)
+			assert.Equal(t, "download", resp.Recommendation)
+
+			events := notifier.Events()
+			assert.Len(t, events, tt.wantNotificationN)
+			if tt.wantNotificationN > 0 {
+				assert.Equal(t, notifications.EventCrossSeedWebhookSucceeded, events[0].Type)
+			}
+		})
+	}
+}
+
 func TestCheckWebhook_NoInstancesAvailable(t *testing.T) {
 	t.Parallel()
 
@@ -2483,6 +2546,20 @@ func TestFindCandidates_NonTVDoesNotMatchUnrelatedTorrents(t *testing.T) {
 
 type fakeInstanceStore struct {
 	instances map[int]*models.Instance
+}
+
+type recordingNotifier struct {
+	events []notifications.Event
+}
+
+func (r *recordingNotifier) Notify(_ context.Context, event notifications.Event) {
+	r.events = append(r.events, event)
+}
+
+func (r *recordingNotifier) Events() []notifications.Event {
+	result := make([]notifications.Event, len(r.events))
+	copy(result, r.events)
+	return result
 }
 
 func (f *fakeInstanceStore) Get(_ context.Context, id int) (*models.Instance, error) {

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -8718,6 +8718,9 @@ func (s *Service) notifyWebhookCheck(ctx context.Context, req *WebhookCheckReque
 			pendingCount++
 		}
 	}
+	if completeCount == 0 {
+		return
+	}
 
 	lines := []string{
 		"Torrent: " + strings.TrimSpace(req.TorrentName),


### PR DESCRIPTION
## Summary
- stop emitting webhook success notifications when all matches are still pending
- keep notifications for complete matches only
- add regression coverage for pending-only vs complete-match notification behavior

Validation run: go test -race -count=3 ./internal/services/crossseed -run 'TestCheckWebhook_(AutobrrPayload|NotificationRequiresCompleteMatch)$'; make test; make lint (backend lint passed, frontend lint blocked in this env because web/node_modules is missing and eslint is unavailable).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook notifications now only trigger when cross-seed matches reach completion, preventing notifications from being sent for partial or pending match states.

* **Tests**
  * Implemented comprehensive webhook notification behavior tests, validating that notifications are correctly emitted for complete matches while remaining suppressed for pending scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->