### PR TITLE
fix(qbittorrent): stop reboot torrent_completed spam

### DIFF
--- a/internal/qbittorrent/client.go
+++ b/internal/qbittorrent/client.go
@@ -528,8 +528,6 @@ func (c *Client) StartSyncManager(ctx context.Context) error {
 	return syncManager.Start(ctx)
 }
 
-const completionProgressThreshold = 0.9999
-
 const torrentAddedGraceWindow = 60 * time.Second
 
 func (c *Client) handleCompletionUpdates(data *qbt.MainData) {
@@ -656,27 +654,7 @@ func isTorrentComplete(t *qbt.Torrent) bool {
 		return false
 	}
 
-	if t.Progress < completionProgressThreshold {
-		return false
-	}
-
-	switch t.State {
-	case qbt.TorrentStateDownloading,
-		qbt.TorrentStateMetaDl,
-		qbt.TorrentStatePausedDl,
-		qbt.TorrentStateStoppedDl,
-		qbt.TorrentStateQueuedDl,
-		qbt.TorrentStateStalledDl,
-		qbt.TorrentStateCheckingDl,
-		qbt.TorrentStateForcedDl,
-		qbt.TorrentStateCheckingResumeData,
-		qbt.TorrentStateAllocating,
-		qbt.TorrentStateMoving,
-		qbt.TorrentStateUnknown:
-		return false
-	default:
-		return true
-	}
+	return t.CompletionOn > 0
 }
 
 // GetOrCreatePeerSyncManager gets or creates a PeerSyncManager for a specific torrent

