### PR TITLE
feat: add mediainfo api endpoint

### DIFF
--- a/documentation/static/openapi.yaml
+++ b/documentation/static/openapi.yaml
@@ -520,6 +520,60 @@ paths:
         '500':
           description: Internal server error (failed to get client for instance, failed to retrieve torrent info)
 
+  /proxy/{api-key}/api/v2/torrents/mediainfo:
+    get:
+      tags:
+        - Proxy
+      summary: Get MediaInfo via proxy API key
+      description: >
+        Returns MediaInfo summary text and JSON output for an instance-relative content path using
+        a client API key in the proxy path.
+      security: []
+      parameters:
+        - name: api-key
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Client API key
+        - name: contentPath
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Instance-relative content path
+        - name: content_path
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Legacy alias for contentPath
+      responses:
+        '200':
+          description: MediaInfo summary and JSON
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  contentPath:
+                    type: string
+                  summaryTxt:
+                    type: string
+                  mediaInfoJson:
+                    type: object
+                    additionalProperties: true
+        '400':
+          description: Invalid content path
+        '401':
+          description: Missing or invalid client API key
+        '403':
+          description: Instance does not have local filesystem access
+        '404':
+          description: Instance or file not found
+        '500':
+          description: Internal server error
+
   /api/arr/instances:
     get:
       tags:
@@ -5493,3 +5547,5 @@ tags:
     description: Orphan file scanning and cleanup (files on disk not associated with any torrent)
   - name: Theme Licenses
     description: Theme license management (optional feature)
+  - name: Proxy
+    description: qBittorrent-compatible proxy endpoints authenticated by client API key

--- a/documentation/static/openapi.yaml
+++ b/documentation/static/openapi.yaml
@@ -538,16 +538,39 @@ paths:
           description: Client API key
         - name: contentPath
           in: query
-          required: true
+          required: false
           schema:
             type: string
-          description: Instance-relative content path
+          description: Canonical instance-relative content path (legacy alias: content_path)
         - name: content_path
           in: query
           required: false
           schema:
             type: string
           description: Legacy alias for contentPath
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                contentPath:
+                  type: string
+                  description: Canonical instance-relative content path
+                content_path:
+                  type: string
+                  description: Legacy alias for contentPath
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                contentPath:
+                  type: string
+                  description: Canonical instance-relative content path
+                content_path:
+                  type: string
+                  description: Legacy alias for contentPath
       responses:
         '200':
           description: MediaInfo summary and JSON

--- a/documentation/static/openapi.yaml
+++ b/documentation/static/openapi.yaml
@@ -541,7 +541,7 @@ paths:
           required: false
           schema:
             type: string
-          description: Canonical instance-relative content path (legacy alias: content_path)
+          description: "Canonical instance-relative content path (legacy alias: content_path)"
         - name: content_path
           in: query
           required: false

--- a/internal/api/handlers/torrents.go
+++ b/internal/api/handlers/torrents.go
@@ -2630,17 +2630,51 @@ func (h *TorrentsHandler) requireLocalAccess(w http.ResponseWriter, r *http.Requ
 }
 
 // resolveTorrentFilePath joins basePath with relativePath and validates against
-// directory traversal. Returns the cleaned absolute path or an error.
+// directory traversal, including symlink escapes. Returns the resolved absolute
+// path or an error.
 func resolveTorrentFilePath(basePath, relativePath string) (string, error) {
-	full := filepath.Join(basePath, filepath.FromSlash(relativePath))
 	cleanBase := filepath.Clean(basePath)
+	if !filepath.IsAbs(cleanBase) {
+		return "", errors.New("base path must be absolute")
+	}
+
+	full := filepath.Join(cleanBase, filepath.FromSlash(relativePath))
 	cleanFull := filepath.Clean(full)
 
 	rel, err := filepath.Rel(cleanBase, cleanFull)
 	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return "", errors.New("path traversal detected")
 	}
-	return cleanFull, nil
+
+	// #nosec G703 -- cleanBase is validated as absolute and constrained by traversal checks above.
+	if _, err := os.Lstat(cleanBase); err != nil {
+		return "", fmt.Errorf("failed to access base path: %w", err)
+	}
+
+	evaluatedBase, err := filepath.EvalSymlinks(cleanBase)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve base path symlinks: %w", err)
+	}
+
+	// #nosec G703 -- cleanFull is derived from a validated base path and traversal-checked relative input.
+	if _, err := os.Lstat(cleanFull); err != nil {
+		if os.IsNotExist(err) {
+			return cleanFull, nil
+		}
+		return "", fmt.Errorf("failed to access candidate path: %w", err)
+	}
+
+	evaluatedFull, err := filepath.EvalSymlinks(cleanFull)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve candidate path symlinks: %w", err)
+	}
+
+	rel, err = filepath.Rel(evaluatedBase, evaluatedFull)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", errors.New("path traversal detected")
+	}
+
+	return evaluatedFull, nil
 }
 
 func appendUniqueCandidate(candidates []string, seen map[string]struct{}, candidate string) []string {

--- a/internal/api/handlers/torrents.go
+++ b/internal/api/handlers/torrents.go
@@ -119,6 +119,9 @@ func (h *TorrentsHandler) getAppPreferences(ctx context.Context, instanceID int)
 	if h.torrentAdder != nil {
 		return h.torrentAdder.GetAppPreferences(ctx, instanceID)
 	}
+	if h.syncManager == nil {
+		return qbt.AppPreferences{}, errors.New("sync manager not configured")
+	}
 	return h.syncManager.GetAppPreferences(ctx, instanceID)
 }
 
@@ -2905,6 +2908,100 @@ type torrentFileMediaInfoResponse struct {
 	RawJSON      string                       `json:"rawJSON"`
 }
 
+type contentPathMediaInfoRequest struct {
+	ContentPath string `json:"contentPath"`
+}
+
+type contentPathMediaInfoResponse struct {
+	ContentPath   string          `json:"contentPath"`
+	SummaryTxt    string          `json:"summaryTxt"`
+	MediaInfoJSON json.RawMessage `json:"mediaInfoJson"`
+}
+
+func mapReportToMediaInfoStreams(report mediainfo.Report) []torrentFileMediaInfoStream {
+	streams := make([]torrentFileMediaInfoStream, 0, 1+len(report.Streams))
+	generalFields := make([]torrentFileMediaInfoField, 0, len(report.General.Fields))
+	for _, field := range report.General.Fields {
+		generalFields = append(generalFields, torrentFileMediaInfoField{Name: field.Name, Value: field.Value})
+	}
+	streams = append(streams, torrentFileMediaInfoStream{
+		Kind:   string(report.General.Kind),
+		Fields: generalFields,
+	})
+
+	for _, stream := range report.Streams {
+		fields := make([]torrentFileMediaInfoField, 0, len(stream.Fields))
+		for _, field := range stream.Fields {
+			fields = append(fields, torrentFileMediaInfoField{Name: field.Name, Value: field.Value})
+		}
+		streams = append(streams, torrentFileMediaInfoStream{
+			Kind:   string(stream.Kind),
+			Fields: fields,
+		})
+	}
+
+	return streams
+}
+
+func normalizeContentPathRelativeInput(raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", errors.New("content path is required")
+	}
+
+	normalized := filepath.Clean(filepath.FromSlash(trimmed))
+	if filepath.IsAbs(normalized) {
+		return "", errors.New("absolute paths are not allowed")
+	}
+	if normalized == ".." || strings.HasPrefix(normalized, ".."+string(filepath.Separator)) {
+		return "", errors.New("path traversal detected")
+	}
+
+	return normalized, nil
+}
+
+func contentPathCandidatesFromPreferences(prefs qbt.AppPreferences, relativePath string) []string {
+	candidates := make([]string, 0, 2)
+	seen := make(map[string]struct{})
+
+	if p, err := resolveTorrentFilePath(prefs.SavePath, relativePath); err == nil {
+		candidates = appendUniqueCandidate(candidates, seen, p)
+	}
+
+	if prefs.TempPathEnabled {
+		if p, err := resolveTorrentFilePath(prefs.TempPath, relativePath); err == nil {
+			candidates = appendUniqueCandidate(candidates, seen, p)
+		}
+	}
+
+	return candidates
+}
+
+func findExistingContentFile(candidates []string) (string, bool) {
+	for _, candidate := range candidates {
+		// #nosec G703,G304 -- candidate is constructed from validated base paths via resolveTorrentFilePath.
+		f, err := os.Open(candidate)
+		if err != nil {
+			continue
+		}
+
+		stat, err := f.Stat()
+		if err != nil {
+			_ = f.Close()
+			continue
+		}
+		if stat.IsDir() {
+			_ = f.Close()
+			continue
+		}
+		_ = f.Close()
+
+		return candidate, true
+	}
+
+	return "", false
+}
+
 // GetTorrentFileMediaInfo returns MediaInfo output for a single torrent content file on disk.
 // GET /api/instances/{instanceID}/torrents/{hash}/files/{fileIndex}/mediainfo
 func (h *TorrentsHandler) GetTorrentFileMediaInfo(w http.ResponseWriter, r *http.Request) {
@@ -2928,31 +3025,85 @@ func (h *TorrentsHandler) GetTorrentFileMediaInfo(w http.ResponseWriter, r *http
 		return
 	}
 
-	streams := make([]torrentFileMediaInfoStream, 0, 1+len(report.Streams))
-	generalFields := make([]torrentFileMediaInfoField, 0, len(report.General.Fields))
-	for _, field := range report.General.Fields {
-		generalFields = append(generalFields, torrentFileMediaInfoField{Name: field.Name, Value: field.Value})
-	}
-	streams = append(streams, torrentFileMediaInfoStream{
-		Kind:   string(report.General.Kind),
-		Fields: generalFields,
-	})
-
-	for _, stream := range report.Streams {
-		fields := make([]torrentFileMediaInfoField, 0, len(stream.Fields))
-		for _, field := range stream.Fields {
-			fields = append(fields, torrentFileMediaInfoField{Name: field.Name, Value: field.Value})
-		}
-		streams = append(streams, torrentFileMediaInfoStream{
-			Kind:   string(stream.Kind),
-			Fields: fields,
-		})
-	}
-
 	RespondJSON(w, http.StatusOK, torrentFileMediaInfoResponse{
 		FileIndex:    resolved.FileIndex,
 		RelativePath: resolved.RelativePath,
-		Streams:      streams,
+		Streams:      mapReportToMediaInfoStreams(report),
 		RawJSON:      rawJSON,
+	})
+}
+
+// GetContentPathMediaInfo returns MediaInfo summary text and JSON for an instance-relative content path.
+// GET /api/instances/{instanceID}/mediainfo?contentPath=...
+func (h *TorrentsHandler) GetContentPathMediaInfo(w http.ResponseWriter, r *http.Request) {
+	instanceID, err := strconv.Atoi(chi.URLParam(r, "instanceID"))
+	if err != nil {
+		RespondError(w, http.StatusBadRequest, "Invalid instance ID")
+		return
+	}
+
+	if !h.requireLocalAccess(w, r, instanceID) {
+		return
+	}
+
+	rawContentPath := strings.TrimSpace(r.URL.Query().Get("contentPath"))
+	if rawContentPath == "" {
+		rawContentPath = strings.TrimSpace(r.URL.Query().Get("content_path"))
+	}
+
+	relativePath, err := normalizeContentPathRelativeInput(rawContentPath)
+	if err != nil {
+		RespondError(w, http.StatusBadRequest, "Invalid content path")
+		return
+	}
+
+	prefs, err := h.getAppPreferences(r.Context(), instanceID)
+	if err != nil {
+		if respondIfInstanceDisabled(w, err, instanceID, "torrents:getContentPathMediaInfo") {
+			return
+		}
+		log.Error().Err(err).Int("instanceID", instanceID).Msg("Failed to get app preferences for MediaInfo")
+		RespondError(w, http.StatusInternalServerError, "Failed to get app preferences")
+		return
+	}
+
+	candidates := contentPathCandidatesFromPreferences(prefs, relativePath)
+	if len(candidates) == 0 {
+		RespondError(w, http.StatusBadRequest, "No content roots configured for instance")
+		return
+	}
+
+	resolvedPath, ok := findExistingContentFile(candidates)
+	if !ok {
+		RespondError(w, http.StatusNotFound, "File not found on disk")
+		return
+	}
+
+	// #nosec G304 -- resolvedPath is constructed from validated base paths via resolveTorrentFilePath.
+	report, err := mediainfo.AnalyzeFile(resolvedPath, mediainfo.WithParseSpeed(0.5))
+	if err != nil {
+		log.Error().Err(err).Int("instanceID", instanceID).Str("contentPath", relativePath).Msg("Failed to analyze file with MediaInfo")
+		RespondError(w, http.StatusInternalServerError, "Failed to analyze file")
+		return
+	}
+
+	summaryTxt, err := mediainfo.Render([]mediainfo.Report{report}, mediainfo.OutputText)
+	if err != nil {
+		log.Error().Err(err).Int("instanceID", instanceID).Str("contentPath", relativePath).Msg("Failed to render MediaInfo summary text")
+		RespondError(w, http.StatusInternalServerError, "Failed to render MediaInfo")
+		return
+	}
+
+	rawJSON, err := mediainfo.Render([]mediainfo.Report{report}, mediainfo.OutputJSON)
+	if err != nil {
+		log.Error().Err(err).Int("instanceID", instanceID).Str("contentPath", relativePath).Msg("Failed to render MediaInfo JSON")
+		RespondError(w, http.StatusInternalServerError, "Failed to render MediaInfo")
+		return
+	}
+
+	RespondJSON(w, http.StatusOK, contentPathMediaInfoResponse{
+		ContentPath:   relativePath,
+		SummaryTxt:    summaryTxt,
+		MediaInfoJSON: json.RawMessage(rawJSON),
 	})
 }

