### PR TITLE
fix(dirscan): select concrete hardlink base dir

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,8 @@ When running tests, always use `-race` and `-count=1`.
 
 For changes under `internal/services/crossseed` or `internal/qbittorrent`, run targeted package tests first, then run the full `make test` suite.
 
+When adding Go tests that create files with `os.WriteFile`, use `0o600` or tighter permissions unless the test explicitly needs broader mode bits. This avoids `gosec` `G306` lint failures.
+
 ## Commit & Pull Request Guidelines
 
 Follow the conventional commit style in history (`feat(scope):`, `fix(scope):`, etc.) and link issues or PR numbers in the body when relevant. Keep commits focused—split backend and frontend changes when practical.

--- a/internal/services/crossseed/hardlink_mode_test.go
+++ b/internal/services/crossseed/hardlink_mode_test.go
@@ -338,7 +338,7 @@ func TestFindMatchingBaseDir(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := findMatchingBaseDir(tt.configured, "/some/source/path")
+			result, err := FindMatchingBaseDir(tt.configured, "/some/source/path")
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -367,7 +367,7 @@ func TestFindMatchingBaseDir_ParsesCommaSeparated(t *testing.T) {
 	require.NoError(t, os.WriteFile(invalidPath3, []byte("file"), 0o600))
 
 	configured := invalidPath1 + ", " + invalidPath2 + " , " + invalidPath3
-	_, err := findMatchingBaseDir(configured, sourceFile)
+	_, err := FindMatchingBaseDir(configured, sourceFile)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no base directory")
@@ -402,7 +402,7 @@ func TestFindMatchingBaseDir_TrimsWhitespace(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := findMatchingBaseDir(tt.configured, "/nonexistent/source")
+			_, err := FindMatchingBaseDir(tt.configured, "/nonexistent/source")
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "no base directory")
 		})
