### PR TITLE
fix(orphan-scan): simplify qBittorrent readiness handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,13 @@ Keep Go code `gofmt`-clean with PascalCase exports, camelCase locals, and packag
 
 **Single-user self-hosted context:** qui runs on someone's home server, not as a multi-tenant SaaS with untrusted input and complex failure modes. Skip paranoid defensive programming for impossible or purely theoretical scenarios. Code that guards against states that can't happen adds complexity without value. Prioritize readable, maintainable code over excessive robustness.
 
+## Code Shape
+
+- Prefer behavior-bearing branches only. If multiple `switch` cases return the same value as `default`, collapse them.
+- In boolean classifiers, list only the exceptional cases (`true` cases or error cases). Let `default` handle the common path.
+- Do not add documentation-only branches unless they enforce something mechanically via compiler, linter, or tests.
+- When a branch only enumerates known states, ask whether it changes behavior, improves safety, or provides exhaustiveness checking. If not, delete it.
+
 ## React Effects
 
 - Use `useEffect` only to sync with external systems (DOM, subscriptions, network).

--- a/internal/qbittorrent/client.go
+++ b/internal/qbittorrent/client.go
@@ -51,7 +51,6 @@ type Client struct {
 	trackerIncludeSupported  bool
 	supportsSetRSSFeedURL    bool
 	lastHealthCheck          time.Time
-	lastRecoveryTime         time.Time // When client transitioned from unhealthy→healthy (or was created)
 	isHealthy                bool
 	syncManager              *qbt.SyncManager
 	peerSyncManager          map[string]*qbt.PeerSyncManager // Map of torrent hash to PeerSyncManager
@@ -102,11 +101,10 @@ func NewClientWithTimeout(instanceID int, instanceHost, username, password strin
 	}
 
 	client := &Client{
-		Client:           qbtClient,
-		instanceID:       instanceID,
-		lastHealthCheck:  time.Now(),
-		lastRecoveryTime: time.Now(), // Treat fresh client as "just recovered"
-		isHealthy:        true,
+		Client:          qbtClient,
+		instanceID:      instanceID,
+		lastHealthCheck: time.Now(),
+		isHealthy:       true,
 		optimisticUpdates: ttlcache.New(ttlcache.Options[string, *OptimisticTorrentUpdate]{}.
 			SetDefaultTTL(30 * time.Second)), // Updates expire after 30 seconds
 		trackerExclusions: make(map[string]map[string]struct{}),
@@ -186,11 +184,6 @@ func (c *Client) updateHealthStatus(healthy bool) {
 	c.healthMu.Lock()
 	defer c.healthMu.Unlock()
 
-	// Track recovery time when transitioning to healthy
-	if healthy && !c.isHealthy {
-		c.lastRecoveryTime = time.Now()
-	}
-
 	c.isHealthy = healthy
 	c.lastHealthCheck = time.Now()
 }
@@ -199,12 +192,6 @@ func (c *Client) IsHealthy() bool {
 	c.healthMu.RLock()
 	defer c.healthMu.RUnlock()
 	return c.isHealthy
-}
-
-func (c *Client) GetLastRecoveryTime() time.Time {
-	c.healthMu.RLock()
-	defer c.healthMu.RUnlock()
-	return c.lastRecoveryTime
 }
 
 func (c *Client) SupportsTorrentCreation() bool {

--- a/internal/services/orphanscan/config.go
+++ b/internal/services/orphanscan/config.go
@@ -5,30 +5,9 @@ package orphanscan
 
 import "time"
 
-// Safety constants for orphan scan readiness checks.
-// These are intentionally non-configurable to prevent data loss.
+// MaxSyncAge is the maximum age of sync data trusted by orphan scan readiness checks.
 const (
-	// RecoveryGracePeriod is how long to wait after qBit client recovers before scanning.
-	RecoveryGracePeriod = 3 * time.Minute
-
-	// SettlingSampleInterval is the time between stability samples.
-	SettlingSampleInterval = 20 * time.Second
-
-	// SettlingSampleCount is the number of samples to take (4 × 20s = ~60s window).
-	SettlingSampleCount = 4
-
-	// MaxSyncAge is the maximum age of sync data for it to be trusted.
 	MaxSyncAge = 2 * time.Minute
-
-	// MaxCheckingStatePercent is the threshold for torrents in checking states.
-	MaxCheckingStatePercent = 5.0
-
-	// MaxMissingFilesCount is the maximum number of eligible torrents allowed to have no files.
-	// Zero tolerance: any missing files = partial data detected = fail scan.
-	MaxMissingFilesCount = 0
-
-	// SettlingCountToleranceMin is the minimum tolerance for count fluctuations.
-	SettlingCountToleranceMin = 10
 )
 
 // Config holds the service configuration.

--- a/internal/services/orphanscan/service.go
+++ b/internal/services/orphanscan/service.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -29,7 +28,6 @@ import (
 // Extracted as an interface to enable unit testing without a real qBittorrent connection.
 type healthChecker interface {
 	IsHealthy() bool
-	GetLastRecoveryTime() time.Time
 	GetLastSyncUpdate() time.Time
 }
 
@@ -48,11 +46,6 @@ type Service struct {
 	// In-memory cancel handles keyed by runID
 	cancelFuncs map[int64]context.CancelFunc
 	cancelMu    sync.Mutex
-
-	// Memoize "settled" status per instance/recovery to avoid repeating the 60s settling check
-	// on every scan. This resets automatically when the client recovers (recovery time changes).
-	settledMu           sync.RWMutex
-	settledRecoveryTime map[int]time.Time
 
 	// Providers for testing (nil = use real sync manager)
 	getAllTorrentsProvider       func(ctx context.Context, instanceID int) ([]qbt.Torrent, error)
@@ -74,50 +67,14 @@ func NewService(cfg Config, instanceStore *models.InstanceStore, store *models.O
 		cfg.StuckRunThreshold = DefaultConfig().StuckRunThreshold
 	}
 	return &Service{
-		cfg:                 cfg,
-		instanceStore:       instanceStore,
-		store:               store,
-		syncManager:         syncManager,
-		notifier:            notifier,
-		instanceMu:          make(map[int]*sync.Mutex),
-		cancelFuncs:         make(map[int64]context.CancelFunc),
-		settledRecoveryTime: make(map[int]time.Time),
+		cfg:           cfg,
+		instanceStore: instanceStore,
+		store:         store,
+		syncManager:   syncManager,
+		notifier:      notifier,
+		instanceMu:    make(map[int]*sync.Mutex),
+		cancelFuncs:   make(map[int64]context.CancelFunc),
 	}
-}
-
-func (s *Service) isSettledForRecovery(instanceID int, recoveryTime time.Time) bool {
-	if recoveryTime.IsZero() {
-		return false
-	}
-
-	s.settledMu.RLock()
-	settledRecoveryTime, ok := s.settledRecoveryTime[instanceID]
-	s.settledMu.RUnlock()
-
-	return ok && settledRecoveryTime.Equal(recoveryTime)
-}
-
-func (s *Service) markSettledForRecovery(instanceID int, recoveryTime time.Time) {
-	if recoveryTime.IsZero() {
-		return
-	}
-
-	s.settledMu.Lock()
-	s.settledRecoveryTime[instanceID] = recoveryTime
-	s.settledMu.Unlock()
-}
-
-func (s *Service) clearSettledForRecovery(instanceID int, recoveryTime time.Time) {
-	if recoveryTime.IsZero() {
-		return
-	}
-
-	s.settledMu.Lock()
-	settledRecoveryTime, ok := s.settledRecoveryTime[instanceID]
-	if ok && settledRecoveryTime.Equal(recoveryTime) {
-		delete(s.settledRecoveryTime, instanceID)
-	}
-	s.settledMu.Unlock()
 }
 
 // getAllTorrents returns all torrents for an instance, using the provider if set.
@@ -340,32 +297,11 @@ func (s *Service) checkScheduledScans(ctx context.Context) {
 				return
 			}
 
-			// Pre-check 2: Readiness gates (health, recovery grace, sync freshness)
+			// Pre-check 2: Readiness gates (health + fresh sync)
 			if readinessErr := checkReadinessGates(client); readinessErr != nil {
 				log.Debug().Err(readinessErr).Int("instance", scan.instanceID).
 					Msg("orphanscan: skipping scheduled scan (readiness check failed)")
 				return
-			}
-
-			recoveryTime := client.GetLastRecoveryTime()
-			if !s.isSettledForRecovery(scan.instanceID, recoveryTime) {
-				// Pre-check 3: Settling (expensive - samples 4x over 60s)
-				settleResult, settleErr := s.checkSettled(ctx, scan.instanceID, client)
-				if settleErr != nil {
-					log.Debug().Err(settleErr).Int("instance", scan.instanceID).
-						Msg("orphanscan: skipping scheduled scan (settling check error)")
-					return
-				}
-				if !settleResult.settled {
-					log.Debug().
-						Int("instance", scan.instanceID).
-						Str("reason", settleResult.reason).
-						Msg("orphanscan: skipping scheduled scan (not settled)")
-					return
-				}
-
-				// Avoid a second 60s settling loop inside buildFileMap for this scheduled run.
-				s.markSettledForRecovery(scan.instanceID, recoveryTime)
 			}
 
 			// All pre-checks passed - now safe to create run and execute
@@ -565,6 +501,15 @@ func (s *Service) executeScan(ctx context.Context, instanceID int, runID int64) 
 		Int("torrentCount", result.torrentCount).
 		Msg("orphanscan: built file map")
 
+	if len(result.skippedRoots) > 0 {
+		warnMsg := fmt.Sprintf(
+			"Skipped %d scan path(s) because qBittorrent had transitional torrents with unavailable file lists:\n%s",
+			len(result.skippedRoots),
+			strings.Join(result.skippedRoots, "\n"),
+		)
+		s.warnRun(ctx, runID, warnMsg)
+	}
+
 	// Update scan paths
 	if err := s.store.UpdateRunScanPaths(ctx, runID, scanRoots); err != nil {
 		log.Error().Err(err).Msg("orphanscan: failed to update scan paths")
@@ -572,6 +517,10 @@ func (s *Service) executeScan(ctx context.Context, instanceID int, runID int64) 
 
 	if len(scanRoots) == 0 {
 		log.Warn().Msg("orphanscan: no scan roots found")
+		if len(result.skippedRoots) > 0 {
+			s.failRun(ctx, runID, instanceID, "no scan roots available: qBittorrent still has transitional torrents with unavailable file lists")
+			return
+		}
 		s.failRun(ctx, runID, instanceID, "no scan roots found (no torrents with absolute save paths)")
 		return
 	}
@@ -1081,36 +1030,16 @@ func (s *Service) updateFileStatus(ctx context.Context, fileID int64, status, er
 	}
 }
 
-// settlingResult contains the result of stability sampling
-type settlingResult struct {
-	settled        bool
-	reason         string
-	torrents       []qbt.Torrent // Final torrent list (reuse in buildFileMap)
-	maxCheckingPct float64       // Max checking% seen across all samples
-}
-
-// checkReadinessGates performs cheap pre-checks before expensive settling.
-// Returns nil if all checks pass, otherwise an error describing the failure.
+// checkReadinessGates performs cheap pre-checks before building a file map.
 func checkReadinessGates(client healthChecker) error {
 	if !client.IsHealthy() {
 		return errors.New("qBittorrent client is unhealthy")
-	}
-
-	recoveryTime := client.GetLastRecoveryTime()
-	if !recoveryTime.IsZero() && time.Since(recoveryTime) < RecoveryGracePeriod {
-		return fmt.Errorf(
-			"qBittorrent recovered %v ago, waiting for grace period (%v)",
-			time.Since(recoveryTime).Round(time.Second), RecoveryGracePeriod)
 	}
 
 	lastSync := client.GetLastSyncUpdate()
 	if lastSync.IsZero() {
 		return errors.New("instance not ready: waiting for first sync")
 	}
-	if !recoveryTime.IsZero() && lastSync.Before(recoveryTime) {
-		return errors.New("instance not ready: waiting for sync after recovery")
-	}
-
 	if time.Since(lastSync) > MaxSyncAge {
 		return fmt.Errorf("sync data stale (last sync %v ago, threshold %v)",
 			time.Since(lastSync).Round(time.Second), MaxSyncAge)
@@ -1119,164 +1048,102 @@ func checkReadinessGates(client healthChecker) error {
 	return nil
 }
 
-// SampleStats holds statistics from a single torrent sample.
-// Exported for testing.
-type SampleStats struct {
-	Count       int
-	CheckingPct float64
-	MetaDlPct   float64
+func isTransientTorrentStateForOrphanScan(state qbt.TorrentState) bool {
+	switch state {
+	case qbt.TorrentStateMetaDl,
+		qbt.TorrentStateCheckingResumeData,
+		qbt.TorrentStateCheckingDl,
+		qbt.TorrentStateCheckingUp,
+		qbt.TorrentStateAllocating,
+		qbt.TorrentStateMoving:
+		return true
+	case qbt.TorrentStateError,
+		qbt.TorrentStateMissingFiles,
+		qbt.TorrentStateUploading,
+		qbt.TorrentStatePausedUp,
+		qbt.TorrentStateStoppedUp,
+		qbt.TorrentStateQueuedUp,
+		qbt.TorrentStateStalledUp,
+		qbt.TorrentStateForcedUp,
+		qbt.TorrentStateDownloading,
+		qbt.TorrentStatePausedDl,
+		qbt.TorrentStateStoppedDl,
+		qbt.TorrentStateQueuedDl,
+		qbt.TorrentStateStalledDl,
+		qbt.TorrentStateForcedDl,
+		qbt.TorrentStateUnknown:
+		return false
+	default:
+		return false
+	}
 }
 
-// EvaluateSettlingSamples analyzes sample statistics to determine if qBit is settled.
-// This is a pure function extracted for testability.
-// syncAge is time since last sync (pass time.Since(lastSyncTime) from caller).
-func EvaluateSettlingSamples(stats []SampleStats, syncAge time.Duration) (settled bool, reason string, maxCheckingPct float64) {
-	if len(stats) == 0 {
-		return false, "no samples provided", 0
+func sortedRoots(roots map[string]struct{}) []string {
+	items := make([]string, 0, len(roots))
+	for root := range roots {
+		items = append(items, root)
 	}
-
-	// Check 1: Zero torrents is always suspicious
-	if stats[len(stats)-1].Count == 0 {
-		return false, "no torrents returned - instance not ready", 0
-	}
-
-	// Check 2: Samples must be stable within tolerance and detect batch loading
-	seriesStr, minMax, batchJump := analyzeCountSeries(stats)
-	tolerance := max(minMax.max/1000, SettlingCountToleranceMin) // 0.1% or minimum
-	if minMax.max-minMax.min > tolerance {
-		return false, fmt.Sprintf("torrent count not stable: [%s] (delta %d > tolerance %d)",
-			seriesStr, minMax.max-minMax.min, tolerance), 0
-	}
-	if batchJump > 0 {
-		return false, fmt.Sprintf("torrent count jump of %d detected: [%s] (batch loading)", batchJump, seriesStr), 0
-	}
-
-	// Check 3: Max checking% across ALL samples must be below threshold
-	for _, st := range stats {
-		maxCheckingPct = max(maxCheckingPct, st.CheckingPct)
-	}
-	if maxCheckingPct > MaxCheckingStatePercent {
-		return false, fmt.Sprintf("%.1f%% of torrents in checking state (threshold: %.1f%%)",
-			maxCheckingPct, MaxCheckingStatePercent), maxCheckingPct
-	}
-
-	// Check 4: Sync must be recent
-	if syncAge > MaxSyncAge {
-		return false, fmt.Sprintf("sync data stale (last sync %v ago, threshold %v)",
-			syncAge.Round(time.Second), MaxSyncAge), maxCheckingPct
-	}
-
-	return true, "", maxCheckingPct
-}
-
-// countMinMax holds min/max values from sample analysis.
-type countMinMax struct{ min, max int }
-
-// analyzeCountSeries computes count series string, min/max, and detects batch loading jumps.
-// Returns the series string, min/max values, and first batch jump >= 50 (or 0 if none).
-func analyzeCountSeries(stats []SampleStats) (seriesStr string, minMax countMinMax, batchJump int) {
-	counts := make([]string, len(stats))
-	minMax = countMinMax{min: stats[0].Count, max: stats[0].Count}
-
-	for i, st := range stats {
-		counts[i] = strconv.Itoa(st.Count)
-		minMax.min = min(minMax.min, st.Count)
-		minMax.max = max(minMax.max, st.Count)
-
-		// Detect batch loading (step increase >= 50)
-		if i > 0 && batchJump == 0 {
-			if jump := st.Count - stats[i-1].Count; jump >= 50 {
-				batchJump = jump
-			}
-		}
-	}
-
-	return strings.Join(counts, ", "), minMax, batchJump
-}
-
-// countTorrentStates counts torrents in checking/loading and metaDL states.
-func countTorrentStates(torrents []qbt.Torrent) (checkingCount, metaDlCount int) {
-	for i := range torrents {
-		switch torrents[i].State {
-		case qbt.TorrentStateCheckingResumeData,
-			qbt.TorrentStateCheckingDl,
-			qbt.TorrentStateCheckingUp,
-			qbt.TorrentStateAllocating:
-			checkingCount++
-		case qbt.TorrentStateMetaDl:
-			metaDlCount++
-		default:
-			// Other states don't affect settling check
-		}
-	}
-	return checkingCount, metaDlCount
-}
-
-// calculateStatePercentages computes checking and metaDL percentages.
-func calculateStatePercentages(total, checkingCount, metaDlCount int) (checkingPct, metaDlPct float64) {
-	if total > 0 {
-		checkingPct = float64(checkingCount) / float64(total) * 100
-		metaDlPct = float64(metaDlCount) / float64(total) * 100
-	}
-	return checkingPct, metaDlPct
-}
-
-// checkSettled samples torrent state multiple times to ensure qBit has finished loading.
-// Returns error if context cancelled, otherwise returns settlingResult with final torrent list.
-// Takes client to check sync freshness at the end.
-func (s *Service) checkSettled(ctx context.Context, instanceID int, client healthChecker) (*settlingResult, error) {
-	var stats []SampleStats
-	var finalTorrents []qbt.Torrent
-
-	for i := range SettlingSampleCount {
-		if i > 0 {
-			select {
-			case <-ctx.Done():
-				return nil, fmt.Errorf("settling check canceled: %w", ctx.Err())
-			case <-time.After(SettlingSampleInterval):
-			}
-		}
-
-		torrents, err := s.getAllTorrents(ctx, instanceID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get torrents (sample %d): %w", i+1, err)
-		}
-
-		checkingCount, metaDlCount := countTorrentStates(torrents)
-		checkingPct, metaDlPct := calculateStatePercentages(len(torrents), checkingCount, metaDlCount)
-
-		stats = append(stats, SampleStats{
-			Count:       len(torrents),
-			CheckingPct: checkingPct,
-			MetaDlPct:   metaDlPct,
-		})
-		finalTorrents = torrents
-
-		log.Debug().
-			Int("sample", i+1).
-			Int("count", len(torrents)).
-			Int("checking", checkingCount).
-			Int("metaDl", metaDlCount).
-			Float64("checkingPct", checkingPct).
-			Float64("metaDlPct", metaDlPct).
-			Msg("orphanscan: settling sample")
-	}
-
-	// Use pure function for evaluation
-	settled, reason, maxCheckingPct := EvaluateSettlingSamples(stats, time.Since(client.GetLastSyncUpdate()))
-	return &settlingResult{
-		settled:        settled,
-		reason:         reason,
-		torrents:       finalTorrents,
-		maxCheckingPct: maxCheckingPct,
-	}, nil
+	sort.Strings(items)
+	return items
 }
 
 // buildFileMapResult contains the file map plus metadata for storage
 type buildFileMapResult struct {
 	fileMap      *TorrentFileMap
 	scanRoots    []string
+	skippedRoots []string
 	torrentCount int
+}
+
+func buildFileMapFromTorrents(torrents []qbt.Torrent, filesByHash map[string]qbt.TorrentFiles) (*buildFileMapResult, error) {
+	tfm := NewTorrentFileMap()
+	scanRoots := make(map[string]struct{})
+	skippedRoots := make(map[string]struct{})
+	stableMissingFiles := 0
+
+	for i := range torrents {
+		torrent := torrents[i]
+		savePath := filepath.Clean(torrent.SavePath)
+		hasAbsSavePath := savePath != "" && filepath.IsAbs(savePath)
+		files, ok := filesByHash[canonicalizeHash(torrent.Hash)]
+		hasFiles := ok && len(files) > 0
+
+		if !hasFiles {
+			if isTransientTorrentStateForOrphanScan(torrent.State) {
+				if hasAbsSavePath {
+					skippedRoots[savePath] = struct{}{}
+				}
+				continue
+			}
+
+			stableMissingFiles++
+			continue
+		}
+
+		if !hasAbsSavePath {
+			continue
+		}
+
+		scanRoots[savePath] = struct{}{}
+		for _, f := range files {
+			tfm.Add(normalizePath(filepath.Join(savePath, f.Name)))
+		}
+	}
+
+	if stableMissingFiles > 0 {
+		return nil, fmt.Errorf("%d stable torrents returned no files - partial data detected", stableMissingFiles)
+	}
+
+	for root := range skippedRoots {
+		delete(scanRoots, root)
+	}
+
+	return &buildFileMapResult{
+		fileMap:      tfm,
+		scanRoots:    sortedRoots(scanRoots),
+		skippedRoots: sortedRoots(skippedRoots),
+		torrentCount: len(torrents),
+	}, nil
 }
 
 func (s *Service) getOtherLocalInstances(ctx context.Context, excludeInstanceID int) ([]*models.Instance, error) {
@@ -1317,7 +1184,7 @@ func (s *Service) buildInstanceScanRoots(ctx context.Context, instanceID int, ti
 		return nil, fmt.Errorf("failed to get torrents: %w", err)
 	}
 	if len(torrents) == 0 {
-		return nil, fmt.Errorf("no torrents returned - instance not ready")
+		return nil, errors.New("no torrents returned - instance not ready")
 	}
 
 	return scanRootsFromTorrents(torrents), nil
@@ -1340,7 +1207,7 @@ func (s *Service) instanceScanRootsForOverlap(ctx context.Context, instanceID in
 	return lastRun.ScanPaths, "last_completed_run", nil
 }
 
-func (s *Service) buildInstanceScanRootsSettled(ctx context.Context, instanceID int, timeout time.Duration) (roots []string, err error) {
+func (s *Service) buildInstanceFileMap(ctx context.Context, instanceID int, timeout time.Duration) (*buildFileMapResult, error) {
 	if timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, timeout)
@@ -1351,112 +1218,25 @@ func (s *Service) buildInstanceScanRootsSettled(ctx context.Context, instanceID 
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client: %w", err)
 	}
-
-	recoveryTime := client.GetLastRecoveryTime()
-	defer func() {
-		if err != nil {
-			s.clearSettledForRecovery(instanceID, recoveryTime)
-		}
-	}()
-
 	if readinessErr := checkReadinessGates(client); readinessErr != nil {
 		return nil, readinessErr
 	}
 
-	var torrents []qbt.Torrent
-	if s.isSettledForRecovery(instanceID, recoveryTime) {
-		torrents, err = s.getAllTorrents(ctx, instanceID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get torrents: %w", err)
-		}
-		if len(torrents) == 0 {
-			return nil, fmt.Errorf("no torrents returned - instance not ready")
-		}
-	} else {
-		settleResult, settleErr := s.checkSettled(ctx, instanceID, client)
-		if settleErr != nil {
-			return nil, fmt.Errorf("settling check failed: %w", settleErr)
-		}
-		if !settleResult.settled {
-			return nil, fmt.Errorf("instance not settled: %s", settleResult.reason)
-		}
-		torrents = settleResult.torrents
-	}
-
-	roots = scanRootsFromTorrents(torrents)
-	s.markSettledForRecovery(instanceID, recoveryTime)
-	return roots, nil
-}
-
-func (s *Service) buildInstanceFileMap(ctx context.Context, instanceID int, timeout time.Duration) (result *buildFileMapResult, err error) {
-	if timeout > 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, timeout)
-		defer cancel()
-	}
-
-	// Step 1: Get client and verify readiness
-	client, err := s.getClient(ctx, instanceID)
+	torrents, err := s.getAllTorrents(ctx, instanceID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get client: %w", err)
+		return nil, fmt.Errorf("failed to get torrents: %w", err)
 	}
-	recoveryTime := client.GetLastRecoveryTime()
-	defer func() {
-		if err != nil {
-			s.clearSettledForRecovery(instanceID, recoveryTime)
-		}
-	}()
-
-	if readinessErr := checkReadinessGates(client); readinessErr != nil {
-		return nil, readinessErr
+	if len(torrents) == 0 {
+		return nil, errors.New("no torrents returned - instance not ready")
 	}
-
-	var torrents []qbt.Torrent
-	if s.isSettledForRecovery(instanceID, recoveryTime) {
-		torrents, err = s.getAllTorrents(ctx, instanceID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get torrents: %w", err)
-		}
-		if len(torrents) == 0 {
-			return nil, fmt.Errorf("no torrents returned - instance not ready")
-		}
-		log.Debug().
-			Int("torrentCount", len(torrents)).
-			Msg("orphanscan: skipping settling check (already settled)")
-	} else {
-		// Step 2: Run settling check (samples torrent state multiple times)
-		settleResult, settleErr := s.checkSettled(ctx, instanceID, client)
-		if settleErr != nil {
-			return nil, fmt.Errorf("settling check failed: %w", settleErr)
-		}
-		if !settleResult.settled {
-			return nil, fmt.Errorf("instance not settled: %s", settleResult.reason)
-		}
-
-		log.Info().
-			Int("torrentCount", len(settleResult.torrents)).
-			Float64("maxCheckingPct", settleResult.maxCheckingPct).
-			Msg("orphanscan: settling check passed")
-		torrents = settleResult.torrents
-	}
-
-	// Step 3: Fetch and validate file data
-	hashToTorrent, hashes := buildTorrentHashLookup(torrents)
 
 	filesCtx := qbittorrent.WithForceFilesRefresh(ctx)
-	filesByHash, err := s.getTorrentFilesBatch(filesCtx, instanceID, hashes)
+	filesByHash, err := s.getTorrentFilesBatch(filesCtx, instanceID, torrentHashes(torrents))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get torrent files: %w", err)
 	}
 
-	if err := validateFileCompleteness(torrents, filesByHash); err != nil {
-		return nil, err
-	}
-
-	// Step 4: Build file map from validated data
-	result = buildFileMapFromTorrents(hashToTorrent, filesByHash, len(torrents))
-	s.markSettledForRecovery(instanceID, recoveryTime)
-	return result, nil
+	return buildFileMapFromTorrents(torrents, filesByHash)
 }
 
 func (s *Service) buildFileMap(ctx context.Context, instanceID int) (*buildFileMapResult, error) {
@@ -1479,7 +1259,7 @@ func (s *Service) buildFileMap(ctx context.Context, instanceID int) (*buildFileM
 		}
 
 		if !scanRootsOverlap(result.scanRoots, otherRoots) {
-			confirmedRoots, err := s.buildInstanceScanRootsSettled(ctx, inst.ID, 90*time.Second)
+			confirmedRoots, err := s.buildInstanceScanRoots(ctx, inst.ID, 90*time.Second)
 			if err != nil {
 				return nil, fmt.Errorf("could not confirm non-overlapping scan roots for other local-access instance (id=%d name=%q): %w", inst.ID, inst.Name, err)
 			}
@@ -1504,77 +1284,12 @@ func (s *Service) buildFileMap(ctx context.Context, instanceID int) (*buildFileM
 	return result, nil
 }
 
-// buildTorrentHashLookup creates a hash-to-torrent lookup map and hash list.
-func buildTorrentHashLookup(torrents []qbt.Torrent) (hashToTorrent map[string]qbt.Torrent, hashes []string) {
-	hashToTorrent = make(map[string]qbt.Torrent, len(torrents)*2)
-	hashes = make([]string, 0, len(torrents))
+func torrentHashes(torrents []qbt.Torrent) []string {
+	hashes := make([]string, 0, len(torrents))
 	for i := range torrents {
 		hashes = append(hashes, torrents[i].Hash)
-		hashToTorrent[torrents[i].Hash] = torrents[i]
-		hashToTorrent[canonicalizeHash(torrents[i].Hash)] = torrents[i]
 	}
-	return hashToTorrent, hashes
-}
-
-// validateFileCompleteness checks that all eligible torrents have file data.
-func validateFileCompleteness(torrents []qbt.Torrent, filesByHash map[string]qbt.TorrentFiles) error {
-	var missingFilesCount, eligibleCount int
-	for i := range torrents {
-		if torrents[i].State == qbt.TorrentStateMetaDl {
-			continue // Not eligible - legitimately has no files
-		}
-		eligibleCount++
-		canonHash := canonicalizeHash(torrents[i].Hash)
-		if files, ok := filesByHash[canonHash]; !ok || len(files) == 0 {
-			missingFilesCount++
-		}
-	}
-
-	if missingFilesCount > MaxMissingFilesCount {
-		return fmt.Errorf(
-			"%d eligible torrents returned no files - partial data detected (scheduled scans will retry)",
-			missingFilesCount)
-	}
-
-	log.Info().
-		Int("torrents", len(torrents)).
-		Int("eligible", eligibleCount).
-		Int("missingFiles", missingFilesCount).
-		Msg("orphanscan: file map completeness passed")
-	return nil
-}
-
-// buildFileMapFromTorrents constructs the file map and scan roots from torrent data.
-func buildFileMapFromTorrents(hashToTorrent map[string]qbt.Torrent, filesByHash map[string]qbt.TorrentFiles, torrentCount int) *buildFileMapResult {
-	tfm := NewTorrentFileMap()
-	scanRoots := make(map[string]struct{})
-
-	for hash, files := range filesByHash {
-		t, ok := hashToTorrent[hash]
-		if !ok {
-			continue
-		}
-		savePath := filepath.Clean(t.SavePath)
-		if !filepath.IsAbs(savePath) {
-			continue
-		}
-		scanRoots[savePath] = struct{}{}
-
-		for _, f := range files {
-			tfm.Add(normalizePath(filepath.Join(savePath, f.Name)))
-		}
-	}
-
-	roots := make([]string, 0, len(scanRoots))
-	for r := range scanRoots {
-		roots = append(roots, r)
-	}
-
-	return &buildFileMapResult{
-		fileMap:      tfm,
-		scanRoots:    roots,
-		torrentCount: torrentCount,
-	}
+	return hashes
 }
 
 // findScanRoot finds the scan root that contains the given path.

--- a/internal/services/orphanscan/service.go
+++ b/internal/services/orphanscan/service.go
@@ -1048,6 +1048,7 @@ func checkReadinessGates(client healthChecker) error {
 	return nil
 }
 
+//nolint:exhaustive // Only transient torrent states belong here; all others are non-transient.
 func isTransientTorrentStateForOrphanScan(state qbt.TorrentState) bool {
 	switch state {
 	case qbt.TorrentStateMetaDl,

--- a/internal/services/orphanscan/service.go
+++ b/internal/services/orphanscan/service.go
@@ -1202,9 +1202,6 @@ func (s *Service) buildInstanceScanRoots(ctx context.Context, instanceID int, ti
 	if err != nil {
 		return nil, fmt.Errorf("failed to get torrents: %w", err)
 	}
-	if len(torrents) == 0 {
-		return nil, errors.New("no torrents returned - instance not ready")
-	}
 
 	return scanRootsFromTorrents(torrents), nil
 }
@@ -1244,9 +1241,6 @@ func (s *Service) buildInstanceFileMap(ctx context.Context, instanceID int, time
 	torrents, err := s.getAllTorrents(ctx, instanceID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get torrents: %w", err)
-	}
-	if len(torrents) == 0 {
-		return nil, errors.New("no torrents returned - instance not ready")
 	}
 
 	filesCtx := qbittorrent.WithForceFilesRefresh(ctx)

--- a/internal/services/orphanscan/service.go
+++ b/internal/services/orphanscan/service.go
@@ -525,8 +525,10 @@ func (s *Service) executeScan(ctx context.Context, instanceID int, runID int64) 
 		return
 	}
 
+	allIgnorePaths := append(append([]string(nil), settings.IgnorePaths...), result.skippedRoots...)
+
 	// Normalize ignore paths
-	ignorePaths, err := NormalizeIgnorePaths(settings.IgnorePaths)
+	ignorePaths, err := NormalizeIgnorePaths(allIgnorePaths)
 	if err != nil {
 		if ctx.Err() != nil {
 			log.Info().Int64("run", runID).Msg("orphanscan: scan canceled during ignore path normalization")
@@ -1072,6 +1074,39 @@ func sortedRoots(roots map[string]struct{}) []string {
 	return items
 }
 
+func mergeRootLists(rootLists ...[]string) []string {
+	merged := make(map[string]struct{})
+	for _, roots := range rootLists {
+		for _, root := range roots {
+			merged[filepath.Clean(root)] = struct{}{}
+		}
+	}
+	return sortedRoots(merged)
+}
+
+func isSameOrDescendantPath(path, base string) bool {
+	nPath := normalizePath(path)
+	nBase := normalizePath(base)
+	return nPath == nBase || isPathUnderNormalized(nPath, nBase)
+}
+
+func filterScanRootsCoveredBySkippedRoots(scanRoots, skippedRoots []string) []string {
+	filtered := make([]string, 0, len(scanRoots))
+	for _, root := range scanRoots {
+		covered := false
+		for _, skippedRoot := range skippedRoots {
+			if isSameOrDescendantPath(root, skippedRoot) {
+				covered = true
+				break
+			}
+		}
+		if !covered {
+			filtered = append(filtered, filepath.Clean(root))
+		}
+	}
+	return filtered
+}
+
 // buildFileMapResult contains the file map plus metadata for storage
 type buildFileMapResult struct {
 	fileMap      *TorrentFileMap
@@ -1119,14 +1154,13 @@ func buildFileMapFromTorrents(torrents []qbt.Torrent, filesByHash map[string]qbt
 		return nil, fmt.Errorf("%d stable torrents returned no files - partial data detected", stableMissingFiles)
 	}
 
-	for root := range skippedRoots {
-		delete(scanRoots, root)
-	}
+	skippedRootList := sortedRoots(skippedRoots)
+	scanRootList := filterScanRootsCoveredBySkippedRoots(sortedRoots(scanRoots), skippedRootList)
 
 	return &buildFileMapResult{
 		fileMap:      tfm,
-		scanRoots:    sortedRoots(scanRoots),
-		skippedRoots: sortedRoots(skippedRoots),
+		scanRoots:    scanRootList,
+		skippedRoots: skippedRootList,
 		torrentCount: len(torrents),
 	}, nil
 }
@@ -1259,6 +1293,8 @@ func (s *Service) buildFileMap(ctx context.Context, instanceID int) (*buildFileM
 		}
 
 		added := result.fileMap.MergeFrom(otherResult.fileMap)
+		result.skippedRoots = mergeRootLists(result.skippedRoots, otherResult.skippedRoots)
+		result.scanRoots = filterScanRootsCoveredBySkippedRoots(result.scanRoots, result.skippedRoots)
 		log.Debug().
 			Int("instance", inst.ID).
 			Int("filesAdded", added).

--- a/internal/services/orphanscan/service.go
+++ b/internal/services/orphanscan/service.go
@@ -1057,22 +1057,6 @@ func isTransientTorrentStateForOrphanScan(state qbt.TorrentState) bool {
 		qbt.TorrentStateAllocating,
 		qbt.TorrentStateMoving:
 		return true
-	case qbt.TorrentStateError,
-		qbt.TorrentStateMissingFiles,
-		qbt.TorrentStateUploading,
-		qbt.TorrentStatePausedUp,
-		qbt.TorrentStateStoppedUp,
-		qbt.TorrentStateQueuedUp,
-		qbt.TorrentStateStalledUp,
-		qbt.TorrentStateForcedUp,
-		qbt.TorrentStateDownloading,
-		qbt.TorrentStatePausedDl,
-		qbt.TorrentStateStoppedDl,
-		qbt.TorrentStateQueuedDl,
-		qbt.TorrentStateStalledDl,
-		qbt.TorrentStateForcedDl,
-		qbt.TorrentStateUnknown:
-		return false
 	default:
 		return false
 	}

--- a/internal/services/orphanscan/service_cross_instance_test.go
+++ b/internal/services/orphanscan/service_cross_instance_test.go
@@ -100,9 +100,6 @@ func TestBuildFileMap_CrossInstance(t *testing.T) {
 		}
 	}
 
-	svc.markSettledForRecovery(1, recoveryTime)
-	svc.markSettledForRecovery(2, recoveryTime)
-
 	result, err := svc.buildFileMap(context.Background(), 1)
 	if err != nil {
 		t.Fatalf("buildFileMap: %v", err)
@@ -164,8 +161,6 @@ func TestBuildFileMap_BailsWhenOtherLocalInstanceUnavailable(t *testing.T) {
 		}, nil
 	}
 
-	svc.markSettledForRecovery(1, recoveryTime)
-
 	_, err := svc.buildFileMap(context.Background(), 1)
 	if err == nil {
 		t.Fatalf("expected error")
@@ -222,9 +217,6 @@ func TestBuildFileMap_BailsWhenOverlappingInstanceFileMapUnavailable(t *testing.
 			"a": {{Name: "one.mkv", Size: 1}},
 		}, nil
 	}
-
-	svc.markSettledForRecovery(1, recoveryTime)
-	svc.markSettledForRecovery(2, recoveryTime)
 
 	_, err := svc.buildFileMap(context.Background(), 1)
 	if err == nil {
@@ -287,9 +279,6 @@ func TestBuildFileMap_DoesNotMergeWhenNoOverlap(t *testing.T) {
 			return map[string]qbt.TorrentFiles{}, nil
 		}
 	}
-
-	svc.markSettledForRecovery(1, recoveryTime)
-	svc.markSettledForRecovery(2, recoveryTime)
 
 	result, err := svc.buildFileMap(context.Background(), 1)
 	if err != nil {
@@ -355,8 +344,6 @@ func TestBuildFileMap_StaleNonOverlappingRootsDoNotBypassSafety(t *testing.T) {
 			"a": {{Name: "one.mkv", Size: 1}},
 		}, nil
 	}
-
-	svc.markSettledForRecovery(1, recoveryTime)
 
 	_, err := svc.buildFileMap(context.Background(), 1)
 	if err == nil {

--- a/internal/services/orphanscan/service_cross_instance_test.go
+++ b/internal/services/orphanscan/service_cross_instance_test.go
@@ -293,6 +293,142 @@ func TestBuildFileMap_DoesNotMergeWhenNoOverlap(t *testing.T) {
 	}
 }
 
+func TestBuildFileMap_MergesSkippedRootsFromOverlappingInstance(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	stableRoot := filepath.Join(root, "stable")
+	skippedRoot := filepath.Join(stableRoot, "partial")
+
+	svc := NewService(DefaultConfig(), nil, nil, nil, nil)
+
+	now := time.Now()
+	recoveryTime := now.Add(-10 * time.Minute)
+	lastSync := now.Add(-10 * time.Second)
+
+	svc.getClientProvider = func(_ context.Context, _ int) (healthChecker, error) {
+		return stubHealthChecker{
+			healthy:      true,
+			recoveryTime: recoveryTime,
+			lastSync:     lastSync,
+		}, nil
+	}
+
+	svc.listInstancesProvider = func(_ context.Context) ([]*models.Instance, error) {
+		return []*models.Instance{
+			{ID: 1, Name: "one", IsActive: true, HasLocalFilesystemAccess: true},
+			{ID: 2, Name: "two", IsActive: true, HasLocalFilesystemAccess: true},
+		}, nil
+	}
+
+	svc.getAllTorrentsProvider = func(_ context.Context, instanceID int) ([]qbt.Torrent, error) {
+		switch instanceID {
+		case 1:
+			return []qbt.Torrent{{Hash: "A", SavePath: stableRoot, State: qbt.TorrentStatePausedUp}}, nil
+		case 2:
+			return []qbt.Torrent{{Hash: "B", SavePath: skippedRoot, State: qbt.TorrentStateCheckingResumeData}}, nil
+		default:
+			return nil, nil
+		}
+	}
+
+	svc.getTorrentFilesBatchProvider = func(_ context.Context, instanceID int, _ []string) (map[string]qbt.TorrentFiles, error) {
+		switch instanceID {
+		case 1:
+			return map[string]qbt.TorrentFiles{
+				"a": {{Name: "one.mkv", Size: 1}},
+			}, nil
+		case 2:
+			return map[string]qbt.TorrentFiles{}, nil
+		default:
+			return map[string]qbt.TorrentFiles{}, nil
+		}
+	}
+
+	result, err := svc.buildFileMap(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("buildFileMap: %v", err)
+	}
+
+	if !result.fileMap.Has(normalizePath(filepath.Join(stableRoot, "one.mkv"))) {
+		t.Fatalf("expected instance 1 file to be protected")
+	}
+	if !slices.Equal(result.scanRoots, []string{filepath.Clean(stableRoot)}) {
+		t.Fatalf("scanRoots mismatch: got=%v want=%v", result.scanRoots, []string{filepath.Clean(stableRoot)})
+	}
+	if !slices.Equal(result.skippedRoots, []string{filepath.Clean(skippedRoot)}) {
+		t.Fatalf("skippedRoots mismatch: got=%v want=%v", result.skippedRoots, []string{filepath.Clean(skippedRoot)})
+	}
+}
+
+func TestBuildFileMap_DropsScanRootsCoveredByOverlappingSkippedRoots(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	skippedRoot := filepath.Join(root, "partial")
+	stableRoot := filepath.Join(skippedRoot, "complete")
+
+	svc := NewService(DefaultConfig(), nil, nil, nil, nil)
+
+	now := time.Now()
+	recoveryTime := now.Add(-10 * time.Minute)
+	lastSync := now.Add(-10 * time.Second)
+
+	svc.getClientProvider = func(_ context.Context, _ int) (healthChecker, error) {
+		return stubHealthChecker{
+			healthy:      true,
+			recoveryTime: recoveryTime,
+			lastSync:     lastSync,
+		}, nil
+	}
+
+	svc.listInstancesProvider = func(_ context.Context) ([]*models.Instance, error) {
+		return []*models.Instance{
+			{ID: 1, Name: "one", IsActive: true, HasLocalFilesystemAccess: true},
+			{ID: 2, Name: "two", IsActive: true, HasLocalFilesystemAccess: true},
+		}, nil
+	}
+
+	svc.getAllTorrentsProvider = func(_ context.Context, instanceID int) ([]qbt.Torrent, error) {
+		switch instanceID {
+		case 1:
+			return []qbt.Torrent{{Hash: "A", SavePath: stableRoot, State: qbt.TorrentStatePausedUp}}, nil
+		case 2:
+			return []qbt.Torrent{{Hash: "B", SavePath: skippedRoot, State: qbt.TorrentStateCheckingResumeData}}, nil
+		default:
+			return nil, nil
+		}
+	}
+
+	svc.getTorrentFilesBatchProvider = func(_ context.Context, instanceID int, _ []string) (map[string]qbt.TorrentFiles, error) {
+		switch instanceID {
+		case 1:
+			return map[string]qbt.TorrentFiles{
+				"a": {{Name: "one.mkv", Size: 1}},
+			}, nil
+		case 2:
+			return map[string]qbt.TorrentFiles{}, nil
+		default:
+			return map[string]qbt.TorrentFiles{}, nil
+		}
+	}
+
+	result, err := svc.buildFileMap(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("buildFileMap: %v", err)
+	}
+
+	if !result.fileMap.Has(normalizePath(filepath.Join(stableRoot, "one.mkv"))) {
+		t.Fatalf("expected instance 1 file to be protected")
+	}
+	if len(result.scanRoots) != 0 {
+		t.Fatalf("expected scanRoots to be empty, got=%v", result.scanRoots)
+	}
+	if !slices.Equal(result.skippedRoots, []string{filepath.Clean(skippedRoot)}) {
+		t.Fatalf("skippedRoots mismatch: got=%v want=%v", result.skippedRoots, []string{filepath.Clean(skippedRoot)})
+	}
+}
+
 func TestBuildFileMap_StaleNonOverlappingRootsDoNotBypassSafety(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/orphanscan/service_cross_instance_test.go
+++ b/internal/services/orphanscan/service_cross_instance_test.go
@@ -293,6 +293,43 @@ func TestBuildFileMap_DoesNotMergeWhenNoOverlap(t *testing.T) {
 	}
 }
 
+func TestInstanceScanRootsForOverlap_EmptyHealthyInstanceDoesNotUseStaleFallback(t *testing.T) {
+	t.Parallel()
+
+	svc := NewService(DefaultConfig(), nil, nil, nil, nil)
+
+	now := time.Now()
+	recoveryTime := now.Add(-10 * time.Minute)
+	lastSync := now.Add(-10 * time.Second)
+
+	svc.getClientProvider = func(_ context.Context, _ int) (healthChecker, error) {
+		return stubHealthChecker{
+			healthy:      true,
+			recoveryTime: recoveryTime,
+			lastSync:     lastSync,
+		}, nil
+	}
+
+	svc.getAllTorrentsProvider = func(_ context.Context, _ int) ([]qbt.Torrent, error) {
+		return []qbt.Torrent{}, nil
+	}
+
+	svc.getLastCompletedRunProvider = func(_ context.Context, _ int) (*models.OrphanScanRun, error) {
+		return &models.OrphanScanRun{ScanPaths: []string{"/stale/root"}}, nil
+	}
+
+	roots, source, err := svc.instanceScanRootsForOverlap(context.Background(), 2)
+	if err != nil {
+		t.Fatalf("instanceScanRootsForOverlap: %v", err)
+	}
+	if source != "live" {
+		t.Fatalf("source mismatch: got=%q want=%q", source, "live")
+	}
+	if len(roots) != 0 {
+		t.Fatalf("expected no roots for empty instance, got=%v", roots)
+	}
+}
+
 func TestBuildFileMap_MergesSkippedRootsFromOverlappingInstance(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/orphanscan/service_cross_instance_test.go
+++ b/internal/services/orphanscan/service_cross_instance_test.go
@@ -17,14 +17,12 @@ import (
 )
 
 type stubHealthChecker struct {
-	healthy      bool
-	recoveryTime time.Time
-	lastSync     time.Time
+	healthy  bool
+	lastSync time.Time
 }
 
-func (s stubHealthChecker) IsHealthy() bool                { return s.healthy }
-func (s stubHealthChecker) GetLastRecoveryTime() time.Time { return s.recoveryTime }
-func (s stubHealthChecker) GetLastSyncUpdate() time.Time   { return s.lastSync }
+func (s stubHealthChecker) IsHealthy() bool              { return s.healthy }
+func (s stubHealthChecker) GetLastSyncUpdate() time.Time { return s.lastSync }
 
 func TestGetOtherLocalInstances(t *testing.T) {
 	t.Parallel()
@@ -56,14 +54,12 @@ func TestBuildFileMap_CrossInstance(t *testing.T) {
 	svc := NewService(DefaultConfig(), nil, nil, nil, nil)
 
 	now := time.Now()
-	recoveryTime := now.Add(-10 * time.Minute)
 	lastSync := now.Add(-10 * time.Second)
 
 	svc.getClientProvider = func(_ context.Context, _ int) (healthChecker, error) {
 		return stubHealthChecker{
-			healthy:      true,
-			recoveryTime: recoveryTime,
-			lastSync:     lastSync,
+			healthy:  true,
+			lastSync: lastSync,
 		}, nil
 	}
 
@@ -128,7 +124,6 @@ func TestBuildFileMap_BailsWhenOtherLocalInstanceUnavailable(t *testing.T) {
 	svc := NewService(DefaultConfig(), nil, nil, nil, nil)
 
 	now := time.Now()
-	recoveryTime := now.Add(-10 * time.Minute)
 	lastSync := now.Add(-10 * time.Second)
 
 	offlineErr := errors.New("offline")
@@ -138,9 +133,8 @@ func TestBuildFileMap_BailsWhenOtherLocalInstanceUnavailable(t *testing.T) {
 			return nil, offlineErr
 		}
 		return stubHealthChecker{
-			healthy:      true,
-			recoveryTime: recoveryTime,
-			lastSync:     lastSync,
+			healthy:  true,
+			lastSync: lastSync,
 		}, nil
 	}
 
@@ -178,16 +172,14 @@ func TestBuildFileMap_BailsWhenOverlappingInstanceFileMapUnavailable(t *testing.
 	svc := NewService(DefaultConfig(), nil, nil, nil, nil)
 
 	now := time.Now()
-	recoveryTime := now.Add(-10 * time.Minute)
 	lastSync := now.Add(-10 * time.Second)
 
 	offlineErr := errors.New("offline")
 
 	svc.getClientProvider = func(_ context.Context, _ int) (healthChecker, error) {
 		return stubHealthChecker{
-			healthy:      true,
-			recoveryTime: recoveryTime,
-			lastSync:     lastSync,
+			healthy:  true,
+			lastSync: lastSync,
 		}, nil
 	}
 
@@ -236,14 +228,12 @@ func TestBuildFileMap_DoesNotMergeWhenNoOverlap(t *testing.T) {
 	svc := NewService(DefaultConfig(), nil, nil, nil, nil)
 
 	now := time.Now()
-	recoveryTime := now.Add(-10 * time.Minute)
 	lastSync := now.Add(-10 * time.Second)
 
 	svc.getClientProvider = func(_ context.Context, _ int) (healthChecker, error) {
 		return stubHealthChecker{
-			healthy:      true,
-			recoveryTime: recoveryTime,
-			lastSync:     lastSync,
+			healthy:  true,
+			lastSync: lastSync,
 		}, nil
 	}
 
@@ -299,14 +289,12 @@ func TestInstanceScanRootsForOverlap_EmptyHealthyInstanceDoesNotUseStaleFallback
 	svc := NewService(DefaultConfig(), nil, nil, nil, nil)
 
 	now := time.Now()
-	recoveryTime := now.Add(-10 * time.Minute)
 	lastSync := now.Add(-10 * time.Second)
 
 	svc.getClientProvider = func(_ context.Context, _ int) (healthChecker, error) {
 		return stubHealthChecker{
-			healthy:      true,
-			recoveryTime: recoveryTime,
-			lastSync:     lastSync,
+			healthy:  true,
+			lastSync: lastSync,
 		}, nil
 	}
 
@@ -340,14 +328,12 @@ func TestBuildFileMap_MergesSkippedRootsFromOverlappingInstance(t *testing.T) {
 	svc := NewService(DefaultConfig(), nil, nil, nil, nil)
 
 	now := time.Now()
-	recoveryTime := now.Add(-10 * time.Minute)
 	lastSync := now.Add(-10 * time.Second)
 
 	svc.getClientProvider = func(_ context.Context, _ int) (healthChecker, error) {
 		return stubHealthChecker{
-			healthy:      true,
-			recoveryTime: recoveryTime,
-			lastSync:     lastSync,
+			healthy:  true,
+			lastSync: lastSync,
 		}, nil
 	}
 
@@ -408,14 +394,12 @@ func TestBuildFileMap_DropsScanRootsCoveredByOverlappingSkippedRoots(t *testing.
 	svc := NewService(DefaultConfig(), nil, nil, nil, nil)
 
 	now := time.Now()
-	recoveryTime := now.Add(-10 * time.Minute)
 	lastSync := now.Add(-10 * time.Second)
 
 	svc.getClientProvider = func(_ context.Context, _ int) (healthChecker, error) {
 		return stubHealthChecker{
-			healthy:      true,
-			recoveryTime: recoveryTime,
-			lastSync:     lastSync,
+			healthy:  true,
+			lastSync: lastSync,
 		}, nil
 	}
 
@@ -475,7 +459,6 @@ func TestBuildFileMap_StaleNonOverlappingRootsDoNotBypassSafety(t *testing.T) {
 	svc := NewService(DefaultConfig(), nil, nil, nil, nil)
 
 	now := time.Now()
-	recoveryTime := now.Add(-10 * time.Minute)
 	lastSync := now.Add(-10 * time.Second)
 
 	offlineErr := errors.New("offline")
@@ -485,9 +468,8 @@ func TestBuildFileMap_StaleNonOverlappingRootsDoNotBypassSafety(t *testing.T) {
 			return nil, offlineErr
 		}
 		return stubHealthChecker{
-			healthy:      true,
-			recoveryTime: recoveryTime,
-			lastSync:     lastSync,
+			healthy:  true,
+			lastSync: lastSync,
 		}, nil
 	}
 

--- a/internal/services/orphanscan/settling_test.go
+++ b/internal/services/orphanscan/settling_test.go
@@ -4,220 +4,23 @@
 package orphanscan
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	qbt "github.com/autobrr/go-qbittorrent"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestEvaluateSettlingSamples(t *testing.T) {
-	t.Parallel()
-
-	freshSyncAge := 30 * time.Second // well within MaxSyncAge (2 min)
-	staleSyncAge := 5 * time.Minute  // older than MaxSyncAge (2 min)
-
-	tests := []struct {
-		name           string
-		stats          []SampleStats
-		syncAge        time.Duration
-		wantSettled    bool
-		wantReasonPart string // substring to check in reason
-	}{
-		{
-			name:           "no samples",
-			stats:          []SampleStats{},
-			syncAge:        freshSyncAge,
-			wantSettled:    false,
-			wantReasonPart: "no samples provided",
-		},
-		{
-			name: "zero torrents - not ready",
-			stats: []SampleStats{
-				{Count: 100},
-				{Count: 100},
-				{Count: 100},
-				{Count: 0},
-			},
-			syncAge:        freshSyncAge,
-			wantSettled:    false,
-			wantReasonPart: "no torrents returned",
-		},
-		{
-			name: "count delta exceeds tolerance",
-			stats: []SampleStats{
-				{Count: 1000},
-				{Count: 1005},
-				{Count: 1010},
-				{Count: 1025}, // delta=25 > tolerance=10
-			},
-			syncAge:        freshSyncAge,
-			wantSettled:    false,
-			wantReasonPart: "torrent count not stable",
-		},
-		{
-			name: "batch loading - step increase >= 50",
-			stats: []SampleStats{
-				{Count: 60000},
-				{Count: 60050}, // +50 = batch loading (delta within 0.1%=60 tolerance)
-				{Count: 60050},
-				{Count: 60050},
-			},
-			syncAge:        freshSyncAge,
-			wantSettled:    false,
-			wantReasonPart: "batch loading",
-		},
-		{
-			name: "batch loading - plateau then jump",
-			stats: []SampleStats{
-				{Count: 200000},
-				{Count: 200050}, // +50
-				{Count: 200050},
-				{Count: 200100}, // +50
-			},
-			syncAge:        freshSyncAge,
-			wantSettled:    false,
-			wantReasonPart: "batch loading",
-		},
-		{
-			name: "high checking percent",
-			stats: []SampleStats{
-				{Count: 1000, CheckingPct: 2.0},
-				{Count: 1000, CheckingPct: 3.0},
-				{Count: 1000, CheckingPct: 6.0}, // > 5%
-				{Count: 1000, CheckingPct: 4.0},
-			},
-			syncAge:        freshSyncAge,
-			wantSettled:    false,
-			wantReasonPart: "checking state",
-		},
-		{
-			name: "stale sync data",
-			stats: []SampleStats{
-				{Count: 1000},
-				{Count: 1000},
-				{Count: 1000},
-				{Count: 1000},
-			},
-			syncAge:        staleSyncAge,
-			wantSettled:    false,
-			wantReasonPart: "sync data stale",
-		},
-		{
-			name: "stable - count within tolerance",
-			stats: []SampleStats{
-				{Count: 1000},
-				{Count: 1005},
-				{Count: 1002},
-				{Count: 1008}, // delta=8 <= tolerance=10
-			},
-			syncAge:     freshSyncAge,
-			wantSettled: true,
-		},
-		{
-			name: "stable - all equal",
-			stats: []SampleStats{
-				{Count: 5000, CheckingPct: 1.0},
-				{Count: 5000, CheckingPct: 2.0},
-				{Count: 5000, CheckingPct: 1.5},
-				{Count: 5000, CheckingPct: 0.5},
-			},
-			syncAge:     freshSyncAge,
-			wantSettled: true,
-		},
-		{
-			name: "stable - large collection with 0.1% tolerance",
-			stats: []SampleStats{
-				{Count: 200000},
-				{Count: 200010}, // small increments, no jump >= 50
-				{Count: 200020},
-				{Count: 200030}, // delta=30 < tolerance (200000/1000=200)
-			},
-			syncAge:     freshSyncAge,
-			wantSettled: true,
-		},
-		{
-			name: "step increase of 49 is ok",
-			stats: []SampleStats{
-				{Count: 50000},
-				{Count: 50049}, // +49 < 50, delta 49 within 0.1%=50 tolerance
-				{Count: 50049},
-				{Count: 50049},
-			},
-			syncAge:     freshSyncAge,
-			wantSettled: true,
-		},
-		{
-			name: "checking at threshold is ok",
-			stats: []SampleStats{
-				{Count: 1000, CheckingPct: 5.0}, // exactly at threshold
-				{Count: 1000, CheckingPct: 4.0},
-				{Count: 1000, CheckingPct: 3.0},
-				{Count: 1000, CheckingPct: 2.0},
-			},
-			syncAge:     freshSyncAge,
-			wantSettled: true,
-		},
-		{
-			name: "metaDL percent does not affect settling",
-			stats: []SampleStats{
-				{Count: 1000, CheckingPct: 1.0, MetaDlPct: 50.0}, // high metaDL is fine
-				{Count: 1000, CheckingPct: 1.0, MetaDlPct: 50.0},
-				{Count: 1000, CheckingPct: 1.0, MetaDlPct: 50.0},
-				{Count: 1000, CheckingPct: 1.0, MetaDlPct: 50.0},
-			},
-			syncAge:     freshSyncAge,
-			wantSettled: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			settled, reason, _ := EvaluateSettlingSamples(tt.stats, tt.syncAge)
-
-			assert.Equal(t, tt.wantSettled, settled, "settled mismatch")
-			if tt.wantReasonPart != "" {
-				assert.True(t, strings.Contains(reason, tt.wantReasonPart),
-					"reason %q should contain %q", reason, tt.wantReasonPart)
-			}
-			if tt.wantSettled {
-				assert.Empty(t, reason, "settled should have empty reason")
-			}
-		})
-	}
-}
-
-func TestEvaluateSettlingSamples_MaxCheckingPct(t *testing.T) {
-	t.Parallel()
-
-	freshSyncAge := 30 * time.Second
-
-	stats := []SampleStats{
-		{Count: 1000, CheckingPct: 1.0},
-		{Count: 1000, CheckingPct: 3.5},
-		{Count: 1000, CheckingPct: 2.0},
-		{Count: 1000, CheckingPct: 4.0},
-	}
-
-	settled, _, maxCheckingPct := EvaluateSettlingSamples(stats, freshSyncAge)
-
-	require.True(t, settled)
-	assert.Equal(t, 4.0, maxCheckingPct, "should return max checking% across all samples")
-}
-
-// mockHealthChecker implements healthChecker for testing
 type mockHealthChecker struct {
-	healthy      bool
-	recoveryTime time.Time
-	lastSync     time.Time
+	healthy  bool
+	lastSync time.Time
 }
 
-func (m *mockHealthChecker) IsHealthy() bool                { return m.healthy }
-func (m *mockHealthChecker) GetLastRecoveryTime() time.Time { return m.recoveryTime }
-func (m *mockHealthChecker) GetLastSyncUpdate() time.Time   { return m.lastSync }
+func (m *mockHealthChecker) IsHealthy() bool              { return m.healthy }
+func (m *mockHealthChecker) GetLastSyncUpdate() time.Time { return m.lastSync }
 
 func TestReadinessChecks(t *testing.T) {
 	t.Parallel()
@@ -233,49 +36,26 @@ func TestReadinessChecks(t *testing.T) {
 		{
 			name: "client unhealthy",
 			client: &mockHealthChecker{
-				healthy:      false,
-				recoveryTime: now.Add(-10 * time.Minute),
-				lastSync:     now,
+				healthy:  false,
+				lastSync: now,
 			},
 			wantErr:     true,
 			wantErrPart: "unhealthy",
 		},
 		{
-			name: "recovery grace period active",
-			client: &mockHealthChecker{
-				healthy:      true,
-				recoveryTime: now.Add(-1 * time.Minute), // recovered 1 min ago < 3 min grace
-				lastSync:     now,
-			},
-			wantErr:     true,
-			wantErrPart: "grace period",
-		},
-		{
 			name: "never synced",
 			client: &mockHealthChecker{
-				healthy:      true,
-				recoveryTime: now.Add(-10 * time.Minute),
-				lastSync:     time.Time{}, // zero = never synced
+				healthy:  true,
+				lastSync: time.Time{},
 			},
 			wantErr:     true,
 			wantErrPart: "waiting for first sync",
 		},
 		{
-			name: "no sync since recovery",
-			client: &mockHealthChecker{
-				healthy:      true,
-				recoveryTime: now.Add(-5 * time.Minute),  // recovered 5 min ago
-				lastSync:     now.Add(-10 * time.Minute), // last sync 10 min ago (before recovery)
-			},
-			wantErr:     true,
-			wantErrPart: "waiting for sync after recovery",
-		},
-		{
 			name: "sync data stale",
 			client: &mockHealthChecker{
-				healthy:      true,
-				recoveryTime: now.Add(-10 * time.Minute),
-				lastSync:     now.Add(-5 * time.Minute), // 5 min > MaxSyncAge (2 min)
+				healthy:  true,
+				lastSync: now.Add(-5 * time.Minute),
 			},
 			wantErr:     true,
 			wantErrPart: "sync data stale",
@@ -283,11 +63,9 @@ func TestReadinessChecks(t *testing.T) {
 		{
 			name: "all checks pass",
 			client: &mockHealthChecker{
-				healthy:      true,
-				recoveryTime: now.Add(-10 * time.Minute), // recovered 10 min ago > 3 min grace
-				lastSync:     now.Add(-30 * time.Second), // fresh sync
+				healthy:  true,
+				lastSync: now.Add(-30 * time.Second),
 			},
-			wantErr: false,
 		},
 	}
 
@@ -295,16 +73,91 @@ func TestReadinessChecks(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Test the readiness gates (now using the production function)
 			err := checkReadinessGates(tt.client)
 
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.True(t, strings.Contains(err.Error(), tt.wantErrPart),
 					"error %q should contain %q", err.Error(), tt.wantErrPart)
-			} else {
-				require.NoError(t, err)
+				return
 			}
+
+			require.NoError(t, err)
 		})
 	}
+}
+
+func TestIsTransientTorrentStateForOrphanScan(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		state qbt.TorrentState
+		want  bool
+	}{
+		{state: qbt.TorrentStateMetaDl, want: true},
+		{state: qbt.TorrentStateCheckingResumeData, want: true},
+		{state: qbt.TorrentStateCheckingDl, want: true},
+		{state: qbt.TorrentStateCheckingUp, want: true},
+		{state: qbt.TorrentStateAllocating, want: true},
+		{state: qbt.TorrentStateMoving, want: true},
+		{state: qbt.TorrentStatePausedUp, want: false},
+		{state: qbt.TorrentStateUploading, want: false},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, isTransientTorrentStateForOrphanScan(tt.state), "state=%q", tt.state)
+	}
+}
+
+func TestBuildFileMapFromTorrents_FailsWhenStableTorrentMissingFiles(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+
+	_, err := buildFileMapFromTorrents([]qbt.Torrent{
+		{Hash: "stable", SavePath: root, State: qbt.TorrentStatePausedUp},
+	}, map[string]qbt.TorrentFiles{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stable torrents returned no files")
+}
+
+func TestBuildFileMapFromTorrents_SkipsTransientMissingRoots(t *testing.T) {
+	t.Parallel()
+
+	stableRoot := filepath.Join(t.TempDir(), "stable")
+	transientRoot := filepath.Join(t.TempDir(), "transient")
+
+	result, err := buildFileMapFromTorrents(
+		[]qbt.Torrent{
+			{Hash: "stable", SavePath: stableRoot, State: qbt.TorrentStatePausedUp},
+			{Hash: "checking", SavePath: transientRoot, State: qbt.TorrentStateCheckingResumeData},
+		},
+		map[string]qbt.TorrentFiles{
+			"stable": {{Name: "movie.mkv", Size: 1}},
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []string{filepath.Clean(stableRoot)}, result.scanRoots)
+	assert.Equal(t, []string{filepath.Clean(transientRoot)}, result.skippedRoots)
+	assert.True(t, result.fileMap.Has(normalizePath(filepath.Join(stableRoot, "movie.mkv"))))
+}
+
+func TestBuildFileMapFromTorrents_SkipsSharedRootWhenTransientTorrentHasNoFiles(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+
+	result, err := buildFileMapFromTorrents(
+		[]qbt.Torrent{
+			{Hash: "stable", SavePath: root, State: qbt.TorrentStatePausedUp},
+			{Hash: "allocating", SavePath: root, State: qbt.TorrentStateAllocating},
+		},
+		map[string]qbt.TorrentFiles{
+			"stable": {{Name: "movie.mkv", Size: 1}},
+		},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, result.scanRoots)
+	assert.Equal(t, []string{filepath.Clean(root)}, result.skippedRoots)
+	assert.True(t, result.fileMap.Has(normalizePath(filepath.Join(root, "movie.mkv"))))
 }

--- a/internal/services/orphanscan/settling_test.go
+++ b/internal/services/orphanscan/settling_test.go
@@ -5,7 +5,6 @@ package orphanscan
 
 import (
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -77,7 +76,7 @@ func TestReadinessChecks(t *testing.T) {
 
 			if tt.wantErr {
 				require.Error(t, err)
-				assert.True(t, strings.Contains(err.Error(), tt.wantErrPart),
+				assert.Contains(t, err.Error(), tt.wantErrPart,
 					"error %q should contain %q", err.Error(), tt.wantErrPart)
 				return
 			}

--- a/internal/services/orphanscan/settling_test.go
+++ b/internal/services/orphanscan/settling_test.go
@@ -161,3 +161,41 @@ func TestBuildFileMapFromTorrents_SkipsSharedRootWhenTransientTorrentHasNoFiles(
 	assert.Equal(t, []string{filepath.Clean(root)}, result.skippedRoots)
 	assert.True(t, result.fileMap.Has(normalizePath(filepath.Join(root, "movie.mkv"))))
 }
+
+func TestFilterScanRootsCoveredBySkippedRoots(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join(t.TempDir(), "library")
+	child := filepath.Join(root, "transient")
+	descendant := filepath.Join(child, "nested")
+	sibling := filepath.Join(root, "stable")
+
+	tests := []struct {
+		name         string
+		scanRoots    []string
+		skippedRoots []string
+		want         []string
+	}{
+		{
+			name:         "keeps parent root when skipped root is child",
+			scanRoots:    []string{root, sibling},
+			skippedRoots: []string{child},
+			want:         []string{filepath.Clean(root), filepath.Clean(sibling)},
+		},
+		{
+			name:         "drops descendant root covered by skipped ancestor",
+			scanRoots:    []string{descendant, sibling},
+			skippedRoots: []string{child},
+			want:         []string{filepath.Clean(sibling)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := filterScanRootsCoveredBySkippedRoots(tt.scanRoots, tt.skippedRoots)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Fix orphan scan failures caused by contradictory readiness checks around qBittorrent recovery and settling.

This removes the recovery-grace and settling heuristics and replaces them with a simpler model:

- require the client to be healthy
- require a fresh sync
- treat checking/allocating/moving/metaDL torrents as transitional
- do not fail the whole scan when transitional torrents have no file list
- still fail if stable torrents return no files

Ref: https://github.com/autobrr/qui/discussions/1406


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of transient torrent states and skipped roots to avoid false failures and preserve protected files.
  * Simplified readiness checks to reduce spurious aborts and surface clearer warnings when no usable scan roots remain.

* **Refactor**
  * Overhauled orphan-scan flow: simplified file-map construction, cross-instance merge behavior, and removed recovery-time based settling logic and related readiness constants.
  * Removed legacy recovery-time tracking from client health checks.

* **Tests**
  * Updated and added tests for transient-state handling, skipped-root merging, overlap scenarios, and readiness gates.

* **Documentation**
  * Added code-shape and React effects guidance to project docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->