### PR TITLE
docs(cross-seed): clarify Prowlarr filter behavior

### DIFF
--- a/documentation/docs/features/cross-seed/overview.md
+++ b/documentation/docs/features/cross-seed/overview.md
@@ -28,6 +28,12 @@ Disc-based media (Blu-ray/DVD) requires manual verification. See [troubleshootin
 
 You need Prowlarr or Jackett to provide Torznab indexer feeds. Add your indexers in **Settings → Indexers** using the "1-click sync" feature to import from Prowlarr/Jackett automatically.
 
+:::note Prowlarr indexer filters are preserved
+When using Prowlarr-backed indexers, qui searches the exact Prowlarr indexer you selected. Any tracker-side filter configured on that Prowlarr entry, such as **freeleech only**, still applies during cross-seed searches.
+
+If you keep separate Prowlarr entries for normal grabbing vs cross-seed/manual searching, select the non-filtered variant for qui cross-seed workflows.
+:::
+
 Optional: qui can also query OPS/RED via the trackers' Gazelle JSON APIs. This complements Torznab (and excludes OPS/RED Torznab indexers for per-torrent searches only when **both** Gazelle keys are configured). See [OPS/RED (Gazelle)](gazelle-ops-red).
 
 **Optional but recommended:** Configure Sonarr/Radarr instances in **Settings → Integrations** to enable external ID lookups (IMDb, TMDb, TVDb, TVMaze). When configured, qui queries your *arr instances to resolve IDs for cross-seed searches, improving match accuracy on indexers that support ID-based queries.

--- a/documentation/docs/features/cross-seed/troubleshooting.md
+++ b/documentation/docs/features/cross-seed/troubleshooting.md
@@ -26,6 +26,12 @@ qui uses strict matching to ensure cross-seeds have identical files. Both releas
 
 By default, season packs only match other season packs. Enable **Find individual episodes** in settings to allow season packs to match individual episode releases.
 
+### Prowlarr entry filters removed expected results
+
+When using Prowlarr-backed indexers, qui searches the exact Prowlarr indexer you selected. If that Prowlarr entry is configured with tracker-side restrictions such as **freeleech only**, those restrictions still apply during cross-seed searches.
+
+If you expect non-freeleech matches to appear for cross-seeding, use an unfiltered Prowlarr entry for qui or maintain a separate search/cross-seed variant of that tracker in Prowlarr.
+
 ## How do I see why a release was filtered?
 
 Enable trace logging to see detailed rejection reasons:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how Prowlarr indexer filters are preserved during cross-seed searches.
  * Added troubleshooting guidance explaining tracker-side restrictions apply to cross-seed operations.
  * Provided recommendations for using non-filtered variants or separate entries for cross-seed workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->