### PR TITLE
feat(torrents): MediaInfo dialog

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/autobrr/qui
 
-go 1.25
+go 1.25.6
 
 require (
 	github.com/CAFxX/httpcompression v0.0.9
@@ -10,6 +10,7 @@ require (
 	github.com/anacrolix/torrent v1.60.0
 	github.com/andybalholm/brotli v1.2.0
 	github.com/autobrr/autobrr v1.72.1
+	github.com/autobrr/go-mediainfo v0.3.0
 	github.com/autobrr/go-qbittorrent v1.15.0-rc1.0.20260221205148-5cc22ac80d42
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/cespare/xxhash/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,8 @@ github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUS
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/autobrr/autobrr v1.72.1 h1:rtsSIexhkfXv5q2nJeJ2Sh6x+Ln4o04EQh9U+uFZdhs=
 github.com/autobrr/autobrr v1.72.1/go.mod h1:i2Z/nqdm3vAWSSY0Uw8DM/I8JYJ+KwhSAT+m4IzwnIY=
-github.com/autobrr/go-qbittorrent v1.15.0-rc1.0.20260121130753-8741290569bc h1:iSDMPD1K6H71WSCR6iv6HY+01uBKEeHXEF2MAvP/S/A=
-github.com/autobrr/go-qbittorrent v1.15.0-rc1.0.20260121130753-8741290569bc/go.mod h1:16BG5dqbTh9kaV6bZru4AeW2/o80TDwGBMDyj5Kj3zI=
+github.com/autobrr/go-mediainfo v0.3.0 h1:rtQDkZ5jIDzNSk5TYK/Emj6oJZKqqeULwkRcoS3//qo=
+github.com/autobrr/go-mediainfo v0.3.0/go.mod h1:xVXgHDAYYpIeGQCQCdTBpoiY/O3tojJfflK+rrbzclQ=
 github.com/autobrr/go-qbittorrent v1.15.0-rc1.0.20260221205148-5cc22ac80d42 h1:NWveC89mG3g4O5wrynalUF8JOxHEx68RFh6l/dkGt7U=
 github.com/autobrr/go-qbittorrent v1.15.0-rc1.0.20260221205148-5cc22ac80d42/go.mod h1:oqvAaTbjH/6RoE5D5qaZg6JZ5TqDMMl+rYnMuyXDgAg=
 github.com/autobrr/rls v0.8.0 h1:Odz78o5nfrO4hsQ17qiuyKYtiG97+Cs5nrD9TFk8/lI=

--- a/internal/api/handlers/torrents_mediainfo_test.go
+++ b/internal/api/handlers/torrents_mediainfo_test.go
@@ -1,0 +1,239 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func newMediaInfoRequest(t *testing.T, instanceID int, hash, fileIndex string) *http.Request {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/instances/"+strconv.Itoa(instanceID)+"/torrents/"+hash+"/files/"+fileIndex+"/mediainfo", nil)
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("instanceID", strconv.Itoa(instanceID))
+	routeCtx.URLParams.Add("hash", hash)
+	routeCtx.URLParams.Add("fileIndex", fileIndex)
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+}
+
+func TestGetTorrentFileMediaInfo_ReturnsServerErrorWithoutInstanceStore(t *testing.T) {
+	t.Parallel()
+
+	handler := NewTorrentsHandlerForTesting(nil, nil)
+	rec := httptest.NewRecorder()
+	req := newMediaInfoRequest(t, 1, "hash123", "0")
+
+	handler.GetTorrentFileMediaInfo(rec, req)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.Contains(t, rec.Body.String(), "Instance store not configured")
+}
+
+func TestGetTorrentFileMediaInfo_RejectsInvalidFileIndex(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		fileIndex string
+	}{
+		{name: "negative", fileIndex: "-1"},
+		{name: "not_integer", fileIndex: "abc"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			instanceStore, instanceID := createInstanceStoreWithInstance(t, true)
+			resolver := &mockContentResolver{}
+			handler := &TorrentsHandler{
+				instanceStore:   instanceStore,
+				contentResolver: resolver,
+			}
+
+			rec := httptest.NewRecorder()
+			req := newMediaInfoRequest(t, instanceID, "hash123", tc.fileIndex)
+
+			handler.GetTorrentFileMediaInfo(rec, req)
+
+			require.Equal(t, http.StatusBadRequest, rec.Code)
+			require.Contains(t, rec.Body.String(), "Invalid file index")
+			require.Equal(t, 0, resolver.filesCalls)
+		})
+	}
+}
+
+func TestGetTorrentFileMediaInfo_ReturnsNotFoundForMissingInstance(t *testing.T) {
+	t.Parallel()
+
+	instanceStore, _ := createInstanceStoreWithInstance(t, true)
+	resolver := &mockContentResolver{}
+	handler := &TorrentsHandler{
+		instanceStore:   instanceStore,
+		contentResolver: resolver,
+	}
+
+	rec := httptest.NewRecorder()
+	req := newMediaInfoRequest(t, 999999, "hash123", "0")
+
+	handler.GetTorrentFileMediaInfo(rec, req)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.Contains(t, rec.Body.String(), "Instance not found")
+	require.Equal(t, 0, resolver.filesCalls)
+}
+
+func TestGetTorrentFileMediaInfo_ReturnsForbiddenWithoutLocalAccess(t *testing.T) {
+	t.Parallel()
+
+	instanceStore, instanceID := createInstanceStoreWithInstance(t, false)
+	resolver := &mockContentResolver{}
+	handler := &TorrentsHandler{
+		instanceStore:   instanceStore,
+		contentResolver: resolver,
+	}
+
+	rec := httptest.NewRecorder()
+	req := newMediaInfoRequest(t, instanceID, "hash123", "0")
+
+	handler.GetTorrentFileMediaInfo(rec, req)
+
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.Contains(t, rec.Body.String(), "local filesystem access")
+	require.Equal(t, 0, resolver.filesCalls)
+}
+
+func TestGetTorrentFileMediaInfo_ReturnsNotFoundForUnknownFileIndex(t *testing.T) {
+	t.Parallel()
+
+	instanceStore, instanceID := createInstanceStoreWithInstance(t, true)
+	files := qbt.TorrentFiles{
+		{Index: 1, Name: "known.mkv"},
+	}
+	resolver := &mockContentResolver{files: &files}
+	handler := &TorrentsHandler{
+		instanceStore:   instanceStore,
+		contentResolver: resolver,
+	}
+
+	rec := httptest.NewRecorder()
+	req := newMediaInfoRequest(t, instanceID, "hash123", "9")
+
+	handler.GetTorrentFileMediaInfo(rec, req)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.Contains(t, rec.Body.String(), "File index not found")
+	require.Equal(t, 1, resolver.filesCalls)
+	require.Equal(t, 0, resolver.propsCalls)
+}
+
+func TestGetTorrentFileMediaInfo_RejectsTraversalPaths(t *testing.T) {
+	t.Parallel()
+
+	instanceStore, instanceID := createInstanceStoreWithInstance(t, true)
+	files := qbt.TorrentFiles{
+		{Index: 5, Name: "../escape.txt"},
+	}
+	resolver := &mockContentResolver{
+		files:      &files,
+		properties: &qbt.TorrentProperties{SavePath: "/downloads"},
+	}
+	handler := &TorrentsHandler{
+		instanceStore:   instanceStore,
+		contentResolver: resolver,
+	}
+
+	rec := httptest.NewRecorder()
+	req := newMediaInfoRequest(t, instanceID, "hash123", "5")
+
+	handler.GetTorrentFileMediaInfo(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "Invalid file path")
+}
+
+func TestGetTorrentFileMediaInfo_ReturnsNotFoundWhenFileMissingOnDisk(t *testing.T) {
+	t.Parallel()
+
+	instanceStore, instanceID := createInstanceStoreWithInstance(t, true)
+	files := qbt.TorrentFiles{
+		{Index: 2, Name: "movie.bin"},
+	}
+	resolver := &mockContentResolver{
+		files:      &files,
+		properties: &qbt.TorrentProperties{SavePath: t.TempDir()},
+	}
+	handler := &TorrentsHandler{
+		instanceStore:   instanceStore,
+		contentResolver: resolver,
+	}
+
+	rec := httptest.NewRecorder()
+	req := newMediaInfoRequest(t, instanceID, "hash123", "2")
+
+	handler.GetTorrentFileMediaInfo(rec, req)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.Contains(t, rec.Body.String(), "File not found on disk")
+}
+
+func TestGetTorrentFileMediaInfo_ReturnsReport(t *testing.T) {
+	t.Parallel()
+
+	instanceStore, instanceID := createInstanceStoreWithInstance(t, true)
+	baseDir := t.TempDir()
+	relativePath := "folder/file.bin"
+	fullPath := filepath.Join(baseDir, relativePath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(fullPath), 0o755))
+	require.NoError(t, os.WriteFile(fullPath, []byte("hello world"), 0o600))
+
+	files := qbt.TorrentFiles{{Index: 3, Name: relativePath}}
+	resolver := &mockContentResolver{
+		files:      &files,
+		properties: &qbt.TorrentProperties{SavePath: baseDir},
+	}
+	handler := &TorrentsHandler{
+		instanceStore:   instanceStore,
+		contentResolver: resolver,
+	}
+
+	rec := httptest.NewRecorder()
+	req := newMediaInfoRequest(t, instanceID, "hash123", "3")
+
+	handler.GetTorrentFileMediaInfo(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		FileIndex    int    `json:"fileIndex"`
+		RelativePath string `json:"relativePath"`
+		Streams      []struct {
+			Kind   string `json:"kind"`
+			Fields []struct {
+				Name  string `json:"name"`
+				Value string `json:"value"`
+			} `json:"fields"`
+		} `json:"streams"`
+		RawJSON string `json:"rawJSON"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, 3, resp.FileIndex)
+	require.Equal(t, relativePath, resp.RelativePath)
+	require.NotEmpty(t, resp.Streams)
+	require.Equal(t, "General", resp.Streams[0].Kind)
+	require.NotEmpty(t, resp.Streams[0].Fields)
+	require.True(t, json.Valid([]byte(resp.RawJSON)))
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -482,6 +482,7 @@ func (s *Server) Handler() (*chi.Mux, error) {
 							r.Put("/rename-file", torrentsHandler.RenameTorrentFile)
 							r.Put("/rename-folder", torrentsHandler.RenameTorrentFolder)
 							r.Get("/files/{fileIndex}/download", torrentsHandler.DownloadTorrentContentFile)
+							r.Get("/files/{fileIndex}/mediainfo", torrentsHandler.GetTorrentFileMediaInfo)
 						})
 					})
 

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -1979,6 +1979,35 @@ paths:
         '500':
           description: Internal server error
 
+  /api/instances/{instanceID}/torrents/{hash}/files/{fileIndex}/mediainfo:
+    get:
+      tags:
+        - Torrent Details
+      summary: Get MediaInfo for a torrent content file
+      description: >
+        Analyzes a single file from the torrent's content on the local filesystem and returns a human-readable
+        stream/field report plus the raw MediaInfo JSON output.
+        Requires the instance to have local filesystem access enabled.
+      parameters:
+        - $ref: '#/components/parameters/instanceID'
+        - $ref: '#/components/parameters/hash'
+        - $ref: '#/components/parameters/fileIndex'
+      responses:
+        '200':
+          description: MediaInfo report
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TorrentFileMediaInfoResponse'
+        '400':
+          description: Invalid instance ID, hash, or file index
+        '403':
+          description: Instance does not have local filesystem access
+        '404':
+          description: Torrent, file index, or file on disk not found
+        '500':
+          description: Internal server error
+
   /api/instances/{instanceID}/torrents/{hash}/rename:
     put:
       tags:
@@ -5507,6 +5536,52 @@ components:
           type: boolean
         availability:
           type: number
+
+    TorrentFileMediaInfoField:
+      type: object
+      required:
+        - name
+        - value
+      properties:
+        name:
+          type: string
+        value:
+          type: string
+
+    TorrentFileMediaInfoStream:
+      type: object
+      required:
+        - kind
+        - fields
+      properties:
+        kind:
+          type: string
+          description: Stream kind (General, Video, Audio, Text, etc.)
+        fields:
+          type: array
+          items:
+            $ref: '#/components/schemas/TorrentFileMediaInfoField'
+
+    TorrentFileMediaInfoResponse:
+      type: object
+      required:
+        - fileIndex
+        - relativePath
+        - streams
+        - rawJSON
+      properties:
+        fileIndex:
+          type: integer
+        relativePath:
+          type: string
+          description: Torrent-relative path from qBittorrent file list
+        streams:
+          type: array
+          items:
+            $ref: '#/components/schemas/TorrentFileMediaInfoStream'
+        rawJSON:
+          type: string
+          description: Raw MediaInfo JSON output
 
     DuplicateTorrentMatch:
       type: object

--- a/web/src/components/torrents/TorrentDetailsPanel.tsx
+++ b/web/src/components/torrents/TorrentDetailsPanel.tsx
@@ -38,6 +38,7 @@ import { toast } from "sonner"
 import { CrossSeedTable, GeneralTabHorizontal, PeersTable, TorrentFileTable, TrackerContextMenu, TrackersTable, WebSeedsTable } from "./details"
 import { EditTrackerDialog, RenameTorrentFileDialog, RenameTorrentFolderDialog } from "./TorrentDialogs"
 import { TorrentFileTree } from "./TorrentFileTree"
+import { TorrentFileMediaInfoDialog } from "./TorrentFileMediaInfoDialog"
 
 interface TorrentDetailsPanelProps {
   instanceId: number;
@@ -660,6 +661,21 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
     if (!torrent || incognitoMode) return
     api.downloadContentFile(instanceId, torrent.hash, file.index)
   }, [instanceId, torrent, incognitoMode])
+
+  const [showMediaInfoDialog, setShowMediaInfoDialog] = useState(false)
+  const [mediaInfoFile, setMediaInfoFile] = useState<TorrentFile | null>(null)
+
+  const handleShowMediaInfo = useCallback((file: TorrentFile) => {
+    setMediaInfoFile(file)
+    setShowMediaInfoDialog(true)
+  }, [])
+
+  const handleMediaInfoDialogOpenChange = useCallback((open: boolean) => {
+    setShowMediaInfoDialog(open)
+    if (!open) {
+      setMediaInfoFile(null)
+    }
+  }, [])
 
   // Handle rename folder
   const handleRenameFolderConfirm = useCallback(({ oldPath, newPath }: { oldPath: string; newPath: string }) => {
@@ -1512,6 +1528,7 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
                 onRenameFile={handleRenameFileClick}
                 onRenameFolder={(folderPath) => { void handleRenameFolderDialogOpen(folderPath) }}
                 onDownloadFile={hasLocalFilesystemAccess ? handleDownloadFile : undefined}
+                onShowMediaInfo={hasLocalFilesystemAccess ? handleShowMediaInfo : undefined}
               />
             ) : activeTab === "content" && loadingFiles && !files ? (
               <div className="flex items-center justify-center p-8 flex-1">
@@ -1565,6 +1582,7 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
                       onRenameFile={handleRenameFileClick}
                       onRenameFolder={(folderPath) => { void handleRenameFolderDialogOpen(folderPath) }}
                       onDownloadFile={hasLocalFilesystemAccess ? handleDownloadFile : undefined}
+                      onShowMediaInfo={hasLocalFilesystemAccess ? handleShowMediaInfo : undefined}
                     />
                   </div>
                 </ScrollArea>
@@ -2047,6 +2065,14 @@ tracker.example.com:8080
         selectedHashes={torrent ? [torrent.hash] : []}
         onConfirm={(oldURL, newURL) => editTrackerMutation.mutate({ oldURL, newURL })}
         isPending={editTrackerMutation.isPending}
+      />
+
+      <TorrentFileMediaInfoDialog
+        open={showMediaInfoDialog}
+        onOpenChange={handleMediaInfoDialogOpenChange}
+        instanceId={instanceId}
+        torrentHash={torrent.hash}
+        file={mediaInfoFile}
       />
     </div>
   )

--- a/web/src/components/torrents/TorrentDetailsPanel.tsx
+++ b/web/src/components/torrents/TorrentDetailsPanel.tsx
@@ -664,16 +664,20 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
 
   const [showMediaInfoDialog, setShowMediaInfoDialog] = useState(false)
   const [mediaInfoFile, setMediaInfoFile] = useState<TorrentFile | null>(null)
+  const [mediaInfoTorrentHash, setMediaInfoTorrentHash] = useState<string | null>(null)
 
   const handleShowMediaInfo = useCallback((file: TorrentFile) => {
+    if (!torrent) return
     setMediaInfoFile(file)
+    setMediaInfoTorrentHash(torrent.hash)
     setShowMediaInfoDialog(true)
-  }, [])
+  }, [torrent])
 
   const handleMediaInfoDialogOpenChange = useCallback((open: boolean) => {
     setShowMediaInfoDialog(open)
     if (!open) {
       setMediaInfoFile(null)
+      setMediaInfoTorrentHash(null)
     }
   }, [])
 
@@ -2071,7 +2075,7 @@ tracker.example.com:8080
         open={showMediaInfoDialog}
         onOpenChange={handleMediaInfoDialogOpenChange}
         instanceId={instanceId}
-        torrentHash={torrent.hash}
+        torrentHash={mediaInfoTorrentHash ?? ""}
         file={mediaInfoFile}
       />
     </div>

--- a/web/src/components/torrents/TorrentFileMediaInfoDialog.tsx
+++ b/web/src/components/torrents/TorrentFileMediaInfoDialog.tsx
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { Button } from "@/components/ui/button"
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { api } from "@/lib/api"
+import { copyTextToClipboard } from "@/lib/utils"
+import type { TorrentFile, TorrentFileMediaInfoResponse } from "@/types"
+import { useQuery } from "@tanstack/react-query"
+import { Copy, Loader2, RotateCw } from "lucide-react"
+import { useMemo } from "react"
+import { toast } from "sonner"
+
+interface TorrentFileMediaInfoDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  instanceId: number
+  torrentHash: string
+  file: TorrentFile | null
+}
+
+function buildStreamLabels(streams: TorrentFileMediaInfoResponse["streams"]): string[] {
+  const totals = new Map<string, number>()
+  for (const stream of streams) {
+    totals.set(stream.kind, (totals.get(stream.kind) ?? 0) + 1)
+  }
+
+  const seen = new Map<string, number>()
+  return streams.map((stream) => {
+    const next = (seen.get(stream.kind) ?? 0) + 1
+    seen.set(stream.kind, next)
+    const total = totals.get(stream.kind) ?? 0
+    if (stream.kind !== "General" && total > 1) {
+      return `${stream.kind} #${next}`
+    }
+    return stream.kind
+  })
+}
+
+export function TorrentFileMediaInfoDialog({
+  open,
+  onOpenChange,
+  instanceId,
+  torrentHash,
+  file,
+}: TorrentFileMediaInfoDialogProps) {
+  const query = useQuery({
+    queryKey: ["torrent-file-mediainfo", instanceId, torrentHash, file?.index],
+    queryFn: () => api.getTorrentFileMediaInfo(instanceId, torrentHash, file!.index),
+    enabled: open && !!file,
+    staleTime: 30000,
+    gcTime: 5 * 60 * 1000,
+  })
+
+  const streamLabels = useMemo(() => {
+    const streams = query.data?.streams ?? []
+    return buildStreamLabels(streams)
+  }, [query.data?.streams])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-3xl max-h-[85vh] overflow-hidden">
+        <DialogHeader>
+          <DialogTitle>MediaInfo</DialogTitle>
+          <DialogDescription className="font-mono text-xs break-all">
+            {query.data?.relativePath ?? file?.name ?? ""}
+          </DialogDescription>
+        </DialogHeader>
+
+        <Tabs defaultValue="summary" className="w-full">
+          <TabsList>
+            <TabsTrigger value="summary">Summary</TabsTrigger>
+            <TabsTrigger value="raw">Raw JSON</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="summary" className="m-0">
+            <ScrollArea className="h-[65vh] pr-4">
+              {query.isLoading ? (
+                <div className="flex items-center justify-center py-16">
+                  <Loader2 className="h-6 w-6 animate-spin" />
+                </div>
+              ) : query.isError ? (
+                <div className="flex flex-col items-start gap-3 py-8">
+                  <p className="text-sm text-muted-foreground">
+                    {query.error instanceof Error ? query.error.message : "Failed to fetch MediaInfo"}
+                  </p>
+                  <Button variant="outline" size="sm" onClick={() => void query.refetch()}>
+                    <RotateCw className="h-4 w-4 mr-2" />
+                    Retry
+                  </Button>
+                </div>
+              ) : query.data ? (
+                <div className="space-y-6">
+                  {query.data.streams.map((stream, idx) => {
+                    const label = streamLabels[idx] ?? stream.kind
+                    const fields = stream.fields.filter(f => f.value.trim() !== "")
+
+                    return (
+                      <section key={`${stream.kind}-${idx}`} className="space-y-3">
+                        <div className="flex items-center justify-between">
+                          <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                            {label}
+                          </h3>
+                          <span className="text-[10px] text-muted-foreground">
+                            {fields.length} field{fields.length !== 1 ? "s" : ""}
+                          </span>
+                        </div>
+
+                        {fields.length === 0 ? (
+                          <p className="text-sm text-muted-foreground">No fields</p>
+                        ) : (
+                          <div className="grid grid-cols-[minmax(10rem,1fr)_minmax(0,2fr)] gap-x-4 gap-y-1">
+                            {fields.map((field, fieldIdx) => (
+                              <div
+                                key={`${field.name}-${fieldIdx}`}
+                                className="contents"
+                              >
+                                <div className="text-xs text-muted-foreground">
+                                  {field.name}
+                                </div>
+                                <div className="text-xs break-words">
+                                  {field.value}
+                                </div>
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                      </section>
+                    )
+                  })}
+                </div>
+              ) : null}
+            </ScrollArea>
+          </TabsContent>
+
+          <TabsContent value="raw" className="m-0">
+            <div className="flex items-center justify-end gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={async () => {
+                  const raw = query.data?.rawJSON
+                  if (!raw) return
+                  try {
+                    await copyTextToClipboard(raw)
+                    toast.success("Raw JSON copied to clipboard")
+                  } catch {
+                    toast.error("Failed to copy to clipboard")
+                  }
+                }}
+                disabled={!query.data?.rawJSON}
+              >
+                <Copy className="h-4 w-4 mr-2" />
+                Copy
+              </Button>
+            </div>
+
+            <ScrollArea className="h-[60vh] mt-3 pr-4">
+              {query.isLoading ? (
+                <div className="flex items-center justify-center py-16">
+                  <Loader2 className="h-6 w-6 animate-spin" />
+                </div>
+              ) : query.isError ? (
+                <div className="flex flex-col items-start gap-3 py-8">
+                  <p className="text-sm text-muted-foreground">
+                    {query.error instanceof Error ? query.error.message : "Failed to fetch MediaInfo"}
+                  </p>
+                  <Button variant="outline" size="sm" onClick={() => void query.refetch()}>
+                    <RotateCw className="h-4 w-4 mr-2" />
+                    Retry
+                  </Button>
+                </div>
+              ) : (
+                <pre className="text-xs font-mono whitespace-pre-wrap break-words">
+                  {query.data?.rawJSON ?? ""}
+                </pre>
+              )}
+            </ScrollArea>
+          </TabsContent>
+        </Tabs>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web/src/components/torrents/TorrentFileMediaInfoDialog.tsx
+++ b/web/src/components/torrents/TorrentFileMediaInfoDialog.tsx
@@ -99,7 +99,7 @@ export function TorrentFileMediaInfoDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-lg md:max-w-3xl max-h-[85vh] overflow-hidden">
+      <DialogContent className="sm:max-w-lg md:max-w-5xl max-h-[85vh] overflow-hidden">
         <DialogHeader>
           <DialogTitle>MediaInfo</DialogTitle>
         </DialogHeader>

--- a/web/src/components/torrents/TorrentFileMediaInfoDialog.tsx
+++ b/web/src/components/torrents/TorrentFileMediaInfoDialog.tsx
@@ -51,7 +51,7 @@ export function TorrentFileMediaInfoDialog({
   const query = useQuery({
     queryKey: ["torrent-file-mediainfo", instanceId, torrentHash, file?.index],
     queryFn: () => api.getTorrentFileMediaInfo(instanceId, torrentHash, file!.index),
-    enabled: open && !!file,
+    enabled: open && !!file && !!torrentHash,
     staleTime: 30000,
     gcTime: 5 * 60 * 1000,
   })

--- a/web/src/components/torrents/TorrentFileMediaInfoDialog.tsx
+++ b/web/src/components/torrents/TorrentFileMediaInfoDialog.tsx
@@ -147,9 +147,6 @@ export function TorrentFileMediaInfoDialog({
                           <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
                             {label}
                           </h3>
-                          <span className="text-[10px] text-muted-foreground">
-                            {fields.length} field{fields.length !== 1 ? "s" : ""}
-                          </span>
                         </div>
 
                         {fields.length === 0 ? (

--- a/web/src/components/torrents/TorrentFileMediaInfoDialog.tsx
+++ b/web/src/components/torrents/TorrentFileMediaInfoDialog.tsx
@@ -122,7 +122,7 @@ export function TorrentFileMediaInfoDialog({
   }, [query.data?.rawJSON])
 
   const copyLabel = tab === "summary" ? "Copy Summary" : "Copy JSON"
-  const copyText = tab === "summary" ? summaryText : (query.data?.rawJSON ?? "")
+  const copyText = tab === "summary" ? summaryText : prettyRawJSON
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>

--- a/web/src/components/torrents/TorrentFileMediaInfoDialog.tsx
+++ b/web/src/components/torrents/TorrentFileMediaInfoDialog.tsx
@@ -105,7 +105,7 @@ export function TorrentFileMediaInfoDialog({
         </DialogHeader>
 
         <Tabs value={tab} onValueChange={(value) => setTab(value as typeof tab)} className="w-full">
-          <div className="flex items-center justify-between gap-2 min-w-0">
+          <div className="flex items-center justify-between gap-2 min-w-0 mb-4">
             <TabsList className="min-w-0">
               <TabsTrigger value="summary">Summary</TabsTrigger>
               <TabsTrigger value="raw">Raw JSON</TabsTrigger>

--- a/web/src/components/torrents/TorrentFileMediaInfoDialog.tsx
+++ b/web/src/components/torrents/TorrentFileMediaInfoDialog.tsx
@@ -43,8 +43,6 @@ function buildStreamLabels(streams: TorrentFileMediaInfoResponse["streams"]): st
 
 function formatSummary(data: TorrentFileMediaInfoResponse, streamLabels: string[]): string {
   const lines: string[] = []
-  lines.push(data.relativePath)
-  lines.push("")
 
   data.streams.forEach((stream, idx) => {
     const label = streamLabels[idx] ?? stream.kind

--- a/web/src/components/torrents/TorrentFileTree.tsx
+++ b/web/src/components/torrents/TorrentFileTree.tsx
@@ -9,7 +9,7 @@ import { getLinuxFileName } from "@/lib/incognito"
 import { cn, formatBytes } from "@/lib/utils"
 import type { TorrentFile } from "@/types"
 import { useVirtualizer } from "@tanstack/react-virtual"
-import { ChevronRight, Download, FilePen, FolderPen, Loader2 } from "lucide-react"
+import { ChevronRight, Download, FilePen, FolderPen, Info, Loader2 } from "lucide-react"
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 interface TorrentFileTreeProps {
@@ -23,6 +23,7 @@ interface TorrentFileTreeProps {
   onRenameFile: (filePath: string) => void
   onRenameFolder: (folderPath: string) => void
   onDownloadFile?: (file: TorrentFile) => void
+  onShowMediaInfo?: (file: TorrentFile) => void
 }
 
 interface FileTreeNode {
@@ -181,6 +182,7 @@ export const TorrentFileTree = memo(function TorrentFileTree({
   onRenameFile,
   onRenameFolder,
   onDownloadFile,
+  onShowMediaInfo,
 }: TorrentFileTreeProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null)
 
@@ -360,6 +362,15 @@ export const TorrentFileTree = memo(function TorrentFileTree({
                     >
                       <Download className="h-4 w-4 mr-2" />
                       Download
+                    </ContextMenuItem>
+                  )}
+                  {onShowMediaInfo && file && (
+                    <ContextMenuItem
+                      onClick={() => onShowMediaInfo(file)}
+                      disabled={incognitoMode}
+                    >
+                      <Info className="h-4 w-4 mr-2" />
+                      MediaInfo
                     </ContextMenuItem>
                   )}
                   <ContextMenuItem

--- a/web/src/components/torrents/details/TorrentFileTable.tsx
+++ b/web/src/components/torrents/details/TorrentFileTable.tsx
@@ -12,7 +12,7 @@ import { getLinuxFileName, getLinuxFolderName } from "@/lib/incognito"
 import { cn, formatBytes } from "@/lib/utils"
 import type { TorrentFile } from "@/types"
 import { useVirtualizer } from "@tanstack/react-virtual"
-import { ChevronDown, ChevronRight, Download, File, Folder, Loader2, Pencil, Search, X } from "lucide-react"
+import { ChevronDown, ChevronRight, Download, File, Folder, Info, Loader2, Pencil, Search, X } from "lucide-react"
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 interface TorrentFileTableProps {
@@ -27,6 +27,7 @@ interface TorrentFileTableProps {
   onRenameFile?: (filePath: string) => void
   onRenameFolder?: (folderPath: string) => void
   onDownloadFile?: (file: TorrentFile) => void
+  onShowMediaInfo?: (file: TorrentFile) => void
 }
 
 interface FileTreeNode {
@@ -172,6 +173,7 @@ export const TorrentFileTable = memo(function TorrentFileTable({
   onRenameFile,
   onRenameFolder,
   onDownloadFile,
+  onShowMediaInfo,
 }: TorrentFileTableProps) {
   const [expandedFolders, setExpandedFolders] = useState<Set<string>>(() => new Set())
   const [searchQuery, setSearchQuery] = useState("")
@@ -450,7 +452,7 @@ export const TorrentFileTable = memo(function TorrentFileTable({
               )
 
               // Wrap with context menu if any file action handlers are provided
-              if (onRenameFile || onRenameFolder || onDownloadFile) {
+              if (onRenameFile || onRenameFolder || onDownloadFile || onShowMediaInfo) {
                 return (
                   <ContextMenu key={node.id}>
                     <ContextMenuTrigger asChild>
@@ -464,6 +466,15 @@ export const TorrentFileTable = memo(function TorrentFileTable({
                         >
                           <Download className="h-3.5 w-3.5 mr-2" />
                           Download
+                        </ContextMenuItem>
+                      )}
+                      {isFile && onShowMediaInfo && node.file && (
+                        <ContextMenuItem
+                          onClick={() => onShowMediaInfo(node.file!)}
+                          disabled={incognitoMode}
+                        >
+                          <Info className="h-3.5 w-3.5 mr-2" />
+                          MediaInfo
                         </ContextMenuItem>
                       )}
                       {isFile && onRenameFile && (

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -96,6 +96,7 @@ import type {
   TorrentCreationTask,
   TorrentCreationTaskResponse,
   TorrentFile,
+  TorrentFileMediaInfoResponse,
   TorrentFilters,
   TorrentProperties,
   TorrentResponse,
@@ -776,6 +777,12 @@ class ApiClient {
     document.body.appendChild(a)
     a.click()
     document.body.removeChild(a)
+  }
+
+  async getTorrentFileMediaInfo(instanceId: number, hash: string, fileIndex: number): Promise<TorrentFileMediaInfoResponse> {
+    return this.request<TorrentFileMediaInfoResponse>(
+      `/instances/${instanceId}/torrents/${encodeURIComponent(hash)}/files/${fileIndex}/mediainfo`
+    )
   }
 
   // Torrent endpoints

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -624,6 +624,23 @@ export interface TorrentFile {
   size: number
 }
 
+export interface TorrentFileMediaInfoField {
+  name: string
+  value: string
+}
+
+export interface TorrentFileMediaInfoStream {
+  kind: string
+  fields: TorrentFileMediaInfoField[]
+}
+
+export interface TorrentFileMediaInfoResponse {
+  fileIndex: number
+  relativePath: string
+  streams: TorrentFileMediaInfoStream[]
+  rawJSON: string
+}
+
 export interface Torrent {
   added_on: number
   amount_left: number


### PR DESCRIPTION
Add MediaInfo endpoint for local-access torrent files.

Content tab: file context-menu action opens a dialog with a readable summary + raw JSON.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MediaInfo viewer for torrent files via context menu, with Summary and Raw JSON tabs, copy-to-clipboard, retry and loading states.

* **API**
  * New endpoint returning structured media information for a specific torrent file (file index, relative path, streams, raw JSON).

* **Tests**
  * Comprehensive unit tests covering error cases and successful media-info responses.

* **Chores**
  * Updated Go toolchain patch version and added a mediainfo dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->