### PR TITLE
fix(backups): preserve partial backups when qB export crashes

### DIFF
--- a/documentation/docs/features/backups.md
+++ b/documentation/docs/features/backups.md
@@ -8,6 +8,12 @@ description: Schedule and restore qBittorrent instance backups.
 
 qui can take scheduled or ad-hoc snapshots of a qBittorrent instance. Each snapshot includes the torrent archive, tags, categories (with save paths), and cached `.torrent` blobs so that you can recreate the original state later.
 
+## Partial Backups
+
+If qBittorrent crashes, hangs, or drops export requests mid-backup, qui now keeps the torrents it already exported and marks the run as completed with warnings instead of discarding the whole backup. The run history highlights these partial backups, and the backup manifest lists each skipped torrent with the export error that caused it.
+
+This is a resilience layer for upstream qBittorrent export bugs, especially around some hybrid torrents. qui does not try to rewrite hashes or guess around the qBittorrent API; it preserves the usable subset and tells you exactly what was skipped.
+
 ## Restore Modes
 
 Once backups are enabled for an instance the backlog UI exposes a **Restore** action for each run. Restores support three distinct modes:

--- a/internal/backups/service.go
+++ b/internal/backups/service.go
@@ -51,6 +51,14 @@ type BackupProgress struct {
 	Percentage float64
 }
 
