### PR TITLE
fix(notifications): improve torrent and automation event samples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,11 @@
 
 Repository guidelines for AI coding agents (Codex, Claude Code, etc.) working on qui.
 
+## Owner Collaboration Notes
+
+- Do not implement review-suggested or extra changes outside requested scope without explicit user approval first.
+- Treat other agent/Codex/CodeRabbit feedback as input to discuss, not automatic action.
+
 ## Project Structure & Module Organization
 
 The Go backend lives in `cmd/qui` (entrypoint) and `internal/` modules for configuration, qBittorrent, metrics, and API routing; shared helpers sit in `pkg/`. The React/Vite client is in `web/src` with static assets in `web/public`, and its production bundle must stay synced to `internal/web/dist`. Reference docs live under `docs/`, while Docker and compose files in the repository root support container workflows.

--- a/cmd/qui/torrent_notifications.go
+++ b/cmd/qui/torrent_notifications.go
@@ -26,25 +26,13 @@ type torrentNotificationSync interface {
 
 func buildTorrentCompletedEvent(syncManager torrentNotificationSync, instanceID int, torrent qbt.Torrent) notifications.Event {
 	return notifications.Event{
-		Type:                   notifications.EventTorrentCompleted,
-		InstanceID:             instanceID,
-		TorrentName:            torrent.Name,
-		TorrentHash:            torrent.Hash,
-		TorrentAddedOn:         torrent.AddedOn,
-		TorrentETASeconds:      torrent.ETA,
-		TorrentState:           string(torrent.State),
-		TorrentProgress:        torrent.Progress,
-		TorrentRatio:           torrent.Ratio,
-		TorrentTotalSizeBytes:  torrent.TotalSize,
-		TorrentDownloadedBytes: torrent.Downloaded,
-		TorrentAmountLeftBytes: torrent.AmountLeft,
-		TorrentDlSpeedBps:      torrent.DlSpeed,
-		TorrentUpSpeedBps:      torrent.UpSpeed,
-		TorrentNumSeeds:        torrent.NumSeeds,
-		TorrentNumLeechs:       torrent.NumLeechs,
-		TrackerDomain:          trackerDomainForTorrent(syncManager, torrent),
-		Category:               torrent.Category,
-		Tags:                   parseTorrentTags(torrent.Tags),
+		Type:          notifications.EventTorrentCompleted,
+		InstanceID:    instanceID,
+		TorrentName:   torrent.Name,
+		TorrentHash:   torrent.Hash,
+		TrackerDomain: trackerDomainForTorrent(syncManager, torrent),
+		Category:      torrent.Category,
+		Tags:          parseTorrentTags(torrent.Tags),
 	}
 }
 

--- a/cmd/qui/torrent_notifications.go
+++ b/cmd/qui/torrent_notifications.go
@@ -26,13 +26,25 @@ type torrentNotificationSync interface {
 
 func buildTorrentCompletedEvent(syncManager torrentNotificationSync, instanceID int, torrent qbt.Torrent) notifications.Event {
 	return notifications.Event{
-		Type:          notifications.EventTorrentCompleted,
-		InstanceID:    instanceID,
-		TorrentName:   torrent.Name,
-		TorrentHash:   torrent.Hash,
-		TrackerDomain: trackerDomainForTorrent(syncManager, torrent),
-		Category:      torrent.Category,
-		Tags:          parseTorrentTags(torrent.Tags),
+		Type:                   notifications.EventTorrentCompleted,
+		InstanceID:             instanceID,
+		TorrentName:            torrent.Name,
+		TorrentHash:            torrent.Hash,
+		TorrentAddedOn:         torrent.AddedOn,
+		TorrentETASeconds:      torrent.ETA,
+		TorrentState:           string(torrent.State),
+		TorrentProgress:        torrent.Progress,
+		TorrentRatio:           torrent.Ratio,
+		TorrentTotalSizeBytes:  torrent.TotalSize,
+		TorrentDownloadedBytes: torrent.Downloaded,
+		TorrentAmountLeftBytes: torrent.AmountLeft,
+		TorrentDlSpeedBps:      torrent.DlSpeed,
+		TorrentUpSpeedBps:      torrent.UpSpeed,
+		TorrentNumSeeds:        torrent.NumSeeds,
+		TorrentNumLeechs:       torrent.NumLeechs,
+		TrackerDomain:          trackerDomainForTorrent(syncManager, torrent),
+		Category:               torrent.Category,
+		Tags:                   parseTorrentTags(torrent.Tags),
 	}
 }
 

--- a/cmd/qui/torrent_notifications.go
+++ b/cmd/qui/torrent_notifications.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package main
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/rs/zerolog/log"
+
+	"github.com/autobrr/qui/internal/services/notifications"
+)
+
+const (
+	torrentAddedNotificationDelay = 10 * time.Second
+	torrentAddedRefreshTimeout    = 5 * time.Second
+)
+
+type torrentNotificationSync interface {
+	GetTorrents(ctx context.Context, instanceID int, filter qbt.TorrentFilterOptions) ([]qbt.Torrent, error)
+	ExtractDomainFromURL(rawURL string) string
+}
+
+func buildTorrentCompletedEvent(syncManager torrentNotificationSync, instanceID int, torrent qbt.Torrent) notifications.Event {
+	return notifications.Event{
+		Type:          notifications.EventTorrentCompleted,
+		InstanceID:    instanceID,
+		TorrentName:   torrent.Name,
+		TorrentHash:   torrent.Hash,
+		TrackerDomain: trackerDomainForTorrent(syncManager, torrent),
+		Category:      torrent.Category,
+		Tags:          parseTorrentTags(torrent.Tags),
+	}
+}
+
+func buildTorrentAddedEvent(syncManager torrentNotificationSync, instanceID int, torrent qbt.Torrent) notifications.Event {
+	return notifications.Event{
+		Type:                   notifications.EventTorrentAdded,
+		InstanceID:             instanceID,
+		TorrentName:            torrent.Name,
+		TorrentHash:            torrent.Hash,
+		TorrentAddedOn:         torrent.AddedOn,
+		TorrentETASeconds:      torrent.ETA,
+		TorrentState:           string(torrent.State),
+		TorrentProgress:        torrent.Progress,
+		TorrentRatio:           torrent.Ratio,
+		TorrentTotalSizeBytes:  torrent.TotalSize,
+		TorrentDownloadedBytes: torrent.Downloaded,
+		TorrentAmountLeftBytes: torrent.AmountLeft,
+		TorrentDlSpeedBps:      torrent.DlSpeed,
+		TorrentUpSpeedBps:      torrent.UpSpeed,
+		TorrentNumSeeds:        torrent.NumSeeds,
+		TorrentNumLeechs:       torrent.NumLeechs,
+		TrackerDomain:          trackerDomainForTorrent(syncManager, torrent),
+		Category:               torrent.Category,
+		Tags:                   parseTorrentTags(torrent.Tags),
+	}
+}
+
+func notifyTorrentAddedWithDelay(ctx context.Context, syncManager torrentNotificationSync, notifier notifications.Notifier, instanceID int, torrent qbt.Torrent) {
+	notifyTorrentAddedWithDelayAfter(ctx, syncManager, notifier, instanceID, torrent, torrentAddedNotificationDelay)
+}
+
+func notifyTorrentAddedWithDelayAfter(ctx context.Context, syncManager torrentNotificationSync, notifier notifications.Notifier, instanceID int, torrent qbt.Torrent, delay time.Duration) {
+	if notifier == nil {
+		return
+	}
+	if delay < 0 {
+		delay = 0
+	}
+
+	baseCtx := context.Background()
+	if ctx != nil {
+		baseCtx = context.WithoutCancel(ctx)
+	}
+
+	go func() {
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
+		<-timer.C
+
+		current := torrent
+		if refreshed, ok := refreshTorrentForNotification(baseCtx, syncManager, instanceID, torrent.Hash); ok {
+			current = refreshed
+		}
+
+		notifier.Notify(baseCtx, buildTorrentAddedEvent(syncManager, instanceID, current))
+	}()
+}
+
+func refreshTorrentForNotification(ctx context.Context, syncManager torrentNotificationSync, instanceID int, hash string) (qbt.Torrent, bool) {
+	if syncManager == nil || strings.TrimSpace(hash) == "" {
+		return qbt.Torrent{}, false
+	}
+
+	refreshCtx := context.Background()
+	if ctx != nil {
+		refreshCtx = context.WithoutCancel(ctx)
+	}
+	refreshCtx, cancel := context.WithTimeout(refreshCtx, torrentAddedRefreshTimeout)
+	defer cancel()
+
+	torrents, err := syncManager.GetTorrents(refreshCtx, instanceID, qbt.TorrentFilterOptions{Hashes: []string{hash}})
+	if err != nil {
+		log.Debug().
+			Err(err).
+			Int("instanceID", instanceID).
+			Str("hash", hash).
+			Msg("torrent-added notification: refresh failed, using initial snapshot")
+		return qbt.Torrent{}, false
+	}
+	if len(torrents) == 0 {
+		return qbt.Torrent{}, false
+	}
+	return torrents[0], true
+}
+
+func trackerDomainForTorrent(syncManager torrentNotificationSync, torrent qbt.Torrent) string {
+	if syncManager == nil || strings.TrimSpace(torrent.Tracker) == "" {
+		return ""
+	}
+	return syncManager.ExtractDomainFromURL(torrent.Tracker)
+}
+
+func parseTorrentTags(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+
+	parts := strings.Split(raw, ",")
+	tags := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
+			continue
+		}
+		tags = append(tags, trimmed)
+	}
+	return tags
+}

