### PR TITLE
fix(web): check field.state.value type in AddTorrentDialog

### DIFF
--- a/web/src/components/torrents/AddTorrentDialog.tsx
+++ b/web/src/components/torrents/AddTorrentDialog.tsx
@@ -953,7 +953,7 @@ export function AddTorrentDialog({ instanceId, open: controlledOpen, onOpenChang
                               </TooltipTrigger>
                               <TooltipContent>
                                 <div className="max-w-xs">
-                                  {field.state.value.slice(0, 3).map((file, index) => {
+                                  {Array.isArray(field.state.value) && field.state.value.slice(0, 3).map((file, index) => {
                                     const fileKey = createFileKey(file)
                                     const duplicateInfo = duplicateFileEntries[fileKey]
                                     return (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the torrent addition dialog where file previews could fail when processing certain file data, improving stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->