### PR TITLE
refactor(reflinking): add windows ReFS filesystem support

### DIFF
--- a/documentation/docs/features/cross-seed/hardlink-mode.md
+++ b/documentation/docs/features/cross-seed/hardlink-mode.md
@@ -103,7 +103,7 @@ Reflink mode creates copy-on-write clones of the matched files. Unlike hardlinks
   - **FreeBSD**: Not currently supported
 
 :::note
-Windows reflink mode uses ReFS block cloning (requiring an ReFS filesystem). NTFS is not supported. If reflink creation fails, fallback still depends on the existing "Fallback to regular mode" setting.
+Windows reflink mode uses ReFS block cloning (requiring a ReFS filesystem). NTFS is not supported. If the matched source path is a symlink, qui resolves it before cloning, and the resolved source plus the reflink base directory still need to be on the same ReFS volume. If reflink creation fails, fallback still depends on the existing "Fallback to regular mode" setting.
 :::
 
 :::tip

--- a/documentation/docs/features/cross-seed/hardlink-mode.md
+++ b/documentation/docs/features/cross-seed/hardlink-mode.md
@@ -88,7 +88,7 @@ Reflink mode creates copy-on-write clones of the matched files. Unlike hardlinks
 ### When to Use Reflink Mode
 
 - You want to cross-seed torrents that hardlink mode would skip due to "extra files share pieces with content"
-- Your filesystem supports copy-on-write clones (BTRFS, XFS on Linux; APFS on macOS)
+- Your filesystem supports copy-on-write clones (BTRFS, XFS on Linux; APFS on macOS; ReFS on Windows)
 - You prefer the safety of copy-on-write over hardlinks
 
 ### Reflink Requirements
@@ -99,7 +99,12 @@ Reflink mode creates copy-on-write clones of the matched files. Unlike hardlinks
 - The filesystem must support reflinks:
   - **Linux**: BTRFS, XFS (with reflink=1), and similar CoW filesystems
   - **macOS**: APFS
-  - **Windows/FreeBSD**: Not currently supported
+  - **Windows**: ReFS on the same volume as the source files and reflink base directory
+  - **FreeBSD**: Not currently supported
+
+:::note
+Windows reflink mode uses ReFS block cloning (requiring an ReFS filesystem). NTFS is not supported. If reflink creation fails, fallback still depends on the existing "Fallback to regular mode" setting.
+:::
 
 :::tip
 On Linux, check the filesystem type with `df -T /path` (you want `xfs`/`btrfs`, not `fuseblk`/`fuse.mergerfs`/`overlayfs`).

--- a/internal/services/crossseed/hardlink_mode_test.go
+++ b/internal/services/crossseed/hardlink_mode_test.go
@@ -5,6 +5,8 @@ package crossseed
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,6 +18,7 @@ import (
 
 	"github.com/autobrr/qui/internal/models"
 	"github.com/autobrr/qui/pkg/hardlinktree"
+	"github.com/autobrr/qui/pkg/reflinktree"
 )
 
 // Note: qbtLayoutToHardlinkLayout is no longer used in hardlink mode.
