### PR TITLE
fix(dirscan): queue webhook scans and tighten age filtering

### DIFF
--- a/documentation/docs/features/cross-seed/dir-scan.md
+++ b/documentation/docs/features/cross-seed/dir-scan.md
@@ -171,7 +171,7 @@ Open **Dir Scan > Settings**:
 | Size Tolerance (%) | Allows small size differences when matching. |
 | Minimum Piece Ratio (%) | For partial matches, minimum percent of torrent data that must exist on disk. |
 | Max searchees per run | Limits how many eligible searchees are processed per run. `0` = unlimited. Useful for making progress across restarts. |
-| Only process items changed within the last (days) | Excludes stale work items before search. Uses video/audio mtimes only. `0` = disabled. |
+| Only process items changed within the last (days) | Excludes stale work items before search. Uses video/audio mtimes only for manual/scheduled scans. Webhook-triggered scans ignore this cutoff. `0` = disabled. |
 | Allow partial matches | Add torrents even if they have extra/missing files compared to disk. |
 | Skip piece boundary safety check | Allow partial matches where downloading missing files could modify pieces containing existing content. |
 | Start torrents paused | Add injected torrents in paused state. |
@@ -197,6 +197,7 @@ This setting reduces tracker/API load by excluding stale content before search b
 - Season-pack searches are kept only when all episode files in that season work item are within the cutoff; otherwise qui falls back to fresh episode-level work only.
 - Cutoff is computed as `now - N days` (for example, `7` means “older than 7 days”).
 - The timestamp used is filesystem **modified time (mtime)** from video/audio files only, not subtitles, extras, release date, or qBittorrent add time.
+- Webhook-triggered scans ignore the cutoff entirely and trust the webhook path as the freshness signal.
 - `0` disables age filtering.
 
 Example with `7` days:
@@ -285,6 +286,8 @@ In split-mount setups, the *arr app must send the same library path that qui see
 | `500` | Internal server error — scan could not be started due to an internal failure |
 
 If a second webhook arrives while the same directory is already scanning, qui returns `202` again. It does not reject the request or require client-side retries. Instead, it updates one queued follow-up run for that directory and expands the queued `scanRoot` to the nearest common ancestor when needed.
+
+Webhook-triggered scans also ignore the global age cutoff. This avoids false skips when Sonarr/Radarr imports files that preserve old filesystem mtimes.
 
 #### Simple mode
 

--- a/documentation/docs/features/cross-seed/dir-scan.md
+++ b/documentation/docs/features/cross-seed/dir-scan.md
@@ -171,7 +171,7 @@ Open **Dir Scan > Settings**:
 | Size Tolerance (%) | Allows small size differences when matching. |
 | Minimum Piece Ratio (%) | For partial matches, minimum percent of torrent data that must exist on disk. |
 | Max searchees per run | Limits how many eligible searchees are processed per run. `0` = unlimited. Useful for making progress across restarts. |
-| Skip searchees older than (days) | Excludes searchees where all files are older than the cutoff. `0` = disabled. |
+| Only process items changed within the last (days) | Excludes stale work items before search. Uses video/audio mtimes only. `0` = disabled. |
 | Allow partial matches | Add torrents even if they have extra/missing files compared to disk. |
 | Skip piece boundary safety check | Allow partial matches where downloading missing files could modify pieces containing existing content. |
 | Start torrents paused | Add injected torrents in paused state. |
@@ -188,19 +188,22 @@ So if **Max searchees per run = 5**, Dir Scan will process up to **5 show folder
 
 This is **not** a cap on the total number of indexer searches. TV folders can trigger multiple searches (season-level + per-episode heuristics), even though they still count as a single top-level searchee.
 
-### "Skip searchees older than (days)" explained
+### "Only process items changed within the last (days)" explained
 
 This setting reduces tracker/API load by excluding stale content before search begins.
 
-- A searchee is excluded only if **all files in that searchee** are older than the cutoff.
+- Movies/music are included only when the item's newest video/audio file is within the cutoff.
+- TV is evaluated at the season/episode work-item level so one fresh episode does not pull an entire older show back in.
+- Season-pack searches are kept only when all episode files in that season work item are within the cutoff; otherwise qui falls back to fresh episode-level work only.
 - Cutoff is computed as `now - N days` (for example, `7` means “older than 7 days”).
-- The timestamp used is filesystem **modified time (mtime)**, not release date or qBittorrent add time.
+- The timestamp used is filesystem **modified time (mtime)** from video/audio files only, not subtitles, extras, release date, or qBittorrent add time.
 - `0` disables age filtering.
 
 Example with `7` days:
 
-- `Movie.2024/` has one subtitle updated yesterday -> included.
-- `Old.Show.S01/` has all files older than 7 days -> skipped.
+- `Movie.2024/` has only an `.srt` updated yesterday while the `.mkv` is old -> skipped.
+- `Show.Name/Season 01/` has one fresh episode and nine old ones -> only the fresh episode stays in scope.
+- `Old.Show.S01/` has all episode files older than 7 days -> skipped.
 
 ## Directories
 

--- a/documentation/docs/features/cross-seed/dir-scan.md
+++ b/documentation/docs/features/cross-seed/dir-scan.md
@@ -277,12 +277,14 @@ In split-mount setups, the *arr app must send the same library path that qui see
 
 | Status Code | Meaning |
 |-------------|---------|
-| `202` | Scan started successfully. Example: `{"runId": 42, "directoryId": 3, "directoryPath": "/data/media/tv", "scanRoot": "/data/media/tv/Show Name"}` |
+| `202` | Scan accepted. If the directory is idle, qui starts the run immediately. If a webhook scan is already running for that directory, qui keeps one follow-up queued run and merges later webhook paths into it. Example: `{"runId": 42, "directoryId": 3, "directoryPath": "/data/media/tv", "scanRoot": "/data/media/tv/Show Name"}` |
 | `204` | Test webhook accepted. No scan started |
 | `400` | Invalid JSON payload, or no supported path field was found in the request body |
 | `404` | No enabled directory matches the path in the payload |
-| `409` | A scan is already in progress for the matched directory |
+| `409` | Multiple directories match the given path |
 | `500` | Internal server error — scan could not be started due to an internal failure |
+
+If a second webhook arrives while the same directory is already scanning, qui returns `202` again. It does not reject the request or require client-side retries. Instead, it updates one queued follow-up run for that directory and expands the queued `scanRoot` to the nearest common ancestor when needed.
 
 #### Simple mode
 

--- a/internal/models/dirscan.go
+++ b/internal/models/dirscan.go
@@ -790,6 +790,28 @@ func (s *DirScanStore) GetActiveRun(ctx context.Context, directoryID int) (*DirS
 		FROM dir_scan_runs
 		WHERE directory_id = ?
 		  AND status IN ('queued', 'scanning', 'searching', 'injecting')
+		ORDER BY CASE status
+			WHEN 'scanning' THEN 0
+			WHEN 'searching' THEN 1
+			WHEN 'injecting' THEN 2
+			WHEN 'queued' THEN 3
+			ELSE 4
+		END,
+		started_at DESC
+		LIMIT 1
+	`, directoryID)
+
+	return s.scanRun(row)
+}
+
+// GetQueuedRun returns the most recent queued run for a directory, if any.
+func (s *DirScanStore) GetQueuedRun(ctx context.Context, directoryID int) (*DirScanRun, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT id, directory_id, status, triggered_by, scan_root, files_found, files_skipped,
+		       matches_found, torrents_added, error_message, started_at, completed_at
+		FROM dir_scan_runs
+		WHERE directory_id = ?
+		  AND status = 'queued'
 		ORDER BY started_at DESC
 		LIMIT 1
 	`, directoryID)
@@ -804,6 +826,22 @@ func (s *DirScanStore) UpdateRunStatus(ctx context.Context, runID int64, status 
 	`, status, runID)
 	if err != nil {
 		return fmt.Errorf("update run status: %w", err)
+	}
+	return nil
+}
+
+// UpdateRunScanRoot updates the scan root of a run.
+func (s *DirScanStore) UpdateRunScanRoot(ctx context.Context, runID int64, scanRoot string) error {
+	var scanRootValue any
+	if scanRoot != "" {
+		scanRootValue = scanRoot
+	}
+
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE dir_scan_runs SET scan_root = ? WHERE id = ?
+	`, scanRootValue, runID)
+	if err != nil {
+		return fmt.Errorf("update run scan root: %w", err)
 	}
 	return nil
 }
@@ -856,6 +894,19 @@ func (s *DirScanStore) UpdateRunCanceled(ctx context.Context, runID int64) error
 	`, DirScanRunStatusCanceled, runID)
 	if err != nil {
 		return fmt.Errorf("update run canceled: %w", err)
+	}
+	return nil
+}
+
+// CancelQueuedRuns marks all queued runs for a directory as canceled.
+func (s *DirScanStore) CancelQueuedRuns(ctx context.Context, directoryID int) error {
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE dir_scan_runs
+		SET status = ?, completed_at = CURRENT_TIMESTAMP
+		WHERE directory_id = ? AND status = 'queued'
+	`, DirScanRunStatusCanceled, directoryID)
+	if err != nil {
+		return fmt.Errorf("cancel queued runs: %w", err)
 	}
 	return nil
 }

