### PR TITLE
fix(crossseed): use autobrr indexer ids for webhooks

### DIFF
--- a/documentation/docs/features/cross-seed/autobrr.md
+++ b/documentation/docs/features/cross-seed/autobrr.md
@@ -10,7 +10,7 @@ qui integrates with autobrr through webhook endpoints, enabling real-time cross-
 ## How It Works
 
 1. autobrr sees a new release from a tracker
-2. autobrr sends the torrent name to qui's `/api/cross-seed/webhook/check` endpoint
+2. autobrr sends the torrent name and indexer identifier to qui's `/api/cross-seed/webhook/check` endpoint
 3. qui searches your qBittorrent instances for matching content
 4. qui responds with:
    - `200 OK` – matching torrent is complete and ready to cross-seed
@@ -62,7 +62,8 @@ In your new autobrr filter, go to **External** tab → **Add new**:
 ```json
 {
   "torrentName": {{ toRawJson .TorrentName }},
-  "instanceIds": [1]
+  "instanceIds": [1],
+  "indexer": {{ toRawJson .Indexer }}
 }
 ```
 
@@ -70,7 +71,8 @@ To search all instances, omit `instanceIds`:
 
 ```json
 {
-  "torrentName": {{ toRawJson .TorrentName }}
+  "torrentName": {{ toRawJson .TorrentName }},
+  "indexer": {{ toRawJson .Indexer }}
 }
 ```
 
@@ -78,6 +80,7 @@ To search all instances, omit `instanceIds`:
 
 - `torrentName` (required): The release name as announced
 - `instanceIds` (optional): qBittorrent instance IDs to scan. Omit to search all instances.
+- `indexer` (optional): autobrr indexer identifier (for example `hdb`). Required for qui's HDBits-specific missing-collection fallback on `/check`.
 - `findIndividualEpisodes` (optional): Override the global episode matching setting
 
 ### 3. Configure Retry Handling
