### PR TITLE
fix(torrents): copy MediaInfo summary without brackets

### DIFF
--- a/web/src/components/torrents/TorrentFileMediaInfoDialog.tsx
+++ b/web/src/components/torrents/TorrentFileMediaInfoDialog.tsx
@@ -47,7 +47,7 @@ function formatSummary(data: TorrentFileMediaInfoResponse, streamLabels: string[
   data.streams.forEach((stream, idx) => {
     const label = streamLabels[idx] ?? stream.kind
     const fields = stream.fields.filter((field) => field.value.trim() !== "")
-    lines.push(`[${label}]`)
+    lines.push(label)
     for (const field of fields) {
       lines.push(`${field.name}: ${field.value}`)
     }


### PR DESCRIPTION
Remove [Section] brackets from the copied MediaInfo summary for better compatibility with site parsers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the formatting of media information labels by removing unnecessary square brackets for clearer readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->