### PR TITLE
fix(database): avoid postgres temp-table statement caching

### DIFF
--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -731,7 +731,7 @@ func tempTableNameFromCreate(query string) (string, bool) {
 		return "", false
 	}
 
-	name := normalizeIdentifier(fields[next])
+	name := normalizeIdentifier(trimIdentifierToken(fields[next]))
 	if name == "" {
 		return "", false
 	}
@@ -752,7 +752,7 @@ func tableNameFromDrop(query string) (string, bool) {
 		return "", false
 	}
 
-	name := normalizeIdentifier(fields[next])
+	name := normalizeIdentifier(trimIdentifierToken(fields[next]))
 	if name == "" {
 		return "", false
 	}
@@ -797,6 +797,19 @@ func normalizeIdentifier(raw string) string {
 	name := strings.TrimSpace(parts[len(parts)-1])
 	name = strings.Trim(name, "\"`[]")
 	return strings.ToLower(name)
+}
+
+func trimIdentifierToken(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+
+	if idx := strings.IndexAny(raw, "(,;"); idx >= 0 {
+		raw = raw[:idx]
+	}
+
+	return strings.TrimSpace(raw)
 }
 
 const sqliteNestedTxErrSubstring = "cannot start a transaction within a transaction"

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -282,8 +282,11 @@ func (t *Tx) QueryRowContext(ctx context.Context, query string, args ...any) *sq
 
 	stmt, err = t.db.getStmt(ctx, query, t)
 	if err != nil {
-		t.markQueryForCaching(query)
-		return t.tx.QueryRowContext(ctx, t.db.bindQuery(query), args...)
+		row := t.tx.QueryRowContext(ctx, t.db.bindQuery(query), args...)
+		if row.Err() == nil {
+			t.markQueryForCaching(query)
+		}
+		return row
 	}
 	return stmt.QueryRowContext(ctx, args...)
 }