@@ -106,7 +109,7 @@ When `/check` returns `200 OK`, send the torrent to `/api/cross-seed/apply`:
 {
   "torrentData": "{{ .TorrentDataRawBytes | toString | b64enc }}",
   "instanceIds": [1],
-  "indexerName": {{ toRawJson .IndexerName }}
+  "indexer": {{ toRawJson .Indexer }}
 }
 ```
 
@@ -114,9 +117,9 @@ When `/check` returns `200 OK`, send the torrent to `/api/cross-seed/apply`:
 
 - `torrentData` (required) - Base64-encoded torrent file bytes
 - `instanceIds` (optional) - Target instances (omit to apply to any matching instance)
-- `indexerName` (optional) - Indexer display name (e.g., "TorrentDB"). Only used when "Use indexer name as category" mode is enabled; ignored otherwise
+- `indexer` (optional) - autobrr indexer identifier (for example `hdb`). When "Use indexer name as category" mode is enabled, qui uses this identifier value as the category; ignored otherwise
 - `tags` (optional) - Override webhook tags from settings
-- `category` (optional) - Override category. Takes precedence over `indexerName`
+- `category` (optional) - Override category. Takes precedence over `indexer`
 - `startPaused` (optional) - Override whether torrents are added paused
 - `skipIfExists` (optional) - Skip adding if the torrent already exists
 - `findIndividualEpisodes` (optional) - Override the global episode matching setting

--- a/documentation/static/openapi.yaml
+++ b/documentation/static/openapi.yaml
@@ -3036,6 +3036,7 @@ paths:
                   description: Total torrent size in bytes (optional - enables size validation when provided)
                 indexer:
                   type: string
+                  minLength: 1
                   description: Optional autobrr indexer identifier (for example "hdb"). Required if you want qui's HDBits-specific missing collection fallback on webhook checks.
                 findIndividualEpisodes:
                   type: boolean
@@ -3114,7 +3115,8 @@ paths:
                   type: boolean
                 indexer:
                   type: string
-                  description: autobrr indexer identifier (for example "hdb"). Only used when "Use indexer name as category" mode is enabled; qui uses this identifier as the category value. Webhook applies cannot derive tracker identity from the torrent file, so this field is required for that mode.
+                  minLength: 1
+                  description: autobrr indexer identifier (for example "hdb"). Only used when "Use indexer name as category" mode is enabled; when provided in that mode, qui uses this identifier as the category value. If omitted, qui falls back to the matched torrent category. Webhook applies cannot derive tracker identity from the torrent file.
       responses:
         '200':
           description: Torrent processed

--- a/documentation/static/openapi.yaml
+++ b/documentation/static/openapi.yaml
@@ -3034,6 +3034,9 @@ paths:
                   type: integer
                   format: uint64
                   description: Total torrent size in bytes (optional - enables size validation when provided)
+                indexer:
+                  type: string
+                  description: Optional autobrr indexer identifier (for example "hdb"). Required if you want qui's HDBits-specific missing collection fallback on webhook checks.
                 findIndividualEpisodes:
                   type: boolean
                   description: Optional override for matching season packs vs episodes. Defaults to the Cross-Seed automation setting when omitted.
@@ -3109,9 +3112,9 @@ paths:
                   type: boolean
                 findIndividualEpisodes:
                   type: boolean
-                indexerName:
+                indexer:
                   type: string
-                  description: Indexer display name (e.g., "TorrentDB"). Only used when "Use indexer name as category" mode is enabled; ignored otherwise. Webhook applies cannot derive the indexer from the torrent file, so this field is required for that mode.
+                  description: autobrr indexer identifier (for example "hdb"). Only used when "Use indexer name as category" mode is enabled; qui uses this identifier as the category value. Webhook applies cannot derive tracker identity from the torrent file, so this field is required for that mode.
       responses:
         '200':
           description: Torrent processed

--- a/internal/api/handlers/crossseed.go
+++ b/internal/api/handlers/crossseed.go
@@ -639,7 +639,7 @@ func (h *CrossSeedHandler) AutobrrApply(w http.ResponseWriter, r *http.Request) 
 		Int64("size", totalSize).
 		Int("fileCount", fileCount).
 		Ints("instanceIds", req.InstanceIDs).
-		Str("indexerName", req.IndexerName).
+		Str("indexer", req.Indexer).
 		Str("category", req.Category).
 		Msg("Webhook apply: received request")
 

--- a/internal/services/crossseed/autobrr_apply_test.go
+++ b/internal/services/crossseed/autobrr_apply_test.go
@@ -136,27 +136,27 @@ func TestAutobrrApplyTargetInstanceIDs(t *testing.T) {
 	}
 }
 
-// TestAutobrrApply_IndexerNamePassthrough verifies that IndexerName from the request
+// TestAutobrrApply_IndexerPassthrough verifies that Indexer from the request
 // is passed through to the CrossSeedRequest, enabling "Use indexer name as category" mode
 // for webhook applies where the indexer cannot be derived from the torrent file.
-func TestAutobrrApply_IndexerNamePassthrough(t *testing.T) {
+func TestAutobrrApply_IndexerPassthrough(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
 
 	tests := []struct {
 		name              string
-		indexerName       string
+		indexer           string
 		expectIndexerName string
 	}{
 		{
-			name:              "indexer name passed through",
-			indexerName:       "TorrentDB",
-			expectIndexerName: "TorrentDB",
+			name:              "indexer passed through",
+			indexer:           "hdb",
+			expectIndexerName: "hdb",
 		},
 		{
-			name:              "empty indexer name remains empty",
-			indexerName:       "",
+			name:              "empty indexer remains empty",
+			indexer:           "",
 			expectIndexerName: "",
 		},
 	}
@@ -175,7 +175,7 @@ func TestAutobrrApply_IndexerNamePassthrough(t *testing.T) {
 			req := &AutobrrApplyRequest{
 				TorrentData: "ZGF0YQ==",
 				InstanceIDs: []int{1},
-				IndexerName: tt.indexerName,
+				Indexer:     tt.indexer,
 			}
 
 			_, err := service.AutobrrApply(ctx, req)

--- a/internal/services/crossseed/crossseed_test.go
+++ b/internal/services/crossseed/crossseed_test.go
@@ -2184,10 +2184,11 @@ func TestCheckWebhook_AutobrrPayload(t *testing.T) {
 			wantMatchType:      "metadata",
 		},
 		{
-			name: "tv webhook tolerates missing incoming collection when group matches",
+			name: "tv webhook tolerates missing incoming collection for hdb when group matches",
 			request: &WebhookCheckRequest{
 				InstanceIDs: instanceIDs,
 				TorrentName: "Sample Show S08E11 1080p WEB-DL DD+5.1 H.264-NTb",
+				Indexer:     "hdb",
 			},
 			existingTorrents: []qbt.Torrent{
 				{
@@ -2202,10 +2203,29 @@ func TestCheckWebhook_AutobrrPayload(t *testing.T) {
 			wantMatchType:      "metadata",
 		},
 		{
+			name: "tv webhook missing collection stays strict for non-hdb even when group matches",
+			request: &WebhookCheckRequest{
+				InstanceIDs: instanceIDs,
+				TorrentName: "Sample Show S08E11 1080p WEB-DL DD+5.1 H.264-NTb",
+				Indexer:     "btn",
+			},
+			existingTorrents: []qbt.Torrent{
+				{
+					Hash:     "sample-show-dsnp-non-hdb",
+					Name:     "Sample.Show.S08E11.Episode.Title.1080p.DSNP.WEB-DL.DDP5.1.H.264-NTb",
+					Progress: 1.0,
+				},
+			},
+			wantCanCrossSeed:   false,
+			wantMatchCount:     0,
+			wantRecommendation: "skip",
+		},
+		{
 			name: "tv webhook missing collection still requires matching group or site",
 			request: &WebhookCheckRequest{
 				InstanceIDs: instanceIDs,
 				TorrentName: "Sample Show S08E11 1080p WEB-DL DD+5.1 H.264",
+				Indexer:     "hdb",
 			},
 			existingTorrents: []qbt.Torrent{
 				{
@@ -2219,10 +2239,11 @@ func TestCheckWebhook_AutobrrPayload(t *testing.T) {
 			wantRecommendation: "skip",
 		},
 		{
-			name: "movie webhook tolerates missing incoming collection when group matches",
+			name: "movie webhook tolerates missing incoming collection for hdb when group matches",
 			request: &WebhookCheckRequest{
 				InstanceIDs: instanceIDs,
 				TorrentName: "Sample Movie 2024 1080p WEB-DL DD+5.1 H.264-NTb",
+				Indexer:     "hdb",
 			},
 			existingTorrents: []qbt.Torrent{
 				{
@@ -2241,6 +2262,7 @@ func TestCheckWebhook_AutobrrPayload(t *testing.T) {
 			request: &WebhookCheckRequest{
 				InstanceIDs: instanceIDs,
 				TorrentName: "Sample Movie 2024 1080p WEB-DL DD+5.1 H.264",
+				Indexer:     "hdb",
 			},
 			existingTorrents: []qbt.Torrent{
 				{

--- a/internal/services/crossseed/matching.go
+++ b/internal/services/crossseed/matching.go
@@ -393,12 +393,14 @@ func (s *Service) releasesMatch(source, candidate *rls.Release, findIndividualEp
 	return true
 }
 
-func (s *Service) releasesMatchWebhook(source, candidate *rls.Release, findIndividualEpisodes bool) bool {
+const hdbitsAutobrrIndexer = "hdb"
+
+func (s *Service) releasesMatchWebhook(source, candidate *rls.Release, findIndividualEpisodes bool, indexer string) bool {
 	if s.releasesMatch(source, candidate, findIndividualEpisodes) {
 		return true
 	}
 
-	if !canFillMissingWebhookCollection(source, candidate, s.stringNormalizer) {
+	if !canUseWebhookCollectionFallback(source, candidate, indexer, s.stringNormalizer) {
 		return false
 	}
 
@@ -408,23 +410,28 @@ func (s *Service) releasesMatchWebhook(source, candidate *rls.Release, findIndiv
 	return s.releasesMatch(&sourceWithCollection, candidate, findIndividualEpisodes)
 }
 
-func canFillMissingWebhookCollection(
+func canUseWebhookCollectionFallback(
 	source, candidate *rls.Release,
+	indexer string,
 	normalizer *stringutils.Normalizer[string, string],
 ) bool {
+	if !supportsWebhookCollectionFallback(indexer) {
+		return false
+	}
+
 	if source == nil || candidate == nil {
 		return false
 	}
 
-	// Some webhook titles omit the collection/service tag entirely ("WEB-DL")
-	// while the existing torrent keeps the canonical source service (for example
-	// "DSNP"). Only retry when the incoming title is missing Collection and the
-	// group or site already anchors the release identity.
+	// Some indexers can announce generic WEB-DL titles without the collection/
+	// service tag while the existing torrent keeps the canonical source service
+	// (for example "DSNP"). Only retry when the incoming title is missing
+	// Collection and the group or site already anchors the release identity.
 	if source.Collection != "" || candidate.Collection == "" {
 		return false
 	}
 
-	if !supportsWebhookCollectionFallback(source, candidate) {
+	if !supportsWebhookCollectionFallbackContent(source, candidate) {
 		return false
 	}
 
@@ -432,7 +439,16 @@ func canFillMissingWebhookCollection(
 		hasNonEmptyNormalizedMatch(normalizer, source.Site, candidate.Site)
 }
 
-func supportsWebhookCollectionFallback(source, candidate *rls.Release) bool {
+func supportsWebhookCollectionFallback(indexer string) bool {
+	switch indexer {
+	case hdbitsAutobrrIndexer:
+		return true
+	default:
+		return false
+	}
+}
+
+func supportsWebhookCollectionFallbackContent(source, candidate *rls.Release) bool {
 	if source == nil || candidate == nil {
 		return false
 	}

--- a/internal/services/crossseed/matching_webhook_test.go
+++ b/internal/services/crossseed/matching_webhook_test.go
@@ -17,12 +17,14 @@ func TestReleasesMatchWebhook_FillsMissingCollection(t *testing.T) {
 
 	tests := []struct {
 		name      string
+		indexer   string
 		source    rls.Release
 		candidate rls.Release
 		wantMatch bool
 	}{
 		{
-			name: "tv missing collection matches when group anchors release",
+			name:    "hdb tv missing collection matches when group anchors release",
+			indexer: "hdb",
 			source: rls.Release{
 				Title:      "Sample Show",
 				Series:     8,
@@ -43,7 +45,8 @@ func TestReleasesMatchWebhook_FillsMissingCollection(t *testing.T) {
 			wantMatch: true,
 		},
 		{
-			name: "web movie missing collection matches when group anchors release",
+			name:    "hdb web movie missing collection matches when group anchors release",
+			indexer: "hdb",
 			source: rls.Release{
 				Title:      "Sample Movie",
 				Year:       2024,
@@ -62,7 +65,47 @@ func TestReleasesMatchWebhook_FillsMissingCollection(t *testing.T) {
 			wantMatch: true,
 		},
 		{
-			name: "missing collection still needs group or site anchor",
+			name:    "non-hdb missing collection stays strict",
+			indexer: "btn",
+			source: rls.Release{
+				Title:      "Sample Movie",
+				Year:       2024,
+				Source:     "WEB-DL",
+				Resolution: "1080p",
+				Group:      "NTb",
+			},
+			candidate: rls.Release{
+				Title:      "Sample Movie",
+				Year:       2024,
+				Source:     "WEB-DL",
+				Resolution: "1080p",
+				Collection: "DSNP",
+				Group:      "NTb",
+			},
+			wantMatch: false,
+		},
+		{
+			name: "missing indexer stays strict",
+			source: rls.Release{
+				Title:      "Sample Movie",
+				Year:       2024,
+				Source:     "WEB-DL",
+				Resolution: "1080p",
+				Group:      "NTb",
+			},
+			candidate: rls.Release{
+				Title:      "Sample Movie",
+				Year:       2024,
+				Source:     "WEB-DL",
+				Resolution: "1080p",
+				Collection: "DSNP",
+				Group:      "NTb",
+			},
+			wantMatch: false,
+		},
+		{
+			name:    "hdb missing collection still needs group or site anchor",
+			indexer: "hdb",
 			source: rls.Release{
 				Title:      "Sample Movie",
 				Year:       2024,
@@ -80,7 +123,8 @@ func TestReleasesMatchWebhook_FillsMissingCollection(t *testing.T) {
 			wantMatch: false,
 		},
 		{
-			name: "non-web movie missing collection stays strict",
+			name:    "hdb non-web movie missing collection stays strict",
+			indexer: "hdb",
 			source: rls.Release{
 				Title:      "Sample Movie",
 				Year:       2024,
@@ -99,7 +143,8 @@ func TestReleasesMatchWebhook_FillsMissingCollection(t *testing.T) {
 			wantMatch: false,
 		},
 		{
-			name: "explicit source collection mismatch stays strict",
+			name:    "hdb explicit source collection mismatch stays strict",
+			indexer: "hdb",
 			source: rls.Release{
 				Title:      "Sample Movie",
 				Year:       2024,
@@ -122,7 +167,7 @@ func TestReleasesMatchWebhook_FillsMissingCollection(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.wantMatch, s.releasesMatchWebhook(&tt.source, &tt.candidate, false))
+			require.Equal(t, tt.wantMatch, s.releasesMatchWebhook(&tt.source, &tt.candidate, false, tt.indexer))
 		})
 	}
 }

--- a/internal/services/crossseed/models.go
+++ b/internal/services/crossseed/models.go
@@ -384,6 +384,9 @@ type WebhookCheckRequest struct {
 	InstanceIDs []int `json:"instanceIds,omitempty"`
 	// Size is the total torrent size in bytes (optional - enables size validation if provided)
 	Size uint64 `json:"size,omitempty"`
+	// Indexer is autobrr's stable indexer identifier (for example "hdb").
+	// Used to apply tracker-specific webhook matching rules.
+	Indexer string `json:"indexer,omitempty"`
 	// FindIndividualEpisodes overrides the default behavior when matching season packs vs episodes.
 	// When omitted, qui uses the automation setting; when set, this explicitly forces the behavior.
 	FindIndividualEpisodes *bool `json:"findIndividualEpisodes,omitempty"`
@@ -418,8 +421,8 @@ type AutobrrApplyRequest struct {
 	SkipIfExists *bool    `json:"skipIfExists,omitempty"`
 	// FindIndividualEpisodes overrides the automation-level episode matching behavior when set.
 	FindIndividualEpisodes *bool `json:"findIndividualEpisodes,omitempty"`
-	// IndexerName is the display name of the indexer (e.g., "TorrentDB") used when
-	// "Use indexer name as category" mode is enabled. Without this field, webhook applies
-	// cannot derive the indexer from the torrent file itself.
-	IndexerName string `json:"indexerName,omitempty"`
+	// Indexer is autobrr's stable indexer identifier (for example "hdb").
+	// Used when "Use indexer name as category" mode is enabled because webhook applies
+	// cannot derive tracker identity from the torrent file itself.
+	Indexer string `json:"indexer,omitempty"`
 }

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -3439,7 +3439,7 @@ func (s *Service) AutobrrApply(ctx context.Context, req *AutobrrApplyRequest) (*
 		SkipAutoResume:               skipAutoResume,
 		SkipRecheck:                  skipRecheck,
 		SkipPieceBoundarySafetyCheck: skipPieceBoundarySafetyCheck,
-		IndexerName:                  req.IndexerName,
+		IndexerName:                  req.Indexer,
 	}
 	// Pass webhook source filters so CrossSeed respects them when finding candidates
 	if settings != nil {
@@ -9689,6 +9689,7 @@ func (s *Service) CheckWebhook(ctx context.Context, req *WebhookCheckRequest) (*
 		Bool("globalScan", len(requestedInstanceIDs) == 0).
 		Str("torrentName", req.TorrentName).
 		Uint64("size", req.Size).
+		Str("indexer", req.Indexer).
 		Str("contentType", contentInfo.ContentType).
 		Bool("findIndividualEpisodes", findIndividualEpisodes).
 		Str("title", incomingRelease.Title).
@@ -9777,7 +9778,7 @@ func (s *Service) CheckWebhook(ctx context.Context, req *WebhookCheckRequest) (*
 
 			// Webhook matching is strict by default, with one narrow retry for
 			// anchored releases whose incoming title omits the collection/service tag.
-			if !s.releasesMatchWebhook(incomingRelease, existingRelease, findIndividualEpisodes) {
+			if !s.releasesMatchWebhook(incomingRelease, existingRelease, findIndividualEpisodes, req.Indexer) {
 				continue
 			}
 

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -3985,6 +3985,7 @@ paths:
                   description: Total torrent size in bytes (optional - enables size validation when provided)
                 indexer:
                   type: string
+                  minLength: 1
                   description: Optional autobrr indexer identifier (for example "hdb"). Required if you want qui's HDBits-specific missing collection fallback on webhook checks.
                 findIndividualEpisodes:
                   type: boolean
@@ -4059,7 +4060,8 @@ paths:
                   type: boolean
                 indexer:
                   type: string
-                  description: autobrr indexer identifier (for example "hdb"). Only used when "Use indexer name as category" mode is enabled; qui uses this identifier as the category value. Webhook applies cannot derive tracker identity from the torrent file, so this field is required for that mode.
+                  minLength: 1
+                  description: autobrr indexer identifier (for example "hdb"). Only used when "Use indexer name as category" mode is enabled; when provided in that mode, qui uses this identifier as the category value. If omitted, qui falls back to the matched torrent category. Webhook applies cannot derive tracker identity from the torrent file.
       responses:
         '200':
           description: Torrent processed

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -3983,6 +3983,9 @@ paths:
                   type: integer
                   format: uint64
                   description: Total torrent size in bytes (optional - enables size validation when provided)
+                indexer:
+                  type: string
+                  description: Optional autobrr indexer identifier (for example "hdb"). Required if you want qui's HDBits-specific missing collection fallback on webhook checks.
                 findIndividualEpisodes:
                   type: boolean
                   description: Optional override for matching season packs vs episodes. Defaults to the Cross-Seed automation setting when omitted.
@@ -4054,9 +4057,9 @@ paths:
                   type: boolean
                 findIndividualEpisodes:
                   type: boolean
-                indexerName:
+                indexer:
                   type: string
-                  description: Indexer display name (e.g., "TorrentDB"). Only used when "Use indexer name as category" mode is enabled; ignored otherwise. Webhook applies cannot derive the indexer from the torrent file, so this field is required for that mode.
+                  description: autobrr indexer identifier (for example "hdb"). Only used when "Use indexer name as category" mode is enabled; qui uses this identifier as the category value. Webhook applies cannot derive tracker identity from the torrent file, so this field is required for that mode.
       responses:
         '200':
           description: Torrent processed


### PR DESCRIPTION
Switch autobrr webhook payloads from display names to stable indexer identifiers. `/api/cross-seed/webhook/check` and `/api/cross-seed/apply` now use `indexer`, the missing-collection fallback is scoped to `hdb` only, and webhook category passthrough now uses the autobrr indexer id consistently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an indexer parameter to cross-seed webhook and apply flows to drive tracker-specific behavior and category assignment
  * Enabled indexer-aware webhook collection fallback logic with selective tracker support (e.g., HDBits)

* **Documentation**
  * Updated API schema and docs to replace indexerName with indexer and describe its usage

* **Tests**
  * Expanded and renamed tests to cover indexer-aware matching and fallback scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->