### PR TITLE
docs(cross-seed): clarify autoTMM behavior

### DIFF
--- a/documentation/docs/features/cross-seed/dir-scan.md
+++ b/documentation/docs/features/cross-seed/dir-scan.md
@@ -110,6 +110,14 @@ For each configured scan directory, qui:
 6. Downloads torrent files and matches their file lists against what's on disk.
 7. If a match is found, adds the torrent to the target qBittorrent instance.
 
+:::note Categories + AutoTMM
+Dir Scan adds torrents using an explicit `savepath` to point qBittorrent at the existing files on disk. That forces **AutoTMM off** for Dir Scan injections.
+
+Dir Scan categories come only from **Dir Scan → Default Category** and per-directory **Category override**. Cross-Seed → Rules category modes (affix / indexer / custom) do not apply to Dir Scan.
+
+If you later enable AutoTMM on an injected torrent, qBittorrent may relocate files based on its default save path + category rules.
+:::
+
 :::info
 Torznab searches run through the shared scheduler at background priority, so they queue behind interactive, RSS, and completion cross-seed work.
 

--- a/documentation/docs/features/cross-seed/hardlink-mode.md
+++ b/documentation/docs/features/cross-seed/hardlink-mode.md
@@ -32,6 +32,7 @@ Example: `/mnt/disk1/cross-seed, /mnt/disk2/cross-seed, /mnt/disk3/cross-seed`
 ## Behavior
 
 - Hardlink mode is a **per-instance setting** (not per request). Each qBittorrent instance can have its own hardlink configuration.
+- Torrents added via hardlink/reflink mode always use an explicit `savepath` (the link-tree root), which forces **AutoTMM off**. Enabling AutoTMM after adding can move files out of the link tree.
 - By default, if a hardlink cannot be created (no local access, filesystem mismatch, invalid base dir, etc.), the cross-seed **fails**.
 - Enable **"Fallback to regular mode"** to allow failed hardlink operations to fall back to regular cross-seed mode instead of failing. This is useful when files may occasionally be on different filesystems.
 - Hardlinked torrents are still categorized using your existing cross-seed category rules (category affix, indexer name, or custom category); the hardlink preset only affects on-disk folder layout.

--- a/documentation/docs/features/cross-seed/link-directories.md
+++ b/documentation/docs/features/cross-seed/link-directories.md
@@ -8,6 +8,8 @@ description: How qui lays out hardlink/reflink trees on disk.
 
 When **Hardlink mode** or **Reflink mode** is enabled for a qBittorrent instance, qui creates a directory tree that matches the incoming torrent’s expected layout, then adds the torrent pointing at that tree.
 
+Because these modes add torrents with an explicit `savepath` (the link-tree root), AutoTMM is always disabled for torrents added via hardlink/reflink mode.
+
 This applies to:
 - Cross-seed searches (RSS, completion, manual, scan)
 - Directory scan (dirscan) injections

--- a/documentation/docs/features/cross-seed/rules.md
+++ b/documentation/docs/features/cross-seed/rules.md
@@ -24,7 +24,7 @@ Choose one of three mutually exclusive category modes:
 
 ### Category Affix (default)
 
-Adds a configurable affix to the matched torrent's category. Prevents Sonarr/Radarr from importing cross-seeded files as duplicates. AutoTMM is inherited from the matched torrent.
+Adds a configurable affix to the matched torrent's category. Prevents Sonarr/Radarr from importing cross-seeded files as duplicates. In **regular mode** (no hardlink/reflink), AutoTMM is inherited from the matched torrent.
 
 **Affix Mode:**
 - **Suffix** (default): Appends the affix to the category (e.g., `movies` → `movies.cross`)
@@ -78,7 +78,7 @@ autoTMM behavior depends on which category mode is active:
 
 | Category Mode | autoTMM Behavior |
 |---------------|------------------|