--- a/internal/models/dirscan.go
+++ b/internal/models/dirscan.go
@@ -797,7 +797,8 @@ func (s *DirScanStore) GetActiveRun(ctx context.Context, directoryID int) (*DirS
 			WHEN 'queued' THEN 3
 			ELSE 4
 		END,
-		started_at DESC
+		started_at DESC,
+		id DESC
 		LIMIT 1
 	`, directoryID)
 
@@ -812,7 +813,7 @@ func (s *DirScanStore) GetQueuedRun(ctx context.Context, directoryID int) (*DirS
 		FROM dir_scan_runs
 		WHERE directory_id = ?
 		  AND status = 'queued'
-		ORDER BY started_at DESC
+		ORDER BY started_at DESC, id DESC
 		LIMIT 1
 	`, directoryID)
 

--- a/internal/models/dirscan_run_status_test.go
+++ b/internal/models/dirscan_run_status_test.go
@@ -99,3 +99,42 @@ func TestDirScanStore_MarkActiveRunsFailed_IncludesQueued(t *testing.T) {
 	require.Equal(t, "restart", run.ErrorMessage)
 	require.NotNil(t, run.CompletedAt)
 }
+
+func TestDirScanStore_GetActiveRun_PrefersRunningOverQueued(t *testing.T) {
+	ctx := context.Background()
+	db := setupDirScanTestDB(t)
+
+	instanceStore, err := models.NewInstanceStore(db, []byte("01234567890123456789012345678901"))
+	require.NoError(t, err)
+
+	instance, err := instanceStore.Create(ctx, "Test", "http://localhost:8080", "user", "pass", nil, nil, false, nil)
+	require.NoError(t, err)
+
+	store := models.NewDirScanStore(db)
+	dir, err := store.CreateDirectory(ctx, &models.DirScanDirectory{
+		Path:                "/data/media",
+		Enabled:             true,
+		TargetInstanceID:    instance.ID,
+		ScanIntervalMinutes: 60,
+	})
+	require.NoError(t, err)
+
+	runningID, err := store.CreateRun(ctx, dir.ID, "webhook", "/data/media/show-a")
+	require.NoError(t, err)
+	require.NoError(t, store.UpdateRunStatus(ctx, runningID, models.DirScanRunStatusScanning))
+
+	queuedID, err := store.CreateRun(ctx, dir.ID, "webhook", "/data/media/show-b")
+	require.NoError(t, err)
+
+	activeRun, err := store.GetActiveRun(ctx, dir.ID)
+	require.NoError(t, err)
+	require.NotNil(t, activeRun)
+	require.Equal(t, runningID, activeRun.ID)
+	require.Equal(t, models.DirScanRunStatusScanning, activeRun.Status)
+
+	queuedRun, err := store.GetQueuedRun(ctx, dir.ID)
+	require.NoError(t, err)
+	require.NotNil(t, queuedRun)
+	require.Equal(t, queuedID, queuedRun.ID)
+	require.Equal(t, models.DirScanRunStatusQueued, queuedRun.Status)
+}

--- a/internal/models/dirscan_run_status_test.go
+++ b/internal/models/dirscan_run_status_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -137,4 +138,47 @@ func TestDirScanStore_GetActiveRun_PrefersRunningOverQueued(t *testing.T) {
 	require.NotNil(t, queuedRun)
 	require.Equal(t, queuedID, queuedRun.ID)
 	require.Equal(t, models.DirScanRunStatusQueued, queuedRun.Status)
+}
+
+func TestDirScanStore_GetQueuedRun_PrefersNewestIDWhenStartedAtTies(t *testing.T) {
+	ctx := context.Background()
+	db := setupDirScanTestDB(t)
+
+	instanceStore, err := models.NewInstanceStore(db, []byte("01234567890123456789012345678901"))
+	require.NoError(t, err)
+
+	instance, err := instanceStore.Create(ctx, "Test", "http://localhost:8080", "user", "pass", nil, nil, false, nil)
+	require.NoError(t, err)
+
+	store := models.NewDirScanStore(db)
+	dir, err := store.CreateDirectory(ctx, &models.DirScanDirectory{
+		Path:                "/data/media",
+		Enabled:             true,
+		TargetInstanceID:    instance.ID,
+		ScanIntervalMinutes: 60,
+	})
+	require.NoError(t, err)
+
+	firstID, err := store.CreateRun(ctx, dir.ID, "webhook", "/data/media/show-a")
+	require.NoError(t, err)
+	secondID, err := store.CreateRun(ctx, dir.ID, "webhook", "/data/media/show-b")
+	require.NoError(t, err)
+
+	tiedStartedAt := time.Date(2026, time.March, 16, 12, 0, 0, 0, time.UTC)
+	_, err = db.ExecContext(ctx, `
+		UPDATE dir_scan_runs
+		SET started_at = ?
+		WHERE id IN (?, ?)
+	`, tiedStartedAt, firstID, secondID)
+	require.NoError(t, err)
+
+	activeRun, err := store.GetActiveRun(ctx, dir.ID)
+	require.NoError(t, err)
+	require.NotNil(t, activeRun)
+	require.Equal(t, secondID, activeRun.ID)
+
+	queuedRun, err := store.GetQueuedRun(ctx, dir.ID)
+	require.NoError(t, err)
+	require.NotNil(t, queuedRun)
+	require.Equal(t, secondID, queuedRun.ID)
 }

--- a/internal/services/dirscan/age_filter_test.go
+++ b/internal/services/dirscan/age_filter_test.go
@@ -107,7 +107,21 @@ func TestWorkItemIsStale_KeepsFreshSeasonPack(t *testing.T) {
 	items := buildSearcheeWorkItems(root, NewParser(nil))
 	// root + 2 episode work items
 	require.Len(t, items, 3)
-	require.False(t, workItemIsStale(items[0], now.AddDate(0, 0, -3)))
+
+	var seasonItem *searcheeWorkItem
+	for i := range items {
+		item := &items[i]
+		if item.searchee == nil {
+			continue
+		}
+		if item.searchee.Path == root.Path && len(item.searchee.Files) == len(root.Files) {
+			seasonItem = item
+			break
+		}
+	}
+
+	require.NotNil(t, seasonItem)
+	require.False(t, workItemIsStale(*seasonItem, now.AddDate(0, 0, -3)))
 }
 
 func TestMaxSearcheeAgeDaysFromSettings(t *testing.T) {

--- a/internal/services/dirscan/age_filter_test.go
+++ b/internal/services/dirscan/age_filter_test.go
@@ -130,3 +130,12 @@ func TestMaxSearcheeAgeDaysFromSettings(t *testing.T) {
 	require.Equal(t, 0, maxSearcheeAgeDaysFromSettings(&models.DirScanSettings{MaxSearcheeAgeDays: -1}))
 	require.Equal(t, 14, maxSearcheeAgeDaysFromSettings(&models.DirScanSettings{MaxSearcheeAgeDays: 14}))
 }
+
+func TestEffectiveMaxSearcheeAgeDays(t *testing.T) {
+	settings := &models.DirScanSettings{MaxSearcheeAgeDays: 14}
+
+	require.Equal(t, 14, effectiveMaxSearcheeAgeDays(settings, "manual"))
+	require.Equal(t, 14, effectiveMaxSearcheeAgeDays(settings, "scheduled"))
+	require.Equal(t, 0, effectiveMaxSearcheeAgeDays(settings, "webhook"))
+	require.Equal(t, 0, effectiveMaxSearcheeAgeDays(nil, "webhook"))
+}

--- a/internal/services/dirscan/age_filter_test.go
+++ b/internal/services/dirscan/age_filter_test.go
@@ -30,7 +30,7 @@ func TestSelectEligibleRootWork_TVKeepsOnlyFreshEpisodeItems(t *testing.T) {
 		},
 	}
 
-	selection := selectEligibleRootWork(scanResult, nil, NewParser(nil), 3, now)
+	selection := selectEligibleRootWork(scanResult, nil, NewParser(nil), 3, now, nil)
 
 	require.Equal(t, now.AddDate(0, 0, -3), selection.cutoff)
 	require.Equal(t, 2, selection.discoveredFiles)
@@ -59,7 +59,7 @@ func TestSelectEligibleRootWork_IgnoresFreshSubtitleBumps(t *testing.T) {
 		},
 	}
 
-	selection := selectEligibleRootWork(scanResult, nil, NewParser(nil), 3, now)
+	selection := selectEligibleRootWork(scanResult, nil, NewParser(nil), 3, now, nil)
 
 	require.Equal(t, 2, selection.discoveredFiles)
 	require.Equal(t, 0, selection.eligibleFiles)
@@ -83,7 +83,7 @@ func TestSelectEligibleRootWork_TreatsAOBAsAudioContent(t *testing.T) {
 		},
 	}
 
-	selection := selectEligibleRootWork(scanResult, nil, NewParser(nil), 3, now)
+	selection := selectEligibleRootWork(scanResult, nil, NewParser(nil), 3, now, nil)
 
 	require.Equal(t, 1, selection.discoveredFiles)
 	require.Equal(t, 0, selection.eligibleFiles)

--- a/internal/services/dirscan/age_filter_test.go
+++ b/internal/services/dirscan/age_filter_test.go
@@ -67,6 +67,30 @@ func TestSelectEligibleRootWork_IgnoresFreshSubtitleBumps(t *testing.T) {
 	require.Empty(t, selection.roots)
 }
 
