### PR TITLE
fix(crossseed): normalize hdr aliases

### DIFF
--- a/internal/services/crossseed/crossseed_test.go
+++ b/internal/services/crossseed/crossseed_test.go
@@ -2166,6 +2166,24 @@ func TestCheckWebhook_AutobrrPayload(t *testing.T) {
 			wantMatchType:      "metadata",
 		},
 		{
+			name: "discussion title matches filename HDR10P alias",
+			request: &WebhookCheckRequest{
+				InstanceIDs: instanceIDs,
+				TorrentName: "End of Watch 2012 Hybrid 2160p UHD BluRay REMUX DV HDR10+ HEVC DTS-HD MA 5.1-FraMeSToR",
+			},
+			existingTorrents: []qbt.Torrent{
+				{
+					Hash:     "framestor",
+					Name:     "End.of.Watch.2012.UHD.BluRay.2160p.DTS-HD.MA.5.1.DV.HDR10P.HEVC.HYBRID.REMUX-FraMeSToR.mkv",
+					Progress: 1.0,
+				},
+			},
+			wantCanCrossSeed:   true,
+			wantMatchCount:     1,
+			wantRecommendation: "download",
+			wantMatchType:      "metadata",
+		},
+		{
 			name: "pending match when torrent still downloading",
 			request: &WebhookCheckRequest{
 				InstanceIDs: instanceIDs,
@@ -2591,6 +2609,52 @@ func TestFindCandidates_NonTVDoesNotMatchUnrelatedTorrents(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Empty(t, resp.Candidates, "unrelated non-TV torrents should not be treated as matches")
+}
+
+func TestFindCandidates_MatchesHDR10PlusAliasAcrossNameFormats(t *testing.T) {
+	instance := &models.Instance{
+		ID:   1,
+		Name: "main",
+	}
+
+	torrents := []qbt.Torrent{
+		{
+			Hash:        "framestor",
+			Name:        "End.of.Watch.2012.UHD.BluRay.2160p.DTS-HD.MA.5.1.DV.HDR10P.HEVC.HYBRID.REMUX-FraMeSToR.mkv",
+			Progress:    1.0,
+			ContentPath: "/downloads/End.of.Watch.2012.UHD.BluRay.2160p.DTS-HD.MA.5.1.DV.HDR10P.HEVC.HYBRID.REMUX-FraMeSToR.mkv",
+			SavePath:    "/downloads",
+		},
+	}
+
+	files := map[string]qbt.TorrentFiles{
+		"framestor": {
+			{Name: "End.of.Watch.2012.UHD.BluRay.2160p.DTS-HD.MA.5.1.DV.HDR10P.HEVC.HYBRID.REMUX-FraMeSToR.mkv", Size: 50 << 30},
+		},
+	}
+
+	store := &fakeInstanceStore{
+		instances: map[int]*models.Instance{
+			instance.ID: instance,
+		},
+	}
+
+	svc := &Service{
+		instanceStore:    store,
+		syncManager:      newFakeSyncManager(instance, torrents, files),
+		releaseCache:     NewReleaseCache(),
+		stringNormalizer: stringutils.NewDefaultNormalizer(),
+	}
+
+	resp, err := svc.FindCandidates(context.Background(), &FindCandidatesRequest{
+		TorrentName:       "End of Watch 2012 Hybrid 2160p UHD BluRay REMUX DV HDR10+ HEVC DTS-HD MA 5.1-FraMeSToR",
+		TargetInstanceIDs: []int{instance.ID},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Candidates, 1)
+	require.Len(t, resp.Candidates[0].Torrents, 1)
+	require.Equal(t, "framestor", resp.Candidates[0].Torrents[0].Hash)
+	require.NotEmpty(t, resp.Candidates[0].MatchType)
 }
 
 type fakeInstanceStore struct {

--- a/internal/services/crossseed/matching.go
+++ b/internal/services/crossseed/matching.go
@@ -300,8 +300,8 @@ func (s *Service) releasesMatch(source, candidate *rls.Release, findIndividualEp
 
 	// HDR must match if either is present (HDR vs SDR are different encodes)
 	// If one release has HDR metadata and the other doesn't, they cannot match
-	sourceHDR := joinNormalizedSlice(source.HDR)
-	candidateHDR := joinNormalizedSlice(candidate.HDR)
+	sourceHDR := joinNormalizedHDRSlice(source.HDR)
+	candidateHDR := joinNormalizedHDRSlice(candidate.HDR)
 	if sourceHDR != candidateHDR {
 		return false
 	}
@@ -404,6 +404,53 @@ func joinNormalizedSlice(slice []string) string {
 	}
 	sort.Strings(normalized)
 	return strings.Join(normalized, " ")
+}
+
+func joinNormalizedHDRSlice(slice []string) string {
+	if len(slice) == 0 {
+		return ""
+	}
+
+	seen := make(map[string]struct{}, len(slice))
+	normalized := make([]string, 0, len(slice))
+	for _, tag := range slice {
+		n := normalizeHDRVariant(tag)
+		if n == "" {
+			continue
+		}
+		if _, ok := seen[n]; ok {
+			continue
+		}
+		seen[n] = struct{}{}
+		normalized = append(normalized, n)
+	}
+
+	sort.Strings(normalized)
+	return strings.Join(normalized, " ")
+}
+
+func normalizeHDRVariant(value string) string {
+	upper := normalizeVariant(value)
+	if upper == "" {
+		return ""
+	}
+
+	key := strings.NewReplacer(" ", "", ".", "", "_", "", "-", "").Replace(upper)
+
+	switch key {
+	case "DOVI", "DOLBYVISION", "DV":
+		return "DV"
+	case "HDR10PLUS", "HDR10P", "HDR10+":
+		return "HDR10+"
+	case "HDR10":
+		return "HDR10"
+	case "HDR":
+		return "HDR"
+	case "HLG":
+		return "HLG"
+	default:
+		return upper
+	}
 }
 
 // videoCodecAliases maps equivalent video codec names to a canonical form.

--- a/internal/services/crossseed/matching.go
+++ b/internal/services/crossseed/matching.go
@@ -412,17 +412,25 @@ func joinNormalizedHDRSlice(slice []string) string {
 	}
 
 	seen := make(map[string]struct{}, len(slice))
-	normalized := make([]string, 0, len(slice))
+	hasHDR10Plus := false
 	for _, tag := range slice {
 		n := normalizeHDRVariant(tag)
 		if n == "" {
 			continue
 		}
-		if _, ok := seen[n]; ok {
-			continue
+		if n == "HDR10+" {
+			hasHDR10Plus = true
 		}
 		seen[n] = struct{}{}
-		normalized = append(normalized, n)
+	}
+
+	if hasHDR10Plus {
+		delete(seen, "HDR10")
+	}
+
+	normalized := make([]string, 0, len(seen))
+	for tag := range seen {
+		normalized = append(normalized, tag)
 	}
 
 	sort.Strings(normalized)

--- a/internal/services/crossseed/matching_hdr_test.go
+++ b/internal/services/crossseed/matching_hdr_test.go
@@ -99,6 +99,45 @@ func TestHDRCollectionMatchingIntegration(t *testing.T) {
 			wantMatch:   true,
 			description: "identical SDR releases should cross-seed",
 		},
+		{
+			name:          "discussion title should match filename HDR10P alias",
+			sourceName:    "End of Watch 2012 Hybrid 2160p UHD BluRay REMUX DV HDR10+ HEVC DTS-HD MA 5.1-FraMeSToR",
+			candidateName: "End.of.Watch.2012.UHD.BluRay.2160p.DTS-HD.MA.5.1.DV.HDR10P.HEVC.HYBRID.REMUX-FraMeSToR.mkv",
+			sourceFiles: qbt.TorrentFiles{
+				{Name: "End.of.Watch.2012.UHD.BluRay.2160p.DTS-HD.MA.5.1.DV.HDR10P.HEVC.HYBRID.REMUX-FraMeSToR.mkv", Size: 50 << 30},
+			},
+			candidateFiles: qbt.TorrentFiles{
+				{Name: "End.of.Watch.2012.UHD.BluRay.2160p.DTS-HD.MA.5.1.DV.HDR10P.HEVC.HYBRID.REMUX-FraMeSToR.mkv", Size: 50 << 30},
+			},
+			wantMatch:   true,
+			description: "HDR10P filename alias should match HDR10+ title metadata",
+		},
+		{
+			name:          "DV HDR10 plus should not match DV only",
+			sourceName:    "Movie.2024.2160p.BluRay.x265.DV.HDR10+-GROUP",
+			candidateName: "Movie.2024.2160p.BluRay.x265.DV-GROUP",
+			sourceFiles: qbt.TorrentFiles{
+				{Name: "Movie.2024.2160p.BluRay.x265.DV.HDR10+-GROUP.mkv", Size: 40 << 30},
+			},
+			candidateFiles: qbt.TorrentFiles{
+				{Name: "Movie.2024.2160p.BluRay.x265.DV-GROUP.mkv", Size: 40 << 30},
+			},
+			wantMatch:   false,
+			description: "adding HDR10+ must remain distinct from DV-only releases",
+		},
+		{
+			name:          "HDR10 plus should not match HDR10",
+			sourceName:    "Movie.2024.2160p.BluRay.x265.HDR10+-GROUP",
+			candidateName: "Movie.2024.2160p.BluRay.x265.HDR10-GROUP",
+			sourceFiles: qbt.TorrentFiles{
+				{Name: "Movie.2024.2160p.BluRay.x265.HDR10+-GROUP.mkv", Size: 40 << 30},
+			},
+			candidateFiles: qbt.TorrentFiles{
+				{Name: "Movie.2024.2160p.BluRay.x265.HDR10-GROUP.mkv", Size: 40 << 30},
+			},
+			wantMatch:   false,
+			description: "HDR10 and HDR10+ remain distinct encodes",
+		},
 		// Collection/streaming service tests
 		{
 			name:          "MA.WEB-DL should NOT match plain WEB-DL",

--- a/pkg/releases/parser.go
+++ b/pkg/releases/parser.go
@@ -22,7 +22,7 @@ var hdrTagMatchers = []struct {
 	re  *regexp.Regexp
 }{
 	{tag: "DV", re: regexp.MustCompile(`(?i)(?:^|[^A-Z0-9])(?:DV|DOVI|DOLBY[ ._-]?VISION)(?:$|[^A-Z0-9])`)},
-	{tag: "HDR10+", re: regexp.MustCompile(`(?i)(?:^|[^A-Z0-9])HDR(?:[ ._-]?10(?:\+|P|PLUS))(?:$|[^A-Z0-9])`)},
+	{tag: "HDR10+", re: regexp.MustCompile(`(?i)(?:^|[^A-Z0-9])HDR(?:[ ._-]?10(?:[ ._-]?(?:\+|P(?:LUS)?)))(?:$|[^A-Z0-9])`)},
 	{tag: "HDR10", re: regexp.MustCompile(`(?i)(?:^|[^A-Z0-9])HDR(?:[ ._-]?10)(?:$|[^A-Z0-9+P])`)},
 	{tag: "HDR", re: regexp.MustCompile(`(?i)(?:^|[^A-Z0-9])HDR(?:$|[^A-Z0-9+])`)},
 	{tag: "HLG", re: regexp.MustCompile(`(?i)(?:^|[^A-Z0-9])HLG(?:$|[^A-Z0-9])`)},
@@ -77,33 +77,80 @@ func enrichReleaseHDR(rawName string, release *rls.Release) {
 		return
 	}
 
-	normalized := make([]string, 0, len(release.HDR)+2)
-	seen := make(map[string]struct{}, len(release.HDR)+2)
-
-	add := func(tag string) {
-		canonical := canonicalHDRTag(tag)
-		if canonical == "" {
-			return
-		}
-		if _, ok := seen[canonical]; ok {
-			return
-		}
-		seen[canonical] = struct{}{}
-		normalized = append(normalized, canonical)
-	}
+	tags := make([]string, 0, len(release.HDR)+2)
 
 	for _, tag := range release.HDR {
-		add(tag)
+		tags = append(tags, tag)
 	}
 
-	for _, matcher := range hdrTagMatchers {
-		if matcher.re.MatchString(rawName) {
-			add(matcher.tag)
+	if shouldScanRawHDR(release) {
+		for _, matcher := range hdrTagMatchers {
+			if matcher.re.MatchString(rawName) {
+				tags = append(tags, matcher.tag)
+			}
 		}
+	}
+
+	release.HDR = normalizeHDRTags(tags)
+}
+
+func shouldScanRawHDR(release *rls.Release) bool {
+	if release == nil {
+		return false
+	}
+
+	if release.Type.Is(rls.Movie, rls.Series, rls.Episode) {
+		return true
+	}
+
+	if release.Resolution != "" || release.Source != "" {
+		return true
+	}
+
+	for _, codec := range release.Codec {
+		switch canonicalHDRTag(codec) {
+		case "DV", "HDR", "HDR10", "HDR10+", "HLG":
+			return true
+		}
+	}
+
+	for _, codec := range release.Codec {
+		upper := strings.ToUpper(strings.TrimSpace(codec))
+		switch upper {
+		case "X264", "H264", "H.264", "AVC", "X265", "H265", "H.265", "HEVC", "AV1", "XVID", "DIVX":
+			return true
+		}
+	}
+
+	return false
+}
+
+func normalizeHDRTags(tags []string) []string {
+	seen := make(map[string]struct{}, len(tags))
+	hasHDR10Plus := false
+
+	for _, tag := range tags {
+		canonical := canonicalHDRTag(tag)
+		if canonical == "" {
+			continue
+		}
+		if canonical == "HDR10+" {
+			hasHDR10Plus = true
+		}
+		seen[canonical] = struct{}{}
+	}
+
+	if hasHDR10Plus {
+		delete(seen, "HDR10")
+	}
+
+	normalized := make([]string, 0, len(seen))
+	for tag := range seen {
+		normalized = append(normalized, tag)
 	}
 
 	sort.Strings(normalized)
-	release.HDR = normalized
+	return normalized
 }
 
 func canonicalHDRTag(tag string) string {

--- a/pkg/releases/parser.go
+++ b/pkg/releases/parser.go
@@ -161,8 +161,14 @@ func trimTrailingGroupOrSite(rawName string, release *rls.Release) string {
 		return trimmed
 	}
 
-	for _, token := range []string{release.Group, release.Site} {
-		trimmed = trimTrailingParsedToken(trimmed, token)
+	for {
+		prev := trimmed
+		for _, token := range []string{release.Group, release.Site} {
+			trimmed = trimTrailingParsedToken(trimmed, token)
+		}
+		if trimmed == prev {
+			break
+		}
 	}
 
 	return trimmed

--- a/pkg/releases/parser.go
+++ b/pkg/releases/parser.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/autobrr/autobrr/pkg/ttlcache"
@@ -27,6 +28,8 @@ var hdrTagMatchers = []struct {
 	{tag: "HDR", re: regexp.MustCompile(`(?i)(?:^|[^A-Z0-9])HDR(?:$|[^A-Z0-9+])`)},
 	{tag: "HLG", re: regexp.MustCompile(`(?i)(?:^|[^A-Z0-9])HLG(?:$|[^A-Z0-9])`)},
 }
+
+var trailingTokenRegexCache sync.Map
 
 // Parser caches rls parsing results so we do not repeatedly parse the same release names.
 type Parser struct {
@@ -184,23 +187,70 @@ func trimTrailingParsedToken(rawName, token string) string {
 		return rawName
 	}
 
-	quoted := regexp.QuoteMeta(token)
-	ext := `(?:\.[^./\\]+)?$`
-	patterns := []string{
-		`(?i)[\s._-]+` + quoted + ext,
-		`(?i)\[` + quoted + `\]` + ext,
-		`(?i)\(` + quoted + `\)` + ext,
+	if trimmed, ok := trimTrailingDelimitedToken(rawName, token); ok {
+		return trimmed
+	}
+	if trimmed, ok := trimTrailingWrappedToken(rawName, "["+token+"]"); ok {
+		return trimmed
+	}
+	if trimmed, ok := trimTrailingWrappedToken(rawName, "("+token+")"); ok {
+		return trimmed
 	}
 
 	trimmed := rawName
-	for _, pattern := range patterns {
-		re := regexp.MustCompile(pattern)
+	for _, re := range trailingTokenRegexes(token) {
 		if idx := re.FindStringIndex(trimmed); idx != nil {
 			trimmed = strings.TrimRight(trimmed[:idx[0]], " ._-")
 		}
 	}
 
 	return strings.TrimSpace(trimmed)
+}
+
+func trimTrailingDelimitedToken(rawName, token string) (string, bool) {
+	if len(rawName) <= len(token) {
+		return "", false
+	}
+
+	start := len(rawName) - len(token)
+	if !strings.EqualFold(rawName[start:], token) {
+		return "", false
+	}
+
+	prefix := rawName[:start]
+	trimmed := strings.TrimRight(prefix, " ._-")
+	if len(trimmed) == len(prefix) {
+		return "", false
+	}
+
+	return strings.TrimSpace(trimmed), true
+}
+
+func trimTrailingWrappedToken(rawName, wrapped string) (string, bool) {
+	if len(rawName) < len(wrapped) {
+		return "", false
+	}
+	if !strings.EqualFold(rawName[len(rawName)-len(wrapped):], wrapped) {
+		return "", false
+	}
+	return strings.TrimSpace(rawName[:len(rawName)-len(wrapped)]), true
+}
+
+func trailingTokenRegexes(token string) []*regexp.Regexp {
+	if cached, ok := trailingTokenRegexCache.Load(token); ok {
+		return cached.([]*regexp.Regexp)
+	}
+
+	quoted := regexp.QuoteMeta(token)
+	ext := `(?:\.[^./\\]+)?$`
+	patterns := []*regexp.Regexp{
+		regexp.MustCompile(`(?i)[\s._-]+` + quoted + ext),
+		regexp.MustCompile(`(?i)\[` + quoted + `\]` + ext),
+		regexp.MustCompile(`(?i)\(` + quoted + `\)` + ext),
+	}
+
+	actual, _ := trailingTokenRegexCache.LoadOrStore(token, patterns)
+	return actual.([]*regexp.Regexp)
 }
 
 func canonicalHDRTag(tag string) string {

--- a/pkg/releases/parser.go
+++ b/pkg/releases/parser.go
@@ -181,10 +181,11 @@ func trimTrailingParsedToken(rawName, token string) string {
 	}
 
 	quoted := regexp.QuoteMeta(token)
+	ext := `(?:\.[^./\\]+)?$`
 	patterns := []string{
-		`(?i)[\s._-]+` + quoted + `$`,
-		`(?i)\[` + quoted + `\]$`,
-		`(?i)\(` + quoted + `\)$`,
+		`(?i)[\s._-]+` + quoted + ext,
+		`(?i)\[` + quoted + `\]` + ext,
+		`(?i)\(` + quoted + `\)` + ext,
 	}
 
 	trimmed := rawName

--- a/pkg/releases/parser.go
+++ b/pkg/releases/parser.go
@@ -142,6 +142,10 @@ func normalizeHDRTags(tags []string) []string {
 		delete(seen, "HDR10")
 	}
 
+	if len(seen) == 0 {
+		return nil
+	}
+
 	normalized := make([]string, 0, len(seen))
 	for tag := range seen {
 		normalized = append(normalized, tag)

--- a/pkg/releases/parser.go
+++ b/pkg/releases/parser.go
@@ -4,6 +4,8 @@
 package releases
 
 import (
+	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -14,6 +16,17 @@ import (
 )
 
 const defaultParserTTL = 5 * time.Minute
+
+var hdrTagMatchers = []struct {
+	tag string
+	re  *regexp.Regexp
+}{
+	{tag: "DV", re: regexp.MustCompile(`(?i)(?:^|[^A-Z0-9])(?:DV|DOVI|DOLBY[ ._-]?VISION)(?:$|[^A-Z0-9])`)},
+	{tag: "HDR10+", re: regexp.MustCompile(`(?i)(?:^|[^A-Z0-9])HDR(?:[ ._-]?10(?:\+|P|PLUS))(?:$|[^A-Z0-9])`)},
+	{tag: "HDR10", re: regexp.MustCompile(`(?i)(?:^|[^A-Z0-9])HDR(?:[ ._-]?10)(?:$|[^A-Z0-9+P])`)},
+	{tag: "HDR", re: regexp.MustCompile(`(?i)(?:^|[^A-Z0-9])HDR(?:$|[^A-Z0-9+])`)},
+	{tag: "HLG", re: regexp.MustCompile(`(?i)(?:^|[^A-Z0-9])HLG(?:$|[^A-Z0-9])`)},
+}
 
 // Parser caches rls parsing results so we do not repeatedly parse the same release names.
 type Parser struct {
@@ -54,8 +67,67 @@ func (p *Parser) Parse(name string) *rls.Release {
 	}
 
 	release := rls.ParseString(key)
+	enrichReleaseHDR(key, &release)
 	p.cache.Set(key, &release, ttlcache.DefaultTTL)
 	return &release
+}
+
+func enrichReleaseHDR(rawName string, release *rls.Release) {
+	if release == nil {
+		return
+	}
+
+	normalized := make([]string, 0, len(release.HDR)+2)
+	seen := make(map[string]struct{}, len(release.HDR)+2)
+
+	add := func(tag string) {
+		canonical := canonicalHDRTag(tag)
+		if canonical == "" {
+			return
+		}
+		if _, ok := seen[canonical]; ok {
+			return
+		}
+		seen[canonical] = struct{}{}
+		normalized = append(normalized, canonical)
+	}
+
+	for _, tag := range release.HDR {
+		add(tag)
+	}
+
+	for _, matcher := range hdrTagMatchers {
+		if matcher.re.MatchString(rawName) {
+			add(matcher.tag)
+		}
+	}
+
+	sort.Strings(normalized)
+	release.HDR = normalized
+}
+
+func canonicalHDRTag(tag string) string {
+	upper := strings.ToUpper(strings.TrimSpace(tag))
+	if upper == "" {
+		return ""
+	}
+
+	key := strings.NewReplacer(" ", "", ".", "", "_", "", "-", "").Replace(upper)
+
+	switch key {
+	case "DOVI", "DOLBYVISION", "DV":
+		return "DV"
+	case "HDR10PLUS", "HDR10P", "HDR10+":
+		return "HDR10+"
+	case "HDR10":
+		return "HDR10"
+	case "HDR":
+		return "HDR"
+	case "HLG":
+		return "HLG"
+	default:
+		return upper
+	}
 }
 
 // Clear removes a cached entry.

--- a/pkg/releases/parser.go
+++ b/pkg/releases/parser.go
@@ -78,14 +78,12 @@ func enrichReleaseHDR(rawName string, release *rls.Release) {
 	}
 
 	tags := make([]string, 0, len(release.HDR)+2)
-
-	for _, tag := range release.HDR {
-		tags = append(tags, tag)
-	}
+	tags = append(tags, release.HDR...)
 
 	if shouldScanRawHDR(release) {
+		scanName := trimTrailingGroupOrSite(rawName, release)
 		for _, matcher := range hdrTagMatchers {
-			if matcher.re.MatchString(rawName) {
+			if matcher.re.MatchString(scanName) {
 				tags = append(tags, matcher.tag)
 			}
 		}
@@ -151,6 +149,47 @@ func normalizeHDRTags(tags []string) []string {
 
 	sort.Strings(normalized)
 	return normalized
+}
+
+func trimTrailingGroupOrSite(rawName string, release *rls.Release) string {
+	if release == nil {
+		return rawName
+	}
+
+	trimmed := strings.TrimSpace(rawName)
+	if trimmed == "" {
+		return trimmed
+	}
+
+	for _, token := range []string{release.Group, release.Site} {
+		trimmed = trimTrailingParsedToken(trimmed, token)
+	}
+
+	return trimmed
+}
+
+func trimTrailingParsedToken(rawName, token string) string {
+	token = strings.TrimSpace(token)
+	if rawName == "" || token == "" {
+		return rawName
+	}
+
+	quoted := regexp.QuoteMeta(token)
+	patterns := []string{
+		`(?i)[\s._-]+` + quoted + `$`,
+		`(?i)\[` + quoted + `\]$`,
+		`(?i)\(` + quoted + `\)$`,
+	}
+
+	trimmed := rawName
+	for _, pattern := range patterns {
+		re := regexp.MustCompile(pattern)
+		if idx := re.FindStringIndex(trimmed); idx != nil {
+			trimmed = strings.TrimRight(trimmed[:idx[0]], " ._-")
+		}
+	}
+
+	return strings.TrimSpace(trimmed)
 }
 
 func canonicalHDRTag(tag string) string {

--- a/pkg/releases/parser_test.go
+++ b/pkg/releases/parser_test.go
@@ -61,6 +61,12 @@ func TestParser_EnrichesHDRAliases(t *testing.T) {
 			wantHDR: nil,
 			notHDR:  []string{"DV", "HDR", "HDR10", "HDR10+", "HLG"},
 		},
+		{
+			name:    "movie trailing DV group does not become HDR",
+			input:   "Movie.2024.2160p.BluRay.x265-GROUP-DV",
+			wantHDR: nil,
+			notHDR:  []string{"DV", "HDR", "HDR10", "HDR10+", "HLG"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/releases/parser_test.go
+++ b/pkg/releases/parser_test.go
@@ -75,6 +75,9 @@ func TestParser_EnrichesHDRAliases(t *testing.T) {
 			t.Parallel()
 
 			release := parser.Parse(tt.input)
+			if len(tt.wantHDR) == 0 {
+				require.Nil(t, release.HDR)
+			}
 			require.ElementsMatch(t, tt.wantHDR, release.HDR)
 			for _, tag := range tt.notHDR {
 				require.NotContains(t, release.HDR, tag)

--- a/pkg/releases/parser_test.go
+++ b/pkg/releases/parser_test.go
@@ -29,12 +29,37 @@ func TestParser_EnrichesHDRAliases(t *testing.T) {
 			name:    "filename alias HDR10P normalizes to HDR10 plus",
 			input:   "End.of.Watch.2012.UHD.BluRay.2160p.DTS-HD.MA.5.1.DV.HDR10P.HEVC.HYBRID.REMUX-FraMeSToR.mkv",
 			wantHDR: []string{"DV", "HDR10+"},
+			notHDR:  []string{"HDR10"},
+		},
+		{
+			name:    "spaced HDR10 PLUS normalizes to HDR10 plus",
+			input:   "Movie.2024.2160p.BluRay.x265.DV.HDR10 PLUS-GROUP",
+			wantHDR: []string{"DV", "HDR10+"},
+			notHDR:  []string{"HDR10"},
+		},
+		{
+			name:    "dotted HDR10 plus drops inherited HDR10",
+			input:   "Movie.2024.2160p.BluRay.x265.DV.HDR10+-GROUP",
+			wantHDR: []string{"DV", "HDR10+"},
+			notHDR:  []string{"HDR10"},
+		},
+		{
+			name:    "underscored HDR10 PLUS normalizes to HDR10 plus",
+			input:   "Movie.2024.2160p.BluRay.x265.DV.HDR10_PLUS-GROUP",
+			wantHDR: []string{"DV", "HDR10+"},
+			notHDR:  []string{"HDR10"},
 		},
 		{
 			name:    "DV only stays DV only",
 			input:   "Movie.2024.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
 			wantHDR: []string{"DV"},
 			notHDR:  []string{"HDR", "HDR10", "HDR10+", "HLG"},
+		},
+		{
+			name:    "scene group DV does not become HDR",
+			input:   "Software.Name.v1.0-DV",
+			wantHDR: nil,
+			notHDR:  []string{"DV", "HDR", "HDR10", "HDR10+", "HLG"},
 		},
 	}
 

--- a/pkg/releases/parser_test.go
+++ b/pkg/releases/parser_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package releases
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParser_EnrichesHDRAliases(t *testing.T) {
+	t.Parallel()
+
+	parser := NewDefaultParser()
+
+	tests := []struct {
+		name    string
+		input   string
+		wantHDR []string
+		notHDR  []string
+	}{
+		{
+			name:    "discussion title keeps HDR10 plus",
+			input:   "End of Watch 2012 Hybrid 2160p UHD BluRay REMUX DV HDR10+ HEVC DTS-HD MA 5.1-FraMeSToR",
+			wantHDR: []string{"DV", "HDR10+"},
+		},
+		{
+			name:    "filename alias HDR10P normalizes to HDR10 plus",
+			input:   "End.of.Watch.2012.UHD.BluRay.2160p.DTS-HD.MA.5.1.DV.HDR10P.HEVC.HYBRID.REMUX-FraMeSToR.mkv",
+			wantHDR: []string{"DV", "HDR10+"},
+		},
+		{
+			name:    "DV only stays DV only",
+			input:   "Movie.2024.2160p.UHD.BluRay.REMUX.DV.HEVC-GROUP",
+			wantHDR: []string{"DV"},
+			notHDR:  []string{"HDR", "HDR10", "HDR10+", "HLG"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			release := parser.Parse(tt.input)
+			require.ElementsMatch(t, tt.wantHDR, release.HDR)
+			for _, tag := range tt.notHDR {
+				require.NotContains(t, release.HDR, tag)
+			}
+		})
+	}
+}

--- a/pkg/releases/parser_test.go
+++ b/pkg/releases/parser_test.go
@@ -94,3 +94,14 @@ func TestTrimTrailingGroupOrSite_RemovesExposedTrailingTokens(t *testing.T) {
 	trimmed := trimTrailingGroupOrSite("Movie.2024.2160p.BluRay.x265-DV [SITE]", release)
 	require.Equal(t, "Movie.2024.2160p.BluRay.x265", trimmed)
 }
+
+func TestTrimTrailingGroupOrSite_RemovesTrailingTokenBeforeExtension(t *testing.T) {
+	t.Parallel()
+
+	release := &rls.Release{
+		Group: "DV",
+	}
+
+	trimmed := trimTrailingGroupOrSite("Movie.2024.2160p.BluRay.x265-DV.mkv", release)
+	require.Equal(t, "Movie.2024.2160p.BluRay.x265", trimmed)
+}

--- a/pkg/releases/parser_test.go
+++ b/pkg/releases/parser_test.go
@@ -108,3 +108,14 @@ func TestTrimTrailingGroupOrSite_RemovesTrailingTokenBeforeExtension(t *testing.
 	trimmed := trimTrailingGroupOrSite("Movie.2024.2160p.BluRay.x265-DV.mkv", release)
 	require.Equal(t, "Movie.2024.2160p.BluRay.x265", trimmed)
 }
+
+func TestTrimTrailingGroupOrSite_RemovesTrailingTokenWithoutExtension(t *testing.T) {
+	t.Parallel()
+
+	release := &rls.Release{
+		Group: "DV",
+	}
+
+	trimmed := trimTrailingGroupOrSite("Movie.2024.2160p.BluRay.x265-DV", release)
+	require.Equal(t, "Movie.2024.2160p.BluRay.x265", trimmed)
+}

--- a/pkg/releases/parser_test.go
+++ b/pkg/releases/parser_test.go
@@ -6,6 +6,7 @@ package releases
 import (
 	"testing"
 
+	"github.com/moistari/rls"
 	"github.com/stretchr/testify/require"
 )
 
@@ -80,4 +81,16 @@ func TestParser_EnrichesHDRAliases(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTrimTrailingGroupOrSite_RemovesExposedTrailingTokens(t *testing.T) {
+	t.Parallel()
+
+	release := &rls.Release{
+		Group: "DV",
+		Site:  "SITE",
+	}
+
+	trimmed := trimTrailingGroupOrSite("Movie.2024.2160p.BluRay.x265-DV [SITE]", release)
+	require.Equal(t, "Movie.2024.2160p.BluRay.x265", trimmed)
 }


### PR DESCRIPTION
Description:

Normalize HDR aliases in cross-seed parsing and matching so HDR10+, HDR10P, and separated HDR10 PLUS forms compare consistently across /check, /apply, and shared candidate discovery. Tighten raw-name HDR enrichment to avoid false positives from scene groups like -DV, and add regressions for the End of Watch repro plus HDR alias edge cases.

ref: https://github.com/autobrr/qui/discussions/1277

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parsing now detects and normalizes more HDR tag variants (HDR10+, HDR10P, DV, HLG) and enriches release HDR tags for more accurate comparisons.
  * Cross-seed matching improved to handle HDR10+ alias variations across different naming and filename formats.
  * Parsing trims exposed trailing group/site tokens for cleaner release names.

* **Tests**
  * Expanded coverage for HDR variant extraction and matching, including HDR10+/HDR10/DV edge cases and cross-format candidate resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->