### PR TITLE
feat(web): Clarify dashboard quick links

### DIFF
--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -2339,8 +2339,8 @@ function QuickActionsDropdown({ statsData }: { statsData: DashboardInstanceStats
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button variant="outline" size="sm" className="w-full sm:w-auto">
-          <Zap className="h-4 w-4 mr-2" />
-          Quick Actions
+          <Plus className="h-4 w-4 mr-2" />
+          Add Torrent
           <ChevronDown className="h-3 w-3 ml-1" />
         </Button>
       </DropdownMenuTrigger>
@@ -2474,7 +2474,7 @@ export function Dashboard() {
               <QuickActionsDropdown statsData={statsData} />
               <Link to="/settings" search={{ tab: "instances" as const, modal: "add-instance" }} className="w-full sm:w-auto">
                 <Button variant="outline" size="sm" className="w-full sm:w-auto">
-                  <Plus className="h-4 w-4 mr-2" />
+                  <HardDrive className="h-4 w-4 mr-2" />
                   Add Instance
                 </Button>
               </Link>
@@ -2574,7 +2574,7 @@ export function Dashboard() {
             </div>
             <Link to="/settings" search={{ tab: "instances" as const, modal: "add-instance" }}>
               <Button>
-                <Plus className="h-4 w-4 mr-2" />
+                <HardDrive className="h-4 w-4 mr-2" />
                 Add Instance
               </Button>
             </Link>


### PR DESCRIPTION
Reconfigure dashboard navigation links to clarify what actions are available.
Suggested in https://github.com/autobrr/qui/discussions/1596 

<img width="936" height="88" alt="image" src="https://github.com/user-attachments/assets/f68acf2e-4485-4008-89e3-93b62b6251ba" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Quick Actions dropdown to display a Plus icon with "Add Torrent" text
  * Changed Add Instance button icons from Plus to HardDrive across the dashboard header and empty-state screens

<!-- end of auto-generated comment: release notes by coderabbit.ai -->