### PR TITLE
fix(external-programs): remove cmd.exe from Windows launches

### DIFF
--- a/documentation/docs/features/external-programs.md
+++ b/documentation/docs/features/external-programs.md
@@ -112,10 +112,22 @@ When "Launch in terminal window" is enabled, qui automatically detects and uses 
    - Terminal.app
 5. **Fallback**: If no terminal is found, the command runs in the background via `sh -c`
 
-On Windows, `cmd.exe` is always used.
+On Windows, qui launches the configured program directly. It does not wrap executions in `cmd.exe`, so torrent metadata is passed as literal arguments instead of shell-parsed text.
+
+:::warning Windows shell scripts
+`.bat`, `.cmd`, and shell-style command snippets are not launched implicitly on Windows.
+
+If you need custom script logic, prefer a wrapper that receives literal arguments, for example:
+
+- `C:\Program Files\PowerShell\7\pwsh.exe` with args `-File C:\path\to\script.ps1 {name}`
+
+Avoid `cmd.exe` or batch-file wrappers when passing torrent-derived placeholders such as `{name}` or `{content_path}`.
+:::
 
 :::tip
-Terminal windows stay open after the command finishes, allowing you to inspect output. Close the window manually when done.
+On Linux and macOS, terminal windows usually stay open after the command finishes so you can inspect output.
+
+On Windows, qui opens the program in a new console but does not keep that window open after the process exits. If you want a persistent terminal, use an explicit wrapper that holds the window open.
 :::
 
 ## Executing Programs

--- a/internal/services/externalprograms/command_other.go
+++ b/internal/services/externalprograms/command_other.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+//go:build !windows
+
+package externalprograms
+
+import (
+	"context"
+	"os/exec"
+)
+
+func buildNativeCommand(ctx context.Context, path string, args []string, _ bool) *exec.Cmd {
+	return exec.CommandContext(ctx, path, args...) //nolint:gosec // intentional external program execution
+}

--- a/internal/services/externalprograms/command_windows.go
+++ b/internal/services/externalprograms/command_windows.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+//go:build windows
+
+package externalprograms
+
+import (
+	"context"
+	"os/exec"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+func buildNativeCommand(ctx context.Context, path string, args []string, useTerminal bool) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, path, args...) //nolint:gosec // intentional external program execution
+	cmd.SysProcAttr = newWindowsSysProcAttr(useTerminal)
+
+	return cmd
+}
+
+func newWindowsSysProcAttr(useTerminal bool) *syscall.SysProcAttr {
+	attr := &syscall.SysProcAttr{
+		CreationFlags: windows.DETACHED_PROCESS,
+	}
+	if useTerminal {
+		attr.CreationFlags = windows.CREATE_NEW_CONSOLE
+	}
+
+	return attr
+}

