### PR TITLE
feat(web): add "Save changes to all instances" button to backup settings

### DIFF
--- a/web/src/pages/InstanceBackups.tsx
+++ b/web/src/pages/InstanceBackups.tsx
@@ -1068,7 +1068,7 @@ export function InstanceBackups() {
                       <Button
                         variant="outline"
                         onClick={handleSave}
-                        disabled={saveDisabled}
+                        disabled={saveDisabled || savingAll}
                         title={requiresCadenceSelection ? "Select at least one cadence to enable automatic backups." : undefined}
                       >
                         <Save className="mr-2 h-4 w-4" /> Save changes

--- a/web/src/pages/InstanceBackups.tsx
+++ b/web/src/pages/InstanceBackups.tsx
@@ -586,11 +586,18 @@ export function InstanceBackups() {
     if (!formState) return
     setSavingAll(true)
     try {
-      await Promise.all(
-        (supportedInstances ?? []).map(inst => api.updateBackupSettings(inst.id, formState))
+      const results = await Promise.allSettled(
+        (supportedInstances ?? []).map(inst => api.updateBackupSettings(inst.id, formState)),
       )
-      queryClient.invalidateQueries({ queryKey: ["instance-backups"] })
-      toast.success("Settings applied to all instances")
+      const failed = results.filter((result: PromiseSettledResult<void>): result is PromiseRejectedResult => result.status === "rejected")
+
+      await queryClient.invalidateQueries({ queryKey: ["instance-backups"] })
+
+      if (failed.length === 0) {
+        toast.success("Settings applied to all instances")
+      } else {
+        toast.error(`Applied to ${results.length - failed.length}/${results.length} instances`)
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : "Failed to apply settings to all instances"
       toast.error(message)

--- a/web/src/pages/InstanceBackups.tsx
+++ b/web/src/pages/InstanceBackups.tsx
@@ -585,25 +585,19 @@ export function InstanceBackups() {
   const handleSaveAll = async () => {
     if (!formState) return
     setSavingAll(true)
-    try {
-      const results = await Promise.allSettled(
-        (supportedInstances ?? []).map(inst => api.updateBackupSettings(inst.id, formState)),
-      )
-      const failed = results.filter((result: PromiseSettledResult<void>): result is PromiseRejectedResult => result.status === "rejected")
+    const results = await Promise.allSettled(
+      (supportedInstances ?? []).map(inst => api.updateBackupSettings(inst.id, formState)),
+    )
+    const failed = results.filter((result): result is PromiseRejectedResult => result.status === "rejected")
 
-      await queryClient.invalidateQueries({ queryKey: ["instance-backups"] })
+    await queryClient.invalidateQueries({ queryKey: ["instance-backups"] })
 
-      if (failed.length === 0) {
-        toast.success("Settings applied to all instances")
-      } else {
-        toast.error(`Applied to ${results.length - failed.length}/${results.length} instances`)
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : "Failed to apply settings to all instances"
-      toast.error(message)
-    } finally {
-      setSavingAll(false)
+    if (failed.length === 0) {
+      toast.success("Settings applied to all instances")
+    } else {
+      toast.error(`Applied to ${results.length - failed.length}/${results.length} instances`)
     }
+    setSavingAll(false)
   }
 
   const handleTrigger = async (kind: BackupRunKind = "manual") => {

--- a/web/src/pages/InstanceBackups.tsx
+++ b/web/src/pages/InstanceBackups.tsx
@@ -4,7 +4,7 @@
  */
 
 import { Link } from "@tanstack/react-router"
-import { ArrowDownToLine, ChevronLeft, ChevronRight, CircleHelp, CircleX, Clock, Download, FileText, HardDrive, ListChecks, RefreshCw, Trash, Undo2 } from "lucide-react"
+import { ArrowDownToLine, ChevronLeft, ChevronRight, CircleHelp, CircleX, Clock, Download, FileText, HardDrive, ListChecks, RefreshCw, Save, Trash, Undo2 } from "lucide-react"
 import type { ChangeEvent } from "react"
 import { useEffect, useMemo, useRef, useState } from "react"
 import { toast } from "sonner"
@@ -580,6 +580,25 @@ export function InstanceBackups() {
     }
   }
 
+  const [savingAll, setSavingAll] = useState(false)
+
+  const handleSaveAll = async () => {
+    if (!formState) return
+    setSavingAll(true)
+    try {
+      await Promise.all(
+        (supportedInstances ?? []).map(inst => api.updateBackupSettings(inst.id, formState))
+      )
+      queryClient.invalidateQueries({ queryKey: ["instance-backups"] })
+      toast.success("Settings applied to all instances")
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to apply settings to all instances"
+      toast.error(message)
+    } finally {
+      setSavingAll(false)
+    }
+  }
+
   const handleTrigger = async (kind: BackupRunKind = "manual") => {
     try {
       await triggerBackup.mutateAsync({ kind, requestedBy: "ui" })
@@ -1038,20 +1057,29 @@ export function InstanceBackups() {
                 </div>
 
                 <div className="space-y-2">
-                  <div className="flex flex-wrap gap-2">
-                    <Button onClick={() => handleTrigger("manual")} disabled={triggerBackup.isPending}>
-                      <ArrowDownToLine className="mr-2 h-4 w-4" /> Run manual backup
-                    </Button>
-                    <Button variant="outline" onClick={() => setImportDialogOpen(true)}>
-                      <FileText className="mr-2 h-4 w-4" /> Import backup
-                    </Button>
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div className="flex flex-wrap gap-2">
+                      <Button onClick={() => handleTrigger("manual")} disabled={triggerBackup.isPending}>
+                        <ArrowDownToLine className="mr-2 h-4 w-4" /> Run manual backup
+                      </Button>
+                      <Button variant="outline" onClick={() => setImportDialogOpen(true)}>
+                        <FileText className="mr-2 h-4 w-4" /> Import backup
+                      </Button>
+                      <Button
+                        variant="outline"
+                        onClick={handleSave}
+                        disabled={saveDisabled}
+                        title={requiresCadenceSelection ? "Select at least one cadence to enable automatic backups." : undefined}
+                      >
+                        <Save className="mr-2 h-4 w-4" /> Save changes
+                      </Button>
+                    </div>
                     <Button
                       variant="outline"
-                      onClick={handleSave}
-                      disabled={saveDisabled}
-                      title={requiresCadenceSelection ? "Select at least one cadence to enable automatic backups." : undefined}
+                      onClick={handleSaveAll}
+                      disabled={saveDisabled || savingAll}
                     >
-                      Save changes
+                      <Save className="mr-2 h-4 w-4" /> Save changes to all instances
                     </Button>
                   </div>
                   {requiresCadenceSelection ? (


### PR DESCRIPTION
Adds a "Save changes to all instances" button to the backup settings page, right-aligned next to the existing Save changes button. When clicked, the current form state is applied to all supported instances in parallel using the existing per-instance settings endpoint. 
Additionally both save buttons now include a floppy disk icon for visual consistency.

Satisfies https://github.com/autobrr/qui/discussions/1649

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Save changes to all instances" to apply current backup settings across all supported instances.
  * Bulk and per-instance save operations show a Save icon and disable controls while running.
  * Bulk save reports success/error counts via toasts and refreshes the backup list after completion.
  * Action bar layout updated to group per-instance controls left and place bulk-save action on the right.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->