+func TestSelectEligibleRootWork_TreatsAOBAsAudioContent(t *testing.T) {
+	now := time.Date(2026, time.March, 16, 13, 0, 0, 0, time.UTC)
+	old := now.AddDate(0, 0, -10)
+
+	scanResult := &ScanResult{
+		Searchees: []*Searchee{
+			{
+				Name: "Album",
+				Path: "/data/music/Album",
+				Files: []*ScannedFile{
+					{Path: "/data/music/Album/AUDIO_TS/ATS_01_1.AOB", ModTime: old, Size: 1000},
+				},
+			},
+		},
+	}
+
+	selection := selectEligibleRootWork(scanResult, nil, NewParser(nil), 3, now)
+
+	require.Equal(t, 1, selection.discoveredFiles)
+	require.Equal(t, 0, selection.eligibleFiles)
+	require.Equal(t, 1, selection.skippedFiles)
+	require.Empty(t, selection.roots)
+}
+
 func TestWorkItemIsStale_KeepsFreshSeasonPack(t *testing.T) {
 	now := time.Date(2026, time.March, 16, 13, 0, 0, 0, time.UTC)
 	fresh := now.Add(-24 * time.Hour)
@@ -81,6 +105,7 @@ func TestWorkItemIsStale_KeepsFreshSeasonPack(t *testing.T) {
 	}
 
 	items := buildSearcheeWorkItems(root, NewParser(nil))
+	// root + 2 episode work items
 	require.Len(t, items, 3)
 	require.False(t, workItemIsStale(items[0], now.AddDate(0, 0, -3)))
 }

--- a/internal/services/dirscan/age_filter_test.go
+++ b/internal/services/dirscan/age_filter_test.go
@@ -12,75 +12,77 @@ import (
 	"github.com/autobrr/qui/internal/models"
 )
 