--- a/internal/qbittorrent/client_completion_test.go
+++ b/internal/qbittorrent/client_completion_test.go
@@ -1,0 +1,151 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package qbittorrent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+)
+
+func TestIsTorrentCompleteUsesCompletionOn(t *testing.T) {
+	t.Parallel()
+
+	torrent := &qbt.Torrent{
+		Hash:         "abc",
+		Name:         "Example",
+		CompletionOn: 123,
+		Progress:     0.12,
+		State:        qbt.TorrentStateCheckingResumeData,
+	}
+
+	if !isTorrentComplete(torrent) {
+		t.Fatal("expected torrent to be treated as complete when CompletionOn is set")
+	}
+}
+
+func TestHandleCompletionUpdatesDoesNotSpamOnStartupStateFlap(t *testing.T) {
+	t.Parallel()
+
+	client := &Client{instanceID: 7}
+
+	seen := make(chan qbt.Torrent, 1)
+	client.SetTorrentCompletionHandler(func(_ context.Context, instanceID int, torrent qbt.Torrent) {
+		if instanceID != 7 {
+			t.Fatalf("unexpected instanceID: %d", instanceID)
+		}
+		seen <- torrent
+	})
+
+	// Startup snapshot: completion set, but state in a transient phase.
+	client.handleCompletionUpdates(&qbt.MainData{
+		Torrents: map[string]qbt.Torrent{
+			"abc": {
+				Hash:         "abc",
+				Name:         "Done",
+				CompletionOn: 123,
+				Progress:     1.0,
+				State:        qbt.TorrentStateCheckingResumeData,
+			},
+		},
+	})
+
+	requireNoTorrentEvent(t, seen, 200*time.Millisecond)
+
+	// Post-startup: state normalizes; this must not look like a fresh completion.
+	client.handleCompletionUpdates(&qbt.MainData{
+		Torrents: map[string]qbt.Torrent{
+			"abc": {
+				Hash:         "abc",
+				Name:         "Done",
+				CompletionOn: 123,
+				Progress:     1.0,
+				State:        qbt.TorrentStateUploading,
+			},
+		},
+	})
+
+	requireNoTorrentEvent(t, seen, 200*time.Millisecond)
+}
+
+func TestHandleCompletionUpdatesFiresOnceWhenCompletionOnAppears(t *testing.T) {
+	t.Parallel()
+
+	client := &Client{instanceID: 9}
+
+	seen := make(chan qbt.Torrent, 2)
+	client.SetTorrentCompletionHandler(func(_ context.Context, instanceID int, torrent qbt.Torrent) {
+		if instanceID != 9 {
+			t.Fatalf("unexpected instanceID: %d", instanceID)
+		}
+		seen <- torrent
+	})
+
+	client.handleCompletionUpdates(&qbt.MainData{
+		Torrents: map[string]qbt.Torrent{
+			"def": {
+				Hash:         "def",
+				Name:         "Still downloading",
+				CompletionOn: -1,
+				Progress:     0.50,
+				State:        qbt.TorrentStateDownloading,
+			},
+		},
+	})
+
+	requireNoTorrentEvent(t, seen, 200*time.Millisecond)
+
+	client.handleCompletionUpdates(&qbt.MainData{
+		Torrents: map[string]qbt.Torrent{
+			"def": {
+				Hash:         "def",
+				Name:         "Done now",
+				CompletionOn: 999,
+				Progress:     1.0,
+				State:        qbt.TorrentStateUploading,
+			},
+		},
+	})
+
+	select {
+	case torrent := <-seen:
+		if torrent.Hash != "def" {
+			t.Fatalf("unexpected hash: %q", torrent.Hash)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected a completion event")
+	}
+
+	// Another update should not re-fire.
+	client.handleCompletionUpdates(&qbt.MainData{
+		Torrents: map[string]qbt.Torrent{
+			"def": {
+				Hash:         "def",
+				Name:         "Done now",
+				CompletionOn: 999,
+				Progress:     1.0,
+				State:        qbt.TorrentStateStalledUp,
+			},
+		},
+	})
+
+	requireNoTorrentEvent(t, seen, 200*time.Millisecond)
+}
+
+func requireNoTorrentEvent(t *testing.T, ch <-chan qbt.Torrent, d time.Duration) {
+	t.Helper()
+
+	select {
+	case torrent := <-ch:
+		t.Fatalf("unexpected completion event: hash=%q name=%q state=%q completionOn=%d",
+			torrent.Hash,
+			torrent.Name,
+			torrent.State,
+			torrent.CompletionOn,
+		)
+	case <-time.After(d):
+	}
+}

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -1393,8 +1393,8 @@ func (s *Service) HandleTorrentCompletion(ctx context.Context, instanceID int, t
 		return
 	}
 
-	if torrent.Progress < 1.0 || torrent.Hash == "" {
-		// Safety check – the qbittorrent completion hook should only fire for 100% torrents.
+	if torrent.CompletionOn <= 0 || torrent.Hash == "" {
+		// Safety check – the qbittorrent completion hook should only fire for completed torrents.
 		return
 	}
 

--- a/internal/services/crossseed/service_completion_gazelle_test.go
+++ b/internal/services/crossseed/service_completion_gazelle_test.go
@@ -211,10 +211,11 @@ func TestHandleTorrentCompletion_AllowsGazelleWhenJackettMissing(t *testing.T) {
 	completionStore := models.NewInstanceCrossSeedCompletionStore(q)
 
 	src := qbt.Torrent{
-		Hash:     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-		Name:     "test (2026) [FLAC]",
-		Tracker:  "https://flacsfor.me/announce",
-		Progress: 1.0,
+		Hash:         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Name:         "test (2026) [FLAC]",
+		Tracker:      "https://flacsfor.me/announce",
+		Progress:     1.0,
+		CompletionOn: 123,
 	}
 
 	syncMock := &completionGazelleSyncMock{torrent: src}


### PR DESCRIPTION
Stops torrent_completed notifications from spamming on restart by using qBittorrent's completion_on timestamp (CompletionOn) as the source of truth for completion events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Completion detection simplified to rely on the torrent's completion marker, reducing duplicate/missed completion signals and startup noise; related service safety check updated accordingly.

* **Tests**
  * Added thorough tests validating completion detection, startup-state fluctuations, and that completion events fire once when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->