+type exportFailureKind int
+
+const (
+	exportFailureFatal exportFailureKind = iota
+	exportFailureMetadataUnavailable
+	exportFailureRecoverable
+)
+
 type missingTorrent struct {
 	hash    string
 	name    string
@@ -77,7 +85,13 @@ type Service struct {
 	progress   map[int64]*BackupProgress
 	progressMu sync.RWMutex
 
-	now func() time.Time
+	listTorrents     func(context.Context, int) ([]qbt.Torrent, error)
+	exportTorrent    func(context.Context, int, string) ([]byte, string, string, error)
+	getCategories    func(context.Context, int) (map[string]qbt.Category, error)
+	getTags          func(context.Context, int) ([]string, error)
+	getWebAPIVersion func(context.Context, int) (string, error)
+	probeInstance    func(context.Context, int) error
+	now              func() time.Time
 }
 
 type job struct {
@@ -94,6 +108,7 @@ type Manifest struct {
 	TorrentCount int                                `json:"torrentCount"`
 	Categories   map[string]models.CategorySnapshot `json:"categories,omitempty"`
 	Tags         []string                           `json:"tags,omitempty"`
+	Warnings     []ManifestWarning                  `json:"warnings,omitempty"`
 	Items        []ManifestItem                     `json:"items"`
 }
 
@@ -108,6 +123,12 @@ type ManifestItem struct {
 	InfoHashV2  *string  `json:"infohashV2,omitempty"`
 	Tags        []string `json:"tags,omitempty"`
 	TorrentBlob string   `json:"torrentBlob,omitempty"`
+}
+
+type ManifestWarning struct {
+	Hash   string `json:"hash"`
+	Name   string `json:"name"`
+	Reason string `json:"reason"`
 }
 
 func NewService(store *models.BackupStore, syncManager *qbittorrent.SyncManager, jackettSvc any, cfg Config, notifier notifications.Notifier) *Service {
@@ -137,7 +158,7 @@ func NewService(store *models.BackupStore, syncManager *qbittorrent.SyncManager,
 		_ = svc // TODO: jackettService = svc when jackett fallback is re-enabled
 	}
 
-	return &Service{
+	svc := &Service{
 		store:       store,
 		syncManager: syncManager,
 		jackettSvc:  jackettService,
@@ -149,6 +170,28 @@ func NewService(store *models.BackupStore, syncManager *qbittorrent.SyncManager,
 		progress:    make(map[int64]*BackupProgress),
 		now:         func() time.Time { return time.Now().UTC() },
 	}
+
+	svc.listTorrents = func(ctx context.Context, instanceID int) ([]qbt.Torrent, error) {
+		return svc.syncManager.GetAllTorrents(ctx, instanceID)
+	}
+	svc.exportTorrent = func(ctx context.Context, instanceID int, hash string) ([]byte, string, string, error) {
+		return svc.syncManager.ExportTorrent(ctx, instanceID, hash)
+	}
+	svc.getCategories = func(ctx context.Context, instanceID int) (map[string]qbt.Category, error) {
+		return svc.syncManager.GetCategories(ctx, instanceID)
+	}
+	svc.getTags = func(ctx context.Context, instanceID int) ([]string, error) {
+		return svc.syncManager.GetTags(ctx, instanceID)
+	}
+	svc.getWebAPIVersion = func(ctx context.Context, instanceID int) (string, error) {
+		return svc.syncManager.GetInstanceWebAPIVersion(ctx, instanceID)
+	}
+	svc.probeInstance = func(ctx context.Context, instanceID int) error {
+		_, err := svc.getWebAPIVersion(ctx, instanceID)
+		return err
+	}
+
+	return svc
 }
 
 func normalizeBackupSettings(settings *models.BackupSettings) bool {
@@ -515,7 +558,11 @@ func (s *Service) handleJob(ctx context.Context, j job) {
 			run.CategoryCounts = result.categoryCounts
 			run.Categories = result.categories
 			run.Tags = result.tags
-			run.ErrorMessage = nil
+			if result.warningSummary != "" {
+				run.ErrorMessage = &result.warningSummary
+			} else {
+				run.ErrorMessage = nil
+			}
 			return nil
 		})
 
@@ -536,6 +583,7 @@ func (s *Service) handleJob(ctx context.Context, j job) {
 			BackupKind:         j.kind,
 			BackupRunID:        j.runID,
 			BackupTorrentCount: result.torrentCount,
+			ErrorMessage:       result.warningSummary,
 			StartedAt:          &start,
 			CompletedAt:        &now,
 		})
@@ -556,6 +604,8 @@ type backupResult struct {
 	totalBytes      int64
 	torrentCount    int
 	categoryCounts  map[string]int
+	warningSummary  string
+	warnings        []ManifestWarning
 	items           []models.BackupItem
 	settings        *models.BackupSettings
 	categories      map[string]models.CategorySnapshot
@@ -569,7 +619,7 @@ func (s *Service) executeBackup(ctx context.Context, j job) (*backupResult, erro
 	}
 	s.normalizeAndPersistSettings(ctx, settings)
 
-	torrents, err := s.syncManager.GetAllTorrents(ctx, j.instanceID)
+	torrents, err := s.listTorrents(ctx, j.instanceID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load torrents: %w", err)
 	}
@@ -599,7 +649,7 @@ func (s *Service) executeBackup(ctx context.Context, j job) (*backupResult, erro
 
 	var snapshotCategories map[string]models.CategorySnapshot
 	if settings.IncludeCategories {
-		categories, err := s.syncManager.GetCategories(ctx, j.instanceID)
+		categories, err := s.getCategories(ctx, j.instanceID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load categories: %w", err)
 		}
@@ -613,7 +663,7 @@ func (s *Service) executeBackup(ctx context.Context, j job) (*backupResult, erro
 
 	var snapshotTags []string
 	if settings.IncludeTags {
-		tags, err := s.syncManager.GetTags(ctx, j.instanceID)
+		tags, err := s.getTags(ctx, j.instanceID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load tags: %w", err)
 		}
@@ -627,7 +677,7 @@ func (s *Service) executeBackup(ctx context.Context, j job) (*backupResult, erro
 
 	webAPIVersion := ""
 	patchTrackers := false
-	if version, err := s.syncManager.GetInstanceWebAPIVersion(ctx, j.instanceID); err != nil {
+	if version, err := s.getWebAPIVersion(ctx, j.instanceID); err != nil {
 		log.Debug().Err(err).Int("instanceID", j.instanceID).Msg("Unable to determine qBittorrent API version for tracker patching")
 	} else {
 		webAPIVersion = version
@@ -652,6 +702,7 @@ func (s *Service) executeBackup(ctx context.Context, j job) (*backupResult, erro
 
 	items := make([]models.BackupItem, 0, len(torrents))
 	manifestItems := make([]ManifestItem, 0, len(torrents))
+	manifestWarnings := make([]ManifestWarning, 0)
 	usedPaths := make(map[string]int)
 	categoryCounts := make(map[string]int)
 	var totalBytes int64
@@ -665,6 +716,7 @@ func (s *Service) executeBackup(ctx context.Context, j job) (*backupResult, erro
 	}
 	s.progressMu.Unlock()
 
+backupLoop:
 	for idx, torrent := range torrents {
 		select {
 		case <-ctx.Done():
@@ -696,9 +748,10 @@ func (s *Service) executeBackup(ctx context.Context, j job) (*backupResult, erro
 				return nil, err
 			}
 			var tracker string
-			data, suggestedName, tracker, err = s.syncManager.ExportTorrent(ctx, j.instanceID, torrent.Hash)
+			data, suggestedName, tracker, err = s.exportTorrent(ctx, j.instanceID, torrent.Hash)
 			if err != nil {
-				if isExportMetadataUnavailable(err) {
+				switch classifyExportFailure(err) {
+				case exportFailureMetadataUnavailable:
 					log.Warn().
 						Err(err).
 						Str("hash", torrent.Hash).
@@ -707,8 +760,39 @@ func (s *Service) executeBackup(ctx context.Context, j job) (*backupResult, erro
 						Msg("Skipping torrent export; metadata not downloaded yet")
 					s.updateProgress(j.runID, idx+1)
 					continue
+				case exportFailureRecoverable:
+					warning := ManifestWarning{
+						Hash:   torrent.Hash,
+						Name:   torrent.Name,
+						Reason: simplifyExportWarning(err),
+					}
+					manifestWarnings = append(manifestWarnings, warning)
+
+					log.Warn().
+						Err(err).
+						Str("hash", torrent.Hash).
+						Str("name", torrent.Name).
+						Int("instanceID", j.instanceID).
+						Msg("Recoverable torrent export failure during backup")
+					s.updateProgress(j.runID, idx+1)
+
+					if probeErr := s.probeInstance(ctx, j.instanceID); probeErr != nil {
+						if len(manifestItems) == 0 {
+							return nil, fmt.Errorf("backup aborted after qBittorrent export failure and instance became unavailable: %w", err)
+						}
+
+						log.Warn().
+							Err(probeErr).
+							Int("instanceID", j.instanceID).
+							Int64("runID", j.runID).
+							Msg("qBittorrent became unavailable during backup; finalizing partial backup")
+						break backupLoop
+					}
+
+					continue
+				default:
+					return nil, fmt.Errorf("export torrent %s: %w", torrent.Hash, err)
 				}
-				return nil, fmt.Errorf("export torrent %s: %w", torrent.Hash, err)
 			}
 			trackerDomain = tracker
 		}
@@ -831,6 +915,13 @@ func (s *Service) executeBackup(ctx context.Context, j job) (*backupResult, erro
 		s.updateProgress(j.runID, idx+1)
 	}
 
+	if len(manifestItems) == 0 {
+		if len(manifestWarnings) > 0 {
+			return nil, fmt.Errorf("backup produced no torrent exports after %d skipped export(s)", len(manifestWarnings))
+		}
+		return nil, errors.New("backup produced no torrent exports")
+	}
+
 	manifest := Manifest{
 		InstanceID:   j.instanceID,
 		Kind:         string(j.kind),
@@ -838,6 +929,7 @@ func (s *Service) executeBackup(ctx context.Context, j job) (*backupResult, erro
 		TorrentCount: len(manifestItems),
 		Categories:   snapshotCategories,
 		Tags:         snapshotTags,
+		Warnings:     manifestWarnings,
 		Items:        manifestItems,
 	}
 
@@ -846,17 +938,17 @@ func (s *Service) executeBackup(ctx context.Context, j job) (*backupResult, erro
 		return nil, fmt.Errorf("marshal manifest: %w", err)
 	}
 
-	manifestPointer := &manifestRelPath
 	if err := os.WriteFile(manifestAbsPath, manifestData, 0o644); err != nil {
-		log.Warn().Err(err).Str("path", manifestAbsPath).Msg("Failed to write manifest to disk")
-		manifestPointer = nil
+		return nil, fmt.Errorf("write manifest: %w", err)
 	}
 
 	return &backupResult{
-		manifestRelPath: manifestPointer,
+		manifestRelPath: &manifestRelPath,
 		totalBytes:      totalBytes,
 		torrentCount:    len(manifestItems),
 		categoryCounts:  categoryCounts,
+		warningSummary:  buildBackupWarningSummary(manifestWarnings),
+		warnings:        manifestWarnings,
 		categories:      snapshotCategories,
 		tags:            snapshotTags,
 		items:           items,
@@ -998,6 +1090,59 @@ func isExportMetadataUnavailable(err error) bool {
 		return true
 	}
 	return strings.Contains(err.Error(), "status code: 409")
+}
+
+func classifyExportFailure(err error) exportFailureKind {
+	if isExportMetadataUnavailable(err) {
+		return exportFailureMetadataUnavailable
+	}
+	if isRecoverableExportFailure(err) {
+		return exportFailureRecoverable
+	}
+	return exportFailureFatal
+}
+
+func isRecoverableExportFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "timeout") ||
+		strings.Contains(message, "deadline exceeded") ||
+		strings.Contains(message, "connection reset by peer") ||
+		strings.Contains(message, "connection refused") ||
+		strings.Contains(message, "broken pipe") ||
+		strings.Contains(message, "unexpected eof") ||
+		strings.Contains(message, "eof") ||
+		strings.Contains(message, "status code: 500") ||
+		strings.Contains(message, "status code: 502") ||
+		strings.Contains(message, "status code: 503") ||
+		strings.Contains(message, "status code: 504")
+}
+
+func simplifyExportWarning(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	message := strings.TrimSpace(err.Error())
+	return strings.TrimPrefix(message, "failed to export torrent: ")
+}
+
+func buildBackupWarningSummary(warnings []ManifestWarning) string {
+	if len(warnings) == 0 {
+		return ""
+	}
+
+	if len(warnings) == 1 {
+		return "Partial backup: skipped 1 torrent export. See manifest warnings for details."
+	}
+
+	return fmt.Sprintf("Partial backup: skipped %d torrent exports. See manifest warnings for details.", len(warnings))
 }
 
 func (s *Service) GetProgress(runID int64) *BackupProgress {
@@ -1288,12 +1433,28 @@ func (s *Service) DeleteAllRuns(ctx context.Context, instanceID int) error {
 }
 
 func (s *Service) LoadManifest(ctx context.Context, runID int64) (*Manifest, error) {
-	items, err := s.store.ListItems(ctx, runID)
+	run, err := s.store.GetRun(ctx, runID)
 	if err != nil {
 		return nil, err
 	}
 
-	run, err := s.store.GetRun(ctx, runID)
+	if run.ManifestPath != nil {
+		manifestPath := filepath.Join(s.cfg.DataDir, *run.ManifestPath)
+		data, readErr := os.ReadFile(manifestPath)
+		if readErr == nil {
+			var manifest Manifest
+			if err := json.Unmarshal(data, &manifest); err != nil {
+				return nil, fmt.Errorf("parse manifest: %w", err)
+			}
+			return &manifest, nil
+		}
+		if !errors.Is(readErr, os.ErrNotExist) {
+			return nil, fmt.Errorf("read manifest: %w", readErr)
+		}
+		log.Warn().Err(readErr).Int64("runID", runID).Str("path", manifestPath).Msg("Backup manifest file missing; falling back to database reconstruction")
+	}
+
+	items, err := s.store.ListItems(ctx, runID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backups/service.go
+++ b/internal/backups/service.go
@@ -1126,7 +1126,6 @@ func isRecoverableExportFailure(err error) bool {
 		strings.Contains(message, "connection refused") ||
 		strings.Contains(message, "broken pipe") ||
 		strings.Contains(message, "unexpected eof") ||
-		strings.Contains(message, "eof") ||
 		strings.Contains(message, "status code: 500") ||
 		strings.Contains(message, "status code: 502") ||
 		strings.Contains(message, "status code: 503") ||

--- a/internal/backups/service.go
+++ b/internal/backups/service.go
@@ -703,6 +703,7 @@ func (s *Service) executeBackup(ctx context.Context, j job) (*backupResult, erro
 	items := make([]models.BackupItem, 0, len(torrents))
 	manifestItems := make([]ManifestItem, 0, len(torrents))
 	manifestWarnings := make([]ManifestWarning, 0)
+	instanceAvailable := true
 	usedPaths := make(map[string]int)
 	categoryCounts := make(map[string]int)
 	var totalBytes int64
@@ -716,7 +717,6 @@ func (s *Service) executeBackup(ctx context.Context, j job) (*backupResult, erro
 	}
 	s.progressMu.Unlock()
 
-backupLoop:
 	for idx, torrent := range torrents {
 		select {
 		case <-ctx.Done():
@@ -744,6 +744,16 @@ backupLoop:
 		}
 
 		if data == nil {
+			if !instanceAvailable {
+				manifestWarnings = append(manifestWarnings, ManifestWarning{
+					Hash:   torrent.Hash,
+					Name:   torrent.Name,
+					Reason: "qBittorrent unavailable after earlier export failure",
+				})
+				s.updateProgress(j.runID, idx+1)
+				continue
+			}
+
 			if err := waitForExportThrottle(ctx, exportThrottle); err != nil {
 				return nil, err
 			}
@@ -781,12 +791,12 @@ backupLoop:
 							return nil, fmt.Errorf("backup aborted after qBittorrent export failure and instance became unavailable: %w", err)
 						}
 
+						instanceAvailable = false
 						log.Warn().
 							Err(probeErr).
 							Int("instanceID", j.instanceID).
 							Int64("runID", j.runID).
-							Msg("qBittorrent became unavailable during backup; finalizing partial backup")
-						break backupLoop
+							Msg("qBittorrent became unavailable during backup; continuing with cached torrents only")
 					}
 					continue
 				case exportFailureFatal:

--- a/internal/backups/service.go
+++ b/internal/backups/service.go
@@ -788,9 +788,8 @@ backupLoop:
 							Msg("qBittorrent became unavailable during backup; finalizing partial backup")
 						break backupLoop
 					}
-
 					continue
-				default:
+				case exportFailureFatal:
 					return nil, fmt.Errorf("export torrent %s: %w", torrent.Hash, err)
 				}
 			}

--- a/internal/backups/service_export_test.go
+++ b/internal/backups/service_export_test.go
@@ -25,3 +25,17 @@ func TestIsExportMetadataUnavailable(t *testing.T) {
 		t.Fatal("expected non-409 status to be non-skippable")
 	}
 }
+
+func TestClassifyExportFailure(t *testing.T) {
+	if kind := classifyExportFailure(errors.New("context deadline exceeded")); kind != exportFailureRecoverable {
+		t.Fatalf("expected deadline exceeded to be recoverable, got %v", kind)
+	}
+
+	if kind := classifyExportFailure(qbt.ErrTorrentMetdataNotDownloadedYet); kind != exportFailureMetadataUnavailable {
+		t.Fatalf("expected metadata-not-downloaded to be classified as metadata unavailable, got %v", kind)
+	}
+
+	if kind := classifyExportFailure(errors.New("status code: 400: bad request")); kind != exportFailureFatal {
+		t.Fatalf("expected 400 to be fatal, got %v", kind)
+	}
+}

--- a/internal/backups/service_export_test.go
+++ b/internal/backups/service_export_test.go
@@ -4,7 +4,9 @@
 package backups
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	qbt "github.com/autobrr/go-qbittorrent"
@@ -27,15 +29,38 @@ func TestIsExportMetadataUnavailable(t *testing.T) {
 }
 
 func TestClassifyExportFailure(t *testing.T) {
-	if kind := classifyExportFailure(errors.New("context deadline exceeded")); kind != exportFailureRecoverable {
-		t.Fatalf("expected deadline exceeded to be recoverable, got %v", kind)
+	tests := []struct {
+		name string
+		err  error
+		want exportFailureKind
+	}{
+		{
+			name: "deadline exceeded",
+			err:  context.DeadlineExceeded,
+			want: exportFailureRecoverable,
+		},
+		{
+			name: "wrapped deadline exceeded",
+			err:  fmt.Errorf("wrap: %w", context.DeadlineExceeded),
+			want: exportFailureRecoverable,
+		},
+		{
+			name: "metadata unavailable",
+			err:  qbt.ErrTorrentMetdataNotDownloadedYet,
+			want: exportFailureMetadataUnavailable,
+		},
+		{
+			name: "fatal 400 response",
+			err:  errors.New("status code: 400: bad request"),
+			want: exportFailureFatal,
+		},
 	}
 
-	if kind := classifyExportFailure(qbt.ErrTorrentMetdataNotDownloadedYet); kind != exportFailureMetadataUnavailable {
-		t.Fatalf("expected metadata-not-downloaded to be classified as metadata unavailable, got %v", kind)
-	}
-
-	if kind := classifyExportFailure(errors.New("status code: 400: bad request")); kind != exportFailureFatal {
-		t.Fatalf("expected 400 to be fatal, got %v", kind)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyExportFailure(tt.err); got != tt.want {
+				t.Fatalf("expected %v, got %v", tt.want, got)
+			}
+		})
 	}
 }

--- a/internal/backups/service_partial_test.go
+++ b/internal/backups/service_partial_test.go
@@ -88,7 +88,7 @@ func TestHandleJobStopsEarlyAndKeepsPartialBackupWhenInstanceDies(t *testing.T) 
 			{Hash: "hash-c", Name: "Charlie", TotalSize: 33},
 		}, nil
 	}
-	seedCachedTorrent(t, ctx, svc, store, instanceID, "hash-c", "cached-charlie")
+	seedCachedTorrent(ctx, t, svc, store, instanceID, "hash-c", "cached-charlie")
 
 	exported := make([]string, 0, 3)
 	svc.exportTorrent = func(_ context.Context, _ int, hash string) ([]byte, string, string, error) {
@@ -206,7 +206,7 @@ func newBackupTestService(t *testing.T, store *models.BackupStore) *Service {
 	return svc
 }
 
-func seedCachedTorrent(t *testing.T, ctx context.Context, svc *Service, store *models.BackupStore, instanceID int, hash string, data string) {
+func seedCachedTorrent(ctx context.Context, t *testing.T, svc *Service, store *models.BackupStore, instanceID int, hash string, data string) {
 	t.Helper()
 
 	run := &models.BackupRun{
@@ -221,7 +221,7 @@ func seedCachedTorrent(t *testing.T, ctx context.Context, svc *Service, store *m
 	blobPath := filepath.ToSlash(filepath.Join("backups", "torrents", hash+".torrent"))
 	absPath := filepath.Join(svc.cfg.DataDir, blobPath)
 	require.NoError(t, os.MkdirAll(filepath.Dir(absPath), 0o755))
-	require.NoError(t, os.WriteFile(absPath, []byte(data), 0o644))
+	require.NoError(t, os.WriteFile(absPath, []byte(data), 0o600))
 	require.NoError(t, store.InsertItems(ctx, run.ID, []models.BackupItem{{
 		RunID:           run.ID,
 		TorrentHash:     hash,

--- a/internal/backups/service_partial_test.go
+++ b/internal/backups/service_partial_test.go
@@ -88,6 +88,7 @@ func TestHandleJobStopsEarlyAndKeepsPartialBackupWhenInstanceDies(t *testing.T) 
 			{Hash: "hash-c", Name: "Charlie", TotalSize: 33},
 		}, nil
 	}
+	seedCachedTorrent(t, ctx, svc, store, instanceID, "hash-c", "cached-charlie")
 
 	exported := make([]string, 0, 3)
 	svc.exportTorrent = func(_ context.Context, _ int, hash string) ([]byte, string, string, error) {
@@ -110,13 +111,14 @@ func TestHandleJobStopsEarlyAndKeepsPartialBackupWhenInstanceDies(t *testing.T) 
 	savedRun, err := store.GetRun(ctx, run.ID)
 	require.NoError(t, err)
 	require.Equal(t, models.BackupRunStatusSuccess, savedRun.Status)
-	require.Equal(t, 1, savedRun.TorrentCount)
+	require.Equal(t, 2, savedRun.TorrentCount)
 	require.Equal(t, []string{"hash-a", "hash-b"}, exported)
 
 	manifest, err := svc.LoadManifest(ctx, run.ID)
 	require.NoError(t, err)
-	require.Len(t, manifest.Items, 1)
+	require.Len(t, manifest.Items, 2)
 	require.Equal(t, "hash-a", manifest.Items[0].Hash)
+	require.Equal(t, "hash-c", manifest.Items[1].Hash)
 	require.Len(t, manifest.Warnings, 1)
 	require.Equal(t, "hash-b", manifest.Warnings[0].Hash)
 }
@@ -194,7 +196,7 @@ func newBackupTestService(t *testing.T, store *models.BackupStore) *Service {
 	svc := NewService(store, &qb.SyncManager{}, nil, Config{
 		DataDir:        t.TempDir(),
 		WorkerCount:    1,
-		ExportThrottle: 0,
+		ExportThrottle: time.Nanosecond,
 	}, nil)
 	svc.now = func() time.Time { return time.Unix(1_700_000_000, 0).UTC() }
 	svc.getCategories = func(context.Context, int) (map[string]qbt.Category, error) { return map[string]qbt.Category{}, nil }
@@ -202,6 +204,31 @@ func newBackupTestService(t *testing.T, store *models.BackupStore) *Service {
 	svc.getWebAPIVersion = func(context.Context, int) (string, error) { return "2.8.11", nil }
 	svc.probeInstance = func(context.Context, int) error { return nil }
 	return svc
+}
+
+func seedCachedTorrent(t *testing.T, ctx context.Context, svc *Service, store *models.BackupStore, instanceID int, hash string, data string) {
+	t.Helper()
+
+	run := &models.BackupRun{
+		InstanceID:  instanceID,
+		Kind:        models.BackupRunKindManual,
+		Status:      models.BackupRunStatusSuccess,
+		RequestedBy: "cache-seed",
+		RequestedAt: time.Unix(1_699_999_000, 0).UTC(),
+	}
+	require.NoError(t, store.CreateRun(ctx, run))
+
+	blobPath := filepath.ToSlash(filepath.Join("backups", "torrents", hash+".torrent"))
+	absPath := filepath.Join(svc.cfg.DataDir, blobPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(absPath), 0o755))
+	require.NoError(t, os.WriteFile(absPath, []byte(data), 0o644))
+	require.NoError(t, store.InsertItems(ctx, run.ID, []models.BackupItem{{
+		RunID:           run.ID,
+		TorrentHash:     hash,
+		Name:            "Cached " + hash,
+		SizeBytes:       int64(len(data)),
+		TorrentBlobPath: &blobPath,
+	}}))
 }
 
 func createBackupRun(ctx context.Context, t *testing.T, store *models.BackupStore, instanceID int, now time.Time) *models.BackupRun {

--- a/internal/backups/service_partial_test.go
+++ b/internal/backups/service_partial_test.go
@@ -1,0 +1,259 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package backups
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/models"
+	qb "github.com/autobrr/qui/internal/qbittorrent"
+)
+
+func TestHandleJobMarksPartialBackupSuccessWhenExportRecovers(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := setupTestBackupDB(t)
+	store := models.NewBackupStore(db)
+	instanceID := insertTestInstance(t, db, "partial-success")
+
+	svc := newBackupTestService(t, store)
+	svc.listTorrents = func(context.Context, int) ([]qbt.Torrent, error) {
+		return []qbt.Torrent{
+			{Hash: "hash-a", Name: "Alpha", TotalSize: 11},
+			{Hash: "hash-b", Name: "Bravo", TotalSize: 22},
+			{Hash: "hash-c", Name: "Charlie", TotalSize: 33},
+		}, nil
+	}
+	svc.exportTorrent = func(_ context.Context, _ int, hash string) ([]byte, string, string, error) {
+		switch hash {
+		case "hash-a":
+			return []byte("alpha"), "Alpha", "", nil
+		case "hash-b":
+			return nil, "", "", errors.New("status code: 502: bad gateway")
+		case "hash-c":
+			return []byte("charlie"), "Charlie", "", nil
+		default:
+			return nil, "", "", errors.New("unexpected hash")
+		}
+	}
+	svc.probeInstance = func(context.Context, int) error { return nil }
+
+	run := createBackupRun(t, ctx, store, instanceID, svc.now())
+	svc.handleJob(ctx, job{runID: run.ID, instanceID: instanceID, kind: models.BackupRunKindManual})
+
+	savedRun, err := store.GetRun(ctx, run.ID)
+	require.NoError(t, err)
+	require.Equal(t, models.BackupRunStatusSuccess, savedRun.Status)
+	require.Equal(t, 2, savedRun.TorrentCount)
+	require.NotNil(t, savedRun.ErrorMessage)
+	require.Contains(t, *savedRun.ErrorMessage, "Partial backup")
+	require.NotNil(t, savedRun.ManifestPath)
+
+	items, err := store.ListItems(ctx, run.ID)
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+	require.Equal(t, "hash-a", items[0].TorrentHash)
+	require.Equal(t, "hash-c", items[1].TorrentHash)
+
+	manifest, err := svc.LoadManifest(ctx, run.ID)
+	require.NoError(t, err)
+	require.Len(t, manifest.Warnings, 1)
+	require.Equal(t, "hash-b", manifest.Warnings[0].Hash)
+	require.Equal(t, "Bravo", manifest.Warnings[0].Name)
+}
+
+func TestHandleJobStopsEarlyAndKeepsPartialBackupWhenInstanceDies(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := setupTestBackupDB(t)
+	store := models.NewBackupStore(db)
+	instanceID := insertTestInstance(t, db, "partial-stop")
+
+	svc := newBackupTestService(t, store)
+	svc.listTorrents = func(context.Context, int) ([]qbt.Torrent, error) {
+		return []qbt.Torrent{
+			{Hash: "hash-a", Name: "Alpha", TotalSize: 11},
+			{Hash: "hash-b", Name: "Bravo", TotalSize: 22},
+			{Hash: "hash-c", Name: "Charlie", TotalSize: 33},
+		}, nil
+	}
+
+	exported := make([]string, 0, 3)
+	svc.exportTorrent = func(_ context.Context, _ int, hash string) ([]byte, string, string, error) {
+		exported = append(exported, hash)
+		switch hash {
+		case "hash-a":
+			return []byte("alpha"), "Alpha", "", nil
+		case "hash-b":
+			return nil, "", "", errors.New("context deadline exceeded")
+		default:
+			t.Fatalf("unexpected export after probe failure: %s", hash)
+			return nil, "", "", nil
+		}
+	}
+	svc.probeInstance = func(context.Context, int) error { return errors.New("connection refused") }
+
+	run := createBackupRun(t, ctx, store, instanceID, svc.now())
+	svc.handleJob(ctx, job{runID: run.ID, instanceID: instanceID, kind: models.BackupRunKindManual})
+
+	savedRun, err := store.GetRun(ctx, run.ID)
+	require.NoError(t, err)
+	require.Equal(t, models.BackupRunStatusSuccess, savedRun.Status)
+	require.Equal(t, 1, savedRun.TorrentCount)
+	require.Equal(t, []string{"hash-a", "hash-b"}, exported)
+
+	manifest, err := svc.LoadManifest(ctx, run.ID)
+	require.NoError(t, err)
+	require.Len(t, manifest.Items, 1)
+	require.Equal(t, "hash-a", manifest.Items[0].Hash)
+	require.Len(t, manifest.Warnings, 1)
+	require.Equal(t, "hash-b", manifest.Warnings[0].Hash)
+}
+
+func TestHandleJobFailsWhenInstanceDiesBeforeAnyTorrentExports(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := setupTestBackupDB(t)
+	store := models.NewBackupStore(db)
+	instanceID := insertTestInstance(t, db, "hard-fail")
+
+	svc := newBackupTestService(t, store)
+	svc.listTorrents = func(context.Context, int) ([]qbt.Torrent, error) {
+		return []qbt.Torrent{{Hash: "hash-a", Name: "Alpha", TotalSize: 11}}, nil
+	}
+	svc.exportTorrent = func(context.Context, int, string) ([]byte, string, string, error) {
+		return nil, "", "", errors.New("connection reset by peer")
+	}
+	svc.probeInstance = func(context.Context, int) error { return errors.New("connection refused") }
+
+	run := createBackupRun(t, ctx, store, instanceID, svc.now())
+	svc.handleJob(ctx, job{runID: run.ID, instanceID: instanceID, kind: models.BackupRunKindManual})
+
+	savedRun, err := store.GetRun(ctx, run.ID)
+	require.NoError(t, err)
+	require.Equal(t, models.BackupRunStatusFailed, savedRun.Status)
+	require.NotNil(t, savedRun.ErrorMessage)
+	require.Contains(t, *savedRun.ErrorMessage, "instance became unavailable")
+
+	items, err := store.ListItems(ctx, run.ID)
+	require.NoError(t, err)
+	require.Len(t, items, 0)
+}
+
+func TestLoadManifestFallsBackToDatabaseForLegacyRuns(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := setupTestBackupDB(t)
+	store := models.NewBackupStore(db)
+	instanceID := insertTestInstance(t, db, "legacy-manifest")
+
+	svc := newBackupTestService(t, store)
+	run := createBackupRun(t, ctx, store, instanceID, svc.now())
+
+	now := svc.now()
+	require.NoError(t, store.UpdateRunMetadata(ctx, run.ID, func(r *models.BackupRun) error {
+		r.Status = models.BackupRunStatusSuccess
+		r.CompletedAt = &now
+		r.Categories = map[string]models.CategorySnapshot{
+			"movies": {SavePath: "/downloads/movies"},
+		}
+		r.Tags = []string{"tag-a"}
+		return nil
+	}))
+
+	require.NoError(t, store.InsertItems(ctx, run.ID, []models.BackupItem{{
+		RunID:       run.ID,
+		TorrentHash: "hash-a",
+		Name:        "Alpha",
+		SizeBytes:   11,
+	}}))
+
+	manifest, err := svc.LoadManifest(ctx, run.ID)
+	require.NoError(t, err)
+	require.Len(t, manifest.Items, 1)
+	require.Nil(t, manifest.Warnings)
+	require.Equal(t, "hash-a", manifest.Items[0].Hash)
+}
+
+func newBackupTestService(t *testing.T, store *models.BackupStore) *Service {
+	t.Helper()
+
+	svc := NewService(store, &qb.SyncManager{}, nil, Config{
+		DataDir:        t.TempDir(),
+		WorkerCount:    1,
+		ExportThrottle: 0,
+	}, nil)
+	svc.now = func() time.Time { return time.Unix(1_700_000_000, 0).UTC() }
+	svc.getCategories = func(context.Context, int) (map[string]qbt.Category, error) { return map[string]qbt.Category{}, nil }
+	svc.getTags = func(context.Context, int) ([]string, error) { return nil, nil }
+	svc.getWebAPIVersion = func(context.Context, int) (string, error) { return "2.8.11", nil }
+	svc.probeInstance = func(context.Context, int) error { return nil }
+	return svc
+}
+
+func createBackupRun(t *testing.T, ctx context.Context, store *models.BackupStore, instanceID int, now time.Time) *models.BackupRun {
+	t.Helper()
+
+	run := &models.BackupRun{
+		InstanceID:  instanceID,
+		Kind:        models.BackupRunKindManual,
+		Status:      models.BackupRunStatusPending,
+		RequestedBy: "tester",
+		RequestedAt: now,
+	}
+	require.NoError(t, store.CreateRun(ctx, run))
+	return run
+}
+
+func TestLoadManifestPrefersSavedManifestFileForWarnings(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := setupTestBackupDB(t)
+	store := models.NewBackupStore(db)
+	instanceID := insertTestInstance(t, db, "saved-manifest")
+
+	svc := newBackupTestService(t, store)
+	svc.listTorrents = func(context.Context, int) ([]qbt.Torrent, error) {
+		return []qbt.Torrent{
+			{Hash: "hash-a", Name: "Alpha", TotalSize: 11},
+			{Hash: "hash-b", Name: "Bravo", TotalSize: 22},
+		}, nil
+	}
+	svc.exportTorrent = func(_ context.Context, _ int, hash string) ([]byte, string, string, error) {
+		if hash == "hash-a" {
+			return []byte("alpha"), "Alpha", "", nil
+		}
+		return nil, "", "", errors.New("status code: 503: service unavailable")
+	}
+
+	run := createBackupRun(t, ctx, store, instanceID, svc.now())
+	svc.handleJob(ctx, job{runID: run.ID, instanceID: instanceID, kind: models.BackupRunKindManual})
+
+	savedRun, err := store.GetRun(ctx, run.ID)
+	require.NoError(t, err)
+	require.NotNil(t, savedRun.ManifestPath)
+
+	manifestPath := savedRun.ManifestPath
+	require.NotNil(t, manifestPath)
+	_, statErr := os.Stat(filepath.Join(svc.cfg.DataDir, *manifestPath))
+	require.NoError(t, statErr)
+
+	manifest, err := svc.LoadManifest(ctx, run.ID)
+	require.NoError(t, err)
+	require.Len(t, manifest.Warnings, 1)
+	require.Equal(t, "hash-b", manifest.Warnings[0].Hash)
+}

--- a/internal/backups/service_partial_test.go
+++ b/internal/backups/service_partial_test.go
@@ -48,7 +48,7 @@ func TestHandleJobMarksPartialBackupSuccessWhenExportRecovers(t *testing.T) {
 	}
 	svc.probeInstance = func(context.Context, int) error { return nil }
 
-	run := createBackupRun(t, ctx, store, instanceID, svc.now())
+	run := createBackupRun(ctx, t, store, instanceID, svc.now())
 	svc.handleJob(ctx, job{runID: run.ID, instanceID: instanceID, kind: models.BackupRunKindManual})
 
 	savedRun, err := store.GetRun(ctx, run.ID)
@@ -104,7 +104,7 @@ func TestHandleJobStopsEarlyAndKeepsPartialBackupWhenInstanceDies(t *testing.T) 
 	}
 	svc.probeInstance = func(context.Context, int) error { return errors.New("connection refused") }
 
-	run := createBackupRun(t, ctx, store, instanceID, svc.now())
+	run := createBackupRun(ctx, t, store, instanceID, svc.now())
 	svc.handleJob(ctx, job{runID: run.ID, instanceID: instanceID, kind: models.BackupRunKindManual})
 
 	savedRun, err := store.GetRun(ctx, run.ID)
@@ -138,7 +138,7 @@ func TestHandleJobFailsWhenInstanceDiesBeforeAnyTorrentExports(t *testing.T) {
 	}
 	svc.probeInstance = func(context.Context, int) error { return errors.New("connection refused") }
 
-	run := createBackupRun(t, ctx, store, instanceID, svc.now())
+	run := createBackupRun(ctx, t, store, instanceID, svc.now())
 	svc.handleJob(ctx, job{runID: run.ID, instanceID: instanceID, kind: models.BackupRunKindManual})
 
 	savedRun, err := store.GetRun(ctx, run.ID)
@@ -149,7 +149,7 @@ func TestHandleJobFailsWhenInstanceDiesBeforeAnyTorrentExports(t *testing.T) {
 
 	items, err := store.ListItems(ctx, run.ID)
 	require.NoError(t, err)
-	require.Len(t, items, 0)
+	require.Empty(t, items)
 }
 
 func TestLoadManifestFallsBackToDatabaseForLegacyRuns(t *testing.T) {
@@ -161,7 +161,7 @@ func TestLoadManifestFallsBackToDatabaseForLegacyRuns(t *testing.T) {
 	instanceID := insertTestInstance(t, db, "legacy-manifest")
 
 	svc := newBackupTestService(t, store)
-	run := createBackupRun(t, ctx, store, instanceID, svc.now())
+	run := createBackupRun(ctx, t, store, instanceID, svc.now())
 
 	now := svc.now()
 	require.NoError(t, store.UpdateRunMetadata(ctx, run.ID, func(r *models.BackupRun) error {
@@ -204,7 +204,7 @@ func newBackupTestService(t *testing.T, store *models.BackupStore) *Service {
 	return svc
 }
 
-func createBackupRun(t *testing.T, ctx context.Context, store *models.BackupStore, instanceID int, now time.Time) *models.BackupRun {
+func createBackupRun(ctx context.Context, t *testing.T, store *models.BackupStore, instanceID int, now time.Time) *models.BackupRun {
 	t.Helper()
 
 	run := &models.BackupRun{
@@ -240,7 +240,7 @@ func TestLoadManifestPrefersSavedManifestFileForWarnings(t *testing.T) {
 		return nil, "", "", errors.New("status code: 503: service unavailable")
 	}
 
-	run := createBackupRun(t, ctx, store, instanceID, svc.now())
+	run := createBackupRun(ctx, t, store, instanceID, svc.now())
 	svc.handleJob(ctx, job{runID: run.ID, instanceID: instanceID, kind: models.BackupRunKindManual})
 
 	savedRun, err := store.GetRun(ctx, run.ID)

--- a/internal/services/notifications/service.go
+++ b/internal/services/notifications/service.go
@@ -339,10 +339,16 @@ func (s *Service) formatEvent(ctx context.Context, event Event, humanReadableMet
 		return title, buildMessage(instanceLabel, lines)
 	case EventBackupSucceeded:
 		title := "Backup completed"
+		if strings.TrimSpace(event.ErrorMessage) != "" {
+			title = "Backup completed with warnings"
+		}
 		lines := []string{
 			formatLine("Backup", formatKind(event.BackupKind)),
 			formatLine("Run", strconv.FormatInt(event.BackupRunID, 10)),
 			formatLine("Torrents", strconv.Itoa(event.BackupTorrentCount)),
+		}
+		if warning := strings.TrimSpace(event.ErrorMessage); warning != "" {
+			lines = append(lines, formatLine("Warnings", formatErrorMessage(warning)))
 		}
 		return title, buildMessage(instanceLabel, lines)
 	case EventBackupFailed:

--- a/web/src/pages/InstanceBackups.tsx
+++ b/web/src/pages/InstanceBackups.tsx
@@ -141,6 +141,7 @@ const statusVariants: Record<BackupRunStatus, "default" | "secondary" | "destruc
 }
 
 const hasBackupWarnings = (run: BackupRun) => run.status === "success" && Boolean(run.errorMessage?.trim())
+const backupStatusLabel = (run: BackupRun) => (hasBackupWarnings(run) ? "success with warnings" : run.status)
 
 export function InstanceBackups() {
   const { instances } = useInstances()
@@ -1752,7 +1753,7 @@ export function InstanceBackups() {
                                   ? "capitalize border-amber-300 bg-amber-50 text-amber-900 hover:bg-amber-50"
                                   : "capitalize"}
                               >
-                                {run.status}
+                                {backupStatusLabel(run)}
                               </Badge>
                               {hasBackupWarnings(run) ? (
                                 <p className="max-w-xs text-xs text-amber-700">{run.errorMessage}</p>

--- a/web/src/pages/InstanceBackups.tsx
+++ b/web/src/pages/InstanceBackups.tsx
@@ -913,7 +913,19 @@ export function InstanceBackups() {
                         </p>
                       </div>
                     ) : (
-                      <p className="text-xs text-muted-foreground capitalize">Status: {lastRun.status}</p>
+                      <div className="space-y-1">
+                        <Badge
+                          variant={statusVariants[lastRun.status]}
+                          className={hasBackupWarnings(lastRun)
+                            ? "capitalize border-amber-300 bg-amber-50 text-amber-900 hover:bg-amber-50"
+                            : "capitalize"}
+                        >
+                          {backupStatusLabel(lastRun)}
+                        </Badge>
+                        {hasBackupWarnings(lastRun) ? (
+                          <p className="max-w-xs text-xs text-amber-700">{lastRun.errorMessage}</p>
+                        ) : null}
+                      </div>
                     )}
                   </div>
                 </div>

--- a/web/src/pages/InstanceBackups.tsx
+++ b/web/src/pages/InstanceBackups.tsx
@@ -140,6 +140,8 @@ const statusVariants: Record<BackupRunStatus, "default" | "secondary" | "destruc
   canceled: "outline",
 }
 
+const hasBackupWarnings = (run: BackupRun) => run.status === "success" && Boolean(run.errorMessage?.trim())
+
 export function InstanceBackups() {
   const { instances } = useInstances()
   const [selectedInstanceId, setSelectedInstanceId] = usePersistedInstanceSelection("backups")
@@ -1743,7 +1745,19 @@ export function InstanceBackups() {
                               </p>
                             </div>
                           ) : (
-                            <Badge variant={statusVariants[run.status]} className="capitalize">{run.status}</Badge>
+                            <div className="space-y-1">
+                              <Badge
+                                variant={statusVariants[run.status]}
+                                className={hasBackupWarnings(run)
+                                  ? "capitalize border-amber-300 bg-amber-50 text-amber-900 hover:bg-amber-50"
+                                  : "capitalize"}
+                              >
+                                {run.status}
+                              </Badge>
+                              {hasBackupWarnings(run) ? (
+                                <p className="max-w-xs text-xs text-amber-700">{run.errorMessage}</p>
+                              ) : null}
+                            </div>
                           )}
                         </TableCell>
                         <TableCell>{formatDateSafe(run.requestedAt, formatDate)}</TableCell>
@@ -1942,8 +1956,26 @@ export function InstanceBackups() {
                       <span>Categories: {manifestCategoryEntries.length}</span>
                     )}
                     {manifestTags.length > 0 && <span>Tags: {manifestTags.length}</span>}
+                    {manifest.warnings && manifest.warnings.length > 0 && <span>Warnings: {manifest.warnings.length}</span>}
                     <span>Generated {formatDateSafe(manifest.generatedAt, formatDate)}</span>
                   </div>
+                  {manifest.warnings && manifest.warnings.length > 0 ? (
+                    <Alert className="border-amber-300 bg-amber-50 text-amber-950">
+                      <AlertTitle>Partial backup warnings</AlertTitle>
+                      <AlertDescription className="space-y-2">
+                        <p>This backup completed, but some torrent exports were skipped.</p>
+                        <ul className="space-y-1 text-xs">
+                          {manifest.warnings.map(warning => (
+                            <li key={`${warning.hash}-${warning.reason}`} className="break-words">
+                              <span className="font-medium">{warning.name || warning.hash}</span>
+                              {" — "}
+                              {warning.reason}
+                            </li>
+                          ))}
+                        </ul>
+                      </AlertDescription>
+                    </Alert>
+                  ) : null}
                   {displayedCategoryEntries.length > 0 && (
                     <div>
                       <p className="font-medium text-foreground mb-2">Categories</p>

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -1060,6 +1060,12 @@ export interface BackupManifestItem {
   torrentBlob?: string
 }
 
+export interface BackupManifestWarning {
+  hash: string
+  name: string
+  reason: string
+}
+
 export interface BackupCategorySnapshot {
   savePath?: string | null
 }
@@ -1071,6 +1077,7 @@ export interface BackupManifest {
   torrentCount: number
   categories?: Record<string, BackupCategorySnapshot>
   tags?: string[]
+  warnings?: BackupManifestWarning[]
   items: BackupManifestItem[]
 }
 


### PR DESCRIPTION
Keep usable backup data when qBittorrent export hangs or drops mid-run: record skipped torrents as manifest warnings, finish the run as success with warnings when at least one torrent was exported, and surface that state in notifications/UI. Context: [qui discussion #1554](https://github.com/autobrr/qui/discussions/1554), [qBittorrent issue #18185](https://github.com/qbittorrent/qBittorrent/issues/18185), [qBittorrent issue #23907](https://github.com/qbittorrent/qBittorrent/issues/23907).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backups can complete as partial runs when an instance crashes or is unavailable, preserving exported torrents and marking the run as completed with warnings.
  * Manifests and backup history now list skipped torrents with human-readable reasons; backup view shows a Warnings count and detailed list.
  * Notifications for successful backups show "completed with warnings" when applicable.

* **Documentation**
  * Added docs describing partial backup behavior and how warnings are presented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->