-func TestApplyMaxSearcheeAgeFilter_ExcludesOnlyFullyStaleSearchees(t *testing.T) {
-	now := time.Date(2026, time.February, 21, 18, 0, 0, 0, time.UTC)
-	fresh := now.Add(-24 * time.Hour)
+func TestSelectEligibleRootWork_TVKeepsOnlyFreshEpisodeItems(t *testing.T) {
+	now := time.Date(2026, time.March, 16, 13, 0, 0, 0, time.UTC)
 	old := now.AddDate(0, 0, -10)
+	fresh := now.Add(-24 * time.Hour)
 
 	scanResult := &ScanResult{
 		Searchees: []*Searchee{
 			{
-				Name: "recent",
+				Name: "Show.Name",
+				Path: "/data/tv/Show.Name",
 				Files: []*ScannedFile{
-					{Path: "/data/recent.mkv", ModTime: fresh, Size: 100},
-				},
-			},
-			{
-				Name: "old",
-				Files: []*ScannedFile{
-					{Path: "/data/old.mkv", ModTime: old, Size: 200},
-				},
-			},
-			{
-				Name: "mixed",
-				Files: []*ScannedFile{
-					{Path: "/data/mixed-old.mkv", ModTime: old, Size: 50},
-					{Path: "/data/mixed-fresh.mkv", ModTime: fresh, Size: 60},
+					{Path: "/data/tv/Show.Name/Season 01/Show.Name.S01E01.mkv", ModTime: old, Size: 100},
+					{Path: "/data/tv/Show.Name/Season 01/Show.Name.S01E02.mkv", ModTime: fresh, Size: 100},
 				},
 			},
 		},
-		TotalFiles:   999,
-		TotalSize:    999,
-		SkippedFiles: 999,
 	}
 
-	stats := applyMaxSearcheeAgeFilter(scanResult, 7, now, nil)
+	selection := selectEligibleRootWork(scanResult, nil, NewParser(nil), 3, now)
 
-	require.Equal(t, 1, stats.ExcludedSearchees)
-	require.Equal(t, 1, stats.ExcludedFiles)
-	require.EqualValues(t, 200, stats.ExcludedBytes)
-	require.Equal(t, now.AddDate(0, 0, -7), stats.Cutoff)
-
-	require.Len(t, scanResult.Searchees, 2)
-	require.Equal(t, "recent", scanResult.Searchees[0].Name)
-	require.Equal(t, "mixed", scanResult.Searchees[1].Name)
-
-	require.Equal(t, 3, scanResult.TotalFiles)
-	require.EqualValues(t, 210, scanResult.TotalSize)
-	require.Equal(t, 0, scanResult.SkippedFiles)
+	require.Equal(t, now.AddDate(0, 0, -3), selection.cutoff)
+	require.Equal(t, 2, selection.discoveredFiles)
+	require.Equal(t, 1, selection.eligibleFiles)
+	require.Equal(t, 1, selection.skippedFiles)
+	require.Len(t, selection.roots, 1)
+	require.Len(t, selection.roots[0].items, 1)
+	require.Equal(t, "Show.Name.S01E02", selection.roots[0].items[0].searchee.Name)
 }
 
-func TestApplyMaxSearcheeAgeFilter_UsesStrictlyOlderThanCutoff(t *testing.T) {
-	now := time.Date(2026, time.February, 21, 18, 0, 0, 0, time.UTC)
-	exactCutoff := now.AddDate(0, 0, -7)
+func TestSelectEligibleRootWork_IgnoresFreshSubtitleBumps(t *testing.T) {
+	now := time.Date(2026, time.March, 16, 13, 0, 0, 0, time.UTC)
+	old := now.AddDate(0, 0, -10)
+	fresh := now.Add(-2 * time.Hour)
 
 	scanResult := &ScanResult{
 		Searchees: []*Searchee{
 			{
-				Name: "at-cutoff",
+				Name: "Movie.2024",
+				Path: "/data/movies/Movie.2024",
 				Files: []*ScannedFile{
-					{Path: "/data/at-cutoff.mkv", ModTime: exactCutoff, Size: 100},
+					{Path: "/data/movies/Movie.2024/movie.mkv", ModTime: old, Size: 1000},
+					{Path: "/data/movies/Movie.2024/movie.srt", ModTime: fresh, Size: 10},
 				},
 			},
 		},
 	}
 
-	stats := applyMaxSearcheeAgeFilter(scanResult, 7, now, nil)
+	selection := selectEligibleRootWork(scanResult, nil, NewParser(nil), 3, now)
 
-	require.Equal(t, 0, stats.ExcludedSearchees)
-	require.Len(t, scanResult.Searchees, 1)
-	require.Equal(t, 1, scanResult.TotalFiles)
-	require.EqualValues(t, 100, scanResult.TotalSize)
+	require.Equal(t, 2, selection.discoveredFiles)
+	require.Equal(t, 0, selection.eligibleFiles)
+	require.Equal(t, 2, selection.skippedFiles)
+	require.Empty(t, selection.roots)
+}
+
+func TestWorkItemIsStale_KeepsFreshSeasonPack(t *testing.T) {
+	now := time.Date(2026, time.March, 16, 13, 0, 0, 0, time.UTC)
+	fresh := now.Add(-24 * time.Hour)
+
+	root := &Searchee{
+		Name: "Show.Name",
+		Path: "/data/tv/Show.Name",
+		Files: []*ScannedFile{
+			{Path: "/data/tv/Show.Name/Season 01/Show.Name.S01E01.mkv", ModTime: fresh, Size: 100},
+			{Path: "/data/tv/Show.Name/Season 01/Show.Name.S01E02.mkv", ModTime: fresh, Size: 100},
+		},
+	}
+
+	items := buildSearcheeWorkItems(root, NewParser(nil))
+	require.Len(t, items, 3)
+	require.False(t, workItemIsStale(items[0], now.AddDate(0, 0, -3)))
 }
 
 func TestMaxSearcheeAgeDaysFromSettings(t *testing.T) {

--- a/internal/services/dirscan/content_detection.go
+++ b/internal/services/dirscan/content_detection.go
@@ -15,7 +15,7 @@ var videoExtensions = map[string]struct{}{
 
 var audioExtensions = map[string]struct{}{
 	".flac": {}, ".mp3": {}, ".wav": {}, ".aac": {}, ".ogg": {}, ".m4a": {},
-	".wma": {}, ".ape": {}, ".alac": {}, ".dsd": {}, ".dsf": {}, ".dff": {},
+	".wma": {}, ".ape": {}, ".alac": {}, ".dsd": {}, ".dsf": {}, ".dff": {}, ".aob": {},
 }
 
 func hasAnyVideoFile(files []*ScannedFile) bool {

--- a/internal/services/dirscan/content_detection.go
+++ b/internal/services/dirscan/content_detection.go
@@ -13,6 +13,11 @@ var videoExtensions = map[string]struct{}{
 	".ts": {}, ".m2ts": {}, ".vob": {}, ".mpg": {}, ".mpeg": {}, ".webm": {}, ".flv": {},
 }
 
+var audioExtensions = map[string]struct{}{
+	".flac": {}, ".mp3": {}, ".wav": {}, ".aac": {}, ".ogg": {}, ".m4a": {},
+	".wma": {}, ".ape": {}, ".alac": {}, ".dsd": {}, ".dsf": {}, ".dff": {},
+}
+
 func hasAnyVideoFile(files []*ScannedFile) bool {
 	for _, f := range files {
 		if f == nil {
@@ -45,6 +50,27 @@ func isVideoPath(path string) bool {
 	ext := strings.ToLower(filepath.Ext(path))
 	_, ok := videoExtensions[ext]
 	return ok
+}
+
+func isAudioPath(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	_, ok := audioExtensions[ext]
+	return ok
+}
+
+func isContentPath(path string) bool {
+	return isVideoPath(path) || isAudioPath(path)
+}
+
+func filterContentFiles(files []*ScannedFile) []*ScannedFile {
+	contentFiles := make([]*ScannedFile, 0, len(files))
+	for _, f := range files {
+		if f == nil || !isContentPath(f.Path) {
+			continue
+		}
+		contentFiles = append(contentFiles, f)
+	}
+	return contentFiles
 }
 
 func shouldPreferFileMetadata(folderMeta, fileMeta *SearcheeMetadata) bool {

--- a/internal/services/dirscan/progress.go
+++ b/internal/services/dirscan/progress.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/autobrr/qui/internal/models"
+	"github.com/rs/zerolog"
 )
 
 type trackedFilesIndex struct {
@@ -55,7 +56,13 @@ func (s *Service) loadTrackedFilesIndex(ctx context.Context, directoryID int) (*
 	return idx, nil
 }
 
-func (s *Service) refreshTrackedFilesFromScan(ctx context.Context, directoryID int, scanResult *ScanResult, fileIDIndex map[string]string) (*trackedFilesIndex, error) {
+func (s *Service) refreshTrackedFilesFromScan(
+	ctx context.Context,
+	directoryID int,
+	scanResult *ScanResult,
+	fileIDIndex map[string]string,
+	l *zerolog.Logger,
+) (*trackedFilesIndex, error) {
 	if s == nil || s.store == nil || scanResult == nil {
 		return nil, nil
 	}
@@ -75,7 +82,7 @@ func (s *Service) refreshTrackedFilesFromScan(ctx context.Context, directoryID i
 			}
 
 			alreadySeeding := isFileAlreadySeedingByFileID(scanned, fileIDIndex)
-			fileModel, err := buildTrackedFileUpsert(directoryID, scanned, idx, alreadySeeding)
+			fileModel, err := buildTrackedFileUpsert(directoryID, scanned, idx, alreadySeeding, l)
 			if err != nil {
 				return nil, err
 			}
@@ -105,7 +112,13 @@ func isFileAlreadySeedingByFileID(scanned *ScannedFile, index map[string]string)
 	return ok
 }
 
-func buildTrackedFileUpsert(directoryID int, scanned *ScannedFile, idx *trackedFilesIndex, alreadySeeding bool) (*models.DirScanFile, error) {
+func buildTrackedFileUpsert(
+	directoryID int,
+	scanned *ScannedFile,
+	idx *trackedFilesIndex,
+	alreadySeeding bool,
+	l *zerolog.Logger,
+) (*models.DirScanFile, error) {
 	if directoryID <= 0 || scanned == nil {
 		return nil, nil
 	}
@@ -115,22 +128,15 @@ func buildTrackedFileUpsert(directoryID int, scanned *ScannedFile, idx *trackedF
 		fileID = scanned.FileID.Bytes()
 	}
 
-	var existing *models.DirScanFile
-	if idx != nil {
-		if fileID != nil {
-			existing = idx.byFileID[string(fileID)]
-		}
-		if existing == nil {
-			existing = idx.byPath[scanned.Path]
-		}
-	}
+	existing, matchedBy := lookupTrackedFile(scanned, idx)
 
 	status := models.DirScanFileStatusPending
 	var matchedTorrentHash string
 	var matchedIndexerID *int
+	unchanged := false
 
 	if existing != nil {
-		unchanged := existing.FileSize == scanned.Size && existing.FileModTime.Equal(scanned.ModTime)
+		unchanged = existing.FileSize == scanned.Size && existing.FileModTime.Equal(scanned.ModTime)
 		if unchanged {
 			status = existing.Status
 			matchedTorrentHash = existing.MatchedTorrentHash
@@ -160,7 +166,7 @@ func buildTrackedFileUpsert(directoryID int, scanned *ScannedFile, idx *trackedF
 		matchedIndexerID = nil
 	}
 
-	return &models.DirScanFile{
+	fileModel := &models.DirScanFile{
 		DirectoryID:        directoryID,
 		FilePath:           scanned.Path,
 		FileSize:           scanned.Size,
@@ -169,7 +175,87 @@ func buildTrackedFileUpsert(directoryID int, scanned *ScannedFile, idx *trackedF
 		Status:             status,
 		MatchedTorrentHash: matchedTorrentHash,
 		MatchedIndexerID:   matchedIndexerID,
-	}, nil
+	}
+
+	logTrackedFileDecision(l, scanned, existing, fileModel, matchedBy, unchanged, alreadySeeding)
+
+	return fileModel, nil
+}
+
+func lookupTrackedFile(scanned *ScannedFile, idx *trackedFilesIndex) (*models.DirScanFile, string) {
+	if scanned == nil || idx == nil {
+		return nil, ""
+	}
+
+	if !scanned.FileID.IsZero() {
+		if existing := idx.byFileID[string(scanned.FileID.Bytes())]; existing != nil {
+			return existing, "file_id"
+		}
+	}
+	if existing := idx.byPath[scanned.Path]; existing != nil {
+		return existing, "path"
+	}
+
+	return nil, ""
+}
+
+func logTrackedFileDecision(
+	l *zerolog.Logger,
+	scanned *ScannedFile,
+	existing *models.DirScanFile,
+	fileModel *models.DirScanFile,
+	matchedBy string,
+	unchanged bool,
+	alreadySeeding bool,
+) {
+	if l == nil || scanned == nil || fileModel == nil {
+		return
+	}
+	if !shouldLogTrackedFileDecision(existing, fileModel, matchedBy, alreadySeeding) {
+		return
+	}
+
+	existingStatus := ""
+	existingPath := ""
+	if existing != nil {
+		existingStatus = string(existing.Status)
+		existingPath = existing.FilePath
+	}
+
+	l.Debug().
+		Str("path", scanned.Path).
+		Str("existingPath", existingPath).
+		Str("matchedBy", matchedBy).
+		Bool("fileIDPresent", !scanned.FileID.IsZero()).
+		Bool("alreadySeeding", alreadySeeding).
+		Bool("unchanged", unchanged).
+		Str("existingStatus", existingStatus).
+		Str("newStatus", string(fileModel.Status)).
+		Int64("size", scanned.Size).
+		Time("modTime", scanned.ModTime).
+		Msg("dirscan: tracked file decision")
+}
+
+func shouldLogTrackedFileDecision(
+	existing *models.DirScanFile,
+	fileModel *models.DirScanFile,
+	matchedBy string,
+	alreadySeeding bool,
+) bool {
+	if fileModel == nil {
+		return false
+	}
+	if alreadySeeding || matchedBy == "file_id" {
+		return true
+	}
+	if fileModel.Status != models.DirScanFileStatusPending {
+		return true
+	}
+	if existing == nil {
+		return false
+	}
+
+	return existing.Status != fileModel.Status || existing.FilePath != fileModel.FilePath
 }
 
 func searcheeIsEligible(searchee *Searchee, idx *trackedFilesIndex) bool {

--- a/internal/services/dirscan/progress.go
+++ b/internal/services/dirscan/progress.go
@@ -7,8 +7,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/autobrr/qui/internal/models"
 	"github.com/rs/zerolog"
+
+	"github.com/autobrr/qui/internal/models"
 )
 
 type trackedFilesIndex struct {

--- a/internal/services/dirscan/service.go
+++ b/internal/services/dirscan/service.go
@@ -78,6 +78,9 @@ type Service struct {
 	cancelFuncs map[int64]context.CancelFunc
 	cancelMu    sync.Mutex
 
+	// Serializes webhook queue/merge decisions so duplicate follow-up runs are not created.
+	webhookMu sync.Mutex
+
 	// In-memory progress snapshot keyed by runID (for live UI updates).
 	runProgress map[int64]*runProgress
 	progressMu  sync.Mutex
@@ -327,7 +330,57 @@ func (s *Service) StartManualScan(ctx context.Context, directoryID int) (int64, 
 
 // StartWebhookScan starts a webhook-triggered subtree scan for a directory.
 func (s *Service) StartWebhookScan(ctx context.Context, directoryID int, scanRoot string) (int64, error) {
-	return s.startScan(ctx, directoryID, "webhook", scanRoot)
+	if s == nil || s.store == nil {
+		return 0, errors.New("dirscan service is not initialized")
+	}
+
+	s.webhookMu.Lock()
+	defer s.webhookMu.Unlock()
+
+	dir, err := s.store.GetDirectory(ctx, directoryID)
+	if err != nil {
+		return 0, fmt.Errorf("get directory: %w", err)
+	}
+
+	active, err := s.store.GetActiveRun(ctx, directoryID)
+	if err != nil {
+		return 0, fmt.Errorf("get active run: %w", err)
+	}
+	if active == nil {
+		return s.startScan(ctx, directoryID, "webhook", scanRoot)
+	}
+
+	mergedRoot := mergeWebhookScanRoots(dir.Path, active.ScanRoot, scanRoot)
+	if active.Status == models.DirScanRunStatusQueued {
+		if mergedRoot != active.ScanRoot {
+			if err := s.store.UpdateRunScanRoot(ctx, active.ID, mergedRoot); err != nil {
+				return 0, fmt.Errorf("merge queued webhook scan root: %w", err)
+			}
+		}
+		return active.ID, nil
+	}
+
+	queued, err := s.store.GetQueuedRun(ctx, directoryID)
+	if err != nil {
+		return 0, fmt.Errorf("get queued run: %w", err)
+	}
+	if queued != nil {
+		mergedRoot = mergeWebhookScanRoots(dir.Path, queued.ScanRoot, scanRoot)
+		if mergedRoot != queued.ScanRoot {
+			if err := s.store.UpdateRunScanRoot(ctx, queued.ID, mergedRoot); err != nil {
+				return 0, fmt.Errorf("merge follow-up webhook scan root: %w", err)
+			}
+		}
+		return queued.ID, nil
+	}
+
+	runID, err := s.store.CreateRun(ctx, directoryID, "webhook", scanRoot)
+	if err != nil {
+		return 0, fmt.Errorf("create queued webhook run: %w", err)
+	}
+
+	s.startRun(context.Background(), directoryID, runID)
+	return runID, nil
 }
 
 // CancelScan cancels an active scan.
@@ -360,6 +413,9 @@ func (s *Service) CancelScan(ctx context.Context, directoryID int) error {
 		if err := s.store.UpdateDirectoryLastScan(context.Background(), directoryID); err != nil {
 			log.Debug().Err(err).Int("directoryID", directoryID).Msg("dirscan: failed to bump last scan after queued cancel")
 		}
+	}
+	if err := s.store.CancelQueuedRuns(context.Background(), directoryID); err != nil {
+		return fmt.Errorf("cancel queued runs: %w", err)
 	}
 	return nil
 }
@@ -463,7 +519,7 @@ func (s *Service) executeScan(ctx context.Context, directoryID int, runID int64)
 		return
 	}
 
-	scanResult, fileIDIndex, ok := s.runScanPhase(ctx, dir, scanRoot, settings, runID, &l)
+	scanResult, fileIDIndex, ok := s.runScanPhase(ctx, dir, scanRoot, runID, &l)
 	if !ok {
 		return
 	}
@@ -475,12 +531,36 @@ func (s *Service) executeScan(ctx context.Context, directoryID int, runID int64)
 		return
 	}
 
+	workSelection := selectEligibleRootWork(
+		scanResult,
+		trackedFiles,
+		s.parser,
+		maxSearcheeAgeDaysFromSettings(settings),
+		time.Now(),
+	)
+
+	if err := s.store.UpdateRunStatus(ctx, runID, models.DirScanRunStatusSearching); err != nil {
+		l.Error().Err(err).Msg("dirscan: failed to update run status")
+	}
+	if err := s.store.UpdateRunStats(ctx, runID, workSelection.eligibleFiles, workSelection.skippedFiles, 0, 0); err != nil {
+		l.Error().Err(err).Msg("dirscan: failed to update run stats")
+	}
+
+	l.Info().
+		Int("searchees", len(scanResult.Searchees)).
+		Int("searcheesEligible", len(workSelection.roots)).
+		Int("filesDiscovered", workSelection.discoveredFiles).
+		Int("filesEligible", workSelection.eligibleFiles).
+		Int("filesSkipped", workSelection.skippedFiles).
+		Int64("totalSize", scanResult.TotalSize).
+		Msg("dirscan: scan phase complete")
+
 	if s.handleCancellation(ctx, runID, &l, "before search phase") {
 		return
 	}
 
-	matchesFound, torrentsAdded := s.runSearchAndInjectPhase(ctx, dir, scanResult, fileIDIndex, trackedFiles, settings, matcher, runID, &l)
-	s.finalizeRun(ctx, runID, scanResult, matchesFound, torrentsAdded, dir.TargetInstanceID, &l)
+	matchesFound, torrentsAdded := s.runSearchAndInjectPhase(ctx, dir, workSelection, fileIDIndex, trackedFiles, settings, matcher, runID, &l)
+	s.finalizeRun(ctx, runID, workSelection.eligibleFiles, workSelection.skippedFiles, matchesFound, torrentsAdded, dir.TargetInstanceID, &l)
 }
 
 func (s *Service) updateDirectoryLastScan(ctx context.Context, directoryID int, l *zerolog.Logger) {
@@ -528,14 +608,13 @@ func matchModeFromSettings(settings *models.DirScanSettings) MatchMode {
 	return MatchModeStrict
 }
 
-func (s *Service) finalizeRun(ctx context.Context, runID int64, scanResult *ScanResult, matchesFound, torrentsAdded int, instanceID int, l *zerolog.Logger) {
-	if s == nil || s.store == nil || scanResult == nil || runID <= 0 {
+func (s *Service) finalizeRun(ctx context.Context, runID int64, filesFound, filesSkipped, matchesFound, torrentsAdded int, instanceID int, l *zerolog.Logger) {
+	if s == nil || s.store == nil || runID <= 0 {
 		return
 	}
 
 	if ctx.Err() != nil {
-		filesFound := scanResult.TotalFiles + scanResult.SkippedFiles
-		if err := s.store.UpdateRunStats(context.Background(), runID, filesFound, scanResult.SkippedFiles, matchesFound, torrentsAdded); err != nil && l != nil {
+		if err := s.store.UpdateRunStats(context.Background(), runID, filesFound, filesSkipped, matchesFound, torrentsAdded); err != nil && l != nil {
 			l.Debug().Err(err).Msg("dirscan: failed to persist run stats before cancel")
 		}
 
@@ -640,8 +719,8 @@ func (s *Service) validateDirectory(ctx context.Context, directoryID int, runID 
 }
 
 // runScanPhase executes the directory scanning phase.
-// Returns the scan result and true if successful, or nil and false on failure.
-func (s *Service) runScanPhase(ctx context.Context, dir *models.DirScanDirectory, scanRoot string, settings *models.DirScanSettings, runID int64, l *zerolog.Logger) (*ScanResult, map[string]string, bool) {
+// Returns the raw scan result and true if successful, or nil and false on failure.
+func (s *Service) runScanPhase(ctx context.Context, dir *models.DirScanDirectory, scanRoot string, runID int64, l *zerolog.Logger) (*ScanResult, map[string]string, bool) {
 	scanner := NewScanner()
 
 	// Build FileID index from qBittorrent torrents for already-seeding detection.
@@ -663,45 +742,7 @@ func (s *Service) runScanPhase(ctx context.Context, dir *models.DirScanDirectory
 		return nil, nil, false
 	}
 
-	maxSearcheeAgeDays := maxSearcheeAgeDaysFromSettings(settings)
-	ageFilterStats := applyMaxSearcheeAgeFilter(scanResult, maxSearcheeAgeDays, time.Now(), fileIDIndex)
-	if ageFilterStats.ExcludedSearchees > 0 {
-		l.Info().
-			Int("maxSearcheeAgeDays", maxSearcheeAgeDays).
-			Time("cutoff", ageFilterStats.Cutoff).
-			Int("excludedSearchees", ageFilterStats.ExcludedSearchees).
-			Int("excludedFiles", ageFilterStats.ExcludedFiles).
-			Int64("excludedBytes", ageFilterStats.ExcludedBytes).
-			Msg("dirscan: excluded stale searchees by age filter")
-	}
-
-	// Update status to searching
-	if err := s.store.UpdateRunStatus(ctx, runID, models.DirScanRunStatusSearching); err != nil {
-		l.Error().Err(err).Msg("dirscan: failed to update run status")
-	}
-
-	// Update run stats with scan results
-	filesFound := scanResult.TotalFiles + scanResult.SkippedFiles
-	if err := s.store.UpdateRunStats(ctx, runID, filesFound, scanResult.SkippedFiles, 0, 0); err != nil {
-		l.Error().Err(err).Msg("dirscan: failed to update run stats")
-	}
-
-	l.Info().
-		Int("searchees", len(scanResult.Searchees)).
-		Int("filesFound", filesFound).
-		Int("filesEligible", scanResult.TotalFiles).
-		Int("filesSkipped", scanResult.SkippedFiles).
-		Int64("totalSize", scanResult.TotalSize).
-		Msg("dirscan: scan phase complete")
-
 	return scanResult, fileIDIndex, true
-}
-
-type scanAgeFilterStats struct {
-	Cutoff            time.Time
-	ExcludedSearchees int
-	ExcludedFiles     int
-	ExcludedBytes     int64
 }
 
 func maxSearcheeAgeDaysFromSettings(settings *models.DirScanSettings) int {
@@ -711,91 +752,11 @@ func maxSearcheeAgeDaysFromSettings(settings *models.DirScanSettings) int {
 	return settings.MaxSearcheeAgeDays
 }
 
-func applyMaxSearcheeAgeFilter(scanResult *ScanResult, maxSearcheeAgeDays int, now time.Time, fileIDIndex map[string]string) scanAgeFilterStats {
-	stats := scanAgeFilterStats{}
-	if scanResult == nil || maxSearcheeAgeDays <= 0 {
-		return stats
-	}
-
-	stats.Cutoff = now.AddDate(0, 0, -maxSearcheeAgeDays)
-	kept := make([]*Searchee, 0, len(scanResult.Searchees))
-	for _, searchee := range scanResult.Searchees {
-		if searchee == nil {
-			continue
-		}
-		if searcheeNewestModTimeBeforeCutoff(searchee, stats.Cutoff) {
-			stats.ExcludedSearchees++
-			stats.ExcludedFiles += len(searchee.Files)
-			for _, f := range searchee.Files {
-				if f == nil {
-					continue
-				}
-				stats.ExcludedBytes += f.Size
-			}
-			continue
-		}
-		kept = append(kept, searchee)
-	}
-
-	scanResult.Searchees = kept
-	recomputeScanResultSummary(scanResult, fileIDIndex)
-	return stats
-}
-
-func searcheeNewestModTimeBeforeCutoff(searchee *Searchee, cutoff time.Time) bool {
-	if searchee == nil || len(searchee.Files) == 0 {
-		return false
-	}
-
-	var newest time.Time
-	for _, f := range searchee.Files {
-		if f == nil {
-			continue
-		}
-		if f.ModTime.After(newest) {
-			newest = f.ModTime
-		}
-	}
-	if newest.IsZero() {
-		return false
-	}
-	return newest.Before(cutoff)
-}
-
-func recomputeScanResultSummary(scanResult *ScanResult, fileIDIndex map[string]string) {
-	if scanResult == nil {
-		return
-	}
-
-	scanResult.TotalFiles = 0
-	scanResult.TotalSize = 0
-	scanResult.SkippedFiles = 0
-
-	for _, searchee := range scanResult.Searchees {
-		if searchee == nil || len(searchee.Files) == 0 {
-			continue
-		}
-
-		if isAlreadySeedingByFileID(searchee, fileIDIndex) {
-			scanResult.SkippedFiles += len(searchee.Files)
-			continue
-		}
-
-		for _, f := range searchee.Files {
-			if f == nil {
-				continue
-			}
-			scanResult.TotalFiles++
-			scanResult.TotalSize += f.Size
-		}
-	}
-}
-
 // runSearchAndInjectPhase searches indexers for each searchee and injects matches.
 func (s *Service) runSearchAndInjectPhase(
 	ctx context.Context,
 	dir *models.DirScanDirectory,
-	scanResult *ScanResult,
+	workSelection scanWorkSelection,
 	fileIDIndex map[string]string,
 	trackedFiles *trackedFilesIndex,
 	settings *models.DirScanSettings,
@@ -803,31 +764,21 @@ func (s *Service) runSearchAndInjectPhase(
 	runID int64,
 	l *zerolog.Logger,
 ) (matchesFound, torrentsAdded int) {
-	if scanResult == nil {
+	if len(workSelection.roots) == 0 {
 		return 0, 0
 	}
 
-	sort.SliceStable(scanResult.Searchees, func(i, j int) bool {
-		if scanResult.Searchees[i] == nil {
+	sort.SliceStable(workSelection.roots, func(i, j int) bool {
+		if workSelection.roots[i].root == nil {
 			return false
 		}
-		if scanResult.Searchees[j] == nil {
+		if workSelection.roots[j].root == nil {
 			return true
 		}
-		return scanResult.Searchees[i].Path < scanResult.Searchees[j].Path
+		return workSelection.roots[i].root.Path < workSelection.roots[j].root.Path
 	})
 
-	eligible := make([]*Searchee, 0, len(scanResult.Searchees))
-	skippedDone := 0
-	for _, searchee := range scanResult.Searchees {
-		if searcheeIsEligible(searchee, trackedFiles) {
-			eligible = append(eligible, searchee)
-		} else {
-			skippedDone++
-		}
-	}
-
-	processed := eligible
+	processed := workSelection.roots
 	maxPerRun := 0
 	if settings != nil {
 		maxPerRun = settings.MaxSearcheesPerRun
@@ -838,9 +789,7 @@ func (s *Service) runSearchAndInjectPhase(
 
 	if l != nil {
 		l.Info().
-			Int("searcheesTotal", len(scanResult.Searchees)).
-			Int("searcheesEligible", len(eligible)).
-			Int("searcheesSkippedDone", skippedDone).
+			Int("searcheesEligible", len(workSelection.roots)).
 			Int("searcheesProcessed", len(processed)).
 			Int("maxSearcheesPerRun", maxPerRun).
 			Msg("dirscan: searchee selection")
@@ -848,7 +797,7 @@ func (s *Service) runSearchAndInjectPhase(
 
 	injectedTVGroups := make(map[tvGroupKey]struct{})
 
-	for _, searchee := range processed {
+	for _, selected := range processed {
 		if ctx.Err() != nil {
 			if l != nil {
 				l.Info().Msg("dirscan: search phase canceled")
@@ -859,7 +808,8 @@ func (s *Service) runSearchAndInjectPhase(
 		matchesFound, torrentsAdded = s.processRootSearchee(
 			ctx,
 			dir,
-			searchee,
+			selected.root,
+			selected.items,
 			fileIDIndex,
 			trackedFiles,
 			injectedTVGroups,
@@ -885,6 +835,7 @@ func (s *Service) processRootSearchee(
 	ctx context.Context,
 	dir *models.DirScanDirectory,
 	searchee *Searchee,
+	workItems []searcheeWorkItem,
 	fileIDIndex map[string]string,
 	trackedFiles *trackedFilesIndex,
 	injectedTVGroups map[tvGroupKey]struct{},
@@ -952,7 +903,6 @@ func (s *Service) processRootSearchee(
 		return matchesFoundOut, torrentsAddedOut
 	}
 
-	workItems := buildSearcheeWorkItems(searchee, s.parser)
 	for _, item := range workItems {
 		if ctx.Err() != nil {
 			hasProcessingError = true

--- a/internal/services/dirscan/service.go
+++ b/internal/services/dirscan/service.go
@@ -535,7 +535,7 @@ func (s *Service) executeScan(ctx context.Context, directoryID int, runID int64)
 		scanResult,
 		trackedFiles,
 		s.parser,
-		maxSearcheeAgeDaysFromSettings(settings),
+		effectiveMaxSearcheeAgeDays(settings, run.TriggeredBy),
 		time.Now(),
 		&l,
 	)
@@ -751,6 +751,14 @@ func maxSearcheeAgeDaysFromSettings(settings *models.DirScanSettings) int {
 		return 0
 	}
 	return settings.MaxSearcheeAgeDays
+}
+
+func effectiveMaxSearcheeAgeDays(settings *models.DirScanSettings, triggeredBy string) int {
+	if triggeredBy == "webhook" {
+		return 0
+	}
+
+	return maxSearcheeAgeDaysFromSettings(settings)
 }
 
 // runSearchAndInjectPhase searches indexers for each searchee and injects matches.

--- a/internal/services/dirscan/service.go
+++ b/internal/services/dirscan/service.go
@@ -524,7 +524,7 @@ func (s *Service) executeScan(ctx context.Context, directoryID int, runID int64)
 		return
 	}
 
-	trackedFiles, err := s.refreshTrackedFilesFromScan(ctx, directoryID, scanResult, fileIDIndex)
+	trackedFiles, err := s.refreshTrackedFilesFromScan(ctx, directoryID, scanResult, fileIDIndex, &l)
 	if err != nil {
 		l.Error().Err(err).Msg("dirscan: failed to persist scan progress")
 		s.markRunFailed(ctx, runID, fmt.Sprintf("persist scan progress: %v", err), dir.TargetInstanceID, &l)
@@ -537,6 +537,7 @@ func (s *Service) executeScan(ctx context.Context, directoryID int, runID int64)
 		s.parser,
 		maxSearcheeAgeDaysFromSettings(settings),
 		time.Now(),
+		&l,
 	)
 
 	if err := s.store.UpdateRunStatus(ctx, runID, models.DirScanRunStatusSearching); err != nil {

--- a/internal/services/dirscan/webhook_queue.go
+++ b/internal/services/dirscan/webhook_queue.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package dirscan
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+func mergeWebhookScanRoots(directoryPath, existing, next string) string {
+	dir := filepath.Clean(directoryPath)
+	current := normalizeQueuedWebhookRoot(dir, existing)
+	incoming := normalizeQueuedWebhookRoot(dir, next)
+
+	if current == incoming {
+		return current
+	}
+	if current == dir || incoming == dir {
+		return dir
+	}
+
+	for candidate := current; candidate != "." && candidate != string(filepath.Separator); candidate = filepath.Dir(candidate) {
+		if isPathWithin(candidate, incoming) && isPathWithin(dir, candidate) {
+			return candidate
+		}
+		if candidate == dir {
+			return dir
+		}
+	}
+
+	return dir
+}
+
+func normalizeQueuedWebhookRoot(directoryPath, scanRoot string) string {
+	if scanRoot == "" {
+		return filepath.Clean(directoryPath)
+	}
+	return filepath.Clean(scanRoot)
+}
+
+func isPathWithin(base, target string) bool {
+	base = filepath.Clean(base)
+	target = filepath.Clean(target)
+	if base == target {
+		return true
+	}
+
+	rel, err := filepath.Rel(base, target)
+	if err != nil {
+		return false
+	}
+
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}

--- a/internal/services/dirscan/webhook_queue_test.go
+++ b/internal/services/dirscan/webhook_queue_test.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package dirscan
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/database"
+	"github.com/autobrr/qui/internal/models"
+)
+
+func TestMergeWebhookScanRoots(t *testing.T) {
+	dir := "/data/media/tv"
+
+	require.Equal(t, dir, mergeWebhookScanRoots(dir, "", dir))
+	require.Equal(t, filepath.Join(dir, "Show"), mergeWebhookScanRoots(
+		dir,
+		filepath.Join(dir, "Show", "Season 01"),
+		filepath.Join(dir, "Show", "Season 02"),
+	))
+	require.Equal(t, dir, mergeWebhookScanRoots(
+		dir,
+		filepath.Join(dir, "Show A", "Season 01"),
+		filepath.Join(dir, "Show B", "Season 01"),
+	))
+}
+
+func TestStartWebhookScan_QueuesAndMergesFollowUpRuns(t *testing.T) {
+	ctx := t.Context()
+
+	dbPath := filepath.Join(t.TempDir(), "webhook-queue.db")
+	db, err := database.New(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	instanceStore, err := models.NewInstanceStore(db, []byte("0123456789abcdef0123456789abcdef"))
+	require.NoError(t, err)
+	localAccess := true
+	instance, err := instanceStore.Create(ctx, "test", "http://localhost:8080", "", "", nil, nil, false, &localAccess)
+	require.NoError(t, err)
+
+	store := models.NewDirScanStore(db)
+	service := NewService(DefaultConfig(), store, nil, instanceStore, nil, nil, nil, nil, nil)
+
+	dirPath := t.TempDir()
+	created, err := service.CreateDirectory(ctx, &models.DirScanDirectory{
+		Path:                dirPath,
+		Enabled:             true,
+		TargetInstanceID:    instance.ID,
+		ScanIntervalMinutes: 60,
+	})
+	require.NoError(t, err)
+
+	activeRunID, err := store.CreateRun(ctx, created.ID, "webhook", filepath.Join(dirPath, "Show", "Season 01"))
+	require.NoError(t, err)
+	require.NoError(t, store.UpdateRunStatus(ctx, activeRunID, models.DirScanRunStatusScanning))
+
+	dirMu := service.getDirectoryMutex(created.ID)
+	dirMu.Lock()
+
+	firstQueuedID, err := service.StartWebhookScan(ctx, created.ID, filepath.Join(dirPath, "Show", "Season 01"))
+	require.NoError(t, err)
+	require.NotZero(t, firstQueuedID)
+	require.NotEqual(t, activeRunID, firstQueuedID)
+
+	secondQueuedID, err := service.StartWebhookScan(ctx, created.ID, filepath.Join(dirPath, "Show", "Season 02"))
+	require.NoError(t, err)
+	require.Equal(t, firstQueuedID, secondQueuedID)
+
+	queuedRun, err := store.GetQueuedRun(ctx, created.ID)
+	require.NoError(t, err)
+	require.NotNil(t, queuedRun)
+	require.Equal(t, filepath.Join(dirPath, "Show"), queuedRun.ScanRoot)
+
+	require.NoError(t, service.CancelScan(ctx, created.ID))
+	dirMu.Unlock()
+
+	require.Eventually(t, func() bool {
+		run, getErr := store.GetRun(ctx, queuedRun.ID)
+		require.NoError(t, getErr)
+		return run != nil && run.Status == models.DirScanRunStatusCanceled
+	}, 5*time.Second, 50*time.Millisecond)
+}

--- a/internal/services/dirscan/work_selection.go
+++ b/internal/services/dirscan/work_selection.go
@@ -9,8 +9,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/autobrr/qui/internal/models"
 	"github.com/rs/zerolog"
+
+	"github.com/autobrr/qui/internal/models"
 )
 
 type rootWorkSelection struct {

--- a/internal/services/dirscan/work_selection.go
+++ b/internal/services/dirscan/work_selection.go
@@ -4,9 +4,13 @@
 package dirscan
 
 import (
+	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/autobrr/qui/internal/models"
+	"github.com/rs/zerolog"
 )
 
 type rootWorkSelection struct {
@@ -28,6 +32,7 @@ func selectEligibleRootWork(
 	parser *Parser,
 	maxSearcheeAgeDays int,
 	now time.Time,
+	l *zerolog.Logger,
 ) scanWorkSelection {
 	selection := scanWorkSelection{}
 	if scanResult == nil {
@@ -55,11 +60,17 @@ func selectEligibleRootWork(
 
 		items := buildSearcheeWorkItems(root, parser)
 		pendingItems := make([]searcheeWorkItem, 0, len(items))
+		droppedItems := make([]workItemDropDecision, 0, len(items))
 		for _, item := range items {
-			if item.searchee == nil || workItemIsStale(item, selection.cutoff) {
+			if item.searchee == nil {
+				continue
+			}
+			if workItemIsStale(item, selection.cutoff) {
+				droppedItems = append(droppedItems, buildWorkItemDropDecision(item, "stale", selection.cutoff, trackedFiles))
 				continue
 			}
 			if !workItemHasPendingFiles(item, trackedFiles) {
+				droppedItems = append(droppedItems, buildWorkItemDropDecision(item, "all_final", selection.cutoff, trackedFiles))
 				continue
 			}
 			pendingItems = append(pendingItems, item)
@@ -72,6 +83,7 @@ func selectEligibleRootWork(
 		}
 
 		if len(pendingItems) == 0 {
+			logRootSelectionDrops(l, root, droppedItems, selection.cutoff)
 			continue
 		}
 
@@ -86,6 +98,15 @@ func selectEligibleRootWork(
 	selection.skippedFiles = max(selection.discoveredFiles-selection.eligibleFiles, 0)
 
 	return selection
+}
+
+type workItemDropDecision struct {
+	name             string
+	path             string
+	reason           string
+	contentFiles     int
+	newestContentMod time.Time
+	statuses         string
 }
 
 func workItemHasPendingFiles(item searcheeWorkItem, trackedFiles *trackedFilesIndex) bool {
@@ -121,6 +142,113 @@ func trackedFileForScannedFile(f *ScannedFile, trackedFiles *trackedFilesIndex) 
 		}
 	}
 	return nil
+}
+
+func buildWorkItemDropDecision(
+	item searcheeWorkItem,
+	reason string,
+	cutoff time.Time,
+	trackedFiles *trackedFilesIndex,
+) workItemDropDecision {
+	decision := workItemDropDecision{reason: reason}
+	if item.searchee == nil {
+		return decision
+	}
+
+	contentFiles := filterContentFiles(item.searchee.Files)
+	decision.name = item.searchee.Name
+	decision.path = item.searchee.Path
+	decision.contentFiles = len(contentFiles)
+	decision.newestContentMod = newestContentModTime(contentFiles)
+	decision.statuses = summarizeTrackedStatuses(item, trackedFiles)
+
+	if decision.reason == "stale" && !cutoff.IsZero() && decision.newestContentMod.IsZero() {
+		decision.statuses = "no_content_files"
+	}
+
+	return decision
+}
+
+func newestContentModTime(files []*ScannedFile) time.Time {
+	var newest time.Time
+	for _, f := range files {
+		if f == nil {
+			continue
+		}
+		if f.ModTime.After(newest) {
+			newest = f.ModTime
+		}
+	}
+	return newest
+}
+
+func summarizeTrackedStatuses(item searcheeWorkItem, trackedFiles *trackedFilesIndex) string {
+	if item.searchee == nil {
+		return ""
+	}
+
+	counts := make(map[string]int)
+	for _, f := range item.searchee.Files {
+		if f == nil {
+			continue
+		}
+
+		status := "untracked"
+		if tracked := trackedFileForScannedFile(f, trackedFiles); tracked != nil {
+			status = string(tracked.Status)
+		}
+		counts[status]++
+	}
+
+	if len(counts) == 0 {
+		return ""
+	}
+
+	keys := make([]string, 0, len(counts))
+	for status := range counts {
+		keys = append(keys, status)
+	}
+	sort.Strings(keys)
+
+	parts := make([]string, 0, len(keys))
+	for _, status := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%d", status, counts[status]))
+	}
+
+	return strings.Join(parts, ", ")
+}
+
+func logRootSelectionDrops(l *zerolog.Logger, root *Searchee, droppedItems []workItemDropDecision, cutoff time.Time) {
+	if l == nil || root == nil || len(droppedItems) == 0 {
+		return
+	}
+
+	event := l.Debug().
+		Str("rootName", root.Name).
+		Str("rootPath", root.Path).
+		Int("rootFiles", len(root.Files)).
+		Int("droppedItems", len(droppedItems))
+	if !cutoff.IsZero() {
+		event = event.Time("cutoff", cutoff)
+	}
+	event.Msg("dirscan: no eligible work items for root")
+
+	for _, item := range droppedItems {
+		event := l.Debug().
+			Str("rootPath", root.Path).
+			Str("itemName", item.name).
+			Str("itemPath", item.path).
+			Str("reason", item.reason).
+			Int("contentFiles", item.contentFiles).
+			Str("statuses", item.statuses)
+		if !item.newestContentMod.IsZero() {
+			event = event.Time("newestContentMod", item.newestContentMod)
+		}
+		if !cutoff.IsZero() {
+			event = event.Time("cutoff", cutoff)
+		}
+		event.Msg("dirscan: dropped work item")
+	}
 }
 
 func workItemIsStale(item searcheeWorkItem, cutoff time.Time) bool {

--- a/internal/services/dirscan/work_selection.go
+++ b/internal/services/dirscan/work_selection.go
@@ -83,10 +83,7 @@ func selectEligibleRootWork(
 
 	selection.discoveredFiles = len(discoveredPaths)
 	selection.eligibleFiles = len(eligiblePaths)
-	selection.skippedFiles = selection.discoveredFiles - selection.eligibleFiles
-	if selection.skippedFiles < 0 {
-		selection.skippedFiles = 0
-	}
+	selection.skippedFiles = max(selection.discoveredFiles-selection.eligibleFiles, 0)
 
 	return selection
 }

--- a/internal/services/dirscan/work_selection.go
+++ b/internal/services/dirscan/work_selection.go
@@ -1,0 +1,164 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package dirscan
+
+import (
+	"time"
+
+	"github.com/autobrr/qui/internal/models"
+)
+
+type rootWorkSelection struct {
+	root  *Searchee
+	items []searcheeWorkItem
+}
+
+type scanWorkSelection struct {
+	roots           []rootWorkSelection
+	cutoff          time.Time
+	discoveredFiles int
+	eligibleFiles   int
+	skippedFiles    int
+}
+
+func selectEligibleRootWork(
+	scanResult *ScanResult,
+	trackedFiles *trackedFilesIndex,
+	parser *Parser,
+	maxSearcheeAgeDays int,
+	now time.Time,
+) scanWorkSelection {
+	selection := scanWorkSelection{}
+	if scanResult == nil {
+		return selection
+	}
+
+	if maxSearcheeAgeDays > 0 {
+		selection.cutoff = now.AddDate(0, 0, -maxSearcheeAgeDays)
+	}
+
+	discoveredPaths := make(map[string]struct{})
+	eligiblePaths := make(map[string]struct{})
+
+	for _, root := range scanResult.Searchees {
+		if root == nil {
+			continue
+		}
+
+		for _, f := range root.Files {
+			if f == nil {
+				continue
+			}
+			discoveredPaths[f.Path] = struct{}{}
+		}
+
+		items := buildSearcheeWorkItems(root, parser)
+		pendingItems := make([]searcheeWorkItem, 0, len(items))
+		for _, item := range items {
+			if item.searchee == nil || workItemIsStale(item, selection.cutoff) {
+				continue
+			}
+			if !workItemHasPendingFiles(item, trackedFiles) {
+				continue
+			}
+			pendingItems = append(pendingItems, item)
+			for _, f := range item.searchee.Files {
+				if f == nil {
+					continue
+				}
+				eligiblePaths[f.Path] = struct{}{}
+			}
+		}
+
+		if len(pendingItems) == 0 {
+			continue
+		}
+
+		selection.roots = append(selection.roots, rootWorkSelection{
+			root:  root,
+			items: pendingItems,
+		})
+	}
+
+	selection.discoveredFiles = len(discoveredPaths)
+	selection.eligibleFiles = len(eligiblePaths)
+	selection.skippedFiles = selection.discoveredFiles - selection.eligibleFiles
+	if selection.skippedFiles < 0 {
+		selection.skippedFiles = 0
+	}
+
+	return selection
+}
+
+func workItemHasPendingFiles(item searcheeWorkItem, trackedFiles *trackedFilesIndex) bool {
+	if item.searchee == nil {
+		return false
+	}
+
+	for _, f := range item.searchee.Files {
+		if f == nil {
+			continue
+		}
+
+		tracked := trackedFileForScannedFile(f, trackedFiles)
+		if tracked == nil || !isFinalFileStatus(tracked.Status) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func trackedFileForScannedFile(f *ScannedFile, trackedFiles *trackedFilesIndex) *models.DirScanFile {
+	if f == nil || trackedFiles == nil {
+		return nil
+	}
+
+	if tracked := trackedFiles.byPath[f.Path]; tracked != nil {
+		return tracked
+	}
+	if !f.FileID.IsZero() {
+		if tracked := trackedFiles.byFileID[string(f.FileID.Bytes())]; tracked != nil {
+			return tracked
+		}
+	}
+	return nil
+}
+
+func workItemIsStale(item searcheeWorkItem, cutoff time.Time) bool {
+	if item.searchee == nil || cutoff.IsZero() {
+		return false
+	}
+
+	contentFiles := filterContentFiles(item.searchee.Files)
+	if len(contentFiles) == 0 {
+		return false
+	}
+
+	if item.tvGroup != nil && len(contentFiles) > 1 {
+		for _, f := range contentFiles {
+			if f == nil {
+				continue
+			}
+			if f.ModTime.Before(cutoff) {
+				return true
+			}
+		}
+		return false
+	}
+
+	var newest time.Time
+	for _, f := range contentFiles {
+		if f == nil {
+			continue
+		}
+		if f.ModTime.After(newest) {
+			newest = f.ModTime
+		}
+	}
+	if newest.IsZero() {
+		return false
+	}
+	return newest.Before(cutoff)
+}

--- a/web/src/components/cross-seed/DirScanTab.tsx
+++ b/web/src/components/cross-seed/DirScanTab.tsx
@@ -459,7 +459,7 @@ function DirectoryStatusBadge({ run }: { run: DirScanRun }) {
   }
 
   const config = statusConfig[run.status]
-  const hasStats = run.filesFound > 0 || run.matchesFound > 0 || run.torrentsAdded > 0
+  const hasStats = run.filesFound > 0 || run.filesSkipped > 0 || run.matchesFound > 0 || run.torrentsAdded > 0
 
   return (
     <div className={`flex items-center gap-1.5 text-xs ${config.color}`}>
@@ -469,7 +469,10 @@ function DirectoryStatusBadge({ run }: { run: DirScanRun }) {
         <span className="inline-flex items-center gap-1">
           <span className="text-muted-foreground">(</span>
           <RunFilesBadge run={run} />
-          <span className="text-muted-foreground">, {run.matchesFound} matches, {run.torrentsAdded} added)</span>
+          <span className="text-muted-foreground">
+            {run.filesSkipped > 0 ? `, ${run.filesSkipped} skipped` : ""}
+            , {run.matchesFound} matches, {run.torrentsAdded} added)
+          </span>
         </span>
       )}
     </div>

--- a/web/src/components/cross-seed/DirScanTab.tsx
+++ b/web/src/components/cross-seed/DirScanTab.tsx
@@ -111,6 +111,34 @@ function formatRelativeTimeStr(date: string | Date): string {
   return formatRelativeTime(typeof date === "string" ? new Date(date) : date)
 }
 
+function getRunDiscoveredFiles(run: DirScanRun): number {
+  return run.filesFound + run.filesSkipped
+}
+
+function getRunFilesLabel(run: DirScanRun): string {
+  return `${run.filesFound} eligible`
+}
+
+function RunFilesBadge({ run }: { run: DirScanRun }) {
+  const discovered = getRunDiscoveredFiles(run)
+  const showDetails = discovered > run.filesFound
+
+  if (!showDetails) {
+    return <span className="text-muted-foreground">{getRunFilesLabel(run)}</span>
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger className="cursor-default text-muted-foreground">
+        {getRunFilesLabel(run)}
+      </TooltipTrigger>
+      <TooltipContent>
+        {discovered} discovered, {run.filesSkipped} skipped
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
 export function DirScanTab({ instances }: DirScanTabProps) {
   const { formatISOTimestamp } = useDateTimeFormatters()
   const [selectedDirectoryId, setSelectedDirectoryId] = useState<number | null>(null)
@@ -438,8 +466,10 @@ function DirectoryStatusBadge({ run }: { run: DirScanRun }) {
       {config.icon}
       <span>{config.label}</span>
       {hasStats && (
-        <span className="text-muted-foreground">
-          ({run.filesFound} files, {run.matchesFound} matches, {run.torrentsAdded} added)
+        <span className="inline-flex items-center gap-1">
+          <span className="text-muted-foreground">(</span>
+          <RunFilesBadge run={run} />
+          <span className="text-muted-foreground">, {run.matchesFound} matches, {run.torrentsAdded} added)</span>
         </span>
       )}
     </div>
@@ -524,7 +554,9 @@ function RunRow({
             )}
           </div>
         </TableCell>
-        <TableCell>{run.filesFound}</TableCell>
+        <TableCell>
+          <RunFilesBadge run={run} />
+        </TableCell>
         <TableCell>{run.matchesFound}</TableCell>
         <TableCell>{run.torrentsAdded}</TableCell>
         <TableCell>
@@ -673,7 +705,7 @@ function DirectoryDetails({ directoryId, formatDateTime, formatRelativeTime }: D
               <TableRow>
                 <TableHead>Started</TableHead>
                 <TableHead>Status</TableHead>
-                <TableHead>Files</TableHead>
+                <TableHead>Eligible</TableHead>
                 <TableHead>Matches</TableHead>
                 <TableHead>Added</TableHead>
                 <TableHead>Duration</TableHead>
@@ -965,7 +997,7 @@ function SettingsDialog({ open, onOpenChange, settings, instances }: SettingsDia
                   }))
                 }}
               />
-              <Label htmlFor="max-searchee-age-enabled">Skip searchees older than</Label>
+              <Label htmlFor="max-searchee-age-enabled">Only process items changed within the last</Label>
             </div>
 
             {ageFilterEnabled && (
@@ -1005,7 +1037,7 @@ function SettingsDialog({ open, onOpenChange, settings, instances }: SettingsDia
                 </div>
 
                 <p className="text-xs text-muted-foreground">
-                  Uses file modified time (mtime). A searchee is skipped only when all files in it are older than the cutoff.
+                  Uses video/audio file modified time (mtime). Fresh subtitles or extras do not keep old items in scope.
                 </p>
                 <p className="text-xs text-muted-foreground">
                   Current cutoff: {ageFilterCutoffPreview}

--- a/web/src/components/cross-seed/DirScanTab.tsx
+++ b/web/src/components/cross-seed/DirScanTab.tsx
@@ -1043,6 +1043,9 @@ function SettingsDialog({ open, onOpenChange, settings, instances }: SettingsDia
                   Uses video/audio file modified time (mtime). Fresh subtitles or extras do not keep old items in scope.
                 </p>
                 <p className="text-xs text-muted-foreground">
+                  Webhook-triggered scans ignore this cutoff and trust the imported path instead.
+                </p>
+                <p className="text-xs text-muted-foreground">
                   Current cutoff: {ageFilterCutoffPreview}
                 </p>
               </>


### PR DESCRIPTION
Webhook-triggered directory scans no longer drop later Sonarr or Radarr imports while a scan is already running. qui now keeps one follow-up queued run per directory and merges later webhook paths into it so imported items are not silently missed.

Dir scan age filtering now uses video and audio mtimes only and applies at TV work-item granularity instead of keeping an entire show alive because one file under it is newer. The UI now reports eligible items as the primary count and moves raw discovered and skipped totals into details.

Closes #1602

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Default Category / Tags" option in Dir Scan settings.
  * Webhook scans now queue and merge follow-up runs, updating queued scan roots instead of rejecting duplicates; queued runs can be canceled.

* **Documentation**
  * Renamed age-filter to "Only process items changed within the last (days)"; clarified per-type rules (video/audio vs TV, season/episode) and examples.
  * Expanded webhook response semantics and guidance for repeated webhooks.

* **UI/UX Improvements**
  * Replaced raw file counts with an "Eligible" badge showing discovered/eligible/skipped breakdown and updated labels/tooltips.

* **Tests**
  * Added tests covering queue/merge behavior and per-type age-selection logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->