### PR TITLE
fix(crossseed): relax discovery matching

### DIFF
--- a/internal/services/crossseed/matching.go
+++ b/internal/services/crossseed/matching.go
@@ -300,7 +300,7 @@ func (s *Service) releasesMatchWithDiscovery(source, candidate *rls.Release, fin
 	// If one release has HDR metadata and the other doesn't, they cannot match
 	sourceHDR := joinNormalizedHDRSlice(source.HDR)
 	candidateHDR := joinNormalizedHDRSlice(candidate.HDR)
-	if sourceHDR != candidateHDR {
+	if sourceHDR != candidateHDR && !shouldSkipBDMVHDRMatch(sourceCtx, sourceHDR) {
 		return false
 	}
 
@@ -560,6 +560,17 @@ func joinNormalizedSlice(slice []string) string {
 func joinNormalizedHDRSlice(slice []string) string {
 	normalized := releases.NormalizeHDRTags(slice)
 	return strings.Join(normalized, " ")
+}
+
+func shouldSkipBDMVHDRMatch(ctx resolutionMatchContext, normalizedHDR string) bool {
+	if !ctx.discLayout || !strings.EqualFold(ctx.discMarker, "BDMV") {
+		return false
+	}
+
+	// COMPLETE BDMV titles often omit HDR metadata entirely, and some rls parses
+	// surface that as an empty HDR payload. Treat empty source HDR as "unknown" so
+	// discovery matching can still consider HDR candidates for the disc.
+	return normalizedHDR == ""
 }
 
 // videoCodecAliases maps equivalent video codec names to a canonical form.

--- a/internal/services/crossseed/matching.go
+++ b/internal/services/crossseed/matching.go
@@ -65,6 +65,12 @@ type releaseKey struct {
 	day   int
 }
 
+type resolutionMatchContext struct {
+	discLayout bool
+	discMarker string
+	rawName    string
+}
+
 // makeReleaseKey creates a releaseKey from a parsed release.
 // Returns the zero value if the release doesn't have identifiable metadata.
 func makeReleaseKey(r *rls.Release) releaseKey {
@@ -119,14 +125,18 @@ func (k releaseKey) String() string {
 // releasesMatch keeps the historical strict identity semantics used by local
 // match views, deduplication, and other places that must avoid widening.
 func (s *Service) releasesMatch(source, candidate *rls.Release, findIndividualEpisodes bool) bool {
-	return s.releasesMatchWithDiscovery(source, candidate, findIndividualEpisodes, false)
+	return s.releasesMatchWithDiscovery(source, candidate, findIndividualEpisodes, false, resolutionMatchContext{}, resolutionMatchContext{})
 }
 
 func (s *Service) releasesMatchDiscovery(source, candidate *rls.Release, findIndividualEpisodes bool) bool {
-	return s.releasesMatchWithDiscovery(source, candidate, findIndividualEpisodes, true)
+	return s.releasesMatchWithDiscovery(source, candidate, findIndividualEpisodes, true, resolutionMatchContext{}, resolutionMatchContext{})
 }
 
-func (s *Service) releasesMatchWithDiscovery(source, candidate *rls.Release, findIndividualEpisodes bool, allowDiscoveryRelaxations bool) bool {
+func (s *Service) releasesMatchDiscoveryWithContext(source, candidate *rls.Release, findIndividualEpisodes bool, sourceCtx, candidateCtx resolutionMatchContext) bool {
+	return s.releasesMatchWithDiscovery(source, candidate, findIndividualEpisodes, true, sourceCtx, candidateCtx)
+}
+
+func (s *Service) releasesMatchWithDiscovery(source, candidate *rls.Release, findIndividualEpisodes bool, allowDiscoveryRelaxations bool, sourceCtx, candidateCtx resolutionMatchContext) bool {
 	if source == candidate {
 		return true
 	}
@@ -212,7 +222,7 @@ func (s *Service) releasesMatchWithDiscovery(source, candidate *rls.Release, fin
 	}
 
 	if allowDiscoveryRelaxations {
-		if !discoveryMetadataMatch(s, source, candidate) {
+		if !discoveryMetadataMatch(s, source, candidate, sourceCtx, candidateCtx) {
 			return false
 		}
 	} else {
@@ -263,24 +273,8 @@ func (s *Service) releasesMatchWithDiscovery(source, candidate *rls.Release, fin
 
 		// Resolution must match (1080p vs 2160p are different files).
 		// Exception: empty resolution is allowed to match SD resolutions (480p, 576p, SD).
-		sourceRes := normalizer.Normalize(source.Resolution)
-		candidateRes := normalizer.Normalize(candidate.Resolution)
-		if sourceRes != candidateRes {
-			// rls omits resolution for many SD releases (e.g. "WEB" without "480p"), so
-			// treat an empty resolution as a match only when the other side is clearly SD.
-			isKnownSD := func(res string) bool {
-				switch normalizeVariant(res) {
-				case "480P", "576P", "SD":
-					return true
-				default:
-					return false
-				}
-			}
-
-			sdFallbackAllowed := (sourceRes == "" && isKnownSD(candidateRes)) || (candidateRes == "" && isKnownSD(sourceRes))
-			if !sdFallbackAllowed {
-				return false
-			}
+		if !resolutionsCompatible(normalizer, source, candidate, sourceCtx, candidateCtx) {
+			return false
 		}
 	}
 
@@ -443,7 +437,7 @@ func normalizeDiscoveryTitle(title string) string {
 	return strings.Join(filtered, " ")
 }
 
-func discoveryMetadataMatch(s *Service, source, candidate *rls.Release) bool {
+func discoveryMetadataMatch(s *Service, source, candidate *rls.Release, sourceCtx, candidateCtx resolutionMatchContext) bool {
 	normalizer := s.stringNormalizer
 	if normalizer == nil {
 		normalizer = stringutils.DefaultNormalizer
@@ -465,22 +459,8 @@ func discoveryMetadataMatch(s *Service, source, candidate *rls.Release) bool {
 		return false
 	}
 
-	sourceRes := normalizer.Normalize(source.Resolution)
-	candidateRes := normalizer.Normalize(candidate.Resolution)
-	if sourceRes != candidateRes {
-		isKnownSD := func(res string) bool {
-			switch normalizeVariant(res) {
-			case "480P", "576P", "SD":
-				return true
-			default:
-				return false
-			}
-		}
-
-		sdFallbackAllowed := (sourceRes == "" && isKnownSD(candidateRes)) || (candidateRes == "" && isKnownSD(sourceRes))
-		if !sdFallbackAllowed {
-			return false
-		}
+	if !resolutionsCompatible(normalizer, source, candidate, sourceCtx, candidateCtx) {
+		return false
 	}
 
 	sourceVersion := normalizer.Normalize(source.Version)
@@ -510,6 +490,57 @@ func discoveryReleaseGroupCompatible(normalizer *stringutils.Normalizer[string, 
 	}
 
 	return strings.HasPrefix(sourceNorm, candidateNorm) || strings.HasPrefix(candidateNorm, sourceNorm)
+}
+
+func resolutionsCompatible(normalizer *stringutils.Normalizer[string, string], source, candidate *rls.Release, sourceCtx, candidateCtx resolutionMatchContext) bool {
+	if normalizer == nil {
+		normalizer = stringutils.DefaultNormalizer
+	}
+
+	sourceRes := normalizeVariant(normalizer.Normalize(source.Resolution))
+	candidateRes := normalizeVariant(normalizer.Normalize(candidate.Resolution))
+	if sourceRes == candidateRes {
+		return true
+	}
+
+	// rls omits resolution for many SD releases (e.g. "WEB" without "480p"), so
+	// treat an empty resolution as a match only when the other side is clearly SD.
+	if (sourceRes == "" && isKnownSDResolution(candidateRes)) || (candidateRes == "" && isKnownSDResolution(sourceRes)) {
+		return true
+	}
+
+	// Disc-layout search sources can omit the explicit resolution even when the
+	// raw torrent name and layout marker clearly identify the disc format.
+	if sourceRes == "" && inferredResolutionFromContext(source, sourceCtx) == candidateRes {
+		return true
+	}
+	if candidateRes == "" && inferredResolutionFromContext(candidate, candidateCtx) == sourceRes {
+		return true
+	}
+
+	return false
+}
+
+func isKnownSDResolution(resolution string) bool {
+	switch normalizeVariant(resolution) {
+	case "480P", "576P", "SD":
+		return true
+	default:
+		return false
+	}
+}
+
+func inferredResolutionFromContext(release *rls.Release, ctx resolutionMatchContext) string {
+	if release == nil || !ctx.discLayout || !strings.EqualFold(ctx.discMarker, "BDMV") {
+		return ""
+	}
+
+	titleHint := normalizeVariant(ctx.rawName)
+	if normalizeSource(release.Source) == "UHD.BLURAY" || strings.Contains(titleHint, "UHD") {
+		return "2160P"
+	}
+
+	return "1080P"
 }
 
 // joinNormalizedSlice converts a string slice to a normalized uppercase string for comparison.

--- a/internal/services/crossseed/matching.go
+++ b/internal/services/crossseed/matching.go
@@ -65,13 +65,6 @@ type releaseKey struct {
 	day   int
 }
 
-type releaseMatchMode uint8
-
-const (
-	releaseMatchModeIdentity releaseMatchMode = iota
-	releaseMatchModeDiscovery
-)
-
 // makeReleaseKey creates a releaseKey from a parsed release.
 // Returns the zero value if the release doesn't have identifiable metadata.
 func makeReleaseKey(r *rls.Release) releaseKey {
@@ -126,19 +119,19 @@ func (k releaseKey) String() string {
 // releasesMatch keeps the historical strict identity semantics used by local
 // match views, deduplication, and other places that must avoid widening.
 func (s *Service) releasesMatch(source, candidate *rls.Release, findIndividualEpisodes bool) bool {
-	return s.releasesMatchMode(source, candidate, findIndividualEpisodes, releaseMatchModeIdentity)
+	return s.releasesMatchWithDiscovery(source, candidate, findIndividualEpisodes, false)
 }
 
 func (s *Service) releasesMatchDiscovery(source, candidate *rls.Release, findIndividualEpisodes bool) bool {
-	return s.releasesMatchMode(source, candidate, findIndividualEpisodes, releaseMatchModeDiscovery)
+	return s.releasesMatchWithDiscovery(source, candidate, findIndividualEpisodes, true)
 }
 
-func (s *Service) releasesMatchMode(source, candidate *rls.Release, findIndividualEpisodes bool, mode releaseMatchMode) bool {
+func (s *Service) releasesMatchWithDiscovery(source, candidate *rls.Release, findIndividualEpisodes bool, allowDiscoveryRelaxations bool) bool {
 	if source == candidate {
 		return true
 	}
 
-	if !releaseTitlesMatch(source.Title, candidate.Title, mode) {
+	if !titlesMatch(source.Title, candidate.Title, allowDiscoveryRelaxations) {
 		return false
 	}
 
@@ -213,7 +206,7 @@ func (s *Service) releasesMatchMode(source, candidate *rls.Release, findIndividu
 		}
 	}
 
-	if mode == releaseMatchModeDiscovery {
+	if allowDiscoveryRelaxations {
 		return discoveryMetadataMatch(s, source, candidate)
 	}
 
@@ -396,7 +389,7 @@ func (s *Service) releasesMatchMode(source, candidate *rls.Release, findIndividu
 	return true
 }
 
-func releaseTitlesMatch(sourceTitle, candidateTitle string, mode releaseMatchMode) bool {
+func titlesMatch(sourceTitle, candidateTitle string, allowDiscoveryRelaxations bool) bool {
 	sourceTitleNorm := stringutils.NormalizeForMatching(sourceTitle)
 	candidateTitleNorm := stringutils.NormalizeForMatching(candidateTitle)
 	if sourceTitleNorm == "" || candidateTitleNorm == "" {
@@ -405,7 +398,7 @@ func releaseTitlesMatch(sourceTitle, candidateTitle string, mode releaseMatchMod
 	if sourceTitleNorm == candidateTitleNorm {
 		return true
 	}
-	if mode != releaseMatchModeDiscovery {
+	if !allowDiscoveryRelaxations {
 		return false
 	}
 
@@ -422,7 +415,18 @@ func normalizeDiscoveryTitle(title string) string {
 
 	filtered := tokens[:0]
 	for _, token := range tokens {
-		if isIgnorableDiscoveryTitleToken(token) {
+		switch strings.TrimSpace(strings.ToLower(token)) {
+		case "", "us", "uk", "au", "ca", "jp", "kr", "cn", "de", "fr", "es", "it", "se", "no", "fi", "dk", "nl", "be":
+			continue
+		}
+		ignorable := true
+		for _, r := range token {
+			if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+				ignorable = false
+				break
+			}
+		}
+		if ignorable {
 			continue
 		}
 		filtered = append(filtered, token)
@@ -430,28 +434,19 @@ func normalizeDiscoveryTitle(title string) string {
 	return strings.Join(filtered, " ")
 }
 
-func isIgnorableDiscoveryTitleToken(token string) bool {
-	switch strings.TrimSpace(strings.ToLower(token)) {
-	case "", "us", "uk", "au", "ca", "jp", "kr", "cn", "de", "fr", "es", "it", "se", "no", "fi", "dk", "nl", "be":
-		return true
-	}
-
-	for _, r := range token {
-		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
-			return false
-		}
-	}
-	return true
-}
-
 func discoveryMetadataMatch(s *Service, source, candidate *rls.Release) bool {
-	sourceGroup := discoveryReleaseGroupValue(s.stringNormalizer, source.Group)
-	candidateGroup := discoveryReleaseGroupValue(s.stringNormalizer, candidate.Group)
+	normalizer := s.stringNormalizer
+	if normalizer == nil {
+		normalizer = stringutils.DefaultNormalizer
+	}
+
+	sourceGroup := normalizer.Normalize(source.Group)
+	candidateGroup := normalizer.Normalize(candidate.Group)
 	if sourceGroup != "" && candidateGroup != "" {
-		if !discoveryReleaseGroupCompatible(s.stringNormalizer, source.Group, candidate.Group) {
+		if !discoveryReleaseGroupCompatible(normalizer, source.Group, candidate.Group) {
 			return false
 		}
-	} else if !discoveryReleaseGroupCompatible(s.stringNormalizer, source.Site, candidate.Site) {
+	} else if !discoveryReleaseGroupCompatible(normalizer, source.Site, candidate.Site) {
 		return false
 	}
 
@@ -489,13 +484,6 @@ func discoveryMetadataMatch(s *Service, source, candidate *rls.Release) bool {
 	}
 
 	return true
-}
-
-func discoveryReleaseGroupValue(normalizer *stringutils.Normalizer[string, string], value string) string {
-	if normalizer == nil {
-		normalizer = stringutils.DefaultNormalizer
-	}
-	return normalizer.Normalize(value)
 }
 
 func discoveryReleaseGroupCompatible(normalizer *stringutils.Normalizer[string, string], sourceValue, candidateValue string) bool {

--- a/internal/services/crossseed/matching.go
+++ b/internal/services/crossseed/matching.go
@@ -65,6 +65,13 @@ type releaseKey struct {
 	day   int
 }
 
+type releaseMatchMode uint8
+
+const (
+	releaseMatchModeIdentity releaseMatchMode = iota
+	releaseMatchModeDiscovery
+)
+
 // makeReleaseKey creates a releaseKey from a parsed release.
 // Returns the zero value if the release doesn't have identifiable metadata.
 func makeReleaseKey(r *rls.Release) releaseKey {
@@ -116,30 +123,22 @@ func (k releaseKey) String() string {
 	return fmt.Sprintf("%d|%d|%d|%d|%d", k.series, k.episode, k.year, k.month, k.day)
 }
 
-// releasesMatch checks if two releases are related using fuzzy matching.
-// This allows matching similar content that isn't exactly the same.
+// releasesMatch keeps the historical strict identity semantics used by local
+// match views, deduplication, and other places that must avoid widening.
 func (s *Service) releasesMatch(source, candidate *rls.Release, findIndividualEpisodes bool) bool {
+	return s.releasesMatchMode(source, candidate, findIndividualEpisodes, releaseMatchModeIdentity)
+}
+
+func (s *Service) releasesMatchDiscovery(source, candidate *rls.Release, findIndividualEpisodes bool) bool {
+	return s.releasesMatchMode(source, candidate, findIndividualEpisodes, releaseMatchModeDiscovery)
+}
+
+func (s *Service) releasesMatchMode(source, candidate *rls.Release, findIndividualEpisodes bool, mode releaseMatchMode) bool {
 	if source == candidate {
 		return true
 	}
 
-	// Title should match closely but not necessarily exactly.
-	// Use punctuation-stripping normalization to handle differences like
-	// "Bob's Burgers" vs "Bobs.Burgers" (apostrophes lost in dot notation).
-	sourceTitleNorm := stringutils.NormalizeForMatching(source.Title)
-	candidateTitleNorm := stringutils.NormalizeForMatching(candidate.Title)
-
-	if sourceTitleNorm == "" || candidateTitleNorm == "" {
-		return false
-	}
-
-	// Require exact title match after normalization.
-	//
-	// This is intentionally strict to avoid false positives between related-but-distinct
-	// TV franchises/spinoffs (e.g. "FBI" vs "FBI Most Wanted") where substring matching
-	// would incorrectly treat them as the same show.
-	if sourceTitleNorm != candidateTitleNorm {
-		// Title mismatches are expected for most candidates - don't log to avoid noise
+	if !releaseTitlesMatch(source.Title, candidate.Title, mode) {
 		return false
 	}
 
@@ -212,6 +211,10 @@ func (s *Service) releasesMatch(source, candidate *rls.Release, findIndividualEp
 				return false
 			}
 		}
+	}
+
+	if mode == releaseMatchModeDiscovery {
+		return discoveryMetadataMatch(s, source, candidate)
 	}
 
 	// Group tags should match for proper cross-seeding compatibility.
@@ -391,6 +394,122 @@ func (s *Service) releasesMatch(source, candidate *rls.Release, findIndividualEp
 	}
 
 	return true
+}
+
+func releaseTitlesMatch(sourceTitle, candidateTitle string, mode releaseMatchMode) bool {
+	sourceTitleNorm := stringutils.NormalizeForMatching(sourceTitle)
+	candidateTitleNorm := stringutils.NormalizeForMatching(candidateTitle)
+	if sourceTitleNorm == "" || candidateTitleNorm == "" {
+		return false
+	}
+	if sourceTitleNorm == candidateTitleNorm {
+		return true
+	}
+	if mode != releaseMatchModeDiscovery {
+		return false
+	}
+
+	sourceDiscovery := normalizeDiscoveryTitle(sourceTitleNorm)
+	candidateDiscovery := normalizeDiscoveryTitle(candidateTitleNorm)
+	return sourceDiscovery != "" && sourceDiscovery == candidateDiscovery
+}
+
+func normalizeDiscoveryTitle(title string) string {
+	tokens := strings.Fields(title)
+	if len(tokens) == 0 {
+		return ""
+	}
+
+	filtered := tokens[:0]
+	for _, token := range tokens {
+		if isIgnorableDiscoveryTitleToken(token) {
+			continue
+		}
+		filtered = append(filtered, token)
+	}
+	return strings.Join(filtered, " ")
+}
+
+func isIgnorableDiscoveryTitleToken(token string) bool {
+	switch strings.TrimSpace(strings.ToLower(token)) {
+	case "", "us", "uk", "au", "ca", "jp", "kr", "cn", "de", "fr", "es", "it", "se", "no", "fi", "dk", "nl", "be":
+		return true
+	}
+
+	for _, r := range token {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			return false
+		}
+	}
+	return true
+}
+
+func discoveryMetadataMatch(s *Service, source, candidate *rls.Release) bool {
+	sourceGroup := discoveryReleaseGroupValue(s.stringNormalizer, source.Group)
+	candidateGroup := discoveryReleaseGroupValue(s.stringNormalizer, candidate.Group)
+	if sourceGroup != "" && candidateGroup != "" {
+		if !discoveryReleaseGroupCompatible(s.stringNormalizer, source.Group, candidate.Group) {
+			return false
+		}
+	} else if !discoveryReleaseGroupCompatible(s.stringNormalizer, source.Site, candidate.Site) {
+		return false
+	}
+
+	sourceSource := normalizeSource(source.Source)
+	candidateSource := normalizeSource(candidate.Source)
+	if !sourcesCompatible(sourceSource, candidateSource) {
+		return false
+	}
+
+	sourceRes := s.stringNormalizer.Normalize(source.Resolution)
+	candidateRes := s.stringNormalizer.Normalize(candidate.Resolution)
+	if sourceRes != candidateRes {
+		isKnownSD := func(res string) bool {
+			switch normalizeVariant(res) {
+			case "480P", "576P", "SD":
+				return true
+			default:
+				return false
+			}
+		}
+
+		sdFallbackAllowed := (sourceRes == "" && isKnownSD(candidateRes)) || (candidateRes == "" && isKnownSD(sourceRes))
+		if !sdFallbackAllowed {
+			return false
+		}
+	}
+
+	sourceVersion := s.stringNormalizer.Normalize(source.Version)
+	candidateVersion := s.stringNormalizer.Normalize(candidate.Version)
+	if (sourceVersion == "") != (candidateVersion == "") {
+		return false
+	}
+	if sourceVersion != "" && candidateVersion != "" && sourceVersion != candidateVersion {
+		return false
+	}
+
+	return true
+}
+
+func discoveryReleaseGroupValue(normalizer *stringutils.Normalizer[string, string], value string) string {
+	if normalizer == nil {
+		normalizer = stringutils.DefaultNormalizer
+	}
+	return normalizer.Normalize(value)
+}
+
+func discoveryReleaseGroupCompatible(normalizer *stringutils.Normalizer[string, string], sourceValue, candidateValue string) bool {
+	if normalizer == nil {
+		normalizer = stringutils.DefaultNormalizer
+	}
+
+	sourceNorm := normalizer.Normalize(sourceValue)
+	candidateNorm := normalizer.Normalize(candidateValue)
+	if sourceNorm == "" || candidateNorm == "" {
+		return true
+	}
+
+	return strings.HasPrefix(sourceNorm, candidateNorm) || strings.HasPrefix(candidateNorm, sourceNorm)
 }
 
 // joinNormalizedSlice converts a string slice to a normalized uppercase string for comparison.

--- a/internal/services/crossseed/matching.go
+++ b/internal/services/crossseed/matching.go
@@ -456,8 +456,8 @@ func discoveryMetadataMatch(s *Service, source, candidate *rls.Release) bool {
 		return false
 	}
 
-	sourceRes := s.stringNormalizer.Normalize(source.Resolution)
-	candidateRes := s.stringNormalizer.Normalize(candidate.Resolution)
+	sourceRes := normalizer.Normalize(source.Resolution)
+	candidateRes := normalizer.Normalize(candidate.Resolution)
 	if sourceRes != candidateRes {
 		isKnownSD := func(res string) bool {
 			switch normalizeVariant(res) {
@@ -474,8 +474,8 @@ func discoveryMetadataMatch(s *Service, source, candidate *rls.Release) bool {
 		}
 	}
 
-	sourceVersion := s.stringNormalizer.Normalize(source.Version)
-	candidateVersion := s.stringNormalizer.Normalize(candidate.Version)
+	sourceVersion := normalizer.Normalize(source.Version)
+	candidateVersion := normalizer.Normalize(candidate.Version)
 	if (sourceVersion == "") != (candidateVersion == "") {
 		return false
 	}
@@ -486,6 +486,9 @@ func discoveryMetadataMatch(s *Service, source, candidate *rls.Release) bool {
 	return true
 }
 
+// discoveryReleaseGroupCompatible is intentionally permissive for discovery filtering.
+// It uses strings.HasPrefix on normalized values, so "FLUX" and "FLUXUS" are treated
+// as compatible here and stricter downstream file verification decides the final match.
 func discoveryReleaseGroupCompatible(normalizer *stringutils.Normalizer[string, string], sourceValue, candidateValue string) bool {
 	if normalizer == nil {
 		normalizer = stringutils.DefaultNormalizer

--- a/internal/services/crossseed/matching.go
+++ b/internal/services/crossseed/matching.go
@@ -131,6 +131,11 @@ func (s *Service) releasesMatchWithDiscovery(source, candidate *rls.Release, fin
 		return true
 	}
 
+	normalizer := s.stringNormalizer
+	if normalizer == nil {
+		normalizer = stringutils.DefaultNormalizer
+	}
+
 	if !titlesMatch(source.Title, candidate.Title, allowDiscoveryRelaxations) {
 		return false
 	}
@@ -140,8 +145,8 @@ func (s *Service) releasesMatchWithDiscovery(source, candidate *rls.Release, fin
 	// Artist must match for content with artist metadata (music, 0day scene radio shows, etc.)
 	// This prevents matching different artists with the same show/album title.
 	if source.Artist != "" && candidate.Artist != "" {
-		sourceArtist := s.stringNormalizer.Normalize(source.Artist)
-		candidateArtist := s.stringNormalizer.Normalize(candidate.Artist)
+		sourceArtist := normalizer.Normalize(source.Artist)
+		candidateArtist := normalizer.Normalize(candidate.Artist)
 		if sourceArtist != candidateArtist {
 			return false
 		}
@@ -207,80 +212,82 @@ func (s *Service) releasesMatchWithDiscovery(source, candidate *rls.Release, fin
 	}
 
 	if allowDiscoveryRelaxations {
-		return discoveryMetadataMatch(s, source, candidate)
-	}
-
-	// Group tags should match for proper cross-seeding compatibility.
-	// Different release groups often have different encoding settings and file structures.
-	sourceGroup := s.stringNormalizer.Normalize((source.Group))
-	candidateGroup := s.stringNormalizer.Normalize((candidate.Group))
-
-	// Only enforce group matching if the source has a group tag
-	if sourceGroup != "" {
-		// If source has a group, candidate must have the same group
-		if candidateGroup == "" || sourceGroup != candidateGroup {
+		if !discoveryMetadataMatch(s, source, candidate) {
 			return false
 		}
-	}
-	// If source has no group, we don't care about candidate's group
+	} else {
+		// Group tags should match for proper cross-seeding compatibility.
+		// Different release groups often have different encoding settings and file structures.
+		sourceGroup := normalizer.Normalize(source.Group)
+		candidateGroup := normalizer.Normalize(candidate.Group)
 
-	// Site field is used by anime releases where group is in brackets like [SubsPlease].
-	// rls parses these as Site rather than Group. Different fansub groups can never
-	// cross-seed, but many indexer titles omit the site tag entirely. Treat mismatched
-	// non-empty site tags as incompatible, but don't reject candidates that simply
-	// lack this metadata.
-	sourceSite := s.stringNormalizer.Normalize(source.Site)
-	candidateSite := s.stringNormalizer.Normalize(candidate.Site)
-	if sourceSite != "" && candidateSite != "" && sourceSite != candidateSite {
-		return false
-	}
+		// Only enforce group matching if the source has a group tag
+		if sourceGroup != "" {
+			// If source has a group, candidate must have the same group
+			if candidateGroup == "" || sourceGroup != candidateGroup {
+				return false
+			}
+		}
+		// If source has no group, we don't care about candidate's group
 
-	// Sum field contains the CRC32 checksum for anime releases like [32ECE75A].
-	// Different checksums mean different files with 100% certainty.
-	sourceSum := s.stringNormalizer.Normalize(source.Sum)
-	candidateSum := s.stringNormalizer.Normalize(candidate.Sum)
-	if sourceSum != "" {
-		if candidateSum == "" || sourceSum != candidateSum {
+		// Site field is used by anime releases where group is in brackets like [SubsPlease].
+		// rls parses these as Site rather than Group. Different fansub groups can never
+		// cross-seed, but many indexer titles omit the site tag entirely. Treat mismatched
+		// non-empty site tags as incompatible, but don't reject candidates that simply
+		// lack this metadata.
+		sourceSite := normalizer.Normalize(source.Site)
+		candidateSite := normalizer.Normalize(candidate.Site)
+		if sourceSite != "" && candidateSite != "" && sourceSite != candidateSite {
 			return false
 		}
-	}
 
-	// Source must be compatible if both are present.
-	// WEB is ambiguous and matches both WEB-DL and WEBRip.
-	// WEB-DL and WEBRip are explicitly different and do not match.
-	// Other sources (BluRay, HDTV, etc.) must match exactly.
-	sourceSource := normalizeSource(source.Source)
-	candidateSource := normalizeSource(candidate.Source)
-	if !sourcesCompatible(sourceSource, candidateSource) {
-		return false
-	}
-
-	// Resolution must match (1080p vs 2160p are different files).
-	// Exception: empty resolution is allowed to match SD resolutions (480p, 576p, SD).
-	sourceRes := s.stringNormalizer.Normalize((source.Resolution))
-	candidateRes := s.stringNormalizer.Normalize((candidate.Resolution))
-	if sourceRes != candidateRes {
-		// rls omits resolution for many SD releases (e.g. "WEB" without "480p"), so
-		// treat an empty resolution as a match only when the other side is clearly SD.
-		isKnownSD := func(res string) bool {
-			switch normalizeVariant(res) {
-			case "480P", "576P", "SD":
-				return true
-			default:
+		// Sum field contains the CRC32 checksum for anime releases like [32ECE75A].
+		// Different checksums mean different files with 100% certainty.
+		sourceSum := normalizer.Normalize(source.Sum)
+		candidateSum := normalizer.Normalize(candidate.Sum)
+		if sourceSum != "" {
+			if candidateSum == "" || sourceSum != candidateSum {
 				return false
 			}
 		}
 
-		sdFallbackAllowed := (sourceRes == "" && isKnownSD(candidateRes)) || (candidateRes == "" && isKnownSD(sourceRes))
-		if !sdFallbackAllowed {
+		// Source must be compatible if both are present.
+		// WEB is ambiguous and matches both WEB-DL and WEBRip.
+		// WEB-DL and WEBRip are explicitly different and do not match.
+		// Other sources (BluRay, HDTV, etc.) must match exactly.
+		sourceSource := normalizeSource(source.Source)
+		candidateSource := normalizeSource(candidate.Source)
+		if !sourcesCompatible(sourceSource, candidateSource) {
 			return false
+		}
+
+		// Resolution must match (1080p vs 2160p are different files).
+		// Exception: empty resolution is allowed to match SD resolutions (480p, 576p, SD).
+		sourceRes := normalizer.Normalize(source.Resolution)
+		candidateRes := normalizer.Normalize(candidate.Resolution)
+		if sourceRes != candidateRes {
+			// rls omits resolution for many SD releases (e.g. "WEB" without "480p"), so
+			// treat an empty resolution as a match only when the other side is clearly SD.
+			isKnownSD := func(res string) bool {
+				switch normalizeVariant(res) {
+				case "480P", "576P", "SD":
+					return true
+				default:
+					return false
+				}
+			}
+
+			sdFallbackAllowed := (sourceRes == "" && isKnownSD(candidateRes)) || (candidateRes == "" && isKnownSD(sourceRes))
+			if !sdFallbackAllowed {
+				return false
+			}
 		}
 	}
 
 	// Collection must match if either is present (NF vs AMZN vs Criterion are different sources)
 	// If one release has a collection/service tag and the other doesn't, they cannot match
-	sourceCollection := s.stringNormalizer.Normalize((source.Collection))
-	candidateCollection := s.stringNormalizer.Normalize((candidate.Collection))
+	sourceCollection := normalizer.Normalize(source.Collection)
+	candidateCollection := normalizer.Normalize(candidate.Collection)
 	if sourceCollection != candidateCollection {
 		return false
 	}
@@ -305,8 +312,8 @@ func (s *Service) releasesMatchWithDiscovery(source, candidate *rls.Release, fin
 
 	// Bit depth should match when both are present (8-bit vs 10-bit are different encodes).
 	// We intentionally don't enforce "either present" here since indexer titles often omit it.
-	sourceBitDepth := s.stringNormalizer.Normalize(source.BitDepth)
-	candidateBitDepth := s.stringNormalizer.Normalize(candidate.BitDepth)
+	sourceBitDepth := normalizer.Normalize(source.BitDepth)
+	candidateBitDepth := normalizer.Normalize(candidate.BitDepth)
 	if sourceBitDepth != "" && candidateBitDepth != "" && sourceBitDepth != candidateBitDepth {
 		return false
 	}
@@ -351,29 +358,29 @@ func (s *Service) releasesMatchWithDiscovery(source, candidate *rls.Release, fin
 	}
 
 	// Version must match if both are present (v2 often has different files than v1)
-	sourceVersion := s.stringNormalizer.Normalize(source.Version)
-	candidateVersion := s.stringNormalizer.Normalize(candidate.Version)
+	sourceVersion := normalizer.Normalize(source.Version)
+	candidateVersion := normalizer.Normalize(candidate.Version)
 	if sourceVersion != "" && candidateVersion != "" && sourceVersion != candidateVersion {
 		return false
 	}
 
 	// Disc must match if both are present (Disc1 vs Disc2 are different content)
-	sourceDisc := s.stringNormalizer.Normalize(source.Disc)
-	candidateDisc := s.stringNormalizer.Normalize(candidate.Disc)
+	sourceDisc := normalizer.Normalize(source.Disc)
+	candidateDisc := normalizer.Normalize(candidate.Disc)
 	if sourceDisc != "" && candidateDisc != "" && sourceDisc != candidateDisc {
 		return false
 	}
 
 	// Platform must match if both are present (Windows vs macOS are different binaries)
-	sourcePlatform := s.stringNormalizer.Normalize(source.Platform)
-	candidatePlatform := s.stringNormalizer.Normalize(candidate.Platform)
+	sourcePlatform := normalizer.Normalize(source.Platform)
+	candidatePlatform := normalizer.Normalize(candidate.Platform)
 	if sourcePlatform != "" && candidatePlatform != "" && sourcePlatform != candidatePlatform {
 		return false
 	}
 
 	// Architecture must match if both are present (x64 vs x86 are different binaries)
-	sourceArch := s.stringNormalizer.Normalize(source.Arch)
-	candidateArch := s.stringNormalizer.Normalize(candidate.Arch)
+	sourceArch := normalizer.Normalize(source.Arch)
+	candidateArch := normalizer.Normalize(candidate.Arch)
 	if sourceArch != "" && candidateArch != "" && sourceArch != candidateArch {
 		return false
 	}
@@ -414,10 +421,12 @@ func normalizeDiscoveryTitle(title string) string {
 	}
 
 	filtered := tokens[:0]
-	for _, token := range tokens {
+	for i, token := range tokens {
 		switch strings.TrimSpace(strings.ToLower(token)) {
 		case "", "us", "uk", "au", "ca", "jp", "kr", "cn", "de", "fr", "es", "it", "se", "no", "fi", "dk", "nl", "be":
-			continue
+			if i == len(tokens)-1 {
+				continue
+			}
 		}
 		ignorable := true
 		for _, r := range token {

--- a/internal/services/crossseed/matching_discovery_test.go
+++ b/internal/services/crossseed/matching_discovery_test.go
@@ -309,3 +309,61 @@ func TestReleasesMatchDiscovery_Infers1080pFromPlainBlurayDiscLayout(t *testing.
 		resolutionMatchContext{},
 	))
 }
+
+func TestReleasesMatchDiscovery_SkipsEmptyBDMVSourceHDRPayload(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
+
+	source := &rls.Release{
+		Title:      "Salt",
+		Year:       2010,
+		Source:     "UHD BluRay",
+		Resolution: "2160p",
+	}
+	candidate := &rls.Release{
+		Title:      "Salt",
+		Year:       2010,
+		Source:     "UHD BluRay",
+		Resolution: "2160p",
+		HDR:        []string{"HDR10"},
+	}
+
+	require.False(t, svc.releasesMatchDiscovery(source, candidate, false))
+	require.True(t, svc.releasesMatchDiscoveryWithContext(
+		source,
+		candidate,
+		false,
+		resolutionMatchContext{discLayout: true, discMarker: "BDMV", rawName: "Salt.2010.COMPLETE.UHD.BLURAY-COASTER"},
+		resolutionMatchContext{},
+	))
+}
+
+func TestReleasesMatchDiscovery_SkipsNormalizedEmptyBDMVSourceHDRPayload(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
+
+	source := &rls.Release{
+		Title:      "Salt",
+		Year:       2010,
+		Source:     "UHD BluRay",
+		Resolution: "2160p",
+		HDR:        []string{""},
+	}
+	candidate := &rls.Release{
+		Title:      "Salt",
+		Year:       2010,
+		Source:     "UHD BluRay",
+		Resolution: "2160p",
+		HDR:        []string{"HDR10"},
+	}
+
+	require.True(t, svc.releasesMatchDiscoveryWithContext(
+		source,
+		candidate,
+		false,
+		resolutionMatchContext{discLayout: true, discMarker: "BDMV", rawName: "Salt.2010.COMPLETE.UHD.BLURAY-COASTER"},
+		resolutionMatchContext{},
+	))
+}

--- a/internal/services/crossseed/matching_discovery_test.go
+++ b/internal/services/crossseed/matching_discovery_test.go
@@ -85,6 +85,29 @@ func TestReleasesMatchDiscovery_IgnoresBilingualAndRegionTitleNoise(t *testing.T
 	})
 }
 
+func TestReleasesMatchDiscovery_KeepsInternalRegionLikeTokens(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
+
+	source := &rls.Release{
+		Title:      "The IT Crowd",
+		Series:     1,
+		Episode:    1,
+		Source:     "WEB-DL",
+		Resolution: "1080p",
+	}
+	candidate := &rls.Release{
+		Title:      "The Crowd",
+		Series:     1,
+		Episode:    1,
+		Source:     "WEB-DL",
+		Resolution: "1080p",
+	}
+
+	require.False(t, svc.releasesMatchDiscovery(source, candidate, false))
+}
+
 func TestReleasesMatchDiscovery_StillRejectsDistinctSpinoffs(t *testing.T) {
 	t.Parallel()
 
@@ -149,6 +172,54 @@ func TestReleasesMatchDiscovery_KeepsSourceAndVersionBoundaries(t *testing.T) {
 			Episode:    4,
 			Source:     "WEB-DL",
 			Resolution: "1080p",
+		}
+
+		require.False(t, svc.releasesMatchDiscovery(source, candidate, false))
+	})
+}
+
+func TestReleasesMatchDiscovery_KeepsSharedCompatibilityChecks(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
+
+	t.Run("collection mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		source := &rls.Release{
+			Title:      "Gladiator",
+			Year:       2000,
+			Group:      "UBWEB",
+			Source:     "WEB-DL",
+			Resolution: "2160p",
+			Collection: "NF",
+		}
+		candidate := &rls.Release{
+			Title:      "Gladiator",
+			Year:       2000,
+			Source:     "WEB-DL",
+			Resolution: "2160p",
+		}
+
+		require.False(t, svc.releasesMatchDiscovery(source, candidate, false))
+	})
+
+	t.Run("variant mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		source := &rls.Release{
+			Title:      "Gladiator",
+			Year:       2000,
+			Group:      "UBWEB",
+			Source:     "WEB-DL",
+			Resolution: "2160p",
+			Other:      []string{"PROPER"},
+		}
+		candidate := &rls.Release{
+			Title:      "Gladiator",
+			Year:       2000,
+			Source:     "WEB-DL",
+			Resolution: "2160p",
 		}
 
 		require.False(t, svc.releasesMatchDiscovery(source, candidate, false))

--- a/internal/services/crossseed/matching_discovery_test.go
+++ b/internal/services/crossseed/matching_discovery_test.go
@@ -249,3 +249,63 @@ func TestReleasesMatchDiscovery_UsesDefaultNormalizerFallback(t *testing.T) {
 		require.True(t, svc.releasesMatchDiscovery(source, candidate, false))
 	})
 }
+
+func TestReleasesMatchDiscovery_AllowsImplicitUHDToMatchExplicit2160p(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{
+		releaseCache:     NewReleaseCache(),
+		stringNormalizer: stringutils.NewDefaultNormalizer(),
+	}
+
+	source := svc.releaseCache.Parse("Salt.2010.COMPLETE.UHD.BLURAY-COASTER")
+	candidate := svc.releaseCache.Parse("Salt 2010 Theatrical Cut 2160p UHD Blu-ray HEVC TrueHD 7.1-COASTER")
+
+	require.True(t, svc.releasesMatchDiscoveryWithContext(
+		source,
+		candidate,
+		false,
+		resolutionMatchContext{discLayout: true, discMarker: "BDMV", rawName: "Salt.2010.COMPLETE.UHD.BLURAY-COASTER"},
+		resolutionMatchContext{},
+	))
+}
+
+func TestReleasesMatchDiscovery_DoesNotInfer2160pFromPlainBluray(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{
+		releaseCache:     NewReleaseCache(),
+		stringNormalizer: stringutils.NewDefaultNormalizer(),
+	}
+
+	source := svc.releaseCache.Parse("Salt.2010.COMPLETE.BLURAY-COASTER")
+	candidate := svc.releaseCache.Parse("Salt 2010 2160p Blu-ray HEVC TrueHD 7.1-COASTER")
+
+	require.False(t, svc.releasesMatchDiscoveryWithContext(
+		source,
+		candidate,
+		false,
+		resolutionMatchContext{discLayout: true, discMarker: "BDMV", rawName: "Salt.2010.COMPLETE.BLURAY-COASTER"},
+		resolutionMatchContext{},
+	))
+}
+
+func TestReleasesMatchDiscovery_Infers1080pFromPlainBlurayDiscLayout(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{
+		releaseCache:     NewReleaseCache(),
+		stringNormalizer: stringutils.NewDefaultNormalizer(),
+	}
+
+	source := svc.releaseCache.Parse("Salt.2010.COMPLETE.BLURAY-COASTER")
+	candidate := svc.releaseCache.Parse("Salt 2010 1080p Blu-ray AVC TrueHD 5.1-COASTER")
+
+	require.True(t, svc.releasesMatchDiscoveryWithContext(
+		source,
+		candidate,
+		false,
+		resolutionMatchContext{discLayout: true, discMarker: "BDMV", rawName: "Salt.2010.COMPLETE.BLURAY-COASTER"},
+		resolutionMatchContext{},
+	))
+}

--- a/internal/services/crossseed/matching_discovery_test.go
+++ b/internal/services/crossseed/matching_discovery_test.go
@@ -1,0 +1,156 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package crossseed
+
+import (
+	"testing"
+
+	"github.com/moistari/rls"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/pkg/stringutils"
+)
+
+func TestReleasesMatchDiscovery_AllowsMissingGroupWithSameCoreRelease(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
+
+	source := &rls.Release{
+		Title:      "Gladiator",
+		Year:       2000,
+		Group:      "UBWEB",
+		Source:     "WEB-DL",
+		Resolution: "2160p",
+	}
+	candidate := &rls.Release{
+		Title:      "Gladiator",
+		Year:       2000,
+		Source:     "WEB-DL",
+		Resolution: "2160p",
+	}
+
+	require.False(t, svc.releasesMatch(source, candidate, false))
+	require.True(t, svc.releasesMatchDiscovery(source, candidate, false))
+}
+
+func TestReleasesMatchDiscovery_IgnoresBilingualAndRegionTitleNoise(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
+
+	t.Run("bilingual title", func(t *testing.T) {
+		t.Parallel()
+
+		source := &rls.Release{
+			Title:      "角斗士 Gladiator",
+			Year:       2000,
+			Group:      "UBWEB",
+			Source:     "WEB-DL",
+			Resolution: "2160p",
+		}
+		candidate := &rls.Release{
+			Title:      "Gladiator",
+			Year:       2000,
+			Source:     "WEB-DL",
+			Resolution: "2160p",
+		}
+
+		require.False(t, svc.releasesMatch(source, candidate, false))
+		require.True(t, svc.releasesMatchDiscovery(source, candidate, false))
+	})
+
+	t.Run("region suffix", func(t *testing.T) {
+		t.Parallel()
+
+		source := &rls.Release{
+			Title:      "Doc US",
+			Series:     2,
+			Episode:    17,
+			Group:      "Kitsune",
+			Source:     "WEB-DL",
+			Resolution: "1080p",
+		}
+		candidate := &rls.Release{
+			Title:      "Doc",
+			Series:     2,
+			Episode:    17,
+			Source:     "WEB-DL",
+			Resolution: "1080p",
+		}
+
+		require.False(t, svc.releasesMatch(source, candidate, false))
+		require.True(t, svc.releasesMatchDiscovery(source, candidate, false))
+	})
+}
+
+func TestReleasesMatchDiscovery_StillRejectsDistinctSpinoffs(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
+
+	source := &rls.Release{
+		Title:      "FBI",
+		Series:     1,
+		Episode:    1,
+		Source:     "WEB-DL",
+		Resolution: "1080p",
+	}
+	candidate := &rls.Release{
+		Title:      "FBI Most Wanted",
+		Series:     1,
+		Episode:    1,
+		Source:     "WEB-DL",
+		Resolution: "1080p",
+	}
+
+	require.False(t, svc.releasesMatchDiscovery(source, candidate, false))
+}
+
+func TestReleasesMatchDiscovery_KeepsSourceAndVersionBoundaries(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
+
+	t.Run("source mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		source := &rls.Release{
+			Title:      "Movie",
+			Year:       2025,
+			Source:     "WEB-DL",
+			Resolution: "1080p",
+		}
+		candidate := &rls.Release{
+			Title:      "Movie",
+			Year:       2025,
+			Source:     "BluRay",
+			Resolution: "1080p",
+		}
+
+		require.False(t, svc.releasesMatchDiscovery(source, candidate, false))
+	})
+
+	t.Run("version mismatch", func(t *testing.T) {
+		t.Parallel()
+
+		source := &rls.Release{
+			Title:      "Show",
+			Series:     1,
+			Episode:    4,
+			Source:     "WEB-DL",
+			Resolution: "1080p",
+			Version:    "v2",
+		}
+		candidate := &rls.Release{
+			Title:      "Show",
+			Series:     1,
+			Episode:    4,
+			Source:     "WEB-DL",
+			Resolution: "1080p",
+		}
+
+		require.False(t, svc.releasesMatchDiscovery(source, candidate, false))
+	})
+}

--- a/internal/services/crossseed/matching_discovery_test.go
+++ b/internal/services/crossseed/matching_discovery_test.go
@@ -154,3 +154,27 @@ func TestReleasesMatchDiscovery_KeepsSourceAndVersionBoundaries(t *testing.T) {
 		require.False(t, svc.releasesMatchDiscovery(source, candidate, false))
 	})
 }
+
+func TestReleasesMatchDiscovery_UsesDefaultNormalizerFallback(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{}
+
+	source := &rls.Release{
+		Title:      "Gladiator",
+		Year:       2000,
+		Group:      "UBWEB",
+		Source:     "WEB-DL",
+		Resolution: "2160p",
+	}
+	candidate := &rls.Release{
+		Title:      "Gladiator",
+		Year:       2000,
+		Source:     "WEB-DL",
+		Resolution: "2160p",
+	}
+
+	require.NotPanics(t, func() {
+		require.True(t, svc.releasesMatchDiscovery(source, candidate, false))
+	})
+}

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -3151,7 +3151,7 @@ func (s *Service) findCandidates(ctx context.Context, req *FindCandidatesRequest
 			}
 
 			// Check if releases are related (quick filter)
-			if !s.releasesMatch(targetRelease, candidateRelease, req.FindIndividualEpisodes) {
+			if !s.releasesMatchDiscovery(targetRelease, candidateRelease, req.FindIndividualEpisodes) {
 				continue
 			}
 
@@ -6419,7 +6419,7 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 		}
 
 		candidateRelease := s.releaseCache.Parse(res.Title)
-		if !s.releasesMatch(searchRelease, candidateRelease, opts.FindIndividualEpisodes) {
+		if !s.releasesMatchDiscovery(searchRelease, candidateRelease, opts.FindIndividualEpisodes) {
 			releaseFilteredCount++
 			continue
 		}
@@ -9776,7 +9776,7 @@ func (s *Service) CheckWebhook(ctx context.Context, req *WebhookCheckRequest) (*
 			}
 
 			// Check if releases match using the configured strict or episode-aware matching.
-			if !s.releasesMatch(incomingRelease, existingRelease, findIndividualEpisodes) {
+			if !s.releasesMatchDiscovery(incomingRelease, existingRelease, findIndividualEpisodes) {
 				continue
 			}
 

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -236,6 +236,7 @@ const (
 	minSearchCooldownMinutes            = 720
 	maxCompletionSearchAttempts         = 3
 	defaultCompletionRetryDelay         = 30 * time.Second
+	maxSinglePageTorznabSearchLimit     = 500
 
 	// User-facing message when cross-seed is skipped due to recheck requirement
 	skippedRecheckMessage = "Skipped: requires recheck. Disable 'Skip recheck' in Cross-Seed settings to allow"
@@ -6038,11 +6039,7 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 			Msg("[CROSSSEED-SEARCH] Generated search query with fallback parsing")
 	}
 
-	limit := opts.Limit
-	if limit <= 0 {
-		limit = 40
-	}
-	requestLimit := max(limit*3, limit)
+	requestLimit := max(opts.Limit, maxSinglePageTorznabSearchLimit)
 
 	// Apply indexer filtering (capabilities first, then optionally content filtering async)
 	var filteredIndexerIDs []int
@@ -6502,10 +6499,6 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 		}
 		return scored[i].score > scored[j].score
 	})
-
-	if len(scored) > limit {
-		scored = scored[:limit]
-	}
 
 	results := make([]TorrentSearchResult, 0, len(scored))
 	for _, item := range scored {

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -6405,6 +6405,11 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 	seen := make(map[string]struct{})
 	sizeFilteredCount := 0
 	releaseFilteredCount := 0
+	sourceResolutionCtx := resolutionMatchContext{
+		discLayout: sourceInfo.DiscLayout,
+		discMarker: sourceInfo.DiscMarker,
+		rawName:    sourceTorrent.Name,
+	}
 
 	for _, res := range searchResults {
 		key := res.GUID
@@ -6419,7 +6424,7 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 		}
 
 		candidateRelease := s.releaseCache.Parse(res.Title)
-		if !s.releasesMatchDiscovery(searchRelease, candidateRelease, opts.FindIndividualEpisodes) {
+		if !s.releasesMatchDiscoveryWithContext(searchRelease, candidateRelease, opts.FindIndividualEpisodes, sourceResolutionCtx, resolutionMatchContext{}) {
 			releaseFilteredCount++
 			continue
 		}


### PR DESCRIPTION
Split cross-seed release matching into strict identity checks and looser discovery checks. RSS automation, webhook prechecks, and remote search candidate filtering now tolerate missing groups and some title noise without widening dedup, local match detection, or indexer filtering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced release-matching with a discovery-aware pathway that optionally relaxes group/site, title, resolution and metadata checks during candidate selection, search and webhook filtering; adds context-aware title normalization, resolution inference (disc-layout aware) and safeguards for HDR/disc edge cases while preserving strict non-discovery behavior.

* **Tests**
  * Added unit tests covering discovery scenarios: relaxed title/region handling, group compatibility, spinoff rejection, source/version boundaries, resolution/HDR inference and context-aware cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->