### PR TITLE
refactor(web): tighten unified scope navigation

### DIFF
--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -682,7 +682,7 @@ export function Header({
                         <Link
                           to="/instances/$instanceId"
                           params={{ instanceId: instance.id.toString() }}
-                          className="flex cursor-pointer pl-6"
+                          className="flex cursor-pointer"
                         >
                           <HardDrive className="mr-2 h-4 w-4" />
                           <span className="truncate">{instance.name}</span>

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -4,11 +4,11 @@
  */
 
 import { InstancePreferencesDialog } from "@/components/instances/preferences/InstancePreferencesDialog"
+import { UnifiedScopeDropdownSection } from "@/components/layout/UnifiedScopeDropdownSection"
 import { TorrentManagementBar } from "@/components/torrents/TorrentManagementBar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
-  DropdownMenuCheckboxItem,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -101,8 +101,6 @@ export function Header({
     [persistedUnifiedFilter, activeInstanceIds]
   )
   const effectiveUnifiedInstanceIds = normalizedUnifiedInstanceIds.length > 0? normalizedUnifiedInstanceIds: activeInstanceIds
-  const hasCustomUnifiedScope = normalizedUnifiedInstanceIds.length > 0
-  const unifiedScopeSummary = `${effectiveUnifiedInstanceIds.length}/${activeInstances.length}`
   const applyUnifiedScope = useCallback((nextIds: number[]) => {
     const normalizedIds = normalizeUnifiedInstanceIds(nextIds, activeInstanceIds)
     saveUnifiedFilter(normalizedIds)
@@ -263,70 +261,19 @@ export function Header({
             </DropdownMenuTrigger>
             <DropdownMenuContent className="w-64 mt-2" side="bottom" align="start">
               <DropdownMenuLabel className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
-                Switch Scope
+                Instances
               </DropdownMenuLabel>
               <DropdownMenuSeparator />
               {hasMultipleActiveInstances && (
                 <>
-                  <DropdownMenuItem asChild>
-                    <Link
-                      to="/instances"
-                      className={cn(
-                        "flex items-center gap-2 cursor-pointer rounded-sm px-2 py-1.5 text-sm focus-visible:outline-none",
-                        isAllInstancesRoute ? "bg-accent text-accent-foreground font-medium" : "hover:bg-accent/80 data-[highlighted]:bg-accent/80 text-foreground"
-                      )}
-                    >
-                      <HardDrive className="h-4 w-4 flex-shrink-0" />
-                      <span className="flex-1 truncate">Unified</span>
-                      <span className="rounded border px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground">
-                        {activeInstances.length} active
-                      </span>
-                      {hasCustomUnifiedScope && (
-                        <span className="rounded border border-primary/40 px-1.5 py-0.5 text-[10px] font-medium leading-none text-primary">
-                          {unifiedScopeSummary}
-                        </span>
-                      )}
-                    </Link>
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuLabel className="text-xs text-muted-foreground uppercase tracking-wide">
-                    Unified Scope
-                  </DropdownMenuLabel>
-                  <DropdownMenuItem
-                    onSelect={(event) => {
-                      event.preventDefault()
-                      resetUnifiedScope()
-                    }}
-                    className="cursor-pointer text-xs"
-                  >
-                    All active ({activeInstances.length})
-                  </DropdownMenuItem>
-                  {activeInstances.map((instance) => {
-                    const checked = effectiveUnifiedInstanceIds.includes(instance.id)
-                    return (
-                      <DropdownMenuCheckboxItem
-                        key={`scope-${instance.id}`}
-                        checked={checked}
-                        onSelect={(event) => {
-                          event.preventDefault()
-                          toggleUnifiedScopeInstance(instance.id)
-                        }}
-                        className="cursor-pointer"
-                      >
-                        <span className="flex w-full items-center justify-between gap-2">
-                          <span className="truncate">{instance.name}</span>
-                          <span
-                            className={cn(
-                              "h-2 w-2 rounded-full flex-shrink-0",
-                              instance.connected ? "bg-green-500" : "bg-red-500"
-                            )}
-                            aria-hidden="true"
-                          />
-                        </span>
-                      </DropdownMenuCheckboxItem>
-                    )
-                  })}
-                  <DropdownMenuSeparator />
+                  <UnifiedScopeDropdownSection
+                    activeInstances={activeInstances}
+                    effectiveUnifiedInstanceIds={effectiveUnifiedInstanceIds}
+                    isAllInstancesRoute={isAllInstancesRoute}
+                    onResetUnifiedScope={resetUnifiedScope}
+                    onToggleUnifiedScopeInstance={toggleUnifiedScopeInstance}
+                    scopeKeyPrefix="header-switch-scope"
+                  />
                 </>
               )}
               <div className="max-h-64 overflow-y-auto space-y-1">
@@ -709,76 +656,22 @@ export function Header({
                   Logs
                 </Link>
               </DropdownMenuItem>
-              {hasMultipleActiveInstances && (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem asChild>
-                    <Link
-                      to="/instances"
-                      className={cn(
-                        "flex cursor-pointer",
-                        isAllInstancesRoute && "bg-accent text-accent-foreground font-medium"
-                      )}
-                    >
-                      <HardDrive className="mr-2 h-4 w-4" />
-                      <span className="truncate">Unified</span>
-                      <span className="ml-auto rounded border px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground">
-                        {activeInstances.length} active
-                      </span>
-                      {hasCustomUnifiedScope && (
-                        <span className="rounded border border-primary/40 px-1.5 py-0.5 text-[10px] font-medium leading-none text-primary">
-                          {unifiedScopeSummary}
-                        </span>
-                      )}
-                    </Link>
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuLabel className="text-xs text-muted-foreground uppercase tracking-wide">
-                    Unified Scope
-                  </DropdownMenuLabel>
-                  <DropdownMenuItem
-                    onSelect={(event) => {
-                      event.preventDefault()
-                      resetUnifiedScope()
-                    }}
-                    className="cursor-pointer text-xs"
-                  >
-                    All active ({activeInstances.length})
-                  </DropdownMenuItem>
-                  {activeInstances.map((instance) => {
-                    const checked = effectiveUnifiedInstanceIds.includes(instance.id)
-                    return (
-                      <DropdownMenuCheckboxItem
-                        key={`menu-scope-${instance.id}`}
-                        checked={checked}
-                        onSelect={(event) => {
-                          event.preventDefault()
-                          toggleUnifiedScopeInstance(instance.id)
-                        }}
-                        className="cursor-pointer"
-                      >
-                        <span className="flex w-full items-center justify-between gap-2">
-                          <span className="truncate">{instance.name}</span>
-                          <span
-                            className={cn(
-                              "h-2 w-2 rounded-full flex-shrink-0",
-                              instance.connected ? "bg-green-500" : "bg-red-500"
-                            )}
-                            aria-hidden="true"
-                          />
-                        </span>
-                      </DropdownMenuCheckboxItem>
-                    )
-                  })}
-                  <DropdownMenuSeparator />
-                </>
-              )}
+              {activeInstances.length > 0 && <DropdownMenuSeparator />}
               {activeInstances.length > 0 ? (
                 <>
-                  {!hasMultipleActiveInstances && <DropdownMenuSeparator />}
                   <DropdownMenuLabel className="text-xs text-muted-foreground uppercase tracking-wide">
                     Instances
                   </DropdownMenuLabel>
+                  {hasMultipleActiveInstances && (
+                    <UnifiedScopeDropdownSection
+                      activeInstances={activeInstances}
+                      effectiveUnifiedInstanceIds={effectiveUnifiedInstanceIds}
+                      isAllInstancesRoute={isAllInstancesRoute}
+                      onResetUnifiedScope={resetUnifiedScope}
+                      onToggleUnifiedScopeInstance={toggleUnifiedScopeInstance}
+                      scopeKeyPrefix="header-menu-scope"
+                    />
+                  )}
                   {activeInstances.map((instance) => {
                     const csState = crossSeedInstanceState[instance.id]
                     const hasRss = csState?.rssEnabled || csState?.rssRunning

--- a/web/src/components/layout/MobileFooterNav.tsx
+++ b/web/src/components/layout/MobileFooterNav.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
+import { UnifiedScopeDropdownSection } from "@/components/layout/UnifiedScopeDropdownSection"
 import { Badge } from "@/components/ui/badge"
 import {
   Dialog,
@@ -12,7 +13,6 @@ import {
 } from "@/components/ui/dialog"
 import {
   DropdownMenu,
-  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
@@ -140,8 +140,6 @@ export function MobileFooterNav() {
     [persistedUnifiedFilter, activeInstanceIds]
   )
   const effectiveUnifiedInstanceIds = normalizedUnifiedInstanceIds.length > 0? normalizedUnifiedInstanceIds: activeInstanceIds
-  const hasCustomUnifiedScope = normalizedUnifiedInstanceIds.length > 0
-  const unifiedScopeSummary = `${effectiveUnifiedInstanceIds.length}/${activeInstances.length}`
   const hasMultipleActiveInstances = activeInstances.length > 1
   const applyUnifiedScope = useCallback((nextIds: number[]) => {
     const normalizedIds = normalizeUnifiedInstanceIds(nextIds, activeInstanceIds)
@@ -164,12 +162,14 @@ export function MobileFooterNav() {
 
     applyUnifiedScope(nextIds)
   }, [applyUnifiedScope, effectiveUnifiedInstanceIds])
+  const resetUnifiedScope = useCallback(() => {
+    applyUnifiedScope(activeInstanceIds)
+  }, [activeInstanceIds, applyUnifiedScope])
   const hasActiveInstances = activeInstances.length > 0
   const hasClientScopeEntry = isOnAllInstancesPage || hasActiveInstances
   const currentInstanceId = !isOnAllInstancesPage && location.pathname.startsWith("/instances/") ? location.pathname.split("/")[2] : null
   const currentInstance = instances?.find(i => i.id.toString() === currentInstanceId)
   const currentInstanceLabel = isOnAllInstancesPage? (hasMultipleActiveInstances ? "Unified" : (activeInstances[0]?.name ?? null)): (currentInstance && currentInstance.isActive ? currentInstance.name : null)
-  const activeInstancesSummary = `${activeInstances.length} active instance${activeInstances.length === 1 ? "" : "s"}`
 
   const handleModeSelect = useCallback(async (mode: ThemeMode) => {
     await setThemeMode(mode)
@@ -277,126 +277,81 @@ export function MobileFooterNav() {
             <DropdownMenuContent align="center" side="top" className="w-56 mb-2">
               <DropdownMenuLabel>qBittorrent Clients</DropdownMenuLabel>
               <DropdownMenuSeparator />
-              {hasMultipleActiveInstances && (
+              {activeInstances.length > 0 ? (
                 <>
-                  <DropdownMenuItem asChild>
-                    <Link
-                      to="/instances"
-                      className="flex items-center gap-2 min-w-0"
-                    >
-                      <HardDrive className="h-4 w-4" />
-                      <span className="flex-1 min-w-0 truncate font-medium">Unified</span>
-                      <span className="rounded border px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground">
-                        {activeInstancesSummary}
-                      </span>
-                      {hasCustomUnifiedScope && (
-                        <span className="rounded border border-primary/40 px-1.5 py-0.5 text-[10px] font-medium leading-none text-primary">
-                          {unifiedScopeSummary}
-                        </span>
-                      )}
-                    </Link>
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
                   <DropdownMenuLabel className="text-xs uppercase tracking-wide text-muted-foreground">
-                    Unified Scope
+                    Instances
                   </DropdownMenuLabel>
-                  <DropdownMenuItem
-                    onSelect={(event) => {
-                      event.preventDefault()
-                      applyUnifiedScope(activeInstanceIds)
-                    }}
-                    className="cursor-pointer text-xs"
-                  >
-                    All active ({activeInstances.length})
-                  </DropdownMenuItem>
+                  {hasMultipleActiveInstances && (
+                    <UnifiedScopeDropdownSection
+                      activeInstances={activeInstances}
+                      effectiveUnifiedInstanceIds={effectiveUnifiedInstanceIds}
+                      isAllInstancesRoute={isOnAllInstancesPage}
+                      onResetUnifiedScope={resetUnifiedScope}
+                      onToggleUnifiedScopeInstance={toggleUnifiedScopeInstance}
+                      scopeKeyPrefix="mobile-scope"
+                    />
+                  )}
                   {activeInstances.map((instance) => {
-                    const checked = effectiveUnifiedInstanceIds.includes(instance.id)
+                    const csState = crossSeedInstanceState[instance.id]
+                    const hasRss = csState?.rssEnabled || csState?.rssRunning
+                    const hasSearch = csState?.searchRunning
+
                     return (
-                      <DropdownMenuCheckboxItem
-                        key={`mobile-scope-${instance.id}`}
-                        checked={checked}
-                        onSelect={(event) => {
-                          event.preventDefault()
-                          toggleUnifiedScopeInstance(instance.id)
-                        }}
-                        className="cursor-pointer"
-                      >
-                        <span className="flex w-full items-center justify-between gap-2">
-                          <span className="truncate">{instance.name}</span>
+                      <DropdownMenuItem key={instance.id} asChild>
+                        <Link
+                          to="/instances/$instanceId"
+                          params={{ instanceId: instance.id.toString() }}
+                          className="flex items-center gap-2 min-w-0"
+                        >
+                          <HardDrive className="h-4 w-4" />
                           <span
-                            className={cn(
-                              "h-2 w-2 rounded-full",
-                              instance.connected ? "bg-green-500" : "bg-red-500"
+                            className="flex-1 min-w-0 truncate"
+                            title={instance.name}
+                          >
+                            {instance.name}
+                          </span>
+                          <span className="flex items-center gap-1.5">
+                            {hasRss && (
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <span className="flex items-center">
+                                    {csState?.rssRunning ? (
+                                      <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
+                                    ) : (
+                                      <Rss className="h-3 w-3 text-muted-foreground" />
+                                    )}
+                                  </span>
+                                </TooltipTrigger>
+                                <TooltipContent side="left" className="text-xs">
+                                  RSS {csState?.rssRunning ? "running" : "enabled"}
+                                </TooltipContent>
+                              </Tooltip>
                             )}
-                            aria-hidden="true"
-                          />
-                        </span>
-                      </DropdownMenuCheckboxItem>
+                            {hasSearch && (
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <span className="flex items-center">
+                                    <SearchCode className="h-3 w-3 text-muted-foreground" />
+                                  </span>
+                                </TooltipTrigger>
+                                <TooltipContent side="left" className="text-xs">
+                                  Scan running
+                                </TooltipContent>
+                              </Tooltip>
+                            )}
+                            <span
+                              className={cn(
+                                "h-2 w-2 rounded-full",
+                                instance.connected ? "bg-green-500" : "bg-red-500"
+                              )}
+                            />
+                          </span>
+                        </Link>
+                      </DropdownMenuItem>
                     )
                   })}
-                  <DropdownMenuSeparator />
                 </>
-              )}
-              {activeInstances.length > 0 ? (
-                activeInstances.map((instance) => {
-                  const csState = crossSeedInstanceState[instance.id]
-                  const hasRss = csState?.rssEnabled || csState?.rssRunning
-                  const hasSearch = csState?.searchRunning
-
-                  return (
-                    <DropdownMenuItem key={instance.id} asChild>
-                      <Link
-                        to="/instances/$instanceId"
-                        params={{ instanceId: instance.id.toString() }}
-                        className="flex items-center gap-2 min-w-0"
-                      >
-                        <HardDrive className="h-4 w-4" />
-                        <span
-                          className="flex-1 min-w-0 truncate"
-                          title={instance.name}
-                        >
-                          {instance.name}
-                        </span>
-                        <span className="flex items-center gap-1.5">
-                          {hasRss && (
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <span className="flex items-center">
-                                  {csState?.rssRunning ? (
-                                    <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
-                                  ) : (
-                                    <Rss className="h-3 w-3 text-muted-foreground" />
-                                  )}
-                                </span>
-                              </TooltipTrigger>
-                              <TooltipContent side="left" className="text-xs">
-                                RSS {csState?.rssRunning ? "running" : "enabled"}
-                              </TooltipContent>
-                            </Tooltip>
-                          )}
-                          {hasSearch && (
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <span className="flex items-center">
-                                  <SearchCode className="h-3 w-3 text-muted-foreground" />
-                                </span>
-                              </TooltipTrigger>
-                              <TooltipContent side="left" className="text-xs">
-                                Scan running
-                              </TooltipContent>
-                            </Tooltip>
-                          )}
-                          <span
-                            className={cn(
-                              "h-2 w-2 rounded-full",
-                              instance.connected ? "bg-green-500" : "bg-red-500"
-                            )}
-                          />
-                        </span>
-                      </Link>
-                    </DropdownMenuItem>
-                  )
-                })
               ) : (
                 <DropdownMenuItem disabled className="text-xs text-muted-foreground">
                   No active instances

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -4,15 +4,7 @@
  */
 
 import { Button } from "@/components/ui/button"
-import {
-  DropdownMenu,
-  DropdownMenuCheckboxItem,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger
-} from "@/components/ui/dropdown-menu"
+import { UnifiedScopeDropdownSection } from "@/components/layout/UnifiedScopeDropdownSection"
 import { Logo } from "@/components/ui/Logo"
 import { NapsterLogo } from "@/components/ui/NapsterLogo"
 import { Separator } from "@/components/ui/separator"
@@ -43,7 +35,6 @@ import {
   Search,
   SearchCode,
   Settings,
-  SlidersHorizontal,
   Zap
 } from "lucide-react"
 import { useCallback, useMemo } from "react"
@@ -139,8 +130,6 @@ export function Sidebar() {
   )
   const effectiveUnifiedInstanceIds = normalizedUnifiedInstanceIds.length > 0? normalizedUnifiedInstanceIds: activeInstanceIds
   const isAllInstancesActive = location.pathname === "/instances" || location.pathname === "/instances/"
-  const hasCustomUnifiedScope = normalizedUnifiedInstanceIds.length > 0
-  const unifiedScopeSummary = `${effectiveUnifiedInstanceIds.length}/${activeInstances.length}`
   const hasMultipleActiveInstances = activeInstances.length > 1
   const applyUnifiedScope = useCallback((nextIds: number[]) => {
     const normalizedIds = normalizeUnifiedInstanceIds(nextIds, activeInstanceIds)
@@ -218,82 +207,15 @@ export function Sidebar() {
             <div className="mt-1 flex-1 overflow-y-auto space-y-1 pr-1">
               {hasMultipleActiveInstances && (
                 <>
-                  <Link
-                    to="/instances"
-                    className={cn(
-                      "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-all duration-200 ease-out",
-                      isAllInstancesActive ? "bg-sidebar-primary text-sidebar-primary-foreground" : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
-                    )}
-                  >
-                    <HardDrive className="h-4 w-4 flex-shrink-0" />
-                    <span className="truncate max-w-36">Unified</span>
-                    <span
-                      className={cn(
-                        "ml-auto rounded border px-1.5 py-0.5 text-[10px] font-medium leading-none flex-shrink-0",
-                        isAllInstancesActive ? "border-sidebar-primary-foreground/35 text-sidebar-primary-foreground/90" : "border-sidebar-border text-sidebar-foreground/70"
-                      )}
-                    >
-                      {hasCustomUnifiedScope ? `${unifiedScopeSummary} active` : `${activeInstances.length} active`}
-                    </span>
-                  </Link>
-                  <div className="px-3">
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <button
-                          type="button"
-                          className={cn(
-                            "mt-1 w-full rounded-md border border-sidebar-border/70 px-2 py-1 text-xs",
-                            "text-sidebar-foreground/80 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
-                            "inline-flex items-center gap-1.5"
-                          )}
-                        >
-                          <SlidersHorizontal className="h-3 w-3" />
-                          Scope
-                        </button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent side="right" align="start" className="w-56">
-                        <DropdownMenuLabel className="text-xs uppercase tracking-wide text-muted-foreground">
-                          Unified Scope
-                        </DropdownMenuLabel>
-                        <DropdownMenuSeparator />
-                        <DropdownMenuItem
-                          onSelect={(event) => {
-                            event.preventDefault()
-                            applyUnifiedScope(activeInstanceIds)
-                          }}
-                          className="cursor-pointer text-xs"
-                        >
-                          All active ({activeInstances.length})
-                        </DropdownMenuItem>
-                        <DropdownMenuSeparator />
-                        {activeInstances.map((instance) => {
-                          const checked = effectiveUnifiedInstanceIds.includes(instance.id)
-                          return (
-                            <DropdownMenuCheckboxItem
-                              key={`sidebar-scope-${instance.id}`}
-                              checked={checked}
-                              onSelect={(event) => {
-                                event.preventDefault()
-                                toggleUnifiedScopeInstance(instance.id)
-                              }}
-                              className="cursor-pointer"
-                            >
-                              <span className="flex w-full items-center justify-between gap-2">
-                                <span className="truncate">{instance.name}</span>
-                                <span
-                                  className={cn(
-                                    "h-2 w-2 rounded-full flex-shrink-0",
-                                    instance.connected ? "bg-green-500" : "bg-red-500"
-                                  )}
-                                  aria-hidden="true"
-                                />
-                              </span>
-                            </DropdownMenuCheckboxItem>
-                          )
-                        })}
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  </div>
+                  <UnifiedScopeDropdownSection
+                    activeInstances={activeInstances}
+                    effectiveUnifiedInstanceIds={effectiveUnifiedInstanceIds}
+                    isAllInstancesRoute={isAllInstancesActive}
+                    onResetUnifiedScope={() => applyUnifiedScope(activeInstanceIds)}
+                    onToggleUnifiedScopeInstance={toggleUnifiedScopeInstance}
+                    scopeKeyPrefix="sidebar-scope"
+                    variant="sidebar"
+                  />
                   <Separator className="my-2" />
                 </>
               )}

--- a/web/src/components/layout/UnifiedScopeDropdownSection.tsx
+++ b/web/src/components/layout/UnifiedScopeDropdownSection.tsx
@@ -18,6 +18,7 @@ interface UnifiedScopeDropdownSectionProps {
   onResetUnifiedScope: () => void
   onToggleUnifiedScopeInstance: (instanceId: number) => void
   scopeKeyPrefix: string
+  variant?: "dropdown" | "sidebar"
 }
 
 export function UnifiedScopeDropdownSection({
@@ -27,25 +28,49 @@ export function UnifiedScopeDropdownSection({
   onResetUnifiedScope,
   onToggleUnifiedScopeInstance,
   scopeKeyPrefix,
+  variant = "dropdown",
 }: UnifiedScopeDropdownSectionProps) {
   const [isExpanded, setIsExpanded] = useState(false)
   const hasCustomUnifiedScope = effectiveUnifiedInstanceIds.length !== activeInstances.length
   const scopeSummary = hasCustomUnifiedScope ? `${effectiveUnifiedInstanceIds.length}/${activeInstances.length}` : "ALL"
+  const isSidebar = variant === "sidebar"
+
+  const rowContainerClassName = isSidebar ? cn(
+    "flex items-stretch rounded-md text-sm transition-all duration-200 ease-out",
+    isAllInstancesRoute ? "bg-sidebar-primary text-sidebar-primary-foreground font-medium" : "text-sidebar-foreground"
+  ) : cn(
+    "flex items-stretch rounded-sm text-sm",
+    isAllInstancesRoute ? "bg-accent text-accent-foreground font-medium" : "text-foreground"
+  )
+
+  const rowLinkClassName = isSidebar ? cn(
+    "flex min-w-0 flex-1 items-center gap-3 px-3 py-2 outline-hidden transition-all duration-200 ease-out",
+    isAllInstancesRoute ? "rounded-l-md" : "rounded-l-md hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:bg-sidebar-accent focus-visible:text-sidebar-accent-foreground"
+  ) : cn(
+    "flex min-w-0 flex-1 items-center gap-2 px-2 py-1.5 outline-hidden transition-colors",
+    isAllInstancesRoute ? "rounded-l-sm" : "rounded-l-sm hover:bg-accent/80 focus-visible:bg-accent/80"
+  )
+
+  const triggerClassName = isSidebar ? cn(
+    "flex items-center gap-1 rounded-r-md px-2.5 outline-hidden transition-all duration-200 ease-out",
+    isAllInstancesRoute ? "text-sidebar-primary-foreground/75 hover:bg-sidebar-primary/90 focus-visible:bg-sidebar-primary/90" : "text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:bg-sidebar-accent focus-visible:text-sidebar-accent-foreground"
+  ) : cn(
+    "flex items-center gap-1 rounded-r-sm px-2 outline-hidden transition-colors",
+    isAllInstancesRoute ? "text-accent-foreground/70 hover:bg-accent/90 focus-visible:bg-accent/90" : "text-muted-foreground hover:bg-accent/80 hover:text-foreground focus-visible:bg-accent/80 focus-visible:text-foreground"
+  )
+
+  const contentClassName = "overflow-hidden data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+
+  const contentInnerClassName = isSidebar ? "ml-6 space-y-1 border-l border-sidebar-border/70 pl-3" : "ml-4 space-y-1 border-l border-border/60 pl-2"
+
+  const sidebarScopeRowClassName = "flex w-full items-center justify-between gap-2 rounded-md px-3 py-2 text-sm font-medium transition-all duration-200 ease-out outline-hidden"
 
   return (
     <Collapsible open={isExpanded} onOpenChange={setIsExpanded} className="space-y-1">
-      <div
-        className={cn(
-          "flex items-stretch rounded-sm text-sm",
-          isAllInstancesRoute ? "bg-accent text-accent-foreground font-medium" : "text-foreground"
-        )}
-      >
+      <div className={rowContainerClassName}>
         <Link
           to="/instances"
-          className={cn(
-            "flex min-w-0 flex-1 items-center gap-2 px-2 py-1.5 outline-hidden transition-colors",
-            isAllInstancesRoute ? "rounded-l-sm" : "rounded-l-sm hover:bg-accent/80 focus-visible:bg-accent/80"
-          )}
+          className={rowLinkClassName}
         >
           <HardDrive className="h-4 w-4 flex-shrink-0" />
           <span className="truncate">Unified</span>
@@ -53,10 +78,7 @@ export function UnifiedScopeDropdownSection({
         <CollapsibleTrigger asChild>
           <button
             type="button"
-            className={cn(
-              "flex items-center gap-1 rounded-r-sm px-2 outline-hidden transition-colors",
-              isAllInstancesRoute ? "text-accent-foreground/70 hover:bg-accent/90 focus-visible:bg-accent/90" : "text-muted-foreground hover:bg-accent/80 hover:text-foreground focus-visible:bg-accent/80 focus-visible:text-foreground"
-            )}
+            className={triggerClassName}
             aria-label={isExpanded ? "Collapse unified scope" : "Expand unified scope"}
           >
             <span className="text-[10px] font-semibold uppercase tracking-[0.18em]">
@@ -72,43 +94,84 @@ export function UnifiedScopeDropdownSection({
         </CollapsibleTrigger>
       </div>
 
-      <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
-        <div className="ml-4 space-y-1 border-l border-border/60 pl-2">
-          <DropdownMenuItem
-            onSelect={(event) => {
-              event.preventDefault()
-              onResetUnifiedScope()
-            }}
-            className="cursor-pointer text-sm"
-          >
-            All active ({activeInstances.length})
-          </DropdownMenuItem>
-          {activeInstances.map((instance) => {
-            const checked = effectiveUnifiedInstanceIds.includes(instance.id)
+      <CollapsibleContent className={contentClassName}>
+        <div className={contentInnerClassName}>
+          {isSidebar ? (
+            <>
+              <button
+                type="button"
+                onClick={onResetUnifiedScope}
+                className={cn(
+                  sidebarScopeRowClassName,
+                  "text-sidebar-foreground/80 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:bg-sidebar-accent focus-visible:text-sidebar-accent-foreground"
+                )}
+              >
+                <span className="truncate">All active ({activeInstances.length})</span>
+              </button>
+              {activeInstances.map((instance) => {
+                const checked = effectiveUnifiedInstanceIds.includes(instance.id)
 
-            return (
-              <DropdownMenuCheckboxItem
-                key={`${scopeKeyPrefix}-${instance.id}`}
-                checked={checked}
+                return (
+                  <button
+                    key={`${scopeKeyPrefix}-${instance.id}`}
+                    type="button"
+                    onClick={() => onToggleUnifiedScopeInstance(instance.id)}
+                    className={cn(
+                      sidebarScopeRowClassName,
+                      checked ? "bg-sidebar-accent text-sidebar-accent-foreground" : "text-sidebar-foreground/80 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:bg-sidebar-accent focus-visible:text-sidebar-accent-foreground"
+                    )}
+                  >
+                    <span className="truncate">{instance.name}</span>
+                    <span
+                      className={cn(
+                        "h-2 w-2 rounded-full flex-shrink-0",
+                        instance.connected ? "bg-green-500" : "bg-red-500"
+                      )}
+                      aria-hidden="true"
+                    />
+                  </button>
+                )
+              })}
+            </>
+          ) : (
+            <>
+              <DropdownMenuItem
                 onSelect={(event) => {
                   event.preventDefault()
-                  onToggleUnifiedScopeInstance(instance.id)
+                  onResetUnifiedScope()
                 }}
-                className="cursor-pointer"
+                className="cursor-pointer text-sm"
               >
-                <span className="flex w-full items-center justify-between gap-2">
-                  <span className="truncate">{instance.name}</span>
-                  <span
-                    className={cn(
-                      "h-2 w-2 rounded-full flex-shrink-0",
-                      instance.connected ? "bg-green-500" : "bg-red-500"
-                    )}
-                    aria-hidden="true"
-                  />
-                </span>
-              </DropdownMenuCheckboxItem>
-            )
-          })}
+                All active ({activeInstances.length})
+              </DropdownMenuItem>
+              {activeInstances.map((instance) => {
+                const checked = effectiveUnifiedInstanceIds.includes(instance.id)
+
+                return (
+                  <DropdownMenuCheckboxItem
+                    key={`${scopeKeyPrefix}-${instance.id}`}
+                    checked={checked}
+                    onSelect={(event) => {
+                      event.preventDefault()
+                      onToggleUnifiedScopeInstance(instance.id)
+                    }}
+                    className="cursor-pointer"
+                  >
+                    <span className="flex w-full items-center justify-between gap-2">
+                      <span className="truncate">{instance.name}</span>
+                      <span
+                        className={cn(
+                          "h-2 w-2 rounded-full flex-shrink-0",
+                          instance.connected ? "bg-green-500" : "bg-red-500"
+                        )}
+                        aria-hidden="true"
+                      />
+                    </span>
+                  </DropdownMenuCheckboxItem>
+                )
+              })}
+            </>
+          )}
         </div>
       </CollapsibleContent>
     </Collapsible>

--- a/web/src/components/layout/UnifiedScopeDropdownSection.tsx
+++ b/web/src/components/layout/UnifiedScopeDropdownSection.tsx
@@ -59,39 +59,85 @@ export function UnifiedScopeDropdownSection({
     isAllInstancesRoute ? "text-accent-foreground/70 hover:bg-accent/90 focus-visible:bg-accent/90" : "text-muted-foreground hover:bg-accent/80 hover:text-foreground focus-visible:bg-accent/80 focus-visible:text-foreground"
   )
 
-  const contentClassName = "overflow-hidden data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+  const dropdownHeaderItemClassName = "cursor-pointer p-0"
 
-  const contentInnerClassName = isSidebar ? "ml-6 space-y-1 border-l border-sidebar-border/70 pl-3" : "ml-4 space-y-1 border-l border-border/60 pl-2"
+  const contentClassName = cn(
+    "overflow-hidden data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down",
+    !isSidebar && "max-h-[min(18rem,calc(100vh-14rem))]"
+  )
+
+  const contentInnerClassName = isSidebar ? "ml-6 space-y-1 border-l border-sidebar-border/70 pl-3" : "ml-4 max-h-[min(18rem,calc(100vh-14rem))] space-y-1 overflow-y-auto overscroll-contain border-l border-border/60 pl-2 pr-1"
 
   const sidebarScopeRowClassName = "flex w-full items-center justify-between gap-2 rounded-md px-3 py-2 text-sm font-medium transition-all duration-200 ease-out outline-hidden"
 
   return (
     <Collapsible open={isExpanded} onOpenChange={setIsExpanded} className="space-y-1">
       <div className={rowContainerClassName}>
-        <Link
-          to="/instances"
-          className={rowLinkClassName}
-        >
-          <HardDrive className="h-4 w-4 flex-shrink-0" />
-          <span className="truncate">Unified</span>
-        </Link>
-        <CollapsibleTrigger asChild>
-          <button
-            type="button"
-            className={triggerClassName}
-            aria-label={isExpanded ? "Collapse unified scope" : "Expand unified scope"}
-          >
-            <span className="text-[10px] font-semibold uppercase tracking-[0.18em]">
-              {scopeSummary}
-            </span>
-            <ChevronRight
-              className={cn(
-                "h-4 w-4 transition-transform duration-200",
-                isExpanded && "rotate-90"
-              )}
-            />
-          </button>
-        </CollapsibleTrigger>
+        {isSidebar ? (
+          <>
+            <Link
+              to="/instances"
+              className={rowLinkClassName}
+            >
+              <HardDrive className="h-4 w-4 flex-shrink-0" />
+              <span className="truncate">Unified</span>
+            </Link>
+            <CollapsibleTrigger asChild>
+              <button
+                type="button"
+                className={triggerClassName}
+                aria-label={isExpanded ? "Collapse unified scope" : "Expand unified scope"}
+              >
+                <span className="text-[10px] font-semibold uppercase tracking-[0.18em]">
+                  {scopeSummary}
+                </span>
+                <ChevronRight
+                  className={cn(
+                    "h-4 w-4 transition-transform duration-200",
+                    isExpanded && "rotate-90"
+                  )}
+                />
+              </button>
+            </CollapsibleTrigger>
+          </>
+        ) : (
+          <>
+            <DropdownMenuItem asChild className={dropdownHeaderItemClassName}>
+              <Link
+                to="/instances"
+                className={rowLinkClassName}
+              >
+                <HardDrive className="h-4 w-4 flex-shrink-0" />
+                <span className="truncate">Unified</span>
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              asChild
+              className={dropdownHeaderItemClassName}
+              onSelect={(event) => {
+                event.preventDefault()
+              }}
+            >
+              <CollapsibleTrigger asChild>
+                <button
+                  type="button"
+                  className={triggerClassName}
+                  aria-label={isExpanded ? "Collapse unified scope" : "Expand unified scope"}
+                >
+                  <span className="text-[10px] font-semibold uppercase tracking-[0.18em]">
+                    {scopeSummary}
+                  </span>
+                  <ChevronRight
+                    className={cn(
+                      "h-4 w-4 transition-transform duration-200",
+                      isExpanded && "rotate-90"
+                    )}
+                  />
+                </button>
+              </CollapsibleTrigger>
+            </DropdownMenuItem>
+          </>
+        )}
       </div>
 
       <CollapsibleContent className={contentClassName}>

--- a/web/src/components/layout/UnifiedScopeDropdownSection.tsx
+++ b/web/src/components/layout/UnifiedScopeDropdownSection.tsx
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
+import { DropdownMenuCheckboxItem, DropdownMenuItem } from "@/components/ui/dropdown-menu"
+import { cn } from "@/lib/utils"
+import type { InstanceResponse } from "@/types"
+import { Link } from "@tanstack/react-router"
+import { ChevronRight, HardDrive } from "lucide-react"
+import { useState } from "react"
+
+interface UnifiedScopeDropdownSectionProps {
+  activeInstances: InstanceResponse[]
+  effectiveUnifiedInstanceIds: number[]
+  isAllInstancesRoute: boolean
+  onResetUnifiedScope: () => void
+  onToggleUnifiedScopeInstance: (instanceId: number) => void
+  scopeKeyPrefix: string
+}
+
+export function UnifiedScopeDropdownSection({
+  activeInstances,
+  effectiveUnifiedInstanceIds,
+  isAllInstancesRoute,
+  onResetUnifiedScope,
+  onToggleUnifiedScopeInstance,
+  scopeKeyPrefix,
+}: UnifiedScopeDropdownSectionProps) {
+  const [isExpanded, setIsExpanded] = useState(false)
+  const hasCustomUnifiedScope = effectiveUnifiedInstanceIds.length !== activeInstances.length
+  const scopeSummary = hasCustomUnifiedScope ? `${effectiveUnifiedInstanceIds.length}/${activeInstances.length}` : "ALL"
+
+  return (
+    <Collapsible open={isExpanded} onOpenChange={setIsExpanded} className="space-y-1">
+      <div
+        className={cn(
+          "flex items-stretch rounded-sm text-sm",
+          isAllInstancesRoute ? "bg-accent text-accent-foreground font-medium" : "text-foreground"
+        )}
+      >
+        <Link
+          to="/instances"
+          className={cn(
+            "flex min-w-0 flex-1 items-center gap-2 px-2 py-1.5 outline-hidden transition-colors",
+            isAllInstancesRoute ? "rounded-l-sm" : "rounded-l-sm hover:bg-accent/80 focus-visible:bg-accent/80"
+          )}
+        >
+          <HardDrive className="h-4 w-4 flex-shrink-0" />
+          <span className="truncate">Unified</span>
+        </Link>
+        <CollapsibleTrigger asChild>
+          <button
+            type="button"
+            className={cn(
+              "flex items-center gap-1 rounded-r-sm px-2 outline-hidden transition-colors",
+              isAllInstancesRoute ? "text-accent-foreground/70 hover:bg-accent/90 focus-visible:bg-accent/90" : "text-muted-foreground hover:bg-accent/80 hover:text-foreground focus-visible:bg-accent/80 focus-visible:text-foreground"
+            )}
+            aria-label={isExpanded ? "Collapse unified scope" : "Expand unified scope"}
+          >
+            <span className="text-[10px] font-semibold uppercase tracking-[0.18em]">
+              {scopeSummary}
+            </span>
+            <ChevronRight
+              className={cn(
+                "h-4 w-4 transition-transform duration-200",
+                isExpanded && "rotate-90"
+              )}
+            />
+          </button>
+        </CollapsibleTrigger>
+      </div>
+
+      <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
+        <div className="ml-4 space-y-1 border-l border-border/60 pl-2">
+          <DropdownMenuItem
+            onSelect={(event) => {
+              event.preventDefault()
+              onResetUnifiedScope()
+            }}
+            className="cursor-pointer text-sm"
+          >
+            All active ({activeInstances.length})
+          </DropdownMenuItem>
+          {activeInstances.map((instance) => {
+            const checked = effectiveUnifiedInstanceIds.includes(instance.id)
+
+            return (
+              <DropdownMenuCheckboxItem
+                key={`${scopeKeyPrefix}-${instance.id}`}
+                checked={checked}
+                onSelect={(event) => {
+                  event.preventDefault()
+                  onToggleUnifiedScopeInstance(instance.id)
+                }}
+                className="cursor-pointer"
+              >
+                <span className="flex w-full items-center justify-between gap-2">
+                  <span className="truncate">{instance.name}</span>
+                  <span
+                    className={cn(
+                      "h-2 w-2 rounded-full flex-shrink-0",
+                      instance.connected ? "bg-green-500" : "bg-red-500"
+                    )}
+                    aria-hidden="true"
+                  />
+                </span>
+              </DropdownMenuCheckboxItem>
+            )
+          })}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}


### PR DESCRIPTION
Moved unified scope controls into the Instances section across header, mobile footer nav, and sidebar. Unified is now compact by default and expands scope controls only from the chevron area, which keeps the primary row clean and preserves navigation on row click.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified instance selector component added across header, sidebar, and mobile footer for consistent scope management.
  * Per-instance links now show connectivity and operation status (including an animated loader when running) and support resetting to all active instances.

* **Style**
  * Navigation label updated from "Switch Scope" to "Instances".
  * Streamlined instance selection UI for clearer organization and improved mobile/desktop parity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->