### PR TITLE
fix(web): handle SSO proxy redirect to /index.html

### DIFF
--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -69,6 +69,21 @@ func (h *Handler) RegisterRoutes(r chi.Router) {
 	r.Get("/swizzin.png", h.serveAssets)
 	r.Get("/napster.png", h.serveAssets)
 
+	// Redirect /index.html to the SPA root so SSO proxies that preserve
+	// the original request path (Pangolin, Cloudflare Access, etc.) don't
+	// land on a client-side 404.
+	spaRoot := h.baseURL
+	if spaRoot == "" {
+		spaRoot = "/"
+	}
+	r.Get("/index.html", func(w http.ResponseWriter, r *http.Request) {
+		target := spaRoot
+		if r.URL.RawQuery != "" {
+			target += "?" + r.URL.RawQuery
+		}
+		http.Redirect(w, r, target, http.StatusMovedPermanently)
+	})
+
 	// SPA routes
 	r.Get("/", h.serveSPA)
 	r.Get("/*", h.serveSPA)

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -321,14 +321,36 @@ async function attemptSSORecoveryNavigation(options?: { bypassGuard?: boolean; t
   sessionStorage.setItem(SSO_RECOVERY_GUARD_KEY, "1")
   sessionStorage.setItem(SSO_RECOVERY_TS_KEY, Date.now().toString())
 
-  // Clear all caches (including the service worker's precache) so the next
-  // navigation goes to the network. The SW stays registered but will fall back
-  // to the network on cache miss, letting the SSO proxy intercept the request.
-  // Unregistering the SW entirely can break the SSO proxy's auth flow.
+  // Scope cleanup to qui's own service worker and caches to avoid disrupting
+  // other apps on a shared origin (e.g. https://host/qui alongside https://host/photos).
+  const quiScope = new URL(withBasePath("/"), window.location.origin).href
+
+  // Unregister qui's service worker so its NavigationRoute cannot intercept the
+  // recovery navigation. Without this, Workbox's createHandlerBoundToURL tries
+  // to fetch index.html from the network on cache miss, which Badger/Pangolin
+  // redirect cross-origin — the SW can't handle that response for a navigation
+  // request, and some mobile browsers don't fall back to the network properly.
+  // The SW re-registers automatically on the next page load via pwa.ts.
+  if ("serviceWorker" in navigator) {
+    try {
+      const registrations = await navigator.serviceWorker.getRegistrations()
+      await Promise.all(
+        registrations.filter(r => r.scope === quiScope).map(r => r.unregister()),
+      )
+    } catch {
+      // ignore unregister errors
+    }
+  }
+
+  // Clear qui's caches so the next navigation goes straight to the network,
+  // letting the SSO proxy intercept. Workbox names its precache after the SW
+  // scope, so filtering by quiScope avoids touching other apps' caches.
   if ("caches" in window) {
     try {
       const names = await caches.keys()
-      await Promise.all(names.map(name => caches.delete(name)))
+      await Promise.all(
+        names.filter(name => name.endsWith(quiScope)).map(name => caches.delete(name)),
+      )
     } catch {
       // ignore cache clear errors
     }


### PR DESCRIPTION
SSO proxies like Pangolin preserve the original request URL through auth.
When the service worker precaches index.html, the proxy captures that path
and redirects back to /index.html after authentication — which the
client-side router doesn't recognize, showing a 404.

Adds a server-side 301 from /index.html to the SPA root, and unregisters
the service worker during SSO recovery so Workbox's NavigationRoute can't
intercept the recovery navigation with a cross-origin fetch that fails on
mobile. Both SW and cache cleanup are scoped to qui's own registration.

Ref: https://github.com/autobrr/qui/discussions/1599

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed /index.html redirect handling to preserve base URL and query parameters.
  * Improved service worker cleanup for SSO recovery to isolate changes to the current application only, reducing unintended cross-app impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->