### PR TITLE
refactor(releases): share hdr normalization helpers

### DIFF
--- a/internal/services/crossseed/matching.go
+++ b/internal/services/crossseed/matching.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog/log"
 
+	"github.com/autobrr/qui/pkg/releases"
 	"github.com/autobrr/qui/pkg/stringutils"
 )
 
@@ -407,58 +408,8 @@ func joinNormalizedSlice(slice []string) string {
 }
 
 func joinNormalizedHDRSlice(slice []string) string {
-	if len(slice) == 0 {
-		return ""
-	}
-
-	seen := make(map[string]struct{}, len(slice))
-	hasHDR10Plus := false
-	for _, tag := range slice {
-		n := normalizeHDRVariant(tag)
-		if n == "" {
-			continue
-		}
-		if n == "HDR10+" {
-			hasHDR10Plus = true
-		}
-		seen[n] = struct{}{}
-	}
-
-	if hasHDR10Plus {
-		delete(seen, "HDR10")
-	}
-
-	normalized := make([]string, 0, len(seen))
-	for tag := range seen {
-		normalized = append(normalized, tag)
-	}
-
-	sort.Strings(normalized)
+	normalized := releases.NormalizeHDRTags(slice)
 	return strings.Join(normalized, " ")
-}
-
-func normalizeHDRVariant(value string) string {
-	upper := normalizeVariant(value)
-	if upper == "" {
-		return ""
-	}
-
-	key := strings.NewReplacer(" ", "", ".", "", "_", "", "-", "").Replace(upper)
-
-	switch key {
-	case "DOVI", "DOLBYVISION", "DV":
-		return "DV"
-	case "HDR10PLUS", "HDR10P", "HDR10+":
-		return "HDR10+"
-	case "HDR10":
-		return "HDR10"
-	case "HDR":
-		return "HDR"
-	case "HLG":
-		return "HLG"
-	default:
-		return upper
-	}
 }
 
 // videoCodecAliases maps equivalent video codec names to a canonical form.

--- a/pkg/releases/parser.go
+++ b/pkg/releases/parser.go
@@ -92,7 +92,7 @@ func enrichReleaseHDR(rawName string, release *rls.Release) {
 		}
 	}
 
-	release.HDR = normalizeHDRTags(tags)
+	release.HDR = NormalizeHDRTags(tags)
 }
 
 func shouldScanRawHDR(release *rls.Release) bool {
@@ -109,13 +109,10 @@ func shouldScanRawHDR(release *rls.Release) bool {
 	}
 
 	for _, codec := range release.Codec {
-		switch canonicalHDRTag(codec) {
+		switch CanonicalHDRTag(codec) {
 		case "DV", "HDR", "HDR10", "HDR10+", "HLG":
 			return true
 		}
-	}
-
-	for _, codec := range release.Codec {
 		upper := strings.ToUpper(strings.TrimSpace(codec))
 		switch upper {
 		case "X264", "H264", "H.264", "AVC", "X265", "H265", "H.265", "HEVC", "AV1", "XVID", "DIVX":
@@ -126,12 +123,14 @@ func shouldScanRawHDR(release *rls.Release) bool {
 	return false
 }
 
-func normalizeHDRTags(tags []string) []string {
+// NormalizeHDRTags deduplicates and canonicalizes a slice of HDR tag strings.
+// HDR10 is subsumed by HDR10+ when both are present. Returns nil for empty input.
+func NormalizeHDRTags(tags []string) []string {
 	seen := make(map[string]struct{}, len(tags))
 	hasHDR10Plus := false
 
 	for _, tag := range tags {
-		canonical := canonicalHDRTag(tag)
+		canonical := CanonicalHDRTag(tag)
 		if canonical == "" {
 			continue
 		}
@@ -253,7 +252,9 @@ func trailingTokenRegexes(token string) []*regexp.Regexp {
 	return actual.([]*regexp.Regexp)
 }
 
-func canonicalHDRTag(tag string) string {
+// CanonicalHDRTag maps an HDR tag string to its canonical form.
+// For example, "HDR10P", "HDR10PLUS", and "HDR10+" all map to "HDR10+".
+func CanonicalHDRTag(tag string) string {
 	upper := strings.ToUpper(strings.TrimSpace(tag))
 	if upper == "" {
 		return ""


### PR DESCRIPTION
Extract HDR canonicalization/normalization into pkg/releases and reuse it from cross-seed matching. This removes duplicated logic so parsing and matching stay aligned.\n\nVerified with make build and go test -race ./....

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized HDR tag normalization logic across the application for improved consistency and maintainability.
  * Enhanced HDR tag deduplication and canonicalization to more accurately handle tag variations and edge cases.
  * Improved HDR10+ tag handling to properly manage scenarios where both HDR10 and HDR10+ tags are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->