--- a/cmd/qui/torrent_notifications_test.go
+++ b/cmd/qui/torrent_notifications_test.go
@@ -59,52 +59,6 @@ func TestParseTorrentTags(t *testing.T) {
 	require.Equal(t, []string{"alpha", "beta", "gamma"}, got)
 }
 
-func TestBuildTorrentCompletedEventIncludesTorrentMetrics(t *testing.T) {
-	t.Parallel()
-
-	syncStub := &stubTorrentNotificationSync{extractDomain: "tracker.example"}
-	torrent := qbt.Torrent{
-		Name:       "Done.Release",
-		Hash:       "AAAA1111",
-		Tracker:    "https://tracker.example/announce",
-		AddedOn:    123,
-		ETA:        0,
-		State:      qbt.TorrentStateUploading,
-		Progress:   1,
-		Ratio:      2.5,
-		TotalSize:  9_000,
-		Downloaded: 9_000,
-		AmountLeft: 0,
-		DlSpeed:    0,
-		UpSpeed:    321,
-		NumSeeds:   12,
-		NumLeechs:  4,
-		Category:   "tv",
-		Tags:       "cross-seed, completed",
-	}
-
-	event := buildTorrentCompletedEvent(syncStub, 3, torrent)
-	require.Equal(t, notifications.EventTorrentCompleted, event.Type)
-	require.Equal(t, 3, event.InstanceID)
-	require.Equal(t, "Done.Release", event.TorrentName)
-	require.Equal(t, "AAAA1111", event.TorrentHash)
-	require.Equal(t, int64(123), event.TorrentAddedOn)
-	require.Equal(t, int64(0), event.TorrentETASeconds)
-	require.Equal(t, string(qbt.TorrentStateUploading), event.TorrentState)
-	require.InDelta(t, 1, event.TorrentProgress, 1e-9)
-	require.InDelta(t, 2.5, event.TorrentRatio, 1e-9)
-	require.Equal(t, int64(9_000), event.TorrentTotalSizeBytes)
-	require.Equal(t, int64(9_000), event.TorrentDownloadedBytes)
-	require.Equal(t, int64(0), event.TorrentAmountLeftBytes)
-	require.Equal(t, int64(0), event.TorrentDlSpeedBps)
-	require.Equal(t, int64(321), event.TorrentUpSpeedBps)
-	require.Equal(t, int64(12), event.TorrentNumSeeds)
-	require.Equal(t, int64(4), event.TorrentNumLeechs)
-	require.Equal(t, "tracker.example", event.TrackerDomain)
-	require.Equal(t, "tv", event.Category)
-	require.Equal(t, []string{"cross-seed", "completed"}, event.Tags)
-}
-
 func TestNotifyTorrentAddedWithDelayAfterRefreshesSnapshot(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/qui/torrent_notifications_test.go
+++ b/cmd/qui/torrent_notifications_test.go
@@ -59,6 +59,52 @@ func TestParseTorrentTags(t *testing.T) {
 	require.Equal(t, []string{"alpha", "beta", "gamma"}, got)
 }
 
+func TestBuildTorrentCompletedEventIncludesTorrentMetrics(t *testing.T) {
+	t.Parallel()
+
+	syncStub := &stubTorrentNotificationSync{extractDomain: "tracker.example"}
+	torrent := qbt.Torrent{
+		Name:       "Done.Release",
+		Hash:       "AAAA1111",
+		Tracker:    "https://tracker.example/announce",
+		AddedOn:    123,
+		ETA:        0,
+		State:      qbt.TorrentStateUploading,
+		Progress:   1,
+		Ratio:      2.5,
+		TotalSize:  9_000,
+		Downloaded: 9_000,
+		AmountLeft: 0,
+		DlSpeed:    0,
+		UpSpeed:    321,
+		NumSeeds:   12,
+		NumLeechs:  4,
+		Category:   "tv",
+		Tags:       "cross-seed, completed",
+	}
+
+	event := buildTorrentCompletedEvent(syncStub, 3, torrent)
+	require.Equal(t, notifications.EventTorrentCompleted, event.Type)
+	require.Equal(t, 3, event.InstanceID)
+	require.Equal(t, "Done.Release", event.TorrentName)
+	require.Equal(t, "AAAA1111", event.TorrentHash)
+	require.Equal(t, int64(123), event.TorrentAddedOn)
+	require.Equal(t, int64(0), event.TorrentETASeconds)
+	require.Equal(t, string(qbt.TorrentStateUploading), event.TorrentState)
+	require.InDelta(t, 1, event.TorrentProgress, 1e-9)
+	require.InDelta(t, 2.5, event.TorrentRatio, 1e-9)
+	require.Equal(t, int64(9_000), event.TorrentTotalSizeBytes)
+	require.Equal(t, int64(9_000), event.TorrentDownloadedBytes)
+	require.Equal(t, int64(0), event.TorrentAmountLeftBytes)
+	require.Equal(t, int64(0), event.TorrentDlSpeedBps)
+	require.Equal(t, int64(321), event.TorrentUpSpeedBps)
+	require.Equal(t, int64(12), event.TorrentNumSeeds)
+	require.Equal(t, int64(4), event.TorrentNumLeechs)
+	require.Equal(t, "tracker.example", event.TrackerDomain)
+	require.Equal(t, "tv", event.Category)
+	require.Equal(t, []string{"cross-seed", "completed"}, event.Tags)
+}
+
 func TestNotifyTorrentAddedWithDelayAfterRefreshesSnapshot(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/qui/torrent_notifications_test.go
+++ b/cmd/qui/torrent_notifications_test.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/services/notifications"
+)
+
+type stubTorrentNotificationSync struct {
+	torrents       []qbt.Torrent
+	err            error
+	lastHashes     []string
+	extractDomain  string
+	extractInvoked bool
+}
+
+func (s *stubTorrentNotificationSync) GetTorrents(_ context.Context, _ int, filter qbt.TorrentFilterOptions) ([]qbt.Torrent, error) {
+	s.lastHashes = append([]string(nil), filter.Hashes...)
+	if s.err != nil {
+		return nil, s.err
+	}
+	return append([]qbt.Torrent(nil), s.torrents...), nil
+}
+
+func (s *stubTorrentNotificationSync) ExtractDomainFromURL(rawURL string) string {
+	s.extractInvoked = true
+	if s.extractDomain != "" {
+		return s.extractDomain
+	}
+	trimmed := strings.TrimSpace(rawURL)
+	trimmed = strings.TrimPrefix(trimmed, "https://")
+	trimmed = strings.TrimPrefix(trimmed, "http://")
+	parts := strings.SplitN(trimmed, "/", 2)
+	return parts[0]
+}
+
+type captureNotifier struct {
+	events chan notifications.Event
+}
+
+func (n *captureNotifier) Notify(_ context.Context, event notifications.Event) {
+	n.events <- event
+}
+
+func TestParseTorrentTags(t *testing.T) {
+	t.Parallel()
+
+	got := parseTorrentTags(" alpha, beta ,, gamma ")
+	require.Equal(t, []string{"alpha", "beta", "gamma"}, got)
+}
+
+func TestNotifyTorrentAddedWithDelayAfterRefreshesSnapshot(t *testing.T) {
+	t.Parallel()
+
+	initial := qbt.Torrent{
+		Name:      "Example.Release",
+		Hash:      "ABC123",
+		Tracker:   "https://tracker.example/announce",
+		AddedOn:   100,
+		ETA:       86400,
+		Progress:  0,
+		DlSpeed:   0,
+		UpSpeed:   0,
+		NumSeeds:  0,
+		NumLeechs: 0,
+	}
+	refreshed := initial
+	refreshed.Progress = 0.42
+	refreshed.DlSpeed = 1_234_567
+	refreshed.UpSpeed = 12_345
+	refreshed.NumSeeds = 88
+	refreshed.NumLeechs = 11
+
+	syncStub := &stubTorrentNotificationSync{
+		torrents:      []qbt.Torrent{refreshed},
+		extractDomain: "tracker.example",
+	}
+	notifier := &captureNotifier{events: make(chan notifications.Event, 1)}
+
+	notifyTorrentAddedWithDelayAfter(context.Background(), syncStub, notifier, 7, initial, 5*time.Millisecond)
+
+	select {
+	case event := <-notifier.events:
+		require.Equal(t, notifications.EventTorrentAdded, event.Type)
+		require.Equal(t, 7, event.InstanceID)
+		require.Equal(t, "Example.Release", event.TorrentName)
+		require.Equal(t, "ABC123", event.TorrentHash)
+		require.InDelta(t, 0.42, event.TorrentProgress, 1e-9)
+		require.Equal(t, int64(1_234_567), event.TorrentDlSpeedBps)
+		require.Equal(t, int64(12_345), event.TorrentUpSpeedBps)
+		require.Equal(t, int64(88), event.TorrentNumSeeds)
+		require.Equal(t, int64(11), event.TorrentNumLeechs)
+		require.Equal(t, "tracker.example", event.TrackerDomain)
+	case <-time.After(time.Second):
+		t.Fatal("expected delayed torrent_added notification")
+	}
+
+	require.Equal(t, []string{"ABC123"}, syncStub.lastHashes)
+}
+
+func TestNotifyTorrentAddedWithDelayAfterFallsBackToInitialSnapshot(t *testing.T) {
+	t.Parallel()
+
+	initial := qbt.Torrent{
+		Name:      "Fallback.Release",
+		Hash:      "DEF456",
+		Tracker:   "https://fallback.example/announce",
+		Progress:  0.11,
+		DlSpeed:   111,
+		UpSpeed:   222,
+		NumSeeds:  3,
+		NumLeechs: 4,
+	}
+
+	syncStub := &stubTorrentNotificationSync{
+		err:           errors.New("temporary failure"),
+		extractDomain: "fallback.example",
+	}
+	notifier := &captureNotifier{events: make(chan notifications.Event, 1)}
+
+	notifyTorrentAddedWithDelayAfter(context.Background(), syncStub, notifier, 2, initial, 5*time.Millisecond)
+
+	select {
+	case event := <-notifier.events:
+		require.Equal(t, notifications.EventTorrentAdded, event.Type)
+		require.Equal(t, "Fallback.Release", event.TorrentName)
+		require.InDelta(t, 0.11, event.TorrentProgress, 1e-9)
+		require.Equal(t, int64(111), event.TorrentDlSpeedBps)
+		require.Equal(t, int64(222), event.TorrentUpSpeedBps)
+		require.Equal(t, int64(3), event.TorrentNumSeeds)
+		require.Equal(t, int64(4), event.TorrentNumLeechs)
+	case <-time.After(time.Second):
+		t.Fatal("expected delayed torrent_added notification")
+	}
+}

--- a/internal/services/automations/service.go
+++ b/internal/services/automations/service.go
@@ -176,11 +176,20 @@ func (s *automationSummary) addSamplesFromActivity(activity *models.AutomationAc
 	if s == nil || activity == nil {
 		return
 	}
-	if activity.TorrentName != "" && (strings.HasPrefix(activity.Action, "deleted_") || activity.Action == models.ActivityActionDeleteFailed) {
+	if activity.TorrentName != "" {
 		s.addSample(&s.sampleTorrents, activity.TorrentName, 3)
 	}
 	if activity.Outcome == models.ActivityOutcomeFailed && strings.TrimSpace(activity.Reason) != "" {
 		s.addSample(&s.sampleErrors, activity.Reason, 2)
+	}
+}
+
+func (s *automationSummary) addTorrentSamples(names []string, limit int) {
+	if s == nil || limit <= 0 {
+		return
+	}
+	for _, name := range names {
+		s.addSample(&s.sampleTorrents, name, limit)
 	}
 }
 
@@ -2516,8 +2525,8 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 	defer cancel()
 
 	// Apply speed limits and track success
-	uploadSuccess := s.applySpeedLimits(ctx, instanceID, uploadBatches, "upload", s.syncManager.SetTorrentUploadLimit, summary, uploadRuleByHash)
-	downloadSuccess := s.applySpeedLimits(ctx, instanceID, downloadBatches, "download", s.syncManager.SetTorrentDownloadLimit, summary, downloadRuleByHash)
+	uploadSuccess := s.applySpeedLimits(ctx, instanceID, uploadBatches, "upload", s.syncManager.SetTorrentUploadLimit, summary, uploadRuleByHash, torrentByHash)
+	downloadSuccess := s.applySpeedLimits(ctx, instanceID, downloadBatches, "download", s.syncManager.SetTorrentDownloadLimit, summary, downloadRuleByHash, torrentByHash)
 
 	// Record aggregated speed limit activity
 	if len(uploadSuccess) > 0 || len(downloadSuccess) > 0 {
@@ -2550,6 +2559,8 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 			models.ActivityOutcomeSuccess,
 			buildRuleCountsFromHashes(flattenHashGroups(downloadSuccess), downloadRuleByHash),
 		)
+		speedSampleHashes := append(flattenHashGroups(uploadSuccess), flattenHashGroups(downloadSuccess)...)
+		summary.addTorrentSamples(collectTorrentNamesForHashes(speedSampleHashes, torrentByHash), 3)
 		if s.activityStore != nil {
 			activityID, err := s.activityStore.CreateWithID(ctx, activity)
 			if err != nil {
@@ -2593,6 +2604,7 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 				models.ActivityOutcomeFailed,
 				buildRuleCountsFromHashMaps(batch, shareRatioRuleByHash, shareSeedingRuleByHash),
 			)
+			summary.addTorrentSamples(collectTorrentNamesForHashes(batch, torrentByHash), 3)
 			if s.activityStore != nil {
 				if actErr := s.activityStore.Create(ctx, activity); actErr != nil {
 					log.Warn().Err(actErr).Int("instanceID", instanceID).Msg("automations: failed to record activity")
@@ -2624,6 +2636,7 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 			models.ActivityOutcomeSuccess,
 			buildRuleCountsFromHashMaps(flattenHashGroupsByShareKey(shareLimitSuccess), shareRatioRuleByHash, shareSeedingRuleByHash),
 		)
+		summary.addTorrentSamples(collectTorrentNamesForHashes(flattenHashGroupsByShareKey(shareLimitSuccess), torrentByHash), 3)
 		if s.activityStore != nil {
 			activityID, err := s.activityStore.CreateWithID(ctx, activity)
 			if err != nil {
@@ -2669,6 +2682,7 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 			models.ActivityOutcomeSuccess,
 			buildRuleCountsFromHashes(pausedHashesSuccess, pauseRuleByHash),
 		)
+		summary.addTorrentSamples(collectTorrentNamesForHashes(pausedHashesSuccess, torrentByHash), 3)
 		if s.activityStore != nil {
 			activityID, err := s.activityStore.CreateWithID(ctx, activity)
 			if err != nil {
@@ -2714,6 +2728,7 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 			models.ActivityOutcomeSuccess,
 			buildRuleCountsFromHashes(resumedHashesSuccess, resumeRuleByHash),
 		)
+		summary.addTorrentSamples(collectTorrentNamesForHashes(resumedHashesSuccess, torrentByHash), 3)
 		if s.activityStore != nil {
 			activityID, err := s.activityStore.CreateWithID(ctx, activity)
 			if err != nil {
@@ -2759,6 +2774,7 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 			models.ActivityOutcomeSuccess,
 			buildRuleCountsFromHashes(recheckedHashesSuccess, recheckRuleByHash),
 		)
+		summary.addTorrentSamples(collectTorrentNamesForHashes(recheckedHashesSuccess, torrentByHash), 3)
 		if s.activityStore != nil {
 			activityID, err := s.activityStore.CreateWithID(ctx, activity)
 			if err != nil {
@@ -2804,6 +2820,7 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 			models.ActivityOutcomeSuccess,
 			buildRuleCountsFromHashes(reannouncedHashesSuccess, reannounceRuleByHash),
 		)
+		summary.addTorrentSamples(collectTorrentNamesForHashes(reannouncedHashesSuccess, torrentByHash), 3)
 		if s.activityStore != nil {
 			activityID, err := s.activityStore.CreateWithID(ctx, activity)
 			if err != nil {
@@ -2963,6 +2980,7 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 			summary.recordRuleCounts(models.ActivityActionTagsChanged, models.ActivityOutcomeSuccess, tagRuleCounts)
 			summary.addTagCounts(addCounts, removeCounts)
 			summary.addTagSamples(collectTorrentNamesForHashes(tagSampleHashes, torrentByHash), 3)
+			summary.addTorrentSamples(collectTorrentNamesForHashes(tagSampleHashes, torrentByHash), 3)
 			if s.activityStore != nil {
 				activityID, err := s.activityStore.CreateWithID(ctx, activity)
 				if err != nil {
@@ -3163,6 +3181,7 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 			models.ActivityOutcomeSuccess,
 			buildRuleCountsFromHashes(categoryMoveHashes(successfulMoves), categoryRuleByHash),
 		)
+		summary.addTorrentSamples(collectTorrentNamesForHashes(categoryMoveHashes(successfulMoves), torrentByHash), 3)
 		if s.activityStore != nil {
 			activityID, err := s.activityStore.CreateWithID(ctx, activity)
 			if err != nil {
@@ -3187,6 +3206,7 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 	successfulMovesByPath := make(map[string]int)
 	failedMovesByPath := make(map[string]int)
 	successfulMoveHashesByPath := make(map[string][]string)
+	failedMoveHashesByPath := make(map[string][]string)
 	for _, path := range sortedPaths {
 		hashes := moveBatches[path]
 		successfulMovesForPath := 0
@@ -3351,6 +3371,7 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 			if err := s.syncManager.SetLocation(ctx, instanceID, batch, path); err != nil {
 				log.Warn().Err(err).Int("instanceID", instanceID).Str("path", path).Strs("hashes", batch).Msg("automations: move failed")
 				failedMovesForPath += len(batch)
+				failedMoveHashesByPath[path] = append(failedMoveHashesByPath[path], batch...)
 			} else {
 				log.Debug().Int("instanceID", instanceID).Str("path", path).Strs("hashes", batch).Msg("automations: moved torrent")
 				successfulMovesForPath += len(batch)
@@ -3387,6 +3408,7 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 			models.ActivityOutcomeSuccess,
 			buildRuleCountsFromHashes(flattenHashGroupsByPath(successfulMoveHashesByPath), moveRuleByHash),
 		)
+		summary.addTorrentSamples(collectTorrentNamesForHashes(flattenHashGroupsByPath(successfulMoveHashesByPath), torrentByHash), 3)
 		if s.activityStore != nil {
 			activityID, err := s.activityStore.CreateWithID(ctx, activity)
 			if err != nil {
@@ -3409,6 +3431,7 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 			Details:    detailsJSON,
 		}
 		summary.recordActivity(activity, failureCount)
+		summary.addTorrentSamples(collectTorrentNamesForHashes(flattenHashGroupsByPath(failedMoveHashesByPath), torrentByHash), 3)
 		if s.activityStore != nil {
 			if err := s.activityStore.Create(ctx, activity); err != nil {
 				log.Warn().Err(err).Int("instanceID", instanceID).Msg("automations: failed to record move activity")
@@ -4449,6 +4472,7 @@ func (s *Service) applySpeedLimits(
 	setLimit func(ctx context.Context, instanceID int, hashes []string, limit int64) error,
 	summary *automationSummary,
 	ruleByHash map[string]ruleRef,
+	torrentByHash map[string]qbt.Torrent,
 ) map[int64][]string {
 	successHashes := make(map[int64][]string)
 	for limit, hashes := range batches {
@@ -4475,6 +4499,7 @@ func (s *Service) applySpeedLimits(
 						models.ActivityOutcomeFailed,
 						buildRuleCountsFromHashes(batch, ruleByHash),
 					)
+					summary.addTorrentSamples(collectTorrentNamesForHashes(batch, torrentByHash), 3)
 				}
 				if s.activityStore != nil {
 					if err := s.activityStore.Create(ctx, activity); err != nil {

--- a/internal/services/automations/summary_test.go
+++ b/internal/services/automations/summary_test.go
@@ -134,3 +134,35 @@ func TestAutomationSummaryMessageIncludesTagDetailsAndSamples(t *testing.T) {
 	require.Contains(t, msg, "Torrent A")
 	require.Contains(t, msg, "Torrent B")
 }
+
+func TestAutomationSummaryMessageIncludesSamplesForNonDeleteActions(t *testing.T) {
+	t.Parallel()
+
+	summary := newAutomationSummary()
+	summary.recordActivity(&models.AutomationActivity{
+		Action:      models.ActivityActionMoved,
+		Outcome:     models.ActivityOutcomeSuccess,
+		TorrentName: "Some.Release.2026",
+	}, 1)
+
+	msg := summary.message()
+	require.Contains(t, msg, "Samples: Some.Release.2026")
+}
+
+func TestAutomationSummaryAddTorrentSamplesUsesLimitAndDedupes(t *testing.T) {
+	t.Parallel()
+
+	summary := newAutomationSummary()
+	summary.addTorrentSamples([]string{
+		"Torrent C",
+		"Torrent A",
+		"Torrent A",
+		"Torrent B",
+	}, 3)
+
+	msg := summary.message()
+	require.Contains(t, msg, "Samples:")
+	require.Contains(t, msg, "Torrent A")
+	require.Contains(t, msg, "Torrent B")
+	require.Contains(t, msg, "Torrent C")
+}

--- a/internal/services/notifications/notifiarr_api.go
+++ b/internal/services/notifications/notifiarr_api.go
@@ -257,6 +257,9 @@ func (s *Service) buildNotifiarrAPIData(ctx context.Context, event Event, title,
 	}
 
 	data.Torrent = func() *notifiarrAPITorrent {
+		hasTorrentContext := event.Type == EventTorrentAdded || event.Type == EventTorrentCompleted ||
+			strings.TrimSpace(event.TorrentName) != "" || strings.TrimSpace(event.TorrentHash) != ""
+
 		t := &notifiarrAPITorrent{
 			Name:          stringPtr(event.TorrentName),
 			Hash:          stringPtr(event.TorrentHash),
@@ -267,7 +270,7 @@ func (s *Service) buildNotifiarrAPIData(ctx context.Context, event Event, title,
 			addedAt := time.Unix(event.TorrentAddedOn, 0).UTC()
 			t.AddedAt = &addedAt
 		}
-		if event.TorrentETASeconds > 0 {
+		if hasTorrentContext {
 			eta := event.TorrentETASeconds
 			t.EtaSeconds = &eta
 			estimated := data.Timestamp.Add(time.Duration(eta) * time.Second)
@@ -276,39 +279,23 @@ func (s *Service) buildNotifiarrAPIData(ctx context.Context, event Event, title,
 		if strings.TrimSpace(event.TorrentState) != "" {
 			t.State = stringPtr(event.TorrentState)
 		}
-		if event.TorrentProgress > 0 {
+		if hasTorrentContext {
 			progress := event.TorrentProgress
 			t.Progress = &progress
-		}
-		if event.TorrentRatio > 0 {
 			ratio := event.TorrentRatio
 			t.Ratio = &ratio
-		}
-		if event.TorrentTotalSizeBytes > 0 {
 			total := event.TorrentTotalSizeBytes
 			t.TotalSizeBytes = &total
-		}
-		if event.TorrentDownloadedBytes > 0 {
 			downloaded := event.TorrentDownloadedBytes
 			t.DownloadedBytes = &downloaded
-		}
-		if event.TorrentAmountLeftBytes > 0 {
 			left := event.TorrentAmountLeftBytes
 			t.AmountLeftBytes = &left
-		}
-		if event.TorrentDlSpeedBps > 0 {
 			dl := event.TorrentDlSpeedBps
 			t.DlSpeedBps = &dl
-		}
-		if event.TorrentUpSpeedBps > 0 {
 			ul := event.TorrentUpSpeedBps
 			t.UpSpeedBps = &ul
-		}
-		if event.TorrentNumSeeds > 0 {
 			seeds := event.TorrentNumSeeds
 			t.NumSeeds = &seeds
-		}
-		if event.TorrentNumLeechs > 0 {
 			leechs := event.TorrentNumLeechs
 			t.NumLeechs = &leechs
 		}

--- a/internal/services/notifications/notifiarr_api_test.go
+++ b/internal/services/notifications/notifiarr_api_test.go
@@ -166,3 +166,49 @@ func TestBuildNotifiarrAPIDataIncludesTorrentFields(t *testing.T) {
 	require.NotNil(t, data.Torrent.NumLeechs)
 	require.Equal(t, int64(35), *data.Torrent.NumLeechs)
 }
+
+func TestBuildNotifiarrAPIDataIncludesZeroValueTorrentMetrics(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{}
+	event := Event{
+		Type:                   EventTorrentAdded,
+		TorrentName:            "Zero.Value.Release",
+		TorrentHash:            "1234567890abcdef1234567890abcdef12345678",
+		TorrentETASeconds:      0,
+		TorrentProgress:        0,
+		TorrentRatio:           0,
+		TorrentDlSpeedBps:      0,
+		TorrentUpSpeedBps:      0,
+		TorrentNumSeeds:        0,
+		TorrentNumLeechs:       0,
+		TorrentTotalSizeBytes:  0,
+		TorrentDownloadedBytes: 0,
+		TorrentAmountLeftBytes: 0,
+	}
+
+	data := svc.buildNotifiarrAPIData(context.Background(), event, "title", "message")
+	require.NotNil(t, data.Torrent)
+	require.NotNil(t, data.Torrent.EtaSeconds)
+	require.Equal(t, int64(0), *data.Torrent.EtaSeconds)
+	require.NotNil(t, data.Torrent.EstimatedCompletionAt)
+	require.True(t, data.Torrent.EstimatedCompletionAt.Equal(data.Timestamp))
+	require.NotNil(t, data.Torrent.Progress)
+	require.InDelta(t, 0, *data.Torrent.Progress, 1e-9)
+	require.NotNil(t, data.Torrent.Ratio)
+	require.InDelta(t, 0, *data.Torrent.Ratio, 1e-9)
+	require.NotNil(t, data.Torrent.TotalSizeBytes)
+	require.Equal(t, int64(0), *data.Torrent.TotalSizeBytes)
+	require.NotNil(t, data.Torrent.DownloadedBytes)
+	require.Equal(t, int64(0), *data.Torrent.DownloadedBytes)
+	require.NotNil(t, data.Torrent.AmountLeftBytes)
+	require.Equal(t, int64(0), *data.Torrent.AmountLeftBytes)
+	require.NotNil(t, data.Torrent.DlSpeedBps)
+	require.Equal(t, int64(0), *data.Torrent.DlSpeedBps)
+	require.NotNil(t, data.Torrent.UpSpeedBps)
+	require.Equal(t, int64(0), *data.Torrent.UpSpeedBps)
+	require.NotNil(t, data.Torrent.NumSeeds)
+	require.Equal(t, int64(0), *data.Torrent.NumSeeds)
+	require.NotNil(t, data.Torrent.NumLeechs)
+	require.Equal(t, int64(0), *data.Torrent.NumLeechs)
+}

--- a/internal/services/notifications/service.go
+++ b/internal/services/notifications/service.go
@@ -502,19 +502,18 @@ func formatTransferSpeed(value int64) string {
 		value = 0
 	}
 
-	units := []string{"B/s", "KB/s", "MB/s", "GB/s", "TB/s"}
-	speed := float64(value)
-	unit := units[0]
-	for i := 1; i < len(units) && speed >= 1000; i++ {
-		speed /= 1000
-		unit = units[i]
+	switch {
+	case value < 1_000:
+		return fmt.Sprintf("%d B/s", value)
+	case value < 1_000_000:
+		return fmt.Sprintf("%.2f KB/s", float64(value)/1_000.0)
+	case value < 1_000_000_000:
+		return fmt.Sprintf("%.2f MB/s", float64(value)/1_000_000.0)
+	case value < 1_000_000_000_000:
+		return fmt.Sprintf("%.2f GB/s", float64(value)/1_000_000_000.0)
+	default:
+		return fmt.Sprintf("%.2f TB/s", float64(value)/1_000_000_000_000.0)
 	}
-
-	if unit == "B/s" {
-		return fmt.Sprintf("%d %s", value, unit)
-	}
-
-	return fmt.Sprintf("%.2f %s", speed, unit)
 }
 
 func formatLine(label, value string) string {

--- a/internal/services/notifications/service.go
+++ b/internal/services/notifications/service.go
@@ -322,7 +322,9 @@ func (s *Service) formatEvent(ctx context.Context, event Event, humanReadableMet
 		lines := []string{
 			formatLine("Torrent", fmt.Sprintf("%s%s", event.TorrentName, formatHashSuffix(event.TorrentHash))),
 		}
-		lines = append(lines, formatTorrentMetricLines(event, humanReadableMetrics)...)
+		if !humanReadableMetrics {
+			lines = append(lines, formatTorrentMetricLines(event, humanReadableMetrics)...)
+		}
 		if tracker := strings.TrimSpace(event.TrackerDomain); tracker != "" {
 			lines = append(lines, formatLine("Tracker", tracker))
 		}

--- a/internal/services/notifications/service.go
+++ b/internal/services/notifications/service.go
@@ -304,6 +304,7 @@ func (s *Service) formatEvent(ctx context.Context, event Event) (string, string)
 		if eta := formatETA(event.TorrentETASeconds); eta != "" {
 			lines = append(lines, formatLine("ETA", eta))
 		}
+		lines = append(lines, formatTorrentMetricLines(event)...)
 		if tracker := strings.TrimSpace(event.TrackerDomain); tracker != "" {
 			lines = append(lines, formatLine("Tracker", tracker))
 		}
@@ -321,6 +322,7 @@ func (s *Service) formatEvent(ctx context.Context, event Event) (string, string)
 		lines := []string{
 			formatLine("Torrent", fmt.Sprintf("%s%s", event.TorrentName, formatHashSuffix(event.TorrentHash))),
 		}
+		lines = append(lines, formatTorrentMetricLines(event)...)
 		if tracker := strings.TrimSpace(event.TrackerDomain); tracker != "" {
 			lines = append(lines, formatLine("Tracker", tracker))
 		}
@@ -454,6 +456,25 @@ func formatETA(seconds int64) string {
 		return ""
 	}
 	return (time.Duration(seconds) * time.Second).Round(time.Second).String()
+}
+
+func formatTorrentMetricLines(event Event) []string {
+	lines := make([]string, 0, 10)
+
+	if state := strings.TrimSpace(event.TorrentState); state != "" {
+		lines = append(lines, formatLine("State", state))
+	}
+	lines = append(lines, formatLine("Progress", strconv.FormatFloat(event.TorrentProgress, 'f', 4, 64)))
+	lines = append(lines, formatLine("Ratio", strconv.FormatFloat(event.TorrentRatio, 'f', 4, 64)))
+	lines = append(lines, formatLine("Total size bytes", strconv.FormatInt(event.TorrentTotalSizeBytes, 10)))
+	lines = append(lines, formatLine("Downloaded bytes", strconv.FormatInt(event.TorrentDownloadedBytes, 10)))
+	lines = append(lines, formatLine("Amount left bytes", strconv.FormatInt(event.TorrentAmountLeftBytes, 10)))
+	lines = append(lines, formatLine("DL speed bps", strconv.FormatInt(event.TorrentDlSpeedBps, 10)))
+	lines = append(lines, formatLine("UP speed bps", strconv.FormatInt(event.TorrentUpSpeedBps, 10)))
+	lines = append(lines, formatLine("Seeds", strconv.FormatInt(event.TorrentNumSeeds, 10)))
+	lines = append(lines, formatLine("Leechs", strconv.FormatInt(event.TorrentNumLeechs, 10)))
+
+	return lines
 }
 
 func formatLine(label, value string) string {

--- a/internal/services/notifications/service_format_test.go
+++ b/internal/services/notifications/service_format_test.go
@@ -96,3 +96,39 @@ func TestFormatEventTorrentAddedNotifiarrAPIMetricsStayRaw(t *testing.T) {
 	require.Contains(t, message, "DL speed bps: 29308908")
 	require.Contains(t, message, "UP speed bps: 0")
 }
+
+func TestFormatEventAutomationsActionsAppliedDedupesSamplesOutsideNotifiarrAPI(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{}
+	title, message := svc.formatEvent(context.Background(), Event{
+		Type: EventAutomationsActionsApplied,
+		Message: "Applied: 1\n" +
+			"Top actions: Tags updated=1\n" +
+			"Tags: +no_hl=1\n" +
+			"Tag samples: Hamnet.2025.720p.Blu-ray.DD5.1.x264-TRT\n" +
+			"Samples: Hamnet.2025.720p.Blu-ray.DD5.1.x264-TRT",
+	}, true)
+
+	require.Equal(t, "Automations actions applied", title)
+	require.Contains(t, message, "Tag samples: Hamnet.2025.720p.Blu-ray.DD5.1.x264-TRT")
+	require.NotContains(t, message, "\nSamples: Hamnet.2025.720p.Blu-ray.DD5.1.x264-TRT")
+}
+
+func TestFormatEventAutomationsActionsAppliedKeepsSamplesForNotifiarrAPI(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{}
+	title, message := svc.formatEvent(context.Background(), Event{
+		Type: EventAutomationsActionsApplied,
+		Message: "Applied: 1\n" +
+			"Top actions: Tags updated=1\n" +
+			"Tags: +no_hl=1\n" +
+			"Tag samples: Hamnet.2025.720p.Blu-ray.DD5.1.x264-TRT\n" +
+			"Samples: Hamnet.2025.720p.Blu-ray.DD5.1.x264-TRT",
+	}, false)
+
+	require.Equal(t, "Automations actions applied", title)
+	require.Contains(t, message, "Tag samples: Hamnet.2025.720p.Blu-ray.DD5.1.x264-TRT")
+	require.Contains(t, message, "Samples: Hamnet.2025.720p.Blu-ray.DD5.1.x264-TRT")
+}

--- a/internal/services/notifications/service_format_test.go
+++ b/internal/services/notifications/service_format_test.go
@@ -29,13 +29,14 @@ func TestFormatEventTorrentAddedIncludesMetricLines(t *testing.T) {
 		TorrentUpSpeedBps:      0,
 		TorrentNumSeeds:        0,
 		TorrentNumLeechs:       0,
-	})
+	}, true)
 
 	require.Equal(t, "Torrent added", title)
-	require.Contains(t, message, "Progress: 0.0000")
+	require.Contains(t, message, "Progress: 0.00")
 	require.Contains(t, message, "Ratio: 0.0000")
-	require.Contains(t, message, "DL speed bps: 0")
-	require.Contains(t, message, "UP speed bps: 0")
+	require.Contains(t, message, "Total size: 0.00 GB")
+	require.Contains(t, message, "DL speed: 0 B/s")
+	require.Contains(t, message, "UP speed: 0 B/s")
 	require.Contains(t, message, "Seeds: 0")
 	require.Contains(t, message, "Leechs: 0")
 }
@@ -58,12 +59,40 @@ func TestFormatEventTorrentCompletedIncludesMetricLines(t *testing.T) {
 		TorrentUpSpeedBps:      42,
 		TorrentNumSeeds:        7,
 		TorrentNumLeechs:       2,
-	})
+	}, true)
 
 	require.Equal(t, "Torrent completed", title)
-	require.Contains(t, message, "Progress: 1.0000")
+	require.Contains(t, message, "Progress: 1.00")
 	require.Contains(t, message, "Ratio: 1.5000")
-	require.Contains(t, message, "UP speed bps: 42")
+	require.Contains(t, message, "Total size: 0.00 GB")
+	require.Contains(t, message, "UP speed: 42 B/s")
 	require.Contains(t, message, "Seeds: 7")
 	require.Contains(t, message, "Leechs: 2")
+}
+
+func TestFormatEventTorrentAddedNotifiarrAPIMetricsStayRaw(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{}
+	title, message := svc.formatEvent(context.Background(), Event{
+		Type:                   EventTorrentAdded,
+		InstanceID:             1,
+		TorrentName:            "Example.Release",
+		TorrentHash:            "0123456789abcdef",
+		TorrentProgress:        0.0306,
+		TorrentRatio:           0,
+		TorrentTotalSizeBytes:  7_926_201_054,
+		TorrentDownloadedBytes: 176_551_163,
+		TorrentAmountLeftBytes: 7_683_996_382,
+		TorrentDlSpeedBps:      29_308_908,
+		TorrentUpSpeedBps:      0,
+		TorrentNumSeeds:        26,
+		TorrentNumLeechs:       1,
+	}, false)
+
+	require.Equal(t, "Torrent added", title)
+	require.Contains(t, message, "Progress: 0.0306")
+	require.Contains(t, message, "Total size bytes: 7926201054")
+	require.Contains(t, message, "DL speed bps: 29308908")
+	require.Contains(t, message, "UP speed bps: 0")
 }

--- a/internal/services/notifications/service_format_test.go
+++ b/internal/services/notifications/service_format_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package notifications
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatEventTorrentAddedIncludesMetricLines(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{}
+	title, message := svc.formatEvent(context.Background(), Event{
+		Type:                   EventTorrentAdded,
+		InstanceID:             1,
+		TorrentName:            "Example.Release",
+		TorrentHash:            "0123456789abcdef",
+		TorrentETASeconds:      30,
+		TorrentProgress:        0,
+		TorrentRatio:           0,
+		TorrentTotalSizeBytes:  0,
+		TorrentDownloadedBytes: 0,
+		TorrentAmountLeftBytes: 0,
+		TorrentDlSpeedBps:      0,
+		TorrentUpSpeedBps:      0,
+		TorrentNumSeeds:        0,
+		TorrentNumLeechs:       0,
+	})
+
+	require.Equal(t, "Torrent added", title)
+	require.Contains(t, message, "Progress: 0.0000")
+	require.Contains(t, message, "Ratio: 0.0000")
+	require.Contains(t, message, "DL speed bps: 0")
+	require.Contains(t, message, "UP speed bps: 0")
+	require.Contains(t, message, "Seeds: 0")
+	require.Contains(t, message, "Leechs: 0")
+}
+
+func TestFormatEventTorrentCompletedIncludesMetricLines(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{}
+	title, message := svc.formatEvent(context.Background(), Event{
+		Type:                   EventTorrentCompleted,
+		InstanceID:             1,
+		TorrentName:            "Done.Release",
+		TorrentHash:            "fedcba9876543210",
+		TorrentProgress:        1,
+		TorrentRatio:           1.5,
+		TorrentTotalSizeBytes:  123,
+		TorrentDownloadedBytes: 123,
+		TorrentAmountLeftBytes: 0,
+		TorrentDlSpeedBps:      0,
+		TorrentUpSpeedBps:      42,
+		TorrentNumSeeds:        7,
+		TorrentNumLeechs:       2,
+	})
+
+	require.Equal(t, "Torrent completed", title)
+	require.Contains(t, message, "Progress: 1.0000")
+	require.Contains(t, message, "Ratio: 1.5000")
+	require.Contains(t, message, "UP speed bps: 42")
+	require.Contains(t, message, "Seeds: 7")
+	require.Contains(t, message, "Leechs: 2")
+}

--- a/internal/services/notifications/service_format_test.go
+++ b/internal/services/notifications/service_format_test.go
@@ -5,6 +5,7 @@ package notifications
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -139,7 +140,7 @@ func TestFormatEventTorrentCompletedNotifiarrAPIMetricsStayRaw(t *testing.T) {
 	require.Contains(t, message, "Leechs: 2")
 }
 
-func TestFormatEventAutomationsActionsAppliedDedupesSamplesOutsideNotifiarrAPI(t *testing.T) {
+func TestFormatEventAutomationsActionsAppliedMergesSamplesOutsideNotifiarrAPI(t *testing.T) {
 	t.Parallel()
 
 	svc := &Service{}
@@ -148,13 +149,14 @@ func TestFormatEventAutomationsActionsAppliedDedupesSamplesOutsideNotifiarrAPI(t
 		Message: "Applied: 1\n" +
 			"Top actions: Tags updated=1\n" +
 			"Tags: +no_hl=1\n" +
-			"Tag samples: Hamnet.2025.720p.Blu-ray.DD5.1.x264-TRT\n" +
-			"Samples: Hamnet.2025.720p.Blu-ray.DD5.1.x264-TRT",
+			"Tag samples: Godzilla.Minus.One.2023.Hybrid.1080p.BluRay.DUAL.DDP7.1.x264-ZoroSenpai.mkv; Mercy.2026.720p.AMZN.WEB-DL.DDP5.1.Atmos.H.264-BYNDR\n" +
+			"Samples: Hamnet.2025.Hybrid.1080p.BluRay.DDP7.1.x264-ZoroSenpai.mkv",
 	}, true)
 
 	require.Equal(t, "Automations actions applied", title)
-	require.Contains(t, message, "Tag samples: Hamnet.2025.720p.Blu-ray.DD5.1.x264-TRT")
-	require.NotContains(t, message, "\nSamples: Hamnet.2025.720p.Blu-ray.DD5.1.x264-TRT")
+	require.NotContains(t, message, "Tag samples:")
+	require.Contains(t, message, "Samples: Godzilla.Minus.One.2023.Hybrid.1080p.BluRay.DUAL.DDP7.1.x264-ZoroSenpai.mkv; Mercy.2026.720p.AMZN.WEB-DL.DDP5.1.Atmos.H.264-BYNDR; Hamnet.2025.Hybrid.1080p.BluRay.DDP7.1.x264-ZoroSenpai.mkv")
+	require.Equal(t, 1, strings.Count(message, "Samples:"))
 }
 
 func TestFormatEventAutomationsActionsAppliedKeepsSamplesForNotifiarrAPI(t *testing.T) {


### PR DESCRIPTION
## Summary
- delay `torrent_added` notifications by 10 seconds and refresh torrent stats before dispatch
- keep notifiarrapi torrent metric fields present for torrent events even when values are zero
- include torrent metric lines in formatted torrent notifications for shoutrrr/discord rendering
- expand automation summary samples beyond delete-only actions when torrent names are available
- add regression coverage for delayed refresh/fallback behavior and zero-value payload fields

Validated with `go test ./cmd/qui/... ./internal/services/notifications/... ./internal/services/automations/...` and earlier full `make test`/`make build` in this branch context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notifications include comprehensive torrent metrics with optional human-readable formatting.

* **Improvements**
  * Added a brief delay for torrent-added notifications to refresh snapshots before sending.
  * Tracker domain and tag extraction moved to centralized helpers.
  * Automation summaries now surface deduplicated, limited torrent name samples across more actions.

* **Tests**
  * Added tests for notification formatting, delayed notification behavior, and sample collection.

* **Documentation**
  * Added owner collaboration notes for review workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->