### PR TITLE
feat(web): Add action buttons to unified instance.

### DIFF
--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -180,7 +180,7 @@ export function Header({
   })
   const unifiedTorrentCreationInstances = useMemo(
     () => unifiedManageableInstances.filter((_instance, i) =>
-      unifiedCapabilitiesResults[i]?.data?.supportsTorrentCreation ?? true
+      unifiedCapabilitiesResults[i]?.data?.supportsTorrentCreation === true
     ),
     [unifiedManageableInstances, unifiedCapabilitiesResults],
   )
@@ -455,20 +455,24 @@ export function Header({
                   instances={unifiedManageableInstances}
                   onSelectInstance={setUnifiedAddTorrentInstanceId}
                 />
-                <UnifiedActionDropdown
-                  icon={<FileEdit className="h-4 w-4" />}
-                  tooltip="Create torrent"
-                  label="Create for instance"
-                  instances={unifiedTorrentCreationInstances}
-                  onSelectInstance={setUnifiedCreateTorrentInstanceId}
-                />
-                <UnifiedActionDropdown
-                  icon={<ListTodo className="h-4 w-4" />}
-                  tooltip="Torrent creation tasks"
-                  label="Tasks for instance"
-                  instances={unifiedTorrentCreationInstances}
-                  onSelectInstance={setUnifiedTasksInstanceId}
-                />
+                {unifiedTorrentCreationInstances.length > 0 && (
+                  <>
+                    <UnifiedActionDropdown
+                      icon={<FileEdit className="h-4 w-4" />}
+                      tooltip="Create torrent"
+                      label="Create for instance"
+                      instances={unifiedTorrentCreationInstances}
+                      onSelectInstance={setUnifiedCreateTorrentInstanceId}
+                    />
+                    <UnifiedActionDropdown
+                      icon={<ListTodo className="h-4 w-4" />}
+                      tooltip="Torrent creation tasks"
+                      label="Tasks for instance"
+                      instances={unifiedTorrentCreationInstances}
+                      onSelectInstance={setUnifiedTasksInstanceId}
+                    />
+                  </>
+                )}
                 <UnifiedActionDropdown
                   icon={<Cog className="h-4 w-4" />}
                   tooltip="Instance settings"

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -5,6 +5,15 @@
 
 import { InstancePreferencesDialog } from "@/components/instances/preferences/InstancePreferencesDialog"
 import { UnifiedScopeDropdownSection } from "@/components/layout/UnifiedScopeDropdownSection"
+import { AddTorrentDialog } from "@/components/torrents/AddTorrentDialog"
+import { TorrentCreationTasks } from "@/components/torrents/TorrentCreationTasks"
+import { TorrentCreatorDialog } from "@/components/torrents/TorrentCreatorDialog"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
 import { TorrentManagementBar } from "@/components/torrents/TorrentManagementBar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -101,6 +110,10 @@ export function Header({
     [persistedUnifiedFilter, activeInstanceIds]
   )
   const effectiveUnifiedInstanceIds = normalizedUnifiedInstanceIds.length > 0? normalizedUnifiedInstanceIds: activeInstanceIds
+  const unifiedScopeInstances = useMemo(
+    () => activeInstances.filter(instance => effectiveUnifiedInstanceIds.includes(instance.id)),
+    [activeInstances, effectiveUnifiedInstanceIds]
+  )
   const applyUnifiedScope = useCallback((nextIds: number[]) => {
     const normalizedIds = normalizeUnifiedInstanceIds(nextIds, activeInstanceIds)
     saveUnifiedFilter(normalizedIds)
@@ -217,6 +230,10 @@ export function Header({
 
   // Instance settings dialog state
   const [instanceSettingsOpen, setInstanceSettingsOpen] = useState(false)
+  const [unifiedAddTorrentInstanceId, setUnifiedAddTorrentInstanceId] = useState<number | null>(null)
+  const [unifiedCreateTorrentInstanceId, setUnifiedCreateTorrentInstanceId] = useState<number | null>(null)
+  const [unifiedTasksInstanceId, setUnifiedTasksInstanceId] = useState<number | null>(null)
+  const [unifiedSettingsInstanceId, setUnifiedSettingsInstanceId] = useState<number | null>(null)
 
   useEffect(() => {
     setInstanceSettingsOpen(false)
@@ -353,6 +370,173 @@ export function Header({
               </TooltipTrigger>
               <TooltipContent>{filterSidebarCollapsed ? "Show filters" : "Hide filters"}</TooltipContent>
             </Tooltip>
+            {isAllInstancesRoute && unifiedScopeInstances.length > 0 && (
+              <DropdownMenu>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        variant="outline"
+                        size="icon"
+                        className="hidden md:inline-flex"
+                        aria-label="Add torrent"
+                      >
+                        <Plus className="h-4 w-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                  </TooltipTrigger>
+                  <TooltipContent>Add torrent</TooltipContent>
+                </Tooltip>
+                <DropdownMenuContent align="start">
+                  <DropdownMenuLabel className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                    Add to instance
+                  </DropdownMenuLabel>
+                  <DropdownMenuSeparator />
+                  {unifiedScopeInstances.map((instance) => (
+                    <DropdownMenuItem
+                      key={instance.id}
+                      onClick={() => setUnifiedAddTorrentInstanceId(instance.id)}
+                      className="cursor-pointer"
+                    >
+                      <HardDrive className="mr-2 h-4 w-4 flex-shrink-0" />
+                      <span className="flex-1 truncate">{instance.name}</span>
+                      <span
+                        className={cn(
+                          "ml-2 h-2 w-2 rounded-full flex-shrink-0",
+                          instance.connected ? "bg-green-500" : "bg-red-500"
+                        )}
+                      />
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+            {isAllInstancesRoute && unifiedScopeInstances.some(i => i.id > 0) && (
+              <>
+                {/* Unified Create Torrent dropdown */}
+                <DropdownMenu>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="outline"
+                          size="icon"
+                          className="hidden md:inline-flex"
+                          aria-label="Create torrent"
+                        >
+                          <FileEdit className="h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent>Create torrent</TooltipContent>
+                  </Tooltip>
+                  <DropdownMenuContent align="start">
+                    <DropdownMenuLabel className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                      Create for instance
+                    </DropdownMenuLabel>
+                    <DropdownMenuSeparator />
+                    {unifiedScopeInstances.filter(i => i.id > 0).map((instance) => (
+                      <DropdownMenuItem
+                        key={instance.id}
+                        onClick={() => setUnifiedCreateTorrentInstanceId(instance.id)}
+                        className="cursor-pointer"
+                      >
+                        <HardDrive className="mr-2 h-4 w-4 flex-shrink-0" />
+                        <span className="flex-1 truncate">{instance.name}</span>
+                        <span
+                          className={cn(
+                            "ml-2 h-2 w-2 rounded-full flex-shrink-0",
+                            instance.connected ? "bg-green-500" : "bg-red-500"
+                          )}
+                        />
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+
+                {/* Unified Tasks dropdown */}
+                <DropdownMenu>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="outline"
+                          size="icon"
+                          className="hidden md:inline-flex"
+                          aria-label="Torrent creation tasks"
+                        >
+                          <ListTodo className="h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent>Torrent creation tasks</TooltipContent>
+                  </Tooltip>
+                  <DropdownMenuContent align="start">
+                    <DropdownMenuLabel className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                      Tasks for instance
+                    </DropdownMenuLabel>
+                    <DropdownMenuSeparator />
+                    {unifiedScopeInstances.filter(i => i.id > 0).map((instance) => (
+                      <DropdownMenuItem
+                        key={instance.id}
+                        onClick={() => setUnifiedTasksInstanceId(instance.id)}
+                        className="cursor-pointer"
+                      >
+                        <HardDrive className="mr-2 h-4 w-4 flex-shrink-0" />
+                        <span className="flex-1 truncate">{instance.name}</span>
+                        <span
+                          className={cn(
+                            "ml-2 h-2 w-2 rounded-full flex-shrink-0",
+                            instance.connected ? "bg-green-500" : "bg-red-500"
+                          )}
+                        />
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+
+                {/* Unified Instance Settings dropdown */}
+                <DropdownMenu>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="outline"
+                          size="icon"
+                          className="hidden md:inline-flex"
+                          aria-label="Instance settings"
+                        >
+                          <Cog className="h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent>Instance settings</TooltipContent>
+                  </Tooltip>
+                  <DropdownMenuContent align="start">
+                    <DropdownMenuLabel className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                      Settings for instance
+                    </DropdownMenuLabel>
+                    <DropdownMenuSeparator />
+                    {unifiedScopeInstances.filter(i => i.id > 0).map((instance) => (
+                      <DropdownMenuItem
+                        key={instance.id}
+                        onClick={() => setUnifiedSettingsInstanceId(instance.id)}
+                        className="cursor-pointer"
+                      >
+                        <HardDrive className="mr-2 h-4 w-4 flex-shrink-0" />
+                        <span className="flex-1 truncate">{instance.name}</span>
+                        <span
+                          className={cn(
+                            "ml-2 h-2 w-2 rounded-full flex-shrink-0",
+                            instance.connected ? "bg-green-500" : "bg-red-500"
+                          )}
+                        />
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </>
+            )}
             {canManageSelectedInstance && (
               <>
                 {/* Add Torrent button */}
@@ -762,6 +946,60 @@ export function Header({
           instance={currentInstance}
         />
       )}
+
+      {/* Unified Add Torrent Dialog */}
+      {unifiedAddTorrentInstanceId !== null && (
+        <AddTorrentDialog
+          instanceId={unifiedAddTorrentInstanceId}
+          open={true}
+          onOpenChange={(open) => {
+            if (!open) setUnifiedAddTorrentInstanceId(null)
+          }}
+        />
+      )}
+
+      {/* Unified Create Torrent Dialog */}
+      {unifiedCreateTorrentInstanceId !== null && (
+        <TorrentCreatorDialog
+          instanceId={unifiedCreateTorrentInstanceId}
+          open={true}
+          onOpenChange={(open) => {
+            if (!open) setUnifiedCreateTorrentInstanceId(null)
+          }}
+        />
+      )}
+
+      {/* Unified Torrent Creation Tasks Dialog */}
+      {unifiedTasksInstanceId !== null && (() => {
+        const inst = activeInstances.find(i => i.id === unifiedTasksInstanceId)
+        return (
+          <Dialog open={true} onOpenChange={(open) => { if (!open) setUnifiedTasksInstanceId(null) }}>
+            <DialogContent className="w-full sm:max-w-screen-sm md:max-w-screen-md lg:max-w-screen-xl xl:max-w-screen-xl max-h-[85vh] overflow-hidden flex flex-col">
+              <DialogHeader>
+                <DialogTitle>Torrent Creation Tasks{inst ? ` — ${inst.name}` : ""}</DialogTitle>
+              </DialogHeader>
+              <div className="flex-1 overflow-auto">
+                <TorrentCreationTasks instanceId={unifiedTasksInstanceId} />
+              </div>
+            </DialogContent>
+          </Dialog>
+        )
+      })()}
+
+      {/* Unified Instance Settings Dialog */}
+      {unifiedSettingsInstanceId !== null && (() => {
+        const inst = activeInstances.find(i => i.id === unifiedSettingsInstanceId)
+        if (!inst) return null
+        return (
+          <InstancePreferencesDialog
+            open={true}
+            onOpenChange={(open) => { if (!open) setUnifiedSettingsInstanceId(null) }}
+            instanceId={unifiedSettingsInstanceId}
+            instanceName={inst.name}
+            instance={inst}
+          />
+        )
+      })()}
     </header>
   )
 }

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -64,6 +64,28 @@ interface HeaderProps {
   sidebarCollapsed?: boolean
 }
 
+function renderUnifiedInstanceMenuItems(
+  instances: Array<{ id: number; name: string; connected: boolean }>,
+  onSelect: (id: number) => void,
+) {
+  return instances.map((instance) => (
+    <DropdownMenuItem
+      key={instance.id}
+      onClick={() => onSelect(instance.id)}
+      className="cursor-pointer"
+    >
+      <HardDrive className="mr-2 h-4 w-4 flex-shrink-0" />
+      <span className="flex-1 truncate">{instance.name}</span>
+      <span
+        className={cn(
+          "ml-2 h-2 w-2 rounded-full flex-shrink-0",
+          instance.connected ? "bg-green-500" : "bg-red-500",
+        )}
+      />
+    </DropdownMenuItem>
+  ))
+}
+
 export function Header({
   children,
   sidebarCollapsed = false,
@@ -398,48 +420,33 @@ export function Header({
               <TooltipContent>{filterSidebarCollapsed ? "Show filters" : "Hide filters"}</TooltipContent>
             </Tooltip>
             {isAllInstancesRoute && unifiedManageableInstances.length > 0 && (
-              <DropdownMenu>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <DropdownMenuTrigger asChild>
-                      <Button
-                        variant="outline"
-                        size="icon"
-                        className="hidden md:inline-flex"
-                        aria-label="Add torrent"
-                      >
-                        <Plus className="h-4 w-4" />
-                      </Button>
-                    </DropdownMenuTrigger>
-                  </TooltipTrigger>
-                  <TooltipContent>Add torrent</TooltipContent>
-                </Tooltip>
-                <DropdownMenuContent align="start">
-                  <DropdownMenuLabel className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
-                    Add to instance
-                  </DropdownMenuLabel>
-                  <DropdownMenuSeparator />
-                  {unifiedManageableInstances.map((instance) => (
-                    <DropdownMenuItem
-                      key={instance.id}
-                      onClick={() => setUnifiedAddTorrentInstanceId(instance.id)}
-                      className="cursor-pointer"
-                    >
-                      <HardDrive className="mr-2 h-4 w-4 flex-shrink-0" />
-                      <span className="flex-1 truncate">{instance.name}</span>
-                      <span
-                        className={cn(
-                          "ml-2 h-2 w-2 rounded-full flex-shrink-0",
-                          instance.connected ? "bg-green-500" : "bg-red-500"
-                        )}
-                      />
-                    </DropdownMenuItem>
-                  ))}
-                </DropdownMenuContent>
-              </DropdownMenu>
-            )}
-            {isAllInstancesRoute && unifiedManageableInstances.length > 0 && (
               <>
+                {/* Unified Add Torrent dropdown */}
+                <DropdownMenu>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="outline"
+                          size="icon"
+                          className="hidden md:inline-flex"
+                          aria-label="Add torrent"
+                        >
+                          <Plus className="h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent>Add torrent</TooltipContent>
+                  </Tooltip>
+                  <DropdownMenuContent align="start">
+                    <DropdownMenuLabel className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                      Add to instance
+                    </DropdownMenuLabel>
+                    <DropdownMenuSeparator />
+                    {renderUnifiedInstanceMenuItems(unifiedManageableInstances, setUnifiedAddTorrentInstanceId)}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+
                 {/* Unified Create Torrent dropdown */}
                 <DropdownMenu>
                   <Tooltip>
@@ -462,22 +469,7 @@ export function Header({
                       Create for instance
                     </DropdownMenuLabel>
                     <DropdownMenuSeparator />
-                    {unifiedManageableInstances.map((instance) => (
-                      <DropdownMenuItem
-                        key={instance.id}
-                        onClick={() => setUnifiedCreateTorrentInstanceId(instance.id)}
-                        className="cursor-pointer"
-                      >
-                        <HardDrive className="mr-2 h-4 w-4 flex-shrink-0" />
-                        <span className="flex-1 truncate">{instance.name}</span>
-                        <span
-                          className={cn(
-                            "ml-2 h-2 w-2 rounded-full flex-shrink-0",
-                            instance.connected ? "bg-green-500" : "bg-red-500"
-                          )}
-                        />
-                      </DropdownMenuItem>
-                    ))}
+                    {renderUnifiedInstanceMenuItems(unifiedManageableInstances, setUnifiedCreateTorrentInstanceId)}
                   </DropdownMenuContent>
                 </DropdownMenu>
 
@@ -503,22 +495,7 @@ export function Header({
                       Tasks for instance
                     </DropdownMenuLabel>
                     <DropdownMenuSeparator />
-                    {unifiedManageableInstances.map((instance) => (
-                      <DropdownMenuItem
-                        key={instance.id}
-                        onClick={() => setUnifiedTasksInstanceId(instance.id)}
-                        className="cursor-pointer"
-                      >
-                        <HardDrive className="mr-2 h-4 w-4 flex-shrink-0" />
-                        <span className="flex-1 truncate">{instance.name}</span>
-                        <span
-                          className={cn(
-                            "ml-2 h-2 w-2 rounded-full flex-shrink-0",
-                            instance.connected ? "bg-green-500" : "bg-red-500"
-                          )}
-                        />
-                      </DropdownMenuItem>
-                    ))}
+                    {renderUnifiedInstanceMenuItems(unifiedManageableInstances, setUnifiedTasksInstanceId)}
                   </DropdownMenuContent>
                 </DropdownMenu>
 
@@ -544,22 +521,7 @@ export function Header({
                       Settings for instance
                     </DropdownMenuLabel>
                     <DropdownMenuSeparator />
-                    {unifiedManageableInstances.map((instance) => (
-                      <DropdownMenuItem
-                        key={instance.id}
-                        onClick={() => setUnifiedSettingsInstanceId(instance.id)}
-                        className="cursor-pointer"
-                      >
-                        <HardDrive className="mr-2 h-4 w-4 flex-shrink-0" />
-                        <span className="flex-1 truncate">{instance.name}</span>
-                        <span
-                          className={cn(
-                            "ml-2 h-2 w-2 rounded-full flex-shrink-0",
-                            instance.connected ? "bg-green-500" : "bg-red-500"
-                          )}
-                        />
-                      </DropdownMenuItem>
-                    ))}
+                    {renderUnifiedInstanceMenuItems(unifiedManageableInstances, setUnifiedSettingsInstanceId)}
                   </DropdownMenuContent>
                 </DropdownMenu>
               </>
@@ -999,6 +961,7 @@ export function Header({
       {/* Unified Torrent Creation Tasks Dialog */}
       {unifiedTasksInstanceId !== null && (() => {
         const inst = activeInstances.find(i => i.id === unifiedTasksInstanceId)
+        if (!inst) return null
         return (
           <Dialog open={true} onOpenChange={(open) => { if (!open) setUnifiedTasksInstanceId(null) }}>
             <DialogContent className="w-full sm:max-w-screen-sm md:max-w-screen-md lg:max-w-screen-xl xl:max-w-screen-xl max-h-[85vh] overflow-hidden flex flex-col">

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -310,6 +310,10 @@ export function Header({
     () => new Set(unifiedManageableInstances.map((instance) => instance.id)),
     [unifiedManageableInstances],
   )
+  const validUnifiedTorrentCreationIds = useMemo(
+    () => new Set(unifiedTorrentCreationInstances.map((instance) => instance.id)),
+    [unifiedTorrentCreationInstances],
+  )
 
   useEffect(() => {
     setInstanceSettingsOpen(false)
@@ -904,7 +908,7 @@ export function Header({
       )}
 
       {/* Unified Create Torrent Dialog */}
-      {unifiedCreateTorrentInstanceId !== null && validUnifiedIds.has(unifiedCreateTorrentInstanceId) && (
+      {unifiedCreateTorrentInstanceId !== null && validUnifiedTorrentCreationIds.has(unifiedCreateTorrentInstanceId) && (
         <TorrentCreatorDialog
           instanceId={unifiedCreateTorrentInstanceId}
           open={true}
@@ -915,7 +919,7 @@ export function Header({
       )}
 
       {/* Unified Torrent Creation Tasks Dialog */}
-      {unifiedTasksInstanceId !== null && validUnifiedIds.has(unifiedTasksInstanceId) && (() => {
+      {unifiedTasksInstanceId !== null && validUnifiedTorrentCreationIds.has(unifiedTasksInstanceId) && (() => {
         const inst = activeInstances.find(i => i.id === unifiedTasksInstanceId)
         if (!inst) return null
         return (

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -114,6 +114,10 @@ export function Header({
     () => activeInstances.filter(instance => effectiveUnifiedInstanceIds.includes(instance.id)),
     [activeInstances, effectiveUnifiedInstanceIds]
   )
+  const unifiedManageableInstances = useMemo(
+    () => unifiedScopeInstances.filter((instance) => instance.id > 0),
+    [unifiedScopeInstances],
+  )
   const applyUnifiedScope = useCallback((nextIds: number[]) => {
     const normalizedIds = normalizeUnifiedInstanceIds(nextIds, activeInstanceIds)
     saveUnifiedFilter(normalizedIds)
@@ -238,6 +242,29 @@ export function Header({
   useEffect(() => {
     setInstanceSettingsOpen(false)
   }, [selectedInstanceId])
+
+  // Clear stale unified dialog IDs when the scope instance set changes
+  useEffect(() => {
+    const validIds = new Set(unifiedManageableInstances.map((instance) => instance.id))
+    if (unifiedAddTorrentInstanceId !== null && !validIds.has(unifiedAddTorrentInstanceId)) {
+      setUnifiedAddTorrentInstanceId(null)
+    }
+    if (unifiedCreateTorrentInstanceId !== null && !validIds.has(unifiedCreateTorrentInstanceId)) {
+      setUnifiedCreateTorrentInstanceId(null)
+    }
+    if (unifiedTasksInstanceId !== null && !validIds.has(unifiedTasksInstanceId)) {
+      setUnifiedTasksInstanceId(null)
+    }
+    if (unifiedSettingsInstanceId !== null && !validIds.has(unifiedSettingsInstanceId)) {
+      setUnifiedSettingsInstanceId(null)
+    }
+  }, [
+    unifiedManageableInstances,
+    unifiedAddTorrentInstanceId,
+    unifiedCreateTorrentInstanceId,
+    unifiedTasksInstanceId,
+    unifiedSettingsInstanceId,
+  ])
 
   const { state: crossSeedInstanceState } = useCrossSeedInstanceState()
 
@@ -370,7 +397,7 @@ export function Header({
               </TooltipTrigger>
               <TooltipContent>{filterSidebarCollapsed ? "Show filters" : "Hide filters"}</TooltipContent>
             </Tooltip>
-            {isAllInstancesRoute && unifiedScopeInstances.length > 0 && (
+            {isAllInstancesRoute && unifiedManageableInstances.length > 0 && (
               <DropdownMenu>
                 <Tooltip>
                   <TooltipTrigger asChild>
@@ -392,7 +419,7 @@ export function Header({
                     Add to instance
                   </DropdownMenuLabel>
                   <DropdownMenuSeparator />
-                  {unifiedScopeInstances.map((instance) => (
+                  {unifiedManageableInstances.map((instance) => (
                     <DropdownMenuItem
                       key={instance.id}
                       onClick={() => setUnifiedAddTorrentInstanceId(instance.id)}
@@ -411,7 +438,7 @@ export function Header({
                 </DropdownMenuContent>
               </DropdownMenu>
             )}
-            {isAllInstancesRoute && unifiedScopeInstances.some(i => i.id > 0) && (
+            {isAllInstancesRoute && unifiedManageableInstances.length > 0 && (
               <>
                 {/* Unified Create Torrent dropdown */}
                 <DropdownMenu>
@@ -435,7 +462,7 @@ export function Header({
                       Create for instance
                     </DropdownMenuLabel>
                     <DropdownMenuSeparator />
-                    {unifiedScopeInstances.filter(i => i.id > 0).map((instance) => (
+                    {unifiedManageableInstances.map((instance) => (
                       <DropdownMenuItem
                         key={instance.id}
                         onClick={() => setUnifiedCreateTorrentInstanceId(instance.id)}
@@ -476,7 +503,7 @@ export function Header({
                       Tasks for instance
                     </DropdownMenuLabel>
                     <DropdownMenuSeparator />
-                    {unifiedScopeInstances.filter(i => i.id > 0).map((instance) => (
+                    {unifiedManageableInstances.map((instance) => (
                       <DropdownMenuItem
                         key={instance.id}
                         onClick={() => setUnifiedTasksInstanceId(instance.id)}
@@ -517,7 +544,7 @@ export function Header({
                       Settings for instance
                     </DropdownMenuLabel>
                     <DropdownMenuSeparator />
-                    {unifiedScopeInstances.filter(i => i.id > 0).map((instance) => (
+                    {unifiedManageableInstances.map((instance) => (
                       <DropdownMenuItem
                         key={instance.id}
                         onClick={() => setUnifiedSettingsInstanceId(instance.id)}

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -53,7 +53,7 @@ import {
 } from "@/lib/instances"
 import { cn } from "@/lib/utils"
 import type { InstanceCapabilities } from "@/types"
-import { useQuery } from "@tanstack/react-query"
+import { useQueries, useQuery } from "@tanstack/react-query"
 import { Link, useNavigate, useSearch } from "@tanstack/react-router"
 import { Archive, ChevronsUpDown, Cog, Download, FileEdit, FileText, FunnelPlus, FunnelX, GitBranch, HardDrive, Home, Info, ListTodo, Loader2, LogOut, Menu, Plus, Rss, Search, SearchCode, Server, Settings, X, Zap } from "lucide-react"
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react"
@@ -64,26 +64,56 @@ interface HeaderProps {
   sidebarCollapsed?: boolean
 }
 
-function renderUnifiedInstanceMenuItems(
-  instances: Array<{ id: number; name: string; connected: boolean }>,
-  onSelect: (id: number) => void,
-) {
-  return instances.map((instance) => (
-    <DropdownMenuItem
-      key={instance.id}
-      onClick={() => onSelect(instance.id)}
-      className="cursor-pointer"
-    >
-      <HardDrive className="mr-2 h-4 w-4 flex-shrink-0" />
-      <span className="flex-1 truncate">{instance.name}</span>
-      <span
-        className={cn(
-          "ml-2 h-2 w-2 rounded-full flex-shrink-0",
-          instance.connected ? "bg-green-500" : "bg-red-500",
-        )}
-      />
-    </DropdownMenuItem>
-  ))
+interface UnifiedActionDropdownProps {
+  icon: ReactNode
+  tooltip: string
+  label: string
+  instances: Array<{ id: number; name: string; connected: boolean }>
+  onSelectInstance: (id: number) => void
+}
+
+function UnifiedActionDropdown({ icon, tooltip, label, instances, onSelectInstance }: UnifiedActionDropdownProps) {
+  return (
+    <DropdownMenu>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="outline"
+              size="icon"
+              className="hidden md:inline-flex"
+              aria-label={tooltip}
+            >
+              {icon}
+            </Button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent>{tooltip}</TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent align="start">
+        <DropdownMenuLabel className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+          {label}
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {instances.map((instance) => (
+          <DropdownMenuItem
+            key={instance.id}
+            onSelect={() => onSelectInstance(instance.id)}
+            className="cursor-pointer"
+          >
+            <HardDrive className="mr-2 h-4 w-4 flex-shrink-0" />
+            <span className="flex-1 truncate">{instance.name}</span>
+            <span
+              className={cn(
+                "ml-2 h-2 w-2 rounded-full flex-shrink-0",
+                instance.connected ? "bg-green-500" : "bg-red-500",
+              )}
+            />
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
 }
 
 export function Header({
@@ -139,6 +169,20 @@ export function Header({
   const unifiedManageableInstances = useMemo(
     () => unifiedScopeInstances.filter((instance) => instance.id > 0),
     [unifiedScopeInstances],
+  )
+  const unifiedCapabilitiesResults = useQueries({
+    queries: unifiedManageableInstances.map((instance) => ({
+      queryKey: ["instance-capabilities", instance.id],
+      queryFn: () => api.getInstanceCapabilities(instance.id),
+      staleTime: 60_000,
+      enabled: isAllInstancesRoute,
+    })),
+  })
+  const unifiedTorrentCreationInstances = useMemo(
+    () => unifiedManageableInstances.filter((_instance, i) =>
+      unifiedCapabilitiesResults[i]?.data?.supportsTorrentCreation ?? true
+    ),
+    [unifiedManageableInstances, unifiedCapabilitiesResults],
   )
   const applyUnifiedScope = useCallback((nextIds: number[]) => {
     const normalizedIds = normalizeUnifiedInstanceIds(nextIds, activeInstanceIds)
@@ -261,32 +305,15 @@ export function Header({
   const [unifiedTasksInstanceId, setUnifiedTasksInstanceId] = useState<number | null>(null)
   const [unifiedSettingsInstanceId, setUnifiedSettingsInstanceId] = useState<number | null>(null)
 
+  // Derived at render time — avoids a cleanup Effect for stale IDs
+  const validUnifiedIds = useMemo(
+    () => new Set(unifiedManageableInstances.map((instance) => instance.id)),
+    [unifiedManageableInstances],
+  )
+
   useEffect(() => {
     setInstanceSettingsOpen(false)
   }, [selectedInstanceId])
-
-  // Clear stale unified dialog IDs when the scope instance set changes
-  useEffect(() => {
-    const validIds = new Set(unifiedManageableInstances.map((instance) => instance.id))
-    if (unifiedAddTorrentInstanceId !== null && !validIds.has(unifiedAddTorrentInstanceId)) {
-      setUnifiedAddTorrentInstanceId(null)
-    }
-    if (unifiedCreateTorrentInstanceId !== null && !validIds.has(unifiedCreateTorrentInstanceId)) {
-      setUnifiedCreateTorrentInstanceId(null)
-    }
-    if (unifiedTasksInstanceId !== null && !validIds.has(unifiedTasksInstanceId)) {
-      setUnifiedTasksInstanceId(null)
-    }
-    if (unifiedSettingsInstanceId !== null && !validIds.has(unifiedSettingsInstanceId)) {
-      setUnifiedSettingsInstanceId(null)
-    }
-  }, [
-    unifiedManageableInstances,
-    unifiedAddTorrentInstanceId,
-    unifiedCreateTorrentInstanceId,
-    unifiedTasksInstanceId,
-    unifiedSettingsInstanceId,
-  ])
 
   const { state: crossSeedInstanceState } = useCrossSeedInstanceState()
 
@@ -421,109 +448,34 @@ export function Header({
             </Tooltip>
             {isAllInstancesRoute && unifiedManageableInstances.length > 0 && (
               <>
-                {/* Unified Add Torrent dropdown */}
-                <DropdownMenu>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <DropdownMenuTrigger asChild>
-                        <Button
-                          variant="outline"
-                          size="icon"
-                          className="hidden md:inline-flex"
-                          aria-label="Add torrent"
-                        >
-                          <Plus className="h-4 w-4" />
-                        </Button>
-                      </DropdownMenuTrigger>
-                    </TooltipTrigger>
-                    <TooltipContent>Add torrent</TooltipContent>
-                  </Tooltip>
-                  <DropdownMenuContent align="start">
-                    <DropdownMenuLabel className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
-                      Add to instance
-                    </DropdownMenuLabel>
-                    <DropdownMenuSeparator />
-                    {renderUnifiedInstanceMenuItems(unifiedManageableInstances, setUnifiedAddTorrentInstanceId)}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-
-                {/* Unified Create Torrent dropdown */}
-                <DropdownMenu>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <DropdownMenuTrigger asChild>
-                        <Button
-                          variant="outline"
-                          size="icon"
-                          className="hidden md:inline-flex"
-                          aria-label="Create torrent"
-                        >
-                          <FileEdit className="h-4 w-4" />
-                        </Button>
-                      </DropdownMenuTrigger>
-                    </TooltipTrigger>
-                    <TooltipContent>Create torrent</TooltipContent>
-                  </Tooltip>
-                  <DropdownMenuContent align="start">
-                    <DropdownMenuLabel className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
-                      Create for instance
-                    </DropdownMenuLabel>
-                    <DropdownMenuSeparator />
-                    {renderUnifiedInstanceMenuItems(unifiedManageableInstances, setUnifiedCreateTorrentInstanceId)}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-
-                {/* Unified Tasks dropdown */}
-                <DropdownMenu>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <DropdownMenuTrigger asChild>
-                        <Button
-                          variant="outline"
-                          size="icon"
-                          className="hidden md:inline-flex"
-                          aria-label="Torrent creation tasks"
-                        >
-                          <ListTodo className="h-4 w-4" />
-                        </Button>
-                      </DropdownMenuTrigger>
-                    </TooltipTrigger>
-                    <TooltipContent>Torrent creation tasks</TooltipContent>
-                  </Tooltip>
-                  <DropdownMenuContent align="start">
-                    <DropdownMenuLabel className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
-                      Tasks for instance
-                    </DropdownMenuLabel>
-                    <DropdownMenuSeparator />
-                    {renderUnifiedInstanceMenuItems(unifiedManageableInstances, setUnifiedTasksInstanceId)}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-
-                {/* Unified Instance Settings dropdown */}
-                <DropdownMenu>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <DropdownMenuTrigger asChild>
-                        <Button
-                          variant="outline"
-                          size="icon"
-                          className="hidden md:inline-flex"
-                          aria-label="Instance settings"
-                        >
-                          <Cog className="h-4 w-4" />
-                        </Button>
-                      </DropdownMenuTrigger>
-                    </TooltipTrigger>
-                    <TooltipContent>Instance settings</TooltipContent>
-                  </Tooltip>
-                  <DropdownMenuContent align="start">
-                    <DropdownMenuLabel className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
-                      Settings for instance
-                    </DropdownMenuLabel>
-                    <DropdownMenuSeparator />
-                    {renderUnifiedInstanceMenuItems(unifiedManageableInstances, setUnifiedSettingsInstanceId)}
-                  </DropdownMenuContent>
-                </DropdownMenu>
+                <UnifiedActionDropdown
+                  icon={<Plus className="h-4 w-4" />}
+                  tooltip="Add torrent"
+                  label="Add to instance"
+                  instances={unifiedManageableInstances}
+                  onSelectInstance={setUnifiedAddTorrentInstanceId}
+                />
+                <UnifiedActionDropdown
+                  icon={<FileEdit className="h-4 w-4" />}
+                  tooltip="Create torrent"
+                  label="Create for instance"
+                  instances={unifiedTorrentCreationInstances}
+                  onSelectInstance={setUnifiedCreateTorrentInstanceId}
+                />
+                <UnifiedActionDropdown
+                  icon={<ListTodo className="h-4 w-4" />}
+                  tooltip="Torrent creation tasks"
+                  label="Tasks for instance"
+                  instances={unifiedTorrentCreationInstances}
+                  onSelectInstance={setUnifiedTasksInstanceId}
+                />
+                <UnifiedActionDropdown
+                  icon={<Cog className="h-4 w-4" />}
+                  tooltip="Instance settings"
+                  label="Settings for instance"
+                  instances={unifiedManageableInstances}
+                  onSelectInstance={setUnifiedSettingsInstanceId}
+                />
               </>
             )}
             {canManageSelectedInstance && (
@@ -937,7 +889,7 @@ export function Header({
       )}
 
       {/* Unified Add Torrent Dialog */}
-      {unifiedAddTorrentInstanceId !== null && (
+      {unifiedAddTorrentInstanceId !== null && validUnifiedIds.has(unifiedAddTorrentInstanceId) && (
         <AddTorrentDialog
           instanceId={unifiedAddTorrentInstanceId}
           open={true}
@@ -948,7 +900,7 @@ export function Header({
       )}
 
       {/* Unified Create Torrent Dialog */}
-      {unifiedCreateTorrentInstanceId !== null && (
+      {unifiedCreateTorrentInstanceId !== null && validUnifiedIds.has(unifiedCreateTorrentInstanceId) && (
         <TorrentCreatorDialog
           instanceId={unifiedCreateTorrentInstanceId}
           open={true}
@@ -959,7 +911,7 @@ export function Header({
       )}
 
       {/* Unified Torrent Creation Tasks Dialog */}
-      {unifiedTasksInstanceId !== null && (() => {
+      {unifiedTasksInstanceId !== null && validUnifiedIds.has(unifiedTasksInstanceId) && (() => {
         const inst = activeInstances.find(i => i.id === unifiedTasksInstanceId)
         if (!inst) return null
         return (
@@ -977,7 +929,7 @@ export function Header({
       })()}
 
       {/* Unified Instance Settings Dialog */}
-      {unifiedSettingsInstanceId !== null && (() => {
+      {unifiedSettingsInstanceId !== null && validUnifiedIds.has(unifiedSettingsInstanceId) && (() => {
         const inst = activeInstances.find(i => i.id === unifiedSettingsInstanceId)
         if (!inst) return null
         return (


### PR DESCRIPTION
Add torrent actions to navbar for unified instance, dropdown selectively filters available instances to match the selected instances.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Header adds four per-instance action dropdowns on the "all instances" view: Add, Create, Tasks, and Settings; each opens a focused dialog for the selected instance.
  * Dropdown options adapt to each instance's capabilities (e.g., torrent creation availability) and show connection status.
  * Dialogs mount only for valid selections and prefill instance-specific settings.

* **Bug Fixes**
  * Selections and open dialogs are cleared if the chosen instance becomes unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->