--- a/internal/api/handlers/torrents.go
+++ b/internal/api/handlers/torrents.go
@@ -2979,6 +2979,7 @@ func normalizeContentPathRelativeInput(raw string) (string, error) {
 		return "", errors.New("content path is required")
 	}
 
+	trimmed = strings.ReplaceAll(trimmed, "\\", "/")
 	normalized := filepath.Clean(filepath.FromSlash(trimmed))
 	if filepath.IsAbs(normalized) {
 		return "", errors.New("absolute paths are not allowed")

--- a/internal/api/handlers/torrents.go
+++ b/internal/api/handlers/torrents.go
@@ -2834,14 +2834,21 @@ func resolveTorrentContentFilePathOnDisk(ctx context.Context, resolver torrentCo
 
 		stat, err := f.Stat()
 		if err != nil {
-			_ = f.Close()
+			if cerr := f.Close(); cerr != nil {
+				log.Warn().Err(cerr).Str("candidate", candidate).Msg("Failed to close candidate file after stat error")
+			}
 			continue
 		}
 		if stat.IsDir() {
-			_ = f.Close()
+			if cerr := f.Close(); cerr != nil {
+				log.Warn().Err(cerr).Str("candidate", candidate).Msg("Failed to close candidate directory handle")
+			}
 			continue
 		}
-		_ = f.Close()
+		if cerr := f.Close(); cerr != nil {
+			log.Warn().Err(cerr).Str("candidate", candidate).Msg("Failed to close candidate file")
+			continue
+		}
 
 		return candidate, true
 	}
@@ -3018,14 +3025,21 @@ func findExistingContentFile(candidates []string) (string, bool) {
 
 		stat, err := f.Stat()
 		if err != nil {
-			_ = f.Close()
+			if cerr := f.Close(); cerr != nil {
+				log.Warn().Err(cerr).Str("candidate", candidate).Msg("Failed to close candidate file after stat error")
+			}
 			continue
 		}
 		if stat.IsDir() {
-			_ = f.Close()
+			if cerr := f.Close(); cerr != nil {
+				log.Warn().Err(cerr).Str("candidate", candidate).Msg("Failed to close candidate directory handle")
+			}
 			continue
 		}
-		_ = f.Close()
+		if cerr := f.Close(); cerr != nil {
+			log.Warn().Err(cerr).Str("candidate", candidate).Msg("Failed to close candidate file")
+			continue
+		}
 
 		return candidate, true
 	}

--- a/internal/api/handlers/torrents.go
+++ b/internal/api/handlers/torrents.go
@@ -2908,10 +2908,6 @@ type torrentFileMediaInfoResponse struct {
 	RawJSON      string                       `json:"rawJSON"`
 }
 
-type contentPathMediaInfoRequest struct {
-	ContentPath string `json:"contentPath"`
-}
-
 type contentPathMediaInfoResponse struct {
 	ContentPath   string          `json:"contentPath"`
 	SummaryTxt    string          `json:"summaryTxt"`

--- a/internal/api/handlers/torrents_content_path_mediainfo_test.go
+++ b/internal/api/handlers/torrents_content_path_mediainfo_test.go
@@ -1,0 +1,260 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/require"
+)
+
+type mockMediaInfoPreferencesAdder struct {
+	prefs     qbt.AppPreferences
+	prefsErr  error
+	prefsCall int
+}
+
+func (m *mockMediaInfoPreferencesAdder) AddTorrent(context.Context, int, []byte, map[string]string) error {
+	return nil
+}
+
+func (m *mockMediaInfoPreferencesAdder) AddTorrentFromURLs(context.Context, int, []string, map[string]string) error {
+	return nil
+}
+
+func (m *mockMediaInfoPreferencesAdder) GetAppPreferences(context.Context, int) (qbt.AppPreferences, error) {
+	m.prefsCall++
+	return m.prefs, m.prefsErr
+}
+
+func newContentPathMediaInfoRequest(t *testing.T, instanceID int, contentPath string) *http.Request {
+	t.Helper()
+
+	target := "/api/instances/" + strconv.Itoa(instanceID) + "/mediainfo"
+	if contentPath != "" {
+		target += "?contentPath=" + url.QueryEscape(contentPath)
+	}
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("instanceID", strconv.Itoa(instanceID))
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+}
+
+func TestGetContentPathMediaInfo_ReturnsServerErrorWithoutInstanceStore(t *testing.T) {
+	t.Parallel()
+
+	handler := NewTorrentsHandlerForTesting(nil, nil)
+	rec := httptest.NewRecorder()
+	req := newContentPathMediaInfoRequest(t, 1, "folder/file.bin")
+
+	handler.GetContentPathMediaInfo(rec, req)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.Contains(t, rec.Body.String(), "Instance store not configured")
+}
+
+func TestGetContentPathMediaInfo_RejectsInvalidInstanceID(t *testing.T) {
+	t.Parallel()
+
+	handler := NewTorrentsHandlerForTesting(nil, nil)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/instances/not-an-int/mediainfo?contentPath=folder%2Ffile.bin", nil)
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("instanceID", "not-an-int")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+
+	handler.GetContentPathMediaInfo(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "Invalid instance ID")
+}
+
+func TestGetContentPathMediaInfo_ReturnsNotFoundForMissingInstance(t *testing.T) {
+	t.Parallel()
+
+	instanceStore, _ := createInstanceStoreWithInstance(t, true)
+	handler := &TorrentsHandler{instanceStore: instanceStore, torrentAdder: &mockMediaInfoPreferencesAdder{}}
+
+	rec := httptest.NewRecorder()
+	req := newContentPathMediaInfoRequest(t, 999999, "folder/file.bin")
+
+	handler.GetContentPathMediaInfo(rec, req)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.Contains(t, rec.Body.String(), "Instance not found")
+}
+
+func TestGetContentPathMediaInfo_ReturnsForbiddenWithoutLocalAccess(t *testing.T) {
+	t.Parallel()
+
+	instanceStore, instanceID := createInstanceStoreWithInstance(t, false)
+	mockAdder := &mockMediaInfoPreferencesAdder{}
+	handler := &TorrentsHandler{instanceStore: instanceStore, torrentAdder: mockAdder}
+
+	rec := httptest.NewRecorder()
+	req := newContentPathMediaInfoRequest(t, instanceID, "folder/file.bin")
+
+	handler.GetContentPathMediaInfo(rec, req)
+
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.Contains(t, rec.Body.String(), "local filesystem access")
+	require.Equal(t, 0, mockAdder.prefsCall)
+}
+
+func TestGetContentPathMediaInfo_RejectsMissingContentPath(t *testing.T) {
+	t.Parallel()
+
+	instanceStore, instanceID := createInstanceStoreWithInstance(t, true)
+	mockAdder := &mockMediaInfoPreferencesAdder{}
+	handler := &TorrentsHandler{instanceStore: instanceStore, torrentAdder: mockAdder}
+
+	rec := httptest.NewRecorder()
+	req := newContentPathMediaInfoRequest(t, instanceID, "")
+
+	handler.GetContentPathMediaInfo(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "Invalid content path")
+	require.Equal(t, 0, mockAdder.prefsCall)
+}
+
+func TestGetContentPathMediaInfo_RejectsInvalidContentPath(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		contentPath string
+	}{
+		{name: "traversal", contentPath: "../escape.bin"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			instanceStore, instanceID := createInstanceStoreWithInstance(t, true)
+			mockAdder := &mockMediaInfoPreferencesAdder{}
+			handler := &TorrentsHandler{instanceStore: instanceStore, torrentAdder: mockAdder}
+
+			rec := httptest.NewRecorder()
+			req := newContentPathMediaInfoRequest(t, instanceID, tc.contentPath)
+
+			handler.GetContentPathMediaInfo(rec, req)
+
+			require.Equal(t, http.StatusBadRequest, rec.Code)
+			require.Contains(t, rec.Body.String(), "Invalid content path")
+			require.Equal(t, 0, mockAdder.prefsCall)
+		})
+	}
+}
+
+func TestGetContentPathMediaInfo_RejectsAbsoluteContentPath(t *testing.T) {
+	t.Parallel()
+
+	instanceStore, instanceID := createInstanceStoreWithInstance(t, true)
+	mockAdder := &mockMediaInfoPreferencesAdder{}
+	handler := &TorrentsHandler{instanceStore: instanceStore, torrentAdder: mockAdder}
+
+	absolutePath := filepath.Join(t.TempDir(), "movie.bin")
+	rec := httptest.NewRecorder()
+	req := newContentPathMediaInfoRequest(t, instanceID, absolutePath)
+
+	handler.GetContentPathMediaInfo(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "Invalid content path")
+	require.Equal(t, 0, mockAdder.prefsCall)
+}
+
+func TestGetContentPathMediaInfo_ReturnsErrorWhenPreferencesUnavailable(t *testing.T) {
+	t.Parallel()
+
+	instanceStore, instanceID := createInstanceStoreWithInstance(t, true)
+	handler := &TorrentsHandler{instanceStore: instanceStore}
+
+	rec := httptest.NewRecorder()
+	req := newContentPathMediaInfoRequest(t, instanceID, "folder/file.bin")
+
+	handler.GetContentPathMediaInfo(rec, req)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.Contains(t, rec.Body.String(), "Failed to get app preferences")
+}
+
+func TestGetContentPathMediaInfo_ReturnsBadRequestWhenRootsNotConfigured(t *testing.T) {
+	t.Parallel()
+
+	instanceStore, instanceID := createInstanceStoreWithInstance(t, true)
+	mockAdder := &mockMediaInfoPreferencesAdder{prefs: qbt.AppPreferences{}}
+	handler := &TorrentsHandler{instanceStore: instanceStore, torrentAdder: mockAdder}
+
+	rec := httptest.NewRecorder()
+	req := newContentPathMediaInfoRequest(t, instanceID, "folder/file.bin")
+
+	handler.GetContentPathMediaInfo(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "No content roots configured")
+	require.Equal(t, 1, mockAdder.prefsCall)
+}
+
+func TestGetContentPathMediaInfo_ReturnsNotFoundWhenFileMissingOnDisk(t *testing.T) {
+	t.Parallel()
+
+	instanceStore, instanceID := createInstanceStoreWithInstance(t, true)
+	root := t.TempDir()
+	mockAdder := &mockMediaInfoPreferencesAdder{prefs: qbt.AppPreferences{SavePath: root}}
+	handler := &TorrentsHandler{instanceStore: instanceStore, torrentAdder: mockAdder}
+
+	rec := httptest.NewRecorder()
+	req := newContentPathMediaInfoRequest(t, instanceID, "folder/file.bin")
+
+	handler.GetContentPathMediaInfo(rec, req)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.Contains(t, rec.Body.String(), "File not found on disk")
+	require.Equal(t, 1, mockAdder.prefsCall)
+}
+
+func TestGetContentPathMediaInfo_ReturnsSummaryAndJSON(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	relativePath := filepath.Join("movies", "sample.bin")
+	fullPath := filepath.Join(root, relativePath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(fullPath), 0o755))
+	require.NoError(t, os.WriteFile(fullPath, []byte("hello world"), 0o600))
+
+	instanceStore, instanceID := createInstanceStoreWithInstance(t, true)
+	mockAdder := &mockMediaInfoPreferencesAdder{prefs: qbt.AppPreferences{SavePath: root}}
+	handler := &TorrentsHandler{instanceStore: instanceStore, torrentAdder: mockAdder}
+
+	rec := httptest.NewRecorder()
+	req := newContentPathMediaInfoRequest(t, instanceID, filepath.ToSlash(relativePath))
+
+	handler.GetContentPathMediaInfo(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		ContentPath   string         `json:"contentPath"`
+		SummaryTxt    string         `json:"summaryTxt"`
+		MediaInfoJSON map[string]any `json:"mediaInfoJson"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, filepath.ToSlash(relativePath), filepath.ToSlash(resp.ContentPath))
+	require.NotEmpty(t, resp.SummaryTxt)
+	require.Contains(t, resp.MediaInfoJSON, "media")
+	require.Equal(t, 1, mockAdder.prefsCall)
+}

--- a/internal/api/handlers/torrents_content_path_mediainfo_test.go
+++ b/internal/api/handlers/torrents_content_path_mediainfo_test.go
@@ -25,6 +25,14 @@ type mockMediaInfoPreferencesAdder struct {
 	prefsCall int
 }
 
+type mediaInfoJSONPayload struct {
+	Media mediaInfoJSONMedia `json:"media"`
+}
+
+type mediaInfoJSONMedia struct {
+	Track []json.RawMessage `json:"track"`
+}
+
 func (m *mockMediaInfoPreferencesAdder) AddTorrent(context.Context, int, []byte, map[string]string) error {
 	return nil
 }
@@ -248,13 +256,13 @@ func TestGetContentPathMediaInfo_ReturnsSummaryAndJSON(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	var resp struct {
-		ContentPath   string         `json:"contentPath"`
-		SummaryTxt    string         `json:"summaryTxt"`
-		MediaInfoJSON map[string]any `json:"mediaInfoJson"`
+		ContentPath   string               `json:"contentPath"`
+		SummaryTxt    string               `json:"summaryTxt"`
+		MediaInfoJSON mediaInfoJSONPayload `json:"mediaInfoJson"`
 	}
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	require.Equal(t, filepath.ToSlash(relativePath), filepath.ToSlash(resp.ContentPath))
 	require.NotEmpty(t, resp.SummaryTxt)
-	require.Contains(t, resp.MediaInfoJSON, "media")
+	require.NotEmpty(t, resp.MediaInfoJSON.Media.Track)
 	require.Equal(t, 1, mockAdder.prefsCall)
 }

--- a/internal/api/handlers/torrents_content_path_mediainfo_test.go
+++ b/internal/api/handlers/torrents_content_path_mediainfo_test.go
@@ -145,6 +145,7 @@ func TestGetContentPathMediaInfo_RejectsInvalidContentPath(t *testing.T) {
 		contentPath string
 	}{
 		{name: "traversal", contentPath: "../escape.bin"},
+		{name: "windows-traversal", contentPath: "..\\escape.bin"},
 	}
 
 	for _, tc := range testCases {

--- a/internal/api/handlers/torrents_download_test.go
+++ b/internal/api/handlers/torrents_download_test.go
@@ -340,6 +340,7 @@ func TestDownloadTorrentContentFile_StreamsFile(t *testing.T) {
 }
 
 func TestFilePathCandidates(t *testing.T) {
+	baseRoot := filepath.Join(os.TempDir(), "qui-file-path-candidates")
 	testCases := []struct {
 		name         string
 		savePath     string
@@ -351,13 +352,13 @@ func TestFilePathCandidates(t *testing.T) {
 	}{
 		{
 			name:         "content_path_single_file_fallback",
-			savePath:     "/downloads/tv",
-			contentPath:  "/downloads/tv/Show.S01E01/Show.S01E01.mkv",
+			savePath:     filepath.Join(baseRoot, "downloads", "tv"),
+			contentPath:  filepath.Join(baseRoot, "downloads", "tv", "Show.S01E01", "Show.S01E01.mkv"),
 			relativePath: "Show.S01E01.v2.mkv",
 			singleFile:   true,
 			check: func(t *testing.T, candidates []string) {
-				savePath := "/downloads/tv"
-				contentPath := "/downloads/tv/Show.S01E01/Show.S01E01.mkv"
+				savePath := filepath.Join(baseRoot, "downloads", "tv")
+				contentPath := filepath.Join(baseRoot, "downloads", "tv", "Show.S01E01", "Show.S01E01.mkv")
 				relativePath := "Show.S01E01.v2.mkv"
 				require.Contains(t, candidates, filepath.Clean(filepath.Join(savePath, relativePath)))
 				require.Contains(t, candidates, filepath.Clean(contentPath))
@@ -366,13 +367,13 @@ func TestFilePathCandidates(t *testing.T) {
 		},
 		{
 			name:         "content_path_multi_file_fallback",
-			savePath:     "/downloads",
-			contentPath:  "/downloads/Show.S01",
+			savePath:     filepath.Join(baseRoot, "downloads"),
+			contentPath:  filepath.Join(baseRoot, "downloads", "Show.S01"),
 			relativePath: "Show.S01/Show.S01E01.mkv",
 			singleFile:   false,
 			check: func(t *testing.T, candidates []string) {
-				savePath := "/downloads"
-				contentPath := "/downloads/Show.S01"
+				savePath := filepath.Join(baseRoot, "downloads")
+				contentPath := filepath.Join(baseRoot, "downloads", "Show.S01")
 				relativePath := "Show.S01/Show.S01E01.mkv"
 				require.Contains(t, candidates, filepath.Clean(filepath.Join(savePath, relativePath)))
 				require.Contains(t, candidates, filepath.Clean(filepath.Join(contentPath, relativePath)))
@@ -380,12 +381,12 @@ func TestFilePathCandidates(t *testing.T) {
 		},
 		{
 			name:         "deduplicates_equivalent_paths",
-			savePath:     "/downloads",
-			contentPath:  "/downloads/Movie.mkv",
+			savePath:     filepath.Join(baseRoot, "downloads"),
+			contentPath:  filepath.Join(baseRoot, "downloads", "Movie.mkv"),
 			relativePath: "Movie.mkv",
 			singleFile:   true,
 			check: func(t *testing.T, candidates []string) {
-				want := filepath.Clean("/downloads/Movie.mkv")
+				want := filepath.Clean(filepath.Join(baseRoot, "downloads", "Movie.mkv"))
 				count := 0
 				for _, candidate := range candidates {
 					if candidate == want {
@@ -397,15 +398,15 @@ func TestFilePathCandidates(t *testing.T) {
 		},
 		{
 			name:         "uses_download_path_after_content_and_save",
-			savePath:     "/downloads",
-			downloadPath: "/tmp/incomplete",
-			contentPath:  "/downloads/Show.S01",
+			savePath:     filepath.Join(baseRoot, "downloads"),
+			downloadPath: filepath.Join(baseRoot, "tmp", "incomplete"),
+			contentPath:  filepath.Join(baseRoot, "downloads", "Show.S01"),
 			relativePath: "Show.S01/Show.S01E01.mkv",
 			singleFile:   false,
 			check: func(t *testing.T, candidates []string) {
-				savePath := "/downloads"
-				downloadPath := "/tmp/incomplete"
-				contentPath := "/downloads/Show.S01"
+				savePath := filepath.Join(baseRoot, "downloads")
+				downloadPath := filepath.Join(baseRoot, "tmp", "incomplete")
+				contentPath := filepath.Join(baseRoot, "downloads", "Show.S01")
 				relativePath := "Show.S01/Show.S01E01.mkv"
 				require.GreaterOrEqual(t, len(candidates), 3)
 				contentCandidate := filepath.Clean(filepath.Join(contentPath, relativePath))

--- a/internal/api/handlers/torrents_download_test.go
+++ b/internal/api/handlers/torrents_download_test.go
@@ -427,8 +427,57 @@ func TestFilePathCandidates(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			if tc.savePath != "" {
+				require.NoError(t, os.MkdirAll(tc.savePath, 0o755))
+			}
+			if tc.downloadPath != "" {
+				require.NoError(t, os.MkdirAll(tc.downloadPath, 0o755))
+			}
+			if tc.contentPath != "" {
+				if tc.singleFile {
+					require.NoError(t, os.MkdirAll(filepath.Dir(tc.contentPath), 0o755))
+					require.NoError(t, os.WriteFile(tc.contentPath, []byte("content"), 0o600))
+				} else {
+					require.NoError(t, os.MkdirAll(tc.contentPath, 0o755))
+				}
+			}
 			candidates := filePathCandidates(tc.savePath, tc.downloadPath, tc.contentPath, tc.relativePath, tc.singleFile)
 			tc.check(t, candidates)
 		})
 	}
+}
+
+func TestResolveTorrentFilePath_ResolvesSymlinkPathWithinBase(t *testing.T) {
+	baseDir := t.TempDir()
+	realDir := filepath.Join(baseDir, "real")
+	require.NoError(t, os.MkdirAll(realDir, 0o755))
+
+	target := filepath.Join(realDir, "file.mkv")
+	require.NoError(t, os.WriteFile(target, []byte("ok"), 0o600))
+
+	symlinkPath := filepath.Join(baseDir, "alias.mkv")
+	if err := os.Symlink(target, symlinkPath); err != nil {
+		t.Skipf("symlink not supported on this system: %v", err)
+	}
+
+	resolved, err := resolveTorrentFilePath(baseDir, "alias.mkv")
+	require.NoError(t, err)
+	require.Equal(t, target, resolved)
+}
+
+func TestResolveTorrentFilePath_RejectsSymlinkEscapeOutsideBase(t *testing.T) {
+	baseDir := t.TempDir()
+	outsideDir := t.TempDir()
+
+	target := filepath.Join(outsideDir, "outside.mkv")
+	require.NoError(t, os.WriteFile(target, []byte("ok"), 0o600))
+
+	symlinkPath := filepath.Join(baseDir, "escape.mkv")
+	if err := os.Symlink(target, symlinkPath); err != nil {
+		t.Skipf("symlink not supported on this system: %v", err)
+	}
+
+	_, err := resolveTorrentFilePath(baseDir, "escape.mkv")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "path traversal")
 }

--- a/internal/api/handlers/torrents_download_test.go
+++ b/internal/api/handlers/torrents_download_test.go
@@ -340,53 +340,46 @@ func TestDownloadTorrentContentFile_StreamsFile(t *testing.T) {
 }
 
 func TestFilePathCandidates(t *testing.T) {
-	baseRoot := filepath.Join(os.TempDir(), "qui-file-path-candidates")
 	testCases := []struct {
-		name         string
-		savePath     string
-		downloadPath string
-		contentPath  string
-		relativePath string
-		singleFile   bool
-		check        func(t *testing.T, candidates []string)
+		name            string
+		savePathRel     string
+		downloadPathRel string
+		contentPathRel  string
+		relativePath    string
+		singleFile      bool
+		check           func(t *testing.T, candidates []string, savePath, downloadPath, contentPath, relativePath string)
 	}{
 		{
-			name:         "content_path_single_file_fallback",
-			savePath:     filepath.Join(baseRoot, "downloads", "tv"),
-			contentPath:  filepath.Join(baseRoot, "downloads", "tv", "Show.S01E01", "Show.S01E01.mkv"),
-			relativePath: "Show.S01E01.v2.mkv",
-			singleFile:   true,
-			check: func(t *testing.T, candidates []string) {
-				savePath := filepath.Join(baseRoot, "downloads", "tv")
-				contentPath := filepath.Join(baseRoot, "downloads", "tv", "Show.S01E01", "Show.S01E01.mkv")
-				relativePath := "Show.S01E01.v2.mkv"
+			name:           "content_path_single_file_fallback",
+			savePathRel:    filepath.Join("downloads", "tv"),
+			contentPathRel: filepath.Join("downloads", "tv", "Show.S01E01", "Show.S01E01.mkv"),
+			relativePath:   "Show.S01E01.v2.mkv",
+			singleFile:     true,
+			check: func(t *testing.T, candidates []string, savePath, _, contentPath, relativePath string) {
 				require.Contains(t, candidates, filepath.Clean(filepath.Join(savePath, relativePath)))
 				require.Contains(t, candidates, filepath.Clean(contentPath))
 				require.Contains(t, candidates, filepath.Clean(filepath.Join(filepath.Dir(contentPath), relativePath)))
 			},
 		},
 		{
-			name:         "content_path_multi_file_fallback",
-			savePath:     filepath.Join(baseRoot, "downloads"),
-			contentPath:  filepath.Join(baseRoot, "downloads", "Show.S01"),
-			relativePath: "Show.S01/Show.S01E01.mkv",
-			singleFile:   false,
-			check: func(t *testing.T, candidates []string) {
-				savePath := filepath.Join(baseRoot, "downloads")
-				contentPath := filepath.Join(baseRoot, "downloads", "Show.S01")
-				relativePath := "Show.S01/Show.S01E01.mkv"
+			name:           "content_path_multi_file_fallback",
+			savePathRel:    "downloads",
+			contentPathRel: filepath.Join("downloads", "Show.S01"),
+			relativePath:   "Show.S01/Show.S01E01.mkv",
+			singleFile:     false,
+			check: func(t *testing.T, candidates []string, savePath, _, contentPath, relativePath string) {
 				require.Contains(t, candidates, filepath.Clean(filepath.Join(savePath, relativePath)))
 				require.Contains(t, candidates, filepath.Clean(filepath.Join(contentPath, relativePath)))
 			},
 		},
 		{
-			name:         "deduplicates_equivalent_paths",
-			savePath:     filepath.Join(baseRoot, "downloads"),
-			contentPath:  filepath.Join(baseRoot, "downloads", "Movie.mkv"),
-			relativePath: "Movie.mkv",
-			singleFile:   true,
-			check: func(t *testing.T, candidates []string) {
-				want := filepath.Clean(filepath.Join(baseRoot, "downloads", "Movie.mkv"))
+			name:           "deduplicates_equivalent_paths",
+			savePathRel:    "downloads",
+			contentPathRel: filepath.Join("downloads", "Movie.mkv"),
+			relativePath:   "Movie.mkv",
+			singleFile:     true,
+			check: func(t *testing.T, candidates []string, savePath, _, _, relativePath string) {
+				want := filepath.Clean(filepath.Join(savePath, relativePath))
 				count := 0
 				for _, candidate := range candidates {
 					if candidate == want {
@@ -397,17 +390,13 @@ func TestFilePathCandidates(t *testing.T) {
 			},
 		},
 		{
-			name:         "uses_download_path_after_content_and_save",
-			savePath:     filepath.Join(baseRoot, "downloads"),
-			downloadPath: filepath.Join(baseRoot, "tmp", "incomplete"),
-			contentPath:  filepath.Join(baseRoot, "downloads", "Show.S01"),
-			relativePath: "Show.S01/Show.S01E01.mkv",
-			singleFile:   false,
-			check: func(t *testing.T, candidates []string) {
-				savePath := filepath.Join(baseRoot, "downloads")
-				downloadPath := filepath.Join(baseRoot, "tmp", "incomplete")
-				contentPath := filepath.Join(baseRoot, "downloads", "Show.S01")
-				relativePath := "Show.S01/Show.S01E01.mkv"
+			name:            "uses_download_path_after_content_and_save",
+			savePathRel:     "downloads",
+			downloadPathRel: filepath.Join("tmp", "incomplete"),
+			contentPathRel:  filepath.Join("downloads", "Show.S01"),
+			relativePath:    "Show.S01/Show.S01E01.mkv",
+			singleFile:      false,
+			check: func(t *testing.T, candidates []string, savePath, downloadPath, contentPath, relativePath string) {
 				require.GreaterOrEqual(t, len(candidates), 3)
 				contentCandidate := filepath.Clean(filepath.Join(contentPath, relativePath))
 				saveCandidate := filepath.Clean(filepath.Join(savePath, relativePath))
@@ -427,22 +416,33 @@ func TestFilePathCandidates(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if tc.savePath != "" {
-				require.NoError(t, os.MkdirAll(tc.savePath, 0o755))
+			baseRoot := filepath.Join(t.TempDir(), "qui-file-path-candidates")
+
+			savePath := ""
+			if tc.savePathRel != "" {
+				savePath = filepath.Join(baseRoot, tc.savePathRel)
+				require.NoError(t, os.MkdirAll(savePath, 0o755))
 			}
-			if tc.downloadPath != "" {
-				require.NoError(t, os.MkdirAll(tc.downloadPath, 0o755))
+
+			downloadPath := ""
+			if tc.downloadPathRel != "" {
+				downloadPath = filepath.Join(baseRoot, tc.downloadPathRel)
+				require.NoError(t, os.MkdirAll(downloadPath, 0o755))
 			}
-			if tc.contentPath != "" {
+
+			contentPath := ""
+			if tc.contentPathRel != "" {
+				contentPath = filepath.Join(baseRoot, tc.contentPathRel)
 				if tc.singleFile {
-					require.NoError(t, os.MkdirAll(filepath.Dir(tc.contentPath), 0o755))
-					require.NoError(t, os.WriteFile(tc.contentPath, []byte("content"), 0o600))
+					require.NoError(t, os.MkdirAll(filepath.Dir(contentPath), 0o755))
+					require.NoError(t, os.WriteFile(contentPath, []byte("content"), 0o600))
 				} else {
-					require.NoError(t, os.MkdirAll(tc.contentPath, 0o755))
+					require.NoError(t, os.MkdirAll(contentPath, 0o755))
 				}
 			}
-			candidates := filePathCandidates(tc.savePath, tc.downloadPath, tc.contentPath, tc.relativePath, tc.singleFile)
-			tc.check(t, candidates)
+
+			candidates := filePathCandidates(savePath, downloadPath, contentPath, tc.relativePath, tc.singleFile)
+			tc.check(t, candidates, savePath, downloadPath, contentPath, tc.relativePath)
 		})
 	}
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -454,6 +454,7 @@ func (s *Server) Handler() (*chi.Mux, error) {
 					r.Put("/", instancesHandler.UpdateInstance)
 					r.Delete("/", instancesHandler.DeleteInstance)
 					r.Post("/test", instancesHandler.TestConnection)
+					r.Get("/mediainfo", torrentsHandler.GetContentPathMediaInfo)
 
 					// Torrent operations
 					r.Route("/torrents", func(r chi.Router) {

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -586,6 +586,125 @@ func writeJSONError(w http.ResponseWriter, status int, message string) {
 	}
 }
 
+type proxyMediaInfoRequestError struct {
+	status  int
+	message string
+}
+
+func (e *proxyMediaInfoRequestError) Error() string {
+	return e.message
+}
+
+type proxyMediaInfoResponseWriteError struct {
+	encodeErr   error
+	fallbackErr error
+}
+
+func (e *proxyMediaInfoResponseWriteError) Error() string {
+	if e.fallbackErr != nil {
+		return e.fallbackErr.Error()
+	}
+	if e.encodeErr != nil {
+		return e.encodeErr.Error()
+	}
+	return "proxy mediainfo response write failed"
+}
+
+func validateProxyMediainfoRequest(ctx context.Context, instanceStore *models.InstanceStore, syncManager *qbittorrent.SyncManager, instanceID int) (*models.Instance, qbt.AppPreferences, error) {
+	if instanceStore == nil || syncManager == nil {
+		log.Error().Int("instanceId", instanceID).Msg("Proxy mediainfo dependencies not configured")
+		return nil, qbt.AppPreferences{}, &proxyMediaInfoRequestError{status: http.StatusInternalServerError, message: "MediaInfo service unavailable"}
+	}
+
+	instance, err := instanceStore.Get(ctx, instanceID)
+	if err != nil {
+		if errors.Is(err, models.ErrInstanceNotFound) {
+			return nil, qbt.AppPreferences{}, &proxyMediaInfoRequestError{status: http.StatusNotFound, message: "Instance not found"}
+		}
+
+		log.Error().Err(err).Int("instanceId", instanceID).Msg("Failed to load instance for proxy mediainfo")
+		return nil, qbt.AppPreferences{}, &proxyMediaInfoRequestError{status: http.StatusInternalServerError, message: "Failed to load instance"}
+	}
+
+	if instance == nil {
+		return nil, qbt.AppPreferences{}, &proxyMediaInfoRequestError{status: http.StatusNotFound, message: "Instance not found"}
+	}
+
+	if !instance.HasLocalFilesystemAccess {
+		return nil, qbt.AppPreferences{}, &proxyMediaInfoRequestError{status: http.StatusForbidden, message: "Instance does not have local filesystem access enabled"}
+	}
+
+	prefs, err := syncManager.GetAppPreferences(ctx, instanceID)
+	if err != nil {
+		log.Error().Err(err).Int("instanceId", instanceID).Msg("Failed to get app preferences for proxy mediainfo")
+		return nil, qbt.AppPreferences{}, &proxyMediaInfoRequestError{status: http.StatusInternalServerError, message: "Failed to get app preferences"}
+	}
+
+	return instance, prefs, nil
+}
+
+func resolveProxyContentPathCandidates(r *http.Request, prefs qbt.AppPreferences, contentPathCandidates func(qbt.AppPreferences, string) []string) (string, string, error) {
+	contentPath, err := parseProxyMediaInfoContentPath(r)
+	if err != nil {
+		return "", "", &proxyMediaInfoRequestError{status: http.StatusBadRequest, message: "Invalid content path"}
+	}
+
+	candidates := contentPathCandidates(prefs, contentPath)
+	if len(candidates) == 0 {
+		return "", "", &proxyMediaInfoRequestError{status: http.StatusBadRequest, message: "No content roots configured for instance"}
+	}
+
+	resolvedPath, ok := findExistingProxyContentFile(candidates)
+	if !ok {
+		return "", "", &proxyMediaInfoRequestError{status: http.StatusNotFound, message: "File not found on disk"}
+	}
+
+	return contentPath, resolvedPath, nil
+}
+
+func analyzeMediaFile(resolvedPath, contentPath string, instanceID int) (string, string, error) {
+	// #nosec G304 -- resolvedPath is constructed from validated base paths via resolveProxyContentPath.
+	report, err := mediainfo.AnalyzeFile(resolvedPath, mediainfo.WithParseSpeed(0.5))
+	if err != nil {
+		log.Error().Err(err).Int("instanceId", instanceID).Str("contentPath", contentPath).Msg("Failed to analyze file with MediaInfo")
+		return "", "", &proxyMediaInfoRequestError{status: http.StatusInternalServerError, message: "Failed to analyze file"}
+	}
+
+	summaryTxt, err := mediainfo.Render([]mediainfo.Report{report}, mediainfo.OutputText)
+	if err != nil {
+		log.Error().Err(err).Int("instanceId", instanceID).Str("contentPath", contentPath).Msg("Failed to render MediaInfo summary text")
+		return "", "", &proxyMediaInfoRequestError{status: http.StatusInternalServerError, message: "Failed to render MediaInfo"}
+	}
+
+	rawJSON, err := mediainfo.Render([]mediainfo.Report{report}, mediainfo.OutputJSON)
+	if err != nil {
+		log.Error().Err(err).Int("instanceId", instanceID).Str("contentPath", contentPath).Msg("Failed to render MediaInfo JSON")
+		return "", "", &proxyMediaInfoRequestError{status: http.StatusInternalServerError, message: "Failed to render MediaInfo"}
+	}
+
+	return summaryTxt, rawJSON, nil
+}
+
+func writeProxyMediaInfoResponse(w http.ResponseWriter, contentPath, summaryTxt, rawJSON string) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	err := json.NewEncoder(w).Encode(proxyContentPathMediaInfoResponse{
+		ContentPath:   contentPath,
+		SummaryTxt:    summaryTxt,
+		MediaInfoJSON: json.RawMessage(rawJSON),
+	})
+	if err == nil {
+		return nil
+	}
+
+	writeErr := error(nil)
+	if _, fallbackErr := io.WriteString(w, "{}\n"); fallbackErr != nil {
+		writeErr = fallbackErr
+	}
+
+	return &proxyMediaInfoResponseWriteError{encodeErr: err, fallbackErr: writeErr}
+}
+
 func normalizeContentPathRelativeInput(raw string) (string, error) {
 	trimmed := strings.TrimSpace(raw)
 	if trimmed == "" {
@@ -1504,37 +1623,28 @@ func (h *Handler) handleTorrentMediaInfo(w http.ResponseWriter, r *http.Request)
 	instanceID := GetInstanceIDFromContext(ctx)
 	clientAPIKey := GetClientAPIKeyFromContext(ctx)
 
-	if h.instanceStore == nil || h.syncManager == nil {
-		log.Error().Int("instanceId", instanceID).Msg("Proxy mediainfo dependencies not configured")
-		writeJSONError(w, http.StatusInternalServerError, "MediaInfo service unavailable")
-		return
-	}
-
-	instance, err := h.instanceStore.Get(ctx, instanceID)
+	instance, prefs, err := validateProxyMediainfoRequest(ctx, h.instanceStore, h.syncManager, instanceID)
 	if err != nil {
-		if errors.Is(err, models.ErrInstanceNotFound) {
-			writeJSONError(w, http.StatusNotFound, "Instance not found")
+		var reqErr *proxyMediaInfoRequestError
+		if errors.As(err, &reqErr) {
+			writeJSONError(w, reqErr.status, reqErr.message)
 			return
 		}
 
-		log.Error().Err(err).Int("instanceId", instanceID).Msg("Failed to load instance for proxy mediainfo")
 		writeJSONError(w, http.StatusInternalServerError, "Failed to load instance")
 		return
 	}
+	_ = instance
 
-	if instance == nil {
-		writeJSONError(w, http.StatusNotFound, "Instance not found")
-		return
-	}
-
-	if !instance.HasLocalFilesystemAccess {
-		writeJSONError(w, http.StatusForbidden, "Instance does not have local filesystem access enabled")
-		return
-	}
-
-	contentPath, err := parseProxyMediaInfoContentPath(r)
+	contentPath, resolvedPath, err := resolveProxyContentPathCandidates(r, prefs, contentPathCandidatesFromPreferences)
 	if err != nil {
-		writeJSONError(w, http.StatusBadRequest, "Invalid content path")
+		var reqErr *proxyMediaInfoRequestError
+		if errors.As(err, &reqErr) {
+			writeJSONError(w, reqErr.status, reqErr.message)
+			return
+		}
+
+		writeJSONError(w, http.StatusInternalServerError, "File not found on disk")
 		return
 	}
 
@@ -1549,59 +1659,31 @@ func (h *Handler) handleTorrentMediaInfo(w http.ResponseWriter, r *http.Request)
 		Str("contentPath", contentPath).
 		Msg("Handling torrent mediainfo request via proxy endpoint")
 
-	prefs, err := h.syncManager.GetAppPreferences(ctx, instanceID)
+	summaryTxt, rawJSON, err := analyzeMediaFile(resolvedPath, contentPath, instanceID)
 	if err != nil {
-		log.Error().Err(err).Int("instanceId", instanceID).Msg("Failed to get app preferences for proxy mediainfo")
-		writeJSONError(w, http.StatusInternalServerError, "Failed to get app preferences")
-		return
-	}
+		var reqErr *proxyMediaInfoRequestError
+		if errors.As(err, &reqErr) {
+			writeJSONError(w, reqErr.status, reqErr.message)
+			return
+		}
 
-	candidates := contentPathCandidatesFromPreferences(prefs, contentPath)
-	if len(candidates) == 0 {
-		writeJSONError(w, http.StatusBadRequest, "No content roots configured for instance")
-		return
-	}
-
-	resolvedPath, ok := findExistingProxyContentFile(candidates)
-	if !ok {
-		writeJSONError(w, http.StatusNotFound, "File not found on disk")
-		return
-	}
-
-	// #nosec G304 -- resolvedPath is constructed from validated base paths via resolveProxyContentPath.
-	report, err := mediainfo.AnalyzeFile(resolvedPath, mediainfo.WithParseSpeed(0.5))
-	if err != nil {
-		log.Error().Err(err).Int("instanceId", instanceID).Str("contentPath", contentPath).Msg("Failed to analyze file with MediaInfo")
 		writeJSONError(w, http.StatusInternalServerError, "Failed to analyze file")
 		return
 	}
 
-	summaryTxt, err := mediainfo.Render([]mediainfo.Report{report}, mediainfo.OutputText)
-	if err != nil {
-		log.Error().Err(err).Int("instanceId", instanceID).Str("contentPath", contentPath).Msg("Failed to render MediaInfo summary text")
-		writeJSONError(w, http.StatusInternalServerError, "Failed to render MediaInfo")
-		return
-	}
-
-	rawJSON, err := mediainfo.Render([]mediainfo.Report{report}, mediainfo.OutputJSON)
-	if err != nil {
-		log.Error().Err(err).Int("instanceId", instanceID).Str("contentPath", contentPath).Msg("Failed to render MediaInfo JSON")
-		writeJSONError(w, http.StatusInternalServerError, "Failed to render MediaInfo")
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	err = json.NewEncoder(w).Encode(proxyContentPathMediaInfoResponse{
-		ContentPath:   contentPath,
-		SummaryTxt:    summaryTxt,
-		MediaInfoJSON: json.RawMessage(rawJSON),
-	})
-	if err != nil {
-		log.Error().Err(err).Int("instanceId", instanceID).Str("contentPath", contentPath).Msg("Failed to encode proxy mediainfo response")
-		if _, writeErr := io.WriteString(w, "{}\n"); writeErr != nil {
-			log.Error().Err(writeErr).Int("instanceId", instanceID).Str("contentPath", contentPath).Msg("Failed to write proxy mediainfo fallback response")
+	if err = writeProxyMediaInfoResponse(w, contentPath, summaryTxt, rawJSON); err != nil {
+		var writeErr *proxyMediaInfoResponseWriteError
+		if errors.As(err, &writeErr) {
+			if writeErr.encodeErr != nil {
+				log.Error().Err(writeErr.encodeErr).Int("instanceId", instanceID).Str("contentPath", contentPath).Msg("Failed to encode proxy mediainfo response")
+			}
+			if writeErr.fallbackErr != nil {
+				log.Error().Err(writeErr.fallbackErr).Int("instanceId", instanceID).Str("contentPath", contentPath).Msg("Failed to write proxy mediainfo fallback response")
+			}
+			return
 		}
+
+		log.Error().Err(err).Int("instanceId", instanceID).Str("contentPath", contentPath).Msg("Failed to encode proxy mediainfo response")
 	}
 }
 

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -15,11 +15,14 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/autobrr/autobrr/pkg/sharedhttp"
+	mediainfo "github.com/autobrr/go-mediainfo"
 	qbt "github.com/autobrr/go-qbittorrent"
 	"github.com/go-chi/chi/v5"
 	"github.com/rs/zerolog"
@@ -66,6 +69,16 @@ type proxyContext struct {
 	instanceURL *url.URL
 	httpClient  *http.Client
 	basicAuth   *basicAuthCredentials
+}
+
+type proxyContentPathMediaInfoRequest struct {
+	ContentPath string `json:"contentPath"`
+}
+
+type proxyContentPathMediaInfoResponse struct {
+	ContentPath   string          `json:"contentPath"`
+	SummaryTxt    string          `json:"summaryTxt"`
+	MediaInfoJSON json.RawMessage `json:"mediaInfoJson"`
 }
 
 // NewHandler creates a new proxy handler
@@ -408,6 +421,7 @@ func (h *Handler) Routes(r chi.Router) {
 		pr.Get("/api/v2/torrents/trackers", h.handleTorrentTrackers)
 		pr.Get("/api/v2/torrents/files", h.handleTorrentFiles)
 		pr.Get("/api/v2/torrents/search", h.handleTorrentSearch)
+		pr.Get("/api/v2/torrents/mediainfo", h.handleTorrentMediaInfo)
 
 		// Intercepted write operations for cache invalidation
 		pr.Post("/api/v2/torrents/setLocation", h.handleSetLocation)
@@ -557,6 +571,142 @@ func difference(all, subset []string) []string {
 		remaining = append(remaining, val)
 	}
 	return remaining
+}
+
+func writeJSONError(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": message})
+}
+
+func normalizeContentPathRelativeInput(raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", errors.New("content path is required")
+	}
+
+	normalized := filepath.Clean(filepath.FromSlash(trimmed))
+	if filepath.IsAbs(normalized) {
+		return "", errors.New("absolute paths are not allowed")
+	}
+	if normalized == ".." || strings.HasPrefix(normalized, ".."+string(filepath.Separator)) {
+		return "", errors.New("path traversal detected")
+	}
+
+	return normalized, nil
+}
+
+func resolveProxyContentPath(basePath, relativePath string) (string, error) {
+	full := filepath.Join(basePath, filepath.FromSlash(relativePath))
+	cleanBase := filepath.Clean(basePath)
+	cleanFull := filepath.Clean(full)
+
+	evaluatedBase, err := filepath.EvalSymlinks(cleanBase)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve base path symlinks: %w", err)
+	}
+
+	evaluatedFull, err := filepath.EvalSymlinks(cleanFull)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve candidate path symlinks: %w", err)
+	}
+
+	rel, err := filepath.Rel(evaluatedBase, evaluatedFull)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", errors.New("path traversal detected")
+	}
+
+	return evaluatedFull, nil
+}
+
+func appendUniqueProxyCandidate(candidates []string, seen map[string]struct{}, candidate string) []string {
+	if candidate == "" {
+		return candidates
+	}
+
+	cleanCandidate := filepath.Clean(candidate)
+	if !filepath.IsAbs(cleanCandidate) {
+		return candidates
+	}
+	if _, ok := seen[cleanCandidate]; ok {
+		return candidates
+	}
+
+	seen[cleanCandidate] = struct{}{}
+	return append(candidates, cleanCandidate)
+}
+
+func contentPathCandidatesFromPreferences(prefs qbt.AppPreferences, relativePath string) []string {
+	candidates := make([]string, 0, 2)
+	seen := make(map[string]struct{})
+
+	if p, err := resolveProxyContentPath(prefs.SavePath, relativePath); err == nil {
+		candidates = appendUniqueProxyCandidate(candidates, seen, p)
+	}
+
+	if prefs.TempPathEnabled {
+		if p, err := resolveProxyContentPath(prefs.TempPath, relativePath); err == nil {
+			candidates = appendUniqueProxyCandidate(candidates, seen, p)
+		}
+	}
+
+	return candidates
+}
+
+func findExistingProxyContentFile(candidates []string) (string, bool) {
+	for _, candidate := range candidates {
+		// #nosec G703,G304 -- candidate is constructed from validated base paths via resolveProxyContentPath.
+		f, err := os.Open(candidate)
+		if err != nil {
+			continue
+		}
+
+		stat, err := f.Stat()
+		if err != nil {
+			_ = f.Close()
+			continue
+		}
+		if stat.IsDir() {
+			_ = f.Close()
+			continue
+		}
+		_ = f.Close()
+
+		return candidate, true
+	}
+
+	return "", false
+}
+
+func parseProxyMediaInfoContentPath(r *http.Request) (string, error) {
+	queryContentPath := strings.TrimSpace(r.URL.Query().Get("contentPath"))
+	if queryContentPath == "" {
+		queryContentPath = strings.TrimSpace(r.URL.Query().Get("content_path"))
+	}
+	if queryContentPath != "" {
+		return normalizeContentPathRelativeInput(queryContentPath)
+	}
+
+	contentType := strings.TrimSpace(strings.ToLower(r.Header.Get("Content-Type")))
+	if strings.HasPrefix(contentType, "application/json") {
+		var req proxyContentPathMediaInfoRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			return "", errors.New("invalid request body")
+		}
+		return normalizeContentPathRelativeInput(req.ContentPath)
+	}
+
+	if err := r.ParseForm(); err != nil {
+		return "", errors.New("invalid form data")
+	}
+
+	contentPath := r.FormValue("contentPath")
+	if strings.TrimSpace(contentPath) == "" {
+		contentPath = r.FormValue("content_path")
+	}
+
+	return normalizeContentPathRelativeInput(contentPath)
 }
 
 func generateLoginCookieValue() (string, error) {
@@ -1318,6 +1468,107 @@ func (h *Handler) handleTorrentFiles(w http.ResponseWriter, r *http.Request) {
 			Int("instanceId", instanceID).
 			Msg("Failed to encode files response")
 	}
+}
+
+// handleTorrentMediaInfo handles /api/v2/torrents/mediainfo requests.
+func (h *Handler) handleTorrentMediaInfo(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	instanceID := GetInstanceIDFromContext(ctx)
+	clientAPIKey := GetClientAPIKeyFromContext(ctx)
+
+	if h.instanceStore == nil || h.syncManager == nil {
+		log.Error().Int("instanceId", instanceID).Msg("Proxy mediainfo dependencies not configured")
+		writeJSONError(w, http.StatusInternalServerError, "MediaInfo service unavailable")
+		return
+	}
+
+	instance, err := h.instanceStore.Get(ctx, instanceID)
+	if err != nil {
+		if errors.Is(err, models.ErrInstanceNotFound) {
+			writeJSONError(w, http.StatusNotFound, "Instance not found")
+			return
+		}
+
+		log.Error().Err(err).Int("instanceId", instanceID).Msg("Failed to load instance for proxy mediainfo")
+		writeJSONError(w, http.StatusInternalServerError, "Failed to load instance")
+		return
+	}
+
+	if instance == nil {
+		writeJSONError(w, http.StatusNotFound, "Instance not found")
+		return
+	}
+
+	if !instance.HasLocalFilesystemAccess {
+		writeJSONError(w, http.StatusForbidden, "Instance does not have local filesystem access enabled")
+		return
+	}
+
+	contentPath, err := parseProxyMediaInfoContentPath(r)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "Invalid content path")
+		return
+	}
+
+	clientName := "unknown"
+	if clientAPIKey != nil {
+		clientName = clientAPIKey.ClientName
+	}
+
+	log.Debug().
+		Int("instanceId", instanceID).
+		Str("client", clientName).
+		Str("contentPath", contentPath).
+		Msg("Handling torrent mediainfo request via proxy endpoint")
+
+	prefs, err := h.syncManager.GetAppPreferences(ctx, instanceID)
+	if err != nil {
+		log.Error().Err(err).Int("instanceId", instanceID).Msg("Failed to get app preferences for proxy mediainfo")
+		writeJSONError(w, http.StatusInternalServerError, "Failed to get app preferences")
+		return
+	}
+
+	candidates := contentPathCandidatesFromPreferences(prefs, contentPath)
+	if len(candidates) == 0 {
+		writeJSONError(w, http.StatusBadRequest, "No content roots configured for instance")
+		return
+	}
+
+	resolvedPath, ok := findExistingProxyContentFile(candidates)
+	if !ok {
+		writeJSONError(w, http.StatusNotFound, "File not found on disk")
+		return
+	}
+
+	// #nosec G304 -- resolvedPath is constructed from validated base paths via resolveProxyContentPath.
+	report, err := mediainfo.AnalyzeFile(resolvedPath, mediainfo.WithParseSpeed(0.5))
+	if err != nil {
+		log.Error().Err(err).Int("instanceId", instanceID).Str("contentPath", contentPath).Msg("Failed to analyze file with MediaInfo")
+		writeJSONError(w, http.StatusInternalServerError, "Failed to analyze file")
+		return
+	}
+
+	summaryTxt, err := mediainfo.Render([]mediainfo.Report{report}, mediainfo.OutputText)
+	if err != nil {
+		log.Error().Err(err).Int("instanceId", instanceID).Str("contentPath", contentPath).Msg("Failed to render MediaInfo summary text")
+		writeJSONError(w, http.StatusInternalServerError, "Failed to render MediaInfo")
+		return
+	}
+
+	rawJSON, err := mediainfo.Render([]mediainfo.Report{report}, mediainfo.OutputJSON)
+	if err != nil {
+		log.Error().Err(err).Int("instanceId", instanceID).Str("contentPath", contentPath).Msg("Failed to render MediaInfo JSON")
+		writeJSONError(w, http.StatusInternalServerError, "Failed to render MediaInfo")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(proxyContentPathMediaInfoResponse{
+		ContentPath:   contentPath,
+		SummaryTxt:    summaryTxt,
+		MediaInfoJSON: json.RawMessage(rawJSON),
+	})
 }
 
 // handleAuthLogin handles /api/v2/auth/login requests (ceremonial - proxy already authenticated)

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -730,6 +730,7 @@ func normalizeContentPathRelativeInput(raw string) (string, error) {
 		return "", errors.New("content path is required")
 	}
 
+	trimmed = strings.ReplaceAll(trimmed, "\\", "/")
 	normalized := filepath.Clean(filepath.FromSlash(trimmed))
 	if filepath.IsAbs(normalized) {
 		return "", errors.New("absolute paths are not allowed")

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -75,6 +75,25 @@ type proxyContentPathMediaInfoRequest struct {
 	ContentPath string `json:"contentPath"`
 }
 
+func (r *proxyContentPathMediaInfoRequest) UnmarshalJSON(data []byte) error {
+	type proxyContentPathMediaInfoRequestAlias struct {
+		ContentPath       string `json:"contentPath"`
+		LegacyContentPath string `json:"content_path"`
+	}
+
+	var decoded proxyContentPathMediaInfoRequestAlias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+
+	r.ContentPath = decoded.ContentPath
+	if strings.TrimSpace(r.ContentPath) == "" {
+		r.ContentPath = decoded.LegacyContentPath
+	}
+
+	return nil
+}
+
 type proxyContentPathMediaInfoResponse struct {
 	ContentPath   string          `json:"contentPath"`
 	SummaryTxt    string          `json:"summaryTxt"`
@@ -811,14 +830,21 @@ func findExistingProxyContentFile(candidates []string) (string, bool) {
 
 		stat, err := f.Stat()
 		if err != nil {
-			_ = f.Close()
+			if cerr := f.Close(); cerr != nil {
+				log.Warn().Err(cerr).Str("candidate", candidate).Msg("failed to close probed content file")
+			}
 			continue
 		}
 		if stat.IsDir() {
-			_ = f.Close()
+			if cerr := f.Close(); cerr != nil {
+				log.Warn().Err(cerr).Str("candidate", candidate).Msg("failed to close probed content file")
+			}
 			continue
 		}
-		_ = f.Close()
+		if cerr := f.Close(); cerr != nil {
+			log.Warn().Err(cerr).Str("candidate", candidate).Msg("failed to close probed content file")
+			continue
+		}
 
 		return candidate, true
 	}

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -577,7 +577,13 @@ func writeJSONError(w http.ResponseWriter, status int, message string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 
-	_ = json.NewEncoder(w).Encode(map[string]string{"error": message})
+	err := json.NewEncoder(w).Encode(map[string]string{"error": message})
+	if err != nil {
+		log.Error().Err(err).Int("status", status).Msg("Failed to encode JSON error response")
+		if _, writeErr := io.WriteString(w, "error\n"); writeErr != nil {
+			log.Error().Err(writeErr).Int("status", status).Msg("Failed to write JSON error fallback response")
+		}
+	}
 }
 
 func normalizeContentPathRelativeInput(raw string) (string, error) {
@@ -598,13 +604,35 @@ func normalizeContentPathRelativeInput(raw string) (string, error) {
 }
 
 func resolveProxyContentPath(basePath, relativePath string) (string, error) {
-	full := filepath.Join(basePath, filepath.FromSlash(relativePath))
 	cleanBase := filepath.Clean(basePath)
+	if !filepath.IsAbs(cleanBase) {
+		return "", errors.New("base path must be absolute")
+	}
+
+	full := filepath.Join(cleanBase, filepath.FromSlash(relativePath))
 	cleanFull := filepath.Clean(full)
+
+	rel, err := filepath.Rel(cleanBase, cleanFull)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", errors.New("path traversal detected")
+	}
+
+	// #nosec G703 -- cleanBase is validated as absolute and constrained by traversal checks above.
+	if _, err := os.Lstat(cleanBase); err != nil {
+		return "", fmt.Errorf("failed to access base path: %w", err)
+	}
 
 	evaluatedBase, err := filepath.EvalSymlinks(cleanBase)
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve base path symlinks: %w", err)
+	}
+
+	// #nosec G703 -- cleanFull is derived from a validated base path and traversal-checked relative input.
+	if _, err := os.Lstat(cleanFull); err != nil {
+		if os.IsNotExist(err) {
+			return cleanFull, nil
+		}
+		return "", fmt.Errorf("failed to access candidate path: %w", err)
 	}
 
 	evaluatedFull, err := filepath.EvalSymlinks(cleanFull)
@@ -612,7 +640,7 @@ func resolveProxyContentPath(basePath, relativePath string) (string, error) {
 		return "", fmt.Errorf("failed to resolve candidate path symlinks: %w", err)
 	}
 
-	rel, err := filepath.Rel(evaluatedBase, evaluatedFull)
+	rel, err = filepath.Rel(evaluatedBase, evaluatedFull)
 	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return "", errors.New("path traversal detected")
 	}
@@ -1564,11 +1592,17 @@ func (h *Handler) handleTorrentMediaInfo(w http.ResponseWriter, r *http.Request)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(proxyContentPathMediaInfoResponse{
+	err = json.NewEncoder(w).Encode(proxyContentPathMediaInfoResponse{
 		ContentPath:   contentPath,
 		SummaryTxt:    summaryTxt,
 		MediaInfoJSON: json.RawMessage(rawJSON),
 	})
+	if err != nil {
+		log.Error().Err(err).Int("instanceId", instanceID).Str("contentPath", contentPath).Msg("Failed to encode proxy mediainfo response")
+		if _, writeErr := io.WriteString(w, "{}\n"); writeErr != nil {
+			log.Error().Err(writeErr).Int("instanceId", instanceID).Str("contentPath", contentPath).Msg("Failed to write proxy mediainfo fallback response")
+		}
+	}
 }
 
 // handleAuthLogin handles /api/v2/auth/login requests (ceremonial - proxy already authenticated)

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -6,11 +6,14 @@ package proxy
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
 	"net/url"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"sync/atomic"
@@ -303,4 +306,68 @@ func TestBuildTorrentSearchFilters_EnhancedAndLegacyCompatibility(t *testing.T) 
 	require.True(t, slices.Equal([]string{"tracker-c", "tracker-d"}, filters.ExcludeTrackers))
 	require.True(t, slices.Equal([]string{"ABC", "DEF", "GHI"}, filters.Hashes))
 	require.Equal(t, "ratio > 1", filters.Expr)
+}
+
+func TestNormalizeContentPathRelativeInput(t *testing.T) {
+	t.Helper()
+
+	testCases := []struct {
+		name      string
+		input     string
+		wantError bool
+	}{
+		{name: "valid", input: "folder/file.mkv", wantError: false},
+		{name: "empty", input: "", wantError: true},
+		{name: "traversal", input: "../escape.mkv", wantError: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			normalized, err := normalizeContentPathRelativeInput(tc.input)
+			if tc.wantError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, filepath.FromSlash(tc.input), normalized)
+		})
+	}
+}
+
+func TestParseProxyMediaInfoContentPath_JSON(t *testing.T) {
+	t.Helper()
+
+	body, err := json.Marshal(map[string]string{"contentPath": "folder/file.mkv"})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/proxy/test/api/v2/torrents/mediainfo", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	contentPath, err := parseProxyMediaInfoContentPath(req)
+	require.NoError(t, err)
+	require.Equal(t, filepath.FromSlash("folder/file.mkv"), contentPath)
+}
+
+func TestParseProxyMediaInfoContentPath_Form(t *testing.T) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "/proxy/test/api/v2/torrents/mediainfo", strings.NewReader("content_path=folder%2Ffile.mkv"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	contentPath, err := parseProxyMediaInfoContentPath(req)
+	require.NoError(t, err)
+	require.Equal(t, filepath.FromSlash("folder/file.mkv"), contentPath)
+}
+
+func TestFindExistingProxyContentFile(t *testing.T) {
+	t.Helper()
+
+	root := t.TempDir()
+	goodPath := filepath.Join(root, "good.mkv")
+	require.NoError(t, os.WriteFile(goodPath, []byte("ok"), 0o600))
+
+	found, ok := findExistingProxyContentFile([]string{filepath.Join(root, "missing.mkv"), goodPath})
+	require.True(t, ok)
+	require.Equal(t, goodPath, found)
 }

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -319,6 +319,7 @@ func TestNormalizeContentPathRelativeInput(t *testing.T) {
 		{name: "valid", input: "folder/file.mkv", wantError: false},
 		{name: "empty", input: "", wantError: true},
 		{name: "traversal", input: "../escape.mkv", wantError: true},
+		{name: "windows-traversal", input: "..\\escape.mkv", wantError: true},
 	}
 
 	for _, tc := range testCases {

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -350,6 +350,37 @@ func TestParseProxyMediaInfoContentPath_JSON(t *testing.T) {
 	require.Equal(t, filepath.FromSlash("folder/file.mkv"), contentPath)
 }
 
+func TestParseProxyMediaInfoContentPath_JSON_LegacyAlias(t *testing.T) {
+	t.Helper()
+
+	body, err := json.Marshal(map[string]string{"content_path": "folder/file.mkv"})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/proxy/test/api/v2/torrents/mediainfo", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	contentPath, err := parseProxyMediaInfoContentPath(req)
+	require.NoError(t, err)
+	require.Equal(t, filepath.FromSlash("folder/file.mkv"), contentPath)
+}
+
+func TestParseProxyMediaInfoContentPath_JSON_PrefersCanonicalWhenBothPresent(t *testing.T) {
+	t.Helper()
+
+	body, err := json.Marshal(map[string]string{
+		"contentPath":  "folder/canonical.mkv",
+		"content_path": "folder/legacy.mkv",
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/proxy/test/api/v2/torrents/mediainfo", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	contentPath, err := parseProxyMediaInfoContentPath(req)
+	require.NoError(t, err)
+	require.Equal(t, filepath.FromSlash("folder/canonical.mkv"), contentPath)
+}
+
 func TestParseProxyMediaInfoContentPath_Form(t *testing.T) {
 	t.Helper()
 

--- a/internal/services/crossseed/hardlink_mode_test.go
+++ b/internal/services/crossseed/hardlink_mode_test.go
@@ -352,7 +352,19 @@ func TestFindMatchingBaseDir(t *testing.T) {
 }
 
 func TestFindMatchingBaseDir_ParsesCommaSeparated(t *testing.T) {
-	_, err := findMatchingBaseDir("/path1, /path2 , /path3", "/nonexistent")
+	sourceRoot := t.TempDir()
+	sourceFile := filepath.Join(sourceRoot, "source.bin")
+	require.NoError(t, os.WriteFile(sourceFile, []byte("source"), 0o600))
+
+	invalidPath1 := filepath.Join(t.TempDir(), "not-a-directory-1")
+	invalidPath2 := filepath.Join(t.TempDir(), "not-a-directory-2")
+	invalidPath3 := filepath.Join(t.TempDir(), "not-a-directory-3")
+	require.NoError(t, os.WriteFile(invalidPath1, []byte("file"), 0o600))
+	require.NoError(t, os.WriteFile(invalidPath2, []byte("file"), 0o600))
+	require.NoError(t, os.WriteFile(invalidPath3, []byte("file"), 0o600))
+
+	configured := invalidPath1 + ", " + invalidPath2 + " , " + invalidPath3
+	_, err := findMatchingBaseDir(configured, sourceFile)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no base directory")

--- a/internal/services/externalprograms/service_test.go
+++ b/internal/services/externalprograms/service_test.go
@@ -1381,6 +1381,10 @@ func TestBuildCommand_Windows(t *testing.T) {
 
 	service := &Service{}
 	ctx := context.Background()
+	assertWindowsCmdPath := func(t *testing.T, path string) {
+		t.Helper()
+		assert.Equal(t, "cmd.exe", strings.ToLower(filepath.Base(path)))
+	}
 
 	t.Run("terminal mode uses cmd.exe with start cmd /k", func(t *testing.T) {
 		program := &models.ExternalProgram{
@@ -1389,7 +1393,7 @@ func TestBuildCommand_Windows(t *testing.T) {
 		}
 		cmd := service.buildCommand(ctx, program, []string{"arg1", "arg2"})
 
-		assert.Equal(t, "cmd.exe", cmd.Path)
+		assertWindowsCmdPath(t, cmd.Path)
 		// Args should be: [cmd.exe, /c, start, "", cmd, /k, C:\Programs\test.exe, arg1, arg2]
 		assert.Contains(t, cmd.Args, "/c")
 		assert.Contains(t, cmd.Args, "start")
@@ -1405,7 +1409,7 @@ func TestBuildCommand_Windows(t *testing.T) {
 		}
 		cmd := service.buildCommand(ctx, program, []string{"arg1"})
 
-		assert.Equal(t, "cmd.exe", cmd.Path)
+		assertWindowsCmdPath(t, cmd.Path)
 		// Args should be: [cmd.exe, /c, start, "", /b, C:\Programs\test.exe, arg1]
 		assert.Contains(t, cmd.Args, "/c")
 		assert.Contains(t, cmd.Args, "start")
@@ -1433,7 +1437,7 @@ func TestBuildCommand_Windows(t *testing.T) {
 		}
 		cmd := service.buildCommand(ctx, program, nil)
 
-		assert.Equal(t, "cmd.exe", cmd.Path)
+		assertWindowsCmdPath(t, cmd.Path)
 		assert.Contains(t, cmd.Args, "/c")
 		assert.Contains(t, cmd.Args, "start")
 		assert.Contains(t, cmd.Args, "cmd")
@@ -1448,7 +1452,7 @@ func TestBuildCommand_Windows(t *testing.T) {
 		}
 		cmd := service.buildCommand(ctx, program, nil)
 
-		assert.Equal(t, "cmd.exe", cmd.Path)
+		assertWindowsCmdPath(t, cmd.Path)
 		assert.Contains(t, cmd.Args, "/c")
 		assert.Contains(t, cmd.Args, "start")
 		assert.Contains(t, cmd.Args, "/b")
@@ -1462,7 +1466,7 @@ func TestBuildCommand_Windows(t *testing.T) {
 		}
 		cmd := service.buildCommand(ctx, program, []string{"--arg", "value"})
 
-		assert.Equal(t, "cmd.exe", cmd.Path)
+		assertWindowsCmdPath(t, cmd.Path)
 		assert.Contains(t, cmd.Args, "C:\\Program Files\\My App\\test.exe")
 	})
 
@@ -1473,7 +1477,7 @@ func TestBuildCommand_Windows(t *testing.T) {
 		}
 		cmd := service.buildCommand(ctx, program, []string{"--arg", "value"})
 
-		assert.Equal(t, "cmd.exe", cmd.Path)
+		assertWindowsCmdPath(t, cmd.Path)
 		assert.Contains(t, cmd.Args, "C:\\Program Files\\My App\\test.exe")
 	})
 

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -2021,14 +2021,15 @@ paths:
         - $ref: '#/components/parameters/instanceID'
         - name: contentPath
           in: query
-          required: false
-          description: Instance-relative content path (alias of content_path)
+          required: true
+          description: "Canonical instance-relative content path parameter (legacy alias: content_path)"
           schema:
             type: string
         - name: content_path
           in: query
+          deprecated: true
           required: false
-          description: Legacy alias of contentPath
+          description: Legacy alias for contentPath (maps to the canonical contentPath parameter)
           schema:
             type: string
       responses:

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -2067,7 +2067,7 @@ paths:
         - name: contentPath
           in: query
           required: false
-          description: Instance-relative content path (alias of content_path)
+          description: "Canonical instance-relative content path (legacy alias: content_path)"
           schema:
             type: string
         - name: content_path
@@ -2076,6 +2076,29 @@ paths:
           description: Legacy alias of contentPath
           schema:
             type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                contentPath:
+                  type: string
+                  description: Canonical instance-relative content path
+                content_path:
+                  type: string
+                  description: Legacy alias for contentPath
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                contentPath:
+                  type: string
+                  description: Canonical instance-relative content path
+                content_path:
+                  type: string
+                  description: Legacy alias for contentPath
       responses:
         '200':
           description: MediaInfo summary and JSON

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -2008,6 +2008,91 @@ paths:
         '500':
           description: Internal server error
 
+  /api/instances/{instanceID}/mediainfo:
+    get:
+      tags:
+        - Torrent Details
+      summary: Get MediaInfo for an instance content path
+      description: >
+        Analyzes a file from an instance-relative content path and returns both text summary and parsed
+        MediaInfo JSON output.
+        Requires the instance to have local filesystem access enabled.
+      parameters:
+        - $ref: '#/components/parameters/instanceID'
+        - name: contentPath
+          in: query
+          required: false
+          description: Instance-relative content path (alias of content_path)
+          schema:
+            type: string
+        - name: content_path
+          in: query
+          required: false
+          description: Legacy alias of contentPath
+          schema:
+            type: string
+      responses:
+        '200':
+          description: MediaInfo summary and JSON
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContentPathMediaInfoResponse'
+        '400':
+          description: Invalid instance ID or content path
+        '403':
+          description: Instance does not have local filesystem access
+        '404':
+          description: File not found on disk
+        '500':
+          description: Internal server error
+
+  /proxy/{api-key}/api/v2/torrents/mediainfo:
+    get:
+      tags:
+        - Proxy
+      summary: Get MediaInfo via proxy API key
+      description: >
+        Returns MediaInfo summary text and JSON output for an instance-relative content path using
+        a client API key in the proxy path.
+      security: []
+      parameters:
+        - name: api-key
+          in: path
+          required: true
+          description: Client API key created in qui client API keys.
+          schema:
+            type: string
+        - name: contentPath
+          in: query
+          required: false
+          description: Instance-relative content path (alias of content_path)
+          schema:
+            type: string
+        - name: content_path
+          in: query
+          required: false
+          description: Legacy alias of contentPath
+          schema:
+            type: string
+      responses:
+        '200':
+          description: MediaInfo summary and JSON
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContentPathMediaInfoResponse'
+        '400':
+          description: Invalid content path
+        '401':
+          description: Missing or invalid client API key
+        '403':
+          description: Instance does not have local filesystem access
+        '404':
+          description: Instance or file not found
+        '500':
+          description: Internal server error
+
   /api/instances/{instanceID}/torrents/{hash}/rename:
     put:
       tags:
@@ -5583,6 +5668,33 @@ components:
           type: string
           description: Raw MediaInfo JSON output
 
+    ContentPathMediaInfoRequest:
+      type: object
+      required:
+        - contentPath
+      properties:
+        contentPath:
+          type: string
+          description: Instance-relative file path to analyze
+
+    ContentPathMediaInfoResponse:
+      type: object
+      required:
+        - contentPath
+        - summaryTxt
+        - mediaInfoJson
+      properties:
+        contentPath:
+          type: string
+          description: Normalized instance-relative file path that was analyzed
+        summaryTxt:
+          type: string
+          description: Human-readable MediaInfo text summary
+        mediaInfoJson:
+          type: object
+          description: Parsed MediaInfo JSON output
+          additionalProperties: true
+
     DuplicateTorrentMatch:
       type: object
       properties:
@@ -7550,3 +7662,5 @@ tags:
     description: RSS feed and auto-download rule management
   - name: Theme Licenses
     description: Theme license management (optional feature)
+  - name: Proxy
+    description: qBittorrent-compatible proxy endpoints authenticated by client API key


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MediaInfo endpoints to retrieve detailed media information by content path for instances and via a qBittorrent-compatible proxy (API-key). Responses include contentPath, MediaInfo summary text, and full MediaInfo JSON.

* **Documentation**
  * Updated API docs and schemas to expose the new MediaInfo endpoints, request/response models, and a new "Proxy" API tag.

* **Tests**
  * Added comprehensive unit tests for content-path parsing, validation, resolution, symlink safety, and MediaInfo responses.

* **Bug Fixes**
  * Improved error handling for missing preferences/sync configuration and tightened access/path validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->