--- a/internal/services/externalprograms/service.go
+++ b/internal/services/externalprograms/service.go
@@ -210,50 +210,28 @@ func (s *Service) executeAsync(
 	// Use background context for activity logging since parent context may be cancelled
 	ctx := context.Background()
 
-	if runtime.GOOS == "windows" {
-		// Windows: Use Run() which waits for cmd.exe to complete
-		// The 'start' command will spawn the process and cmd.exe will exit quickly
-		execErr := cmd.Run()
-		if execErr != nil {
-			log.Error().
-				Err(execErr).
-				Str("program", program.Name).
-				Str("hash", req.Torrent.Hash).
-				Str("command", fmt.Sprintf("%v", cmd.Args)).
-				Msg("external program failed to start")
-			s.logActivity(ctx, req.InstanceID, req.Torrent, program, req.RuleID, req.RuleName, false, fmt.Sprintf("program failed to start: %v", execErr))
-			return
-		}
-		// Log success - on Windows, Run() completing without error means the program started
-		s.logActivity(ctx, req.InstanceID, req.Torrent, program, req.RuleID, req.RuleName, true, "program started")
-	} else {
-		// Unix/Linux: Start the terminal emulator or direct process
-		execErr := cmd.Start()
-		if execErr != nil {
-			log.Error().
-				Err(execErr).
-				Str("program", program.Name).
-				Str("hash", req.Torrent.Hash).
-				Str("command", fmt.Sprintf("%v", cmd.Args)).
-				Msg("external program failed to start")
-			// Log failure activity
-			s.logActivity(ctx, req.InstanceID, req.Torrent, program, req.RuleID, req.RuleName, false, fmt.Sprintf("failed to start: %v", execErr))
-			return
-		}
+	execErr := cmd.Start()
+	if execErr != nil {
+		log.Error().
+			Err(execErr).
+			Str("program", program.Name).
+			Str("hash", req.Torrent.Hash).
+			Str("command", fmt.Sprintf("%v", cmd.Args)).
+			Msg("external program failed to start")
+		s.logActivity(ctx, req.InstanceID, req.Torrent, program, req.RuleID, req.RuleName, false, fmt.Sprintf("failed to start: %v", execErr))
+		return
+	}
 
-		// Log success - the program has actually started
-		s.logActivity(ctx, req.InstanceID, req.Torrent, program, req.RuleID, req.RuleName, true, "program started")
+	s.logActivity(ctx, req.InstanceID, req.Torrent, program, req.RuleID, req.RuleName, true, "program started")
 
-		// Wait for the process to prevent zombie processes
-		waitErr := cmd.Wait()
-		if waitErr != nil {
-			log.Warn().
-				Err(waitErr).
-				Str("program", program.Name).
-				Str("hash", req.Torrent.Hash).
-				Str("command", fmt.Sprintf("%v", cmd.Args)).
-				Msg("process exited with error (may be normal for terminal emulators)")
-		}
+	waitErr := cmd.Wait()
+	if waitErr != nil {
+		log.Warn().
+			Err(waitErr).
+			Str("program", program.Name).
+			Str("hash", req.Torrent.Hash).
+			Str("command", fmt.Sprintf("%v", cmd.Args)).
+			Msg("process exited with error (may be normal for terminal emulators)")
 	}
 
 	log.Info().
@@ -274,11 +252,8 @@ func (s *Service) buildCommand(ctx context.Context, program *models.ExternalProg
 // buildTerminalCommand creates a command that opens in a terminal window.
 func (s *Service) buildTerminalCommand(ctx context.Context, program *models.ExternalProgram, args []string) *exec.Cmd {
 	if runtime.GOOS == "windows" {
-		// Windows: Use cmd.exe /c start cmd /k to open a new visible terminal window
-		cmdArgs := make([]string, 0, 6+len(args))
-		cmdArgs = append(cmdArgs, "/c", "start", "", "cmd", "/k", program.Path)
-		cmdArgs = append(cmdArgs, args...)
-		return exec.CommandContext(ctx, "cmd.exe", cmdArgs...) //nolint:gosec // intentional external program execution
+		// Windows: launch the target directly in a new console to avoid cmd.exe injection.
+		return buildNativeCommand(ctx, program.Path, args, true)
 	}
 
 	// Unix/Linux: Build command string and spawn in a terminal
@@ -290,18 +265,12 @@ func (s *Service) buildTerminalCommand(ctx context.Context, program *models.Exte
 // buildDirectCommand creates a command that runs directly without a terminal.
 func (s *Service) buildDirectCommand(ctx context.Context, program *models.ExternalProgram, args []string) *exec.Cmd {
 	if runtime.GOOS == "windows" {
-		// Windows: Use 'start' to launch GUI apps properly (detached from parent process)
-		cmdArgs := make([]string, 0, 5+len(args))
-		cmdArgs = append(cmdArgs, "/c", "start", "", "/b", program.Path)
-		cmdArgs = append(cmdArgs, args...)
-		return exec.CommandContext(ctx, "cmd.exe", cmdArgs...) //nolint:gosec // intentional external program execution
+		// Windows: launch the target directly without cmd.exe to keep args literal.
+		return buildNativeCommand(ctx, program.Path, args, false)
 	}
 
 	// Unix/Linux: Direct execution
-	if len(args) > 0 {
-		return exec.CommandContext(ctx, program.Path, args...) //nolint:gosec // intentional external program execution
-	}
-	return exec.CommandContext(ctx, program.Path) //nolint:gosec // intentional external program execution
+	return buildNativeCommand(ctx, program.Path, args, false)
 }
 
 // terminalCandidate represents a terminal emulator to check for availability.

--- a/internal/services/externalprograms/service_test.go
+++ b/internal/services/externalprograms/service_test.go
@@ -1383,43 +1383,32 @@ func TestBuildCommand_Windows(t *testing.T) {
 
 	service := &Service{}
 	ctx := context.Background()
-	assertWindowsCmdPath := func(t *testing.T, path string) {
-		t.Helper()
-		assert.Equal(t, "cmd.exe", strings.ToLower(filepath.Base(path)))
-	}
 
-	t.Run("terminal mode uses cmd.exe with start cmd /k", func(t *testing.T) {
+	t.Run("terminal mode launches target directly", func(t *testing.T) {
 		program := &models.ExternalProgram{
 			Path:        "C:\\Programs\\test.exe",
 			UseTerminal: true,
 		}
 		cmd := service.buildCommand(ctx, program, []string{"arg1", "arg2"})
 
-		assertWindowsCmdPath(t, cmd.Path)
-		// Args should be: [cmd.exe, /c, start, "", cmd, /k, C:\Programs\test.exe, arg1, arg2]
-		assert.Contains(t, cmd.Args, "/c")
-		assert.Contains(t, cmd.Args, "start")
-		assert.Contains(t, cmd.Args, "cmd")
-		assert.Contains(t, cmd.Args, "/k")
-		assert.Contains(t, cmd.Args, "C:\\Programs\\test.exe")
+		assert.Equal(t, program.Path, cmd.Path)
+		assert.Equal(t, []string{program.Path, "arg1", "arg2"}, cmd.Args)
+		assert.NotNil(t, cmd.SysProcAttr)
 	})
 
-	t.Run("direct mode uses cmd.exe with start /b", func(t *testing.T) {
+	t.Run("direct mode launches target directly", func(t *testing.T) {
 		program := &models.ExternalProgram{
 			Path:        "C:\\Programs\\test.exe",
 			UseTerminal: false,
 		}
 		cmd := service.buildCommand(ctx, program, []string{"arg1"})
 
-		assertWindowsCmdPath(t, cmd.Path)
-		// Args should be: [cmd.exe, /c, start, "", /b, C:\Programs\test.exe, arg1]
-		assert.Contains(t, cmd.Args, "/c")
-		assert.Contains(t, cmd.Args, "start")
-		assert.Contains(t, cmd.Args, "/b")
-		assert.Contains(t, cmd.Args, "C:\\Programs\\test.exe")
+		assert.Equal(t, program.Path, cmd.Path)
+		assert.Equal(t, []string{program.Path, "arg1"}, cmd.Args)
+		assert.NotNil(t, cmd.SysProcAttr)
 	})
 
-	t.Run("arguments are passed correctly", func(t *testing.T) {
+	t.Run("arguments are passed literally", func(t *testing.T) {
 		program := &models.ExternalProgram{
 			Path:        "C:\\Programs\\test.exe",
 			UseTerminal: false,
@@ -1427,9 +1416,7 @@ func TestBuildCommand_Windows(t *testing.T) {
 		args := []string{"--name", "test value", "--hash", "abc123"}
 		cmd := service.buildCommand(ctx, program, args)
 
-		for _, arg := range args {
-			assert.Contains(t, cmd.Args, arg, "argument %q should be in command", arg)
-		}
+		assert.Equal(t, append([]string{program.Path}, args...), cmd.Args)
 	})
 
 	t.Run("terminal mode with no arguments", func(t *testing.T) {
@@ -1439,12 +1426,9 @@ func TestBuildCommand_Windows(t *testing.T) {
 		}
 		cmd := service.buildCommand(ctx, program, nil)
 
-		assertWindowsCmdPath(t, cmd.Path)
-		assert.Contains(t, cmd.Args, "/c")
-		assert.Contains(t, cmd.Args, "start")
-		assert.Contains(t, cmd.Args, "cmd")
-		assert.Contains(t, cmd.Args, "/k")
-		assert.Contains(t, cmd.Args, "C:\\Programs\\test.exe")
+		assert.Equal(t, program.Path, cmd.Path)
+		assert.Equal(t, []string{program.Path}, cmd.Args)
+		assert.NotNil(t, cmd.SysProcAttr)
 	})
 
 	t.Run("direct mode with no arguments", func(t *testing.T) {
@@ -1454,11 +1438,9 @@ func TestBuildCommand_Windows(t *testing.T) {
 		}
 		cmd := service.buildCommand(ctx, program, nil)
 
-		assertWindowsCmdPath(t, cmd.Path)
-		assert.Contains(t, cmd.Args, "/c")
-		assert.Contains(t, cmd.Args, "start")
-		assert.Contains(t, cmd.Args, "/b")
-		assert.Contains(t, cmd.Args, "C:\\Programs\\test.exe")
+		assert.Equal(t, program.Path, cmd.Path)
+		assert.Equal(t, []string{program.Path}, cmd.Args)
+		assert.NotNil(t, cmd.SysProcAttr)
 	})
 
 	t.Run("path with spaces in terminal mode", func(t *testing.T) {
@@ -1468,8 +1450,8 @@ func TestBuildCommand_Windows(t *testing.T) {
 		}
 		cmd := service.buildCommand(ctx, program, []string{"--arg", "value"})
 
-		assertWindowsCmdPath(t, cmd.Path)
-		assert.Contains(t, cmd.Args, "C:\\Program Files\\My App\\test.exe")
+		assert.Equal(t, program.Path, cmd.Path)
+		assert.Equal(t, []string{program.Path, "--arg", "value"}, cmd.Args)
 	})
 
 	t.Run("path with spaces in direct mode", func(t *testing.T) {
@@ -1479,21 +1461,19 @@ func TestBuildCommand_Windows(t *testing.T) {
 		}
 		cmd := service.buildCommand(ctx, program, []string{"--arg", "value"})
 
-		assertWindowsCmdPath(t, cmd.Path)
-		assert.Contains(t, cmd.Args, "C:\\Program Files\\My App\\test.exe")
+		assert.Equal(t, program.Path, cmd.Path)
+		assert.Equal(t, []string{program.Path, "--arg", "value"}, cmd.Args)
 	})
 
-	t.Run("arguments with special characters", func(t *testing.T) {
+	t.Run("metacharacters stay inside arguments", func(t *testing.T) {
 		program := &models.ExternalProgram{
 			Path:        "C:\\Programs\\test.exe",
 			UseTerminal: false,
 		}
-		args := []string{"--name", "Test & Value", "--path", "C:\\My Files\\data"}
+		args := []string{"--name", "SAFE&whoami>%TEMP%\\qui_poc.txt", "--path", "C:\\My Files\\data"}
 		cmd := service.buildCommand(ctx, program, args)
 
-		for _, arg := range args {
-			assert.Contains(t, cmd.Args, arg, "argument %q should be in command", arg)
-		}
+		assert.Equal(t, append([]string{program.Path}, args...), cmd.Args)
 	})
 }
 

--- a/internal/services/externalprograms/service_windows_test.go
+++ b/internal/services/externalprograms/service_windows_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+//go:build windows
+
+package externalprograms
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/autobrr/qui/internal/models"
+)
+
+func TestBuildCommand_WindowsCreationFlags(t *testing.T) {
+	service := &Service{}
+	ctx := context.Background()
+
+	t.Run("terminal mode gets new console", func(t *testing.T) {
+		cmd := service.buildCommand(ctx, &models.ExternalProgram{
+			Path:        `C:\Programs\test.exe`,
+			UseTerminal: true,
+		}, []string{"arg1"})
+
+		assert.NotNil(t, cmd.SysProcAttr)
+		assert.Equal(t, newWindowsSysProcAttr(true).CreationFlags, cmd.SysProcAttr.CreationFlags)
+	})
+
+	t.Run("direct mode stays detached", func(t *testing.T) {
+		cmd := service.buildCommand(ctx, &models.ExternalProgram{
+			Path:        `C:\Programs\test.exe`,
+			UseTerminal: false,
+		}, []string{"arg1"})
+
+		assert.NotNil(t, cmd.SysProcAttr)
+		assert.Equal(t, newWindowsSysProcAttr(false).CreationFlags, cmd.SysProcAttr.CreationFlags)
+	})
+}


### PR DESCRIPTION
This removes the Windows `cmd.exe` hop from external program execution and launches configured programs directly instead. That closes the command-injection path where torrent-derived metadata could be interpreted as shell syntax.

It also updates Windows-specific tests and the external programs docs to reflect the new behavior, including the hard cut that shell wrappers must now be configured explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * External programs on Windows now launch directly without shell interpretation; arguments are passed literally.
  
* **Bug Fixes**
  * Improved argument handling to prevent shell metacharacter injection across platforms.

* **Documentation**
  * Updated guidance on external program execution with platform-specific behavior clarifications for Windows, Linux, and macOS.
  * Added recommendations for shell script handling and terminal window persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->