### PR TITLE
fix(crossseed): skip disabled instances

### DIFF
--- a/internal/services/crossseed/crossseed_test.go
+++ b/internal/services/crossseed/crossseed_test.go
@@ -2753,6 +2753,20 @@ type fakeInstanceStore struct {
 	instances map[int]*models.Instance
 }
 
+func cloneFakeInstance(instance *models.Instance) *models.Instance {
+	if instance == nil {
+		return nil
+	}
+
+	clone := *instance
+	if !clone.IsActive {
+		// Test fixtures in this file usually omit IsActive; production defaults those instances to active.
+		clone.IsActive = true
+	}
+
+	return &clone
+}
+
 type recordingNotifier struct {
 	events []notifications.Event
 }
@@ -2769,7 +2783,7 @@ func (r *recordingNotifier) Events() []notifications.Event {
 
 func (f *fakeInstanceStore) Get(_ context.Context, id int) (*models.Instance, error) {
 	if inst, ok := f.instances[id]; ok {
-		return inst, nil
+		return cloneFakeInstance(inst), nil
 	}
 	return nil, models.ErrInstanceNotFound
 }
@@ -2777,7 +2791,7 @@ func (f *fakeInstanceStore) Get(_ context.Context, id int) (*models.Instance, er
 func (f *fakeInstanceStore) List(_ context.Context) ([]*models.Instance, error) {
 	result := make([]*models.Instance, 0, len(f.instances))
 	for _, inst := range f.instances {
-		result = append(result, inst)
+		result = append(result, cloneFakeInstance(inst))
 	}
 	return result, nil
 }

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -475,6 +475,7 @@ func (s *Service) FindLocalMatches(ctx context.Context, sourceInstanceID int, so
 	if err != nil {
 		return nil, fmt.Errorf("failed to list instances: %w", err)
 	}
+	instances = activeInstancesOnly(instances)
 
 	// Find the source torrent
 	sourceTorrents, err := s.syncManager.GetTorrents(ctx, sourceInstanceID, qbt.TorrentFilterOptions{
@@ -557,6 +558,17 @@ func (s *Service) collectLocalMatches(
 	}
 
 	return matches
+}
+
+func activeInstancesOnly(instances []*models.Instance) []*models.Instance {
+	active := make([]*models.Instance, 0, len(instances))
+	for _, instance := range instances {
+		if instance == nil || !instance.IsActive {
+			continue
+		}
+		active = append(active, instance)
+	}
+	return active
 }
 
 // matchTorrentsInInstance checks torrents in a single instance for matches.
@@ -9606,7 +9618,7 @@ func (s *Service) resolveInstances(ctx context.Context, requested []int) ([]*mod
 		if err != nil {
 			return nil, fmt.Errorf("failed to list cross-seed instances: %w", err)
 		}
-		return instances, nil
+		return activeInstancesOnly(instances), nil
 	}
 
 	instances := make([]*models.Instance, 0, len(requested))
@@ -9620,6 +9632,9 @@ func (s *Service) resolveInstances(ctx context.Context, requested []int) ([]*mod
 				continue
 			}
 			return nil, fmt.Errorf("failed to get instance %d: %w", id, err)
+		}
+		if instance == nil || !instance.IsActive {
+			continue
 		}
 		instances = append(instances, instance)
 	}

--- a/internal/services/crossseed/service_instances_test.go
+++ b/internal/services/crossseed/service_instances_test.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package crossseed
+
+import (
+	"context"
+	"testing"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/models"
+	internalqb "github.com/autobrr/qui/internal/qbittorrent"
+)
+
+type orderedInstanceStore struct {
+	ordered []*models.Instance
+	byID    map[int]*models.Instance
+}
+
+func newOrderedInstanceStore(instances ...*models.Instance) *orderedInstanceStore {
+	byID := make(map[int]*models.Instance, len(instances))
+	for _, instance := range instances {
+		byID[instance.ID] = instance
+	}
+	return &orderedInstanceStore{
+		ordered: instances,
+		byID:    byID,
+	}
+}
+
+func (s *orderedInstanceStore) Get(_ context.Context, id int) (*models.Instance, error) {
+	instance, ok := s.byID[id]
+	if !ok {
+		return nil, models.ErrInstanceNotFound
+	}
+	return instance, nil
+}
+
+func (s *orderedInstanceStore) List(_ context.Context) ([]*models.Instance, error) {
+	instances := make([]*models.Instance, len(s.ordered))
+	copy(instances, s.ordered)
+	return instances, nil
+}
+
+func TestResolveInstances_SkipsDisabledInstances(t *testing.T) {
+	t.Parallel()
+
+	active := &models.Instance{ID: 1, Name: "active", IsActive: true}
+	disabled := &models.Instance{ID: 2, Name: "disabled", IsActive: false}
+
+	svc := &Service{
+		instanceStore: newOrderedInstanceStore(active, disabled),
+	}
+
+	tests := []struct {
+		name      string
+		requested []int
+	}{
+		{name: "global", requested: nil},
+		{name: "targeted", requested: []int{active.ID, disabled.ID}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instances, err := svc.resolveInstances(context.Background(), tt.requested)
+			require.NoError(t, err)
+			require.Len(t, instances, 1)
+			require.Equal(t, active.ID, instances[0].ID)
+		})
+	}
+}
+
+type findLocalMatchesSyncManager struct {
+	localMatchSyncManager
+	sourceTorrent     qbt.Torrent
+	cachedInstanceIDs []int
+}
+
+//nolint:gocritic // Interface requires value type for TorrentFilterOptions
+func (m *findLocalMatchesSyncManager) GetTorrents(_ context.Context, instanceID int, filter qbt.TorrentFilterOptions) ([]qbt.Torrent, error) {
+	if instanceID == 1 && len(filter.Hashes) == 1 && normalizeHash(filter.Hashes[0]) == normalizeHash(m.sourceTorrent.Hash) {
+		return []qbt.Torrent{m.sourceTorrent}, nil
+	}
+	return nil, nil
+}
+
+func (m *findLocalMatchesSyncManager) GetCachedInstanceTorrents(_ context.Context, instanceID int) ([]internalqb.CrossInstanceTorrentView, error) {
+	m.cachedInstanceIDs = append(m.cachedInstanceIDs, instanceID)
+	return nil, nil
+}
+
+func TestFindLocalMatches_SkipsDisabledInstances(t *testing.T) {
+	t.Parallel()
+
+	active := &models.Instance{ID: 1, Name: "active", IsActive: true}
+	disabled := &models.Instance{ID: 2, Name: "disabled", IsActive: false}
+	source := qbt.Torrent{
+		Hash:        "abc123def456abc123def456abc123def456abc1",
+		Name:        "Movie.2025.1080p.BluRay.x264-GRP",
+		SavePath:    "/downloads",
+		ContentPath: "/downloads/Movie.2025.1080p.BluRay.x264-GRP.mkv",
+	}
+
+	syncManager := &findLocalMatchesSyncManager{
+		sourceTorrent: source,
+	}
+
+	svc := &Service{
+		instanceStore: newOrderedInstanceStore(active, disabled),
+		syncManager:   syncManager,
+		releaseCache:  NewReleaseCache(),
+	}
+
+	resp, err := svc.FindLocalMatches(context.Background(), active.ID, source.Hash, false)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, []int{active.ID}, syncManager.cachedInstanceIDs)
+}


### PR DESCRIPTION
Skip disabled qBittorrent instances when cross-seed resolves scan targets for webhook checks and local match lookups. This removes repeated warning noise from normal disabled-instance state while preserving warnings for real client failures.

Add regression coverage for disabled-instance filtering and keep existing cross-seed fixtures behaving like production defaults when `IsActive` is omitted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Inactive instances are now properly excluded from instance resolution and local match discovery processes, ensuring only active instances are processed.

* **Tests**
  * Added comprehensive unit tests for instance resolution and local match discovery to verify proper handling of inactive instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->