### PR TITLE
fix(proxy): reauth qbit passthrough requests

### DIFF
--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -64,11 +64,16 @@ type basicAuthCredentials struct {
 	password string
 }
 
+type sessionRefresher interface {
+	LoginCtx(context.Context) error
+}
+
 type proxyContext struct {
 	instanceID  int
 	instanceURL *url.URL
 	httpClient  *http.Client
 	basicAuth   *basicAuthCredentials
+	session     sessionRefresher
 }
 
 type proxyContentPathMediaInfoRequest struct {
@@ -158,28 +163,7 @@ func (h *Handler) rewriteRequest(pr *httputil.ProxyRequest) {
 		return
 	}
 
-	if proxyCtx.httpClient != nil && proxyCtx.httpClient.Jar != nil {
-		// Get cookies for the target URL from the cookie jar
-		cookies := proxyCtx.httpClient.Jar.Cookies(instanceURL)
-		if len(cookies) > 0 {
-			var cookiePairs []string
-			for _, cookie := range cookies {
-				cookiePairs = append(cookiePairs, fmt.Sprintf("%s=%s", cookie.Name, cookie.Value))
-			}
-			pr.Out.Header.Set("Cookie", strings.Join(cookiePairs, "; "))
-			log.Debug().Int("instanceId", instanceID).Int("cookieCount", len(cookies)).Msg("Added cookies from HTTP client jar to proxy request")
-		} else {
-			log.Debug().Int("instanceId", instanceID).Msg("No cookies found in HTTP client jar")
-		}
-	} else {
-		log.Debug().Int("instanceId", instanceID).Msg("No HTTP client or cookie jar available")
-	}
-
-	if proxyCtx.basicAuth != nil {
-		pr.Out.SetBasicAuth(proxyCtx.basicAuth.username, proxyCtx.basicAuth.password)
-	} else {
-		pr.Out.Header.Del("Authorization")
-	}
+	proxyCtx.applyAuthHeaders(pr.Out)
 
 	// Strip the proxy prefix from the path
 	apiKey := chi.URLParam(pr.In, "api-key")
@@ -521,6 +505,7 @@ func (h *Handler) prepareProxyContext(r *http.Request) (*proxyContext, error) {
 		instanceURL: instanceURL,
 		httpClient:  client.GetHTTPClient(),
 		basicAuth:   basicAuth,
+		session:     client,
 	}
 
 	return proxyCtx, nil
@@ -532,6 +517,38 @@ func getProxyContext(ctx context.Context) (*proxyContext, bool) {
 	}
 	proxyCtx, ok := ctx.Value(proxyContextKey).(*proxyContext)
 	return proxyCtx, ok
+}
+
+func (pc *proxyContext) applyAuthHeaders(req *http.Request) {
+	if pc == nil || req == nil {
+		return
+	}
+
+	if pc.httpClient != nil && pc.httpClient.Jar != nil && pc.instanceURL != nil {
+		cookies := pc.httpClient.Jar.Cookies(pc.instanceURL)
+		if len(cookies) > 0 {
+			var cookiePairs []string
+			for _, cookie := range cookies {
+				cookiePairs = append(cookiePairs, fmt.Sprintf("%s=%s", cookie.Name, cookie.Value))
+			}
+			req.Header.Set("Cookie", strings.Join(cookiePairs, "; "))
+		} else {
+			req.Header.Del("Cookie")
+		}
+	}
+
+	if pc.basicAuth != nil {
+		req.SetBasicAuth(pc.basicAuth.username, pc.basicAuth.password)
+	} else {
+		req.Header.Del("Authorization")
+	}
+}
+
+func (pc *proxyContext) refreshSession(ctx context.Context) error {
+	if pc == nil || pc.session == nil {
+		return errors.New("proxy session refresh unavailable")
+	}
+	return pc.session.LoginCtx(ctx)
 }
 
 func (h *Handler) writeProxyError(w http.ResponseWriter) {

--- a/internal/proxy/retry_transport.go
+++ b/internal/proxy/retry_transport.go
@@ -155,7 +155,7 @@ func prepareRequestReplay(req *http.Request) (requestReplayState, error) {
 
 func cloneRequestForAttempt(req *http.Request) (*http.Request, error) {
 	reqClone := req.Clone(req.Context())
-	if req == nil || req.Body == nil {
+	if req.Body == nil {
 		return reqClone, nil
 	}
 

--- a/internal/proxy/retry_transport.go
+++ b/internal/proxy/retry_transport.go
@@ -153,7 +153,7 @@ func prepareRequestReplay(req *http.Request) (requestReplayState, error) {
 	return requestReplayState{replayable: true}, nil
 }
 
-func cloneRequestForAttempt(req *http.Request, replay requestReplayState) (*http.Request, error) {
+func cloneRequestForAttempt(req *http.Request) (*http.Request, error) {
 	reqClone := req.Clone(req.Context())
 	if req == nil || req.Body == nil {
 		return reqClone, nil
@@ -206,7 +206,7 @@ func (t *RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	authRetried := false
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
-		reqClone, err := cloneRequestForAttempt(req, replay)
+		reqClone, err := cloneRequestForAttempt(req)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/proxy/retry_transport.go
+++ b/internal/proxy/retry_transport.go
@@ -158,7 +158,11 @@ func prepareRequestReplay(req *http.Request) (requestReplayState, error) {
 	return requestReplayState{replayable: true}, nil
 }
 
-func cloneRequestForAttempt(req *http.Request) (*http.Request, error) {
+func cloneRequestForAttempt(req *http.Request, attempt int) (*http.Request, error) {
+	if attempt == 0 {
+		return req, nil
+	}
+
 	reqClone := req.Clone(req.Context())
 	if req.Body == nil {
 		return reqClone, nil
@@ -211,7 +215,7 @@ func (t *RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	authRetried := false
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
-		reqClone, err := cloneRequestForAttempt(req)
+		reqClone, err := cloneRequestForAttempt(req, attempt)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/proxy/retry_transport.go
+++ b/internal/proxy/retry_transport.go
@@ -180,7 +180,7 @@ func closeResponseBody(resp *http.Response) {
 }
 
 func canRetryForbidden(req *http.Request, proxyCtx *proxyContext, replay requestReplayState, authRetried bool) bool {
-	if authRetried || proxyCtx == nil {
+	if authRetried || proxyCtx == nil || proxyCtx.session == nil {
 		return false
 	}
 

--- a/internal/proxy/retry_transport.go
+++ b/internal/proxy/retry_transport.go
@@ -4,6 +4,7 @@
 package proxy
 
 import (
+	"bytes"
 	"errors"
 	"io"
 	"net"
@@ -23,6 +24,8 @@ const (
 	maxRetries       = 3
 	initialRetryWait = 50 * time.Millisecond
 	maxRetryWait     = 500 * time.Millisecond
+	// Small qBittorrent form posts should be replayable after re-login.
+	maxAuthReplayBodySize = 10 * 1024 * 1024
 )
 
 // RetryTransport wraps an http.RoundTripper with retry logic for transient network errors
@@ -120,6 +123,74 @@ func waitForRetry(req *http.Request, backoff time.Duration) error {
 	}
 }
 
+type requestReplayState struct {
+	replayable bool
+}
+
+func prepareRequestReplay(req *http.Request) (requestReplayState, error) {
+	if req == nil || req.Body == nil {
+		return requestReplayState{replayable: true}, nil
+	}
+
+	if req.GetBody != nil {
+		return requestReplayState{replayable: true}, nil
+	}
+
+	if req.ContentLength < 0 || req.ContentLength > maxAuthReplayBodySize {
+		return requestReplayState{}, nil
+	}
+
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return requestReplayState{}, err
+	}
+
+	req.Body = io.NopCloser(bytes.NewReader(body))
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(body)), nil
+	}
+
+	return requestReplayState{replayable: true}, nil
+}
+
+func cloneRequestForAttempt(req *http.Request, replay requestReplayState) (*http.Request, error) {
+	reqClone := req.Clone(req.Context())
+	if req == nil || req.Body == nil {
+		return reqClone, nil
+	}
+
+	if req.GetBody != nil {
+		body, err := req.GetBody()
+		if err != nil {
+			return nil, err
+		}
+		reqClone.Body = body
+	}
+
+	return reqClone, nil
+}
+
+func closeResponseBody(resp *http.Response) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+}
+
+func canRetryForbidden(req *http.Request, proxyCtx *proxyContext, replay requestReplayState, authRetried bool) bool {
+	if authRetried || proxyCtx == nil {
+		return false
+	}
+
+	if req == nil || req.Body == nil {
+		return true
+	}
+
+	return replay.replayable && req.GetBody != nil
+}
+
 // RoundTrip implements http.RoundTripper with retry logic for transient errors
 //
 //nolint:wrapcheck // RoundTrip should not wrap errors - callers expect unwrapped transport errors
@@ -127,15 +198,34 @@ func (t *RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	var lastErr error
 
 	base := t.transportFor(req)
+	proxyCtx, _ := getProxyContext(req.Context())
+	replay, err := prepareRequestReplay(req)
+	if err != nil {
+		return nil, err
+	}
+	authRetried := false
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
-		// Clone the request for retry attempts to ensure body can be replayed if needed
-		reqClone := req.Clone(req.Context())
+		reqClone, err := cloneRequestForAttempt(req, replay)
+		if err != nil {
+			return nil, err
+		}
+		if proxyCtx != nil {
+			proxyCtx.applyAuthHeaders(reqClone)
+		}
 
 		resp, err := base.RoundTrip(reqClone)
 
 		// Success case
 		if err == nil {
+			if resp != nil && resp.StatusCode == http.StatusForbidden && canRetryForbidden(req, proxyCtx, replay, authRetried) {
+				closeResponseBody(resp)
+				if err := proxyCtx.refreshSession(req.Context()); err != nil {
+					return nil, err
+				}
+				authRetried = true
+				continue
+			}
 			if attempt > 0 {
 				log.Debug().
 					Str("method", req.Method).

--- a/internal/proxy/retry_transport.go
+++ b/internal/proxy/retry_transport.go
@@ -159,12 +159,8 @@ func prepareRequestReplay(req *http.Request) (requestReplayState, error) {
 }
 
 func cloneRequestForAttempt(req *http.Request, attempt int) (*http.Request, error) {
-	if attempt == 0 {
-		return req, nil
-	}
-
 	reqClone := req.Clone(req.Context())
-	if req.Body == nil {
+	if attempt == 0 || req.Body == nil {
 		return reqClone, nil
 	}
 
@@ -214,8 +210,8 @@ func (t *RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 	authRetried := false
 
-	for attempt := 0; attempt <= maxRetries; attempt++ {
-		reqClone, err := cloneRequestForAttempt(req, attempt)
+	for attempt, sendAttempt := 0, 0; attempt <= maxRetries; sendAttempt++ {
+		reqClone, err := cloneRequestForAttempt(req, sendAttempt)
 		if err != nil {
 			return nil, err
 		}
@@ -255,6 +251,8 @@ func (t *RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		if err := waitForRetry(req, backoff); err != nil {
 			return nil, err
 		}
+
+		attempt++
 	}
 
 	return nil, lastErr

--- a/internal/proxy/retry_transport.go
+++ b/internal/proxy/retry_transport.go
@@ -132,17 +132,22 @@ func prepareRequestReplay(req *http.Request) (requestReplayState, error) {
 		return requestReplayState{replayable: true}, nil
 	}
 
-	if req.GetBody != nil {
-		return requestReplayState{replayable: true}, nil
-	}
-
 	if req.ContentLength < 0 || req.ContentLength > maxAuthReplayBodySize {
 		return requestReplayState{}, nil
 	}
 
-	body, err := io.ReadAll(req.Body)
+	if req.GetBody != nil {
+		return requestReplayState{replayable: true}, nil
+	}
+
+	originalBody := req.Body
+	body, err := io.ReadAll(originalBody)
+	closeErr := originalBody.Close()
 	if err != nil {
 		return requestReplayState{}, err
+	}
+	if closeErr != nil {
+		return requestReplayState{}, closeErr
 	}
 
 	req.Body = io.NopCloser(bytes.NewReader(body))

--- a/internal/proxy/retry_transport_test.go
+++ b/internal/proxy/retry_transport_test.go
@@ -311,7 +311,7 @@ func TestRetryTransport_ReauthsAndReplaysForbiddenPOST(t *testing.T) {
 	}})
 
 	session := &stubSessionRefresher{}
-	session.login = func(ctx context.Context) error {
+	session.login = func(_ context.Context) error {
 		jar.SetCookies(instanceURL, []*http.Cookie{{
 			Name:  "SID",
 			Value: "fresh",
@@ -321,7 +321,7 @@ func TestRetryTransport_ReauthsAndReplaysForbiddenPOST(t *testing.T) {
 
 	var requestBodies []string
 
-	transport := NewRetryTransportWithSelector(nil, func(req *http.Request) http.RoundTripper {
+	transport := NewRetryTransportWithSelector(nil, func(_ *http.Request) http.RoundTripper {
 		return retryRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 			body, readErr := io.ReadAll(req.Body)
 			require.NoError(t, readErr)
@@ -380,7 +380,7 @@ func TestRetryTransport_DoesNotReplayLargeForbiddenPOST(t *testing.T) {
 	session := &stubSessionRefresher{}
 	attempts := 0
 
-	transport := NewRetryTransportWithSelector(nil, func(req *http.Request) http.RoundTripper {
+	transport := NewRetryTransportWithSelector(nil, func(_ *http.Request) http.RoundTripper {
 		return retryRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 			attempts++
 			return &http.Response{

--- a/internal/proxy/retry_transport_test.go
+++ b/internal/proxy/retry_transport_test.go
@@ -399,6 +399,7 @@ func TestRetryTransport_ReauthsAndReplaysForbiddenPOST(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, 1, session.loginCalls)
 	assert.Equal(t, []string{formBody, formBody}, requestBodies)
+	assert.Empty(t, req.Header.Get("Cookie"))
 }
 
 func TestRetryTransport_DoesNotReplayLargeForbiddenPOST(t *testing.T) {
@@ -443,6 +444,78 @@ func TestRetryTransport_DoesNotReplayLargeForbiddenPOST(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 	assert.Equal(t, 1, attempts)
 	assert.Equal(t, 0, session.loginCalls)
+}
+
+func TestRetryTransport_ForbiddenReplayDoesNotConsumeRetryBudget(t *testing.T) {
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+
+	instanceURL, err := url.Parse("http://qbittorrent.example")
+	require.NoError(t, err)
+
+	jar.SetCookies(instanceURL, []*http.Cookie{{
+		Name:  "SID",
+		Value: "stale",
+	}})
+
+	session := &stubSessionRefresher{}
+	session.login = func(_ context.Context) error {
+		jar.SetCookies(instanceURL, []*http.Cookie{{
+			Name:  "SID",
+			Value: "fresh",
+		}})
+		return nil
+	}
+
+	attempts := 0
+
+	transport := NewRetryTransportWithSelector(nil, func(_ *http.Request) http.RoundTripper {
+		return retryRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			attempts++
+
+			if attempts == 1 {
+				require.Equal(t, "SID=stale", req.Header.Get("Cookie"))
+				return &http.Response{
+					StatusCode: http.StatusForbidden,
+					Body:       io.NopCloser(strings.NewReader("Forbidden")),
+					Header:     make(http.Header),
+					Request:    req,
+				}, nil
+			}
+
+			require.Equal(t, "SID=fresh", req.Header.Get("Cookie"))
+
+			if attempts <= maxRetries+1 {
+				return nil, syscall.ECONNREFUSED
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("OK")),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		})
+	})
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://proxy.example/api/v2/torrents/info", http.NoBody)
+	require.NoError(t, err)
+
+	ctx := context.WithValue(req.Context(), proxyContextKey, &proxyContext{
+		instanceURL: instanceURL,
+		httpClient:  &http.Client{Jar: jar},
+		session:     session,
+	})
+	req = req.WithContext(ctx)
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 1, session.loginCalls)
+	assert.Equal(t, maxRetries+2, attempts)
 }
 
 func TestRetryTransport_ReturnsForbiddenWhenSessionRefreshUnavailable(t *testing.T) {

--- a/internal/proxy/retry_transport_test.go
+++ b/internal/proxy/retry_transport_test.go
@@ -297,8 +297,6 @@ func TestRetryTransport_IdempotentMethods(t *testing.T) {
 }
 
 func TestRetryTransport_ReauthsAndReplaysForbiddenPOST(t *testing.T) {
-	t.Helper()
-
 	jar, err := cookiejar.New(nil)
 	require.NoError(t, err)
 
@@ -369,8 +367,6 @@ func TestRetryTransport_ReauthsAndReplaysForbiddenPOST(t *testing.T) {
 }
 
 func TestRetryTransport_DoesNotReplayLargeForbiddenPOST(t *testing.T) {
-	t.Helper()
-
 	jar, err := cookiejar.New(nil)
 	require.NoError(t, err)
 
@@ -415,8 +411,6 @@ func TestRetryTransport_DoesNotReplayLargeForbiddenPOST(t *testing.T) {
 }
 
 func TestRetryTransport_ReturnsForbiddenWhenSessionRefreshUnavailable(t *testing.T) {
-	t.Helper()
-
 	jar, err := cookiejar.New(nil)
 	require.NoError(t, err)
 

--- a/internal/proxy/retry_transport_test.go
+++ b/internal/proxy/retry_transport_test.go
@@ -62,6 +62,16 @@ func (s *stubSessionRefresher) LoginCtx(ctx context.Context) error {
 	return nil
 }
 
+type trackedReadCloser struct {
+	io.Reader
+	closed bool
+}
+
+func (t *trackedReadCloser) Close() error {
+	t.closed = true
+	return nil
+}
+
 func TestRetryTransport_Success(t *testing.T) {
 	mock := &mockRoundTripper{
 		response: &http.Response{
@@ -294,6 +304,31 @@ func TestRetryTransport_IdempotentMethods(t *testing.T) {
 			assert.Equal(t, 2, mock.attempts, "Should retry idempotent methods")
 		})
 	}
+}
+
+func TestPrepareRequestReplay_ClosesOriginalBody(t *testing.T) {
+	reader := &trackedReadCloser{Reader: strings.NewReader("hashes=abc")}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://proxy.example/api/v2/torrents/setCategory", reader)
+	require.NoError(t, err)
+	req.GetBody = nil
+	req.ContentLength = int64(len("hashes=abc"))
+
+	replay, err := prepareRequestReplay(req)
+	require.NoError(t, err)
+	assert.True(t, replay.replayable)
+	assert.True(t, reader.closed)
+	require.NotNil(t, req.GetBody)
+}
+
+func TestPrepareRequestReplay_DoesNotReplayOversizedGetBodyRequest(t *testing.T) {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://proxy.example/api/v2/torrents/setCategory", strings.NewReader("x"))
+	require.NoError(t, err)
+	req.ContentLength = maxAuthReplayBodySize + 1
+
+	replay, err := prepareRequestReplay(req)
+	require.NoError(t, err)
+	assert.False(t, replay.replayable)
 }
 
 func TestRetryTransport_ReauthsAndReplaysForbiddenPOST(t *testing.T) {

--- a/internal/proxy/retry_transport_test.go
+++ b/internal/proxy/retry_transport_test.go
@@ -414,6 +414,47 @@ func TestRetryTransport_DoesNotReplayLargeForbiddenPOST(t *testing.T) {
 	assert.Equal(t, 0, session.loginCalls)
 }
 
+func TestRetryTransport_ReturnsForbiddenWhenSessionRefreshUnavailable(t *testing.T) {
+	t.Helper()
+
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+
+	instanceURL, err := url.Parse("http://qbittorrent.example")
+	require.NoError(t, err)
+
+	attempts := 0
+
+	transport := NewRetryTransportWithSelector(nil, func(_ *http.Request) http.RoundTripper {
+		return retryRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			return &http.Response{
+				StatusCode: http.StatusForbidden,
+				Body:       io.NopCloser(strings.NewReader("Forbidden")),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		})
+	})
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://proxy.example/api/v2/torrents/info", http.NoBody)
+	require.NoError(t, err)
+
+	ctx := context.WithValue(req.Context(), proxyContextKey, &proxyContext{
+		instanceURL: instanceURL,
+		httpClient:  &http.Client{Jar: jar},
+	})
+	req = req.WithContext(ctx)
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	assert.Equal(t, 1, attempts)
+}
+
 func TestRetryTransport_MaxRetries(t *testing.T) {
 	mock := &mockRoundTripper{
 		err:        syscall.ECONNREFUSED,

--- a/internal/proxy/retry_transport_test.go
+++ b/internal/proxy/retry_transport_test.go
@@ -4,11 +4,13 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
 	"net"
 	"net/http"
+	"net/http/cookiejar"
 	"net/url"
 	"strings"
 	"syscall"
@@ -39,6 +41,25 @@ func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 		StatusCode: http.StatusOK,
 		Body:       io.NopCloser(strings.NewReader("OK")),
 	}, nil
+}
+
+type retryRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f retryRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type stubSessionRefresher struct {
+	loginCalls int
+	login      func(context.Context) error
+}
+
+func (s *stubSessionRefresher) LoginCtx(ctx context.Context) error {
+	s.loginCalls++
+	if s.login != nil {
+		return s.login(ctx)
+	}
+	return nil
 }
 
 func TestRetryTransport_Success(t *testing.T) {
@@ -273,6 +294,124 @@ func TestRetryTransport_IdempotentMethods(t *testing.T) {
 			assert.Equal(t, 2, mock.attempts, "Should retry idempotent methods")
 		})
 	}
+}
+
+func TestRetryTransport_ReauthsAndReplaysForbiddenPOST(t *testing.T) {
+	t.Helper()
+
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+
+	instanceURL, err := url.Parse("http://qbittorrent.example")
+	require.NoError(t, err)
+
+	jar.SetCookies(instanceURL, []*http.Cookie{{
+		Name:  "SID",
+		Value: "stale",
+	}})
+
+	session := &stubSessionRefresher{}
+	session.login = func(ctx context.Context) error {
+		jar.SetCookies(instanceURL, []*http.Cookie{{
+			Name:  "SID",
+			Value: "fresh",
+		}})
+		return nil
+	}
+
+	var requestBodies []string
+
+	transport := NewRetryTransportWithSelector(nil, func(req *http.Request) http.RoundTripper {
+		return retryRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			body, readErr := io.ReadAll(req.Body)
+			require.NoError(t, readErr)
+			requestBodies = append(requestBodies, string(body))
+
+			if req.Header.Get("Cookie") != "SID=fresh" {
+				return &http.Response{
+					StatusCode: http.StatusForbidden,
+					Body:       io.NopCloser(strings.NewReader("Forbidden")),
+					Header:     make(http.Header),
+					Request:    req,
+				}, nil
+			}
+
+			require.Equal(t, "hashes=abc&category=movies-hd", string(body))
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("Ok.")),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		})
+	})
+
+	formBody := "hashes=abc&category=movies-hd"
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://proxy.example/api/v2/torrents/setCategory", bytes.NewBufferString(formBody))
+	require.NoError(t, err)
+	req.ContentLength = int64(len(formBody))
+
+	ctx := context.WithValue(req.Context(), proxyContextKey, &proxyContext{
+		instanceURL: instanceURL,
+		httpClient:  &http.Client{Jar: jar},
+		session:     session,
+	})
+	req = req.WithContext(ctx)
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 1, session.loginCalls)
+	assert.Equal(t, []string{formBody, formBody}, requestBodies)
+}
+
+func TestRetryTransport_DoesNotReplayLargeForbiddenPOST(t *testing.T) {
+	t.Helper()
+
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+
+	instanceURL, err := url.Parse("http://qbittorrent.example")
+	require.NoError(t, err)
+
+	session := &stubSessionRefresher{}
+	attempts := 0
+
+	transport := NewRetryTransportWithSelector(nil, func(req *http.Request) http.RoundTripper {
+		return retryRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			return &http.Response{
+				StatusCode: http.StatusForbidden,
+				Body:       io.NopCloser(strings.NewReader("Forbidden")),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		})
+	})
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://proxy.example/api/v2/torrents/setCategory", strings.NewReader("x"))
+	require.NoError(t, err)
+	req.ContentLength = maxAuthReplayBodySize + 1
+	req.GetBody = nil
+
+	ctx := context.WithValue(req.Context(), proxyContextKey, &proxyContext{
+		instanceURL: instanceURL,
+		httpClient:  &http.Client{Jar: jar},
+		session:     session,
+	})
+	req = req.WithContext(ctx)
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	assert.Equal(t, 1, attempts)
+	assert.Equal(t, 0, session.loginCalls)
 }
 
 func TestRetryTransport_MaxRetries(t *testing.T) {

--- a/internal/proxy/retry_transport_test.go
+++ b/internal/proxy/retry_transport_test.go
@@ -4,7 +4,6 @@
 package proxy
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -380,7 +379,8 @@ func TestRetryTransport_ReauthsAndReplaysForbiddenPOST(t *testing.T) {
 	})
 
 	formBody := "hashes=abc&category=movies-hd"
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://proxy.example/api/v2/torrents/setCategory", bytes.NewBufferString(formBody))
+	reqBody := &trackedReadCloser{Reader: strings.NewReader(formBody)}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://proxy.example/api/v2/torrents/setCategory", reqBody)
 	require.NoError(t, err)
 	req.ContentLength = int64(len(formBody))
 


### PR DESCRIPTION
Refresh the shared qBittorrent session when proxied passthrough requests get a 403, then replay the request once with fresh auth headers. This fixes stale-session failures that Radarr/Sonarr surface as post-import category errors even when the category exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session-based authentication for proxy requests and centralized auth header application before each attempt.
  * Safe request-replay support for retryable requests using preserved request bodies when feasible.

* **Bug Fixes**
  * Refreshes session and retries once on 403 Forbidden responses.
  * Prevents replay of oversized request bodies to avoid errors and resource leaks.

* **Tests**
  * Added tests for session refresh, retry/replay behavior, cookie handling, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->