### PR TITLE
fix(qbit): prune empty managed dirs after delete_with_files

### DIFF
--- a/internal/qbittorrent/delete_cleanup.go
+++ b/internal/qbittorrent/delete_cleanup.go
@@ -94,13 +94,18 @@ func matchManagedDeleteBaseDir(baseDirs []string, path string) (string, bool) {
 		return "", false
 	}
 
+	bestMatch := ""
 	for _, baseDir := range baseDirs {
-		if isManagedDeletePathInsideBase(path, baseDir) {
-			return baseDir, true
+		if isManagedDeletePathInsideBase(path, baseDir) && len(baseDir) > len(bestMatch) {
+			bestMatch = baseDir
 		}
 	}
 
-	return "", false
+	if bestMatch == "" {
+		return "", false
+	}
+
+	return bestMatch, true
 }
 
 func isManagedDeletePathInsideBase(path, baseDir string) bool {

--- a/internal/qbittorrent/delete_cleanup.go
+++ b/internal/qbittorrent/delete_cleanup.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package qbittorrent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/rs/zerolog/log"
+)
+
+type managedDeleteCleanupTarget struct {
+	dir     string
+	baseDir string
+}
+
+func buildManagedDeleteCleanupTargets(configuredBaseDirs string, torrents []qbt.Torrent) []managedDeleteCleanupTarget {
+	baseDirs := parseManagedDeleteBaseDirs(configuredBaseDirs)
+	if len(baseDirs) == 0 || len(torrents) == 0 {
+		return nil
+	}
+
+	targets := make([]managedDeleteCleanupTarget, 0, len(torrents))
+	seen := make(map[string]struct{}, len(torrents))
+
+	for _, torrent := range torrents {
+		dir, baseDir, ok := managedDeleteCleanupDir(baseDirs, torrent)
+		if !ok {
+			continue
+		}
+
+		key := baseDir + "\x00" + dir
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		targets = append(targets, managedDeleteCleanupTarget{
+			dir:     dir,
+			baseDir: baseDir,
+		})
+	}
+
+	return targets
+}
+
+func cleanupManagedDeleteTargets(targets []managedDeleteCleanupTarget) {
+	for _, target := range targets {
+		pruneEmptyManagedDeleteDir(target)
+	}
+}
+
+func managedDeleteCleanupDir(baseDirs []string, torrent qbt.Torrent) (string, string, bool) {
+	contentPath := filepath.Clean(torrent.ContentPath)
+	savePath := filepath.Clean(torrent.SavePath)
+
+	if info, err := os.Stat(contentPath); err == nil {
+		baseDir, ok := matchManagedDeleteBaseDir(baseDirs, contentPath)
+		if ok {
+			if info.IsDir() {
+				return contentPath, baseDir, true
+			}
+			return filepath.Dir(contentPath), baseDir, true
+		}
+	}
+
+	if baseDir, ok := matchManagedDeleteBaseDir(baseDirs, savePath); ok {
+		return savePath, baseDir, true
+	}
+
+	return "", "", false
+}
+
+func parseManagedDeleteBaseDirs(configuredBaseDirs string) []string {
+	parts := strings.Split(configuredBaseDirs, ",")
+	baseDirs := make([]string, 0, len(parts))
+
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		baseDirs = append(baseDirs, filepath.Clean(part))
+	}
+
+	return baseDirs
+}
+
+func matchManagedDeleteBaseDir(baseDirs []string, path string) (string, bool) {
+	path = filepath.Clean(path)
+	if path == "" || path == "." {
+		return "", false
+	}
+
+	for _, baseDir := range baseDirs {
+		if isManagedDeletePathInsideBase(path, baseDir) {
+			return baseDir, true
+		}
+	}
+
+	return "", false
+}
+
+func isManagedDeletePathInsideBase(path, baseDir string) bool {
+	if path == "" || baseDir == "" {
+		return false
+	}
+
+	rel, err := filepath.Rel(baseDir, path)
+	if err != nil {
+		return false
+	}
+
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}
+
+func pruneEmptyManagedDeleteDir(target managedDeleteCleanupTarget) {
+	dir := filepath.Clean(target.dir)
+	baseDir := filepath.Clean(target.baseDir)
+
+	for isManagedDeletePathInsideBase(dir, baseDir) && dir != baseDir {
+		err := os.Remove(dir)
+		switch {
+		case err == nil, os.IsNotExist(err):
+		case isDirNotEmpty(err):
+			return
+		default:
+			log.Debug().Err(err).Str("dir", dir).Str("baseDir", baseDir).
+				Msg("delete cleanup: failed to prune empty managed directory")
+			return
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return
+		}
+		dir = parent
+	}
+}
+
+func isDirNotEmpty(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return strings.Contains(strings.ToLower(err.Error()), "not empty")
+}

