### PR TITLE
fix(crossseed): queue completion searches and retry rate-limit waits

### DIFF
--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -241,7 +241,17 @@ const (
 	skippedRecheckMessage = "Skipped: requires recheck. Disable 'Skip recheck' in Cross-Seed settings to allow"
 )
 
-var completionRateLimitTokens = []string{"429", "rate limit", "too many requests"}
+var completionRateLimitTokens = []string{
+	"429",
+	"rate limit",
+	"rate-limited",
+	"too many requests",
+	"cooldown",
+	"request limit reached",
+	"query limit",
+	"grab limit",
+	"disabled till",
+}
 
 func computeAutomationSearchTimeout(indexerCount int) time.Duration {
 	return timeouts.AdaptiveSearchTimeout(indexerCount)

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -234,10 +234,14 @@ const (
 	minSearchIntervalSecondsTorznab     = 60
 	minSearchIntervalSecondsGazelleOnly = 5
 	minSearchCooldownMinutes            = 720
+	maxCompletionSearchAttempts         = 3
+	defaultCompletionRetryDelay         = 30 * time.Second
 
 	// User-facing message when cross-seed is skipped due to recheck requirement
 	skippedRecheckMessage = "Skipped: requires recheck. Disable 'Skip recheck' in Cross-Seed settings to allow"
 )
+
+var completionRateLimitTokens = []string{"429", "rate limit", "too many requests"}
 
 func computeAutomationSearchTimeout(indexerCount int) time.Duration {
 	return timeouts.AdaptiveSearchTimeout(indexerCount)
@@ -321,9 +325,15 @@ type Service struct {
 	// Metrics for monitoring service health and performance
 	metrics *ServiceMetrics
 
+	// Per-instance completion coordination.
+	// Ensures completion-triggered searches run serially per instance.
+	completionLaneMu sync.Mutex
+	completionLanes  map[int]*completionLane
+
 	// test hooks
-	crossSeedInvoker    func(ctx context.Context, req *CrossSeedRequest) (*CrossSeedResponse, error)
-	torrentDownloadFunc func(ctx context.Context, req jackett.TorrentDownloadRequest) ([]byte, error)
+	crossSeedInvoker        func(ctx context.Context, req *CrossSeedRequest) (*CrossSeedResponse, error)
+	torrentDownloadFunc     func(ctx context.Context, req jackett.TorrentDownloadRequest) ([]byte, error)
+	completionSearchInvoker func(context.Context, int, *qbt.Torrent, *models.CrossSeedAutomationSettings, *models.InstanceCrossSeedCompletionSettings) error
 
 	// Recheck resume worker
 	recheckResumeChan   chan *pendingResume
@@ -337,6 +347,10 @@ type pendingResume struct {
 	hash       string
 	threshold  float64
 	addedAt    time.Time
+}
+
+type completionLane struct {
+	mu sync.Mutex
 }
 
 // NewService creates a new cross-seed service
@@ -393,6 +407,7 @@ func NewService(
 		torrentFilesCache:             contentFilesCache,
 		dedupCache:                    dedupCache,
 		metrics:                       NewServiceMetrics(),
+		completionLanes:               make(map[int]*completionLane),
 		recheckResumeChan:             make(chan *pendingResume, 100),
 		recheckResumeCtx:              recheckCtx,
 		recheckResumeCancel:           recheckCancel,
@@ -1430,8 +1445,11 @@ func (s *Service) HandleTorrentCompletion(ctx context.Context, instanceID int, t
 		settings = models.DefaultCrossSeedAutomationSettings()
 	}
 
-	// Execute cross-seed search immediately
-	err = s.executeCompletionSearch(ctx, instanceID, &torrent, settings, completionSettings)
+	lane := s.getCompletionLane(instanceID)
+	lane.mu.Lock()
+	defer lane.mu.Unlock()
+
+	err = s.executeCompletionSearchWithRetry(ctx, instanceID, &torrent, settings, completionSettings)
 	if err != nil {
 		log.Warn().
 			Err(err).
@@ -1440,6 +1458,100 @@ func (s *Service) HandleTorrentCompletion(ctx context.Context, instanceID int, t
 			Str("name", torrent.Name).
 			Msg("[CROSSSEED-COMPLETION] Failed to execute completion search")
 	}
+}
+
+func (s *Service) getCompletionLane(instanceID int) *completionLane {
+	s.completionLaneMu.Lock()
+	defer s.completionLaneMu.Unlock()
+
+	if s.completionLanes == nil {
+		s.completionLanes = make(map[int]*completionLane)
+	}
+
+	lane, ok := s.completionLanes[instanceID]
+	if !ok {
+		lane = &completionLane{}
+		s.completionLanes[instanceID] = lane
+	}
+	return lane
+}
+
+func (s *Service) executeCompletionSearchWithRetry(
+	ctx context.Context,
+	instanceID int,
+	torrent *qbt.Torrent,
+	settings *models.CrossSeedAutomationSettings,
+	completionSettings *models.InstanceCrossSeedCompletionSettings,
+) error {
+	var lastErr error
+	for attempt := 1; attempt <= maxCompletionSearchAttempts; attempt++ {
+		err := s.invokeCompletionSearch(ctx, instanceID, torrent, settings, completionSettings)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+
+		retryAfter, retry := completionRetryDelay(err)
+		if !retry || attempt == maxCompletionSearchAttempts {
+			break
+		}
+		if retryAfter <= 0 {
+			retryAfter = defaultCompletionRetryDelay
+		}
+
+		log.Warn().
+			Err(err).
+			Int("instanceID", instanceID).
+			Str("hash", torrent.Hash).
+			Int("attempt", attempt).
+			Dur("retryAfter", retryAfter).
+			Msg("[CROSSSEED-COMPLETION] Rate-limited completion search, retrying")
+
+		timer := time.NewTimer(retryAfter)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return lastErr
+}
+
+func (s *Service) invokeCompletionSearch(
+	ctx context.Context,
+	instanceID int,
+	torrent *qbt.Torrent,
+	settings *models.CrossSeedAutomationSettings,
+	completionSettings *models.InstanceCrossSeedCompletionSettings,
+) error {
+	if s.completionSearchInvoker != nil {
+		return s.completionSearchInvoker(ctx, instanceID, torrent, settings, completionSettings)
+	}
+	return s.executeCompletionSearch(ctx, instanceID, torrent, settings, completionSettings)
+}
+
+func completionRetryDelay(err error) (time.Duration, bool) {
+	if err == nil {
+		return 0, false
+	}
+
+	var waitErr *jackett.RateLimitWaitError
+	if errors.As(err, &waitErr) {
+		if waitErr.Wait > 0 {
+			return waitErr.Wait, true
+		}
+		return defaultCompletionRetryDelay, true
+	}
+
+	msg := strings.ToLower(strings.TrimSpace(err.Error()))
+	for _, token := range completionRateLimitTokens {
+		if strings.Contains(msg, token) {
+			return defaultCompletionRetryDelay, true
+		}
+	}
+
+	return 0, false
 }
 
 // updateAutomationRunWithRetry attempts to update the automation run in the database with retries

--- a/internal/services/crossseed/service_completion_gazelle_test.go
+++ b/internal/services/crossseed/service_completion_gazelle_test.go
@@ -183,27 +183,27 @@ func TestHandleTorrentCompletion_AllowsGazelleWhenJackettMissing(t *testing.T) {
 	q := &testQuerier{DB: db}
 
 	_, err = q.ExecContext(context.Background(), `
-		CREATE TABLE instance_crossseed_completion_settings (
-			instance_id INTEGER PRIMARY KEY,
-			enabled INTEGER NOT NULL,
-			categories_json TEXT NOT NULL,
-			tags_json TEXT NOT NULL,
-			exclude_categories_json TEXT NOT NULL,
-			exclude_tags_json TEXT NOT NULL,
-			indexer_ids_json TEXT NOT NULL,
-			updated_at DATETIME NOT NULL
-		);
-	`)
+			CREATE TABLE instance_crossseed_completion_settings (
+				instance_id INTEGER PRIMARY KEY,
+				enabled INTEGER NOT NULL,
+				categories_json TEXT NOT NULL,
+				tags_json TEXT NOT NULL,
+				exclude_categories_json TEXT NOT NULL,
+				exclude_tags_json TEXT NOT NULL,
+				indexer_ids_json TEXT NOT NULL,
+				updated_at DATETIME NOT NULL
+			);
+		`)
 	if err != nil {
 		t.Fatalf("create completion settings table: %v", err)
 	}
 
 	_, err = q.ExecContext(context.Background(), `
-		INSERT INTO instance_crossseed_completion_settings (
-			instance_id, enabled, categories_json, tags_json,
-			exclude_categories_json, exclude_tags_json, indexer_ids_json, updated_at
-		) VALUES (1, 1, '[]', '[]', '[]', '[]', '[]', ?);
-	`, time.Now().UTC())
+			INSERT INTO instance_crossseed_completion_settings (
+				instance_id, enabled, categories_json, tags_json,
+				exclude_categories_json, exclude_tags_json, indexer_ids_json, updated_at
+			) VALUES (1, 1, '[]', '[]', '[]', '[]', '[]', ?);
+		`, time.Now().UTC())
 	if err != nil {
 		t.Fatalf("insert completion settings: %v", err)
 	}

--- a/internal/services/crossseed/service_completion_queue_test.go
+++ b/internal/services/crossseed/service_completion_queue_test.go
@@ -93,14 +93,15 @@ func TestHandleTorrentCompletion_QueuesPerInstance(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		svc.HandleTorrentCompletion(context.Background(), 1, qbt.Torrent{
-			Hash:     firstHash,
-			Name:     "first",
-			Progress: 1.0,
-		})
-	}()
+		go func() {
+			defer wg.Done()
+			svc.HandleTorrentCompletion(context.Background(), 1, qbt.Torrent{
+				Hash:     firstHash,
+				Name:     "first",
+				Progress: 1.0,
+				CompletionOn: 123,
+			})
+		}()
 
 	select {
 	case <-firstStarted:
@@ -108,14 +109,15 @@ func TestHandleTorrentCompletion_QueuesPerInstance(t *testing.T) {
 		t.Fatal("first completion search did not start")
 	}
 
-	go func() {
-		defer wg.Done()
-		svc.HandleTorrentCompletion(context.Background(), 1, qbt.Torrent{
-			Hash:     secondHash,
-			Name:     "second",
-			Progress: 1.0,
-		})
-	}()
+		go func() {
+			defer wg.Done()
+			svc.HandleTorrentCompletion(context.Background(), 1, qbt.Torrent{
+				Hash:     secondHash,
+				Name:     "second",
+				Progress: 1.0,
+				CompletionOn: 124,
+			})
+		}()
 
 	select {
 	case <-secondStarted:
@@ -165,6 +167,7 @@ func TestHandleTorrentCompletion_RetriesOnRateLimitError(t *testing.T) {
 		Hash:     "cccccccccccccccccccccccccccccccccccccccc",
 		Name:     "retry-me",
 		Progress: 1.0,
+		CompletionOn: 125,
 	})
 
 	assert.Equal(t, 2, attempts)

--- a/internal/services/crossseed/service_completion_queue_test.go
+++ b/internal/services/crossseed/service_completion_queue_test.go
@@ -93,15 +93,15 @@ func TestHandleTorrentCompletion_QueuesPerInstance(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(2)
-		go func() {
-			defer wg.Done()
-			svc.HandleTorrentCompletion(context.Background(), 1, qbt.Torrent{
-				Hash:     firstHash,
-				Name:     "first",
-				Progress: 1.0,
-				CompletionOn: 123,
-			})
-		}()
+	go func() {
+		defer wg.Done()
+		svc.HandleTorrentCompletion(context.Background(), 1, qbt.Torrent{
+			Hash:         firstHash,
+			Name:         "first",
+			Progress:     1.0,
+			CompletionOn: 123,
+		})
+	}()
 
 	select {
 	case <-firstStarted:
@@ -109,15 +109,15 @@ func TestHandleTorrentCompletion_QueuesPerInstance(t *testing.T) {
 		t.Fatal("first completion search did not start")
 	}
 
-		go func() {
-			defer wg.Done()
-			svc.HandleTorrentCompletion(context.Background(), 1, qbt.Torrent{
-				Hash:     secondHash,
-				Name:     "second",
-				Progress: 1.0,
-				CompletionOn: 124,
-			})
-		}()
+	go func() {
+		defer wg.Done()
+		svc.HandleTorrentCompletion(context.Background(), 1, qbt.Torrent{
+			Hash:         secondHash,
+			Name:         "second",
+			Progress:     1.0,
+			CompletionOn: 124,
+		})
+	}()
 
 	select {
 	case <-secondStarted:
@@ -164,9 +164,9 @@ func TestHandleTorrentCompletion_RetriesOnRateLimitError(t *testing.T) {
 	}
 
 	svc.HandleTorrentCompletion(context.Background(), 1, qbt.Torrent{
-		Hash:     "cccccccccccccccccccccccccccccccccccccccc",
-		Name:     "retry-me",
-		Progress: 1.0,
+		Hash:         "cccccccccccccccccccccccccccccccccccccccc",
+		Name:         "retry-me",
+		Progress:     1.0,
 		CompletionOn: 125,
 	})
 

--- a/internal/services/crossseed/service_completion_queue_test.go
+++ b/internal/services/crossseed/service_completion_queue_test.go
@@ -1,0 +1,166 @@
+package crossseed
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+	"testing"
+	"time"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+
+	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/services/jackett"
+)
+
+func setupCompletionStoreForQueueTests(t *testing.T) *models.InstanceCrossSeedCompletionStore {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", "file:completion_queue_tests?mode=memory&cache=shared")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	q := &testQuerier{DB: db}
+
+	_, err = q.ExecContext(context.Background(), `
+		CREATE TABLE IF NOT EXISTS instance_crossseed_completion_settings (
+			instance_id INTEGER PRIMARY KEY,
+			enabled INTEGER NOT NULL,
+			categories_json TEXT NOT NULL,
+			tags_json TEXT NOT NULL,
+			exclude_categories_json TEXT NOT NULL,
+			exclude_tags_json TEXT NOT NULL,
+			indexer_ids_json TEXT NOT NULL,
+			updated_at DATETIME NOT NULL
+		);
+	`)
+	require.NoError(t, err)
+
+	_, err = q.ExecContext(context.Background(), `
+		INSERT OR REPLACE INTO instance_crossseed_completion_settings (
+			instance_id, enabled, categories_json, tags_json,
+			exclude_categories_json, exclude_tags_json, indexer_ids_json, updated_at
+		) VALUES (1, 1, '[]', '[]', '[]', '[]', '[]', ?);
+	`, time.Now().UTC())
+	require.NoError(t, err)
+
+	return models.NewInstanceCrossSeedCompletionStore(q)
+}
+
+func TestHandleTorrentCompletion_QueuesPerInstance(t *testing.T) {
+	completionStore := setupCompletionStoreForQueueTests(t)
+
+	firstHash := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	secondHash := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	firstStarted := make(chan struct{})
+	secondStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	invocationOrder := make([]string, 0, 2)
+	var orderMu sync.Mutex
+	var firstOnce sync.Once
+	var secondOnce sync.Once
+
+	svc := &Service{
+		completionStore: completionStore,
+		automationSettingsLoader: func(context.Context) (*models.CrossSeedAutomationSettings, error) {
+			return models.DefaultCrossSeedAutomationSettings(), nil
+		},
+		completionSearchInvoker: func(_ context.Context, _ int, torrent *qbt.Torrent, _ *models.CrossSeedAutomationSettings, _ *models.InstanceCrossSeedCompletionSettings) error {
+			orderMu.Lock()
+			invocationOrder = append(invocationOrder, torrent.Hash)
+			orderMu.Unlock()
+
+			switch torrent.Hash {
+			case firstHash:
+				firstOnce.Do(func() { close(firstStarted) })
+				<-releaseFirst
+			case secondHash:
+				secondOnce.Do(func() { close(secondStarted) })
+			}
+			return nil
+		},
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		svc.HandleTorrentCompletion(context.Background(), 1, qbt.Torrent{
+			Hash:     firstHash,
+			Name:     "first",
+			Progress: 1.0,
+		})
+	}()
+
+	select {
+	case <-firstStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first completion search did not start")
+	}
+
+	go func() {
+		defer wg.Done()
+		svc.HandleTorrentCompletion(context.Background(), 1, qbt.Torrent{
+			Hash:     secondHash,
+			Name:     "second",
+			Progress: 1.0,
+		})
+	}()
+
+	select {
+	case <-secondStarted:
+		t.Fatal("second completion search started before first released")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseFirst)
+	wg.Wait()
+
+	select {
+	case <-secondStarted:
+	case <-time.After(time.Second):
+		t.Fatal("second completion search did not start after first completed")
+	}
+
+	orderMu.Lock()
+	defer orderMu.Unlock()
+	require.Equal(t, []string{firstHash, secondHash}, invocationOrder)
+}
+
+func TestHandleTorrentCompletion_RetriesOnRateLimitError(t *testing.T) {
+	completionStore := setupCompletionStoreForQueueTests(t)
+
+	attempts := 0
+	svc := &Service{
+		completionStore: completionStore,
+		automationSettingsLoader: func(context.Context) (*models.CrossSeedAutomationSettings, error) {
+			return models.DefaultCrossSeedAutomationSettings(), nil
+		},
+		completionSearchInvoker: func(context.Context, int, *qbt.Torrent, *models.CrossSeedAutomationSettings, *models.InstanceCrossSeedCompletionSettings) error {
+			attempts++
+			if attempts == 1 {
+				return &jackett.RateLimitWaitError{
+					IndexerID:   1,
+					IndexerName: "test",
+					Wait:        10 * time.Millisecond,
+					MaxWait:     30 * time.Second,
+					Priority:    jackett.RateLimitPriorityCompletion,
+				}
+			}
+			return nil
+		},
+	}
+
+	started := time.Now()
+	svc.HandleTorrentCompletion(context.Background(), 1, qbt.Torrent{
+		Hash:     "cccccccccccccccccccccccccccccccccccccccc",
+		Name:     "retry-me",
+		Progress: 1.0,
+	})
+
+	assert.Equal(t, 2, attempts)
+	assert.GreaterOrEqual(t, time.Since(started), 8*time.Millisecond)
+}


### PR DESCRIPTION
Fixes completion-triggered cross-seed bursts by processing completion searches one-at-a-time per instance and automatically retrying when Torznab/Prowlarr returns rate-limit wait errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Completion searches now retry on rate-limit conditions and are serialized per instance to prevent concurrent conflicts and lost attempts.
  * Scheduler now surfaces rate-limit-wait outcomes when all indexers are skipped.

* **Improvements**
  * Added per-instance coordination and retry/backoff handling plus metrics to better track rate-limit waits and retries.

* **Tests**
  * New tests cover per-instance queuing, retry behavior on rate limits, retry-delay parsing, and scheduler behavior when all indexers are skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->