### PR TITLE
fix(crossseed): avoid completion timeout misses on non-Gazelle torrents

### DIFF
--- a/internal/services/crossseed/models.go
+++ b/internal/services/crossseed/models.go
@@ -226,6 +226,9 @@ type TorrentSearchOptions struct {
 	CacheMode string `json:"cache_mode,omitempty"`
 	// DisableTorznab skips all Torznab search stages while still allowing Gazelle matching.
 	DisableTorznab bool `json:"disable_torznab,omitempty"`
+	// SkipGazelle disables Gazelle pre-search in mixed search mode.
+	// Internal-only (not exposed in API payloads).
+	SkipGazelle bool `json:"-"`
 }
 
 // TorrentSearchResult represents an indexer search result that appears to match the seeded torrent.

--- a/internal/services/crossseed/service_completion_gazelle_test.go
+++ b/internal/services/crossseed/service_completion_gazelle_test.go
@@ -410,7 +410,7 @@ func TestExecuteCompletionSearch_NonGazelleSourceSkipsGazellePresearch(t *testin
 
 	src := qbt.Torrent{
 		Hash:     "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
-		Name:     "Formula.1.Drive.to.Survive.S08.1080p.ATVP.WEB-DL.DDP5.1.H.264-NTb",
+		Name:     "Velocity.Circuit.Chronicles.S03.1080p.WEB-DL.DDP5.1.H.264-TESTGRP",
 		Tracker:  "https://tracker.example/announce",
 		Progress: 1.0,
 	}

--- a/internal/services/crossseed/service_completion_gazelle_test.go
+++ b/internal/services/crossseed/service_completion_gazelle_test.go
@@ -77,6 +77,7 @@ func (s *staticInstanceStore) List(_ context.Context) ([]*models.Instance, error
 type completionGazelleSyncMock struct {
 	torrent         qbt.Torrent
 	getTorrentsHits int
+	exportHits      int
 }
 
 func (m *completionGazelleSyncMock) GetTorrents(_ context.Context, _ int, filter qbt.TorrentFilterOptions) ([]qbt.Torrent, error) {
@@ -101,6 +102,7 @@ func (m *completionGazelleSyncMock) GetTorrentFilesBatch(_ context.Context, _ in
 }
 
 func (m *completionGazelleSyncMock) ExportTorrent(context.Context, int, string) ([]byte, string, string, error) {
+	m.exportHits++
 	return nil, "", "", nil
 }
 
@@ -400,5 +402,49 @@ func TestExecuteCompletionSearch_GazelleSourceFallsBackToTorznabWhenTargetKeyUnd
 	}
 	if !strings.Contains(err.Error(), fallbackErrMsg) {
 		t.Fatalf("expected torznab fallback error %q, got: %v", fallbackErrMsg, err)
+	}
+}
+
+func TestExecuteCompletionSearch_NonGazelleSourceSkipsGazellePresearch(t *testing.T) {
+	t.Parallel()
+
+	src := qbt.Torrent{
+		Hash:     "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+		Name:     "Formula.1.Drive.to.Survive.S08.1080p.ATVP.WEB-DL.DDP5.1.H.264-NTb",
+		Tracker:  "https://tracker.example/announce",
+		Progress: 1.0,
+	}
+	syncMock := &completionGazelleSyncMock{torrent: src}
+
+	indexers := []*models.TorznabIndexer{
+		{
+			ID:             999,
+			Name:           "Test Indexer",
+			BaseURL:        "http://127.0.0.1:1",
+			Enabled:        true,
+			TimeoutSeconds: 1,
+			Backend:        models.TorznabBackendProwlarr,
+		},
+	}
+
+	svc := &Service{
+		instanceStore:  &staticInstanceStore{inst: &models.Instance{ID: 1, Name: "main"}},
+		syncManager:    syncMock,
+		jackettService: newJackettServiceWithIndexers(indexers),
+		releaseCache:   NewReleaseCache(),
+	}
+
+	_ = svc.executeCompletionSearch(context.Background(), 1, &src, &models.CrossSeedAutomationSettings{
+		GazelleEnabled:         true,
+		OrpheusAPIKey:          "ops-key",
+		FindIndividualEpisodes: true,
+	}, &models.InstanceCrossSeedCompletionSettings{
+		InstanceID: 1,
+		Enabled:    true,
+		IndexerIDs: []int{999},
+	})
+
+	if syncMock.exportHits != 0 {
+		t.Fatalf("expected non-gazelle completion path to skip gazelle pre-search, got %d export attempts", syncMock.exportHits)
 	}
 }


### PR DESCRIPTION
## Summary
- remove completion-specific outer timeout wrapper around cross-seed search and rely on Jackett search budget
- add internal `SkipGazelle` search option for mixed Torznab+Gazelle mode
- set completion searches to skip Gazelle pre-search when source torrent is not Gazelle-backed
- add regression test to assert non-Gazelle completion path does not run Gazelle pre-search



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Completion search now skips Gazelle pre-search for non-Gazelle sources, reducing unnecessary work and improving search responsiveness.
  * Preserves previous behavior when Gazelle is not configured, ensuring consistent results.

* **Tests**
  * Added tests verifying Gazelle pre-search is skipped for non-Gazelle sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->