### PR TITLE
docs: add password reset section to CLI commands

### DIFF
--- a/documentation/docs/configuration/cli-commands.md
+++ b/documentation/docs/configuration/cli-commands.md
@@ -56,6 +56,32 @@ printf "password" | ./qui change-password --username admin
 - Commands will create the database if it doesn't exist
 - No password confirmation required - perfect for automation
 
+### Reset a Forgotten Password {#reset-password}
+
+If you've forgotten your password, use the `change-password` command to set a new one. No old password is required.
+
+**Linux / macOS:**
+
+```bash
+./qui change-password --username admin --new-password mynewpassword
+```
+
+**Windows (Command Prompt):**
+
+Navigate to the folder containing `qui.exe` and run:
+
+```batch
+qui.exe change-password --username admin --new-password mynewpassword
+```
+
+**Docker:**
+
+```bash
+docker exec -it <container-name> qui change-password --username admin --new-password mynewpassword
+```
+
+Replace `admin` with your username and `mynewpassword` with your desired password (minimum 8 characters).
+
 ## Update Command
 
 Keep your qui installation up-to-date:


### PR DESCRIPTION
Add a dedicated "Reset a Forgotten Password" subsection with platform-specific examples for Linux/macOS, Windows, and Docker to make password recovery more discoverable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for resetting a forgotten password via CLI commands, including instructions for Linux/macOS, Windows, and Docker environments with usage examples and password requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->