### PR TITLE
fix(auth): allow loopback health probes

### DIFF
--- a/documentation/docs/configuration/environment.md
+++ b/documentation/docs/configuration/environment.md
@@ -125,6 +125,8 @@ Non-canonical CIDRs with host bits set (for example `10.0.0.5/8`) are rejected.
 
 Only use this when qui runs behind a reverse proxy that already handles authentication (e.g., Authelia, Authentik, Caddy with forward_auth). See the [Configuration Reference](./reference#authentication) for a full explanation of the risks.
 
+Built-in health endpoints (`/health`, `/healthz/readiness`, `/healthz/liveness`) always allow loopback probes, so the official Docker image healthcheck continues to work even if your allowlist only includes the reverse proxy subnet(s).
+
 ## External Programs
 
 Configure the allow list from `config.toml`; there is no environment override to keep it read-only from the UI.

--- a/documentation/docs/configuration/reference.md
+++ b/documentation/docs/configuration/reference.md
@@ -108,6 +108,7 @@ Non-canonical CIDRs with host bits set (for example `10.0.0.5/8`) are rejected.
 When authentication is disabled:
 
 - Requests are allowed only if the direct client IP matches `authDisabledAllowedCIDRs`.
+- Built-in health endpoints (`/health`, `/healthz/readiness`, `/healthz/liveness`) still allow loopback probes so the official Docker image healthcheck works without adding `127.0.0.1/32` or `::1/128` to your reverse proxy allowlist.
 - `/api/auth/me` returns a synthetic `admin` user so the frontend works without login.
 - `/api/auth/validate` returns a synthetic `admin` user so callback/session checks work without login.
 - The setup screen is skipped entirely.

--- a/internal/api/middleware/auth_disabled_ip_allowlist.go
+++ b/internal/api/middleware/auth_disabled_ip_allowlist.go
@@ -38,6 +38,11 @@ func RequireAuthDisabledIPAllowlist(cfg *domain.Config) func(http.Handler) http.
 				return
 			}
 
+			if addr.IsLoopback() && isBuiltInHealthEndpoint(r.URL.Path) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
 			for _, prefix := range prefixes {
 				if prefix.Contains(addr) {
 					next.ServeHTTP(w, r)
@@ -71,4 +76,13 @@ func parseRemoteAddrIP(remoteAddr string) (netip.Addr, error) {
 	}
 
 	return addr.Unmap(), nil
+}
+
+func isBuiltInHealthEndpoint(path string) bool {
+	switch path {
+	case "/health", "/healthz/readiness", "/healthz/liveness":
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/api/middleware/auth_disabled_ip_allowlist_test.go
+++ b/internal/api/middleware/auth_disabled_ip_allowlist_test.go
@@ -4,6 +4,7 @@
 package middleware
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -21,18 +22,21 @@ func TestRequireAuthDisabledIPAllowlist(t *testing.T) {
 	tests := []struct {
 		name       string
 		cfg        *domain.Config
+		path       string
 		remoteAddr string
 		wantStatus int
 	}{
 		{
 			name:       "passes through when config is nil",
 			cfg:        nil,
+			path:       "/api/instances",
 			remoteAddr: "203.0.113.10:12345",
 			wantStatus: http.StatusOK,
 		},
 		{
 			name:       "passes when auth-disabled mode is off",
 			cfg:        &domain.Config{},
+			path:       "/api/instances",
 			remoteAddr: "203.0.113.10:12345",
 			wantStatus: http.StatusOK,
 		},
@@ -43,6 +47,7 @@ func TestRequireAuthDisabledIPAllowlist(t *testing.T) {
 				IAcknowledgeThisIsABadIdea: true,
 				AuthDisabledAllowedCIDRs:   []string{"127.0.0.1/32"},
 			},
+			path:       "/api/instances",
 			remoteAddr: "127.0.0.1:54321",
 			wantStatus: http.StatusOK,
 		},
@@ -53,6 +58,7 @@ func TestRequireAuthDisabledIPAllowlist(t *testing.T) {
 				IAcknowledgeThisIsABadIdea: true,
 				AuthDisabledAllowedCIDRs:   []string{"127.0.0.1/32"},
 			},
+			path:       "/api/instances",
 			remoteAddr: "203.0.113.10:54321",
 			wantStatus: http.StatusForbidden,
 		},
@@ -63,6 +69,7 @@ func TestRequireAuthDisabledIPAllowlist(t *testing.T) {
 				IAcknowledgeThisIsABadIdea: true,
 				AuthDisabledAllowedCIDRs:   []string{"invalid-cidr"},
 			},
+			path:       "/api/instances",
 			remoteAddr: "127.0.0.1:54321",
 			wantStatus: http.StatusForbidden,
 		},
@@ -73,6 +80,7 @@ func TestRequireAuthDisabledIPAllowlist(t *testing.T) {
 				IAcknowledgeThisIsABadIdea: true,
 				AuthDisabledAllowedCIDRs:   []string{},
 			},
+			path:       "/api/instances",
 			remoteAddr: "127.0.0.1:54321",
 			wantStatus: http.StatusForbidden,
 		},
@@ -83,7 +91,41 @@ func TestRequireAuthDisabledIPAllowlist(t *testing.T) {
 				IAcknowledgeThisIsABadIdea: true,
 				AuthDisabledAllowedCIDRs:   []string{"127.0.0.1/32"},
 			},
+			path:       "/api/instances",
 			remoteAddr: "not-an-address",
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name: "allows IPv4 loopback health probe outside configured CIDRs",
+			cfg: &domain.Config{
+				AuthDisabled:               true,
+				IAcknowledgeThisIsABadIdea: true,
+				AuthDisabledAllowedCIDRs:   []string{"192.168.1.0/24"},
+			},
+			path:       "/health",
+			remoteAddr: "127.0.0.1:54321",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "allows IPv6 loopback health probe outside configured CIDRs",
+			cfg: &domain.Config{
+				AuthDisabled:               true,
+				IAcknowledgeThisIsABadIdea: true,
+				AuthDisabledAllowedCIDRs:   []string{"192.168.1.0/24"},
+			},
+			path:       "/healthz/liveness",
+			remoteAddr: "[::1]:54321",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "blocks non-health loopback request outside configured CIDRs",
+			cfg: &domain.Config{
+				AuthDisabled:               true,
+				IAcknowledgeThisIsABadIdea: true,
+				AuthDisabledAllowedCIDRs:   []string{"192.168.1.0/24"},
+			},
+			path:       "/api/instances",
+			remoteAddr: "127.0.0.1:54321",
 			wantStatus: http.StatusForbidden,
 		},
 	}
@@ -92,7 +134,7 @@ func TestRequireAuthDisabledIPAllowlist(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			handler := RequireAuthDisabledIPAllowlist(tc.cfg)(inner)
 
-			req := httptest.NewRequest(http.MethodGet, "/api/instances", nil)
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, tc.path, nil)
 			req.RemoteAddr = tc.remoteAddr
 			resp := httptest.NewRecorder()
 


### PR DESCRIPTION
When auth-disabled mode is used behind a reverse proxy, the Docker image's built-in localhost healthcheck could be rejected unless loopback CIDRs were explicitly allowlisted. This change permits loopback access only for built-in health endpoints, while keeping normal auth-disabled allowlist behavior unchanged.

https://github.com/autobrr/qui/discussions/1620

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Health endpoints now allow loopback probes even when the allowlist includes only reverse proxy subnets, ensuring Docker healthchecks remain functional.

* **Documentation**
  * Clarified built-in health endpoint behavior and loopback probe handling in configuration guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->