### PR TITLE
fix(dirscan): honor canceled queued webhook runs

### DIFF
--- a/internal/models/dirscan.go
+++ b/internal/models/dirscan.go
@@ -831,6 +831,25 @@ func (s *DirScanStore) UpdateRunStatus(ctx context.Context, runID int64, status 
 	return nil
 }
 
+// UpdateRunStatusIfCurrent updates the status of a run only when it is still in the expected state.
+func (s *DirScanStore) UpdateRunStatusIfCurrent(ctx context.Context, runID int64, currentStatus, nextStatus DirScanRunStatus) (bool, error) {
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE dir_scan_runs
+		SET status = ?
+		WHERE id = ? AND status = ?
+	`, nextStatus, runID, currentStatus)
+	if err != nil {
+		return false, fmt.Errorf("update run status conditionally: %w", err)
+	}
+
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("rows affected: %w", err)
+	}
+
+	return rows > 0, nil
+}
+
 // UpdateRunScanRoot updates the scan root of a run.
 func (s *DirScanStore) UpdateRunScanRoot(ctx context.Context, runID int64, scanRoot string) error {
 	var scanRootValue any

--- a/internal/services/dirscan/service.go
+++ b/internal/services/dirscan/service.go
@@ -488,9 +488,23 @@ func (s *Service) executeScan(ctx context.Context, directoryID int, runID int64)
 	dirMu.Lock()
 	defer dirMu.Unlock()
 
-	// Transition from queued to scanning once we have a run slot and hold the directory lock.
-	if err := s.store.UpdateRunStatus(ctx, runID, models.DirScanRunStatusScanning); err != nil {
+	// Only the still-queued run that won the lock may advance to scanning.
+	advanced, err := s.store.UpdateRunStatusIfCurrent(ctx, runID, models.DirScanRunStatusQueued, models.DirScanRunStatusScanning)
+	if err != nil {
 		l.Debug().Err(err).Msg("dirscan: failed to update run status to scanning")
+		return
+	}
+	if !advanced {
+		return
+	}
+
+	run, err = s.store.GetRun(ctx, runID)
+	if err != nil {
+		l.Error().Err(err).Msg("dirscan: failed to reload run")
+		return
+	}
+	if run == nil {
+		return
 	}
 
 	s.updateDirectoryLastScan(ctx, directoryID, &l)


### PR DESCRIPTION
Queued webhook follow-up runs could still advance to scanning after a cancel if their worker was already waiting on the directory lock. That leaves canceled work running anyway and makes the webhook queue regression test flaky.

This makes the queued-to-scanning transition conditional on the run still being queued, then reloads the run before continuing so canceled work exits cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory scanning service state management to prevent invalid status transitions during concurrent operations and ensure only valid queued runs can proceed to scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->