### PR TITLE
feat: unify bulk tag editor

### DIFF
--- a/internal/api/handlers/torrents.go
+++ b/internal/api/handlers/torrents.go
@@ -278,8 +278,8 @@ func (h *TorrentsHandler) GetTorrentField(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if req.Field != "name" && req.Field != "hash" && req.Field != "full_path" {
-		RespondError(w, http.StatusBadRequest, "Invalid field: must be name, hash, or full_path")
+	if req.Field != "name" && req.Field != "hash" && req.Field != "full_path" && req.Field != "tags" {
+		RespondError(w, http.StatusBadRequest, "Invalid field: must be name, hash, full_path, or tags")
 		return
 	}
 
@@ -335,6 +335,8 @@ func (h *TorrentsHandler) GetTorrentField(w http.ResponseWriter, r *http.Request
 				value = preferredCrossInstanceHashValue(torrent)
 			case "full_path":
 				value = fullPathValue(torrent.SavePath, torrent.Name)
+			case "tags":
+				value = strings.TrimSpace(torrent.Tags)
 			}
 
 			if value != "" {

--- a/internal/api/handlers/torrents.go
+++ b/internal/api/handlers/torrents.go
@@ -344,9 +344,6 @@ func (h *TorrentsHandler) GetTorrentField(w http.ResponseWriter, r *http.Request
 
 				for _, torrent := range response.CrossInstanceTorrents {
 					normalized := normalizeHashValue(torrent.Hash)
-					if requestedHashes == nil {
-						continue
-					}
 					if _, ok := requestedHashes[normalized]; !ok {
 						continue
 					}
@@ -394,10 +391,8 @@ func (h *TorrentsHandler) GetTorrentField(w http.ResponseWriter, r *http.Request
 			requestedCount += len(targetsByInstance[targetInstanceID])
 			for _, torrent := range torrents {
 				normalized := normalizeHashValue(torrent.Hash)
-				if requestedHashes != nil {
-					if _, ok := requestedHashes[normalized]; !ok {
-						continue
-					}
+				if _, ok := requestedHashes[normalized]; !ok {
+					continue
 				}
 
 				value := torrentFieldValue(req.Field, torrent.Name, torrent.Hash, torrent.InfohashV1, torrent.InfohashV2, torrent.SavePath, torrent.Tags)

--- a/internal/api/handlers/torrents.go
+++ b/internal/api/handlers/torrents.go
@@ -430,6 +430,14 @@ func (h *TorrentsHandler) GetTorrentField(w http.ResponseWriter, r *http.Request
 			RespondError(w, http.StatusInternalServerError, "Failed to get torrent field")
 			return
 		}
+		if response.PartialResults && req.Field == "tags" {
+			log.Error().
+				Int("instanceID", instanceID).
+				Str("field", req.Field).
+				Msg("Cross-instance torrent field returned partial results for tag baseline")
+			RespondError(w, http.StatusInternalServerError, "Failed to resolve the full tag baseline")
+			return
+		}
 
 		excludeHashes := buildExcludeHashSet(req.ExcludeHashes)
 		excludeTargets := buildExcludeTargetSet(req.ExcludeTargets)
@@ -464,7 +472,17 @@ func (h *TorrentsHandler) GetTorrentField(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	fieldResponse, err := h.syncManager.GetTorrentField(r.Context(), instanceID, req.Field, req.Sort, req.Order, req.Search, req.Filters, req.ExcludeHashes)
+	fieldResponse, err := h.syncManager.GetTorrentField(
+		r.Context(),
+		instanceID,
+		req.Field,
+		req.Sort,
+		req.Order,
+		req.Search,
+		req.Filters,
+		req.ExcludeHashes,
+		toQBittorrentTargets(req.ExcludeTargets),
+	)
 	if err != nil {
 		if respondIfInstanceDisabled(w, err, instanceID, "torrents:metadata") {
 			return
@@ -498,6 +516,22 @@ func torrentFieldValue(field, name, hash, infohashV1, infohashV2, savePath, tags
 
 func shouldIncludeTorrentFieldValue(field, value string) bool {
 	return field == "tags" || value != ""
+}
+
+func toQBittorrentTargets(targets []BulkActionTarget) []qbittorrent.TorrentTarget {
+	if len(targets) == 0 {
+		return nil
+	}
+
+	result := make([]qbittorrent.TorrentTarget, 0, len(targets))
+	for _, target := range targets {
+		result = append(result, qbittorrent.TorrentTarget{
+			InstanceID: target.InstanceID,
+			Hash:       target.Hash,
+		})
+	}
+
+	return result
 }
 
 // CheckDuplicates validates if any of the provided hashes already exist in qBittorrent.

--- a/internal/api/handlers/torrents.go
+++ b/internal/api/handlers/torrents.go
@@ -343,11 +343,10 @@ func (h *TorrentsHandler) GetTorrentField(w http.ResponseWriter, r *http.Request
 				}
 
 				for _, torrent := range response.CrossInstanceTorrents {
-					normalized := normalizeHashValue(torrent.Hash)
-					if _, ok := requestedHashes[normalized]; !ok {
+					if !matchesRequestedHashSet(requestedHashes, torrent.Hash, torrent.InfohashV1, torrent.InfohashV2) {
 						continue
 					}
-					addBulkTarget(targetsByInstance, seenTargets, torrent.InstanceID, torrent.Hash)
+					addBulkTarget(targetsByInstance, seenTargets, torrent.InstanceID, resolvedTorrentFieldHash(torrent.Hash, torrent.InfohashV1, torrent.InfohashV2))
 				}
 			} else if instanceID != allInstancesID {
 				for _, hash := range req.Hashes {
@@ -390,8 +389,7 @@ func (h *TorrentsHandler) GetTorrentField(w http.ResponseWriter, r *http.Request
 			requestedHashes := buildExcludeHashSet(targetsByInstance[targetInstanceID])
 			requestedCount += len(targetsByInstance[targetInstanceID])
 			for _, torrent := range torrents {
-				normalized := normalizeHashValue(torrent.Hash)
-				if _, ok := requestedHashes[normalized]; !ok {
+				if !matchesRequestedHashSet(requestedHashes, torrent.Hash, torrent.InfohashV1, torrent.InfohashV2) {
 					continue
 				}
 
@@ -435,7 +433,7 @@ func (h *TorrentsHandler) GetTorrentField(w http.ResponseWriter, r *http.Request
 				Int("instanceID", instanceID).
 				Str("field", req.Field).
 				Msg("Cross-instance torrent field returned partial results for tag baseline")
-			RespondError(w, http.StatusInternalServerError, "Failed to resolve the full tag baseline")
+			RespondError(w, http.StatusServiceUnavailable, "Failed to resolve the full tag baseline")
 			return
 		}
 
@@ -443,20 +441,14 @@ func (h *TorrentsHandler) GetTorrentField(w http.ResponseWriter, r *http.Request
 		excludeTargets := buildExcludeTargetSet(req.ExcludeTargets)
 		values := make([]string, 0, len(response.CrossInstanceTorrents))
 		for _, torrent := range response.CrossInstanceTorrents {
-			normalized := normalizeHashValue(torrent.Hash)
-			if normalized == "" {
+			if !hasTorrentFieldHash(torrent.Hash, torrent.InfohashV1, torrent.InfohashV2) {
 				continue
 			}
-			if excludeHashes != nil {
-				if _, skip := excludeHashes[normalized]; skip {
-					continue
-				}
+			if matchesRequestedHashSet(excludeHashes, torrent.Hash, torrent.InfohashV1, torrent.InfohashV2) {
+				continue
 			}
-			if excludeTargets != nil {
-				key := fmt.Sprintf("%d:%s", torrent.InstanceID, normalized)
-				if _, skip := excludeTargets[key]; skip {
-					continue
-				}
+			if matchesExcludedTargetSet(excludeTargets, torrent.InstanceID, torrent.Hash, torrent.InfohashV1, torrent.InfohashV2) {
+				continue
 			}
 
 			value := torrentFieldValue(req.Field, torrent.Name, torrent.Hash, torrent.InfohashV1, torrent.InfohashV2, torrent.SavePath, torrent.Tags)
@@ -516,6 +508,69 @@ func torrentFieldValue(field, name, hash, infohashV1, infohashV2, savePath, tags
 
 func shouldIncludeTorrentFieldValue(field, value string) bool {
 	return field == "tags" || value != ""
+}
+
+func resolvedTorrentFieldHash(hash, infohashV1, infohashV2 string) string {
+	preferred := preferredHashValue(&qbt.Torrent{
+		Hash:       hash,
+		InfohashV1: infohashV1,
+		InfohashV2: infohashV2,
+	})
+	if preferred != "" {
+		return preferred
+	}
+	return strings.TrimSpace(hash)
+}
+
+func torrentFieldHashVariants(hash, infohashV1, infohashV2 string) []string {
+	candidates := []string{
+		hash,
+		infohashV1,
+		infohashV2,
+		resolvedTorrentFieldHash(hash, infohashV1, infohashV2),
+	}
+	seen := make(map[string]struct{}, len(candidates))
+	var variants []string
+	for _, candidate := range candidates {
+		normalized := normalizeHashValue(candidate)
+		if normalized == "" {
+			continue
+		}
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		variants = append(variants, normalized)
+	}
+	return variants
+}
+
+func hasTorrentFieldHash(hash, infohashV1, infohashV2 string) bool {
+	return len(torrentFieldHashVariants(hash, infohashV1, infohashV2)) > 0
+}
+
+func matchesRequestedHashSet(requestedHashes map[string]struct{}, hash, infohashV1, infohashV2 string) bool {
+	if len(requestedHashes) == 0 {
+		return false
+	}
+	for _, candidate := range torrentFieldHashVariants(hash, infohashV1, infohashV2) {
+		if _, ok := requestedHashes[candidate]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func matchesExcludedTargetSet(excludeTargets map[string]struct{}, instanceID int, hash, infohashV1, infohashV2 string) bool {
+	if len(excludeTargets) == 0 {
+		return false
+	}
+	for _, candidate := range torrentFieldHashVariants(hash, infohashV1, infohashV2) {
+		if _, ok := excludeTargets[fmt.Sprintf("%d:%s", instanceID, candidate)]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func toQBittorrentTargets(targets []BulkActionTarget) []qbittorrent.TorrentTarget {

--- a/internal/api/handlers/torrents.go
+++ b/internal/api/handlers/torrents.go
@@ -371,6 +371,8 @@ func (h *TorrentsHandler) GetTorrentField(w http.ResponseWriter, r *http.Request
 		slices.Sort(targetInstanceIDs)
 
 		values := make([]string, 0, len(flattenTargetHashes(targetsByInstance)))
+		requestedCount := 0
+		resolvedCount := 0
 		for _, targetInstanceID := range targetInstanceIDs {
 			torrents, fieldErr := h.syncManager.GetCachedInstanceTorrents(r.Context(), targetInstanceID)
 			if fieldErr != nil {
@@ -389,6 +391,7 @@ func (h *TorrentsHandler) GetTorrentField(w http.ResponseWriter, r *http.Request
 			}
 
 			requestedHashes := buildExcludeHashSet(targetsByInstance[targetInstanceID])
+			requestedCount += len(targetsByInstance[targetInstanceID])
 			for _, torrent := range torrents {
 				normalized := normalizeHashValue(torrent.Hash)
 				if requestedHashes != nil {
@@ -400,8 +403,13 @@ func (h *TorrentsHandler) GetTorrentField(w http.ResponseWriter, r *http.Request
 				value := torrentFieldValue(req.Field, torrent.Name, torrent.Hash, torrent.InfohashV1, torrent.InfohashV2, torrent.SavePath, torrent.Tags)
 				if shouldIncludeTorrentFieldValue(req.Field, value) {
 					values = append(values, value)
+					resolvedCount++
 				}
 			}
+		}
+		if req.Field == "tags" && resolvedCount < requestedCount {
+			RespondError(w, http.StatusConflict, "Could not resolve the full tag baseline for the selected torrents")
+			return
 		}
 
 		RespondJSON(w, http.StatusOK, &qbittorrent.TorrentFieldResponse{

--- a/internal/api/handlers/torrents.go
+++ b/internal/api/handlers/torrents.go
@@ -241,8 +241,8 @@ func (h *TorrentsHandler) ListTorrents(w http.ResponseWriter, r *http.Request) {
 	RespondJSON(w, http.StatusOK, response)
 }
 
-// GetTorrentField returns field values for torrents matching the given filters.
-// Used for select all copy operations (Copy Name, Copy Hash, Copy Full Path).
+// GetTorrentField returns field values for torrents matching either the current filters
+// or an explicit selection payload. Used for copy operations and tag baseline lookups.
 func (h *TorrentsHandler) GetTorrentField(w http.ResponseWriter, r *http.Request) {
 	instanceID, err := strconv.Atoi(chi.URLParam(r, "instanceID"))
 	if err != nil {
@@ -255,6 +255,9 @@ func (h *TorrentsHandler) GetTorrentField(w http.ResponseWriter, r *http.Request
 		Sort           string                    `json:"sort"`
 		Order          string                    `json:"order"`
 		Search         string                    `json:"search"`
+		Hashes         []string                  `json:"hashes"`
+		Targets        []BulkActionTarget        `json:"targets"`
+		SelectAll      bool                      `json:"selectAll"`
 		Filters        qbittorrent.FilterOptions `json:"filters"`
 		InstanceIDs    []int                     `json:"instanceIds"`
 		ExcludeHashes  []string                  `json:"excludeHashes"`
@@ -277,6 +280,10 @@ func (h *TorrentsHandler) GetTorrentField(w http.ResponseWriter, r *http.Request
 		RespondError(w, http.StatusBadRequest, "Too many exclude hashes provided (maximum 512)")
 		return
 	}
+	if req.SelectAll && (len(req.Hashes) > 0 || len(req.Targets) > 0) {
+		RespondError(w, http.StatusBadRequest, "Cannot specify hashes/targets together with selectAll")
+		return
+	}
 
 	if req.Field != "name" && req.Field != "hash" && req.Field != "full_path" && req.Field != "tags" {
 		RespondError(w, http.StatusBadRequest, "Invalid field: must be name, hash, full_path, or tags")
@@ -288,6 +295,120 @@ func (h *TorrentsHandler) GetTorrentField(w http.ResponseWriter, r *http.Request
 	}
 	if req.Order == "" {
 		req.Order = "desc"
+	}
+
+	if len(req.Targets) > 0 || len(req.Hashes) > 0 {
+		targetsByInstance := make(map[int][]string)
+		seenTargets := make(map[int]map[string]struct{})
+
+		for _, target := range req.Targets {
+			targetInstanceID := target.InstanceID
+			if targetInstanceID <= 0 {
+				if instanceID == allInstancesID {
+					continue
+				}
+				targetInstanceID = instanceID
+			}
+			if instanceID != allInstancesID && targetInstanceID != instanceID {
+				continue
+			}
+			addBulkTarget(targetsByInstance, seenTargets, targetInstanceID, target.Hash)
+		}
+
+		if len(req.Hashes) > 0 {
+			if instanceID == allInstancesID && len(req.Targets) == 0 {
+				requestedHashes := buildExcludeHashSet(req.Hashes)
+				response, crossErr := h.syncManager.GetCrossInstanceTorrentsWithFilters(
+					r.Context(),
+					0,
+					0,
+					"",
+					"",
+					"",
+					qbittorrent.FilterOptions{},
+					req.InstanceIDs,
+				)
+				if crossErr != nil {
+					log.Error().Err(crossErr).Str("field", req.Field).Msg("Failed to resolve hash targets for torrent field request")
+					RespondError(w, http.StatusInternalServerError, "Failed to get torrent field")
+					return
+				}
+				if response.PartialResults {
+					log.Warn().
+						Str("field", req.Field).
+						Ints("instanceIDs", req.InstanceIDs).
+						Msg("Cross-instance hash resolution aborted due to partial results")
+					RespondError(w, http.StatusServiceUnavailable, "Unable to resolve all scoped instances for torrent field request")
+					return
+				}
+
+				for _, torrent := range response.CrossInstanceTorrents {
+					normalized := normalizeHashValue(torrent.Hash)
+					if requestedHashes == nil {
+						continue
+					}
+					if _, ok := requestedHashes[normalized]; !ok {
+						continue
+					}
+					addBulkTarget(targetsByInstance, seenTargets, torrent.InstanceID, torrent.Hash)
+				}
+			} else if instanceID != allInstancesID {
+				for _, hash := range req.Hashes {
+					addBulkTarget(targetsByInstance, seenTargets, instanceID, hash)
+				}
+			}
+		}
+
+		if len(targetsByInstance) == 0 {
+			RespondError(w, http.StatusBadRequest, "No torrents match the selection criteria")
+			return
+		}
+
+		targetInstanceIDs := make([]int, 0, len(targetsByInstance))
+		for targetInstanceID := range targetsByInstance {
+			targetInstanceIDs = append(targetInstanceIDs, targetInstanceID)
+		}
+		slices.Sort(targetInstanceIDs)
+
+		values := make([]string, 0, len(flattenTargetHashes(targetsByInstance)))
+		for _, targetInstanceID := range targetInstanceIDs {
+			torrents, fieldErr := h.syncManager.GetCachedInstanceTorrents(r.Context(), targetInstanceID)
+			if fieldErr != nil {
+				if instanceID != allInstancesID {
+					if respondIfInstanceDisabled(w, fieldErr, targetInstanceID, "torrents:metadata") {
+						return
+					}
+				}
+				log.Error().
+					Err(fieldErr).
+					Int("instanceID", targetInstanceID).
+					Str("field", req.Field).
+					Msg("Failed to get cached torrents for explicit field request")
+				RespondError(w, http.StatusInternalServerError, "Failed to get torrent field")
+				return
+			}
+
+			requestedHashes := buildExcludeHashSet(targetsByInstance[targetInstanceID])
+			for _, torrent := range torrents {
+				normalized := normalizeHashValue(torrent.Hash)
+				if requestedHashes != nil {
+					if _, ok := requestedHashes[normalized]; !ok {
+						continue
+					}
+				}
+
+				value := torrentFieldValue(req.Field, torrent.Name, torrent.Hash, torrent.InfohashV1, torrent.InfohashV2, torrent.SavePath, torrent.Tags)
+				if shouldIncludeTorrentFieldValue(req.Field, value) {
+					values = append(values, value)
+				}
+			}
+		}
+
+		RespondJSON(w, http.StatusOK, &qbittorrent.TorrentFieldResponse{
+			Values: values,
+			Total:  len(values),
+		})
+		return
 	}
 
 	if instanceID == allInstancesID {
@@ -327,19 +448,8 @@ func (h *TorrentsHandler) GetTorrentField(w http.ResponseWriter, r *http.Request
 				}
 			}
 
-			var value string
-			switch req.Field {
-			case "name":
-				value = strings.TrimSpace(torrent.Name)
-			case "hash":
-				value = preferredCrossInstanceHashValue(torrent)
-			case "full_path":
-				value = fullPathValue(torrent.SavePath, torrent.Name)
-			case "tags":
-				value = strings.TrimSpace(torrent.Tags)
-			}
-
-			if value != "" {
+			value := torrentFieldValue(req.Field, torrent.Name, torrent.Hash, torrent.InfohashV1, torrent.InfohashV2, torrent.SavePath, torrent.Tags)
+			if shouldIncludeTorrentFieldValue(req.Field, value) {
 				values = append(values, value)
 			}
 		}
@@ -362,6 +472,29 @@ func (h *TorrentsHandler) GetTorrentField(w http.ResponseWriter, r *http.Request
 	}
 
 	RespondJSON(w, http.StatusOK, fieldResponse)
+}
+
+func torrentFieldValue(field, name, hash, infohashV1, infohashV2, savePath, tags string) string {
+	switch field {
+	case "name":
+		return strings.TrimSpace(name)
+	case "hash":
+		return preferredHashValue(&qbt.Torrent{
+			Hash:       hash,
+			InfohashV1: infohashV1,
+			InfohashV2: infohashV2,
+		})
+	case "full_path":
+		return fullPathValue(savePath, name)
+	case "tags":
+		return tags
+	default:
+		return ""
+	}
+}
+
+func shouldIncludeTorrentFieldValue(field, value string) bool {
+	return field == "tags" || value != ""
 }
 
 // CheckDuplicates validates if any of the provided hashes already exist in qBittorrent.

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -1267,7 +1267,7 @@ type TorrentFieldResponse struct {
 }
 
 // GetTorrentField returns field values for torrents matching the given filters.
-// Supported fields: "name", "hash", "full_path" (save_path/name).
+// Supported fields: "name", "hash", "full_path" (save_path/name), "tags".
 // excludeHashes removes specific torrents from the result
 func (sm *SyncManager) GetTorrentField(ctx context.Context, instanceID int, field, sort, order, search string, filters FilterOptions, excludeHashes []string) (*TorrentFieldResponse, error) {
 	response, err := sm.GetTorrentsWithFilters(ctx, instanceID, 0, 0, sort, order, search, filters)
@@ -1317,6 +1317,8 @@ func (sm *SyncManager) GetTorrentField(ctx context.Context, instanceID int, fiel
 					v = savePath + "/" + t.Name
 				}
 			}
+		case "tags":
+			v = t.Tags
 		}
 		if v != "" {
 			values = append(values, v)

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -1320,7 +1320,7 @@ func (sm *SyncManager) GetTorrentField(ctx context.Context, instanceID int, fiel
 		case "tags":
 			v = t.Tags
 		}
-		if v != "" {
+		if field == "tags" || v != "" {
 			values = append(values, v)
 		}
 	}

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -107,6 +107,11 @@ type CrossInstanceTorrentView struct {
 	InstanceName string `json:"instance_name"`
 }
 
+type TorrentTarget struct {
+	InstanceID int
+	Hash       string
+}
+
 type TorrentResponse struct {
 	Torrents               []TorrentView              `json:"torrents"`
 	CrossInstanceTorrents  []CrossInstanceTorrentView `json:"cross_instance_torrents,omitempty"`
@@ -1268,8 +1273,15 @@ type TorrentFieldResponse struct {
 
 // GetTorrentField returns field values for torrents matching the given filters.
 // Supported fields: "name", "hash", "full_path" (save_path/name), "tags".
-// excludeHashes removes specific torrents from the result
-func (sm *SyncManager) GetTorrentField(ctx context.Context, instanceID int, field, sort, order, search string, filters FilterOptions, excludeHashes []string) (*TorrentFieldResponse, error) {
+// excludeHashes and excludeTargets remove specific torrents from the result.
+func (sm *SyncManager) GetTorrentField(
+	ctx context.Context,
+	instanceID int,
+	field, sort, order, search string,
+	filters FilterOptions,
+	excludeHashes []string,
+	excludeTargets []TorrentTarget,
+) (*TorrentFieldResponse, error) {
 	response, err := sm.GetTorrentsWithFilters(ctx, instanceID, 0, 0, sort, order, search, filters)
 	if err != nil {
 		return nil, err
@@ -1280,14 +1292,37 @@ func (sm *SyncManager) GetTorrentField(ctx context.Context, instanceID int, fiel
 	if len(excludeHashes) > 0 {
 		excluded = make(map[string]struct{}, len(excludeHashes))
 		for _, h := range excludeHashes {
-			excluded[h] = struct{}{}
+			normalized := normalizeTorrentFieldHash(h)
+			if normalized != "" {
+				excluded[normalized] = struct{}{}
+			}
+		}
+	}
+
+	var excludedTargets map[string]struct{}
+	if len(excludeTargets) > 0 {
+		excludedTargets = make(map[string]struct{}, len(excludeTargets))
+		for _, target := range excludeTargets {
+			if target.InstanceID != instanceID {
+				continue
+			}
+			normalized := normalizeTorrentFieldHash(target.Hash)
+			if normalized != "" {
+				excludedTargets[normalized] = struct{}{}
+			}
 		}
 	}
 
 	values := make([]string, 0, len(response.Torrents))
 	for _, t := range response.Torrents {
+		normalizedHash := normalizeTorrentFieldHash(t.Hash)
 		if excluded != nil {
-			if _, skip := excluded[t.Hash]; skip {
+			if _, skip := excluded[normalizedHash]; skip {
+				continue
+			}
+		}
+		if excludedTargets != nil {
+			if _, skip := excludedTargets[normalizedHash]; skip {
 				continue
 			}
 		}
@@ -1329,6 +1364,10 @@ func (sm *SyncManager) GetTorrentField(ctx context.Context, instanceID int, fiel
 		Values: values,
 		Total:  len(values),
 	}, nil
+}
+
+func normalizeTorrentFieldHash(hash string) string {
+	return strings.ToLower(strings.TrimSpace(hash))
 }
 
 // GetCachedInstanceTorrents returns a snapshot of torrents for a single instance using cached sync data.

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -1315,16 +1315,8 @@ func (sm *SyncManager) GetTorrentField(
 
 	values := make([]string, 0, len(response.Torrents))
 	for _, t := range response.Torrents {
-		normalizedHash := normalizeTorrentFieldHash(t.Hash)
-		if excluded != nil {
-			if _, skip := excluded[normalizedHash]; skip {
-				continue
-			}
-		}
-		if excludedTargets != nil {
-			if _, skip := excludedTargets[normalizedHash]; skip {
-				continue
-			}
+		if torrentFieldHashExcluded(excluded, excludedTargets, t.Hash, t.InfohashV1, t.InfohashV2) {
+			continue
 		}
 
 		var v string
@@ -1368,6 +1360,47 @@ func (sm *SyncManager) GetTorrentField(
 
 func normalizeTorrentFieldHash(hash string) string {
 	return strings.ToLower(strings.TrimSpace(hash))
+}
+
+func torrentFieldHashVariants(hash, infohashV1, infohashV2 string) []string {
+	candidates := []string{
+		hash,
+		infohashV1,
+		infohashV2,
+		canonicalizeHash(hash),
+		canonicalizeHash(infohashV1),
+		canonicalizeHash(infohashV2),
+	}
+	seen := make(map[string]struct{}, len(candidates))
+	var variants []string
+	for _, candidate := range candidates {
+		normalized := normalizeTorrentFieldHash(candidate)
+		if normalized == "" {
+			continue
+		}
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		variants = append(variants, normalized)
+	}
+	return variants
+}
+
+func torrentFieldHashExcluded(excluded, excludedTargets map[string]struct{}, hash, infohashV1, infohashV2 string) bool {
+	for _, candidate := range torrentFieldHashVariants(hash, infohashV1, infohashV2) {
+		if excluded != nil {
+			if _, skip := excluded[candidate]; skip {
+				return true
+			}
+		}
+		if excludedTargets != nil {
+			if _, skip := excludedTargets[candidate]; skip {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // GetCachedInstanceTorrents returns a snapshot of torrents for a single instance using cached sync data.

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -1623,7 +1623,7 @@ paths:
       tags:
         - Torrents
       summary: Get torrent field values
-      description: Returns field values for torrents matching the given filters. Used for select all copy operations (copy name, hash, or full path).
+      description: Returns field values for torrents matching the given filters. Used for select all copy operations and bulk tag baselines.
       parameters:
         - $ref: '#/components/parameters/instanceID'
       requestBody:
@@ -1642,6 +1642,7 @@ paths:
                     - name
                     - hash
                     - full_path
+                    - tags
                 sort:
                   type: string
                   description: Sort field. Defaults to added_on.

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -1637,7 +1637,7 @@ paths:
               properties:
                 field:
                   type: string
-                  description: The torrent field to retrieve.
+                  description: The torrent field to retrieve. When set to `tags`, the 200 response `values` array contains one raw comma-separated tag string per matching torrent, and empty strings represent untagged torrents.
                   enum:
                     - name
                     - hash
@@ -1652,6 +1652,27 @@ paths:
                   enum:
                     - asc
                     - desc
+                hashes:
+                  type: array
+                  description: Explicit torrent hashes to query when not using filter scope.
+                  items:
+                    type: string
+                targets:
+                  type: array
+                  description: Explicit instance/hash targets to query when not using filter scope.
+                  items:
+                    type: object
+                    required:
+                      - instanceId
+                      - hash
+                    properties:
+                      instanceId:
+                        type: integer
+                      hash:
+                        type: string
+                selectAll:
+                  type: boolean
+                  description: When true, query all torrents matching filters/search/exclusions.
                 search:
                   type: string
                   description: Optional search query to filter torrents.
@@ -1692,7 +1713,10 @@ paths:
                     type: array
                     items:
                       type: string
-                    description: List of field values for matching torrents.
+                    description: |
+                      List of per-torrent field values for the matching torrents. When `field=tags`, each item is the raw
+                      comma-separated tag string returned for one matching torrent, and an empty string indicates
+                      an untagged torrent.
 
   /api/instances/{instanceID}/torrents/{hash}/export:
     get:

--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -2407,7 +2407,10 @@ export function TorrentCardsMobile({
         selectionRequest={{
           instanceId,
           instanceIds,
-          filters: isAllSelected ? filters : undefined,
+          hashes: !isAllSelected ? selectedRequestHashes : undefined,
+          targets: !isAllSelected && selectedActionTargets.length === selectedRequestHashes.length ? selectedActionTargets : undefined,
+          selectAll: isAllSelected,
+          filters: isAllSelected ? effectiveFilters : undefined,
           search: isAllSelected ? effectiveSearch : undefined,
           excludeHashes: isAllSelected ? excludeHashesForRequest : undefined,
           excludeTargets: isAllSelected

--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -1777,7 +1777,7 @@ export function TorrentCardsMobile({
       plan,
       hashes,
       isAllSelected,
-      isAllSelected ? filters : undefined,
+      isAllSelected ? effectiveFilters : undefined,
       isAllSelected ? effectiveSearch : undefined,
       isAllSelected ? excludeHashesForRequest : undefined,
       {
@@ -1790,7 +1790,7 @@ export function TorrentCardsMobile({
       }
     )
     setActionTorrents([])
-  }, [isAllSelected, selectedRequestHashes, handleUpdateTags, filters, effectiveSearch, excludedFromSelectAll, torrents, effectiveSelectionCount, instanceId, getSelectionIdentity, excludeHashesForRequest, excludedTorrents, selectedActionTargets])
+  }, [isAllSelected, selectedRequestHashes, handleUpdateTags, effectiveFilters, effectiveSearch, excludedFromSelectAll, torrents, effectiveSelectionCount, instanceId, getSelectionIdentity, excludeHashesForRequest, excludedTorrents, selectedActionTargets])
 
   const handleSetCategoryWrapper = useCallback(async (category: string) => {
     const hashes = isAllSelected ? [] : selectedRequestHashes

--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -41,7 +41,7 @@ import { api } from "@/lib/api"
 import { buildTrackerCustomizationLookup, extractTrackerHost, getTrackerCustomizationsCacheKey, resolveTrackerDisplay, type TrackerCustomizationLookup } from "@/lib/tracker-customizations"
 import { resolveTrackerIconSrc } from "@/lib/tracker-icons"
 import { buildTorrentActionTargets } from "@/lib/torrent-action-targets"
-import { anyTorrentHasTag, getCommonCategory, getCommonSavePath, getCommonTags, getTorrentHashesWithTag } from "@/lib/torrent-utils"
+import { anyTorrentHasTag, getCommonCategory, getCommonSavePath, getTorrentHashesWithTag } from "@/lib/torrent-utils"
 import { isAllInstancesScope } from "@/lib/instances"
 import { useNavigate, useSearch } from "@tanstack/react-router"
 import { useVirtualizer } from "@tanstack/react-virtual"
@@ -78,7 +78,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { AddTorrentDialog } from "./AddTorrentDialog"
 import { DeleteTorrentDialog } from "./DeleteTorrentDialog"
-import { LocationWarningDialog, RemoveTagsDialog, SetCategoryDialog, SetLocationDialog, SetTagsDialog, TmmConfirmDialog } from "./TorrentDialogs"
+import { LocationWarningDialog, SetCategoryDialog, SetLocationDialog, TagEditorDialog, TmmConfirmDialog } from "./TorrentDialogs"
 // import { createPortal } from 'react-dom'
 // Columns dropdown removed on mobile
 import { useTorrentSelection } from "@/contexts/TorrentSelectionContext"
@@ -1071,10 +1071,8 @@ export function TorrentCardsMobile({
     setBlockCrossSeeds,
     deleteCrossSeeds,
     setDeleteCrossSeeds,
-    showSetTagsDialog,
-    setShowSetTagsDialog,
-    showRemoveTagsDialog,
-    setShowRemoveTagsDialog,
+    showTagsDialog,
+    setShowTagsDialog,
     showCategoryDialog,
     setShowCategoryDialog,
     showLocationDialog,
@@ -1087,8 +1085,7 @@ export function TorrentCardsMobile({
     isPending,
     handleAction,
     handleDelete,
-    handleSetTags,
-    handleRemoveTags,
+    handleUpdateTags,
     handleSetCategory,
     handleSetLocation,
     handleSetShareLimit,
@@ -1772,12 +1769,12 @@ export function TorrentCardsMobile({
     excludeHashesForRequest,
   ])
 
-  const handleSetTagsWrapper = useCallback(async (tags: string[]) => {
+  const handleTagsWrapper = useCallback(async (plan: Parameters<typeof handleUpdateTags>[0]) => {
     const hashes = isAllSelected ? [] : selectedRequestHashes
     const visibleHashes = isAllSelected ? torrents.filter(t => !excludedFromSelectAll.has(getSelectionIdentity(t))).map(t => t.hash) : selectedRequestHashes
     const totalSelected = isAllSelected ? effectiveSelectionCount : selectedActionTargets.length || visibleHashes.length
-    await handleSetTags(
-      tags,
+    await handleUpdateTags(
+      plan,
       hashes,
       isAllSelected,
       isAllSelected ? filters : undefined,
@@ -1793,7 +1790,7 @@ export function TorrentCardsMobile({
       }
     )
     setActionTorrents([])
-  }, [isAllSelected, selectedRequestHashes, handleSetTags, filters, effectiveSearch, excludedFromSelectAll, torrents, effectiveSelectionCount, instanceId, getSelectionIdentity, excludeHashesForRequest, excludedTorrents, selectedActionTargets])
+  }, [isAllSelected, selectedRequestHashes, handleUpdateTags, filters, effectiveSearch, excludedFromSelectAll, torrents, effectiveSelectionCount, instanceId, getSelectionIdentity, excludeHashesForRequest, excludedTorrents, selectedActionTargets])
 
   const handleSetCategoryWrapper = useCallback(async (category: string) => {
     const hashes = isAllSelected ? [] : selectedRequestHashes
@@ -2137,7 +2134,7 @@ export function TorrentCardsMobile({
             <button
               onClick={() => {
                 setActionTorrents(getSelectedTorrents)
-                setShowSetTagsDialog(true)
+                setShowTagsDialog(true)
               }}
               className="flex flex-col items-center justify-center gap-1 px-3 py-2 text-xs font-medium transition-colors min-w-0 flex-1 text-muted-foreground hover:text-foreground"
             >
@@ -2401,14 +2398,24 @@ export function TorrentCardsMobile({
       />
 
       {/* Tags dialog */}
-      <SetTagsDialog
-        open={showSetTagsDialog}
-        onOpenChange={setShowSetTagsDialog}
+      <TagEditorDialog
+        open={showTagsDialog}
+        onOpenChange={setShowTagsDialog}
         availableTags={availableTags || []}
-        hashCount={actionTorrents.length}
-        onConfirm={handleSetTagsWrapper}
+        selectedTorrents={actionTorrents}
+        hashCount={effectiveSelectionCount}
+        selectionRequest={{
+          instanceId,
+          instanceIds,
+          filters: isAllSelected ? filters : undefined,
+          search: isAllSelected ? effectiveSearch : undefined,
+          excludeHashes: isAllSelected ? excludeHashesForRequest : undefined,
+          excludeTargets: isAllSelected
+            ? buildTorrentActionTargets(excludedTorrents, instanceId)
+            : undefined,
+        }}
+        onConfirm={handleTagsWrapper}
         isPending={isPending}
-        initialTags={getCommonTags(actionTorrents)}
       />
 
       {/* Category dialog */}
@@ -2421,37 +2428,6 @@ export function TorrentCardsMobile({
         isPending={isPending}
         initialCategory={getCommonCategory(actionTorrents)}
         useSubcategories={allowSubcategories}
-      />
-
-      {/* Remove Tags dialog */}
-      <RemoveTagsDialog
-        open={showRemoveTagsDialog}
-        onOpenChange={setShowRemoveTagsDialog}
-        availableTags={availableTags || []}
-        hashCount={actionTorrents.length}
-        onConfirm={async (tags) => {
-          const hashes = isAllSelected ? [] : selectedRequestHashes
-          const visibleHashes = isAllSelected ? torrents.filter(t => !excludedFromSelectAll.has(getSelectionIdentity(t))).map(t => t.hash) : selectedRequestHashes
-          const totalSelected = isAllSelected ? effectiveSelectionCount : selectedActionTargets.length || visibleHashes.length
-          await handleRemoveTags(
-            tags,
-            hashes,
-            isAllSelected,
-            isAllSelected ? filters : undefined,
-            isAllSelected ? effectiveSearch : undefined,
-            isAllSelected ? excludeHashesForRequest : undefined,
-            {
-              clientHashes: visibleHashes,
-              totalSelected,
-              actionTargets: isAllSelected ? undefined : selectedActionTargets,
-              excludeTargets: isAllSelected
-                ? buildTorrentActionTargets(excludedTorrents, instanceId)
-                : undefined,
-            }
-          )
-          setActionTorrents([])
-        }}
-        isPending={isPending}
       />
 
       {/* Share Limits Dialog */}

--- a/web/src/components/torrents/TorrentContextMenu.tsx
+++ b/web/src/components/torrents/TorrentContextMenu.tsx
@@ -62,7 +62,7 @@ interface TorrentContextMenuProps {
   onTorrentSelect?: (torrent: Torrent | null, initialTab?: string) => void
   onAction: (action: TorrentAction, hashes: string[], options?: { enable?: boolean; targets?: Array<{ instanceId: number; hash: string }> }) => void
   onPrepareDelete: (hashes: string[], torrents?: Torrent[]) => void
-  onPrepareTags: (action: "add" | "set" | "remove", hashes: string[], torrents?: Torrent[]) => void
+  onPrepareTags: (hashes: string[], torrents?: Torrent[]) => void
   onPrepareCategory: (hashes: string[], torrents?: Torrent[]) => void
   onPrepareCreateCategory: (hashes: string[], torrents?: Torrent[]) => void
   onPrepareShareLimit: (hashes: string[], torrents?: Torrent[]) => void
@@ -474,18 +474,11 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
             )}
             {(canCrossSeedSearch || onFilterChange) && <ContextMenuSeparator />}
             <ContextMenuItem
-              onClick={() => onPrepareTags("add", hashes, torrents)}
+              onClick={() => onPrepareTags(hashes, torrents)}
               disabled={isPending}
             >
               <Tag className="mr-2 h-4 w-4" />
-              Add Tags {count > 1 ? `(${count})` : ""}
-            </ContextMenuItem>
-            <ContextMenuItem
-              onClick={() => onPrepareTags("set", hashes, torrents)}
-              disabled={isPending}
-            >
-              <Tag className="mr-2 h-4 w-4" />
-              Replace Tags {count > 1 ? `(${count})` : ""}
+              Set Tags {count > 1 ? `(${count})` : ""}
             </ContextMenuItem>
             <CategorySubmenu
               type="context"

--- a/web/src/components/torrents/TorrentDialogs.tsx
+++ b/web/src/components/torrents/TorrentDialogs.tsx
@@ -100,10 +100,29 @@ export const TagEditorDialog = memo(function TagEditorDialog({
     excludeHashes: selectionRequest?.excludeHashes ?? [],
     excludeTargets: selectionRequest?.excludeTargets ?? [],
   }), [selectionRequest])
+  const selectionRequestSnapshot = useMemo(() => ({
+    instanceId: selectionRequest?.instanceId ?? -1,
+    instanceIds: selectionRequest?.instanceIds,
+    hashes: selectionRequest?.hashes,
+    targets: selectionRequest?.targets,
+    selectAll: selectionRequest?.selectAll,
+    filters: selectionRequest?.filters,
+    search: selectionRequest?.search,
+    excludeHashes: selectionRequest?.excludeHashes,
+    excludeTargets: selectionRequest?.excludeTargets,
+  }), [selectionRequestKey])
+  const selectedTorrentTagsKey = useMemo(
+    () => JSON.stringify(selectedTorrents.map(torrent => torrent.tags)),
+    [selectedTorrents]
+  )
+  const selectedTorrentTagValues = useMemo(
+    () => JSON.parse(selectedTorrentTagsKey) as string[],
+    [selectedTorrentTagsKey]
+  )
   const requiresRemoteBaseline = hashCount > selectedTorrents.length
-  const hasValidInstance = typeof selectionRequest?.instanceId === "number" && selectionRequest.instanceId >= 0
-  const hasExplicitSelection = (selectionRequest?.targets?.length ?? 0) > 0 || (selectionRequest?.hashes?.length ?? 0) > 0
-  const canFetchRemoteBaseline = hasValidInstance && (selectionRequest?.selectAll === true || hasExplicitSelection)
+  const hasValidInstance = selectionRequestSnapshot.instanceId >= 0
+  const hasExplicitSelection = (selectionRequestSnapshot.targets?.length ?? 0) > 0 || (selectionRequestSnapshot.hashes?.length ?? 0) > 0
+  const canFetchRemoteBaseline = hasValidInstance && (selectionRequestSnapshot.selectAll === true || hasExplicitSelection)
 
   useEffect(() => {
     if (!open) {
@@ -123,13 +142,14 @@ export const TagEditorDialog = memo(function TagEditorDialog({
     if (didOpen || selectionRequestChanged) {
       setNewTag("")
       hasEditedRef.current = false
+      setItems([])
     }
     previousOpenRef.current = true
     previousSelectionRequestKeyRef.current = selectionRequestKey
     setSelectionBaselineError(null)
 
     if (!requiresRemoteBaseline) {
-      setSelectionTagValues(selectedTorrents.map(torrent => torrent.tags))
+      setSelectionTagValues(selectedTorrentTagValues)
       setIsLoadingSelectionTags(false)
       return
     }
@@ -146,15 +166,15 @@ export const TagEditorDialog = memo(function TagEditorDialog({
 
     setIsLoadingSelectionTags(true)
 
-    void api.getTorrentField(selectionRequest.instanceId, "tags", {
-      hashes: selectionRequest.hashes,
-      targets: selectionRequest.targets,
-      selectAll: selectionRequest.selectAll,
-      filters: selectionRequest.selectAll ? selectionRequest.filters : undefined,
-      search: selectionRequest.selectAll ? selectionRequest.search : undefined,
-      excludeHashes: selectionRequest.selectAll ? selectionRequest.excludeHashes : undefined,
-      excludeTargets: selectionRequest.selectAll ? selectionRequest.excludeTargets : undefined,
-      instanceIds: selectionRequest.instanceIds,
+    void api.getTorrentField(selectionRequestSnapshot.instanceId, "tags", {
+      hashes: selectionRequestSnapshot.hashes,
+      targets: selectionRequestSnapshot.targets,
+      selectAll: selectionRequestSnapshot.selectAll,
+      filters: selectionRequestSnapshot.selectAll ? selectionRequestSnapshot.filters : undefined,
+      search: selectionRequestSnapshot.selectAll ? selectionRequestSnapshot.search : undefined,
+      excludeHashes: selectionRequestSnapshot.selectAll ? selectionRequestSnapshot.excludeHashes : undefined,
+      excludeTargets: selectionRequestSnapshot.selectAll ? selectionRequestSnapshot.excludeTargets : undefined,
+      instanceIds: selectionRequestSnapshot.instanceIds,
     }).then((response) => {
       if (cancelled) {
         return
@@ -179,7 +199,7 @@ export const TagEditorDialog = memo(function TagEditorDialog({
     return () => {
       cancelled = true
     }
-  }, [canFetchRemoteBaseline, hashCount, onOpenChange, open, requiresRemoteBaseline, selectedTorrents, selectionRequest, selectionRequestKey])
+  }, [canFetchRemoteBaseline, hashCount, onOpenChange, open, requiresRemoteBaseline, selectedTorrentTagValues, selectionRequestKey, selectionRequestSnapshot])
 
   useEffect(() => {
     if (!open || isLoadingTags || isLoadingSelectionTags || hasEditedRef.current || selectionBaselineError) {
@@ -432,7 +452,7 @@ export const TagEditorDialog = memo(function TagEditorDialog({
         </div>
         <DialogFooter>
           <Button variant="outline" onClick={handleCancel}>Cancel</Button>
-          <Button onClick={handleConfirm} disabled={isPending || !hasChanges}>Apply</Button>
+          <Button onClick={handleConfirm} disabled={isPending || !hasChanges || isLoadingState || Boolean(selectionBaselineError)}>Apply</Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/web/src/components/torrents/TorrentDialogs.tsx
+++ b/web/src/components/torrents/TorrentDialogs.tsx
@@ -27,119 +27,255 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Switch } from "@/components/ui/switch"
-import type { Category, InstanceCapabilities, Torrent } from "@/types"
-import { useVirtualizer } from "@tanstack/react-virtual"
-import { AlertTriangle, Loader2, Plus, X } from "lucide-react"
-import type { ChangeEvent, KeyboardEvent } from "react"
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { api } from "@/lib/api"
+import {
+  buildTagEditorItems,
+  buildTagUpdatePlan,
+  cycleTagSelectionState,
+  hasTagUpdatePlan,
+  sortTags,
+  type TagEditorItem,
+  type TagUpdatePlan
+} from "@/lib/tag-editor"
 import { cn } from "@/lib/utils"
 import { usePathAutocomplete } from "@/hooks/usePathAutocomplete"
+import type { Category, InstanceCapabilities, Torrent, TorrentFilters } from "@/types"
+import { useVirtualizer } from "@tanstack/react-virtual"
+import { AlertTriangle, Loader2, Plus } from "lucide-react"
+import type { ChangeEvent, KeyboardEvent } from "react"
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { toast } from "sonner"
 import { buildCategoryTree, type CategoryNode } from "./CategoryTree"
 
-interface SetTagsDialogProps {
+interface TagEditorDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   availableTags: string[] | null
+  selectedTorrents: Torrent[]
   hashCount: number
-  onConfirm: (tags: string[]) => void
+  selectionRequest?: {
+    instanceId: number
+    instanceIds?: number[]
+    filters?: TorrentFilters
+    search?: string
+    excludeHashes?: string[]
+    excludeTargets?: Array<{ instanceId: number; hash: string }>
+  }
+  onConfirm: (plan: TagUpdatePlan) => void
   isPending?: boolean
-  initialTags?: string[]
   isLoadingTags?: boolean
 }
 
-interface AddTagsDialogProps {
-  open: boolean
-  onOpenChange: (open: boolean) => void
-  availableTags: string[] | null
-  hashCount: number
-  onConfirm: (tags: string[]) => void
-  isPending?: boolean
-  initialTags?: string[]
-  isLoadingTags?: boolean
-}
-
-export const AddTagsDialog = memo(function AddTagsDialog({
+export const TagEditorDialog = memo(function TagEditorDialog({
   open,
   onOpenChange,
   availableTags,
+  selectedTorrents,
   hashCount,
+  selectionRequest,
   onConfirm,
   isPending = false,
-  initialTags = [],
   isLoadingTags = false,
-}: AddTagsDialogProps) {
-  const [selectedTags, setSelectedTags] = useState<string[]>([])
+}: TagEditorDialogProps) {
+  const [items, setItems] = useState<TagEditorItem[]>([])
   const [newTag, setNewTag] = useState("")
-  const [temporaryTags, setTemporaryTags] = useState<string[]>([])
-  const wasOpen = useRef(false)
+  const [selectionTagValues, setSelectionTagValues] = useState<string[]>([])
+  const [isLoadingSelectionTags, setIsLoadingSelectionTags] = useState(false)
+  const hasEditedRef = useRef(false)
+  const wasOpenRef = useRef(false)
   const scrollContainerRef = useRef<HTMLDivElement>(null)
 
-  // Initialize selected tags only when dialog transitions from closed to open
   useEffect(() => {
-    if (open && !wasOpen.current) {
-      setSelectedTags([]) // Start with empty selection for add operation
-      setTemporaryTags([])
+    if (!open) {
+      setItems([])
+      setNewTag("")
+      setSelectionTagValues([])
+      setIsLoadingSelectionTags(false)
+      hasEditedRef.current = false
+      wasOpenRef.current = false
+      return
     }
-    wasOpen.current = open
-  }, [open, initialTags])
 
-  // Combine server tags with temporary tags for display
-  const displayTags = [...(availableTags || []), ...temporaryTags].sort()
+    if (wasOpenRef.current) {
+      return
+    }
 
-  // Only use virtualization for large tag lists (>50 tags)
-  const shouldUseVirtualization = displayTags.length > 50
+    wasOpenRef.current = true
+    setNewTag("")
+    hasEditedRef.current = false
 
-  // Virtualization for large tag lists
+    const needsSelectionTagFetch =
+      hashCount > selectedTorrents.length &&
+      typeof selectionRequest?.instanceId === "number" &&
+      selectionRequest.instanceId >= 0
+
+    if (!needsSelectionTagFetch) {
+      setSelectionTagValues(selectedTorrents.map(torrent => torrent.tags))
+      setIsLoadingSelectionTags(false)
+      return
+    }
+
+    let cancelled = false
+    setIsLoadingSelectionTags(true)
+
+    void api.getTorrentField(selectionRequest.instanceId, "tags", {
+      filters: selectionRequest.filters,
+      search: selectionRequest.search,
+      excludeHashes: selectionRequest.excludeHashes,
+      excludeTargets: selectionRequest.excludeTargets,
+      instanceIds: selectionRequest.instanceIds,
+    }).then((response) => {
+      if (cancelled) {
+        return
+      }
+
+      setSelectionTagValues(response.values)
+      setIsLoadingSelectionTags(false)
+    }).catch((error: Error) => {
+      if (cancelled) {
+        return
+      }
+
+      setSelectionTagValues([])
+      setIsLoadingSelectionTags(false)
+      onOpenChange(false)
+      toast.error("Failed to load selected torrent tags", {
+        description: error.message || "Could not build the full tag baseline",
+      })
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [hashCount, onOpenChange, open, selectedTorrents, selectionRequest])
+
+  useEffect(() => {
+    if (!open || isLoadingTags || isLoadingSelectionTags || hasEditedRef.current) {
+      return
+    }
+
+    setItems(buildTagEditorItems(availableTags, selectionTagValues, hashCount))
+  }, [availableTags, hashCount, isLoadingSelectionTags, isLoadingTags, open, selectionTagValues])
+
+  const knownTagSet = useMemo(() => new Set(availableTags ?? []), [availableTags])
+  const updatePlan = useMemo(() => buildTagUpdatePlan(items), [items])
+  const hasChanges = hasTagUpdatePlan(updatePlan)
+  const isLoadingState = isLoadingTags || isLoadingSelectionTags
+  const shouldUseVirtualization = items.length > 50
+
   const virtualizer = useVirtualizer({
-    count: shouldUseVirtualization ? displayTags.length : 0,
+    count: shouldUseVirtualization ? items.length : 0,
     getScrollElement: () => scrollContainerRef.current,
-    estimateSize: () => 32, // Approximate height of each tag item
+    estimateSize: () => 40,
     overscan: 5,
   })
 
-  const handleConfirm = useCallback((): void => {
-    const allTags = [...selectedTags]
-    if (newTag.trim() && !allTags.includes(newTag.trim())) {
-      allTags.push(newTag.trim())
-    }
-    onConfirm(allTags)
-    setSelectedTags([])
+  const resetItems = useCallback(() => {
+    hasEditedRef.current = false
+    setItems(buildTagEditorItems(availableTags, selectionTagValues, hashCount))
     setNewTag("")
-    setTemporaryTags([])
-  }, [selectedTags, newTag, onConfirm])
+  }, [availableTags, hashCount, selectionTagValues])
+
+  const handleConfirm = useCallback((): void => {
+    if (!hasChanges) {
+      onOpenChange(false)
+      return
+    }
+
+    onConfirm(updatePlan)
+    setNewTag("")
+  }, [hasChanges, onConfirm, onOpenChange, updatePlan])
 
   const handleCancel = useCallback((): void => {
-    setSelectedTags([])
     setNewTag("")
-    setTemporaryTags([])
     onOpenChange(false)
   }, [onOpenChange])
 
+  const toggleTag = useCallback((tag: string): void => {
+    hasEditedRef.current = true
+    setItems(prev => prev.map((item) => {
+      if (item.tag !== tag) {
+        return item
+      }
+
+      return {
+        ...item,
+        state: cycleTagSelectionState(item.state),
+      }
+    }))
+  }, [])
+
+  const clearAll = useCallback((): void => {
+    hasEditedRef.current = true
+    setItems(prev => prev.map(item => item.state === "off" ? item : { ...item, state: "off" }))
+  }, [])
+
   const addNewTag = useCallback((tagToAdd: string): void => {
     const trimmedTag = tagToAdd.trim()
-    if (trimmedTag && !displayTags.includes(trimmedTag)) {
-      // Add to temporary tags if it's not already in server tags
-      if (!availableTags?.includes(trimmedTag)) {
-        setTemporaryTags(prev => [...prev, trimmedTag])
-      }
-      // Add to selected tags
-      setSelectedTags(prev => [...prev, trimmedTag])
-      setNewTag("")
+    if (!trimmedTag) {
+      return
     }
-  }, [displayTags, availableTags])
+
+    hasEditedRef.current = true
+    setItems((prev) => {
+      const existing = prev.find(item => item.tag === trimmedTag)
+      if (existing) {
+        return prev.map(item => item.tag === trimmedTag ? { ...item, state: "on" } : item)
+      }
+
+      return sortTags([...prev.map(item => item.tag), trimmedTag]).map((tag) => {
+        if (tag !== trimmedTag) {
+          return prev.find(item => item.tag === tag) as TagEditorItem
+        }
+
+        return {
+          tag,
+          initialState: "off",
+          state: "on",
+        }
+      })
+    })
+    setNewTag("")
+  }, [])
+
+  const renderTagRow = useCallback((item: TagEditorItem) => {
+    const isNew = !knownTagSet.has(item.tag)
+
+    return (
+      <button
+        key={item.tag}
+        type="button"
+        onClick={() => toggleTag(item.tag)}
+        className="flex w-full items-center justify-between gap-3 rounded-md px-2 py-1.5 text-left hover:bg-muted/60"
+      >
+        <div className="flex min-w-0 items-center gap-2">
+          <Checkbox
+            checked={item.state === "mixed" ? "indeterminate" : item.state === "on"}
+            className="pointer-events-none"
+          />
+          <span className={cn("truncate text-sm font-medium", isNew && "text-primary italic")}>
+            {item.tag}
+          </span>
+          {isNew && <span className="text-xs text-muted-foreground">(new)</span>}
+        </div>
+        <span className="shrink-0 text-xs text-muted-foreground">
+          {item.state === "mixed" ? "Mixed" : item.state === "on" ? "On" : "Off"}
+        </span>
+      </button>
+    )
+  }, [knownTagSet, toggleTag])
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-md">
         <DialogHeader>
-          <DialogTitle>Add Tags to {hashCount} torrent(s)</DialogTitle>
+          <DialogTitle>Set Tags for {hashCount} torrent(s)</DialogTitle>
           <DialogDescription>
-            Select tags to add to the selected torrents. These tags will be added to any existing tags on each torrent.
+            Mixed tags stay unchanged until clicked. Click a row to cycle Mixed to On, On to Off, and Off to On.
           </DialogDescription>
         </DialogHeader>
         <div className="py-4 space-y-4">
-          {/* Existing tags */}
-          {isLoadingTags ? (
+          {isLoadingState ? (
             <div className="space-y-2">
               <Label>Available Tags</Label>
               <div className="h-48 border rounded-md p-3 flex items-center justify-center">
@@ -149,26 +285,24 @@ export const AddTagsDialog = memo(function AddTagsDialog({
                 </div>
               </div>
             </div>
-          ) : displayTags && displayTags.length > 0 ? (
+          ) : items.length > 0 ? (
             <div className="space-y-2">
               <div className="flex items-center justify-between">
                 <Label>Available Tags</Label>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  onClick={() => setSelectedTags([])}
-                  disabled={selectedTags.length === 0}
-                >
-                  Deselect All
-                </Button>
+                <div className="flex items-center gap-2">
+                  <Button type="button" size="sm" variant="outline" onClick={resetItems} disabled={!hasChanges}>
+                    Reset
+                  </Button>
+                  <Button type="button" size="sm" variant="outline" onClick={clearAll}>
+                    Clear All
+                  </Button>
+                </div>
               </div>
               <div
                 ref={scrollContainerRef}
                 className="h-48 border rounded-md p-3 overflow-y-auto"
               >
                 {shouldUseVirtualization ? (
-                  // Virtualized rendering for large tag lists
                   <div
                     style={{
                       height: `${virtualizer.getTotalSize()}px`,
@@ -177,11 +311,10 @@ export const AddTagsDialog = memo(function AddTagsDialog({
                     }}
                   >
                     {virtualizer.getVirtualItems().map((virtualRow) => {
-                      const tag = displayTags[virtualRow.index]
-                      const isTemporary = temporaryTags.includes(tag)
+                      const item = items[virtualRow.index]
                       return (
                         <div
-                          key={virtualRow.key}
+                          key={item.tag}
                           data-index={virtualRow.index}
                           ref={virtualizer.measureElement}
                           style={{
@@ -192,314 +325,24 @@ export const AddTagsDialog = memo(function AddTagsDialog({
                             transform: `translateY(${virtualRow.start}px)`,
                           }}
                         >
-                          <div className="flex items-center space-x-2 py-1">
-                            <Checkbox
-                              id={`add-tag-${tag}`}
-                              checked={selectedTags.includes(tag)}
-                              onCheckedChange={(checked: boolean | string) => {
-                                if (checked) {
-                                  setSelectedTags([...selectedTags, tag])
-                                } else {
-                                  setSelectedTags(selectedTags.filter((t: string) => t !== tag))
-                                }
-                              }}
-                            />
-                            <label
-                              htmlFor={`add-tag-${tag}`}
-                              className={`text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer ${
-                                isTemporary ? "text-primary italic" : ""
-                              }`}
-                            >
-                              {tag}
-                              {isTemporary && <span className="ml-1 text-xs text-muted-foreground">(new)</span>}
-                            </label>
-                          </div>
+                          {renderTagRow(item)}
                         </div>
                       )
                     })}
                   </div>
                 ) : (
-                  // Simple rendering for small tag lists - faster!
                   <div className="space-y-1">
-                    {displayTags.map((tag) => {
-                      const isTemporary = temporaryTags.includes(tag)
-                      return (
-                        <div key={tag} className="flex items-center space-x-2 py-1">
-                          <Checkbox
-                            id={`add-tag-${tag}`}
-                            checked={selectedTags.includes(tag)}
-                            onCheckedChange={(checked: boolean | string) => {
-                              if (checked) {
-                                setSelectedTags([...selectedTags, tag])
-                              } else {
-                                setSelectedTags(selectedTags.filter((t: string) => t !== tag))
-                              }
-                            }}
-                          />
-                          <label
-                            htmlFor={`add-tag-${tag}`}
-                            className={`text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer ${
-                              isTemporary ? "text-primary italic" : ""
-                            }`}
-                          >
-                            {tag}
-                            {isTemporary && <span className="ml-1 text-xs text-muted-foreground">(new)</span>}
-                          </label>
-                        </div>
-                      )
-                    })}
+                    {items.map(renderTagRow)}
                   </div>
                 )}
               </div>
             </div>
-          ) : null}
-
-          {/* Add new tag */}
-          <div className="space-y-2">
-            <Label htmlFor="newTag">Create New Tag</Label>
-            <div className="flex gap-2">
-              <Input
-                id="newTag"
-                value={newTag}
-                onChange={(e: ChangeEvent<HTMLInputElement>) => setNewTag(e.target.value)}
-                placeholder="Enter new tag"
-                onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
-                  if (e.key === "Enter" && newTag.trim()) {
-                    e.preventDefault()
-                    addNewTag(newTag)
-                  }
-                }}
-              />
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                onClick={() => addNewTag(newTag)}
-                disabled={!newTag.trim() || displayTags.includes(newTag.trim())}
-              >
-                <Plus className="h-4 w-4" />
-              </Button>
-            </div>
-          </div>
-
-          {/* Selected tags summary */}
-          {selectedTags.length > 0 && (
-            <div className="text-sm text-muted-foreground">
-              Tags to add: {selectedTags.join(", ")}
+          ) : (
+            <div className="text-center py-8 text-muted-foreground">
+              No tags available yet. Add one below.
             </div>
           )}
-        </div>
-        <DialogFooter>
-          <Button variant="outline" onClick={handleCancel}>Cancel</Button>
-          <Button
-            onClick={handleConfirm}
-            disabled={isPending || selectedTags.length === 0}
-          >
-            Add Tags
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  )
-})
 
-export const SetTagsDialog = memo(function SetTagsDialog({
-  open,
-  onOpenChange,
-  availableTags,
-  hashCount,
-  onConfirm,
-  isPending = false,
-  initialTags = [],
-  isLoadingTags = false,
-}: SetTagsDialogProps) {
-  const [selectedTags, setSelectedTags] = useState<string[]>([])
-  const [newTag, setNewTag] = useState("")
-  const [temporaryTags, setTemporaryTags] = useState<string[]>([]) // New state for temporarily created tags
-  const wasOpen = useRef(false)
-  const scrollContainerRef = useRef<HTMLDivElement>(null)
-
-  // Initialize selected tags only when dialog transitions from closed to open
-  useEffect(() => {
-    if (open && !wasOpen.current) {
-      setSelectedTags(initialTags)
-      setTemporaryTags([]) // Clear temporary tags when opening dialog
-    }
-    wasOpen.current = open
-  }, [open, initialTags])
-
-  // Combine server tags with temporary tags for display
-  const displayTags = [...(availableTags || []), ...temporaryTags].sort()
-
-  // Only use virtualization for large tag lists (>50 tags)
-  const shouldUseVirtualization = displayTags.length > 50
-
-  // Virtualization for large tag lists
-  const virtualizer = useVirtualizer({
-    count: shouldUseVirtualization ? displayTags.length : 0,
-    getScrollElement: () => scrollContainerRef.current,
-    estimateSize: () => 32, // Approximate height of each tag item
-    overscan: 5,
-  })
-
-  const handleConfirm = useCallback((): void => {
-    const allTags = [...selectedTags]
-    if (newTag.trim() && !allTags.includes(newTag.trim())) {
-      allTags.push(newTag.trim())
-    }
-    onConfirm(allTags)
-    setSelectedTags([])
-    setNewTag("")
-    setTemporaryTags([]) // Clear temporary tags after confirming
-  }, [selectedTags, newTag, onConfirm])
-
-  const handleCancel = useCallback((): void => {
-    setSelectedTags([])
-    setNewTag("")
-    setTemporaryTags([]) // Clear temporary tags when cancelling
-    onOpenChange(false)
-  }, [onOpenChange])
-
-  const addNewTag = useCallback((tagToAdd: string): void => {
-    const trimmedTag = tagToAdd.trim()
-    if (trimmedTag && !displayTags.includes(trimmedTag)) {
-      // Add to temporary tags if it's not already in server tags
-      if (!availableTags?.includes(trimmedTag)) {
-        setTemporaryTags(prev => [...prev, trimmedTag])
-      }
-      // Add to selected tags
-      setSelectedTags(prev => [...prev, trimmedTag])
-      setNewTag("")
-    }
-  }, [displayTags, availableTags])
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md">
-        <DialogHeader>
-          <DialogTitle>Replace Tags for {hashCount} torrent(s)</DialogTitle>
-          <DialogDescription>
-            Select tags from the list or add a new one. Selected tags will replace all existing tags on the torrents. Leave all unchecked to remove all tags.
-          </DialogDescription>
-        </DialogHeader>
-        <div className="py-4 space-y-4">
-          {/* Existing tags */}
-          {isLoadingTags ? (
-            <div className="space-y-2">
-              <Label>Available Tags</Label>
-              <div className="h-48 border rounded-md p-3 flex items-center justify-center">
-                <div className="flex items-center gap-2 text-muted-foreground">
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                  <span className="text-sm">Loading tags...</span>
-                </div>
-              </div>
-            </div>
-          ) : displayTags && displayTags.length > 0 ? (
-            <div className="space-y-2">
-              <div className="flex items-center justify-between">
-                <Label>Available Tags</Label>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  onClick={() => setSelectedTags([])}
-                  disabled={selectedTags.length === 0}
-                >
-                  Deselect All
-                </Button>
-              </div>
-              <div
-                ref={scrollContainerRef}
-                className="h-48 border rounded-md p-3 overflow-y-auto"
-              >
-                {shouldUseVirtualization ? (
-                  // Virtualized rendering for large tag lists
-                  <div
-                    style={{
-                      height: `${virtualizer.getTotalSize()}px`,
-                      width: "100%",
-                      position: "relative",
-                    }}
-                  >
-                    {virtualizer.getVirtualItems().map((virtualRow) => {
-                      const tag = displayTags[virtualRow.index]
-                      const isTemporary = temporaryTags.includes(tag)
-                      return (
-                        <div
-                          key={virtualRow.key}
-                          data-index={virtualRow.index}
-                          ref={virtualizer.measureElement}
-                          style={{
-                            position: "absolute",
-                            top: 0,
-                            left: 0,
-                            width: "100%",
-                            transform: `translateY(${virtualRow.start}px)`,
-                          }}
-                        >
-                          <div className="flex items-center space-x-2 py-1">
-                            <Checkbox
-                              id={`tag-${tag}`}
-                              checked={selectedTags.includes(tag)}
-                              onCheckedChange={(checked: boolean | string) => {
-                                if (checked) {
-                                  setSelectedTags([...selectedTags, tag])
-                                } else {
-                                  setSelectedTags(selectedTags.filter((t: string) => t !== tag))
-                                }
-                              }}
-                            />
-                            <label
-                              htmlFor={`tag-${tag}`}
-                              className={`text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer ${
-                                isTemporary ? "text-primary italic" : ""
-                              }`}
-                            >
-                              {tag}
-                              {isTemporary && <span className="ml-1 text-xs text-muted-foreground">(new)</span>}
-                            </label>
-                          </div>
-                        </div>
-                      )
-                    })}
-                  </div>
-                ) : (
-                  // Simple rendering for small tag lists - faster!
-                  <div className="space-y-1">
-                    {displayTags.map((tag) => {
-                      const isTemporary = temporaryTags.includes(tag)
-                      return (
-                        <div key={tag} className="flex items-center space-x-2 py-1">
-                          <Checkbox
-                            id={`tag-${tag}`}
-                            checked={selectedTags.includes(tag)}
-                            onCheckedChange={(checked: boolean | string) => {
-                              if (checked) {
-                                setSelectedTags([...selectedTags, tag])
-                              } else {
-                                setSelectedTags(selectedTags.filter((t: string) => t !== tag))
-                              }
-                            }}
-                          />
-                          <label
-                            htmlFor={`tag-${tag}`}
-                            className={`text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer ${
-                              isTemporary ? "text-primary italic" : ""
-                            }`}
-                          >
-                            {tag}
-                            {isTemporary && <span className="ml-1 text-xs text-muted-foreground">(new)</span>}
-                          </label>
-                        </div>
-                      )
-                    })}
-                  </div>
-                )}
-              </div>
-            </div>
-          ) : null}
-
-          {/* Add new tag */}
           <div className="space-y-2">
             <Label htmlFor="newTag">Add New Tag</Label>
             <div className="flex gap-2">
@@ -520,28 +363,31 @@ export const SetTagsDialog = memo(function SetTagsDialog({
                 size="sm"
                 variant="outline"
                 onClick={() => addNewTag(newTag)}
-                disabled={!newTag.trim() || displayTags.includes(newTag.trim())}
+                disabled={!newTag.trim()}
               >
                 <Plus className="h-4 w-4" />
               </Button>
             </div>
           </div>
 
-          {/* Selected tags summary */}
-          {selectedTags.length > 0 && (
+          {hasChanges ? (
             <div className="text-sm text-muted-foreground">
-              Selected: {selectedTags.join(", ")}
+              {updatePlan.add.length > 0 && (
+                <div>Add everywhere: {updatePlan.add.join(", ")}</div>
+              )}
+              {updatePlan.remove.length > 0 && (
+                <div>Remove everywhere: {updatePlan.remove.join(", ")}</div>
+              )}
+            </div>
+          ) : (
+            <div className="text-sm text-muted-foreground">
+              No tag changes.
             </div>
           )}
         </div>
         <DialogFooter>
           <Button variant="outline" onClick={handleCancel}>Cancel</Button>
-          <Button
-            onClick={handleConfirm}
-            disabled={isPending}
-          >
-            Replace Tags
-          </Button>
+          <Button onClick={handleConfirm} disabled={isPending || !hasChanges}>Apply</Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>
@@ -676,9 +522,7 @@ export const SetLocationDialog = memo(function SetLocationDialog({
                         title={entry}
                         className={cn(
                           "w-full px-3 py-2 text-sm hover:bg-accent hover:text-accent-foreground",
-                          highlightedIndex === idx
-                            ? "bg-accent text-accent-foreground"
-                            : "hover:bg-accent/70",
+                          (highlightedIndex === idx) ? "bg-accent text-accent-foreground" : "hover:bg-accent/70"
                         )}
                         onMouseDown={(e) => e.preventDefault()}
                         onClick={() => handleSelect(entry)}
@@ -1466,184 +1310,6 @@ export const CreateAndAssignCategoryDialog = memo(function CreateAndAssignCatego
   )
 })
 
-interface RemoveTagsDialogProps {
-  open: boolean
-  onOpenChange: (open: boolean) => void
-  availableTags: string[] | null
-  hashCount: number
-  onConfirm: (tags: string[]) => void
-  isPending?: boolean
-  currentTags?: string[]
-}
-
-export const RemoveTagsDialog = memo(function RemoveTagsDialog({
-  open,
-  onOpenChange,
-  availableTags,
-  hashCount,
-  onConfirm,
-  isPending = false,
-  currentTags = [],
-}: RemoveTagsDialogProps) {
-  const [selectedTags, setSelectedTags] = useState<string[]>([])
-  const wasOpen = useRef(false)
-  const scrollContainerRef = useRef<HTMLDivElement>(null)
-
-  // Initialize with current tags when dialog opens
-  useEffect(() => {
-    if (open && !wasOpen.current) {
-      // Reset selection when dialog opens
-      setSelectedTags([])
-    }
-    wasOpen.current = open
-  }, [open, currentTags, availableTags])
-
-  const handleConfirm = useCallback(() => {
-    if (selectedTags.length > 0) {
-      onConfirm(selectedTags)
-      setSelectedTags([])
-    }
-  }, [selectedTags, onConfirm])
-
-  const handleCancel = useCallback(() => {
-    setSelectedTags([])
-    onOpenChange(false)
-  }, [onOpenChange])
-
-  // Filter available tags to only show those that are on the selected torrents
-  const relevantTags = (availableTags || []).filter(tag => currentTags.includes(tag))
-
-  // Only use virtualization for large tag lists (>50 tags)
-  const shouldUseVirtualization = relevantTags.length > 50
-
-  // Virtualization for large tag lists
-  const virtualizer = useVirtualizer({
-    count: shouldUseVirtualization ? relevantTags.length : 0,
-    getScrollElement: () => scrollContainerRef.current,
-    estimateSize: () => 32, // Approximate height of each tag item
-    overscan: 5,
-  })
-
-  return (
-    <AlertDialog open={open} onOpenChange={onOpenChange}>
-      <AlertDialogContent className="max-w-md">
-        <AlertDialogHeader>
-          <AlertDialogTitle>Remove Tags from {hashCount} torrent(s)</AlertDialogTitle>
-          <AlertDialogDescription>
-            Select which tags to remove from the selected torrents.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <div className="py-4 space-y-4">
-          {relevantTags.length > 0 ? (
-            <div className="space-y-2">
-              <Label>Tags to Remove</Label>
-              <div
-                ref={scrollContainerRef}
-                className="h-48 border rounded-md p-3 overflow-y-auto"
-              >
-                {shouldUseVirtualization ? (
-                  // Virtualized rendering for large tag lists (>50 tags)
-                  <div
-                    style={{
-                      height: `${virtualizer.getTotalSize()}px`,
-                      width: "100%",
-                      position: "relative",
-                    }}
-                  >
-                    {virtualizer.getVirtualItems().map((virtualRow) => {
-                      const tag = relevantTags[virtualRow.index]
-                      return (
-                        <div
-                          key={virtualRow.key}
-                          data-index={virtualRow.index}
-                          ref={virtualizer.measureElement}
-                          style={{
-                            position: "absolute",
-                            top: 0,
-                            left: 0,
-                            width: "100%",
-                            transform: `translateY(${virtualRow.start}px)`,
-                          }}
-                        >
-                          <div className="flex items-center space-x-2 py-1">
-                            <Checkbox
-                              id={`remove-tag-${tag}`}
-                              checked={selectedTags.includes(tag)}
-                              onCheckedChange={(checked) => {
-                                if (checked) {
-                                  setSelectedTags([...selectedTags, tag])
-                                } else {
-                                  setSelectedTags(selectedTags.filter(t => t !== tag))
-                                }
-                              }}
-                            />
-                            <label
-                              htmlFor={`remove-tag-${tag}`}
-                              className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
-                            >
-                              {tag}
-                            </label>
-                          </div>
-                        </div>
-                      )
-                    })}
-                  </div>
-                ) : (
-                  // Simple rendering for small tag lists (≤50 tags)
-                  <div className="space-y-1">
-                    {relevantTags.map((tag) => (
-                      <div key={tag} className="flex items-center space-x-2 py-1">
-                        <Checkbox
-                          id={`remove-tag-${tag}`}
-                          checked={selectedTags.includes(tag)}
-                          onCheckedChange={(checked) => {
-                            if (checked) {
-                              setSelectedTags([...selectedTags, tag])
-                            } else {
-                              setSelectedTags(selectedTags.filter(t => t !== tag))
-                            }
-                          }}
-                        />
-                        <label
-                          htmlFor={`remove-tag-${tag}`}
-                          className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
-                        >
-                          {tag}
-                        </label>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
-            </div>
-          ) : (
-            <div className="text-center py-8 text-muted-foreground">
-              No tags found on the selected torrents.
-            </div>
-          )}
-
-          {/* Selected tags summary */}
-          {selectedTags.length > 0 && (
-            <div className="text-sm text-muted-foreground">
-              Will remove: {selectedTags.join(", ")}
-            </div>
-          )}
-        </div>
-        <AlertDialogFooter>
-          <AlertDialogCancel onClick={handleCancel}>Cancel</AlertDialogCancel>
-          <AlertDialogAction
-            onClick={handleConfirm}
-            disabled={selectedTags.length === 0 || isPending}
-            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-          >
-            <X className="mr-2 h-4 w-4" />
-            Remove Tags
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
-  )
-})
 
 interface EditTrackerDialogProps {
   open: boolean

--- a/web/src/components/torrents/TorrentDialogs.tsx
+++ b/web/src/components/torrents/TorrentDialogs.tsx
@@ -56,6 +56,9 @@ interface TagEditorDialogProps {
   selectionRequest?: {
     instanceId: number
     instanceIds?: number[]
+    hashes?: string[]
+    targets?: Array<{ instanceId: number; hash: string }>
+    selectAll?: boolean
     filters?: TorrentFilters
     search?: string
     excludeHashes?: string[]
@@ -82,7 +85,6 @@ export const TagEditorDialog = memo(function TagEditorDialog({
   const [selectionTagValues, setSelectionTagValues] = useState<string[]>([])
   const [isLoadingSelectionTags, setIsLoadingSelectionTags] = useState(false)
   const hasEditedRef = useRef(false)
-  const wasOpenRef = useRef(false)
   const scrollContainerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -92,37 +94,44 @@ export const TagEditorDialog = memo(function TagEditorDialog({
       setSelectionTagValues([])
       setIsLoadingSelectionTags(false)
       hasEditedRef.current = false
-      wasOpenRef.current = false
       return
     }
 
-    if (wasOpenRef.current) {
-      return
-    }
-
-    wasOpenRef.current = true
     setNewTag("")
     hasEditedRef.current = false
 
-    const needsSelectionTagFetch =
-      hashCount > selectedTorrents.length &&
-      typeof selectionRequest?.instanceId === "number" &&
-      selectionRequest.instanceId >= 0
+    const requiresRemoteBaseline = hashCount > selectedTorrents.length
+    const hasValidInstance = typeof selectionRequest?.instanceId === "number" && selectionRequest.instanceId >= 0
+    const hasExplicitSelection = (selectionRequest?.targets?.length ?? 0) > 0 || (selectionRequest?.hashes?.length ?? 0) > 0
+    const canFetchRemoteBaseline = hasValidInstance && (selectionRequest?.selectAll === true || hasExplicitSelection)
 
-    if (!needsSelectionTagFetch) {
+    if (!requiresRemoteBaseline) {
       setSelectionTagValues(selectedTorrents.map(torrent => torrent.tags))
       setIsLoadingSelectionTags(false)
       return
     }
 
     let cancelled = false
+
+    if (!canFetchRemoteBaseline) {
+      setSelectionTagValues([])
+      setIsLoadingSelectionTags(false)
+      return () => {
+        cancelled = true
+        setIsLoadingSelectionTags(false)
+      }
+    }
+
     setIsLoadingSelectionTags(true)
 
     void api.getTorrentField(selectionRequest.instanceId, "tags", {
-      filters: selectionRequest.filters,
-      search: selectionRequest.search,
-      excludeHashes: selectionRequest.excludeHashes,
-      excludeTargets: selectionRequest.excludeTargets,
+      hashes: selectionRequest.hashes,
+      targets: selectionRequest.targets,
+      selectAll: selectionRequest.selectAll,
+      filters: selectionRequest.selectAll ? selectionRequest.filters : undefined,
+      search: selectionRequest.selectAll ? selectionRequest.search : undefined,
+      excludeHashes: selectionRequest.selectAll ? selectionRequest.excludeHashes : undefined,
+      excludeTargets: selectionRequest.selectAll ? selectionRequest.excludeTargets : undefined,
       instanceIds: selectionRequest.instanceIds,
     }).then((response) => {
       if (cancelled) {
@@ -146,6 +155,7 @@ export const TagEditorDialog = memo(function TagEditorDialog({
 
     return () => {
       cancelled = true
+      setIsLoadingSelectionTags(false)
     }
   }, [hashCount, onOpenChange, open, selectedTorrents, selectionRequest])
 
@@ -192,7 +202,9 @@ export const TagEditorDialog = memo(function TagEditorDialog({
   }, [onOpenChange])
 
   const toggleTag = useCallback((tag: string): void => {
-    hasEditedRef.current = true
+    if (!isLoadingTags && !isLoadingSelectionTags) {
+      hasEditedRef.current = true
+    }
     setItems(prev => prev.map((item) => {
       if (item.tag !== tag) {
         return item
@@ -203,14 +215,20 @@ export const TagEditorDialog = memo(function TagEditorDialog({
         state: cycleTagSelectionState(item.state),
       }
     }))
-  }, [])
+  }, [isLoadingSelectionTags, isLoadingTags])
 
   const clearAll = useCallback((): void => {
-    hasEditedRef.current = true
+    if (!isLoadingTags && !isLoadingSelectionTags) {
+      hasEditedRef.current = true
+    }
     setItems(prev => prev.map(item => item.state === "off" ? item : { ...item, state: "off" }))
-  }, [])
+  }, [isLoadingSelectionTags, isLoadingTags])
 
   const addNewTag = useCallback((tagToAdd: string): void => {
+    if (isLoadingTags || isLoadingSelectionTags) {
+      return
+    }
+
     const trimmedTag = tagToAdd.trim()
     if (!trimmedTag) {
       return
@@ -236,7 +254,7 @@ export const TagEditorDialog = memo(function TagEditorDialog({
       })
     })
     setNewTag("")
-  }, [])
+  }, [isLoadingSelectionTags, isLoadingTags])
 
   const renderTagRow = useCallback((item: TagEditorItem) => {
     const isNew = !knownTagSet.has(item.tag)
@@ -351,6 +369,7 @@ export const TagEditorDialog = memo(function TagEditorDialog({
                 value={newTag}
                 onChange={(e: ChangeEvent<HTMLInputElement>) => setNewTag(e.target.value)}
                 placeholder="Enter new tag"
+                disabled={isLoadingState}
                 onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
                   if (e.key === "Enter" && newTag.trim()) {
                     e.preventDefault()
@@ -363,7 +382,7 @@ export const TagEditorDialog = memo(function TagEditorDialog({
                 size="sm"
                 variant="outline"
                 onClick={() => addNewTag(newTag)}
-                disabled={!newTag.trim()}
+                disabled={isLoadingState || !newTag.trim()}
               >
                 <Plus className="h-4 w-4" />
               </Button>

--- a/web/src/components/torrents/TorrentDialogs.tsx
+++ b/web/src/components/torrents/TorrentDialogs.tsx
@@ -84,8 +84,26 @@ export const TagEditorDialog = memo(function TagEditorDialog({
   const [newTag, setNewTag] = useState("")
   const [selectionTagValues, setSelectionTagValues] = useState<string[]>([])
   const [isLoadingSelectionTags, setIsLoadingSelectionTags] = useState(false)
+  const [selectionBaselineError, setSelectionBaselineError] = useState<string | null>(null)
   const hasEditedRef = useRef(false)
+  const previousOpenRef = useRef(false)
+  const previousSelectionRequestKeyRef = useRef<string | null>(null)
   const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const selectionRequestKey = useMemo(() => JSON.stringify({
+    instanceId: selectionRequest?.instanceId,
+    instanceIds: selectionRequest?.instanceIds ?? [],
+    hashes: selectionRequest?.hashes ?? [],
+    targets: selectionRequest?.targets ?? [],
+    selectAll: selectionRequest?.selectAll ?? false,
+    filters: selectionRequest?.filters ?? null,
+    search: selectionRequest?.search ?? "",
+    excludeHashes: selectionRequest?.excludeHashes ?? [],
+    excludeTargets: selectionRequest?.excludeTargets ?? [],
+  }), [selectionRequest])
+  const requiresRemoteBaseline = hashCount > selectedTorrents.length
+  const hasValidInstance = typeof selectionRequest?.instanceId === "number" && selectionRequest.instanceId >= 0
+  const hasExplicitSelection = (selectionRequest?.targets?.length ?? 0) > 0 || (selectionRequest?.hashes?.length ?? 0) > 0
+  const canFetchRemoteBaseline = hasValidInstance && (selectionRequest?.selectAll === true || hasExplicitSelection)
 
   useEffect(() => {
     if (!open) {
@@ -93,17 +111,22 @@ export const TagEditorDialog = memo(function TagEditorDialog({
       setNewTag("")
       setSelectionTagValues([])
       setIsLoadingSelectionTags(false)
+      setSelectionBaselineError(null)
       hasEditedRef.current = false
+      previousOpenRef.current = false
+      previousSelectionRequestKeyRef.current = null
       return
     }
 
-    setNewTag("")
-    hasEditedRef.current = false
-
-    const requiresRemoteBaseline = hashCount > selectedTorrents.length
-    const hasValidInstance = typeof selectionRequest?.instanceId === "number" && selectionRequest.instanceId >= 0
-    const hasExplicitSelection = (selectionRequest?.targets?.length ?? 0) > 0 || (selectionRequest?.hashes?.length ?? 0) > 0
-    const canFetchRemoteBaseline = hasValidInstance && (selectionRequest?.selectAll === true || hasExplicitSelection)
+    const didOpen = !previousOpenRef.current
+    const selectionRequestChanged = previousSelectionRequestKeyRef.current !== selectionRequestKey
+    if (didOpen || selectionRequestChanged) {
+      setNewTag("")
+      hasEditedRef.current = false
+    }
+    previousOpenRef.current = true
+    previousSelectionRequestKeyRef.current = selectionRequestKey
+    setSelectionBaselineError(null)
 
     if (!requiresRemoteBaseline) {
       setSelectionTagValues(selectedTorrents.map(torrent => torrent.tags))
@@ -114,11 +137,10 @@ export const TagEditorDialog = memo(function TagEditorDialog({
     let cancelled = false
 
     if (!canFetchRemoteBaseline) {
-      setSelectionTagValues([])
-      setIsLoadingSelectionTags(false)
+      setIsLoadingSelectionTags(true)
+      setSelectionBaselineError("Could not build the full tag baseline for this selection")
       return () => {
         cancelled = true
-        setIsLoadingSelectionTags(false)
       }
     }
 
@@ -139,13 +161,14 @@ export const TagEditorDialog = memo(function TagEditorDialog({
       }
 
       setSelectionTagValues(response.values)
+      setSelectionBaselineError(null)
       setIsLoadingSelectionTags(false)
     }).catch((error: Error) => {
       if (cancelled) {
         return
       }
 
-      setSelectionTagValues([])
+      setSelectionBaselineError(error.message || "Could not build the full tag baseline")
       setIsLoadingSelectionTags(false)
       onOpenChange(false)
       toast.error("Failed to load selected torrent tags", {
@@ -155,17 +178,16 @@ export const TagEditorDialog = memo(function TagEditorDialog({
 
     return () => {
       cancelled = true
-      setIsLoadingSelectionTags(false)
     }
-  }, [hashCount, onOpenChange, open, selectedTorrents, selectionRequest])
+  }, [canFetchRemoteBaseline, hashCount, onOpenChange, open, requiresRemoteBaseline, selectedTorrents, selectionRequest, selectionRequestKey])
 
   useEffect(() => {
-    if (!open || isLoadingTags || isLoadingSelectionTags || hasEditedRef.current) {
+    if (!open || isLoadingTags || isLoadingSelectionTags || hasEditedRef.current || selectionBaselineError) {
       return
     }
 
     setItems(buildTagEditorItems(availableTags, selectionTagValues, hashCount))
-  }, [availableTags, hashCount, isLoadingSelectionTags, isLoadingTags, open, selectionTagValues])
+  }, [availableTags, hashCount, isLoadingSelectionTags, isLoadingTags, open, selectionBaselineError, selectionTagValues])
 
   const knownTagSet = useMemo(() => new Set(availableTags ?? []), [availableTags])
   const updatePlan = useMemo(() => buildTagUpdatePlan(items), [items])
@@ -293,7 +315,11 @@ export const TagEditorDialog = memo(function TagEditorDialog({
           </DialogDescription>
         </DialogHeader>
         <div className="py-4 space-y-4">
-          {isLoadingState ? (
+          {selectionBaselineError ? (
+            <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
+              {selectionBaselineError}
+            </div>
+          ) : isLoadingState ? (
             <div className="space-y-2">
               <Label>Available Tags</Label>
               <div className="h-48 border rounded-md p-3 flex items-center justify-center">

--- a/web/src/components/torrents/TorrentManagementBar.tsx
+++ b/web/src/components/torrents/TorrentManagementBar.tsx
@@ -230,6 +230,54 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
     () => buildTorrentActionTargets(selectedTorrents, actionInstanceId),
     [selectedTorrents, actionInstanceId]
   )
+  const selectedRequestTargets = useMemo(() => {
+    const seen = new Set<string>()
+    const targets: Array<{ instanceId: number; hash: string }> = []
+
+    for (const selectedHash of selectedHashes) {
+      const trimmed = selectedHash.trim()
+      if (!trimmed) {
+        continue
+      }
+
+      const separatorIndex = trimmed.indexOf(":")
+      const target = separatorIndex > 0
+        ? {
+            instanceId: Number(trimmed.slice(0, separatorIndex)),
+            hash: trimmed.slice(separatorIndex + 1),
+          }
+        : {
+            instanceId: actionInstanceId,
+            hash: trimmed,
+          }
+
+      if (target.instanceId <= 0 || !target.hash) {
+        continue
+      }
+
+      const dedupeKey = `${target.instanceId}:${target.hash.toLowerCase()}`
+      if (seen.has(dedupeKey)) {
+        continue
+      }
+
+      seen.add(dedupeKey)
+      targets.push(target)
+    }
+
+    return targets
+  }, [actionInstanceId, selectedHashes])
+  const selectedRequestHashes = useMemo(
+    () => Array.from(new Set(selectedHashes.map((selectedHash) => {
+      const trimmed = selectedHash.trim()
+      if (!trimmed) {
+        return ""
+      }
+
+      const separatorIndex = trimmed.indexOf(":")
+      return separatorIndex > 0 ? trimmed.slice(separatorIndex + 1) : trimmed
+    }).filter(Boolean))),
+    [selectedHashes]
+  )
   const actionOptions = useMemo(() => ({
     instanceIds,
     targets: isAllSelected ? undefined : actionTargets,
@@ -754,10 +802,13 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
         selectionRequest={{
           instanceId: metadataInstanceId,
           instanceIds,
-          filters,
-          search,
-          excludeHashes,
-          excludeTargets,
+          hashes: !isAllSelected ? selectedRequestHashes : undefined,
+          targets: !isAllSelected && selectedRequestTargets.length === selectedRequestHashes.length ? selectedRequestTargets : undefined,
+          selectAll: isAllSelected,
+          filters: isAllSelected ? filters : undefined,
+          search: isAllSelected ? search : undefined,
+          excludeHashes: isAllSelected ? excludeHashes : undefined,
+          excludeTargets: isAllSelected ? excludeTargets : undefined,
         }}
         onConfirm={handleTagsWrapper}
         isPending={isPending}

--- a/web/src/components/torrents/TorrentManagementBar.tsx
+++ b/web/src/components/torrents/TorrentManagementBar.tsx
@@ -26,7 +26,7 @@ import { useInstanceMetadata } from "@/hooks/useInstanceMetadata"
 import { useInstances } from "@/hooks/useInstances"
 import { TORRENT_ACTIONS, useTorrentActions } from "@/hooks/useTorrentActions"
 import { buildTorrentActionTargets } from "@/lib/torrent-action-targets"
-import { anyTorrentHasTag, getCommonCategory, getCommonSavePath, getCommonTags, getTorrentHashesWithTag, getTotalSize, parseTorrentTags } from "@/lib/torrent-utils"
+import { anyTorrentHasTag, getCommonCategory, getCommonSavePath, getTorrentHashesWithTag, getTotalSize, parseTorrentTags } from "@/lib/torrent-utils"
 import { formatBytes } from "@/lib/utils"
 import type { Category, Torrent, TorrentFilters } from "@/types"
 import {
@@ -52,11 +52,10 @@ import {
 import { memo, useCallback, useMemo } from "react"
 import { DeleteTorrentDialog } from "./DeleteTorrentDialog"
 import {
-  AddTagsDialog,
   LocationWarningDialog,
   SetCategoryDialog,
   SetLocationDialog,
-  SetTagsDialog,
+  TagEditorDialog,
   ShareLimitDialog,
   SpeedLimitsDialog,
   TmmConfirmDialog
@@ -156,10 +155,8 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
     setBlockCrossSeeds,
     deleteCrossSeeds,
     setDeleteCrossSeeds,
-    showAddTagsDialog,
-    setShowAddTagsDialog,
-    showSetTagsDialog,
-    setShowSetTagsDialog,
+    showTagsDialog,
+    setShowTagsDialog,
     showCategoryDialog,
     setShowCategoryDialog,
     showShareLimitDialog,
@@ -180,8 +177,7 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
     isPending,
     handleAction,
     handleDelete,
-    handleAddTags,
-    handleSetTags,
+    handleUpdateTags,
     handleSetCategory,
     handleSetLocation,
     handleSetShareLimit,
@@ -316,9 +312,9 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
     supportsCrossSeedDeleteTools,
   ])
 
-  const handleAddTagsWrapper = useCallback((tags: string[]) => {
-    handleAddTags(
-      tags,
+  const handleTagsWrapper = useCallback((plan: Parameters<typeof handleUpdateTags>[0]) => {
+    handleUpdateTags(
+      plan,
       selectedHashes,
       isAllSelected,
       filters,
@@ -326,19 +322,7 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
       excludeHashes,
       clientMeta
     )
-  }, [handleAddTags, selectedHashes, isAllSelected, filters, search, excludeHashes, clientMeta])
-
-  const handleSetTagsWrapper = useCallback((tags: string[]) => {
-    handleSetTags(
-      tags,
-      selectedHashes,
-      isAllSelected,
-      filters,
-      search,
-      excludeHashes,
-      clientMeta
-    )
-  }, [handleSetTags, selectedHashes, isAllSelected, filters, search, excludeHashes, clientMeta])
+  }, [handleUpdateTags, selectedHashes, isAllSelected, filters, search, excludeHashes, clientMeta])
 
   const handleSetCategoryWrapper = useCallback((category: string) => {
     handleSetCategory(
@@ -575,18 +559,11 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
             </Tooltip>
             <DropdownMenuContent align="center">
               <DropdownMenuItem
-                onClick={() => prepareTagsAction("add", selectedHashes, selectedTorrents)}
+                onClick={() => prepareTagsAction(selectedHashes, selectedTorrents)}
                 disabled={isPending || isDisabled}
               >
                 <Tag className="h-4 w-4 mr-2" />
-                Add Tags {selectionCount > 1 ? `(${selectionCount})` : ""}
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() => prepareTagsAction("set", selectedHashes, selectedTorrents)}
-                disabled={isPending || isDisabled}
-              >
-                <Tag className="h-4 w-4 mr-2" />
-                Replace Tags {selectionCount > 1 ? `(${selectionCount})` : ""}
+                Set Tags {selectionCount > 1 ? `(${selectionCount})` : ""}
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
@@ -768,26 +745,22 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
         onConfirm={handleDeleteWrapper}
       />
 
-      {/* Add Tags Dialog */}
-      <AddTagsDialog
-        open={showAddTagsDialog}
-        onOpenChange={setShowAddTagsDialog}
+      <TagEditorDialog
+        open={showTagsDialog}
+        onOpenChange={setShowTagsDialog}
         availableTags={availableTags || []}
+        selectedTorrents={selectedTorrents}
         hashCount={totalSelectionCount || selectedHashes.length}
-        onConfirm={handleAddTagsWrapper}
+        selectionRequest={{
+          instanceId: metadataInstanceId,
+          instanceIds,
+          filters,
+          search,
+          excludeHashes,
+          excludeTargets,
+        }}
+        onConfirm={handleTagsWrapper}
         isPending={isPending}
-        isLoadingTags={isLoadingTagsData}
-      />
-
-      {/* Set Tags Dialog */}
-      <SetTagsDialog
-        open={showSetTagsDialog}
-        onOpenChange={setShowSetTagsDialog}
-        availableTags={availableTags || []}
-        hashCount={totalSelectionCount || selectedHashes.length}
-        onConfirm={handleSetTagsWrapper}
-        isPending={isPending}
-        initialTags={getCommonTags(selectedTorrents)}
         isLoadingTags={isLoadingTagsData}
       />
 

--- a/web/src/components/torrents/TorrentManagementBar.tsx
+++ b/web/src/components/torrents/TorrentManagementBar.tsx
@@ -280,7 +280,7 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
   )
   const actionOptions = useMemo(() => ({
     instanceIds,
-    targets: isAllSelected ? undefined : actionTargets,
+    targets: isAllSelected || selectedRequestTargets.length !== selectedRequestHashes.length ? undefined : selectedRequestTargets,
     selectAll: isAllSelected,
     filters: isAllSelected ? filters : undefined,
     search: isAllSelected ? search : undefined,
@@ -288,14 +288,14 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
     excludeTargets: isAllSelected ? excludeTargets : undefined,
     clientHashes: selectedHashes,
     clientCount: selectionCount,
-  }), [instanceIds, actionTargets, isAllSelected, filters, search, excludeHashes, excludeTargets, selectedHashes, selectionCount])
+  }), [instanceIds, isAllSelected, selectedRequestTargets, selectedRequestHashes.length, filters, search, excludeHashes, excludeTargets, selectedHashes, selectionCount])
 
   const clientMeta = useMemo(() => ({
     clientHashes: selectedHashes,
     totalSelected: selectionCount,
-    actionTargets: isAllSelected ? undefined : actionTargets,
+    actionTargets: isAllSelected || selectedRequestTargets.length !== selectedRequestHashes.length ? undefined : selectedRequestTargets,
     excludeTargets,
-  }), [selectedHashes, selectionCount, isAllSelected, actionTargets, excludeTargets])
+  }), [selectedHashes, selectionCount, isAllSelected, selectedRequestTargets, selectedRequestHashes.length, excludeTargets])
 
   const deleteDialogTotalSize = useMemo(() => {
     if (totalSelectionSize > 0) {
@@ -363,14 +363,14 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
   const handleTagsWrapper = useCallback((plan: Parameters<typeof handleUpdateTags>[0]) => {
     handleUpdateTags(
       plan,
-      selectedHashes,
+      selectedRequestHashes,
       isAllSelected,
       filters,
       search,
       excludeHashes,
       clientMeta
     )
-  }, [handleUpdateTags, selectedHashes, isAllSelected, filters, search, excludeHashes, clientMeta])
+  }, [handleUpdateTags, selectedRequestHashes, isAllSelected, filters, search, excludeHashes, clientMeta])
 
   const handleSetCategoryWrapper = useCallback((category: string) => {
     handleSetCategory(

--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -88,7 +88,7 @@ import { isAllInstancesScope } from "@/lib/instances"
 import { formatSpeedWithUnit, useSpeedUnits } from "@/lib/speedUnits"
 import { buildTorrentActionTargets } from "@/lib/torrent-action-targets"
 import { getStateLabel } from "@/lib/torrent-state-utils"
-import { anyTorrentHasTag, getCommonCategory, getCommonSavePath, getCommonTags, getTorrentHashesWithTag, getTotalSize } from "@/lib/torrent-utils"
+import { anyTorrentHasTag, getCommonCategory, getCommonSavePath, getTorrentHashesWithTag, getTotalSize } from "@/lib/torrent-utils"
 import { cn } from "@/lib/utils"
 import type {
   Category,
@@ -116,16 +116,14 @@ import { DraggableTableHeader } from "./DraggableTableHeader"
 import type { SelectionInfo } from "./GlobalStatusBar"
 import { SelectAllHotkey } from "./SelectAllHotkey"
 import {
-  AddTagsDialog,
   CreateAndAssignCategoryDialog,
   LocationWarningDialog,
-  RemoveTagsDialog,
   RenameTorrentDialog,
   RenameTorrentFileDialog,
   RenameTorrentFolderDialog,
   SetCategoryDialog,
   SetLocationDialog,
-  SetTagsDialog,
+  TagEditorDialog,
   ShareLimitDialog,
   SpeedLimitsDialog,
   TmmConfirmDialog
@@ -765,12 +763,8 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
     setBlockCrossSeeds,
     deleteCrossSeeds,
     setDeleteCrossSeeds,
-    showAddTagsDialog,
-    setShowAddTagsDialog,
-    showSetTagsDialog,
-    setShowSetTagsDialog,
-    showRemoveTagsDialog,
-    setShowRemoveTagsDialog,
+    showTagsDialog,
+    setShowTagsDialog,
     showCategoryDialog,
     setShowCategoryDialog,
     showCreateCategoryDialog,
@@ -801,9 +795,7 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
     isPending,
     handleAction,
     handleDelete,
-    handleAddTags,
-    handleSetTags,
-    handleRemoveTags,
+    handleUpdateTags,
     handleSetCategory,
     handleSetLocation,
     handleRenameTorrent,
@@ -2139,9 +2131,9 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
     shouldBlockCrossSeeds,
   ])
 
-  const handleAddTagsWrapper = useCallback((tags: string[]) => {
-    handleAddTags(
-      tags,
+  const handleTagsWrapper = useCallback((plan: Parameters<typeof handleUpdateTags>[0]) => {
+    handleUpdateTags(
+      plan,
       contextHashes,
       isAllSelected,
       selectAllFilters ?? filters,
@@ -2149,19 +2141,7 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
       selectAllExcludeHashes,
       contextClientMeta
     )
-  }, [handleAddTags, contextHashes, isAllSelected, selectAllFilters, filters, effectiveSearch, selectAllExcludeHashes, contextClientMeta])
-
-  const handleSetTagsWrapper = useCallback((tags: string[]) => {
-    handleSetTags(
-      tags,
-      contextHashes,
-      isAllSelected,
-      selectAllFilters ?? filters,
-      effectiveSearch,
-      selectAllExcludeHashes,
-      contextClientMeta
-    )
-  }, [handleSetTags, contextHashes, isAllSelected, selectAllFilters, filters, effectiveSearch, selectAllExcludeHashes, contextClientMeta])
+  }, [handleUpdateTags, contextHashes, isAllSelected, selectAllFilters, filters, effectiveSearch, selectAllExcludeHashes, contextClientMeta])
 
   const handleSetCategoryWrapper = useCallback((category: string) => {
     handleSetCategory(
@@ -2241,18 +2221,6 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
     if (!oldPath || !newPath) return
     await handleRenameFolder(hash, oldPath, newPath)
   }, [handleRenameFolder, contextHashes])
-
-  const handleRemoveTagsWrapper = useCallback((tags: string[]) => {
-    handleRemoveTags(
-      tags,
-      contextHashes,
-      isAllSelected,
-      selectAllFilters ?? filters,
-      effectiveSearch,
-      selectAllExcludeHashes,
-      contextClientMeta
-    )
-  }, [handleRemoveTags, contextHashes, isAllSelected, selectAllFilters, filters, effectiveSearch, selectAllExcludeHashes, contextClientMeta])
 
   const handleRecheckWrapper = useCallback(() => {
     handleRecheck(
@@ -3038,26 +3006,22 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
           onConfirm={handleDeleteWrapper}
         />
 
-        {/* Add Tags Dialog */}
-        <AddTagsDialog
-          open={showAddTagsDialog}
-          onOpenChange={setShowAddTagsDialog}
+        <TagEditorDialog
+          open={showTagsDialog}
+          onOpenChange={setShowTagsDialog}
           availableTags={availableTags || []}
+          selectedTorrents={contextTorrents}
           hashCount={isAllSelected ? effectiveSelectionCount : contextHashes.length}
-          onConfirm={handleAddTagsWrapper}
+          selectionRequest={{
+            instanceId,
+            instanceIds: isCrossInstanceEndpoint ? instanceIds : undefined,
+            filters: isAllSelected ? (selectAllFilters ?? filters) : undefined,
+            search: isAllSelected ? effectiveSearch : undefined,
+            excludeHashes: isAllSelected ? selectAllExcludeHashes : undefined,
+            excludeTargets: isAllSelected && isCrossInstanceEndpoint ? selectAllExcludedTargets : undefined,
+          }}
+          onConfirm={handleTagsWrapper}
           isPending={isPending}
-          isLoadingTags={isLoadingTags}
-        />
-
-        {/* Set Tags Dialog */}
-        <SetTagsDialog
-          open={showSetTagsDialog}
-          onOpenChange={setShowSetTagsDialog}
-          availableTags={availableTags || []}
-          hashCount={isAllSelected ? effectiveSelectionCount : contextHashes.length}
-          onConfirm={handleSetTagsWrapper}
-          isPending={isPending}
-          initialTags={getCommonTags(contextTorrents)}
           isLoadingTags={isLoadingTags}
         />
 
@@ -3138,16 +3102,6 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
           isPending={isPending}
         />
 
-        {/* Remove Tags Dialog */}
-        <RemoveTagsDialog
-          open={showRemoveTagsDialog}
-          onOpenChange={setShowRemoveTagsDialog}
-          availableTags={availableTags || []}
-          hashCount={isAllSelected ? effectiveSelectionCount : contextHashes.length}
-          onConfirm={handleRemoveTagsWrapper}
-          isPending={isPending}
-          currentTags={getCommonTags(contextTorrents)}
-        />
 
         {/* Force Recheck Confirmation Dialog */}
         <Dialog open={showRecheckDialog} onOpenChange={setShowRecheckDialog}>

--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -2041,6 +2041,18 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
     excludeHashes: isAllSelected ? selectAllExcludeHashes : undefined,
     excludeTargets: isAllSelected && isCrossInstanceEndpoint ? selectAllExcludedTargets : undefined,
   }), [isAllSelected, selectAllFilters, effectiveSearch, selectAllExcludeHashes, isCrossInstanceEndpoint, selectAllExcludedTargets, instanceIds])
+  const normalizedSelectionFilters = useMemo(() => {
+    const sourceFilters = selectAllFilters ?? filters
+    if (!sourceFilters) {
+      return undefined
+    }
+
+    return {
+      ...sourceFilters,
+      categories: sourceFilters.expandedCategories ?? sourceFilters.categories ?? [],
+      excludeCategories: sourceFilters.expandedExcludeCategories ?? sourceFilters.excludeCategories ?? [],
+    }
+  }, [selectAllFilters, filters])
 
   const contextClientMeta = useMemo(() => ({
     clientHashes: contextHashes,
@@ -3015,7 +3027,10 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
           selectionRequest={{
             instanceId,
             instanceIds: isCrossInstanceEndpoint ? instanceIds : undefined,
-            filters: isAllSelected ? (selectAllFilters ?? filters) : undefined,
+            hashes: !isAllSelected ? contextHashes : undefined,
+            targets: !isAllSelected && (contextClientMeta.actionTargets?.length ?? 0) === contextHashes.length ? contextClientMeta.actionTargets : undefined,
+            selectAll: isAllSelected,
+            filters: isAllSelected ? normalizedSelectionFilters : undefined,
             search: isAllSelected ? effectiveSearch : undefined,
             excludeHashes: isAllSelected ? selectAllExcludeHashes : undefined,
             excludeTargets: isAllSelected && isCrossInstanceEndpoint ? selectAllExcludedTargets : undefined,

--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -2148,12 +2148,12 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
       plan,
       contextHashes,
       isAllSelected,
-      selectAllFilters ?? filters,
+      normalizedSelectionFilters ?? selectAllFilters ?? filters,
       effectiveSearch,
       selectAllExcludeHashes,
       contextClientMeta
     )
-  }, [handleUpdateTags, contextHashes, isAllSelected, selectAllFilters, filters, effectiveSearch, selectAllExcludeHashes, contextClientMeta])
+  }, [handleUpdateTags, contextHashes, isAllSelected, normalizedSelectionFilters, selectAllFilters, filters, effectiveSearch, selectAllExcludeHashes, contextClientMeta])
 
   const handleSetCategoryWrapper = useCallback((category: string) => {
     handleSetCategory(

--- a/web/src/hooks/useTorrentActions.ts
+++ b/web/src/hooks/useTorrentActions.ts
@@ -384,6 +384,9 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
       const count = variables.clientCount ?? variables.hashes.length ?? 1
       const torrentText = count === 1 ? "torrent" : "torrents"
       if (error instanceof TagBulkActionError) {
+        setShowTagsDialog(false)
+        setContextHashes([])
+        setContextTorrents([])
         const succeeded = error.results.filter(result => result.status === "success").map(result => result.action)
         const failed = error.results.filter(result => result.status === "failed")
         const succeededLabel = succeeded.length > 0
@@ -403,6 +406,9 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
         return
       }
 
+      setShowTagsDialog(false)
+      setContextHashes([])
+      setContextTorrents([])
       void invalidateTorrentCaches()
       toast.error(`Failed to update tags for ${count} ${torrentText}`, {
         description: error.message || "An unexpected error occurred",

--- a/web/src/hooks/useTorrentActions.ts
+++ b/web/src/hooks/useTorrentActions.ts
@@ -83,8 +83,47 @@ interface ClientMeta {
   excludeTargets?: Array<{ instanceId: number; hash: string }>
 }
 
+type TagBulkActionResult = {
+  action: "add" | "remove"
+  status: "success" | "failed"
+  error?: Error
+}
+
+class TagBulkActionError extends Error {
+  results: TagBulkActionResult[]
+
+  constructor(results: TagBulkActionResult[]) {
+    const succeeded = results.filter(result => result.status === "success").map(result => result.action)
+    const failed = results.filter(result => result.status === "failed").map(result => result.action)
+    const summary = [
+      failed.length > 0 ? `failed to ${failed.join(" and ")}` : "",
+      succeeded.length > 0 ? `after ${succeeded.join(" and ")}` : "",
+    ].filter(Boolean).join(" ")
+
+    super(summary || "Failed to update tags")
+    this.name = "TagBulkActionError"
+    this.results = results
+  }
+}
+
 export function useTorrentActions({ instanceId, instanceIds, onActionComplete }: UseTorrentActionsProps) {
   const queryClient = useQueryClient()
+  const invalidateTorrentCaches = useCallback(async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: ["torrents-list", instanceId],
+        exact: false,
+      }),
+      queryClient.invalidateQueries({
+        queryKey: ["torrent-counts", instanceId],
+        exact: false,
+      }),
+      queryClient.invalidateQueries({
+        queryKey: ["instance-metadata", instanceId],
+        exact: false,
+      }),
+    ])
+  }, [instanceId, queryClient])
 
   // Dialog states
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
@@ -277,22 +316,39 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
         excludeHashes: data.excludeHashes,
         excludeTargets: data.excludeTargets,
       }
+      const results: TagBulkActionResult[] = []
+
+      const runTagBulkAction = async (action: "add" | "remove", tags: string[]) => {
+        try {
+          await api.bulkAction(instanceId, {
+            ...sharedPayload,
+            action: action === "remove" ? "removeTags" : "addTags",
+            tags: tags.join(","),
+          })
+          results.push({ action, status: "success" })
+        } catch (error) {
+          results.push({
+            action,
+            status: "failed",
+            error: error instanceof Error ? error : new Error("Unknown tag update failure"),
+          })
+        }
+      }
 
       if (data.remove.length > 0) {
-        await api.bulkAction(instanceId, {
-          ...sharedPayload,
-          action: "removeTags",
-          tags: data.remove.join(","),
-        })
+        await runTagBulkAction("remove", data.remove)
       }
 
       if (data.add.length > 0) {
-        await api.bulkAction(instanceId, {
-          ...sharedPayload,
-          action: "addTags",
-          tags: data.add.join(","),
-        })
+        await runTagBulkAction("add", data.add)
       }
+
+      if (results.some(result => result.status === "failed")) {
+        await invalidateTorrentCaches()
+        throw new TagBulkActionError(results)
+      }
+
+      return { results }
     },
     onSuccess: async (_, variables) => {
       setTimeout(() => {
@@ -327,6 +383,27 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
     onError: (error: Error, variables) => {
       const count = variables.clientCount ?? variables.hashes.length ?? 1
       const torrentText = count === 1 ? "torrent" : "torrents"
+      if (error instanceof TagBulkActionError) {
+        const succeeded = error.results.filter(result => result.status === "success").map(result => result.action)
+        const failed = error.results.filter(result => result.status === "failed")
+        const succeededLabel = succeeded.length > 0
+          ? `${succeeded.join(" and ")} ${succeeded.length === 1 ? "succeeded" : "succeeded"}`
+          : ""
+        const failedLabel = failed.length > 0
+          ? `${failed.map(result => result.action).join(" and ")} failed`
+          : "tag update failed"
+        const description = failed
+          .map(result => result.error?.message)
+          .filter((message): message is string => Boolean(message))
+          .join("; ")
+
+        toast.error(`Partially updated tags for ${count} ${torrentText}`, {
+          description: [succeededLabel, failedLabel, description].filter(Boolean).join(". "),
+        })
+        return
+      }
+
+      void invalidateTorrentCaches()
       toast.error(`Failed to update tags for ${count} ${torrentText}`, {
         description: error.message || "An unexpected error occurred",
       })

--- a/web/src/hooks/useTorrentActions.ts
+++ b/web/src/hooks/useTorrentActions.ts
@@ -6,6 +6,7 @@
 import { usePersistedDeleteFiles } from "@/hooks/usePersistedDeleteFiles"
 import { usePersistedCrossSeedBlocklist } from "@/hooks/usePersistedCrossSeedBlocklist"
 import { api } from "@/lib/api"
+import type { TagUpdatePlan } from "@/lib/tag-editor"
 import type { Torrent, TorrentFilters } from "@/types"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useCallback, useState } from "react"
@@ -95,9 +96,7 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
   } = usePersistedDeleteFiles(false)
   const { blockCrossSeeds, setBlockCrossSeeds } = usePersistedCrossSeedBlocklist(instanceId, false)
   const [deleteCrossSeeds, setDeleteCrossSeeds] = useState(false)
-  const [showAddTagsDialog, setShowAddTagsDialog] = useState(false)
-  const [showSetTagsDialog, setShowSetTagsDialog] = useState(false)
-  const [showRemoveTagsDialog, setShowRemoveTagsDialog] = useState(false)
+  const [showTagsDialog, setShowTagsDialog] = useState(false)
   const [showCategoryDialog, setShowCategoryDialog] = useState(false)
   const [showCreateCategoryDialog, setShowCreateCategoryDialog] = useState(false)
   const [showShareLimitDialog, setShowShareLimitDialog] = useState(false)
@@ -234,12 +233,6 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
       if (variables.action === "delete") {
         setShowDeleteDialog(false)
         setDeleteCrossSeeds(false)
-      } else if (variables.action === "addTags") {
-        setShowAddTagsDialog(false)
-      } else if (variables.action === "setTags") {
-        setShowSetTagsDialog(false)
-      } else if (variables.action === "removeTags") {
-        setShowRemoveTagsDialog(false)
       } else if (variables.action === "setCategory") {
         setShowCategoryDialog(false)
         setShowCreateCategoryDialog(false)
@@ -261,6 +254,80 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
       const count = variables.hashes.length || 1
       const torrentText = count === 1 ? "torrent" : "torrents"
       toast.error(`Failed to ${variables.action} ${count} ${torrentText}`, {
+        description: error.message || "An unexpected error occurred",
+      })
+    },
+  })
+
+  const updateTagsMutation = useMutation({
+    mutationFn: async (data: TagUpdatePlan & Omit<TorrentActionData, "action" | "tags">) => {
+      const effectiveFilters = data.filters ? {
+        ...data.filters,
+        categories: data.filters.expandedCategories ?? data.filters.categories ?? [],
+        excludeCategories: data.filters.expandedExcludeCategories ?? data.filters.excludeCategories ?? [],
+      } : undefined
+
+      const sharedPayload = {
+        hashes: data.hashes,
+        instanceIds: data.instanceIds,
+        targets: data.targets,
+        selectAll: data.selectAll,
+        filters: effectiveFilters,
+        search: data.search,
+        excludeHashes: data.excludeHashes,
+        excludeTargets: data.excludeTargets,
+      }
+
+      if (data.remove.length > 0) {
+        await api.bulkAction(instanceId, {
+          ...sharedPayload,
+          action: "removeTags",
+          tags: data.remove.join(","),
+        })
+      }
+
+      if (data.add.length > 0) {
+        await api.bulkAction(instanceId, {
+          ...sharedPayload,
+          action: "addTags",
+          tags: data.add.join(","),
+        })
+      }
+    },
+    onSuccess: async (_, variables) => {
+      setTimeout(() => {
+        queryClient.refetchQueries({
+          queryKey: ["torrents-list", instanceId],
+          exact: false,
+          type: "active",
+        })
+        queryClient.refetchQueries({
+          queryKey: ["torrent-counts", instanceId],
+          exact: false,
+          type: "active",
+        })
+      }, 1000)
+
+      setShowTagsDialog(false)
+      setContextHashes([])
+      setContextTorrents([])
+
+      let toastCount = variables.hashes.length
+      if (variables.clientHashes && variables.clientHashes.length > 0) {
+        toastCount = variables.clientHashes.length
+      }
+      if (typeof variables.clientCount === "number") {
+        toastCount = variables.clientCount
+      }
+
+      const normalizedCount = Math.max(1, toastCount)
+      toast.success(`Updated tags for ${normalizedCount} ${normalizedCount === 1 ? "torrent" : "torrents"}`)
+      onActionComplete?.("setTags")
+    },
+    onError: (error: Error, variables) => {
+      const count = variables.clientCount ?? variables.hashes.length ?? 1
+      const torrentText = count === 1 ? "torrent" : "torrents"
+      toast.error(`Failed to update tags for ${count} ${torrentText}`, {
         description: error.message || "An unexpected error occurred",
       })
     },
@@ -418,8 +485,8 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
     setContextTorrents([])
   }, [mutation, deleteFiles, instanceIds])
 
-  const handleAddTags = useCallback(async (
-    tags: string[],
+  const handleUpdateTags = useCallback(async (
+    plan: TagUpdatePlan,
     hashes: string[],
     isAllSelected?: boolean,
     filters?: TorrentActionData["filters"],
@@ -427,98 +494,20 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
     excludeHashes?: string[],
     clientMeta?: ClientMeta
   ) => {
-    const clientHashes = clientMeta?.clientHashes ?? hashes
-    const clientCount = clientMeta?.totalSelected
-      ?? (clientHashes?.length ?? hashes.length)
-    await mutation.mutateAsync({
-      action: "addTags",
-      instanceIds,
-      targets: isAllSelected ? undefined : clientMeta?.actionTargets,
-      tags: tags.join(","),
-      hashes: isAllSelected ? [] : hashes,
-      selectAll: isAllSelected,
-      filters: isAllSelected ? filters : undefined,
-      search: isAllSelected ? search : undefined,
-      excludeHashes: isAllSelected ? excludeHashes : undefined,
-      excludeTargets: isAllSelected ? clientMeta?.excludeTargets : undefined,
-      clientHashes,
-      clientCount,
-    })
-    setShowAddTagsDialog(false)
-    setContextHashes([])
-    setContextTorrents([])
-  }, [mutation, instanceIds])
-
-  const handleSetTags = useCallback(async (
-    tags: string[],
-    hashes: string[],
-    isAllSelected?: boolean,
-    filters?: TorrentActionData["filters"],
-    search?: string,
-    excludeHashes?: string[],
-    clientMeta?: ClientMeta
-  ) => {
-    const clientHashes = clientMeta?.clientHashes ?? hashes
-    const clientCount = clientMeta?.totalSelected
-      ?? (clientHashes?.length ?? hashes.length)
-    try {
-      await mutation.mutateAsync({
-        action: "setTags",
-        instanceIds,
-        targets: isAllSelected ? undefined : clientMeta?.actionTargets,
-        tags: tags.join(","),
-        hashes: isAllSelected ? [] : hashes,
-        selectAll: isAllSelected,
-        filters: isAllSelected ? filters : undefined,
-        search: isAllSelected ? search : undefined,
-        excludeHashes: isAllSelected ? excludeHashes : undefined,
-        excludeTargets: isAllSelected ? clientMeta?.excludeTargets : undefined,
-        clientHashes,
-        clientCount,
-      })
-    } catch (error) {
-      // Fallback to addTags for older qBittorrent versions
-      if ((error as Error).message?.includes("requires qBittorrent")) {
-        await mutation.mutateAsync({
-          action: "addTags",
-          instanceIds,
-          targets: isAllSelected ? undefined : clientMeta?.actionTargets,
-          tags: tags.join(","),
-          hashes: isAllSelected ? [] : hashes,
-          selectAll: isAllSelected,
-          filters: isAllSelected ? filters : undefined,
-          search: isAllSelected ? search : undefined,
-          excludeHashes: isAllSelected ? excludeHashes : undefined,
-          excludeTargets: isAllSelected ? clientMeta?.excludeTargets : undefined,
-          clientHashes,
-          clientCount,
-        })
-      } else {
-        throw error
-      }
+    if ((plan.add.length === 0) && (plan.remove.length === 0)) {
+      setShowTagsDialog(false)
+      setContextHashes([])
+      setContextTorrents([])
+      return
     }
-    setShowSetTagsDialog(false)
-    setContextHashes([])
-    setContextTorrents([])
-  }, [mutation, instanceIds])
 
-  const handleRemoveTags = useCallback(async (
-    tags: string[],
-    hashes: string[],
-    isAllSelected?: boolean,
-    filters?: TorrentActionData["filters"],
-    search?: string,
-    excludeHashes?: string[],
-    clientMeta?: ClientMeta
-  ) => {
     const clientHashes = clientMeta?.clientHashes ?? hashes
     const clientCount = clientMeta?.totalSelected
       ?? (clientHashes?.length ?? hashes.length)
-    await mutation.mutateAsync({
-      action: "removeTags",
+    await updateTagsMutation.mutateAsync({
+      ...plan,
       instanceIds,
       targets: isAllSelected ? undefined : clientMeta?.actionTargets,
-      tags: tags.join(","),
       hashes: isAllSelected ? [] : hashes,
       selectAll: isAllSelected,
       filters: isAllSelected ? filters : undefined,
@@ -528,10 +517,7 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
       clientHashes,
       clientCount,
     })
-    setShowRemoveTagsDialog(false)
-    setContextHashes([])
-    setContextTorrents([])
-  }, [mutation, instanceIds])
+  }, [updateTagsMutation, instanceIds])
 
   const handleSetCategory = useCallback(async (
     category: string,
@@ -790,13 +776,10 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
     setDeleteCrossSeeds(false)
   }, [])
 
-  const prepareTagsAction = useCallback((action: "add" | "set" | "remove", hashes: string[], torrents?: Torrent[]) => {
+  const prepareTagsAction = useCallback((hashes: string[], torrents?: Torrent[]) => {
     setContextHashes(hashes)
     if (torrents) setContextTorrents(torrents)
-
-    if (action === "add") setShowAddTagsDialog(true)
-    else if (action === "set") setShowSetTagsDialog(true)
-    else if (action === "remove") setShowRemoveTagsDialog(true)
+    setShowTagsDialog(true)
   }, [])
 
   const prepareCategoryAction = useCallback((hashes: string[], torrents?: Torrent[]) => {
@@ -909,7 +892,7 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
     setShowRenameFolderDialog(true)
   }, [])
 
-  const isPending = mutation.isPending || renameTorrentMutation.isPending || renameFileMutation.isPending || renameFolderMutation.isPending
+  const isPending = mutation.isPending || updateTagsMutation.isPending || renameTorrentMutation.isPending || renameFileMutation.isPending || renameFolderMutation.isPending
 
 
   return {
@@ -925,12 +908,8 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
     setBlockCrossSeeds,
     deleteCrossSeeds,
     setDeleteCrossSeeds,
-    showAddTagsDialog,
-    setShowAddTagsDialog,
-    showSetTagsDialog,
-    setShowSetTagsDialog,
-    showRemoveTagsDialog,
-    setShowRemoveTagsDialog,
+    showTagsDialog,
+    setShowTagsDialog,
     showCategoryDialog,
     setShowCategoryDialog,
     showCreateCategoryDialog,
@@ -965,9 +944,7 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
     // Direct action handlers
     handleAction,
     handleDelete,
-    handleAddTags,
-    handleSetTags,
-    handleRemoveTags,
+    handleUpdateTags,
     handleSetCategory,
     handleSetShareLimit,
     handleSetSpeedLimits,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -813,7 +813,7 @@ class ApiClient {
 
   async getTorrentField(
     instanceId: number,
-    field: "name" | "hash" | "full_path",
+    field: "name" | "hash" | "full_path" | "tags",
     params: {
       sort?: string
       order?: "asc" | "desc"

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -817,6 +817,9 @@ class ApiClient {
     params: {
       sort?: string
       order?: "asc" | "desc"
+      hashes?: string[]
+      targets?: Array<{ instanceId: number; hash: string }>
+      selectAll?: boolean
       search?: string
       filters?: TorrentFilters
       excludeHashes?: string[]
@@ -832,6 +835,9 @@ class ApiClient {
           field,
           sort: params.sort,
           order: params.order,
+          hashes: params.hashes,
+          targets: params.targets,
+          selectAll: params.selectAll,
           search: params.search,
           filters: params.filters,
           excludeHashes: params.excludeHashes,

--- a/web/src/lib/tag-editor.ts
+++ b/web/src/lib/tag-editor.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { parseTorrentTags } from "@/lib/torrent-utils"
+
+export type TagSelectionState = "on" | "off" | "mixed"
+
+export interface TagEditorItem {
+  tag: string
+  initialState: TagSelectionState
+  state: TagSelectionState
+}
+
+export interface TagUpdatePlan {
+  add: string[]
+  remove: string[]
+}
+
+const tagSortCollator = new Intl.Collator(undefined, { numeric: true, usage: "sort" })
+
+function normalizeTag(tag: string): string {
+  return tag.trim()
+}
+
+function buildTagSourceSet(availableTags: string[] | null | undefined, tagValues: string[]): Set<string> {
+  const tags = new Set<string>()
+
+  for (const tag of availableTags ?? []) {
+    const normalized = normalizeTag(tag)
+    if (normalized) {
+      tags.add(normalized)
+    }
+  }
+
+  for (const tagValue of tagValues) {
+    for (const tag of parseTorrentTags(tagValue)) {
+      tags.add(tag)
+    }
+  }
+
+  return tags
+}
+
+export function sortTags(tags: Iterable<string>): string[] {
+  return Array.from(tags).sort(tagSortCollator.compare)
+}
+
+export function buildTagEditorItems(
+  availableTags: string[] | null | undefined,
+  tagValues: string[],
+  selectedCount: number
+): TagEditorItem[] {
+  const tagCounts = new Map<string, number>()
+
+  for (const tagValue of tagValues) {
+    const seen = new Set(parseTorrentTags(tagValue))
+    for (const tag of seen) {
+      tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1)
+    }
+  }
+
+  return sortTags(buildTagSourceSet(availableTags, tagValues)).map((tag) => {
+    const count = tagCounts.get(tag) ?? 0
+
+    let initialState: TagSelectionState = "off"
+    if ((selectedCount > 0) && (count === selectedCount)) {
+      initialState = "on"
+    } else if (count > 0) {
+      initialState = "mixed"
+    }
+
+    return {
+      tag,
+      initialState,
+      state: initialState,
+    }
+  })
+}
+
+export function cycleTagSelectionState(state: TagSelectionState): TagSelectionState {
+  switch (state) {
+    case "mixed":
+      return "on"
+    case "on":
+      return "off"
+    case "off":
+    default:
+      return "on"
+  }
+}
+
+export function buildTagUpdatePlan(items: TagEditorItem[]): TagUpdatePlan {
+  const add: string[] = []
+  const remove: string[] = []
+
+  for (const item of items) {
+    if ((item.state === "on") && (item.initialState !== "on")) {
+      add.push(item.tag)
+      continue
+    }
+
+    if ((item.state === "off") && (item.initialState !== "off")) {
+      remove.push(item.tag)
+    }
+  }
+
+  return { add, remove }
+}
+
+export function hasTagUpdatePlan(plan: TagUpdatePlan): boolean {
+  return (plan.add.length > 0) || (plan.remove.length > 0)
+}


### PR DESCRIPTION
Implements the unified bulk tag editor

This removes the split Add Tags / Replace Tags flow and replaces it with a single tri-state tag editor that works across desktop and mobile.

ref: https://github.com/autobrr/qui/discussions/1011

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API: Torrent field endpoint now supports "tags", explicit selection (hashes/targets), selectAll, and ordering; responses include per-torrent tag values.
  * Frontend: Tag editor utilities and a new Tag Editor dialog supporting plan-based bulk tag updates with per-item baselines.

* **Improvements**
  * Unified tag workflow: Add/Set/Remove consolidated into a single "Set Tags" editor with Mixed/On/Off states, Reset/Clear, summary, and apply flow.
  * UI updates: Context menus, management bar, tables, and mobile now use the unified tag dialog and batch update flow.

* **Documentation**
  * API docs updated to describe new request/response semantics for tag baselines and selection options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->