@@ -706,49 +709,64 @@ func isTempTableDDL(query string) bool {
 }
 
 func tempTableNameFromCreate(query string) (string, bool) {
-	tokens := sqlKeywordTokens(query)
-	if len(tokens) < 4 || tokens[0] != "create" {
+	fields := strings.Fields(query)
+	if len(fields) < 4 || !strings.EqualFold(fields[0], "create") {
 		return "", false
 	}
 
 	next := 1
-	if tokens[next] != "temp" && tokens[next] != "temporary" {
+	if !strings.EqualFold(fields[next], "temp") && !strings.EqualFold(fields[next], "temporary") {
 		return "", false
 	}
 	next++
 
-	if next >= len(tokens) || tokens[next] != "table" {
+	if next >= len(fields) || !strings.EqualFold(fields[next], "table") {
 		return "", false
 	}
 	next++
 
-	if next+2 < len(tokens) && tokens[next] == "if" && tokens[next+1] == "not" && tokens[next+2] == "exists" {
+	if next+2 < len(fields) &&
+		strings.EqualFold(fields[next], "if") &&
+		strings.EqualFold(fields[next+1], "not") &&
+		strings.EqualFold(fields[next+2], "exists") {
 		next += 3
 	}
-	if next >= len(tokens) {
+	if next >= len(fields) {
 		return "", false
 	}
 
-	return tokens[next], true
+	name := normalizeIdentifier(fields[next])
+	if name == "" {
+		return "", false
+	}
+	return name, true
 }
 
 func tableNameFromDrop(query string) (string, bool) {
-	tokens := sqlKeywordTokens(query)
-	if len(tokens) < 3 || tokens[0] != "drop" || tokens[1] != "table" {
+	fields := strings.Fields(query)
+	if len(fields) < 3 || !strings.EqualFold(fields[0], "drop") || !strings.EqualFold(fields[1], "table") {
 		return "", false
 	}
 
 	next := 2
-	if next+1 < len(tokens) && tokens[next] == "if" && tokens[next+1] == "exists" {
+	if next+1 < len(fields) && strings.EqualFold(fields[next], "if") && strings.EqualFold(fields[next+1], "exists") {
 		next += 2
 	}
-	if next >= len(tokens) {
+	if next >= len(fields) {
 		return "", false
 	}
 
-	return tokens[next], true
+	name := normalizeIdentifier(fields[next])
+	if name == "" {
+		return "", false
+	}
+	return name, true
 }
 
+// queryReferencesTempTable uses lightweight token matching over internal SQL.
+// It intentionally does not parse string literals or comments, so a literal like
+// 'current_hashes' could produce a false positive. That's acceptable here
+// because this helper only guards our fixed-format temp-table maintenance SQL.
 func queryReferencesTempTable(query string, tempTables map[string]struct{}) bool {
 	if len(tempTables) == 0 {
 		return false
@@ -763,10 +781,26 @@ func queryReferencesTempTable(query string, tempTables map[string]struct{}) bool
 	return false
 }
 
+// sqlKeywordTokens is a lightweight tokenizer for internal SQL snippets. It
+// lowercases and splits on non-identifier runes, but it does not understand SQL
+// literals or comments.
 func sqlKeywordTokens(query string) []string {
 	return strings.FieldsFunc(strings.ToLower(query), func(r rune) bool {
 		return !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_'
 	})
+}
+
+func normalizeIdentifier(raw string) string {
+	raw = strings.TrimSpace(raw)
+	raw = strings.TrimRight(raw, ";,(")
+	if raw == "" {
+		return ""
+	}
+
+	parts := strings.Split(raw, ".")
+	name := strings.TrimSpace(parts[len(parts)-1])
+	name = strings.Trim(name, "\"`[]")
+	return strings.ToLower(name)
 }
 
 const sqliteNestedTxErrSubstring = "cannot start a transaction within a transaction"

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -160,44 +160,50 @@ type Tx struct {
 	txMu       sync.Mutex          // protects transaction-local cache metadata
 }
 
-// markQueryForCaching marks a query for promotion to the DB cache
+// markQueryForCaching records a successfully executed query for post-commit
+// statement promotion and tracks temp-table lifecycle within the transaction.
 func (t *Tx) markQueryForCaching(query string) {
 	t.txMu.Lock()
-	if !t.trackCacheableQueryLocked(query) {
-		t.txMu.Unlock()
+	defer t.txMu.Unlock()
+
+	if name, ok := tempTableNameFromCreate(query); ok {
+		if t.tempTables == nil {
+			t.tempTables = make(map[string]struct{})
+		}
+		t.tempTables[name] = struct{}{}
 		return
 	}
+
+	if name, ok := tableNameFromDrop(query); ok {
+		delete(t.tempTables, name)
+		return
+	}
+
+	if queryReferencesTempTable(query, t.tempTables) {
+		return
+	}
+
 	if t.txStmts == nil {
 		t.txStmts = make(map[string]struct{})
 	}
 	t.txStmts[query] = struct{}{}
-	t.txMu.Unlock()
 }
 
 func (t *Tx) shouldBypassStatementCache(query string) bool {
 	t.txMu.Lock()
 	defer t.txMu.Unlock()
 
-	return !t.trackCacheableQueryLocked(query)
-}
-
-func (t *Tx) trackCacheableQueryLocked(query string) bool {
-	if name, ok := tempTableNameFromCreate(query); ok {
-		if t.tempTables == nil {
-			t.tempTables = make(map[string]struct{})
-		}
-		t.tempTables[name] = struct{}{}
-		return false
+	if _, ok := tempTableNameFromCreate(query); ok {
+		return true
 	}
 
 	if name, ok := tableNameFromDrop(query); ok {
 		if _, exists := t.tempTables[name]; exists {
-			delete(t.tempTables, name)
-			return false
+			return true
 		}
 	}
 
-	return !queryReferencesTempTable(query, t.tempTables)
+	return queryReferencesTempTable(query, t.tempTables)
 }
 
 type txExecResult struct{ tx *Tx }
@@ -207,8 +213,11 @@ func (e txExecResult) execStmt(stmt *sql.Stmt, ctx context.Context, args []any) 
 }
 
 func (e txExecResult) execDirect(_ *sql.DB, ctx context.Context, query string, args []any) (sql.Result, error) {
-	e.tx.markQueryForCaching(query)
-	return e.tx.tx.ExecContext(ctx, e.tx.db.bindQuery(query), args...)
+	result, err := e.tx.tx.ExecContext(ctx, e.tx.db.bindQuery(query), args...)
+	if err == nil {
+		e.tx.markQueryForCaching(query)
+	}
+	return result, err
 }
 
 func (txExecResult) getErr(sql.Result) error { return nil }
@@ -221,8 +230,11 @@ func (q txQueryRows) execStmt(stmt *sql.Stmt, ctx context.Context, args []any) (
 }
 
 func (q txQueryRows) execDirect(_ *sql.DB, ctx context.Context, query string, args []any) (*sql.Rows, error) {
-	q.tx.markQueryForCaching(query)
-	return q.tx.tx.QueryContext(ctx, q.tx.db.bindQuery(query), args...)
+	rows, err := q.tx.tx.QueryContext(ctx, q.tx.db.bindQuery(query), args...)
+	if err == nil {
+		q.tx.markQueryForCaching(query)
+	}
+	return rows, err
 }
 
 func (txQueryRows) getErr(r *sql.Rows) error {
@@ -253,8 +265,11 @@ func (t *Tx) QueryContext(ctx context.Context, query string, args ...any) (*sql.
 func (t *Tx) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row {
 	stmt, err := t.db.getStmt(ctx, query, t)
 	if err != nil {
-		t.markQueryForCaching(query)
-		return t.tx.QueryRowContext(ctx, t.db.bindQuery(query), args...)
+		row := t.tx.QueryRowContext(ctx, t.db.bindQuery(query), args...)
+		if row.Err() == nil {
+			t.markQueryForCaching(query)
+		}
+		return row
 	}
 
 	row := stmt.QueryRowContext(ctx, args...)

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -155,18 +155,49 @@ type Tx struct {
 	unlockOnce sync.Once       // ensures unlock happens only once
 
 	// Track statements prepared during this transaction for promotion to DB cache after commit
-	txStmts map[string]struct{} // query -> struct{} (used as set to track which queries to cache)
-	txMu    sync.Mutex          // protects txStmts map
+	txStmts    map[string]struct{} // query -> struct{} (used as set to track which queries to cache)
+	tempTables map[string]struct{} // temp table names created/used in this transaction
+	txMu       sync.Mutex          // protects transaction-local cache metadata
 }
 
 // markQueryForCaching marks a query for promotion to the DB cache
 func (t *Tx) markQueryForCaching(query string) {
 	t.txMu.Lock()
+	if !t.trackCacheableQueryLocked(query) {
+		t.txMu.Unlock()
+		return
+	}
 	if t.txStmts == nil {
 		t.txStmts = make(map[string]struct{})
 	}
 	t.txStmts[query] = struct{}{}
 	t.txMu.Unlock()
+}
+
+func (t *Tx) shouldBypassStatementCache(query string) bool {
+	t.txMu.Lock()
+	defer t.txMu.Unlock()
+
+	return !t.trackCacheableQueryLocked(query)
+}
+
+func (t *Tx) trackCacheableQueryLocked(query string) bool {
+	if name, ok := tempTableNameFromCreate(query); ok {
+		if t.tempTables == nil {
+			t.tempTables = make(map[string]struct{})
+		}
+		t.tempTables[name] = struct{}{}
+		return false
+	}
+
+	if name, ok := tableNameFromDrop(query); ok {
+		if _, exists := t.tempTables[name]; exists {
+			delete(t.tempTables, name)
+			return false
+		}
+	}
+
+	return !queryReferencesTempTable(query, t.tempTables)
 }
 
 type txExecResult struct{ tx *Tx }
@@ -528,6 +559,24 @@ func (db *DB) getStmt(ctx context.Context, query string, tx *Tx) (*sql.Stmt, err
 	}
 	query = db.bindQuery(query)
 
+	if tx != nil {
+		if tx.shouldBypassStatementCache(query) {
+			if tx.isWriteTx {
+				db.deleteStmt(query, true)
+			} else {
+				db.deleteStmt(query, false)
+			}
+			return nil, errors.New("statement not cacheable")
+		}
+	} else if isTempTableDDL(query) {
+		if isWriteQuery(query) {
+			db.deleteStmt(query, true)
+		} else {
+			db.deleteStmt(query, false)
+		}
+		return nil, errors.New("statement not cacheable")
+	}
+
 	db.stmtMu.RLock()
 	defer db.stmtMu.RUnlock()
 
@@ -634,6 +683,75 @@ func isWriteQuery(query string) bool {
 		strings.HasPrefix(upper, "ALTER") ||
 		strings.HasPrefix(upper, "DROP") ||
 		strings.HasPrefix(upper, "VACUUM")
+}
+
+func isTempTableDDL(query string) bool {
+	_, ok := tempTableNameFromCreate(query)
+	return ok
+}
+
+func tempTableNameFromCreate(query string) (string, bool) {
+	tokens := sqlKeywordTokens(query)
+	if len(tokens) < 4 || tokens[0] != "create" {
+		return "", false
+	}
+
+	next := 1
+	if tokens[next] != "temp" && tokens[next] != "temporary" {
+		return "", false
+	}
+	next++
+
+	if next >= len(tokens) || tokens[next] != "table" {
+		return "", false
+	}
+	next++
+
+	if next+2 < len(tokens) && tokens[next] == "if" && tokens[next+1] == "not" && tokens[next+2] == "exists" {
+		next += 3
+	}
+	if next >= len(tokens) {
+		return "", false
+	}
+
+	return tokens[next], true
+}
+
+func tableNameFromDrop(query string) (string, bool) {
+	tokens := sqlKeywordTokens(query)
+	if len(tokens) < 3 || tokens[0] != "drop" || tokens[1] != "table" {
+		return "", false
+	}
+
+	next := 2
+	if next+1 < len(tokens) && tokens[next] == "if" && tokens[next+1] == "exists" {
+		next += 2
+	}
+	if next >= len(tokens) {
+		return "", false
+	}
+
+	return tokens[next], true
+}
+
+func queryReferencesTempTable(query string, tempTables map[string]struct{}) bool {
+	if len(tempTables) == 0 {
+		return false
+	}
+
+	for _, token := range sqlKeywordTokens(query) {
+		if _, ok := tempTables[token]; ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+func sqlKeywordTokens(query string) []string {
+	return strings.FieldsFunc(strings.ToLower(query), func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_'
+	})
 }
 
 const sqliteNestedTxErrSubstring = "cannot start a transaction within a transaction"
@@ -1345,24 +1463,6 @@ func (db *DB) CleanupUnusedStrings(ctx context.Context) (int64, error) {
 	}
 	defer db.cleanupRunning.Store(false)
 
-	// Drop temp table if it exists from previous run
-	_, _ = db.ExecContext(ctx, "DROP TABLE IF EXISTS temp_referenced_strings")
-
-	// Ensure temp table is cleaned up at the end
-	defer func() {
-		_, _ = db.ExecContext(context.Background(), "DROP TABLE IF EXISTS temp_referenced_strings")
-	}()
-
-	// Create temp table for referenced string IDs (automatically indexed due to PRIMARY KEY)
-	_, err := db.ExecContext(ctx, `
-		CREATE TEMP TABLE temp_referenced_strings (
-			string_id INTEGER PRIMARY KEY
-		)
-	`)
-	if err != nil {
-		return 0, fmt.Errorf("failed to create temp table: %w", err)
-	}
-
 	// Begin transaction for the actual cleanup work
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
@@ -1376,6 +1476,16 @@ func (db *DB) CleanupUnusedStrings(ctx context.Context) (int64, error) {
 	// complete and verify constraints at commit time rather than immediately.
 	if err := dbinterface.DeferForeignKeyChecks(ctx, tx); err != nil {
 		return 0, fmt.Errorf("failed to defer foreign keys: %w", err)
+	}
+
+	// Temp tables are connection-local on Postgres, so create and use them on the same tx.
+	_, err = tx.ExecContext(ctx, `
+		CREATE TEMP TABLE temp_referenced_strings (
+			string_id INTEGER PRIMARY KEY
+		)
+	`)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create temp table: %w", err)
 	}
 
 	_, err = tx.ExecContext(ctx, `INSERT INTO temp_referenced_strings (string_id) SELECT DISTINCT string_id FROM (
@@ -1395,6 +1505,11 @@ func (db *DB) CleanupUnusedStrings(ctx context.Context) (int64, error) {
 	`)
 	if err != nil {
 		return 0, fmt.Errorf("failed to delete unused strings: %w", err)
+	}
+
+	_, err = tx.ExecContext(ctx, `DROP TABLE temp_referenced_strings`)
+	if err != nil {
+		return 0, fmt.Errorf("failed to drop temp table: %w", err)
 	}
 
 	if err := tx.Commit(); err != nil {

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -587,11 +587,7 @@ func (db *DB) getStmt(ctx context.Context, query string, tx *Tx) (*sql.Stmt, err
 			return nil, errors.New("statement not cacheable")
 		}
 	} else if isTempTableDDL(query) {
-		if isWriteQuery(query) {
-			db.deleteStmt(query, true)
-		} else {
-			db.deleteStmt(query, false)
-		}
+		db.deleteStmt(query, true)
 		return nil, errors.New("statement not cacheable")
 	}
 

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -579,6 +579,14 @@ func TestTempTableNameParsingUsesFinalIdentifierSegment(t *testing.T) {
 	require.Equal(t, "current_hashes", dropName)
 }
 
+func TestTempTableNameParsingWithoutSpaceBeforeColumns(t *testing.T) {
+	t.Parallel()
+
+	createName, ok := tempTableNameFromCreate(`CREATE TEMP TABLE current_hashes(hash TEXT PRIMARY KEY)`)
+	require.True(t, ok)
+	require.Equal(t, "current_hashes", createName)
+}
+
 // TestTransactionCommitSuccessMutexRelease tests that the writer mutex is properly released
 // after a successful commit.
 func TestTransactionCommitSuccessMutexRelease(t *testing.T) {

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -567,6 +567,18 @@ func TestTxTempTableQueriesBypassStatementCache(t *testing.T) {
 	require.NotContains(t, tx.tempTables, "current_hashes")
 }
 
+func TestTempTableNameParsingUsesFinalIdentifierSegment(t *testing.T) {
+	t.Parallel()
+
+	createName, ok := tempTableNameFromCreate(`CREATE TEMP TABLE "pg_temp"."current_hashes" (hash TEXT PRIMARY KEY)`)
+	require.True(t, ok)
+	require.Equal(t, "current_hashes", createName)
+
+	dropName, ok := tableNameFromDrop("DROP TABLE IF EXISTS [pg_temp].[current_hashes];")
+	require.True(t, ok)
+	require.Equal(t, "current_hashes", dropName)
+}
+
 // TestTransactionCommitSuccessMutexRelease tests that the writer mutex is properly released
 // after a successful commit.
 func TestTransactionCommitSuccessMutexRelease(t *testing.T) {

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -547,6 +547,9 @@ func TestTxTempTableQueriesBypassStatementCache(t *testing.T) {
 	)
 
 	require.True(t, tx.shouldBypassStatementCache(createTemp))
+	require.Empty(t, tx.tempTables)
+
+	tx.markQueryForCaching(createTemp)
 	require.Contains(t, tx.tempTables, "current_hashes")
 
 	tx.markQueryForCaching(insertTemp)
@@ -557,6 +560,10 @@ func TestTxTempTableQueriesBypassStatementCache(t *testing.T) {
 	require.Contains(t, tx.txStmts, normalStmt)
 
 	require.True(t, tx.shouldBypassStatementCache(dropTemp))
+	require.Contains(t, tx.tempTables, "current_hashes")
+
+	tx.markQueryForCaching(dropTemp)
+	require.NotContains(t, tx.txStmts, dropTemp)
 	require.NotContains(t, tx.tempTables, "current_hashes")
 }
 

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -529,6 +529,37 @@ func TestCleanupUnusedStrings_BasicAuthStringRefs(t *testing.T) {
 	require.False(t, exists, "orphan string should be cleaned up")
 }
 
+func TestTxTempTableQueriesBypassStatementCache(t *testing.T) {
+	t.Parallel()
+
+	tx := &Tx{}
+	const (
+		createTemp = "CREATE TEMP TABLE current_hashes (hash TEXT PRIMARY KEY)"
+		insertTemp = "INSERT INTO current_hashes (hash) VALUES (?)"
+		deleteTemp = `
+			DELETE FROM torrent_files_cache
+			WHERE torrent_hash_id NOT IN (
+				SELECT id FROM string_pool WHERE value IN (SELECT hash FROM current_hashes)
+			)
+		`
+		dropTemp   = "DROP TABLE current_hashes"
+		normalStmt = "INSERT INTO string_pool (value) VALUES (?)"
+	)
+
+	require.True(t, tx.shouldBypassStatementCache(createTemp))
+	require.Contains(t, tx.tempTables, "current_hashes")
+
+	tx.markQueryForCaching(insertTemp)
+	tx.markQueryForCaching(deleteTemp)
+	require.Empty(t, tx.txStmts)
+
+	tx.markQueryForCaching(normalStmt)
+	require.Contains(t, tx.txStmts, normalStmt)
+
+	require.True(t, tx.shouldBypassStatementCache(dropTemp))
+	require.NotContains(t, tx.tempTables, "current_hashes")
+}
+
 // TestTransactionCommitSuccessMutexRelease tests that the writer mutex is properly released
 // after a successful commit.
 func TestTransactionCommitSuccessMutexRelease(t *testing.T) {

--- a/internal/database/postgres_integration_test.go
+++ b/internal/database/postgres_integration_test.go
@@ -8,47 +8,21 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/services/filesmanager"
 )
 
 func TestOpenPostgres(t *testing.T) {
 	t.Parallel()
 
-	baseDSN := strings.TrimSpace(os.Getenv("QUI_TEST_POSTGRES_DSN"))
-	if baseDSN == "" {
-		t.Skip("QUI_TEST_POSTGRES_DSN not set")
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	adminPool, err := pgxpool.New(ctx, baseDSN)
-	if err != nil {
-		t.Fatalf("open admin postgres pool: %v", err)
-	}
-	defer adminPool.Close()
-
-	schemaName := fmt.Sprintf("qui_test_%d", time.Now().UnixNano())
-	if _, err := adminPool.Exec(ctx, "CREATE SCHEMA "+quoteIdent(schemaName)); err != nil {
-		t.Fatalf("create schema: %v", err)
-	}
-	t.Cleanup(func() {
-		_, _ = adminPool.Exec(context.Background(), fmt.Sprintf("DROP SCHEMA %s CASCADE", quoteIdent(schemaName)))
-	})
-
-	testDSN := dsnWithSearchPath(t, baseDSN, schemaName)
-	db, err := Open(OpenOptions{
-		Engine:      string(DialectPostgres),
-		PostgresDSN: testDSN,
-	})
-	if err != nil {
-		t.Fatalf("open postgres db: %v", err)
-	}
-	defer db.Close()
+	db, ctx := openPostgresTestDB(t)
 
 	if got := db.Dialect(); got != string(DialectPostgres) {
 		t.Fatalf("unexpected dialect: %s", got)
@@ -61,6 +35,166 @@ func TestOpenPostgres(t *testing.T) {
 	if count == 0 {
 		t.Fatalf("expected at least one postgres migration row, got %d", count)
 	}
+}
+
+func TestCleanupUnusedStringsPostgres(t *testing.T) {
+	t.Parallel()
+
+	db, ctx := openPostgresTestDB(t)
+	conn := db.Conn()
+
+	var referencedID, orphanID int64
+	require.NoError(t, conn.QueryRowContext(ctx, "INSERT INTO string_pool (value) VALUES (?) RETURNING id", "pg_referenced").Scan(&referencedID))
+	require.NoError(t, conn.QueryRowContext(ctx, "INSERT INTO string_pool (value) VALUES (?) RETURNING id", "pg_orphan").Scan(&orphanID))
+
+	_, err := conn.ExecContext(ctx, `
+		INSERT INTO instances (name_id, host_id, username_id, password_encrypted)
+		VALUES (?, ?, ?, ?)
+	`, referencedID, referencedID, referencedID, "dummy_password")
+	require.NoError(t, err)
+
+	deleted, err := db.CleanupUnusedStrings(ctx)
+	require.NoError(t, err)
+	require.Positive(t, deleted)
+
+	var exists bool
+	require.NoError(t, conn.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM string_pool WHERE id = ?)", referencedID).Scan(&exists))
+	require.True(t, exists)
+	require.NoError(t, conn.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM string_pool WHERE id = ?)", orphanID).Scan(&exists))
+	require.False(t, exists)
+
+	deletedAgain, err := db.CleanupUnusedStrings(ctx)
+	require.NoError(t, err)
+	require.Zero(t, deletedAgain)
+}
+
+func TestMigratedSQLiteFilesmanagerCleanupPostgres(t *testing.T) {
+	t.Parallel()
+
+	ctx, testDSN := openPostgresTestSchema(t)
+	sqlitePath := filepath.Join(t.TempDir(), "fixture.db")
+	sqliteDB, err := New(sqlitePath)
+	require.NoError(t, err)
+
+	var (
+		instanceNameID int64
+		hostID         int64
+		usernameID     int64
+		keepHashID     int64
+		dropHashID     int64
+		fileNameID     int64
+	)
+
+	conn := sqliteDB.Conn()
+	require.NoError(t, conn.QueryRowContext(ctx, "INSERT INTO string_pool (value) VALUES (?) RETURNING id", "instance-name").Scan(&instanceNameID))
+	require.NoError(t, conn.QueryRowContext(ctx, "INSERT INTO string_pool (value) VALUES (?) RETURNING id", "instance-host").Scan(&hostID))
+	require.NoError(t, conn.QueryRowContext(ctx, "INSERT INTO string_pool (value) VALUES (?) RETURNING id", "instance-user").Scan(&usernameID))
+	require.NoError(t, conn.QueryRowContext(ctx, "INSERT INTO string_pool (value) VALUES (?) RETURNING id", "keep-hash").Scan(&keepHashID))
+	require.NoError(t, conn.QueryRowContext(ctx, "INSERT INTO string_pool (value) VALUES (?) RETURNING id", "drop-hash").Scan(&dropHashID))
+	require.NoError(t, conn.QueryRowContext(ctx, "INSERT INTO string_pool (value) VALUES (?) RETURNING id", "file.mkv").Scan(&fileNameID))
+
+	_, err = conn.ExecContext(ctx, `
+		INSERT INTO instances (id, name_id, host_id, username_id, password_encrypted)
+		VALUES (?, ?, ?, ?, ?)
+	`, 1, instanceNameID, hostID, usernameID, "enc")
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	_, err = conn.ExecContext(ctx, `
+		INSERT INTO torrent_files_cache
+			(instance_id, torrent_hash_id, file_index, name_id, size, progress, priority, is_seed, piece_range_start, piece_range_end, availability, cached_at)
+		VALUES
+			(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?),
+			(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		1, keepHashID, 0, fileNameID, 100, 1.0, 1, 1, 0, 1, 1.0, now,
+		1, dropHashID, 0, fileNameID, 200, 0.5, 1, 0, 0, 1, 0.5, now,
+	)
+	require.NoError(t, err)
+
+	_, err = conn.ExecContext(ctx, `
+		INSERT INTO torrent_files_sync
+			(instance_id, torrent_hash_id, last_synced_at, torrent_progress, file_count)
+		VALUES
+			(?, ?, ?, ?, ?),
+			(?, ?, ?, ?, ?)
+	`,
+		1, keepHashID, now, 1.0, 1,
+		1, dropHashID, now, 0.5, 1,
+	)
+	require.NoError(t, err)
+	require.NoError(t, sqliteDB.Close())
+
+	report, err := MigrateSQLiteToPostgres(ctx, SQLiteToPostgresMigrationOptions{
+		SQLitePath:  sqlitePath,
+		PostgresDSN: testDSN,
+		Apply:       true,
+	})
+	require.NoError(t, err)
+	require.True(t, report.Applied)
+
+	pgDB, err := Open(OpenOptions{
+		Engine:      string(DialectPostgres),
+		PostgresDSN: testDSN,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, pgDB.Close())
+	})
+
+	repo := filesmanager.NewRepository(pgDB)
+	deleted, err := repo.DeleteCacheForRemovedTorrents(ctx, 1, []string{"keep-hash"})
+	require.NoError(t, err)
+	require.Equal(t, 1, deleted)
+
+	var count int
+	require.NoError(t, pgDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM torrent_files_cache_view WHERE instance_id = ? AND torrent_hash = ?", 1, "keep-hash").Scan(&count))
+	require.Equal(t, 1, count)
+	require.NoError(t, pgDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM torrent_files_cache_view WHERE instance_id = ? AND torrent_hash = ?", 1, "drop-hash").Scan(&count))
+	require.Zero(t, count)
+	require.NoError(t, pgDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM torrent_files_sync_view WHERE instance_id = ? AND torrent_hash = ?", 1, "drop-hash").Scan(&count))
+	require.Zero(t, count)
+}
+
+func openPostgresTestDB(t *testing.T) (*DB, context.Context) {
+	t.Helper()
+
+	ctx, testDSN := openPostgresTestSchema(t)
+	db, err := Open(OpenOptions{
+		Engine:      string(DialectPostgres),
+		PostgresDSN: testDSN,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	return db, ctx
+}
+
+func openPostgresTestSchema(t *testing.T) (context.Context, string) {
+	t.Helper()
+
+	baseDSN := strings.TrimSpace(os.Getenv("QUI_TEST_POSTGRES_DSN"))
+	if baseDSN == "" {
+		t.Skip("QUI_TEST_POSTGRES_DSN not set")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	adminPool, err := pgxpool.New(ctx, baseDSN)
+	require.NoError(t, err)
+	t.Cleanup(adminPool.Close)
+
+	schemaName := fmt.Sprintf("qui_test_%d", time.Now().UnixNano())
+	_, err = adminPool.Exec(ctx, "CREATE SCHEMA "+quoteIdent(schemaName))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = adminPool.Exec(context.Background(), fmt.Sprintf("DROP SCHEMA %s CASCADE", quoteIdent(schemaName)))
+	})
+
+	return ctx, dsnWithSearchPath(t, baseDSN, schemaName)
 }
 
 func dsnWithSearchPath(t *testing.T, dsn string, schema string) string {


### PR DESCRIPTION
Fix postgres temp-table handling in the database layer so temp-table queries are not promoted into the shared statement cache after transaction commit. This removes the hourly `current_hashes` relation error from filesmanager orphan cleanup and fixes the same session-scoping issue in string-pool cleanup.

Adds regression coverage for fresh postgres and migrated sqlite-to-postgres databases, including the filesmanager cleanup path that triggered the reported error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Statement caching now respects transaction-local temp tables and avoids premature cache promotions; error paths no longer mutate caches.
  * Cleanup logic runs within transaction scope for safer temp-table lifecycle handling.

* **Bug Fixes**
  * Queries that create, drop, or reference temp tables bypass statement caching to prevent stale prepared statements.

* **Tests**
  * Added unit tests for temp-table-aware caching and name parsing.
  * Added Postgres integration tests for cleanup and migration; improved test helpers and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->