### PR TITLE
fix(web): warn before enabling reannounce

### DIFF
--- a/web/src/components/instances/preferences/ReannounceEnableWarning.tsx
+++ b/web/src/components/instances/preferences/ReannounceEnableWarning.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import { AlertTriangle } from "lucide-react"
+
+export function ReannounceEnableWarningAlert() {
+  return (
+    <Alert variant="warning" className="border-yellow-500/40 bg-yellow-500/10 text-yellow-950 dark:text-yellow-100">
+      <AlertTriangle className="h-4 w-4 text-yellow-600 dark:text-yellow-400" />
+      <AlertTitle>Leave this off unless you need it</AlertTitle>
+      <AlertDescription className="space-y-1">
+        <p>This only helps with a small subset of trackers that are slow to register new uploads.</p>
+        <p>If you are not seeing stalled torrents, do not enable it.</p>
+      </AlertDescription>
+    </Alert>
+  )
+}
+
+interface ReannounceEnableWarningDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onConfirm: () => void
+  confirming?: boolean
+}
+
+export function ReannounceEnableWarningDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+  confirming = false,
+}: ReannounceEnableWarningDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Enable automatic reannounce?</AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div className="space-y-3">
+              <p>Use this only if stalled torrents are a real problem on this instance.</p>
+              <p>It helps with only a handful of trackers that are slow to register new uploads.</p>
+              <p>If torrents are behaving normally, leave it off.</p>
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={confirming}>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm} disabled={confirming}>
+            {confirming ? "Enabling..." : "Enable"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/web/src/components/instances/preferences/ReannounceOverview.tsx
+++ b/web/src/components/instances/preferences/ReannounceOverview.tsx
@@ -4,6 +4,7 @@
  */
 
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion"
+import { ReannounceEnableWarningDialog } from "@/components/instances/preferences/ReannounceEnableWarning"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
@@ -74,6 +75,7 @@ export function ReannounceOverview({
   const setExpandedInstances = onExpandedInstancesChange ?? setInternalExpanded
   const [hideSkippedMap, setHideSkippedMap] = useState<Record<number, boolean>>({})
   const [searchMap, setSearchMap] = useState<Record<number, string>>({})
+  const [pendingEnableInstance, setPendingEnableInstance] = useState<Instance | null>(null)
 
   const activeInstances = useMemo(
     () => (instances ?? []).filter((inst) => inst.isActive),
@@ -91,7 +93,7 @@ export function ReannounceOverview({
     })),
   })
 
-  const handleToggleEnabled = (instance: Instance, enabled: boolean) => {
+  const saveEnabledState = (instance: Instance, enabled: boolean) => {
     const payload: Partial<InstanceFormData> = {
       name: instance.name,
       host: instance.host,
@@ -124,6 +126,21 @@ export function ReannounceOverview({
     )
   }
 
+  const handleToggleEnabled = (instance: Instance, enabled: boolean) => {
+    if (enabled) {
+      setPendingEnableInstance(instance)
+      return
+    }
+
+    saveEnabledState(instance, false)
+  }
+
+  const confirmEnable = () => {
+    if (!pendingEnableInstance) return
+    saveEnabledState(pendingEnableInstance, true)
+    setPendingEnableInstance(null)
+  }
+
   const outcomeClasses: Record<InstanceReannounceActivity["outcome"], string> = {
     succeeded: "bg-emerald-500/10 text-emerald-500 border-emerald-500/20",
     failed: "bg-destructive/10 text-destructive border-destructive/30",
@@ -154,121 +171,122 @@ export function ReannounceOverview({
   }
 
   return (
-    <Card>
-      <CardHeader className="space-y-2">
-        <div className="flex items-center gap-2">
-          <CardTitle className="text-lg font-semibold">Reannounce</CardTitle>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Info className="h-4 w-4 text-muted-foreground cursor-help" />
-            </TooltipTrigger>
-            <TooltipContent className="max-w-[300px]">
-              <p>
-                qBittorrent doesn't retry failed announces quickly. When a tracker is slow to
-                register a new upload or returns an error, you may be stuck waiting. qui handles
-                this automatically while never spamming trackers.
-              </p>
-            </TooltipContent>
-          </Tooltip>
-        </div>
-        <CardDescription>
-          Monitors <strong>stalled</strong> torrents and reannounces them when no tracker is healthy.
-        </CardDescription>
-      </CardHeader>
+    <>
+      <Card>
+        <CardHeader className="space-y-2">
+          <div className="flex items-center gap-2">
+            <CardTitle className="text-lg font-semibold">Reannounce</CardTitle>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Info className="h-4 w-4 text-muted-foreground cursor-help" />
+              </TooltipTrigger>
+              <TooltipContent className="max-w-[300px]">
+                <p>
+                  qBittorrent doesn't retry failed announces quickly. When a tracker is slow to
+                  register a new upload or returns an error, you may be stuck waiting. qui handles
+                  this automatically while never spamming trackers.
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          </div>
+          <CardDescription>
+            Monitors <strong>stalled</strong> torrents and reannounces them when no tracker is healthy.
+          </CardDescription>
+        </CardHeader>
 
-      <CardContent className="p-0">
-        <Accordion
-          type="multiple"
-          value={expandedInstances}
-          onValueChange={setExpandedInstances}
-          className="border-t"
-        >
-          {activeInstances.map((instance, index) => {
-            const activityQuery = activityQueries[index]
-            const events = activityQuery?.data ?? []
-            const stats = computeStats(events)
-            const settings = instance.reannounceSettings
-            const isEnabled = settings?.enabled ?? false
-            const hideSkipped = hideSkippedMap[instance.id] ?? true
-            const searchTerm = (searchMap[instance.id] ?? "").toLowerCase().trim()
-            // Filter by outcome and search term, limit to 50 events for display
-            const filteredEvents = events
-              .filter((e) => {
-                if (hideSkipped && e.outcome === "skipped") return false
-                if (searchTerm) {
-                  const nameMatch = e.torrentName?.toLowerCase().includes(searchTerm)
-                  const hashMatch = e.hash.toLowerCase().includes(searchTerm)
-                  if (!nameMatch && !hashMatch) return false
-                }
-                return true
-              })
-              .slice(-50)
-              .reverse()
+        <CardContent className="p-0">
+          <Accordion
+            type="multiple"
+            value={expandedInstances}
+            onValueChange={setExpandedInstances}
+            className="border-t"
+          >
+            {activeInstances.map((instance, index) => {
+              const activityQuery = activityQueries[index]
+              const events = activityQuery?.data ?? []
+              const stats = computeStats(events)
+              const settings = instance.reannounceSettings
+              const isEnabled = settings?.enabled ?? false
+              const hideSkipped = hideSkippedMap[instance.id] ?? true
+              const searchTerm = (searchMap[instance.id] ?? "").toLowerCase().trim()
+              // Filter by outcome and search term, limit to 50 events for display
+              const filteredEvents = events
+                .filter((e) => {
+                  if (hideSkipped && e.outcome === "skipped") return false
+                  if (searchTerm) {
+                    const nameMatch = e.torrentName?.toLowerCase().includes(searchTerm)
+                    const hashMatch = e.hash.toLowerCase().includes(searchTerm)
+                    if (!nameMatch && !hashMatch) return false
+                  }
+                  return true
+                })
+                .slice(-50)
+                .reverse()
 
-            return (
-              <AccordionItem key={instance.id} value={String(instance.id)} className="group/item">
-                <div className="grid grid-cols-[1fr_auto] items-center px-6">
-                  <AccordionTrigger className="py-4 pr-4 hover:no-underline [&>svg]:hidden">
-                    <div className="flex items-center justify-between w-full">
-                      <div className="flex items-center gap-3 min-w-0">
-                        <span className="font-medium truncate">{instance.name}</span>
-                        {isEnabled && stats.successToday > 0 && (
-                          <Badge variant="outline" className="bg-emerald-500/10 text-emerald-500 border-emerald-500/20 text-xs">
-                            {stats.successToday} today
-                          </Badge>
-                        )}
-                        {isEnabled && stats.failedToday > 0 && (
-                          <Badge variant="outline" className="bg-destructive/10 text-destructive border-destructive/30 text-xs">
-                            {stats.failedToday} failed
-                          </Badge>
+              return (
+                <AccordionItem key={instance.id} value={String(instance.id)} className="group/item">
+                  <div className="grid grid-cols-[1fr_auto] items-center px-6">
+                    <AccordionTrigger className="py-4 pr-4 hover:no-underline [&>svg]:hidden">
+                      <div className="flex items-center justify-between w-full">
+                        <div className="flex items-center gap-3 min-w-0">
+                          <span className="font-medium truncate">{instance.name}</span>
+                          {isEnabled && stats.successToday > 0 && (
+                            <Badge variant="outline" className="bg-emerald-500/10 text-emerald-500 border-emerald-500/20 text-xs">
+                              {stats.successToday} today
+                            </Badge>
+                          )}
+                          {isEnabled && stats.failedToday > 0 && (
+                            <Badge variant="outline" className="bg-destructive/10 text-destructive border-destructive/30 text-xs">
+                              {stats.failedToday} failed
+                            </Badge>
+                          )}
+                        </div>
+
+                        {isEnabled && stats.lastActivity && (
+                          <span className="text-xs text-muted-foreground hidden sm:block">
+                            {formatRelativeTime(stats.lastActivity)}
+                          </span>
                         )}
                       </div>
-
-                      {isEnabled && stats.lastActivity && (
-                        <span className="text-xs text-muted-foreground hidden sm:block">
-                          {formatRelativeTime(stats.lastActivity)}
+                    </AccordionTrigger>
+                    <div className="flex items-center gap-4 py-4">
+                      <div
+                        className="flex items-center gap-2"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <span className={cn(
+                          "text-xs font-medium",
+                          isEnabled ? "text-emerald-500" : "text-muted-foreground"
+                        )}>
+                          {isEnabled ? "On" : "Off"}
                         </span>
-                      )}
+                        <Switch
+                          checked={isEnabled}
+                          onCheckedChange={(enabled) => handleToggleEnabled(instance, enabled)}
+                          disabled={isUpdating}
+                          className="scale-90"
+                        />
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          const itemValue = String(instance.id)
+                          if (expandedInstances.includes(itemValue)) {
+                            setExpandedInstances(expandedInstances.filter((v) => v !== itemValue))
+                          } else {
+                            setExpandedInstances([...expandedInstances, itemValue])
+                          }
+                        }}
+                        aria-expanded={expandedInstances.includes(String(instance.id))}
+                        aria-label={expandedInstances.includes(String(instance.id)) ? "Collapse" : "Expand"}
+                      >
+                        <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200 group-data-[state=open]/item:rotate-180" />
+                      </button>
                     </div>
-                  </AccordionTrigger>
-                  <div className="flex items-center gap-4 py-4">
-                    <div
-                      className="flex items-center gap-2"
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      <span className={cn(
-                        "text-xs font-medium",
-                        isEnabled ? "text-emerald-500" : "text-muted-foreground"
-                      )}>
-                        {isEnabled ? "On" : "Off"}
-                      </span>
-                      <Switch
-                        checked={isEnabled}
-                        onCheckedChange={(enabled) => handleToggleEnabled(instance, enabled)}
-                        disabled={isUpdating}
-                        className="scale-90"
-                      />
-                    </div>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        const itemValue = String(instance.id)
-                        if (expandedInstances.includes(itemValue)) {
-                          setExpandedInstances(expandedInstances.filter((v) => v !== itemValue))
-                        } else {
-                          setExpandedInstances([...expandedInstances, itemValue])
-                        }
-                      }}
-                      aria-expanded={expandedInstances.includes(String(instance.id))}
-                      aria-label={expandedInstances.includes(String(instance.id)) ? "Collapse" : "Expand"}
-                    >
-                      <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200 group-data-[state=open]/item:rotate-180" />
-                    </button>
                   </div>
-                </div>
 
-                <AccordionContent className="px-6 pb-4">
-                  <div className="space-y-4">
+                  <AccordionContent className="px-6 pb-4">
+                    <div className="space-y-4">
                     {/* Settings summary */}
                     <div className="flex items-center justify-between p-3 rounded-lg bg-muted/40 border">
                       <div className="space-y-0.5">
@@ -473,13 +491,24 @@ export function ReannounceOverview({
                         </p>
                       </div>
                     )}
-                  </div>
-                </AccordionContent>
-              </AccordionItem>
-            )
-          })}
-        </Accordion>
-      </CardContent>
-    </Card>
+                    </div>
+                  </AccordionContent>
+                </AccordionItem>
+              )
+            })}
+          </Accordion>
+        </CardContent>
+      </Card>
+      <ReannounceEnableWarningDialog
+        open={pendingEnableInstance !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPendingEnableInstance(null)
+          }
+        }}
+        onConfirm={confirmEnable}
+        confirming={isUpdating}
+      />
+    </>
   )
 }

--- a/web/src/components/instances/preferences/TrackerReannounceForm.tsx
+++ b/web/src/components/instances/preferences/TrackerReannounceForm.tsx
@@ -62,6 +62,11 @@ const GLOBAL_SCAN_INTERVAL_SECONDS = 7
 
 type MonitorScopeField = keyof Pick<InstanceReannounceSettings, "categories" | "tags" | "trackers">
 
+interface PersistSettingsCallbacks {
+  onSuccess?: () => void
+  onError?: (error: unknown) => void
+}
+
 export function TrackerReannounceForm({ instanceId, onInstanceChange, onSuccess, variant = "card", formId }: TrackerReannounceFormProps) {
   const { instances, updateInstance, isUpdating } = useInstances()
   const { formatISOTimestamp } = useDateTimeFormatters()
@@ -222,7 +227,11 @@ export function TrackerReannounceForm({ instanceId, onInstanceChange, onSuccess,
     })
   }
 
-  const persistSettings = (nextSettings: InstanceReannounceSettings, successMessage = "Settings saved successfully.") => {
+  const persistSettings = (
+    nextSettings: InstanceReannounceSettings,
+    successMessage = "Settings saved successfully.",
+    callbacks?: PersistSettingsCallbacks
+  ) => {
     if (!instance) {
       toast.error("Instance missing", { description: "Please close and reopen the dialog." })
       return
@@ -246,10 +255,12 @@ export function TrackerReannounceForm({ instanceId, onInstanceChange, onSuccess,
       {
         onSuccess: () => {
           toast.success("Tracker monitoring updated", { description: successMessage })
+          callbacks?.onSuccess?.()
           onSuccess?.()
         },
         onError: (error) => {
           toast.error("Update failed", { description: error instanceof Error ? error.message : "Unable to update settings" })
+          callbacks?.onError?.(error)
         },
       }
     )
@@ -271,9 +282,12 @@ export function TrackerReannounceForm({ instanceId, onInstanceChange, onSuccess,
 
   const confirmEnable = () => {
     if (!pendingEnableSettings) return
-    persistSettings(pendingEnableSettings)
-    setPendingEnableSettings(null)
-    setShowEnableDialog(false)
+    persistSettings(pendingEnableSettings, "Settings saved successfully.", {
+      onSuccess: () => {
+        setPendingEnableSettings(null)
+        setShowEnableDialog(false)
+      },
+    })
   }
 
   const handleEnableDialogChange = (open: boolean) => {

--- a/web/src/components/instances/preferences/TrackerReannounceForm.tsx
+++ b/web/src/components/instances/preferences/TrackerReannounceForm.tsx
@@ -254,7 +254,7 @@ export function TrackerReannounceForm({ instanceId, onInstanceChange, onSuccess,
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     const sanitized = sanitizeSettings(settings)
-    const wasEnabled = instance.reannounceSettings?.enabled ?? DEFAULT_SETTINGS.enabled
+    const wasEnabled = instance?.reannounceSettings?.enabled ?? DEFAULT_SETTINGS.enabled
 
     if (!wasEnabled && sanitized.enabled) {
       setPendingEnableSettings(sanitized)

--- a/web/src/components/instances/preferences/TrackerReannounceForm.tsx
+++ b/web/src/components/instances/preferences/TrackerReannounceForm.tsx
@@ -76,12 +76,16 @@ export function TrackerReannounceForm({ instanceId, onInstanceChange, onSuccess,
   const [pendingEnableSettings, setPendingEnableSettings] = useState<InstanceReannounceSettings | null>(null)
   const [showEnableDialog, setShowEnableDialog] = useState(false)
 
-  // Reset settings when instance changes
+  // Sync form values with persisted settings for the active instance.
   useEffect(() => {
     setSettings(cloneSettings(instance?.reannounceSettings))
+  }, [instance?.reannounceSettings])
+
+  // Reset ephemeral dialog state only when switching instances.
+  useEffect(() => {
     setPendingEnableSettings(null)
     setShowEnableDialog(false)
-  }, [instanceId, instance?.reannounceSettings])
+  }, [instanceId])
 
   const trackersQuery = useInstanceTrackers(instanceId, { enabled: !!instance })
   const { data: trackerCustomizations } = useTrackerCustomizations()
@@ -755,7 +759,7 @@ export function TrackerReannounceForm({ instanceId, onInstanceChange, onSuccess,
   // Card mode: show tabs with settings and activity
   return (
     <>
-      <form onSubmit={handleSubmit}>
+      <form id={formId} onSubmit={handleSubmit}>
         <Card className="w-full">
           <CardHeader className="space-y-4">
             {headerContent}

--- a/web/src/components/instances/preferences/TrackerReannounceForm.tsx
+++ b/web/src/components/instances/preferences/TrackerReannounceForm.tsx
@@ -4,6 +4,7 @@
  */
 
 import { buildCategoryTree, type CategoryNode } from "@/components/torrents/CategoryTree"
+import { ReannounceEnableWarningAlert, ReannounceEnableWarningDialog } from "@/components/instances/preferences/ReannounceEnableWarning"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader } from "@/components/ui/card"
@@ -72,10 +73,14 @@ export function TrackerReannounceForm({ instanceId, onInstanceChange, onSuccess,
   const [settings, setSettings] = useState<InstanceReannounceSettings>(() => cloneSettings(instance?.reannounceSettings))
   const [hideSkipped, setHideSkipped] = useState(true)
   const [activeTab, setActiveTab] = useState("settings")
+  const [pendingEnableSettings, setPendingEnableSettings] = useState<InstanceReannounceSettings | null>(null)
+  const [showEnableDialog, setShowEnableDialog] = useState(false)
 
   // Reset settings when instance changes
   useEffect(() => {
     setSettings(cloneSettings(instance?.reannounceSettings))
+    setPendingEnableSettings(null)
+    setShowEnableDialog(false)
   }, [instanceId, instance?.reannounceSettings])
 
   const trackersQuery = useInstanceTrackers(instanceId, { enabled: !!instance })
@@ -248,7 +253,30 @@ export function TrackerReannounceForm({ instanceId, onInstanceChange, onSuccess,
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
-    persistSettings(settings)
+    const sanitized = sanitizeSettings(settings)
+    const wasEnabled = instance.reannounceSettings?.enabled ?? DEFAULT_SETTINGS.enabled
+
+    if (!wasEnabled && sanitized.enabled) {
+      setPendingEnableSettings(sanitized)
+      setShowEnableDialog(true)
+      return
+    }
+
+    persistSettings(sanitized)
+  }
+
+  const confirmEnable = () => {
+    if (!pendingEnableSettings) return
+    persistSettings(pendingEnableSettings)
+    setPendingEnableSettings(null)
+    setShowEnableDialog(false)
+  }
+
+  const handleEnableDialogChange = (open: boolean) => {
+    setShowEnableDialog(open)
+    if (!open) {
+      setPendingEnableSettings(null)
+    }
   }
 
   const handleToggleEnabled = (enabled: boolean) => {
@@ -353,6 +381,8 @@ export function TrackerReannounceForm({ instanceId, onInstanceChange, onSuccess,
 
   const settingsContent = (
     <div className="space-y-6">
+      <ReannounceEnableWarningAlert />
+
       <div className="space-y-4">
         <div className="flex items-center gap-2">
           <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wider">Timing & Behavior</h3>
@@ -700,41 +730,56 @@ export function TrackerReannounceForm({ instanceId, onInstanceChange, onSuccess,
     </div>
   )
 
+  const enableWarningDialog = (
+    <ReannounceEnableWarningDialog
+      open={showEnableDialog}
+      onOpenChange={handleEnableDialogChange}
+      onConfirm={confirmEnable}
+      confirming={isUpdating}
+    />
+  )
+
   if (variant === "embedded") {
     // Embedded mode: only show settings, no tabs (activity is shown in overview)
     return (
-      <form id={formId} onSubmit={handleSubmit} className="space-y-6">
-        {headerContent}
-        {settingsContent}
-      </form>
+      <>
+        <form id={formId} onSubmit={handleSubmit} className="space-y-6">
+          {headerContent}
+          {settingsContent}
+        </form>
+        {enableWarningDialog}
+      </>
     )
   }
 
   // Card mode: show tabs with settings and activity
   return (
-    <form onSubmit={handleSubmit}>
-      <Card className="w-full">
-        <CardHeader className="space-y-4">
-          {headerContent}
-        </CardHeader>
-        <CardContent>
-          <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-            <div className="flex items-center justify-between mb-4">
-              <TabsList className="grid w-full grid-cols-2 lg:w-[400px]">
-                <TabsTrigger value="settings">Settings</TabsTrigger>
-                <TabsTrigger value="activity">Activity Log</TabsTrigger>
-              </TabsList>
-            </div>
-            <TabsContent value="settings" className="mt-0">
-              {settingsContent}
-            </TabsContent>
-            <TabsContent value="activity" className="mt-0">
-              {activityContent}
-            </TabsContent>
-          </Tabs>
-        </CardContent>
-      </Card>
-    </form>
+    <>
+      <form onSubmit={handleSubmit}>
+        <Card className="w-full">
+          <CardHeader className="space-y-4">
+            {headerContent}
+          </CardHeader>
+          <CardContent>
+            <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
+              <div className="flex items-center justify-between mb-4">
+                <TabsList className="grid w-full grid-cols-2 lg:w-[400px]">
+                  <TabsTrigger value="settings">Settings</TabsTrigger>
+                  <TabsTrigger value="activity">Activity Log</TabsTrigger>
+                </TabsList>
+              </div>
+              <TabsContent value="settings" className="mt-0">
+                {settingsContent}
+              </TabsContent>
+              <TabsContent value="activity" className="mt-0">
+                {activityContent}
+              </TabsContent>
+            </Tabs>
+          </CardContent>
+        </Card>
+      </form>
+      {enableWarningDialog}
+    </>
   )
 }
 


### PR DESCRIPTION
Add a persistent caution note and blocking enable confirmation for automatic reannounce in both the settings form and the overview quick toggle. This keeps disable immediate, but makes every off -> on transition explicit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a warning alert and confirmation dialog when enabling reannounce monitoring in instance preferences and tracker settings.
  * Enabling now shows a confirmation step and a confirming/loading state while the change is applied.
  * Warning text clarifies implications of enabling reannounce monitoring.

* **Refactor**
  * Enable flow now defers applying changes until user confirmation; disabling still applies immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->