### PR TITLE
fix(crossseed): handle missing webhook collection tags

### DIFF
--- a/internal/services/crossseed/crossseed_test.go
+++ b/internal/services/crossseed/crossseed_test.go
@@ -2219,6 +2219,41 @@ func TestCheckWebhook_AutobrrPayload(t *testing.T) {
 			wantRecommendation: "skip",
 		},
 		{
+			name: "movie webhook tolerates missing incoming collection when group matches",
+			request: &WebhookCheckRequest{
+				InstanceIDs: instanceIDs,
+				TorrentName: "Sample Movie 2024 1080p WEB-DL DD+5.1 H.264-NTb",
+			},
+			existingTorrents: []qbt.Torrent{
+				{
+					Hash:     "sample-movie-dsnp",
+					Name:     "Sample.Movie.2024.1080p.DSNP.WEB-DL.DDP5.1.H.264-NTb",
+					Progress: 1.0,
+				},
+			},
+			wantCanCrossSeed:   true,
+			wantMatchCount:     1,
+			wantRecommendation: "download",
+			wantMatchType:      "metadata",
+		},
+		{
+			name: "movie webhook missing collection still requires matching group or site",
+			request: &WebhookCheckRequest{
+				InstanceIDs: instanceIDs,
+				TorrentName: "Sample Movie 2024 1080p WEB-DL DD+5.1 H.264",
+			},
+			existingTorrents: []qbt.Torrent{
+				{
+					Hash:     "sample-movie-dsnp-no-group",
+					Name:     "Sample.Movie.2024.1080p.DSNP.WEB-DL.DDP5.1.H.264-NTb",
+					Progress: 1.0,
+				},
+			},
+			wantCanCrossSeed:   false,
+			wantMatchCount:     0,
+			wantRecommendation: "skip",
+		},
+		{
 			name: "pending match when torrent still downloading",
 			request: &WebhookCheckRequest{
 				InstanceIDs: instanceIDs,

--- a/internal/services/crossseed/crossseed_test.go
+++ b/internal/services/crossseed/crossseed_test.go
@@ -2184,6 +2184,41 @@ func TestCheckWebhook_AutobrrPayload(t *testing.T) {
 			wantMatchType:      "metadata",
 		},
 		{
+			name: "tv webhook tolerates missing incoming collection when group matches",
+			request: &WebhookCheckRequest{
+				InstanceIDs: instanceIDs,
+				TorrentName: "Sample Show S08E11 1080p WEB-DL DD+5.1 H.264-NTb",
+			},
+			existingTorrents: []qbt.Torrent{
+				{
+					Hash:     "sample-show-dsnp",
+					Name:     "Sample.Show.S08E11.Episode.Title.1080p.DSNP.WEB-DL.DDP5.1.H.264-NTb",
+					Progress: 1.0,
+				},
+			},
+			wantCanCrossSeed:   true,
+			wantMatchCount:     1,
+			wantRecommendation: "download",
+			wantMatchType:      "metadata",
+		},
+		{
+			name: "tv webhook missing collection still requires matching group or site",
+			request: &WebhookCheckRequest{
+				InstanceIDs: instanceIDs,
+				TorrentName: "Sample Show S08E11 1080p WEB-DL DD+5.1 H.264",
+			},
+			existingTorrents: []qbt.Torrent{
+				{
+					Hash:     "sample-show-dsnp-no-group",
+					Name:     "Sample.Show.S08E11.Episode.Title.1080p.DSNP.WEB-DL.DDP5.1.H.264-NTb",
+					Progress: 1.0,
+				},
+			},
+			wantCanCrossSeed:   false,
+			wantMatchCount:     0,
+			wantRecommendation: "skip",
+		},
+		{
 			name: "pending match when torrent still downloading",
 			request: &WebhookCheckRequest{
 				InstanceIDs: instanceIDs,

--- a/internal/services/crossseed/matching.go
+++ b/internal/services/crossseed/matching.go
@@ -393,6 +393,52 @@ func (s *Service) releasesMatch(source, candidate *rls.Release, findIndividualEp
 	return true
 }
 
+func (s *Service) releasesMatchWebhook(source, candidate *rls.Release, findIndividualEpisodes bool) bool {
+	if s.releasesMatch(source, candidate, findIndividualEpisodes) {
+		return true
+	}
+
+	if !shouldRelaxWebhookCollectionMatch(s, source, candidate) {
+		return false
+	}
+
+	sourceWithCollection := *source
+	sourceWithCollection.Collection = candidate.Collection
+
+	return s.releasesMatch(&sourceWithCollection, candidate, findIndividualEpisodes)
+}
+
+func shouldRelaxWebhookCollectionMatch(s *Service, source, candidate *rls.Release) bool {
+	if source == nil || candidate == nil {
+		return false
+	}
+
+	// HDBits TV announces can omit the service tag entirely ("WEB-DL") while the
+	// existing torrent keeps the canonical source service (for example "DSNP").
+	// Keep this relaxation narrowly scoped to webhook TV matching where the group
+	// or site already anchors the release identity.
+	if source.Series == 0 || candidate.Series == 0 || source.Collection != "" || candidate.Collection == "" {
+		return false
+	}
+
+	normalizer := s.stringNormalizer
+	if normalizer == nil {
+		normalizer = stringutils.DefaultNormalizer
+	}
+
+	return hasNonEmptyNormalizedMatch(normalizer, source.Group, candidate.Group) ||
+		hasNonEmptyNormalizedMatch(normalizer, source.Site, candidate.Site)
+}
+
+func hasNonEmptyNormalizedMatch(normalizer *stringutils.Normalizer[string, string], left, right string) bool {
+	if normalizer == nil {
+		normalizer = stringutils.DefaultNormalizer
+	}
+
+	left = normalizer.Normalize(left)
+	return left != "" && left == normalizer.Normalize(right)
+}
+
 // joinNormalizedSlice converts a string slice to a normalized uppercase string for comparison.
 // Uppercases and joins elements to ensure consistent comparison regardless of case or order.
 func joinNormalizedSlice(slice []string) string {

--- a/internal/services/crossseed/matching.go
+++ b/internal/services/crossseed/matching.go
@@ -398,7 +398,7 @@ func (s *Service) releasesMatchWebhook(source, candidate *rls.Release, findIndiv
 		return true
 	}
 
-	if !shouldRelaxWebhookCollectionMatch(s, source, candidate) {
+	if !canFillMissingWebhookCollection(source, candidate, s.stringNormalizer) {
 		return false
 	}
 
@@ -408,26 +408,40 @@ func (s *Service) releasesMatchWebhook(source, candidate *rls.Release, findIndiv
 	return s.releasesMatch(&sourceWithCollection, candidate, findIndividualEpisodes)
 }
 
-func shouldRelaxWebhookCollectionMatch(s *Service, source, candidate *rls.Release) bool {
+func canFillMissingWebhookCollection(
+	source, candidate *rls.Release,
+	normalizer *stringutils.Normalizer[string, string],
+) bool {
 	if source == nil || candidate == nil {
 		return false
 	}
 
-	// HDBits TV announces can omit the service tag entirely ("WEB-DL") while the
-	// existing torrent keeps the canonical source service (for example "DSNP").
-	// Keep this relaxation narrowly scoped to webhook TV matching where the group
-	// or site already anchors the release identity.
-	if source.Series == 0 || candidate.Series == 0 || source.Collection != "" || candidate.Collection == "" {
+	// Some webhook titles omit the collection/service tag entirely ("WEB-DL")
+	// while the existing torrent keeps the canonical source service (for example
+	// "DSNP"). Only retry when the incoming title is missing Collection and the
+	// group or site already anchors the release identity.
+	if source.Collection != "" || candidate.Collection == "" {
 		return false
 	}
 
-	normalizer := s.stringNormalizer
-	if normalizer == nil {
-		normalizer = stringutils.DefaultNormalizer
+	if !supportsWebhookCollectionFallback(source, candidate) {
+		return false
 	}
 
 	return hasNonEmptyNormalizedMatch(normalizer, source.Group, candidate.Group) ||
 		hasNonEmptyNormalizedMatch(normalizer, source.Site, candidate.Site)
+}
+
+func supportsWebhookCollectionFallback(source, candidate *rls.Release) bool {
+	if source == nil || candidate == nil {
+		return false
+	}
+
+	if source.Series > 0 && candidate.Series > 0 {
+		return true
+	}
+
+	return isWebSource(normalizeSource(source.Source)) && isWebSource(normalizeSource(candidate.Source))
 }
 
 func hasNonEmptyNormalizedMatch(normalizer *stringutils.Normalizer[string, string], left, right string) bool {
@@ -502,6 +516,15 @@ func normalizeSource(source string) string {
 	return upper
 }
 
+func isWebSource(source string) bool {
+	switch source {
+	case "WEB", "WEBDL", "WEBRIP":
+		return true
+	default:
+		return false
+	}
+}
+
 // sourcesCompatible checks if two sources are compatible for cross-seed precheck.
 // Plain "WEB" is ambiguous and matches both WEBDL and WEBRIP.
 // WEBDL and WEBRIP are explicitly different and do not match each other.
@@ -512,17 +535,6 @@ func sourcesCompatible(source, candidate string) bool {
 	}
 	if source == candidate {
 		return true
-	}
-
-	// WEB is ambiguous: treat it as compatible with both WEBDL and WEBRIP.
-	// It must not match non-web sources (BLURAY, HDTV, etc.).
-	isWebSource := func(s string) bool {
-		switch s {
-		case "WEB", "WEBDL", "WEBRIP":
-			return true
-		default:
-			return false
-		}
 	}
 
 	if !isWebSource(source) || !isWebSource(candidate) {

--- a/internal/services/crossseed/matching_webhook_test.go
+++ b/internal/services/crossseed/matching_webhook_test.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package crossseed
+
+import (
+	"testing"
+
+	"github.com/moistari/rls"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/pkg/stringutils"
+)
+
+func TestReleasesMatchWebhook_FillsMissingCollection(t *testing.T) {
+	s := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
+
+	tests := []struct {
+		name      string
+		source    rls.Release
+		candidate rls.Release
+		wantMatch bool
+	}{
+		{
+			name: "tv missing collection matches when group anchors release",
+			source: rls.Release{
+				Title:      "Sample Show",
+				Series:     8,
+				Episode:    11,
+				Source:     "WEB-DL",
+				Resolution: "1080p",
+				Group:      "NTb",
+			},
+			candidate: rls.Release{
+				Title:      "Sample Show",
+				Series:     8,
+				Episode:    11,
+				Source:     "WEB-DL",
+				Resolution: "1080p",
+				Collection: "DSNP",
+				Group:      "NTb",
+			},
+			wantMatch: true,
+		},
+		{
+			name: "web movie missing collection matches when group anchors release",
+			source: rls.Release{
+				Title:      "Sample Movie",
+				Year:       2024,
+				Source:     "WEB-DL",
+				Resolution: "1080p",
+				Group:      "NTb",
+			},
+			candidate: rls.Release{
+				Title:      "Sample Movie",
+				Year:       2024,
+				Source:     "WEB-DL",
+				Resolution: "1080p",
+				Collection: "DSNP",
+				Group:      "NTb",
+			},
+			wantMatch: true,
+		},
+		{
+			name: "missing collection still needs group or site anchor",
+			source: rls.Release{
+				Title:      "Sample Movie",
+				Year:       2024,
+				Source:     "WEB-DL",
+				Resolution: "1080p",
+			},
+			candidate: rls.Release{
+				Title:      "Sample Movie",
+				Year:       2024,
+				Source:     "WEB-DL",
+				Resolution: "1080p",
+				Collection: "DSNP",
+				Group:      "NTb",
+			},
+			wantMatch: false,
+		},
+		{
+			name: "non-web movie missing collection stays strict",
+			source: rls.Release{
+				Title:      "Sample Movie",
+				Year:       2024,
+				Source:     "BluRay",
+				Resolution: "1080p",
+				Group:      "FraMeSToR",
+			},
+			candidate: rls.Release{
+				Title:      "Sample Movie",
+				Year:       2024,
+				Source:     "BluRay",
+				Resolution: "1080p",
+				Collection: "Criterion",
+				Group:      "FraMeSToR",
+			},
+			wantMatch: false,
+		},
+		{
+			name: "explicit source collection mismatch stays strict",
+			source: rls.Release{
+				Title:      "Sample Movie",
+				Year:       2024,
+				Source:     "WEB-DL",
+				Resolution: "1080p",
+				Collection: "AMZN",
+				Group:      "NTb",
+			},
+			candidate: rls.Release{
+				Title:      "Sample Movie",
+				Year:       2024,
+				Source:     "WEB-DL",
+				Resolution: "1080p",
+				Collection: "DSNP",
+				Group:      "NTb",
+			},
+			wantMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.wantMatch, s.releasesMatchWebhook(&tt.source, &tt.candidate, false))
+		})
+	}
+}

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -9775,8 +9775,8 @@ func (s *Service) CheckWebhook(ctx context.Context, req *WebhookCheckRequest) (*
 				continue
 			}
 
-			// Webhook matching is strict by default, with one narrow TV relaxation for
-			// announces that omit the source service tag while the existing torrent keeps it.
+			// Webhook matching is strict by default, with one narrow retry for
+			// anchored releases whose incoming title omits the collection/service tag.
 			if !s.releasesMatchWebhook(incomingRelease, existingRelease, findIndividualEpisodes) {
 				continue
 			}

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -9775,8 +9775,9 @@ func (s *Service) CheckWebhook(ctx context.Context, req *WebhookCheckRequest) (*
 				continue
 			}
 
-			// Check if releases match using the configured strict or episode-aware matching.
-			if !s.releasesMatch(incomingRelease, existingRelease, findIndividualEpisodes) {
+			// Webhook matching is strict by default, with one narrow TV relaxation for
+			// announces that omit the source service tag while the existing torrent keeps it.
+			if !s.releasesMatchWebhook(incomingRelease, existingRelease, findIndividualEpisodes) {
 				continue
 			}
 


### PR DESCRIPTION
This adjusts webhook matching so releases can still match when the announce title omits the collection or service tag, but the existing torrent keeps the canonical tag. That is the gap HDBits can hit on webhook titles, and it affects both TV and web movie releases.

It only applies when the incoming webhook title is missing the collection tag and the release is already anchored by matching group or site. Explicit collection mismatches still stay strict, and non-web movie collection differences are still treated as different releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced webhook matching: strict-by-default matching with a targeted fallback that allows matching releases missing collection tags when group or site metadata align.

* **Tests**
  * Expanded test coverage for webhook matching, covering TV and Movie edge cases where incoming collection information is absent and verifying fallback and strict behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->