@@ -417,7 +417,7 @@ func TestFindMatchingBaseDir_ReturnsFirstMatchingDir(t *testing.T) {
 	firstDir := filepath.Join(t.TempDir(), "first")
 	secondDir := filepath.Join(t.TempDir(), "second")
 
-	result, err := findMatchingBaseDir("  "+firstDir+" , "+secondDir+"  ", sourceFile)
+	result, err := FindMatchingBaseDir("  "+firstDir+" , "+secondDir+"  ", sourceFile)
 	require.NoError(t, err)
 	assert.Equal(t, firstDir, result)
 	assert.DirExists(t, firstDir)
@@ -433,7 +433,7 @@ func TestFindMatchingBaseDir_SkipsInvalidDirAndFindsNextMatch(t *testing.T) {
 
 	validDir := filepath.Join(t.TempDir(), "valid")
 
-	result, err := findMatchingBaseDir(invalidFilePath+", "+validDir, sourceFile)
+	result, err := FindMatchingBaseDir(invalidFilePath+", "+validDir, sourceFile)
 	require.NoError(t, err)
 	assert.Equal(t, validDir, result)
 	assert.DirExists(t, validDir)

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -10459,7 +10459,7 @@ func (s *Service) processHardlinkMode(
 		return handleError("No content path or save path available for matched torrent")
 	}
 
-	selectedBaseDir, err := findMatchingBaseDir(instance.HardlinkBaseDir, existingFilePath)
+	selectedBaseDir, err := FindMatchingBaseDir(instance.HardlinkBaseDir, existingFilePath)
 	if err != nil {
 		log.Warn().
 			Err(err).
@@ -10814,7 +10814,9 @@ func (s *Service) resolveTrackerDisplayName(ctx context.Context, incomingTracker
 // findMatchingBaseDir finds the first base directory from a comma-separated list
 // that is on the same filesystem as the source path. Returns the matching directory
 // or an error if none match.
-func findMatchingBaseDir(configuredDirs string, sourcePath string) (string, error) {
+// FindMatchingBaseDir returns the first configured base directory on the same
+// filesystem as the source path.
+func FindMatchingBaseDir(configuredDirs string, sourcePath string) (string, error) {
 	if strings.TrimSpace(configuredDirs) == "" {
 		return "", errors.New("base directory not configured")
 	}
@@ -11001,7 +11003,7 @@ func (s *Service) processReflinkMode(
 		return handleError("No content path or save path available for matched torrent")
 	}
 
-	selectedBaseDir, err := findMatchingBaseDir(instance.HardlinkBaseDir, existingFilePath)
+	selectedBaseDir, err := FindMatchingBaseDir(instance.HardlinkBaseDir, existingFilePath)
 	if err != nil {
 		log.Warn().
 			Err(err).

--- a/internal/services/dirscan/inject.go
+++ b/internal/services/dirscan/inject.go
@@ -435,25 +435,29 @@ func (i *Injector) materializeLinkTree(ctx context.Context, instance *models.Ins
 	incomingFiles := buildLinkTreeIncomingFiles(req.ParsedTorrent)
 	needsIsolation := !hardlinktree.HasCommonRootFolder(incomingFiles)
 
-	incomingTrackerDomain := crossseed.ParseTorrentAnnounceDomain(req.TorrentBytes)
-	trackerDisplayName := i.resolveTrackerDisplayName(ctx, incomingTrackerDomain, indexerName(req.SearchResult))
-	destDir := buildLinkDestDir(instance, req.ParsedTorrent.InfoHash, req.ParsedTorrent.Name, needsIsolation, trackerDisplayName)
-
-	if err := os.MkdirAll(instance.HardlinkBaseDir, 0o750); err != nil {
-		return nil, "", fmt.Errorf("create hardlink base dir: %w", err)
-	}
-
 	linkableFiles, existingFiles, err := buildLinkTreeMatchedFiles(req.MatchResult)
 	if err != nil {
 		return nil, "", err
 	}
+
+	selectedBaseDir, err := crossseed.FindMatchingBaseDir(instance.HardlinkBaseDir, existingFiles[0].AbsPath)
+	if err != nil {
+		return nil, "", fmt.Errorf("select hardlink base dir: %w", err)
+	}
+	if err := os.MkdirAll(selectedBaseDir, 0o750); err != nil {
+		return nil, "", fmt.Errorf("create hardlink base dir: %w", err)
+	}
+
+	incomingTrackerDomain := crossseed.ParseTorrentAnnounceDomain(req.TorrentBytes)
+	trackerDisplayName := i.resolveTrackerDisplayName(ctx, incomingTrackerDomain, indexerName(req.SearchResult))
+	destDir := buildLinkDestDir(selectedBaseDir, instance, req.ParsedTorrent.InfoHash, req.ParsedTorrent.Name, needsIsolation, trackerDisplayName)
 
 	plan, err := hardlinktree.BuildPlan(linkableFiles, existingFiles, hardlinktree.LayoutOriginal, req.ParsedTorrent.Name, destDir)
 	if err != nil {
 		return nil, "", fmt.Errorf("build link plan: %w", err)
 	}
 
-	mode, err := i.createLinkTree(instance, existingFiles, plan)
+	mode, err := i.createLinkTree(instance, selectedBaseDir, existingFiles, plan)
 	if err != nil {
 		return nil, "", err
 	}
@@ -532,9 +536,9 @@ func buildLinkTreeMatchedFiles(match *MatchResult) ([]hardlinktree.TorrentFile, 
 	return linkableFiles, existingFiles, nil
 }
 
-func (i *Injector) createLinkTree(instance *models.Instance, existingFiles []hardlinktree.ExistingFile, plan *hardlinktree.TreePlan) (string, error) {
+func (i *Injector) createLinkTree(instance *models.Instance, selectedBaseDir string, existingFiles []hardlinktree.ExistingFile, plan *hardlinktree.TreePlan) (string, error) {
 	if instance.UseReflinks {
-		if supported, reason := reflinktree.SupportsReflink(instance.HardlinkBaseDir); !supported {
+		if supported, reason := reflinktree.SupportsReflink(selectedBaseDir); !supported {
 			return "", fmt.Errorf("%w: %s", reflinktree.ErrReflinkUnsupported, reason)
 		}
 		if err := reflinktree.Create(plan); err != nil {
@@ -544,7 +548,7 @@ func (i *Injector) createLinkTree(instance *models.Instance, existingFiles []har
 	}
 
 	if instance.UseHardlinks {
-		sameFS, err := fsutil.SameFilesystem(existingFiles[0].AbsPath, instance.HardlinkBaseDir)
+		sameFS, err := fsutil.SameFilesystem(existingFiles[0].AbsPath, selectedBaseDir)
 		if err != nil {
 			return "", fmt.Errorf("verify same filesystem: %w", err)
 		}
@@ -552,7 +556,7 @@ func (i *Injector) createLinkTree(instance *models.Instance, existingFiles []har
 			return "", fmt.Errorf(
 				"hardlink source (%s) and destination (%s) are on different filesystems",
 				existingFiles[0].AbsPath,
-				instance.HardlinkBaseDir,
+				selectedBaseDir,
 			)
 		}
 
@@ -571,9 +575,7 @@ func (i *Injector) createLinkTree(instance *models.Instance, existingFiles []har
 	return "", errors.New("no link mode enabled")
 }
 
-func buildLinkDestDir(instance *models.Instance, torrentHash, torrentName string, needsIsolation bool, trackerDisplayName string) string {
-	baseDir := instance.HardlinkBaseDir
-
+func buildLinkDestDir(baseDir string, instance *models.Instance, torrentHash, torrentName string, needsIsolation bool, trackerDisplayName string) string {
 	isolationFolder := ""
 	if needsIsolation {
 		isolationFolder = pathutil.IsolationFolderName(torrentHash, torrentName)

--- a/internal/services/dirscan/inject_test.go
+++ b/internal/services/dirscan/inject_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -218,6 +219,83 @@ func TestInjector_Inject_PausedPartial_TriggersRecheckAndResumeWhenComplete(t *t
 	}
 	if manager.resumeCalls[0].opts.Timeout != 60*time.Minute {
 		t.Fatalf("expected timeout 60m, got %v", manager.resumeCalls[0].opts.Timeout)
+	}
+}
+
+func TestInjector_Inject_HardlinkMode_SelectsConcreteBaseDirFromCommaSeparatedList(t *testing.T) {
+	tmp := t.TempDir()
+
+	sourceDir := filepath.Join(tmp, "source")
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	sourceFile := filepath.Join(sourceDir, "file.mkv")
+	if err := os.WriteFile(sourceFile, []byte("data"), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	firstBase := filepath.Join(tmp, "links-a")
+	secondBase := filepath.Join(tmp, "links-b")
+
+	instance := &models.Instance{
+		ID:                       1,
+		Name:                     "test",
+		HasLocalFilesystemAccess: true,
+		UseHardlinks:             true,
+		HardlinkBaseDir:          firstBase + ", " + secondBase,
+		FallbackToRegularMode:    false,
+	}
+
+	manager := &recordingTorrentManager{}
+	injector := NewInjector(nil, manager, nil, &fakeInstanceStore{instance: instance}, nil)
+
+	req := &InjectRequest{
+		InstanceID:   1,
+		TorrentBytes: []byte("x"),
+		ParsedTorrent: &ParsedTorrent{
+			Name:     "Example.Release",
+			InfoHash: "deadbeef",
+			Files: []TorrentFile{
+				{Path: "Example.Release/file.mkv", Size: 4, Offset: 0},
+			},
+			PieceLength: 16384,
+		},
+		Searchee: &Searchee{
+			Name: "Example.Release",
+			Path: sourceDir,
+			Files: []*ScannedFile{{
+				Path:    sourceFile,
+				RelPath: "file.mkv",
+				Size:    4,
+			}},
+		},
+		MatchResult: &MatchResult{
+			MatchedFiles: []MatchedFilePair{{
+				SearcheeFile: &ScannedFile{Path: sourceFile, RelPath: "file.mkv", Size: 4},
+				TorrentFile:  TorrentFile{Path: "Example.Release/file.mkv", Size: 4},
+			}},
+			IsMatch: true,
+		},
+	}
+
+	res, err := injector.Inject(context.Background(), req)
+	if err != nil {
+		t.Fatalf("inject: %v", err)
+	}
+	if !res.Success {
+		t.Fatalf("expected success, got %+v", res)
+	}
+	if res.Mode != injectModeHardlink {
+		t.Fatalf("expected hardlink mode, got %q", res.Mode)
+	}
+	if strings.Contains(res.SavePath, ",") {
+		t.Fatalf("save path should use one base dir, got %q", res.SavePath)
+	}
+	if !strings.HasPrefix(res.SavePath, firstBase+string(os.PathSeparator)) {
+		t.Fatalf("expected save path under first matching base dir %q, got %q", firstBase, res.SavePath)
+	}
+	if got := manager.addOptions["savepath"]; got != res.SavePath {
+		t.Fatalf("expected add savepath %q, got %q", res.SavePath, got)
 	}
 }
 

--- a/internal/services/dirscan/inject_test.go
+++ b/internal/services/dirscan/inject_test.go
@@ -48,7 +48,7 @@ func TestInjector_Inject_RollsBackLinkTreeOnAddFailure(t *testing.T) {
 		t.Fatalf("mkdir source: %v", err)
 	}
 	sourceFile := filepath.Join(sourceDir, "file.mkv")
-	if err := os.WriteFile(sourceFile, []byte("data"), 0o644); err != nil {
+	if err := os.WriteFile(sourceFile, []byte("data"), 0o600); err != nil {
 		t.Fatalf("write source file: %v", err)
 	}
 
@@ -230,7 +230,7 @@ func TestInjector_Inject_HardlinkMode_SelectsConcreteBaseDirFromCommaSeparatedLi
 		t.Fatalf("mkdir source: %v", err)
 	}
 	sourceFile := filepath.Join(sourceDir, "file.mkv")
-	if err := os.WriteFile(sourceFile, []byte("data"), 0o644); err != nil {
+	if err := os.WriteFile(sourceFile, []byte("data"), 0o600); err != nil {
 		t.Fatalf("write source file: %v", err)
 	}
 


### PR DESCRIPTION
Solves https://github.com/autobrr/qui/discussions/1605

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced base-directory selection for hardlink/reflink operations with stronger filesystem validation and clearer error reporting.
  * Automatic creation of missing configured base directories when applicable.

* **Tests**
  * Added tests validating base-directory selection from comma-separated configurations.

* **Documentation**
  * Guidance added to prefer tighter file-permission modes (0o600) in tests to avoid lint warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->