@@ -903,4 +906,40 @@ func TestProcessReflinkMode_FallbackDisabled(t *testing.T) {
 	assert.False(t, result.Success, "result should indicate failure")
 	assert.Equal(t, "reflink_error", result.Result.Status)
 	assert.Contains(t, result.Result.Message, "base directory")
+}
+
+func TestShouldWarnForReflinkCreateError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "plain wrapped unsupported error",
+			err:  fmt.Errorf("reflink create failed: %w", reflinktree.ErrReflinkUnsupported),
+			want: true,
+		},
+		{
+			name: "joined rollback error stays error level",
+			err: errors.Join(
+				fmt.Errorf("reflink create failed: %w", reflinktree.ErrReflinkUnsupported),
+				errors.New("rollback also failed"),
+			),
+			want: false,
+		},
+		{
+			name: "unrelated error",
+			err:  errors.New("boom"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, shouldWarnForReflinkCreateError(tt.err))
+		})
+	}
 }

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -11081,7 +11081,11 @@ func (s *Service) processReflinkMode(
 
 	// Create reflink tree on disk
 	if err := reflinktree.Create(plan); err != nil {
-		log.Error().
+		logEvent := log.Error()
+		if errors.Is(err, reflinktree.ErrReflinkUnsupported) {
+			logEvent = log.Warn()
+		}
+		logEvent.
 			Err(err).
 			Int("instanceID", candidate.InstanceID).
 			Str("torrentName", torrentName).

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -11082,7 +11082,7 @@ func (s *Service) processReflinkMode(
 	// Create reflink tree on disk
 	if err := reflinktree.Create(plan); err != nil {
 		logEvent := log.Error()
-		if errors.Is(err, reflinktree.ErrReflinkUnsupported) {
+		if errors.Is(err, reflinktree.ErrReflinkUnsupported) && errors.Unwrap(err) == nil {
 			logEvent = log.Warn()
 		}
 		logEvent.

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -10861,6 +10861,19 @@ type reflinkModeResult struct {
 	Result InstanceCrossSeedResult
 }
 
+func shouldWarnForReflinkCreateError(err error) bool {
+	if !errors.Is(err, reflinktree.ErrReflinkUnsupported) {
+		return false
+	}
+
+	type multiUnwrapper interface {
+		Unwrap() []error
+	}
+
+	var joined multiUnwrapper
+	return !errors.As(err, &joined)
+}
+
 // processReflinkMode attempts to add a cross-seed torrent using reflink (copy-on-write) mode.
 // This creates a reflink tree matching the incoming torrent's layout, allowing safe
 // modification of cloned files without affecting originals.
@@ -11082,7 +11095,7 @@ func (s *Service) processReflinkMode(
 	// Create reflink tree on disk
 	if err := reflinktree.Create(plan); err != nil {
 		logEvent := log.Error()
-		if errors.Is(err, reflinktree.ErrReflinkUnsupported) && errors.Unwrap(err) == nil {
+		if shouldWarnForReflinkCreateError(err) {
 			logEvent = log.Warn()
 		}
 		logEvent.

--- a/pkg/reflinktree/reflink_test.go
+++ b/pkg/reflinktree/reflink_test.go
@@ -17,8 +17,8 @@ func TestSupportsReflink(t *testing.T) {
 
 	supported, reason := SupportsReflink(tmpDir)
 
-	// On unsupported platforms, should return false
-	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+	// On unsupported platforms, should return false.
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" && runtime.GOOS != "windows" {
 		if supported {
 			t.Errorf("SupportsReflink should return false on %s", runtime.GOOS)
 		}
@@ -28,8 +28,8 @@ func TestSupportsReflink(t *testing.T) {
 		return
 	}
 
-	// On supported platforms, the result depends on filesystem
-	// We just verify the function doesn't panic and returns sensible values
+	// On supported platforms, the result depends on filesystem.
+	// We just verify the function doesn't panic and returns sensible values.
 	t.Logf("SupportsReflink(%s): supported=%v, reason=%s", tmpDir, supported, reason)
 
 	if !supported {

--- a/pkg/reflinktree/reflink_unsupported.go
+++ b/pkg/reflinktree/reflink_unsupported.go
@@ -1,12 +1,12 @@
 // Copyright (c) 2025-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-//go:build !linux && !darwin
+//go:build !linux && !darwin && !windows
 
 package reflinktree
 
 // SupportsReflink returns false on unsupported platforms.
-// Windows and FreeBSD do not have a standard reflink mechanism that we support.
+// FreeBSD do not have a standard reflink mechanism that we support.
 func SupportsReflink(_ string) (supported bool, reason string) {
 	return false, "reflink is not supported on this operating system"
 }

--- a/pkg/reflinktree/reflink_windows.go
+++ b/pkg/reflinktree/reflink_windows.go
@@ -146,8 +146,12 @@ func cloneFile(src, dst string) (retErr error) {
 	if dstParent == "" {
 		dstParent = "."
 	}
+	resolvedDstParent, err := evalSymlinksFn(dstParent)
+	if err != nil {
+		return fmt.Errorf("resolve destination parent: %w", err)
+	}
 
-	volumeRoot, err := ensureSameVolume(resolvedSrc, dstParent)
+	volumeRoot, err := ensureSameVolume(resolvedSrc, resolvedDstParent)
 	if err != nil {
 		return err
 	}
@@ -189,6 +193,9 @@ func cloneFile(src, dst string) (retErr error) {
 	for offset := int64(0); offset < cloneableSize; offset += maxCloneChunkSize {
 		chunkSize := min(maxCloneChunkSize, cloneableSize-offset)
 		if err := duplicateExtentFn(dstHandle, srcHandle, offset, offset, chunkSize); err != nil {
+			if errors.Is(err, windows.ERROR_NOT_SUPPORTED) {
+				return fmt.Errorf("%w: duplicate extents unsupported for this file or volume", ErrReflinkUnsupported)
+			}
 			return fmt.Errorf("duplicate extents: %w", err)
 		}
 	}

--- a/pkg/reflinktree/reflink_windows.go
+++ b/pkg/reflinktree/reflink_windows.go
@@ -23,6 +23,7 @@ const (
 	maxCloneChunkSize           = 1024 * 1024 * 1024
 	copyBufferSize              = 1024 * 1024
 	refsFilesystemName          = "REFS"
+	reflinkProbeData            = "reflink probe test data"
 )
 
 type duplicateExtentsData struct {
@@ -62,7 +63,19 @@ func SupportsReflink(dir string) (supported bool, reason string) {
 	srcPath := srcFile.Name()
 	defer os.Remove(srcPath)
 
-	if _, err := srcFile.WriteString("reflink probe test data"); err != nil {
+	volumeRoot, err := volumeRootForPathFn(srcPath)
+	if err != nil {
+		srcFile.Close()
+		return false, fmt.Sprintf("reflink not supported: get source volume: %v", err)
+	}
+
+	clusterSize, err := ensureRefsVolume(volumeRoot)
+	if err != nil {
+		srcFile.Close()
+		return false, fmt.Sprintf("reflink not supported: %v", err)
+	}
+
+	if err := writeProbeFile(srcFile, clusterSize); err != nil {
 		srcFile.Close()
 		return false, fmt.Sprintf("cannot write to temp file: %v", err)
 	}
@@ -78,6 +91,25 @@ func SupportsReflink(dir string) (supported bool, reason string) {
 	}
 
 	return true, "reflink supported (ReFS block cloning)"
+}
+
+func writeProbeFile(srcFile *os.File, clusterSize int64) error {
+	if _, err := srcFile.WriteString(reflinkProbeData); err != nil {
+		return err
+	}
+
+	probeSize := max(clusterSize+1, int64(len(reflinkProbeData)))
+	if probeSize == int64(len(reflinkProbeData)) {
+		return nil
+	}
+	if err := srcFile.Truncate(probeSize); err != nil {
+		return err
+	}
+	if _, err := srcFile.WriteAt([]byte{'\n'}, probeSize-1); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func cloneFile(src, dst string) (retErr error) {

--- a/pkg/reflinktree/reflink_windows.go
+++ b/pkg/reflinktree/reflink_windows.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -39,6 +40,11 @@ var (
 	clusterSizeForVolFn    = getClusterSize
 	duplicateExtentFn      = duplicateExtent
 	copyFileTailFn         = copyFileTail
+	copyBufferPool         = sync.Pool{
+		New: func() any {
+			return make([]byte, copyBufferSize)
+		},
+	}
 )
 
 // SupportsReflink tests whether the given directory supports reflinks
@@ -286,7 +292,9 @@ func copyFileTail(srcFile, dstFile *os.File, offset, length int64) error {
 		return fmt.Errorf("seek destination: %w", err)
 	}
 
-	buffer := make([]byte, copyBufferSize)
+	buffer := copyBufferPool.Get().([]byte)
+	defer copyBufferPool.Put(buffer)
+
 	copied, err := io.CopyBuffer(dstFile, io.LimitReader(srcFile, length), buffer)
 	if err != nil {
 		return err

--- a/pkg/reflinktree/reflink_windows.go
+++ b/pkg/reflinktree/reflink_windows.go
@@ -1,0 +1,299 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+//go:build windows
+
+package reflinktree
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	fsctlDuplicateExtentsToFile = 0x00098344
+	maxCloneChunkSize           = 1024 * 1024 * 1024
+	copyBufferSize              = 1024 * 1024
+	refsFilesystemName          = "REFS"
+)
+
+type duplicateExtentsData struct {
+	FileHandle       windows.Handle
+	SourceFileOffset int64
+	TargetFileOffset int64
+	ByteCount        int64
+}
+
+var (
+	kernel32DLL            = windows.NewLazySystemDLL("kernel32.dll")
+	procGetDiskFreeSpaceW  = kernel32DLL.NewProc("GetDiskFreeSpaceW")
+	volumeRootForPathFn    = getVolumeRoot
+	filesystemNameForVolFn = getFilesystemName
+	clusterSizeForVolFn    = getClusterSize
+	duplicateExtentFn      = duplicateExtent
+	copyFileTailFn         = copyFileTail
+)
+
+// SupportsReflink tests whether the given directory supports reflinks
+// by attempting an actual clone operation with temporary files.
+// Returns true if reflinks are supported, along with a reason string.
+func SupportsReflink(dir string) (supported bool, reason string) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return false, fmt.Sprintf("cannot access directory: %v", err)
+	}
+
+	srcFile, err := os.CreateTemp(dir, ".reflink_probe_src_*")
+	if err != nil {
+		return false, fmt.Sprintf("cannot create temp file: %v", err)
+	}
+	srcPath := srcFile.Name()
+	defer os.Remove(srcPath)
+
+	if _, err := srcFile.WriteString("reflink probe test data"); err != nil {
+		srcFile.Close()
+		return false, fmt.Sprintf("cannot write to temp file: %v", err)
+	}
+	if err := srcFile.Close(); err != nil {
+		return false, fmt.Sprintf("cannot close temp file: %v", err)
+	}
+
+	dstPath := filepath.Join(dir, ".reflink_probe_dst_"+filepath.Base(srcPath)[len(".reflink_probe_src_"):])
+	defer os.Remove(dstPath)
+
+	if err := cloneFile(srcPath, dstPath); err != nil {
+		return false, fmt.Sprintf("reflink not supported: %v", err)
+	}
+
+	return true, "reflink supported (ReFS block cloning)"
+}
+
+func cloneFile(src, dst string) (retErr error) {
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("stat source: %w", err)
+	}
+
+	dstParent := filepath.Dir(dst)
+	if dstParent == "" {
+		dstParent = "."
+	}
+
+	volumeRoot, err := ensureSameVolume(src, dstParent)
+	if err != nil {
+		return err
+	}
+
+	clusterSize, err := ensureRefsVolume(volumeRoot)
+	if err != nil {
+		return err
+	}
+
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open source: %w", err)
+	}
+	defer srcFile.Close()
+
+	dstFile, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_EXCL, srcInfo.Mode())
+	if err != nil {
+		return fmt.Errorf("create destination: %w", err)
+	}
+	defer func() {
+		_ = dstFile.Close()
+		if retErr != nil {
+			_ = os.Remove(dst)
+		}
+	}()
+
+	if err := dstFile.Truncate(srcInfo.Size()); err != nil {
+		return fmt.Errorf("resize destination: %w", err)
+	}
+
+	srcHandle := windows.Handle(srcFile.Fd())
+	dstHandle := windows.Handle(dstFile.Fd())
+	cloneableSize := srcInfo.Size() - (srcInfo.Size() % clusterSize)
+
+	for offset := int64(0); offset < cloneableSize; offset += maxCloneChunkSize {
+		chunkSize := min(maxCloneChunkSize, cloneableSize-offset)
+		if err := duplicateExtentFn(dstHandle, srcHandle, offset, offset, chunkSize); err != nil {
+			return fmt.Errorf("duplicate extents: %w", err)
+		}
+	}
+
+	if tailSize := srcInfo.Size() - cloneableSize; tailSize > 0 {
+		if err := copyFileTailFn(srcFile, dstFile, cloneableSize, tailSize); err != nil {
+			return fmt.Errorf("copy file tail: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func ensureSameVolume(src, dst string) (string, error) {
+	srcRoot, err := volumeRootForPathFn(src)
+	if err != nil {
+		return "", fmt.Errorf("get source volume: %w", err)
+	}
+
+	dstRoot, err := volumeRootForPathFn(dst)
+	if err != nil {
+		return "", fmt.Errorf("get destination volume: %w", err)
+	}
+
+	if !strings.EqualFold(srcRoot, dstRoot) {
+		return "", errors.New("source and destination must be on the same volume")
+	}
+
+	return srcRoot, nil
+}
+
+func ensureRefsVolume(volumeRoot string) (int64, error) {
+	filesystemName, err := filesystemNameForVolFn(volumeRoot)
+	if err != nil {
+		return 0, err
+	}
+
+	if !strings.EqualFold(filesystemName, refsFilesystemName) {
+		return 0, fmt.Errorf("volume %s is %s, not ReFS", volumeRoot, filesystemName)
+	}
+
+	clusterSize, err := clusterSizeForVolFn(volumeRoot)
+	if err != nil {
+		return 0, err
+	}
+	if clusterSize <= 0 {
+		return 0, errors.New("invalid cluster size")
+	}
+
+	return clusterSize, nil
+}
+
+func getVolumeRoot(path string) (string, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("abs path: %w", err)
+	}
+
+	volumePath := make([]uint16, windows.MAX_PATH+1)
+	pathPtr, err := windows.UTF16PtrFromString(absPath)
+	if err != nil {
+		return "", fmt.Errorf("convert path: %w", err)
+	}
+
+	if err := windows.GetVolumePathName(pathPtr, &volumePath[0], uint32(len(volumePath))); err != nil {
+		return "", fmt.Errorf("get volume path name: %w", err)
+	}
+
+	volumeRoot := windows.UTF16ToString(volumePath)
+	if !strings.HasSuffix(volumeRoot, `\`) {
+		volumeRoot += `\`
+	}
+
+	return volumeRoot, nil
+}
+
+func getFilesystemName(volumeRoot string) (string, error) {
+	volumePathPtr, err := windows.UTF16PtrFromString(volumeRoot)
+	if err != nil {
+		return "", fmt.Errorf("convert volume path: %w", err)
+	}
+
+	filesystemName := make([]uint16, windows.MAX_PATH+1)
+	var volumeSerial uint32
+	var maxComponentLength uint32
+	var flags uint32
+	if err := windows.GetVolumeInformation(
+		volumePathPtr,
+		nil,
+		0,
+		&volumeSerial,
+		&maxComponentLength,
+		&flags,
+		&filesystemName[0],
+		uint32(len(filesystemName)),
+	); err != nil {
+		return "", fmt.Errorf("get volume information: %w", err)
+	}
+
+	name := windows.UTF16ToString(filesystemName)
+	if name == "" {
+		return "", errors.New("filesystem name is empty")
+	}
+
+	return name, nil
+}
+
+func getClusterSize(volumeRoot string) (int64, error) {
+	volumePathPtr, err := windows.UTF16PtrFromString(volumeRoot)
+	if err != nil {
+		return 0, fmt.Errorf("convert volume path: %w", err)
+	}
+
+	var sectorsPerCluster uint32
+	var bytesPerSector uint32
+	var freeClusters uint32
+	var totalClusters uint32
+	r1, _, callErr := procGetDiskFreeSpaceW.Call(
+		uintptr(unsafe.Pointer(volumePathPtr)),
+		uintptr(unsafe.Pointer(&sectorsPerCluster)),
+		uintptr(unsafe.Pointer(&bytesPerSector)),
+		uintptr(unsafe.Pointer(&freeClusters)),
+		uintptr(unsafe.Pointer(&totalClusters)),
+	)
+	if r1 == 0 {
+		if callErr != nil && !errors.Is(callErr, windows.ERROR_SUCCESS) {
+			return 0, fmt.Errorf("get cluster size: %w", callErr)
+		}
+		return 0, errors.New("get cluster size: unknown error")
+	}
+
+	return int64(sectorsPerCluster) * int64(bytesPerSector), nil
+}
+
+func duplicateExtent(targetHandle, sourceHandle windows.Handle, sourceOffset, targetOffset, byteCount int64) error {
+	data := duplicateExtentsData{
+		FileHandle:       sourceHandle,
+		SourceFileOffset: sourceOffset,
+		TargetFileOffset: targetOffset,
+		ByteCount:        byteCount,
+	}
+
+	var bytesReturned uint32
+	return windows.DeviceIoControl(
+		targetHandle,
+		fsctlDuplicateExtentsToFile,
+		(*byte)(unsafe.Pointer(&data)),
+		uint32(unsafe.Sizeof(data)),
+		nil,
+		0,
+		&bytesReturned,
+		nil,
+	)
+}
+
+func copyFileTail(srcFile, dstFile *os.File, offset, length int64) error {
+	if _, err := srcFile.Seek(offset, io.SeekStart); err != nil {
+		return fmt.Errorf("seek source: %w", err)
+	}
+	if _, err := dstFile.Seek(offset, io.SeekStart); err != nil {
+		return fmt.Errorf("seek destination: %w", err)
+	}
+
+	buffer := make([]byte, copyBufferSize)
+	copied, err := io.CopyBuffer(dstFile, io.LimitReader(srcFile, length), buffer)
+	if err != nil {
+		return err
+	}
+	if copied != length {
+		return io.ErrUnexpectedEOF
+	}
+
+	return nil
+}

--- a/pkg/reflinktree/reflink_windows.go
+++ b/pkg/reflinktree/reflink_windows.go
@@ -113,7 +113,13 @@ func writeProbeFile(srcFile *os.File, clusterSize int64) error {
 }
 
 func cloneFile(src, dst string) (retErr error) {
-	srcInfo, err := os.Stat(src)
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open source: %w", err)
+	}
+	defer srcFile.Close()
+
+	srcInfo, err := srcFile.Stat()
 	if err != nil {
 		return fmt.Errorf("stat source: %w", err)
 	}
@@ -132,12 +138,6 @@ func cloneFile(src, dst string) (retErr error) {
 	if err != nil {
 		return err
 	}
-
-	srcFile, err := os.Open(src)
-	if err != nil {
-		return fmt.Errorf("open source: %w", err)
-	}
-	defer srcFile.Close()
 
 	dstFile, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_EXCL, srcInfo.Mode())
 	if err != nil {

--- a/pkg/reflinktree/reflink_windows.go
+++ b/pkg/reflinktree/reflink_windows.go
@@ -20,10 +20,14 @@ import (
 
 const (
 	fsctlDuplicateExtentsToFile = 0x00098344
+	fsctlSetSparse              = 0x000900C4
 	maxCloneChunkSize           = 1024 * 1024 * 1024
 	copyBufferSize              = 1024 * 1024
 	refsFilesystemName          = "REFS"
 	reflinkProbeData            = "reflink probe test data"
+	fileAttributeSparseFile     = 0x00000200
+	invalidFileAttributes       = 0xFFFFFFFF
+	fileBegin                   = 0
 )
 
 type duplicateExtentsData struct {
@@ -36,6 +40,15 @@ type duplicateExtentsData struct {
 var (
 	kernel32DLL            = windows.NewLazySystemDLL("kernel32.dll")
 	procGetDiskFreeSpaceW  = kernel32DLL.NewProc("GetDiskFreeSpaceW")
+	procGetFileAttributesW = kernel32DLL.NewProc("GetFileAttributesW")
+	procSetFilePointerEx   = kernel32DLL.NewProc("SetFilePointerEx")
+	procSetEndOfFile       = kernel32DLL.NewProc("SetEndOfFile")
+	resolveSourcePathFn    = resolveSourcePath
+	lstatPathFn            = os.Lstat
+	evalSymlinksFn         = filepath.EvalSymlinks
+	isSparseFileFn         = isSparseFile
+	markFileSparseFn       = markFileSparse
+	setFileEndFn           = setFileEnd
 	volumeRootForPathFn    = getVolumeRoot
 	filesystemNameForVolFn = getFilesystemName
 	clusterSizeForVolFn    = getClusterSize
@@ -113,7 +126,12 @@ func writeProbeFile(srcFile *os.File, clusterSize int64) error {
 }
 
 func cloneFile(src, dst string) (retErr error) {
-	srcFile, err := os.Open(src)
+	resolvedSrc, err := resolveSourcePathFn(src)
+	if err != nil {
+		return fmt.Errorf("resolve source: %w", err)
+	}
+
+	srcFile, err := os.Open(resolvedSrc)
 	if err != nil {
 		return fmt.Errorf("open source: %w", err)
 	}
@@ -129,7 +147,7 @@ func cloneFile(src, dst string) (retErr error) {
 		dstParent = "."
 	}
 
-	volumeRoot, err := ensureSameVolume(src, dstParent)
+	volumeRoot, err := ensureSameVolume(resolvedSrc, dstParent)
 	if err != nil {
 		return err
 	}
@@ -137,6 +155,11 @@ func cloneFile(src, dst string) (retErr error) {
 	clusterSize, err := ensureRefsVolume(volumeRoot)
 	if err != nil {
 		return err
+	}
+
+	sourceIsSparse, err := isSparseFileFn(resolvedSrc)
+	if err != nil {
+		return fmt.Errorf("check source sparse flag: %w", err)
 	}
 
 	dstFile, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_EXCL, srcInfo.Mode())
@@ -150,12 +173,17 @@ func cloneFile(src, dst string) (retErr error) {
 		}
 	}()
 
-	if err := dstFile.Truncate(srcInfo.Size()); err != nil {
+	srcHandle := windows.Handle(srcFile.Fd())
+	dstHandle := windows.Handle(dstFile.Fd())
+	if sourceIsSparse {
+		if err := markFileSparseFn(dstHandle, dst); err != nil {
+			return fmt.Errorf("mark destination sparse: %w", err)
+		}
+	}
+	if err := setFileEndFn(dstHandle, dst, srcInfo.Size()); err != nil {
 		return fmt.Errorf("resize destination: %w", err)
 	}
 
-	srcHandle := windows.Handle(srcFile.Fd())
-	dstHandle := windows.Handle(dstFile.Fd())
 	cloneableSize := srcInfo.Size() - (srcInfo.Size() % clusterSize)
 
 	for offset := int64(0); offset < cloneableSize; offset += maxCloneChunkSize {
@@ -172,6 +200,20 @@ func cloneFile(src, dst string) (retErr error) {
 	}
 
 	return nil
+}
+
+func resolveSourcePath(src string) (string, error) {
+	_, err := lstatPathFn(src)
+	if err != nil {
+		return "", err
+	}
+
+	resolvedSrc, err := evalSymlinksFn(src)
+	if err != nil {
+		return "", err
+	}
+
+	return resolvedSrc, nil
 }
 
 func ensureSameVolume(src, dst string) (string, error) {
@@ -293,6 +335,67 @@ func getClusterSize(volumeRoot string) (int64, error) {
 	}
 
 	return int64(sectorsPerCluster) * int64(bytesPerSector), nil
+}
+
+func isSparseFile(path string) (bool, error) {
+	pathPtr, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return false, fmt.Errorf("convert path: %w", err)
+	}
+
+	r1, _, callErr := procGetFileAttributesW.Call(uintptr(unsafe.Pointer(pathPtr)))
+	if uint32(r1) == invalidFileAttributes {
+		if callErr != nil && !errors.Is(callErr, windows.ERROR_SUCCESS) {
+			return false, fmt.Errorf("get file attributes: %w", callErr)
+		}
+		return false, errors.New("get file attributes: unknown error")
+	}
+
+	return uint32(r1)&fileAttributeSparseFile != 0, nil
+}
+
+func markFileSparse(fileHandle windows.Handle, path string) error {
+	var bytesReturned uint32
+	if err := windows.DeviceIoControl(
+		fileHandle,
+		fsctlSetSparse,
+		nil,
+		0,
+		nil,
+		0,
+		&bytesReturned,
+		nil,
+	); err != nil {
+		return fmt.Errorf("set sparse %s: %w", path, err)
+	}
+
+	return nil
+}
+
+func setFileEnd(fileHandle windows.Handle, path string, size int64) error {
+	var newPosition int64
+	r1, _, callErr := procSetFilePointerEx.Call(
+		uintptr(fileHandle),
+		uintptr(size),
+		uintptr(unsafe.Pointer(&newPosition)),
+		uintptr(fileBegin),
+	)
+	if r1 == 0 {
+		if callErr != nil && !errors.Is(callErr, windows.ERROR_SUCCESS) {
+			return fmt.Errorf("seek EOF for %s: %w", path, callErr)
+		}
+		return fmt.Errorf("seek EOF for %s: unknown error", path)
+	}
+
+	r1, _, callErr = procSetEndOfFile.Call(uintptr(fileHandle))
+	if r1 == 0 {
+		if callErr != nil && !errors.Is(callErr, windows.ERROR_SUCCESS) {
+			return fmt.Errorf("set EOF for %s: %w", path, callErr)
+		}
+		return fmt.Errorf("set EOF for %s: unknown error", path)
+	}
+
+	return nil
 }
 
 func duplicateExtent(targetHandle, sourceHandle windows.Handle, sourceOffset, targetOffset, byteCount int64) error {

--- a/pkg/reflinktree/reflink_windows_test.go
+++ b/pkg/reflinktree/reflink_windows_test.go
@@ -1,0 +1,268 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+//go:build windows
+
+package reflinktree
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+var errWindowsCloneFailure = errors.New("windows clone failed")
+
+func TestCloneFile_UsesDuplicateExtentsAndCopiesTail(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcPath := filepath.Join(tmpDir, "src.bin")
+	dstPath := filepath.Join(tmpDir, "dst.bin")
+	content := []byte("0123456789")
+	if err := os.WriteFile(srcPath, content, 0o600); err != nil {
+		t.Fatalf("failed to write source file: %v", err)
+	}
+
+	restoreWindowsHelpers(t)
+	volumeRootForPathFn = func(string) (string, error) { return `R:\`, nil }
+	filesystemNameForVolFn = func(string) (string, error) { return "ReFS", nil }
+	clusterSizeForVolFn = func(string) (int64, error) { return 4, nil }
+
+	type cloneCall struct {
+		sourceOffset int64
+		targetOffset int64
+		byteCount    int64
+	}
+	var cloneCalls []cloneCall
+	duplicateExtentFn = func(_ windows.Handle, _ windows.Handle, sourceOffset, targetOffset, byteCount int64) error {
+		cloneCalls = append(cloneCalls, cloneCall{sourceOffset: sourceOffset, targetOffset: targetOffset, byteCount: byteCount})
+		return nil
+	}
+	copyFileTailFn = copyFileTail
+
+	if err := cloneFile(srcPath, dstPath); err != nil {
+		t.Fatalf("cloneFile failed: %v", err)
+	}
+
+	if len(cloneCalls) != 1 {
+		t.Fatalf("expected 1 duplicate-extent call, got %d", len(cloneCalls))
+	}
+	if cloneCalls[0] != (cloneCall{sourceOffset: 0, targetOffset: 0, byteCount: 8}) {
+		t.Fatalf("unexpected first clone call: %+v", cloneCalls[0])
+	}
+
+	dstContent, err := os.ReadFile(dstPath)
+	if err != nil {
+		t.Fatalf("failed to read destination file: %v", err)
+	}
+	if string(dstContent[8:]) != "89" {
+		t.Fatalf("expected tail bytes to be copied, got %q", string(dstContent[8:]))
+	}
+}
+
+func TestCloneFile_RemovesPartialDestinationOnFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcPath := filepath.Join(tmpDir, "src.bin")
+	dstPath := filepath.Join(tmpDir, "dst.bin")
+	if err := os.WriteFile(srcPath, []byte("01234567"), 0o600); err != nil {
+		t.Fatalf("failed to write source file: %v", err)
+	}
+
+	restoreWindowsHelpers(t)
+	volumeRootForPathFn = func(string) (string, error) { return `R:\`, nil }
+	filesystemNameForVolFn = func(string) (string, error) { return "ReFS", nil }
+	clusterSizeForVolFn = func(string) (int64, error) { return 4, nil }
+	duplicateExtentFn = func(windows.Handle, windows.Handle, int64, int64, int64) error {
+		return errors.New("boom")
+	}
+	copyFileTailFn = func(*os.File, *os.File, int64, int64) error {
+		t.Fatal("tail copy should not run when clone fails early")
+		return nil
+	}
+
+	err := cloneFile(srcPath, dstPath)
+	if err == nil {
+		t.Fatal("expected cloneFile to fail")
+	}
+	if !strings.Contains(err.Error(), "duplicate extents") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, statErr := os.Stat(dstPath); !os.IsNotExist(statErr) {
+		t.Fatalf("expected destination cleanup, stat err=%v", statErr)
+	}
+}
+
+func TestSupportsReflink_ReportsWindowsProbeSuccess(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	restoreWindowsHelpers(t)
+	volumeRootForPathFn = func(string) (string, error) { return `R:\`, nil }
+	filesystemNameForVolFn = func(string) (string, error) { return "ReFS", nil }
+	clusterSizeForVolFn = func(string) (int64, error) { return 4096, nil }
+	duplicateExtentFn = func(windows.Handle, windows.Handle, int64, int64, int64) error { return nil }
+	copyFileTailFn = copyFileTail
+
+	supported, reason := SupportsReflink(tmpDir)
+	if !supported {
+		t.Fatalf("expected Windows probe to succeed, reason=%s", reason)
+	}
+	if !strings.Contains(reason, "ReFS") {
+		t.Fatalf("expected ReFS reason, got %q", reason)
+	}
+}
+
+func TestCloneFile_RejectsDifferentVolumes(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcPath := filepath.Join(tmpDir, "src.bin")
+	dstPath := filepath.Join(tmpDir, "dst.bin")
+	dstDir := filepath.Dir(dstPath)
+	if err := os.WriteFile(srcPath, []byte("0123"), 0o600); err != nil {
+		t.Fatalf("failed to write source file: %v", err)
+	}
+
+	restoreWindowsHelpers(t)
+	volumeRootForPathFn = func(path string) (string, error) {
+		switch filepath.Clean(path) {
+		case filepath.Clean(srcPath):
+			return `C:\`, nil
+		case filepath.Clean(dstDir):
+			return `D:\`, nil
+		default:
+			t.Fatalf("unexpected path passed to volumeRootForPathFn: %s", path)
+			return "", nil
+		}
+	}
+	filesystemNameForVolFn = func(string) (string, error) {
+		t.Fatal("filesystem lookup should not run for different volumes")
+		return "", nil
+	}
+	clusterSizeForVolFn = func(string) (int64, error) {
+		t.Fatal("cluster size lookup should not run for different volumes")
+		return 0, nil
+	}
+
+	err := cloneFile(srcPath, dstPath)
+	if err == nil {
+		t.Fatal("expected same-volume validation failure")
+	}
+	if !strings.Contains(err.Error(), "same volume") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCloneFile_RejectsNonReFSFilesystem(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcPath := filepath.Join(tmpDir, "src.bin")
+	dstPath := filepath.Join(tmpDir, "dst.bin")
+	if err := os.WriteFile(srcPath, []byte("0123"), 0o600); err != nil {
+		t.Fatalf("failed to write source file: %v", err)
+	}
+
+	restoreWindowsHelpers(t)
+	volumeRootForPathFn = func(string) (string, error) { return `R:\`, nil }
+	filesystemNameForVolFn = func(string) (string, error) { return "NTFS", nil }
+	clusterSizeForVolFn = func(string) (int64, error) {
+		t.Fatal("cluster size lookup should not run for non-ReFS volumes")
+		return 0, nil
+	}
+
+	err := cloneFile(srcPath, dstPath)
+	if err == nil {
+		t.Fatal("expected non-ReFS validation failure")
+	}
+	if !strings.Contains(err.Error(), "not ReFS") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCloneFile_RejectsInvalidClusterSize(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcPath := filepath.Join(tmpDir, "src.bin")
+	dstPath := filepath.Join(tmpDir, "dst.bin")
+	if err := os.WriteFile(srcPath, []byte("0123"), 0o600); err != nil {
+		t.Fatalf("failed to write source file: %v", err)
+	}
+
+	restoreWindowsHelpers(t)
+	volumeRootForPathFn = func(string) (string, error) { return `R:\`, nil }
+	filesystemNameForVolFn = func(string) (string, error) { return "ReFS", nil }
+	clusterSizeForVolFn = func(string) (int64, error) { return 0, nil }
+
+	err := cloneFile(srcPath, dstPath)
+	if err == nil {
+		t.Fatal("expected invalid cluster size failure")
+	}
+	if !strings.Contains(err.Error(), "invalid cluster size") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCloneFile_WrapsDuplicateExtentError(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcPath := filepath.Join(tmpDir, "src.bin")
+	dstPath := filepath.Join(tmpDir, "dst.bin")
+	if err := os.WriteFile(srcPath, []byte("01234567"), 0o600); err != nil {
+		t.Fatalf("failed to write source file: %v", err)
+	}
+
+	restoreWindowsHelpers(t)
+	volumeRootForPathFn = func(string) (string, error) { return `R:\`, nil }
+	filesystemNameForVolFn = func(string) (string, error) { return "ReFS", nil }
+	clusterSizeForVolFn = func(string) (int64, error) { return 4, nil }
+	duplicateExtentFn = func(windows.Handle, windows.Handle, int64, int64, int64) error {
+		return errWindowsCloneFailure
+	}
+	copyFileTailFn = func(*os.File, *os.File, int64, int64) error {
+		t.Fatal("tail copy should not run when clone fails")
+		return nil
+	}
+
+	err := cloneFile(srcPath, dstPath)
+	if err == nil {
+		t.Fatal("expected wrapped duplicate extents failure")
+	}
+	if !errors.Is(err, errWindowsCloneFailure) {
+		t.Fatalf("expected wrapped clone error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "duplicate extents") {
+		t.Fatalf("expected duplicate extents context, got %v", err)
+	}
+}
+
+func TestSupportsReflink_ReportsProbeFailureReason(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	restoreWindowsHelpers(t)
+	volumeRootForPathFn = func(string) (string, error) { return `R:\`, nil }
+	filesystemNameForVolFn = func(string) (string, error) { return "NTFS", nil }
+	clusterSizeForVolFn = func(string) (int64, error) {
+		t.Fatal("cluster size lookup should not run for non-ReFS volumes")
+		return 0, nil
+	}
+
+	supported, reason := SupportsReflink(tmpDir)
+	if supported {
+		t.Fatalf("expected Windows probe to fail, reason=%s", reason)
+	}
+	if !strings.Contains(reason, "NTFS") || !strings.Contains(reason, "not ReFS") {
+		t.Fatalf("expected detailed probe failure reason, got %q", reason)
+	}
+}
+
+func restoreWindowsHelpers(t *testing.T) {
+	originalVolumeRoot := volumeRootForPathFn
+	originalFilesystemName := filesystemNameForVolFn
+	originalClusterSize := clusterSizeForVolFn
+	originalDuplicateExtent := duplicateExtentFn
+	originalCopyFileTail := copyFileTailFn
+	t.Cleanup(func() {
+		volumeRootForPathFn = originalVolumeRoot
+		filesystemNameForVolFn = originalFilesystemName
+		clusterSizeForVolFn = originalClusterSize
+		duplicateExtentFn = originalDuplicateExtent
+		copyFileTailFn = originalCopyFileTail
+	})
+}

--- a/pkg/reflinktree/reflink_windows_test.go
+++ b/pkg/reflinktree/reflink_windows_test.go
@@ -102,8 +102,19 @@ func TestSupportsReflink_ReportsWindowsProbeSuccess(t *testing.T) {
 	volumeRootForPathFn = func(string) (string, error) { return `R:\`, nil }
 	filesystemNameForVolFn = func(string) (string, error) { return "ReFS", nil }
 	clusterSizeForVolFn = func(string) (int64, error) { return 4096, nil }
-	duplicateExtentFn = func(windows.Handle, windows.Handle, int64, int64, int64) error { return nil }
-	copyFileTailFn = copyFileTail
+	var cloneCalls int
+	duplicateExtentFn = func(_ windows.Handle, _ windows.Handle, sourceOffset, targetOffset, byteCount int64) error {
+		cloneCalls++
+		if sourceOffset != 0 || targetOffset != 0 || byteCount != 4096 {
+			t.Fatalf("unexpected clone call: source=%d target=%d bytes=%d", sourceOffset, targetOffset, byteCount)
+		}
+		return nil
+	}
+	var tailCopyCalled bool
+	copyFileTailFn = func(*os.File, *os.File, int64, int64) error {
+		tailCopyCalled = true
+		return nil
+	}
 
 	supported, reason := SupportsReflink(tmpDir)
 	if !supported {
@@ -111,6 +122,12 @@ func TestSupportsReflink_ReportsWindowsProbeSuccess(t *testing.T) {
 	}
 	if !strings.Contains(reason, "ReFS") {
 		t.Fatalf("expected ReFS reason, got %q", reason)
+	}
+	if cloneCalls != 1 {
+		t.Fatalf("expected probe to call duplicate extents once, got %d", cloneCalls)
+	}
+	if !tailCopyCalled {
+		t.Fatal("expected probe to copy the tail after the cloned prefix")
 	}
 }
 

--- a/pkg/reflinktree/reflink_windows_test.go
+++ b/pkg/reflinktree/reflink_windows_test.go
@@ -391,6 +391,56 @@ func TestCloneFile_UsesResolvedSparseSourceMetadata(t *testing.T) {
 	}
 }
 
+func TestCloneFile_UsesResolvedDestinationParentForVolumeChecks(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcPath := filepath.Join(tmpDir, "src.bin")
+	dstParent := filepath.Join(tmpDir, "dst-parent")
+	resolvedDstParent := filepath.Join(tmpDir, "resolved-dst-parent")
+	dstPath := filepath.Join(dstParent, "dst.bin")
+	if err := os.WriteFile(srcPath, []byte("01234567"), 0o600); err != nil {
+		t.Fatalf("failed to write source file: %v", err)
+	}
+	if err := os.MkdirAll(dstParent, 0o755); err != nil {
+		t.Fatalf("failed to create destination parent: %v", err)
+	}
+
+	restoreWindowsHelpers(t)
+	resolveSourcePathFn = func(src string) (string, error) {
+		if filepath.Clean(src) != filepath.Clean(srcPath) {
+			t.Fatalf("unexpected source path passed to resolver: %s", src)
+		}
+		return srcPath, nil
+	}
+	evalSymlinksFn = func(path string) (string, error) {
+		if filepath.Clean(path) != filepath.Clean(dstParent) {
+			t.Fatalf("unexpected path passed to evalSymlinksFn: %s", path)
+		}
+		return resolvedDstParent, nil
+	}
+	volumeRootForPathFn = func(path string) (string, error) {
+		switch filepath.Clean(path) {
+		case filepath.Clean(srcPath), filepath.Clean(resolvedDstParent):
+			return `R:\`, nil
+		default:
+			t.Fatalf("volumeRootForPathFn received unresolved path: %s", path)
+			return "", nil
+		}
+	}
+	filesystemNameForVolFn = func(string) (string, error) { return "ReFS", nil }
+	clusterSizeForVolFn = func(string) (int64, error) { return 4, nil }
+	duplicateExtentFn = func(_ windows.Handle, _ windows.Handle, _, _, _ int64) error {
+		return nil
+	}
+	copyFileTailFn = func(*os.File, *os.File, int64, int64) error {
+		t.Fatal("tail copy should not run for fully cloneable file")
+		return nil
+	}
+
+	if err := cloneFile(srcPath, dstPath); err != nil {
+		t.Fatalf("cloneFile failed: %v", err)
+	}
+}
+
 func TestCloneFile_FailsWhenMarkSparseFails(t *testing.T) {
 	tmpDir := t.TempDir()
 	srcPath := filepath.Join(tmpDir, "src.bin")
@@ -564,6 +614,38 @@ func TestCloneFile_WrapsDuplicateExtentError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "duplicate extents") {
 		t.Fatalf("expected duplicate extents context, got %v", err)
+	}
+}
+
+func TestCloneFile_MapsUnsupportedDuplicateExtentToReflinkUnsupported(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcPath := filepath.Join(tmpDir, "src.bin")
+	dstPath := filepath.Join(tmpDir, "dst.bin")
+	if err := os.WriteFile(srcPath, []byte("01234567"), 0o600); err != nil {
+		t.Fatalf("failed to write source file: %v", err)
+	}
+
+	restoreWindowsHelpers(t)
+	volumeRootForPathFn = func(string) (string, error) { return `R:\`, nil }
+	filesystemNameForVolFn = func(string) (string, error) { return "ReFS", nil }
+	clusterSizeForVolFn = func(string) (int64, error) { return 4, nil }
+	duplicateExtentFn = func(windows.Handle, windows.Handle, int64, int64, int64) error {
+		return windows.ERROR_NOT_SUPPORTED
+	}
+	copyFileTailFn = func(*os.File, *os.File, int64, int64) error {
+		t.Fatal("tail copy should not run when clone fails")
+		return nil
+	}
+
+	err := cloneFile(srcPath, dstPath)
+	if err == nil {
+		t.Fatal("expected unsupported duplicate extents failure")
+	}
+	if !errors.Is(err, ErrReflinkUnsupported) {
+		t.Fatalf("expected reflink unsupported error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "duplicate extents unsupported") {
+		t.Fatalf("expected unsupported duplicate extents context, got %v", err)
 	}
 }
 

--- a/pkg/reflinktree/reflink_windows_test.go
+++ b/pkg/reflinktree/reflink_windows_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"golang.org/x/sys/windows"
 )
@@ -217,6 +218,323 @@ func TestCloneFile_RejectsInvalidClusterSize(t *testing.T) {
 	}
 }
 
+func TestResolveSourcePath_EvaluatesExistingPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcPath := filepath.Join(tmpDir, "src.bin")
+	resolvedPath := filepath.Join(tmpDir, "resolved.bin")
+
+	restoreWindowsHelpers(t)
+	lstatPathFn = func(path string) (os.FileInfo, error) {
+		if filepath.Clean(path) != filepath.Clean(srcPath) {
+			t.Fatalf("unexpected path passed to lstatPathFn: %s", path)
+		}
+		return fakeFileInfo{}, nil
+	}
+	evalSymlinksFn = func(path string) (string, error) {
+		if filepath.Clean(path) != filepath.Clean(srcPath) {
+			t.Fatalf("unexpected path passed to evalSymlinksFn: %s", path)
+		}
+		return resolvedPath, nil
+	}
+
+	got, err := resolveSourcePath(srcPath)
+	if err != nil {
+		t.Fatalf("resolveSourcePath failed: %v", err)
+	}
+	if filepath.Clean(got) != filepath.Clean(resolvedPath) {
+		t.Fatalf("unexpected resolved path: got %s want %s", got, resolvedPath)
+	}
+}
+
+func TestResolveSourcePath_FailsBeforeEvalWhenLstatFails(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcPath := filepath.Join(tmpDir, "src.bin")
+
+	restoreWindowsHelpers(t)
+	lstatPathFn = func(path string) (os.FileInfo, error) {
+		if filepath.Clean(path) != filepath.Clean(srcPath) {
+			t.Fatalf("unexpected path passed to lstatPathFn: %s", path)
+		}
+		return nil, os.ErrNotExist
+	}
+	evalSymlinksFn = func(string) (string, error) {
+		t.Fatal("evalSymlinksFn should not run when lstat fails")
+		return "", nil
+	}
+
+	_, err := resolveSourcePath(srcPath)
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected lstat error, got %v", err)
+	}
+}
+
+func TestCloneFile_MarksDestinationSparseBeforeResize(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcPath := filepath.Join(tmpDir, "src.bin")
+	dstPath := filepath.Join(tmpDir, "dst.bin")
+	if err := os.WriteFile(srcPath, []byte("01234567"), 0o600); err != nil {
+		t.Fatalf("failed to write source file: %v", err)
+	}
+
+	restoreWindowsHelpers(t)
+	volumeRootForPathFn = func(string) (string, error) { return `R:\`, nil }
+	filesystemNameForVolFn = func(string) (string, error) { return "ReFS", nil }
+	clusterSizeForVolFn = func(string) (int64, error) { return 4, nil }
+	isSparseFileFn = func(path string) (bool, error) {
+		if filepath.Clean(path) != filepath.Clean(srcPath) {
+			t.Fatalf("unexpected path passed to isSparseFileFn: %s", path)
+		}
+		return true, nil
+	}
+	steps := make([]string, 0, 3)
+	markFileSparseFn = func(_ windows.Handle, path string) error {
+		if filepath.Clean(path) != filepath.Clean(dstPath) {
+			t.Fatalf("unexpected path passed to markFileSparseFn: %s", path)
+		}
+		steps = append(steps, "mark")
+		return nil
+	}
+	setFileEndFn = func(_ windows.Handle, path string, size int64) error {
+		if filepath.Clean(path) != filepath.Clean(dstPath) {
+			t.Fatalf("unexpected path passed to setFileEndFn: %s", path)
+		}
+		if size != 8 {
+			t.Fatalf("unexpected resize size: %d", size)
+		}
+		steps = append(steps, "resize")
+		return nil
+	}
+	duplicateExtentFn = func(_ windows.Handle, _ windows.Handle, _, _, _ int64) error {
+		steps = append(steps, "clone")
+		return nil
+	}
+	copyFileTailFn = func(*os.File, *os.File, int64, int64) error {
+		t.Fatal("tail copy should not run for fully cloneable file")
+		return nil
+	}
+
+	if err := cloneFile(srcPath, dstPath); err != nil {
+		t.Fatalf("cloneFile failed: %v", err)
+	}
+
+	if len(steps) != 3 {
+		t.Fatalf("unexpected step count: %v", steps)
+	}
+	if strings.Join(steps, ",") != "mark,resize,clone" {
+		t.Fatalf("unexpected step order: %v", steps)
+	}
+}
+
+func TestCloneFile_UsesResolvedSparseSourceMetadata(t *testing.T) {
+	tmpDir := t.TempDir()
+	realSrcPath := filepath.Join(tmpDir, "real-src.bin")
+	symlinkSrcPath := filepath.Join(tmpDir, "src-link.bin")
+	dstPath := filepath.Join(tmpDir, "dst.bin")
+	if err := os.WriteFile(realSrcPath, []byte("01234567"), 0o600); err != nil {
+		t.Fatalf("failed to write source file: %v", err)
+	}
+
+	restoreWindowsHelpers(t)
+	resolveSourcePathFn = func(src string) (string, error) {
+		if filepath.Clean(src) != filepath.Clean(symlinkSrcPath) {
+			t.Fatalf("unexpected source path passed to resolver: %s", src)
+		}
+		return realSrcPath, nil
+	}
+	volumeRootForPathFn = func(path string) (string, error) {
+		switch filepath.Clean(path) {
+		case filepath.Clean(realSrcPath), filepath.Clean(filepath.Dir(dstPath)):
+			return `R:\`, nil
+		default:
+			t.Fatalf("unexpected path passed to volumeRootForPathFn: %s", path)
+			return "", nil
+		}
+	}
+	filesystemNameForVolFn = func(string) (string, error) { return "ReFS", nil }
+	clusterSizeForVolFn = func(string) (int64, error) { return 4, nil }
+	isSparseFileFn = func(path string) (bool, error) {
+		if filepath.Clean(path) != filepath.Clean(realSrcPath) {
+			t.Fatalf("expected sparse check on resolved path, got %s", path)
+		}
+		return true, nil
+	}
+	markedSparse := false
+	markFileSparseFn = func(_ windows.Handle, path string) error {
+		if filepath.Clean(path) != filepath.Clean(dstPath) {
+			t.Fatalf("unexpected path passed to markFileSparseFn: %s", path)
+		}
+		markedSparse = true
+		return nil
+	}
+	setFileEndFn = func(_ windows.Handle, path string, size int64) error {
+		if filepath.Clean(path) != filepath.Clean(dstPath) {
+			t.Fatalf("unexpected path passed to setFileEndFn: %s", path)
+		}
+		if size != 8 {
+			t.Fatalf("unexpected resize size: %d", size)
+		}
+		return nil
+	}
+	duplicateExtentFn = func(_ windows.Handle, _ windows.Handle, _, _, _ int64) error {
+		return nil
+	}
+	copyFileTailFn = func(*os.File, *os.File, int64, int64) error {
+		t.Fatal("tail copy should not run for fully cloneable file")
+		return nil
+	}
+
+	if err := cloneFile(symlinkSrcPath, dstPath); err != nil {
+		t.Fatalf("cloneFile failed: %v", err)
+	}
+	if !markedSparse {
+		t.Fatal("expected destination to be marked sparse for resolved sparse source")
+	}
+}
+
+func TestCloneFile_FailsWhenMarkSparseFails(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcPath := filepath.Join(tmpDir, "src.bin")
+	dstPath := filepath.Join(tmpDir, "dst.bin")
+	if err := os.WriteFile(srcPath, []byte("01234567"), 0o600); err != nil {
+		t.Fatalf("failed to write source file: %v", err)
+	}
+
+	restoreWindowsHelpers(t)
+	volumeRootForPathFn = func(string) (string, error) { return `R:\`, nil }
+	filesystemNameForVolFn = func(string) (string, error) { return "ReFS", nil }
+	clusterSizeForVolFn = func(string) (int64, error) { return 4, nil }
+	isSparseFileFn = func(string) (bool, error) { return true, nil }
+	markFileSparseFn = func(windows.Handle, string) error {
+		return errWindowsCloneFailure
+	}
+	setFileEndFn = func(windows.Handle, string, int64) error {
+		t.Fatal("resize should not run when mark sparse fails")
+		return nil
+	}
+	duplicateExtentFn = func(windows.Handle, windows.Handle, int64, int64, int64) error {
+		t.Fatal("duplicate extents should not run when mark sparse fails")
+		return nil
+	}
+
+	err := cloneFile(srcPath, dstPath)
+	if err == nil {
+		t.Fatal("expected cloneFile to fail")
+	}
+	if !errors.Is(err, errWindowsCloneFailure) {
+		t.Fatalf("expected wrapped mark sparse error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "mark destination sparse") {
+		t.Fatalf("expected mark sparse context, got %v", err)
+	}
+	if _, statErr := os.Stat(dstPath); !os.IsNotExist(statErr) {
+		t.Fatalf("expected destination cleanup, stat err=%v", statErr)
+	}
+}
+
+func TestCloneFile_ResolvesSourceSymlinkBeforeClone(t *testing.T) {
+	tmpDir := t.TempDir()
+	realSrcPath := filepath.Join(tmpDir, "real-src.bin")
+	symlinkSrcPath := filepath.Join(tmpDir, "src-link.bin")
+	dstPath := filepath.Join(tmpDir, "dst.bin")
+	content := []byte("0123456789")
+	if err := os.WriteFile(realSrcPath, content, 0o600); err != nil {
+		t.Fatalf("failed to write source file: %v", err)
+	}
+
+	restoreWindowsHelpers(t)
+	resolveSourcePathFn = func(src string) (string, error) {
+		if filepath.Clean(src) != filepath.Clean(symlinkSrcPath) {
+			t.Fatalf("unexpected source path passed to resolver: %s", src)
+		}
+		return realSrcPath, nil
+	}
+	volumeRootForPathFn = func(path string) (string, error) {
+		switch filepath.Clean(path) {
+		case filepath.Clean(realSrcPath), filepath.Clean(filepath.Dir(dstPath)):
+			return `R:\`, nil
+		default:
+			t.Fatalf("unexpected path passed to volumeRootForPathFn: %s", path)
+			return "", nil
+		}
+	}
+	filesystemNameForVolFn = func(string) (string, error) { return "ReFS", nil }
+	clusterSizeForVolFn = func(string) (int64, error) { return 4, nil }
+	copyFileTailFn = copyFileTail
+
+	type cloneCall struct {
+		sourceOffset int64
+		targetOffset int64
+		byteCount    int64
+	}
+	var cloneCalls []cloneCall
+	duplicateExtentFn = func(_ windows.Handle, _ windows.Handle, sourceOffset, targetOffset, byteCount int64) error {
+		cloneCalls = append(cloneCalls, cloneCall{sourceOffset: sourceOffset, targetOffset: targetOffset, byteCount: byteCount})
+		return nil
+	}
+
+	if err := cloneFile(symlinkSrcPath, dstPath); err != nil {
+		t.Fatalf("cloneFile failed: %v", err)
+	}
+
+	if len(cloneCalls) != 1 {
+		t.Fatalf("expected 1 duplicate-extent call, got %d", len(cloneCalls))
+	}
+	if cloneCalls[0] != (cloneCall{sourceOffset: 0, targetOffset: 0, byteCount: 8}) {
+		t.Fatalf("unexpected first clone call: %+v", cloneCalls[0])
+	}
+
+	dstContent, err := os.ReadFile(dstPath)
+	if err != nil {
+		t.Fatalf("failed to read destination file: %v", err)
+	}
+	if len(dstContent) != len(content) {
+		t.Fatalf("unexpected destination size: got %d want %d", len(dstContent), len(content))
+	}
+	if string(dstContent[8:]) != "89" {
+		t.Fatalf("expected tail bytes to be copied, got %q", string(dstContent[8:]))
+	}
+}
+
+func TestCloneFile_FailsWhenSourceSymlinkResolutionFails(t *testing.T) {
+	tmpDir := t.TempDir()
+	symlinkSrcPath := filepath.Join(tmpDir, "src-link.bin")
+	dstPath := filepath.Join(tmpDir, "dst.bin")
+
+	restoreWindowsHelpers(t)
+	resolveSourcePathFn = func(src string) (string, error) {
+		if filepath.Clean(src) != filepath.Clean(symlinkSrcPath) {
+			t.Fatalf("unexpected source path passed to resolver: %s", src)
+		}
+		return "", os.ErrNotExist
+	}
+	volumeRootForPathFn = func(string) (string, error) {
+		t.Fatal("volume lookup should not run when source resolution fails")
+		return "", nil
+	}
+	duplicateExtentFn = func(windows.Handle, windows.Handle, int64, int64, int64) error {
+		t.Fatal("duplicate extents should not run when source resolution fails")
+		return nil
+	}
+	copyFileTailFn = func(*os.File, *os.File, int64, int64) error {
+		t.Fatal("tail copy should not run when source resolution fails")
+		return nil
+	}
+
+	err := cloneFile(symlinkSrcPath, dstPath)
+	if err == nil {
+		t.Fatal("expected cloneFile to fail")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected wrapped resolution error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "resolve source") {
+		t.Fatalf("expected resolve source context, got %v", err)
+	}
+	if _, statErr := os.Stat(dstPath); !os.IsNotExist(statErr) {
+		t.Fatalf("expected no destination file, stat err=%v", statErr)
+	}
+}
+
 func TestCloneFile_WrapsDuplicateExtentError(t *testing.T) {
 	tmpDir := t.TempDir()
 	srcPath := filepath.Join(tmpDir, "src.bin")
@@ -270,12 +588,24 @@ func TestSupportsReflink_ReportsProbeFailureReason(t *testing.T) {
 }
 
 func restoreWindowsHelpers(t *testing.T) {
+	originalResolveSourcePath := resolveSourcePathFn
+	originalLstatPath := lstatPathFn
+	originalEvalSymlinks := evalSymlinksFn
+	originalIsSparseFile := isSparseFileFn
+	originalMarkFileSparse := markFileSparseFn
+	originalSetFileEnd := setFileEndFn
 	originalVolumeRoot := volumeRootForPathFn
 	originalFilesystemName := filesystemNameForVolFn
 	originalClusterSize := clusterSizeForVolFn
 	originalDuplicateExtent := duplicateExtentFn
 	originalCopyFileTail := copyFileTailFn
 	t.Cleanup(func() {
+		resolveSourcePathFn = originalResolveSourcePath
+		lstatPathFn = originalLstatPath
+		evalSymlinksFn = originalEvalSymlinks
+		isSparseFileFn = originalIsSparseFile
+		markFileSparseFn = originalMarkFileSparse
+		setFileEndFn = originalSetFileEnd
 		volumeRootForPathFn = originalVolumeRoot
 		filesystemNameForVolFn = originalFilesystemName
 		clusterSizeForVolFn = originalClusterSize
@@ -283,3 +613,12 @@ func restoreWindowsHelpers(t *testing.T) {
 		copyFileTailFn = originalCopyFileTail
 	})
 }
+
+type fakeFileInfo struct{}
+
+func (fakeFileInfo) Name() string       { return "fake" }
+func (fakeFileInfo) Size() int64        { return 0 }
+func (fakeFileInfo) Mode() os.FileMode  { return 0 }
+func (fakeFileInfo) ModTime() time.Time { return time.Time{} }
+func (fakeFileInfo) IsDir() bool        { return false }
+func (fakeFileInfo) Sys() any           { return nil }


### PR DESCRIPTION
```
{"level":"info","instanceID":1,"torrentName":"test.mkv","destDir":"D:\\cross_linked\\tracker\\test--38f12c4a","fileCount":1,"time":"2026-03-09T19:15:48+10:00","message":"[CROSSSEED] Reflink mode: created reflink tree"}
{"level":"info","instanceID":1,"torrentName":"test.mkv","destDir":"D:\\cross_linked\\tracker1\\test--e3e3ee09","fileCount":1,"time":"2026-03-09T19:15:48+10:00","message":"[CROSSSEED] Reflink mode: created reflink tree"}
{"level":"info","instanceID":1,"torrentName":"test.mkv","destDir":"D:\\cross_linked\\tracker2\\test--bbece301","fileCount":1,"time":"2026-03-09T19:15:48+10:00","message":"[CROSSSEED] Reflink mode: created reflink tree"}
```

```
fsutil file queryExtentsAndRefCounts "D:\\cross_linked\\tracker\\test--25249e5b\test.mkv"
VCN: 0x0        Clusters: 0x20       LCN: 0x99c3d0   Ref: 0xa
VCN: 0x20       Clusters: 0x10       LCN: 0x99c180   Ref: 0xa
VCN: 0x30       Clusters: 0x10       LCN: 0x9a2aa2   Ref: 0xa
VCN: 0x40       Clusters: 0xe        LCN: 0x99c190   Ref: 0xa
VCN: 0x4e       Clusters: 0x20       LCN: 0x9a28e5   Ref: 0xa
VCN: 0x6e       Clusters: 0x10       LCN: 0x9a2ab2   Ref: 0xa
.....
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reflink cloning support added for Windows ReFS volumes.

* **Documentation**
  * Reflink docs updated: ReFS explicitly supported on Windows; NTFS unsupported. Base directory must be on the same volume and be a real mount; fallback behavior on reflink failure clarified; Windows-specific notes added.

* **Bug Fixes / Platform Handling**
  * Platform checks/builds updated to account for Windows; logging downgraded to a warning when reflink is unsupported.

* **Tests**
  * Added Windows-specific tests covering reflink probing, cloning, same-volume and filesystem validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->