--- a/internal/qbittorrent/delete_cleanup.go
+++ b/internal/qbittorrent/delete_cleanup.go
@@ -4,9 +4,11 @@
 package qbittorrent
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	qbt "github.com/autobrr/go-qbittorrent"
 	"github.com/rs/zerolog/log"
@@ -148,6 +150,10 @@ func pruneEmptyManagedDeleteDir(target managedDeleteCleanupTarget) {
 func isDirNotEmpty(err error) bool {
 	if err == nil {
 		return false
+	}
+
+	if errors.Is(err, syscall.ENOTEMPTY) {
+		return true
 	}
 
 	return strings.Contains(strings.ToLower(err.Error()), "not empty")

--- a/internal/qbittorrent/delete_cleanup.go
+++ b/internal/qbittorrent/delete_cleanup.go
@@ -130,13 +130,15 @@ func isManagedDeletePathInsideBase(path, baseDir string) bool {
 }
 
 func pruneEmptyManagedDeleteDir(target managedDeleteCleanupTarget) {
-	for range managedDeleteCleanupRetryAttempts {
+	for attempt := range managedDeleteCleanupRetryAttempts {
 		retry := pruneEmptyManagedDeleteDirOnce(target)
 		if !retry {
 			return
 		}
 
-		time.Sleep(managedDeleteCleanupRetryInterval)
+		if attempt < managedDeleteCleanupRetryAttempts-1 {
+			time.Sleep(managedDeleteCleanupRetryInterval)
+		}
 	}
 }
 

--- a/internal/qbittorrent/delete_cleanup.go
+++ b/internal/qbittorrent/delete_cleanup.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
 	qbt "github.com/autobrr/go-qbittorrent"
 	"github.com/rs/zerolog/log"
@@ -18,6 +19,11 @@ type managedDeleteCleanupTarget struct {
 	dir     string
 	baseDir string
 }
+
+const (
+	managedDeleteCleanupRetryInterval = 50 * time.Millisecond
+	managedDeleteCleanupRetryAttempts = 20
+)
 
 func buildManagedDeleteCleanupTargets(configuredBaseDirs string, torrents []qbt.Torrent) []managedDeleteCleanupTarget {
 	baseDirs := parseManagedDeleteBaseDirs(configuredBaseDirs)
@@ -124,27 +130,41 @@ func isManagedDeletePathInsideBase(path, baseDir string) bool {
 }
 
 func pruneEmptyManagedDeleteDir(target managedDeleteCleanupTarget) {
+	for range managedDeleteCleanupRetryAttempts {
+		retry := pruneEmptyManagedDeleteDirOnce(target)
+		if !retry {
+			return
+		}
+
+		time.Sleep(managedDeleteCleanupRetryInterval)
+	}
+}
+
+func pruneEmptyManagedDeleteDirOnce(target managedDeleteCleanupTarget) bool {
 	dir := filepath.Clean(target.dir)
 	baseDir := filepath.Clean(target.baseDir)
+	leafDir := dir
 
 	for isManagedDeletePathInsideBase(dir, baseDir) && dir != baseDir {
 		err := os.Remove(dir)
 		switch {
 		case err == nil, os.IsNotExist(err):
 		case isDirNotEmpty(err):
-			return
+			return dir == leafDir
 		default:
 			log.Debug().Err(err).Str("dir", dir).Str("baseDir", baseDir).
 				Msg("delete cleanup: failed to prune empty managed directory")
-			return
+			return false
 		}
 
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			return
+			return false
 		}
 		dir = parent
 	}
+
+	return false
 }
 
 func isDirNotEmpty(err error) bool {

--- a/internal/qbittorrent/delete_cleanup_test.go
+++ b/internal/qbittorrent/delete_cleanup_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	qbt "github.com/autobrr/go-qbittorrent"
 	"github.com/stretchr/testify/require"
@@ -107,6 +108,43 @@ func TestCleanupManagedDeleteTargets_StopsAtNonEmptyParent(t *testing.T) {
 	info, err = os.Stat(movieBDir)
 	require.NoError(t, err)
 	require.True(t, info.IsDir())
+}
+
+func TestCleanupManagedDeleteTargets_RetriesWhileLeafDirStillBusy(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	trackerDir := filepath.Join(baseDir, "tracker-a")
+	leafDir := filepath.Join(trackerDir, "MovieA")
+	filePath := filepath.Join(leafDir, "MovieA.mkv")
+
+	require.NoError(t, os.MkdirAll(leafDir, 0o755))
+	require.NoError(t, os.WriteFile(filePath, []byte("x"), 0o600))
+
+	targets := buildManagedDeleteCleanupTargets(baseDir, []qbt.Torrent{
+		{
+			Hash:        "abc123",
+			SavePath:    leafDir,
+			ContentPath: filePath,
+		},
+	})
+	require.Len(t, targets, 1)
+
+	done := make(chan struct{})
+	go func() {
+		time.Sleep(75 * time.Millisecond)
+		_ = os.Remove(filePath)
+		close(done)
+	}()
+
+	cleanupManagedDeleteTargets(targets)
+	<-done
+
+	_, err := os.Stat(leafDir)
+	require.ErrorIs(t, err, os.ErrNotExist)
+
+	_, err = os.Stat(trackerDir)
+	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
 func TestBuildManagedDeleteCleanupTargets_PrefersMostSpecificBaseDir(t *testing.T) {

--- a/internal/qbittorrent/delete_cleanup_test.go
+++ b/internal/qbittorrent/delete_cleanup_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package qbittorrent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildManagedDeleteCleanupTargets_SingleFileUsesParentDir(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	trackerDir := filepath.Join(baseDir, "tracker-a")
+	leafDir := filepath.Join(trackerDir, "MovieA")
+	filePath := filepath.Join(leafDir, "MovieA.mkv")
+
+	require.NoError(t, os.MkdirAll(leafDir, 0o755))
+	require.NoError(t, os.WriteFile(filePath, []byte("x"), 0o600))
+
+	targets := buildManagedDeleteCleanupTargets(baseDir, []qbt.Torrent{
+		{
+			Hash:        "abc123",
+			SavePath:    leafDir,
+			ContentPath: filePath,
+		},
+	})
+
+	require.Len(t, targets, 1)
+	require.Equal(t, leafDir, targets[0].dir)
+	require.Equal(t, baseDir, targets[0].baseDir)
+}
+
+func TestCleanupManagedDeleteTargets_RemovesEmptyParentsUntilBase(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	trackerDir := filepath.Join(baseDir, "tracker-a")
+	leafDir := filepath.Join(trackerDir, "MovieA")
+	filePath := filepath.Join(leafDir, "MovieA.mkv")
+
+	require.NoError(t, os.MkdirAll(leafDir, 0o755))
+	require.NoError(t, os.WriteFile(filePath, []byte("x"), 0o600))
+
+	targets := buildManagedDeleteCleanupTargets(baseDir, []qbt.Torrent{
+		{
+			Hash:        "abc123",
+			SavePath:    leafDir,
+			ContentPath: filePath,
+		},
+	})
+	require.Len(t, targets, 1)
+
+	require.NoError(t, os.Remove(filePath))
+	cleanupManagedDeleteTargets(targets)
+
+	_, err := os.Stat(leafDir)
+	require.ErrorIs(t, err, os.ErrNotExist)
+
+	_, err = os.Stat(trackerDir)
+	require.ErrorIs(t, err, os.ErrNotExist)
+
+	info, err := os.Stat(baseDir)
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+}
+
+func TestCleanupManagedDeleteTargets_StopsAtNonEmptyParent(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	trackerDir := filepath.Join(baseDir, "tracker-a")
+	movieADir := filepath.Join(trackerDir, "MovieA")
+	movieBDir := filepath.Join(trackerDir, "MovieB")
+	movieAPath := filepath.Join(movieADir, "MovieA.mkv")
+	movieBPath := filepath.Join(movieBDir, "MovieB.mkv")
+
+	require.NoError(t, os.MkdirAll(movieADir, 0o755))
+	require.NoError(t, os.MkdirAll(movieBDir, 0o755))
+	require.NoError(t, os.WriteFile(movieAPath, []byte("a"), 0o600))
+	require.NoError(t, os.WriteFile(movieBPath, []byte("b"), 0o600))
+
+	targets := buildManagedDeleteCleanupTargets(baseDir, []qbt.Torrent{
+		{
+			Hash:        "abc123",
+			SavePath:    movieADir,
+			ContentPath: movieAPath,
+		},
+	})
+	require.Len(t, targets, 1)
+
+	require.NoError(t, os.Remove(movieAPath))
+	cleanupManagedDeleteTargets(targets)
+
+	_, err := os.Stat(movieADir)
+	require.ErrorIs(t, err, os.ErrNotExist)
+
+	info, err := os.Stat(trackerDir)
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+
+	info, err = os.Stat(movieBDir)
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+}

--- a/internal/qbittorrent/delete_cleanup_test.go
+++ b/internal/qbittorrent/delete_cleanup_test.go
@@ -108,3 +108,27 @@ func TestCleanupManagedDeleteTargets_StopsAtNonEmptyParent(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, info.IsDir())
 }
+
+func TestBuildManagedDeleteCleanupTargets_PrefersMostSpecificBaseDir(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	baseDir := filepath.Join(rootDir, "cross-seeds")
+	specificBaseDir := filepath.Join(baseDir, "tracker-a")
+	leafDir := filepath.Join(specificBaseDir, "MovieA")
+	filePath := filepath.Join(leafDir, "MovieA.mkv")
+
+	require.NoError(t, os.MkdirAll(leafDir, 0o755))
+	require.NoError(t, os.WriteFile(filePath, []byte("x"), 0o600))
+
+	targets := buildManagedDeleteCleanupTargets(baseDir+","+specificBaseDir, []qbt.Torrent{
+		{
+			Hash:        "abc123",
+			SavePath:    leafDir,
+			ContentPath: filePath,
+		},
+	})
+
+	require.Len(t, targets, 1)
+	require.Equal(t, specificBaseDir, targets[0].baseDir)
+}

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -1787,6 +1787,11 @@ func (sm *SyncManager) BulkAction(ctx context.Context, instanceID int, hashes []
 		return fmt.Errorf("no valid torrents found for bulk action: %s", action)
 	}
 
+	var managedDeleteCleanupTargets []managedDeleteCleanupTarget
+	if action == "deleteWithFiles" {
+		managedDeleteCleanupTargets = sm.buildManagedDeleteCleanupTargets(ctx, instanceID, syncManager, canonicalHashes)
+	}
+
 	// Log debug info when variant resolution was used (helps diagnose hybrid hash issues)
 	if variantResolutions > 0 {
 		log.Debug().
@@ -1853,6 +1858,7 @@ func (sm *SyncManager) BulkAction(ctx context.Context, instanceID int, hashes []
 		err = client.DeleteTorrentsCtx(ctx, canonicalHashes, true)
 		// Invalidate caches for deleted torrents
 		if err == nil {
+			cleanupManagedDeleteTargets(managedDeleteCleanupTargets)
 			sm.RemoveHashesFromTrackerHealthCache(instanceID, canonicalHashes)
 			sm.removeHashFromAllTrackerMappings(instanceID, canonicalHashes)
 			if fm := sm.getFilesManager(); fm != nil {
@@ -1899,6 +1905,29 @@ func (sm *SyncManager) BulkAction(ctx context.Context, instanceID int, hashes []
 	}
 
 	return err
+}
+
+func (sm *SyncManager) buildManagedDeleteCleanupTargets(
+	ctx context.Context,
+	instanceID int,
+	syncManager *qbt.SyncManager,
+	hashes []string,
+) []managedDeleteCleanupTarget {
+	if sm == nil || sm.clientPool == nil || sm.clientPool.instanceStore == nil || syncManager == nil {
+		return nil
+	}
+
+	instance, err := sm.clientPool.instanceStore.Get(ctx, instanceID)
+	if err != nil || instance == nil || !instance.HasLocalFilesystemAccess || strings.TrimSpace(instance.HardlinkBaseDir) == "" {
+		return nil
+	}
+
+	torrents := syncManager.GetTorrents(qbt.TorrentFilterOptions{Hashes: hashes})
+	if len(torrents) == 0 {
+		return nil
+	}
+
+	return buildManagedDeleteCleanupTargets(instance.HardlinkBaseDir, torrents)
 }
 
 // bulkActionSyncRetry forces a sync and retries hash resolution for just-added torrents.

--- a/pkg/hardlinktree/create.go
+++ b/pkg/hardlinktree/create.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
 )
 
 // Create materializes the hardlink tree plan on disk.
@@ -165,6 +166,9 @@ func containsPath(paths []string, path string) bool {
 func isDirNotEmpty(err error) bool {
 	if err == nil {
 		return false
+	}
+	if errors.Is(err, syscall.ENOTEMPTY) {
+		return true
 	}
 	// Different OS have different error messages
 	errStr := err.Error()

--- a/pkg/reflinktree/reflink.go
+++ b/pkg/reflinktree/reflink.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"syscall"
 
 	"github.com/autobrr/qui/pkg/hardlinktree"
 )
@@ -174,6 +175,9 @@ func containsPath(paths []string, path string) bool {
 func isDirNotEmpty(err error) bool {
 	if err == nil {
 		return false
+	}
+	if errors.Is(err, syscall.ENOTEMPTY) {
+		return true
 	}
 	// Different OS have different error messages
 	errStr := err.Error()


### PR DESCRIPTION
Delete-with-files now removes empty hardlink/reflink-managed directories left behind after cross-seed deletion. This covers flat, by-tracker, and by-instance layouts by pruning upward from the deleted torrent's leaf directory until the configured base directory.

Adds regression tests for the current single-file hardlink bug and for the cleanup boundaries so non-empty parents and base directories are preserved.

https://github.com/autobrr/qui/discussions/1383

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deleting torrents with files now triggers automatic post-delete cleanup that prunes empty parent directories up to configured base dirs, preferring the most specific base; cleanup runs after successful torrent deletion.

* **Bug Fixes**
  * Improved detection of non-empty directories (recognizes platform ENOTEMPTY) to avoid unintended removals and improve retry behavior.

* **Tests**
  * Added tests for single-file parent handling, nested-directory pruning to base, stopping at non-empty parents, base-dir selection, and retrying transiently busy leaves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->