-| **Category Affix** | Inherited from matched torrent |
+| **Category Affix** | Inherited from matched torrent (regular mode only; hardlink/reflink disables autoTMM) |
 | **Indexer name** | Always disabled (explicit save paths) |
 | **Custom** | Always disabled (explicit save paths) |
 
@@ -87,6 +87,11 @@ When autoTMM is inherited (affix mode):
 - If matched torrent has manual path, cross-seed uses same manual path
 
 When autoTMM is disabled (indexer/custom modes), cross-seeds always use explicit save paths derived from the matched torrent's location.
+
+:::note
+Hardlink/reflink mode always adds torrents with an explicit `savepath` pointing at the link tree, which forces autoTMM off.
+Dir Scan injections are separate from cross-seed rules and also always add with explicit `savepath` (autoTMM off).
+:::
 
 ### Save Path Determination
 

--- a/documentation/docs/features/cross-seed/troubleshooting.md
+++ b/documentation/docs/features/cross-seed/troubleshooting.md
@@ -139,9 +139,12 @@ The `toRawJson` function (from Sprig) properly escapes special characters and ou
 
 - Check your cross-seed settings in qui
 - Verify the matched torrent has the expected category
+- For Dir Scan injections, Cross-Seed → Rules category modes do not apply. Dir Scan uses its own Default Category / Category override, and leaving it blank results in no category.
 
 ## autoTMM unexpectedly enabled/disabled
 
-- In affix mode, autoTMM mirrors the matched torrent's setting (intentional)
+- In reuse/affix mode (regular mode), autoTMM mirrors the matched torrent's setting (intentional)
 - In indexer name or custom category mode, autoTMM is always disabled
+- In hardlink/reflink mode, autoTMM is always disabled (explicit `savepath`)
+- Dir Scan injections always disable autoTMM (explicit `savepath`)
 - Check the original torrent's autoTMM status in qBittorrent

--- a/web/src/pages/CrossSeedPage.tsx
+++ b/web/src/pages/CrossSeedPage.tsx
@@ -2621,7 +2621,7 @@ export function CrossSeedPage({ activeTab, onTabChange }: CrossSeedPageProps) {
                             </button>
                           </TooltipTrigger>
                           <TooltipContent align="start" className="max-w-xs text-xs">
-                            Cross-seeds use the exact same category as the matched torrent. If the matched torrent uses AutoTMM, cross-seeds will too; otherwise the save path is set to match the original.
+                            Cross-seeds use the exact same category as the matched torrent. In regular mode, AutoTMM mirrors the matched torrent; in hardlink/reflink mode, AutoTMM is disabled and an explicit save path is used.
                           </TooltipContent>
                         </Tooltip>
                       </div>
@@ -2640,7 +2640,7 @@ export function CrossSeedPage({ activeTab, onTabChange }: CrossSeedPageProps) {
                             </button>
                           </TooltipTrigger>
                           <TooltipContent align="start" className="max-w-xs text-xs">
-                            Creates isolated categories (e.g., cross-seed/movie or tv.cross) with the same save path as the base category. Cross-seeds inherit autoTMM from the matched torrent and are saved to the same location as the original files.
+                            Creates isolated categories (e.g., cross-seed/movie or tv.cross). In regular mode, cross-seeds inherit AutoTMM from the matched torrent; in hardlink/reflink mode, AutoTMM is disabled and an explicit save path is used.
                           </TooltipContent>
                         </Tooltip>
                       </div>


### PR DESCRIPTION
Clarifies that autoTMM inheritance only applies to regular-mode cross-seeds (no hardlink/reflink) and that Dir Scan + hardlink/reflink always add with explicit save paths (autoTMM off).\n\nAlso documents Dir Scan category behavior (Default Category / per-directory override only) and updates Cross-Seed UI tooltips to match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation and UI tooltips explaining AutoTMM behavior across different cross-seed injection modes (regular mode, hardlink/reflink, and Dir Scan).
  * Clarified how categories and save paths are handled for each injection method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->