### PR TITLE
feat(automations): allow disable of notifications

### DIFF
--- a/internal/api/handlers/automations.go
+++ b/internal/api/handlers/automations.go
@@ -45,6 +45,7 @@ type AutomationPayload struct {
 	TrackerDomains  []string                 `json:"trackerDomains"`
 	Enabled         *bool                    `json:"enabled"`
 	DryRun          *bool                    `json:"dryRun"`
+	Notify          *bool                    `json:"notify"`
 	SortOrder       *int                     `json:"sortOrder"`
 	IntervalSeconds *int                     `json:"intervalSeconds,omitempty"` // nil = use DefaultRuleInterval (15m)
 	Conditions      *models.ActionConditions `json:"conditions"`
@@ -82,6 +83,7 @@ func (p *AutomationPayload) toModel(instanceID int, id int) *models.Automation {
 		SortingConfig:   p.SortingConfig,
 		Enabled:         true,
 		DryRun:          false,
+		Notify:          true,
 		IntervalSeconds: p.IntervalSeconds,
 	}
 	if p.Enabled != nil {
@@ -89,6 +91,9 @@ func (p *AutomationPayload) toModel(instanceID int, id int) *models.Automation {
 	}
 	if p.DryRun != nil {
 		automation.DryRun = *p.DryRun
+	}
+	if p.Notify != nil {
+		automation.Notify = *p.Notify
 	}
 	if p.SortOrder != nil {
 		automation.SortOrder = *p.SortOrder

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -261,6 +261,7 @@ var expectedSchema = map[string][]columnSpec{
 		{Name: "created_at", Type: "DATETIME"},
 		{Name: "updated_at", Type: "DATETIME"},
 		{Name: "sorting_config", Type: "TEXT"},
+		{Name: "notify", Type: "INTEGER"},
 	},
 	"automation_activity": {
 		{Name: "id", Type: "INTEGER", PrimaryKey: true},

--- a/internal/database/migrations/068_add_automation_notification_settings.sql
+++ b/internal/database/migrations/068_add_automation_notification_settings.sql
@@ -1,0 +1,7 @@
+-- Copyright (c) 2026, s0up and the autobrr contributors.
+-- SPDX-License-Identifier: GPL-2.0-or-later
+
+-- Add per-rule notification toggle for automation outcomes.
+-- Defaults to 1 (enabled) to preserve existing behavior where
+-- notifications are always sent when an automation has activity.
+ALTER TABLE automations ADD COLUMN notify INTEGER NOT NULL DEFAULT 1;

--- a/internal/database/postgres_migrations/069_add_automation_notification_settings.sql
+++ b/internal/database/postgres_migrations/069_add_automation_notification_settings.sql
@@ -1,0 +1,7 @@
+-- Copyright (c) 2026, s0up and the autobrr contributors.
+-- SPDX-License-Identifier: GPL-2.0-or-later
+
+-- Add per-rule notification toggle for automation outcomes.
+-- Defaults to 1 (enabled) to preserve existing behavior where
+-- notifications are always sent when an automation has activity.
+ALTER TABLE automations ADD COLUMN IF NOT EXISTS notify INTEGER NOT NULL DEFAULT 1;

--- a/internal/models/automation.go
+++ b/internal/models/automation.go
@@ -175,6 +175,7 @@ type Automation struct {
 	SortingConfig   *SortingConfig    `json:"sortingConfig,omitempty"`   // nil = default sorting (oldest first)
 	Enabled         bool              `json:"enabled"`
 	DryRun          bool              `json:"dryRun"`
+	Notify          bool              `json:"notify"`
 	SortOrder       int               `json:"sortOrder"`
 	IntervalSeconds *int              `json:"intervalSeconds,omitempty"` // nil = use DefaultRuleInterval (15m)
 	CreatedAt       time.Time         `json:"createdAt"`
@@ -231,7 +232,7 @@ func normalizeTrackerPattern(pattern string, domains []string) string {
 
 func (s *AutomationStore) ListByInstance(ctx context.Context, instanceID int) ([]*Automation, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT id, instance_id, name, tracker_pattern, conditions, enabled, dry_run, sort_order, interval_seconds, free_space_source, sorting_config, created_at, updated_at
+		SELECT id, instance_id, name, tracker_pattern, conditions, enabled, dry_run, notify, sort_order, interval_seconds, free_space_source, sorting_config, created_at, updated_at
 		FROM automations
 		WHERE instance_id = ?
 		ORDER BY sort_order ASC, id ASC
@@ -248,7 +249,7 @@ func (s *AutomationStore) ListByInstance(ctx context.Context, instanceID int) ([
 		var intervalSeconds sql.NullInt64
 		var freeSpaceSourceJSON sql.NullString
 		var sortingConfigJSON sql.NullString
-		var enabled, dryRun int
+		var enabled, dryRun, notify int
 
 		if err := rows.Scan(
 			&automation.ID,
@@ -258,6 +259,7 @@ func (s *AutomationStore) ListByInstance(ctx context.Context, instanceID int) ([
 			&conditionsJSON,
 			&enabled,
 			&dryRun,
+			&notify,
 			&automation.SortOrder,
 			&intervalSeconds,
 			&freeSpaceSourceJSON,
@@ -277,6 +279,7 @@ func (s *AutomationStore) ListByInstance(ctx context.Context, instanceID int) ([
 
 		automation.Enabled = SQLiteIntToBool(enabled)
 		automation.DryRun = SQLiteIntToBool(dryRun)
+		automation.Notify = SQLiteIntToBool(notify)
 		automation.TrackerDomains = splitPatterns(automation.TrackerPattern)
 
 		if intervalSeconds.Valid {
@@ -312,7 +315,7 @@ func (s *AutomationStore) ListByInstance(ctx context.Context, instanceID int) ([
 
 func (s *AutomationStore) Get(ctx context.Context, instanceID, id int) (*Automation, error) {
 	row := s.db.QueryRowContext(ctx, `
-		SELECT id, instance_id, name, tracker_pattern, conditions, enabled, dry_run, sort_order, interval_seconds, free_space_source, sorting_config, created_at, updated_at
+		SELECT id, instance_id, name, tracker_pattern, conditions, enabled, dry_run, notify, sort_order, interval_seconds, free_space_source, sorting_config, created_at, updated_at
 		FROM automations
 		WHERE id = ? AND instance_id = ?
 	`, id, instanceID)
@@ -322,7 +325,7 @@ func (s *AutomationStore) Get(ctx context.Context, instanceID, id int) (*Automat
 	var intervalSeconds sql.NullInt64
 	var freeSpaceSourceJSON sql.NullString
 	var sortingConfigJSON sql.NullString
-	var enabled, dryRun int
+	var enabled, dryRun, notify int
 
 	if err := row.Scan(
 		&automation.ID,
@@ -332,6 +335,7 @@ func (s *AutomationStore) Get(ctx context.Context, instanceID, id int) (*Automat
 		&conditionsJSON,
 		&enabled,
 		&dryRun,
+		&notify,
 		&automation.SortOrder,
 		&intervalSeconds,
 		&freeSpaceSourceJSON,
@@ -351,6 +355,7 @@ func (s *AutomationStore) Get(ctx context.Context, instanceID, id int) (*Automat
 
 	automation.Enabled = SQLiteIntToBool(enabled)
 	automation.DryRun = SQLiteIntToBool(dryRun)
+	automation.Notify = SQLiteIntToBool(notify)
 	automation.TrackerDomains = splitPatterns(automation.TrackerPattern)
 
 	if intervalSeconds.Valid {
@@ -445,11 +450,11 @@ func (s *AutomationStore) Create(ctx context.Context, automation *Automation) (*
 	var id int
 	err = s.db.QueryRowContext(ctx, `
 		INSERT INTO automations
-			(instance_id, name, tracker_pattern, conditions, enabled, dry_run, sort_order, interval_seconds, free_space_source, sorting_config)
+			(instance_id, name, tracker_pattern, conditions, enabled, dry_run, notify, sort_order, interval_seconds, free_space_source, sorting_config)
 		VALUES
-			(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		RETURNING id
-	`, automation.InstanceID, automation.Name, automation.TrackerPattern, string(conditionsJSON), boolToInt(automation.Enabled), boolToInt(automation.DryRun), sortOrder, intervalSeconds, freeSpaceSourceJSON, sortingConfigJSON).Scan(&id)
+	`, automation.InstanceID, automation.Name, automation.TrackerPattern, string(conditionsJSON), boolToInt(automation.Enabled), boolToInt(automation.DryRun), boolToInt(automation.Notify), sortOrder, intervalSeconds, freeSpaceSourceJSON, sortingConfigJSON).Scan(&id)
 	if err != nil {
 		return nil, err
 	}
@@ -507,9 +512,9 @@ func (s *AutomationStore) Update(ctx context.Context, automation *Automation) (*
 
 	res, err := s.db.ExecContext(ctx, `
 		UPDATE automations
-		SET name = ?, tracker_pattern = ?, conditions = ?, enabled = ?, dry_run = ?, sort_order = ?, interval_seconds = ?, free_space_source = ?, sorting_config = ?
+		SET name = ?, tracker_pattern = ?, conditions = ?, enabled = ?, dry_run = ?, notify = ?, sort_order = ?, interval_seconds = ?, free_space_source = ?, sorting_config = ?
 		WHERE id = ? AND instance_id = ?
-	`, automation.Name, automation.TrackerPattern, string(conditionsJSON), boolToInt(automation.Enabled), boolToInt(automation.DryRun), automation.SortOrder, intervalSeconds, freeSpaceSourceJSON, sortingConfigJSON, automation.ID, automation.InstanceID)
+	`, automation.Name, automation.TrackerPattern, string(conditionsJSON), boolToInt(automation.Enabled), boolToInt(automation.DryRun), boolToInt(automation.Notify), automation.SortOrder, intervalSeconds, freeSpaceSourceJSON, sortingConfigJSON, automation.ID, automation.InstanceID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/models/postgres_bool_args_test.go
+++ b/internal/models/postgres_bool_args_test.go
@@ -446,6 +446,7 @@ func TestAutomationReadsIntegerBooleanColumns(t *testing.T) {
 			conditions TEXT NOT NULL,
 			enabled INTEGER NOT NULL DEFAULT 1,
 			dry_run INTEGER NOT NULL DEFAULT 0,
+			notify INTEGER NOT NULL DEFAULT 1,
 			sort_order INTEGER NOT NULL DEFAULT 0,
 			interval_seconds INTEGER,
 			free_space_source TEXT,
@@ -455,8 +456,8 @@ func TestAutomationReadsIntegerBooleanColumns(t *testing.T) {
 		)
 	`)
 	mustExec(t, db, `
-		INSERT INTO automations (instance_id, name, tracker_pattern, conditions, enabled, dry_run, sort_order)
-		VALUES (1, 'Auto rule', 'tracker.example', '{}', 1, 0, 1)
+		INSERT INTO automations (instance_id, name, tracker_pattern, conditions, enabled, dry_run, notify, sort_order)
+		VALUES (1, 'Auto rule', 'tracker.example', '{}', 1, 0, 0, 1)
 	`)
 
 	store := NewAutomationStore(&capturingQuerier{db: db})
@@ -465,11 +466,13 @@ func TestAutomationReadsIntegerBooleanColumns(t *testing.T) {
 	require.Len(t, items, 1)
 	require.True(t, items[0].Enabled)
 	require.False(t, items[0].DryRun)
+	require.False(t, items[0].Notify)
 
 	item, err := store.Get(context.Background(), 1, items[0].ID)
 	require.NoError(t, err)
 	require.True(t, item.Enabled)
 	require.False(t, item.DryRun)
+	require.False(t, item.Notify)
 }
 
 func TestOrphanScanReadsIntegerBooleanColumns(t *testing.T) {

--- a/internal/services/automations/service.go
+++ b/internal/services/automations/service.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"path"
 	"path/filepath"
 	"slices"
@@ -3876,12 +3877,8 @@ func buildNotifiedAutomationSummary(summary *automationSummary, rules []*models.
 		filtered.sampleTorrents = append([]string(nil), summary.sampleTorrents...)
 		filtered.sampleErrors = append([]string(nil), summary.sampleErrors...)
 		filtered.tagSamples = append([]string(nil), summary.tagSamples...)
-		for name, count := range summary.tagAddedByName {
-			filtered.tagAddedByName[name] = count
-		}
-		for name, count := range summary.tagRemovedByName {
-			filtered.tagRemovedByName[name] = count
-		}
+		maps.Copy(filtered.tagAddedByName, summary.tagAddedByName)
+		maps.Copy(filtered.tagRemovedByName, summary.tagRemovedByName)
 	}
 
 	return filtered

--- a/internal/services/automations/service.go
+++ b/internal/services/automations/service.go
@@ -3404,6 +3404,7 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 						}
 						expandedHashes = append(expandedHashes, memberHash)
 						movedHashes[memberHash] = struct{}{}
+						inheritRuleRefForMoveGroup(memberHash, hash, moveRuleByHash)
 					}
 					continue
 				}
@@ -3632,22 +3633,27 @@ func (s *Service) notifyAutomationSummary(ctx context.Context, instanceID int, s
 		return
 	}
 
+	notifiedSummary := buildNotifiedAutomationSummary(summary, rules)
+	if notifiedSummary == nil || !notifiedSummary.hasActivity() {
+		return
+	}
+
 	var errorMessage string
 	var errorMessages []string
-	if summary.failed > 0 && len(summary.sampleErrors) > 0 {
-		errorMessages = append([]string(nil), summary.sampleErrors...)
-		errorMessage = summary.sampleErrors[0]
+	if notifiedSummary.failed > 0 && len(notifiedSummary.sampleErrors) > 0 {
+		errorMessages = append([]string(nil), notifiedSummary.sampleErrors...)
+		errorMessage = notifiedSummary.sampleErrors[0]
 	}
 
 	s.notifier.Notify(ctx, notifications.Event{
 		Type:       notifications.EventAutomationsActionsApplied,
 		InstanceID: instanceID,
-		Message:    summary.message(),
+		Message:    notifiedSummary.message(),
 		Automations: &notifications.AutomationsEventData{
-			Applied: summary.applied,
-			Failed:  summary.failed,
-			Rules:   buildAutomationRuleSummaries(summary),
-			Samples: append([]string(nil), summary.sampleTorrents...),
+			Applied: notifiedSummary.applied,
+			Failed:  notifiedSummary.failed,
+			Rules:   buildAutomationRuleSummaries(notifiedSummary),
+			Samples: append([]string(nil), notifiedSummary.sampleTorrents...),
 		},
 		ErrorMessage:  errorMessage,
 		ErrorMessages: errorMessages,
@@ -3811,6 +3817,74 @@ func recordMoveFailureRuleCounts(summary *automationSummary, failedMoveHashesByP
 		models.ActivityOutcomeFailed,
 		buildRuleCountsFromHashes(flattenHashGroupsByPath(failedMoveHashesByPath), moveRuleByHash),
 	)
+}
+
+func buildNotifiedAutomationSummary(summary *automationSummary, rules []*models.Automation) *automationSummary {
+	if summary == nil || len(summary.rules) == 0 || len(rules) == 0 {
+		return nil
+	}
+
+	notifyByRuleID := make(map[int]bool, len(rules))
+	for _, rule := range rules {
+		notifyByRuleID[rule.ID] = rule.Notify
+	}
+
+	filtered := newAutomationSummary()
+	totalRules := 0
+	notifiedRules := 0
+
+	for key, rule := range summary.rules {
+		if rule == nil {
+			continue
+		}
+		totalRules++
+		if !notifyByRuleID[rule.ruleID] {
+			continue
+		}
+		notifiedRules++
+
+		clonedRule := &automationRuleSummary{
+			ruleID:   rule.ruleID,
+			ruleName: rule.ruleName,
+			applied:  rule.applied,
+			failed:   rule.failed,
+			actions:  make(map[string]*automationActionCounts, len(rule.actions)),
+		}
+
+		for action, counts := range rule.actions {
+			if counts == nil {
+				continue
+			}
+			clonedRule.actions[action] = &automationActionCounts{
+				applied: counts.applied,
+				failed:  counts.failed,
+			}
+			filtered.appliedByAction[action] += counts.applied
+			filtered.failedByAction[action] += counts.failed
+		}
+
+		filtered.applied += rule.applied
+		filtered.failed += rule.failed
+		filtered.rules[key] = clonedRule
+	}
+
+	if notifiedRules == 0 {
+		return nil
+	}
+
+	if notifiedRules == totalRules {
+		filtered.sampleTorrents = append([]string(nil), summary.sampleTorrents...)
+		filtered.sampleErrors = append([]string(nil), summary.sampleErrors...)
+		filtered.tagSamples = append([]string(nil), summary.tagSamples...)
+		for name, count := range summary.tagAddedByName {
+			filtered.tagAddedByName[name] = count
+		}
+		for name, count := range summary.tagRemovedByName {
+			filtered.tagRemovedByName[name] = count
+		}
+	}
+
+	return filtered
 }
 
 func buildRuleCountsFromHashMaps(hashes []string, ruleByHashMaps ...map[string]ruleRef) map[ruleRef]int {
@@ -4112,6 +4186,17 @@ func inheritRuleRefForCrossSeed(expandedHash string, key crossSeedKey, ruleByHas
 		return
 	}
 	ref, ok := ruleByCrossSeedKey[key]
+	if !ok {
+		return
+	}
+	ruleByHash[expandedHash] = ref
+}
+
+func inheritRuleRefForMoveGroup(expandedHash, triggerHash string, ruleByHash map[string]ruleRef) {
+	if strings.TrimSpace(expandedHash) == "" || strings.TrimSpace(triggerHash) == "" || len(ruleByHash) == 0 {
+		return
+	}
+	ref, ok := ruleByHash[triggerHash]
 	if !ok {
 		return
 	}

--- a/internal/services/automations/service.go
+++ b/internal/services/automations/service.go
@@ -3506,6 +3506,7 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 			Details:    detailsJSON,
 		}
 		summary.recordActivity(activity, failureCount)
+		recordMoveFailureRuleCounts(summary, failedMoveHashesByPath, moveRuleByHash)
 		summary.addTorrentSamples(collectTorrentNamesForHashes(flattenHashGroupsByPath(failedMoveHashesByPath), torrentByHash), 3)
 		if s.activityStore != nil {
 			if err := s.activityStore.Create(ctx, activity); err != nil {
@@ -3799,6 +3800,17 @@ func buildRuleCountsFromHashes(hashes []string, ruleByHash map[string]ruleRef) m
 		return nil
 	}
 	return counts
+}
+
+func recordMoveFailureRuleCounts(summary *automationSummary, failedMoveHashesByPath map[string][]string, moveRuleByHash map[string]ruleRef) {
+	if summary == nil {
+		return
+	}
+	summary.recordRuleCounts(
+		models.ActivityActionMoved,
+		models.ActivityOutcomeFailed,
+		buildRuleCountsFromHashes(flattenHashGroupsByPath(failedMoveHashesByPath), moveRuleByHash),
+	)
 }
 
 func buildRuleCountsFromHashMaps(hashes []string, ruleByHashMaps ...map[string]ruleRef) map[ruleRef]int {

--- a/internal/services/automations/service.go
+++ b/internal/services/automations/service.go
@@ -3618,12 +3618,16 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 		}
 	}
 
-	s.notifyAutomationSummary(ctx, instanceID, summary)
+	s.notifyAutomationSummary(ctx, instanceID, summary, eligibleRules)
 	return nil, nil
 }
 
-func (s *Service) notifyAutomationSummary(ctx context.Context, instanceID int, summary *automationSummary) {
+func (s *Service) notifyAutomationSummary(ctx context.Context, instanceID int, summary *automationSummary, rules []*models.Automation) {
 	if s == nil || s.notifier == nil || summary == nil || !summary.hasActivity() {
+		return
+	}
+
+	if !shouldNotifyAutomationSummary(summary, rules) {
 		return
 	}
 
@@ -3647,6 +3651,30 @@ func (s *Service) notifyAutomationSummary(ctx context.Context, instanceID int, s
 		ErrorMessage:  errorMessage,
 		ErrorMessages: errorMessages,
 	})
+}
+
+// shouldNotifyAutomationSummary checks whether at least one participating rule
+// has notifications enabled.
+func shouldNotifyAutomationSummary(summary *automationSummary, rules []*models.Automation) bool {
+	if summary == nil || len(rules) == 0 {
+		return false
+	}
+
+	notifyByRuleID := make(map[int]bool, len(rules))
+	for _, rule := range rules {
+		notifyByRuleID[rule.ID] = rule.Notify
+	}
+
+	for _, ruleSummary := range summary.rules {
+		if ruleSummary == nil {
+			continue
+		}
+		if notifyByRuleID[ruleSummary.ruleID] {
+			return true
+		}
+	}
+
+	return false
 }
 
 func buildAutomationRuleSummaries(summary *automationSummary) []notifications.AutomationRuleSummary {

--- a/internal/services/automations/service_test.go
+++ b/internal/services/automations/service_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/autobrr/qui/internal/dbinterface"
 	"github.com/autobrr/qui/internal/models"
 	"github.com/autobrr/qui/internal/qbittorrent"
+	"github.com/autobrr/qui/internal/services/notifications"
 )
 
 // -----------------------------------------------------------------------------
@@ -2282,6 +2283,52 @@ func TestRecordDryRunActivities_NoMatches_DoesNotLogSummaryWhenDisabled(t *testi
 	require.Empty(t, mockDB.activities)
 }
 
+func TestNotifyAutomationSummaryFiltersSuppressedRules(t *testing.T) {
+	t.Parallel()
+
+	notifier := &automationRecordingNotifier{}
+	s := &Service{notifier: notifier}
+
+	summary := newAutomationSummary()
+	notifyRuleID := 42
+	suppressedRuleID := 43
+
+	summary.recordActivity(&models.AutomationActivity{
+		RuleID:      &notifyRuleID,
+		RuleName:    "Notify me",
+		Action:      models.ActivityActionMoved,
+		Outcome:     models.ActivityOutcomeSuccess,
+		TorrentName: "Notify.Release.2026",
+	}, 1)
+	summary.recordActivity(&models.AutomationActivity{
+		RuleID:      &suppressedRuleID,
+		RuleName:    "Suppress me",
+		Action:      models.ActivityActionMoved,
+		Outcome:     models.ActivityOutcomeFailed,
+		TorrentName: "Suppressed.Release.2026",
+		Reason:      "permission denied",
+	}, 1)
+
+	s.notifyAutomationSummary(context.Background(), 1, summary, []*models.Automation{
+		{ID: notifyRuleID, Notify: true},
+		{ID: suppressedRuleID, Notify: false},
+	})
+
+	events := notifier.Events()
+	require.Len(t, events, 1)
+
+	event := events[0]
+	require.Equal(t, notifications.EventAutomationsActionsApplied, event.Type)
+	require.Equal(t, 1, event.Automations.Applied)
+	require.Equal(t, 0, event.Automations.Failed)
+	require.Len(t, event.Automations.Rules, 1)
+	require.Equal(t, notifyRuleID, event.Automations.Rules[0].RuleID)
+	require.Equal(t, "Notify me", event.Automations.Rules[0].RuleName)
+	require.NotContains(t, event.Message, "Suppress me")
+	require.NotContains(t, event.Message, "permission denied")
+	require.NotContains(t, event.Message, "Suppressed.Release.2026")
+}
+
 // mockQuerier implements dbinterface.Querier for testing activity logging
 type mockQuerier struct {
 	activities []*models.AutomationActivity
@@ -2324,3 +2371,17 @@ type mockResult struct{}
 
 func (m mockResult) LastInsertId() (int64, error) { return 0, nil }
 func (m mockResult) RowsAffected() (int64, error) { return 1, nil }
+
+type automationRecordingNotifier struct {
+	events []notifications.Event
+}
+
+func (r *automationRecordingNotifier) Notify(_ context.Context, event notifications.Event) {
+	r.events = append(r.events, event)
+}
+
+func (r *automationRecordingNotifier) Events() []notifications.Event {
+	out := make([]notifications.Event, len(r.events))
+	copy(out, r.events)
+	return out
+}

--- a/internal/services/automations/summary_test.go
+++ b/internal/services/automations/summary_test.go
@@ -170,24 +170,86 @@ func TestAutomationSummaryAddTorrentSamplesUsesLimitAndDedupes(t *testing.T) {
 func TestRecordMoveFailureRuleCountsContributesToNotifyGate(t *testing.T) {
 	t.Parallel()
 
-	summary := newAutomationSummary()
-	summary.recordActivity(&models.AutomationActivity{
-		Action:  models.ActivityActionMoved,
-		Outcome: models.ActivityOutcomeFailed,
-	}, 2)
+	tests := []struct {
+		name               string
+		automations        []*models.Automation
+		ruleByHash         map[string]ruleRef
+		wantNotify         bool
+		wantFailedByRuleID map[int]int
+	}{
+		{
+			name: "notify enabled",
+			automations: []*models.Automation{
+				{ID: 42, Notify: true},
+			},
+			ruleByHash: map[string]ruleRef{
+				"hash-a": {id: 42, name: "Move rule"},
+				"hash-b": {id: 42, name: "Move rule"},
+			},
+			wantNotify:         true,
+			wantFailedByRuleID: map[int]int{42: 2},
+		},
+		{
+			name: "notify disabled",
+			automations: []*models.Automation{
+				{ID: 42, Notify: false},
+			},
+			ruleByHash: map[string]ruleRef{
+				"hash-a": {id: 42, name: "Move rule"},
+				"hash-b": {id: 42, name: "Move rule"},
+			},
+			wantNotify:         false,
+			wantFailedByRuleID: map[int]int{42: 2},
+		},
+		{
+			name: "mixed rules suppress non-notifying rule",
+			automations: []*models.Automation{
+				{ID: 42, Notify: false},
+				{ID: 43, Notify: true},
+			},
+			ruleByHash: map[string]ruleRef{
+				"hash-a": {id: 42, name: "Suppressed rule"},
+				"hash-b": {id: 43, name: "Notifying rule"},
+			},
+			wantNotify:         true,
+			wantFailedByRuleID: map[int]int{42: 1, 43: 1},
+		},
+	}
 
-	recordMoveFailureRuleCounts(summary, map[string][]string{
-		"/library/destination": {"hash-a", "hash-b"},
-	}, map[string]ruleRef{
-		"hash-a": {id: 42, name: "Move rule"},
-		"hash-b": {id: 42, name: "Move rule"},
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	require.True(t, shouldNotifyAutomationSummary(summary, []*models.Automation{
-		{ID: 42, Notify: true},
-	}))
+			summary := newAutomationSummary()
+			summary.recordActivity(&models.AutomationActivity{
+				Action:  models.ActivityActionMoved,
+				Outcome: models.ActivityOutcomeFailed,
+			}, 2)
 
-	got := buildAutomationRuleSummaries(summary)
-	require.Len(t, got, 1)
-	require.Equal(t, 2, got[0].Failed)
+			recordMoveFailureRuleCounts(summary, map[string][]string{
+				"/library/destination": {"hash-a", "hash-b"},
+			}, tt.ruleByHash)
+
+			require.Equal(t, tt.wantNotify, shouldNotifyAutomationSummary(summary, tt.automations))
+
+			got := buildAutomationRuleSummaries(summary)
+			require.Len(t, got, len(tt.wantFailedByRuleID))
+			for _, rule := range got {
+				require.Equal(t, tt.wantFailedByRuleID[rule.RuleID], rule.Failed)
+			}
+		})
+	}
+}
+
+func TestInheritRuleRefForMoveGroupIncludesExpandedMembers(t *testing.T) {
+	t.Parallel()
+
+	moveRuleByHash := map[string]ruleRef{
+		"trigger-hash": {id: 77, name: "Grouped move"},
+	}
+
+	inheritRuleRefForMoveGroup("member-hash", "trigger-hash", moveRuleByHash)
+
+	counts := buildRuleCountsFromHashes([]string{"trigger-hash", "member-hash"}, moveRuleByHash)
+	require.Equal(t, 2, counts[ruleRef{id: 77, name: "Grouped move"}])
 }

--- a/internal/services/automations/summary_test.go
+++ b/internal/services/automations/summary_test.go
@@ -166,3 +166,28 @@ func TestAutomationSummaryAddTorrentSamplesUsesLimitAndDedupes(t *testing.T) {
 	require.Contains(t, msg, "Torrent B")
 	require.Contains(t, msg, "Torrent C")
 }
+
+func TestRecordMoveFailureRuleCountsContributesToNotifyGate(t *testing.T) {
+	t.Parallel()
+
+	summary := newAutomationSummary()
+	summary.recordActivity(&models.AutomationActivity{
+		Action:  models.ActivityActionMoved,
+		Outcome: models.ActivityOutcomeFailed,
+	}, 2)
+
+	recordMoveFailureRuleCounts(summary, map[string][]string{
+		"/library/destination": {"hash-a", "hash-b"},
+	}, map[string]ruleRef{
+		"hash-a": {id: 42, name: "Move rule"},
+		"hash-b": {id: 42, name: "Move rule"},
+	})
+
+	require.True(t, shouldNotifyAutomationSummary(summary, []*models.Automation{
+		{ID: 42, Notify: true},
+	}))
+
+	got := buildAutomationRuleSummaries(summary)
+	require.Len(t, got, 1)
+	require.Equal(t, 2, got[0].Failed)
+}

--- a/web/src/components/instances/preferences/WorkflowDialog.tsx
+++ b/web/src/components/instances/preferences/WorkflowDialog.tsx
@@ -418,6 +418,7 @@ type FormState = {
   applyToAllTrackers: boolean
   enabled: boolean
   dryRun: boolean
+  notify: boolean
   sortOrder?: number
   intervalSeconds: number | null // null = use global default (15m)
   // Shared condition for all actions
@@ -482,6 +483,7 @@ const emptyFormState: FormState = {
   applyToAllTrackers: false,
   enabled: false,
   dryRun: false,
+  notify: true,
   intervalSeconds: null,
   actionCondition: null,
   exprGrouping: undefined,
@@ -671,6 +673,14 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
     const selectedId = formState.exprExternalProgramId
     return allExternalPrograms.filter(p => p.enabled || p.id === selectedId)
   }, [allExternalPrograms, formState.exprExternalProgramId])
+  const { data: notificationTargets } = useQuery({
+    queryKey: ["notificationTargets"],
+    queryFn: () => api.listNotificationTargets(),
+    enabled: open,
+    staleTime: 30 * 1000,
+  })
+  const hasNotificationTargets = (notificationTargets ?? []).length > 0
+
   const supportsTrackerHealth = capabilities?.supportsTrackerHealth ?? false
   const supportsFreeSpacePathSource = capabilities?.supportsFreeSpacePathSource ?? false
   const supportsPathAutocomplete = capabilities?.supportsPathAutocomplete ?? false
@@ -1049,6 +1059,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
           applyToAllTrackers: isAllTrackers,
           enabled: rule.enabled,
           dryRun: rule.dryRun ?? false,
+          notify: rule.notify ?? true,
           sortOrder: rule.sortOrder,
           intervalSeconds: rule.intervalSeconds ?? null,
           actionCondition,
@@ -1427,6 +1438,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
       trackerPattern: input.applyToAllTrackers ? "*" : trackerDomains.join(","),
       enabled: input.enabled,
       dryRun: input.dryRun,
+      notify: input.notify,
       sortOrder: input.sortOrder,
       intervalSeconds: input.intervalSeconds,
       conditions,
@@ -3602,6 +3614,16 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
                   />
                   <Label htmlFor="rule-dry-run" className="text-sm font-normal cursor-pointer">Dry run</Label>
                 </div>
+                {hasNotificationTargets && (
+                  <div className="flex items-center gap-2">
+                    <Switch
+                      id="rule-notify"
+                      checked={formState.notify}
+                      onCheckedChange={(checked) => setFormState(prev => ({ ...prev, notify: checked }))}
+                    />
+                    <Label htmlFor="rule-notify" className="text-sm font-normal cursor-pointer">Notify</Label>
+                  </div>
+                )}
                 <div className="flex items-center gap-2">
                   <Label htmlFor="rule-interval" className="text-sm font-normal text-muted-foreground whitespace-nowrap">Run every</Label>
                   <Select

--- a/web/src/lib/workflow-utils.ts
+++ b/web/src/lib/workflow-utils.ts
@@ -19,6 +19,7 @@ export interface WorkflowExport {
   sortingConfig?: SortingConfig
   intervalSeconds?: number
   dryRun?: boolean
+  notify?: boolean
 }
 
 const DEFAULT_INTERVAL_SECONDS = 900
@@ -47,6 +48,10 @@ export function toExportFormat(workflow: Automation): WorkflowExport {
 
   if (workflow.dryRun) {
     exported.dryRun = true
+  }
+
+  if (!workflow.notify) {
+    exported.notify = false
   }
 
   return exported
@@ -86,6 +91,7 @@ export function fromImportFormat(
     sortingConfig: data.sortingConfig,
     enabled: false, // Always start disabled
     dryRun: data.dryRun ?? false,
+    notify: data.notify ?? true,
   }
 
   // Include intervalSeconds if specified and differs from default
@@ -187,6 +193,10 @@ export function parseImportJSON(jsonString: string): { data: WorkflowExport; err
   // Optional intervalSeconds
   if (typeof obj.intervalSeconds === "number" && obj.intervalSeconds >= 60) {
     data.intervalSeconds = obj.intervalSeconds
+  }
+
+  if (typeof obj.notify === "boolean") {
+    data.notify = obj.notify
   }
 
   return { data, error: null }

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -455,6 +455,7 @@ export interface Automation {
   sortingConfig?: SortingConfig
   enabled: boolean
   dryRun: boolean
+  notify: boolean
   sortOrder: number
   intervalSeconds?: number | null // null = use global default (15 minutes)
   createdAt?: string
@@ -470,6 +471,7 @@ export interface AutomationInput {
   sortingConfig?: SortingConfig
   enabled?: boolean
   dryRun?: boolean
+  notify?: boolean
   sortOrder?: number
   intervalSeconds?: number | null // null = use global default (15 minutes)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-automation notification toggle to enable/disable notifications.
  * "Notify" switch in the workflow dialog (shown only when notification targets exist).
  * Import/export and previews preserve the notify setting; create/update accept an optional notify value.
  * Notifications default to enabled for existing automations.

* **Behavior Change**
  * Summary notifications are suppressed when none of the involved automations have notifications enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->