### PR TITLE
fix(settings): contain settings tab scrolling

### DIFF
--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -62,7 +62,7 @@ import { useForm } from "@tanstack/react-form"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Bell, Clock, Copy, Database, ExternalLink, FileText, Info, Key, Layers, Link2, Loader2, Palette, Plus, RefreshCw, Server, Share2, Shield, Terminal, Trash2 } from "lucide-react"
 import type { FormEvent, ReactNode } from "react"
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { toast } from "sonner"
 
 type SettingsTab = NonNullable<SettingsSearch["tab"]>
@@ -963,9 +963,7 @@ function ApplicationInfoPanel() {
     return { label: "Up to date", detail: "No newer release is currently cached." }
   }, [info, latestVersionQuery.data, latestVersionQuery.isFetching, latestVersionQuery.isLoading])
 
-  const updateCheckedAt = latestVersionQuery.dataUpdatedAt > 0
-    ? formatApplicationDate(new Date(latestVersionQuery.dataUpdatedAt).toISOString())
-    : "Not checked yet"
+  const updateCheckedAt = latestVersionQuery.dataUpdatedAt > 0 ? formatApplicationDate(new Date(latestVersionQuery.dataUpdatedAt).toISOString()) : "Not checked yet"
 
   const buildFields: ApplicationField[] = info ? [
     { label: "Version", value: info.version || "—", monospace: true },
@@ -1094,9 +1092,70 @@ interface SettingsProps {
   onSearchChange: (search: SettingsSearch) => void
 }
 
+interface SettingsScrollPanelProps {
+  children: ReactNode
+  contentClassName?: string
+}
+
+function SettingsScrollPanel({ children, contentClassName }: SettingsScrollPanelProps) {
+  const scrollRef = useRef<HTMLDivElement | null>(null)
+  const contentRef = useRef<HTMLDivElement | null>(null)
+  const [showTopFade, setShowTopFade] = useState(false)
+  const [showBottomFade, setShowBottomFade] = useState(false)
+
+  useEffect(() => {
+    const scrollElement = scrollRef.current
+    const contentElement = contentRef.current
+
+    if (!scrollElement) {
+      return
+    }
+
+    const updateFades = () => {
+      setShowTopFade(scrollElement.scrollTop > 4)
+      setShowBottomFade(scrollElement.scrollTop + scrollElement.clientHeight < scrollElement.scrollHeight - 4)
+    }
+
+    updateFades()
+
+    const resizeObserver = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(() => {
+      updateFades()
+    })
+
+    scrollElement.addEventListener("scroll", updateFades, { passive: true })
+    window.addEventListener("resize", updateFades)
+    resizeObserver?.observe(scrollElement)
+    if (contentElement) {
+      resizeObserver?.observe(contentElement)
+    }
+
+    return () => {
+      scrollElement.removeEventListener("scroll", updateFades)
+      window.removeEventListener("resize", updateFades)
+      resizeObserver?.disconnect()
+    }
+  }, [children])
+
+  return (
+    <div className="relative flex h-full min-h-0 flex-col">
+      <div
+        className={`pointer-events-none absolute inset-x-0 top-0 z-10 h-10 bg-linear-to-b from-background/80 via-background/50 to-transparent transition-opacity duration-150 ${showTopFade ? "opacity-100" : "opacity-0"}`}
+      />
+      <div
+        className={`pointer-events-none absolute inset-x-0 bottom-0 z-10 h-10 bg-linear-to-t from-background/80 via-background/50 to-transparent transition-opacity duration-150 ${showBottomFade ? "opacity-100" : "opacity-0"}`}
+      />
+      <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto md:pr-4">
+        <div ref={contentRef} className={contentClassName}>
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export function Settings({ search, onSearchChange }: SettingsProps) {
   const activeTab: SettingsTab = search.tab ?? "application"
-  const scrollPanelClassName = "h-full min-h-0 space-y-4 overflow-y-auto pr-4"
+  const scrollPanelContentClassName = "space-y-4"
 
   const handleTabChange = (tab: SettingsTab) => {
     onSearchChange({ tab })
@@ -1330,13 +1389,13 @@ export function Settings({ search, onSearchChange }: SettingsProps) {
         {/* Main Content Area */}
         <div className="flex-1 min-w-0 min-h-0 overflow-hidden">
           {activeTab === "application" && (
-            <div className={scrollPanelClassName}>
+            <SettingsScrollPanel contentClassName={scrollPanelContentClassName}>
               <ApplicationInfoPanel />
-            </div>
+            </SettingsScrollPanel>
           )}
 
           {activeTab === "instances" && (
-            <div className={scrollPanelClassName}>
+            <SettingsScrollPanel contentClassName={scrollPanelContentClassName}>
               <Card className="flex min-h-full flex-col">
                 <CardHeader>
                   <CardTitle>Instances</CardTitle>
@@ -1348,23 +1407,23 @@ export function Settings({ search, onSearchChange }: SettingsProps) {
                   <InstancesManager search={search} onSearchChange={onSearchChange} />
                 </CardContent>
               </Card>
-            </div>
+            </SettingsScrollPanel>
           )}
 
           {activeTab === "indexers" && (
-            <div className={scrollPanelClassName}>
+            <SettingsScrollPanel contentClassName={scrollPanelContentClassName}>
               <IndexersPage withContainer={false} />
-            </div>
+            </SettingsScrollPanel>
           )}
 
           {activeTab === "search-cache" && (
-            <div className={scrollPanelClassName}>
+            <SettingsScrollPanel contentClassName={scrollPanelContentClassName}>
               <TorznabSearchCachePanel />
-            </div>
+            </SettingsScrollPanel>
           )}
 
           {activeTab === "integrations" && (
-            <div className={scrollPanelClassName}>
+            <SettingsScrollPanel contentClassName={scrollPanelContentClassName}>
               <Card>
                 <CardHeader>
                   <CardTitle>ARR Integrations</CardTitle>
@@ -1376,11 +1435,11 @@ export function Settings({ search, onSearchChange }: SettingsProps) {
                   <ArrInstancesManager />
                 </CardContent>
               </Card>
-            </div>
+            </SettingsScrollPanel>
           )}
 
           {activeTab === "client-api" && (
-            <div className={scrollPanelClassName}>
+            <SettingsScrollPanel contentClassName={scrollPanelContentClassName}>
               <Card>
                 <CardHeader>
                   <CardTitle>Client Proxy API Keys</CardTitle>
@@ -1392,11 +1451,11 @@ export function Settings({ search, onSearchChange }: SettingsProps) {
                   <ClientApiKeysManager />
                 </CardContent>
               </Card>
-            </div>
+            </SettingsScrollPanel>
           )}
 
           {activeTab === "api" && (
-            <div className={scrollPanelClassName}>
+            <SettingsScrollPanel contentClassName={scrollPanelContentClassName}>
               <Card>
                 <CardHeader>
                   <div className="flex items-start justify-between">
@@ -1422,11 +1481,11 @@ export function Settings({ search, onSearchChange }: SettingsProps) {
                   <ApiKeysManager />
                 </CardContent>
               </Card>
-            </div>
+            </SettingsScrollPanel>
           )}
 
           {activeTab === "external-programs" && (
-            <div className={scrollPanelClassName}>
+            <SettingsScrollPanel contentClassName={scrollPanelContentClassName}>
               <Card>
                 <CardHeader>
                   <CardTitle>External Programs</CardTitle>
@@ -1438,11 +1497,11 @@ export function Settings({ search, onSearchChange }: SettingsProps) {
                   <ExternalProgramsManager />
                 </CardContent>
               </Card>
-            </div>
+            </SettingsScrollPanel>
           )}
 
           {activeTab === "notifications" && (
-            <div className={scrollPanelClassName}>
+            <SettingsScrollPanel contentClassName={scrollPanelContentClassName}>
               <Card>
                 <CardHeader>
                   <CardTitle>Notifications</CardTitle>
@@ -1454,11 +1513,11 @@ export function Settings({ search, onSearchChange }: SettingsProps) {
                   <NotificationsManager />
                 </CardContent>
               </Card>
-            </div>
+            </SettingsScrollPanel>
           )}
 
           {activeTab === "datetime" && (
-            <div className={scrollPanelClassName}>
+            <SettingsScrollPanel contentClassName={scrollPanelContentClassName}>
               <Card>
                 <CardHeader>
                   <CardTitle>Date & Time Preferences</CardTitle>
@@ -1470,22 +1529,22 @@ export function Settings({ search, onSearchChange }: SettingsProps) {
                   <DateTimePreferencesForm />
                 </CardContent>
               </Card>
-            </div>
+            </SettingsScrollPanel>
           )}
 
           {activeTab === "themes" && (
-            <div className={scrollPanelClassName}>
+            <SettingsScrollPanel contentClassName={scrollPanelContentClassName}>
               <LicenseManager
                 checkoutStatus={search.checkout}
                 checkoutPaymentStatus={search.status}
                 onCheckoutConsumed={() => onSearchChange({ tab: "themes" })}
               />
               <ThemeSelector />
-            </div>
+            </SettingsScrollPanel>
           )}
 
           {activeTab === "security" && (
-            <div className={scrollPanelClassName}>
+            <SettingsScrollPanel contentClassName={scrollPanelContentClassName}>
               <Card>
                 <CardHeader>
                   <CardTitle>Change Password</CardTitle>
@@ -1532,13 +1591,13 @@ export function Settings({ search, onSearchChange }: SettingsProps) {
                   </CardContent>
                 </Card>
               )}
-            </div>
+            </SettingsScrollPanel>
           )}
 
           {activeTab === "logs" && (
-            <div className={scrollPanelClassName}>
+            <SettingsScrollPanel contentClassName={scrollPanelContentClassName}>
               <LogSettingsPanel />
-            </div>
+            </SettingsScrollPanel>
           )}
         </div>
       </div>

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -6,8 +6,8 @@
 import { IndexersPage } from "@/components/indexers/IndexersPage"
 import { InstanceCard } from "@/components/instances/InstanceCard"
 import { InstanceForm } from "@/components/instances/InstanceForm"
-import { InstancePreferencesDialog } from "@/components/instances/preferences/InstancePreferencesDialog"
 import { PasswordIssuesBanner } from "@/components/instances/PasswordIssuesBanner"
+import { InstancePreferencesDialog } from "@/components/instances/preferences/InstancePreferencesDialog"
 import { ArrInstancesManager } from "@/components/settings/ArrInstancesManager"
 import { ClientApiKeysManager } from "@/components/settings/ClientApiKeysManager"
 import { DateTimePreferencesForm } from "@/components/settings/DateTimePreferencesForm"
@@ -40,7 +40,8 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { Select,
+import {
+  Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
@@ -1095,14 +1096,15 @@ interface SettingsProps {
 
 export function Settings({ search, onSearchChange }: SettingsProps) {
   const activeTab: SettingsTab = search.tab ?? "application"
+  const scrollPanelClassName = "h-full min-h-0 space-y-4 overflow-y-auto pr-4"
 
   const handleTabChange = (tab: SettingsTab) => {
     onSearchChange({ tab })
   }
 
   return (
-    <div className="container mx-auto p-4 md:p-6">
-      <div className="mb-4 md:mb-6">
+    <div className="container mx-auto flex h-full min-h-0 flex-col overflow-hidden p-4 md:p-6">
+      <div className="mb-4 shrink-0 md:mb-6">
         <h1 className="text-2xl md:text-3xl font-bold">Settings</h1>
         <p className="text-muted-foreground mt-1 md:mt-2 text-sm md:text-base">
           Manage your application preferences and security
@@ -1110,7 +1112,7 @@ export function Settings({ search, onSearchChange }: SettingsProps) {
       </div>
 
       {/* Mobile Dropdown Navigation */}
-      <div className="md:hidden mb-4">
+      <div className="mb-4 shrink-0 md:hidden">
         <Select
           value={activeTab}
           onValueChange={(value) => handleTabChange(value as SettingsTab)}
@@ -1201,9 +1203,9 @@ export function Settings({ search, onSearchChange }: SettingsProps) {
         </Select>
       </div>
 
-      <div className="flex gap-6">
+      <div className="flex min-h-0 flex-1 flex-col gap-6 md:flex-row">
         {/* Desktop Sidebar Navigation */}
-        <div className="hidden md:block w-64 shrink-0">
+        <div className="hidden w-64 shrink-0 overflow-y-auto md:block">
           <nav className="space-y-1">
             <button
               onClick={() => handleTabChange("application")}
@@ -1326,23 +1328,23 @@ export function Settings({ search, onSearchChange }: SettingsProps) {
         </div>
 
         {/* Main Content Area */}
-        <div className="flex-1 min-w-0">
+        <div className="flex-1 min-w-0 min-h-0 overflow-hidden">
           {activeTab === "application" && (
-            <div className="space-y-4">
+            <div className={scrollPanelClassName}>
               <ApplicationInfoPanel />
             </div>
           )}
 
           {activeTab === "instances" && (
-            <div className="space-y-4">
-              <Card>
+            <div className={scrollPanelClassName}>
+              <Card className="flex min-h-full flex-col">
                 <CardHeader>
                   <CardTitle>Instances</CardTitle>
                   <CardDescription>
                     Manage your qBittorrent connection settings
                   </CardDescription>
                 </CardHeader>
-                <CardContent>
+                <CardContent className="min-h-0 flex-1">
                   <InstancesManager search={search} onSearchChange={onSearchChange} />
                 </CardContent>
               </Card>
@@ -1350,19 +1352,19 @@ export function Settings({ search, onSearchChange }: SettingsProps) {
           )}
 
           {activeTab === "indexers" && (
-            <div className="space-y-4">
+            <div className={scrollPanelClassName}>
               <IndexersPage withContainer={false} />
             </div>
           )}
 
           {activeTab === "search-cache" && (
-            <div className="space-y-4">
+            <div className={scrollPanelClassName}>
               <TorznabSearchCachePanel />
             </div>
           )}
 
           {activeTab === "integrations" && (
-            <div className="space-y-4">
+            <div className={scrollPanelClassName}>
               <Card>
                 <CardHeader>
                   <CardTitle>ARR Integrations</CardTitle>
@@ -1378,7 +1380,7 @@ export function Settings({ search, onSearchChange }: SettingsProps) {
           )}
 
           {activeTab === "client-api" && (
-            <div className="space-y-4">
+            <div className={scrollPanelClassName}>
               <Card>
                 <CardHeader>
                   <CardTitle>Client Proxy API Keys</CardTitle>
@@ -1394,7 +1396,7 @@ export function Settings({ search, onSearchChange }: SettingsProps) {
           )}
 
           {activeTab === "api" && (
-            <div className="space-y-4">
+            <div className={scrollPanelClassName}>
               <Card>
                 <CardHeader>
                   <div className="flex items-start justify-between">
@@ -1424,7 +1426,7 @@ export function Settings({ search, onSearchChange }: SettingsProps) {
           )}
 
           {activeTab === "external-programs" && (
-            <div className="space-y-4">
+            <div className={scrollPanelClassName}>
               <Card>
                 <CardHeader>
                   <CardTitle>External Programs</CardTitle>
@@ -1440,7 +1442,7 @@ export function Settings({ search, onSearchChange }: SettingsProps) {
           )}
 
           {activeTab === "notifications" && (
-            <div className="space-y-4">
+            <div className={scrollPanelClassName}>
               <Card>
                 <CardHeader>
                   <CardTitle>Notifications</CardTitle>
@@ -1456,7 +1458,7 @@ export function Settings({ search, onSearchChange }: SettingsProps) {
           )}
 
           {activeTab === "datetime" && (
-            <div className="space-y-4">
+            <div className={scrollPanelClassName}>
               <Card>
                 <CardHeader>
                   <CardTitle>Date & Time Preferences</CardTitle>
@@ -1472,7 +1474,7 @@ export function Settings({ search, onSearchChange }: SettingsProps) {
           )}
 
           {activeTab === "themes" && (
-            <div className="space-y-4">
+            <div className={scrollPanelClassName}>
               <LicenseManager
                 checkoutStatus={search.checkout}
                 checkoutPaymentStatus={search.status}
@@ -1483,7 +1485,7 @@ export function Settings({ search, onSearchChange }: SettingsProps) {
           )}
 
           {activeTab === "security" && (
-            <div className="space-y-4">
+            <div className={scrollPanelClassName}>
               <Card>
                 <CardHeader>
                   <CardTitle>Change Password</CardTitle>
@@ -1534,7 +1536,7 @@ export function Settings({ search, onSearchChange }: SettingsProps) {
           )}
 
           {activeTab === "logs" && (
-            <div className="space-y-4">
+            <div className={scrollPanelClassName}>
               <LogSettingsPanel />
             </div>
           )}


### PR DESCRIPTION
This changes the scroll on the settings page from a full page scroll to only a container scroll.

Before:

https://github.com/user-attachments/assets/aa6c9910-0b33-476b-81a0-83ecab142ad1

After:

https://github.com/user-attachments/assets/ca91a56c-7e70-4e60-a2af-8bc51ccc1f97



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Restructured Settings page layout with improved spacing, header/container flow, and overflow handling.
  * Updated mobile and desktop navigation wrappers for consistent appearance.
  * Refined visual styling across setting tabs for improved consistency.

* **New Features**
  * Introduced a unified scrolling panel for all settings tabs, providing consistent scroll behavior and fade indicators across viewports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->