### PR TITLE
fix(automations): hardlink signature grouping

### DIFF
--- a/internal/services/automations/evaluator.go
+++ b/internal/services/automations/evaluator.go
@@ -65,8 +65,11 @@ type EvalContext struct {
 	// FilesToClear is a map of cross-seed keys to the amount of disk space that will be cleared by the "free space" condition, ensuring we don't double count cross-seeds (current active source)
 	FilesToClear map[crossSeedKey]struct{}
 	// HardlinkSignatureByHash maps torrent hash to its hardlink signature (sorted file IDs joined with ";").
-	// Only populated when includeHardlinks is enabled for FREE_SPACE rules.
+	// Used for hardlink_signature grouping and grouped-condition evaluation.
 	HardlinkSignatureByHash map[string]string
+	// DeleteSafeHardlinkSignatureByHash maps torrent hash to its hardlink signature for torrents whose
+	// hardlinks stay fully inside qBittorrent. Used only by delete/include-hardlinks FREE_SPACE dedupe.
+	DeleteSafeHardlinkSignatureByHash map[string]string
 	// HardlinkSignaturesToClear tracks hardlink signatures already counted in space projection (current active source).
 	// Torrents with the same signature share physical files and should only be counted once.
 	HardlinkSignaturesToClear map[string]struct{}

--- a/internal/services/automations/hardlink_index.go
+++ b/internal/services/automations/hardlink_index.go
@@ -32,12 +32,21 @@ const hardlinkIndexTTL = 2 * time.Minute
 // It enables O(1) lookups for hardlink expansion and FREE_SPACE projection dedupe.
 type HardlinkIndex struct {
 	// SignatureByHash maps torrent hash to its hardlink signature (hex-encoded sha256 of sorted FileIDs).
-	// Only torrents with all files hard-linked within qBittorrent ("safe" duplicates) are included.
+	// Includes all inspected torrents with hardlinks and is used for hardlink_signature grouping.
 	SignatureByHash map[string]string
 
 	// GroupBySignature maps signature to list of torrent hashes sharing that signature.
 	// Only contains groups with 2+ members (actual duplicates).
 	GroupBySignature map[string][]string
+
+	// DeleteSafeSignatureByHash maps torrent hash to its hardlink signature for torrents whose
+	// hardlinks stay fully inside qBittorrent. Used by delete/include-hardlinks expansion and
+	// FREE_SPACE dedupe so destructive paths never follow outside links.
+	DeleteSafeSignatureByHash map[string]string
+
+	// DeleteSafeGroupBySignature maps signature to list of delete-safe torrent hashes sharing it.
+	// Only contains groups with 2+ members.
+	DeleteSafeGroupBySignature map[string][]string
 
 	// ScopeByHash maps torrent hash to its hardlink scope (none, torrents_only, outside_qbittorrent).
 	// Used for HARDLINK_SCOPE condition evaluation.
@@ -148,10 +157,12 @@ type fileIDTracker struct {
 func (s *Service) buildHardlinkIndex(ctx context.Context, instanceID int, torrents []qbt.Torrent, digest string) *HardlinkIndex {
 	startTime := time.Now()
 	index := &HardlinkIndex{
-		SignatureByHash:  make(map[string]string),
-		GroupBySignature: make(map[string][]string),
-		ScopeByHash:      make(map[string]string),
-		digest:           digest,
+		SignatureByHash:            make(map[string]string),
+		GroupBySignature:           make(map[string][]string),
+		DeleteSafeSignatureByHash:  make(map[string]string),
+		DeleteSafeGroupBySignature: make(map[string][]string),
+		ScopeByHash:                make(map[string]string),
+		digest:                     digest,
 		// builtAt is set at the end of a successful build to avoid TTL issues with slow builds
 	}
 
@@ -304,30 +315,28 @@ func (s *Service) buildHardlinkIndex(ctx context.Context, instanceID int, torren
 
 		index.ScopeByHash[hash] = scope
 
-		if hasOutsideLinks {
-			torrentsWithOutsideLinks++
-		}
-
-		// Include in duplicate index if torrent has hardlinks.
-		// Torrents with outside links are still included — the scope is tracked
-		// separately in ScopeByHash so actions (e.g. delete) can check it independently.
+		// Only include in duplicate index if:
+		// 1. Has hardlinks (otherwise not a duplicate candidate)
 		if !info.hasHardlinks {
 			continue // Not a hardlink duplicate candidate
 		}
 
-		// Compute signature: sha256 of sorted FileIDs
+		if hasOutsideLinks {
+			torrentsWithOutsideLinks++
+		}
+
+		// Compute signature once; feed broad grouping map plus delete-safe subset.
 		sig := computeFileIDSignature(info.fileIDs)
 		index.SignatureByHash[hash] = sig
 		index.GroupBySignature[sig] = append(index.GroupBySignature[sig], hash)
-	}
-
-	// Remove singleton groups (not actual duplicates)
-	for sig, hashes := range index.GroupBySignature {
-		if len(hashes) < 2 {
-			delete(index.GroupBySignature, sig)
-			delete(index.SignatureByHash, hashes[0])
+		if !hasOutsideLinks {
+			index.DeleteSafeSignatureByHash[hash] = sig
+			index.DeleteSafeGroupBySignature[sig] = append(index.DeleteSafeGroupBySignature[sig], hash)
 		}
 	}
+
+	pruneSingletonHardlinkGroups(index.SignatureByHash, index.GroupBySignature)
+	pruneSingletonHardlinkGroups(index.DeleteSafeSignatureByHash, index.DeleteSafeGroupBySignature)
 
 	// Set builtAt at the end of successful build (not start) to avoid TTL issues with slow builds
 	index.builtAt = time.Now()
@@ -341,8 +350,10 @@ func (s *Service) buildHardlinkIndex(ctx context.Context, instanceID int, torren
 		Int("instanceID", instanceID).
 		Int("totalTorrents", len(torrents)).
 		Int("scopeComputed", len(index.ScopeByHash)).
-		Int("duplicateGroups", len(index.GroupBySignature)).
-		Int("duplicateTorrents", len(index.SignatureByHash)).
+		Int("groupingDuplicateGroups", len(index.GroupBySignature)).
+		Int("groupingDuplicateTorrents", len(index.SignatureByHash)).
+		Int("deleteSafeDuplicateGroups", len(index.DeleteSafeGroupBySignature)).
+		Int("deleteSafeDuplicateTorrents", len(index.DeleteSafeSignatureByHash)).
 		Int("outsideLinks", torrentsWithOutsideLinks).
 		Int("inaccessible", torrentsInaccessible).
 		Int("invalidPaths", torrentsInvalidPaths).
@@ -350,6 +361,18 @@ func (s *Service) buildHardlinkIndex(ctx context.Context, instanceID int, torren
 		Msg("automations: hardlink index built")
 
 	return index
+}
+
+func pruneSingletonHardlinkGroups(signatureByHash map[string]string, groupsBySignature map[string][]string) {
+	for sig, hashes := range groupsBySignature {
+		if len(hashes) >= 2 {
+			continue
+		}
+		delete(groupsBySignature, sig)
+		if len(hashes) == 1 {
+			delete(signatureByHash, hashes[0])
+		}
+	}
 }
 
 // computeFileIDSignature creates a compact signature from a list of FileIDs.
@@ -404,12 +427,12 @@ func (idx *HardlinkIndex) GetHardlinkCopies(triggerHash string) []string {
 		return nil
 	}
 
-	sig, ok := idx.SignatureByHash[triggerHash]
+	sig, ok := idx.DeleteSafeSignatureByHash[triggerHash]
 	if !ok {
 		return nil
 	}
 
-	group := idx.GroupBySignature[sig]
+	group := idx.DeleteSafeGroupBySignature[sig]
 	if len(group) <= 1 {
 		return nil
 	}

--- a/internal/services/automations/hardlink_index.go
+++ b/internal/services/automations/hardlink_index.go
@@ -304,15 +304,15 @@ func (s *Service) buildHardlinkIndex(ctx context.Context, instanceID int, torren
 
 		index.ScopeByHash[hash] = scope
 
-		// Only include in duplicate index if:
-		// 1. Has hardlinks (otherwise not a duplicate candidate)
-		// 2. No outside links (safe for expansion)
-		if !info.hasHardlinks {
-			continue // Not a hardlink duplicate candidate
-		}
 		if hasOutsideLinks {
 			torrentsWithOutsideLinks++
-			continue
+		}
+
+		// Include in duplicate index if torrent has hardlinks.
+		// Torrents with outside links are still included — the scope is tracked
+		// separately in ScopeByHash so actions (e.g. delete) can check it independently.
+		if !info.hasHardlinks {
+			continue // Not a hardlink duplicate candidate
 		}
 
 		// Compute signature: sha256 of sorted FileIDs

--- a/internal/services/automations/processor.go
+++ b/internal/services/automations/processor.go
@@ -812,7 +812,7 @@ func parseTorrentTags(tags string) map[string]struct{} {
 // updateCumulativeFreeSpaceCleared updates the cumulative free space cleared for the "free space" condition.
 // Only increments SpaceToClear when deleteFreesSpace returns true for the given mode/torrent.
 // This ensures keep-files and preserve-cross-seeds modes don't over-project freed disk space.
-// When HardlinkSignatureByHash is populated, also dedupes by hardlink signature to avoid
+// When DeleteSafeHardlinkSignatureByHash is populated, also dedupes by hardlink signature to avoid
 // double-counting torrents that share the same physical files via hardlinks.
 func updateCumulativeFreeSpaceCleared(torrent qbt.Torrent, evalCtx *EvalContext, deleteMode string, allTorrents []qbt.Torrent) {
 	if evalCtx == nil || evalCtx.FilesToClear == nil {
@@ -828,8 +828,8 @@ func updateCumulativeFreeSpaceCleared(torrent qbt.Torrent, evalCtx *EvalContext,
 	// Hardlink signature dedupe only makes sense when the delete mode can actually delete the
 	// whole hardlink group via expansion; this avoids affecting other delete modes.
 	if deleteMode == DeleteModeWithFilesIncludeCrossSeeds &&
-		evalCtx.HardlinkSignatureByHash != nil && evalCtx.HardlinkSignaturesToClear != nil {
-		if sig, ok := evalCtx.HardlinkSignatureByHash[torrent.Hash]; ok && sig != "" {
+		evalCtx.DeleteSafeHardlinkSignatureByHash != nil && evalCtx.HardlinkSignaturesToClear != nil {
+		if sig, ok := evalCtx.DeleteSafeHardlinkSignatureByHash[torrent.Hash]; ok && sig != "" {
 			if _, counted := evalCtx.HardlinkSignaturesToClear[sig]; counted {
 				// Already counted this hardlink group
 				return

--- a/internal/services/automations/processor_test.go
+++ b/internal/services/automations/processor_test.go
@@ -875,13 +875,13 @@ func TestUpdateCumulativeFreeSpaceCleared(t *testing.T) {
 		require.Len(t, evalCtx.FilesToClear, 1)
 	})
 
-	t.Run("dedupes by hardlink signature when HardlinkSignatureByHash is set", func(t *testing.T) {
+	t.Run("dedupes by delete-safe hardlink signature when configured", func(t *testing.T) {
 		// Two torrents with different ContentPaths but same hardlink signature
 		// (they share the same physical files via hardlinks)
 		evalCtx := &EvalContext{
 			SpaceToClear: 0,
 			FilesToClear: make(map[crossSeedKey]struct{}),
-			HardlinkSignatureByHash: map[string]string{
+			DeleteSafeHardlinkSignatureByHash: map[string]string{
 				"abc123": "fileID1;fileID2", // Same signature = same physical files
 				"def456": "fileID1;fileID2",
 			},
@@ -918,7 +918,7 @@ func TestUpdateCumulativeFreeSpaceCleared(t *testing.T) {
 		evalCtx := &EvalContext{
 			SpaceToClear: 0,
 			FilesToClear: make(map[crossSeedKey]struct{}),
-			HardlinkSignatureByHash: map[string]string{
+			DeleteSafeHardlinkSignatureByHash: map[string]string{
 				"abc123": "fileID1;fileID2",
 			},
 			HardlinkSignaturesToClear: make(map[string]struct{}),
@@ -946,7 +946,7 @@ func TestUpdateCumulativeFreeSpaceCleared(t *testing.T) {
 		evalCtx := &EvalContext{
 			SpaceToClear: 0,
 			FilesToClear: make(map[crossSeedKey]struct{}),
-			HardlinkSignatureByHash: map[string]string{
+			DeleteSafeHardlinkSignatureByHash: map[string]string{
 				"abc123": "fileID1;fileID2",
 				// def456 has no signature
 			},
@@ -980,11 +980,11 @@ func TestUpdateCumulativeFreeSpaceCleared(t *testing.T) {
 
 	t.Run("hardlink signature dedupe only applies to include-cross-seeds mode", func(t *testing.T) {
 		// With DeleteModeWithFiles, hardlink signature should NOT be used for dedupe,
-		// even if HardlinkSignatureByHash is set (falls through to cross-seed key dedupe)
+		// even if the delete-safe signature map is set (falls through to cross-seed key dedupe)
 		evalCtx := &EvalContext{
 			SpaceToClear: 0,
 			FilesToClear: make(map[crossSeedKey]struct{}),
-			HardlinkSignatureByHash: map[string]string{
+			DeleteSafeHardlinkSignatureByHash: map[string]string{
 				"abc123": "fileID1;fileID2",
 				"def456": "fileID1;fileID2", // Same signature
 			},
@@ -1015,6 +1015,33 @@ func TestUpdateCumulativeFreeSpaceCleared(t *testing.T) {
 		require.Equal(t, int64(100000000000), evalCtx.SpaceToClear)
 		require.Len(t, evalCtx.HardlinkSignaturesToClear, 0) // Not used
 		require.Len(t, evalCtx.FilesToClear, 2)              // Both tracked as separate cross-seed keys
+	})
+
+	t.Run("grouping signatures remain available while delete-safe dedupe runs", func(t *testing.T) {
+		evalCtx := &EvalContext{
+			SpaceToClear: 0,
+			FilesToClear: make(map[crossSeedKey]struct{}),
+			HardlinkSignatureByHash: map[string]string{
+				"abc123": "grouping-sig",
+			},
+			DeleteSafeHardlinkSignatureByHash: map[string]string{
+				"abc123": "delete-sig",
+			},
+			HardlinkSignaturesToClear: make(map[string]struct{}),
+		}
+
+		torrent := qbt.Torrent{
+			Hash:        "abc123",
+			Size:        50000000000,
+			ContentPath: "/data/movie",
+			SavePath:    "/data",
+		}
+
+		updateCumulativeFreeSpaceCleared(torrent, evalCtx, DeleteModeWithFilesIncludeCrossSeeds, []qbt.Torrent{torrent})
+
+		require.Equal(t, map[string]string{"abc123": "grouping-sig"}, evalCtx.HardlinkSignatureByHash)
+		require.Equal(t, map[string]string{"abc123": "delete-sig"}, evalCtx.DeleteSafeHardlinkSignatureByHash)
+		require.Contains(t, evalCtx.HardlinkSignaturesToClear, "delete-sig")
 	})
 }
 

--- a/internal/services/automations/service.go
+++ b/internal/services/automations/service.go
@@ -4524,10 +4524,7 @@ func ruleUsesHardlinkSignatureGrouping(rule *models.Automation) bool {
 		return false
 	}
 
-	grouping := rule.Conditions.Grouping
-	if grouping == nil {
-		return false
-	}
+	grouping := rule.Conditions.Grouping // may be nil for built-in group IDs
 
 	groupUsesHardlinkSignature := func(groupID string) bool {
 		id := strings.TrimSpace(groupID)
@@ -4542,7 +4539,7 @@ func ruleUsesHardlinkSignatureGrouping(rule *models.Automation) bool {
 	}
 
 	// Default group for group-aware conditions (GROUP_SIZE / IS_GROUPED).
-	if groupUsesHardlinkSignature(grouping.DefaultGroupID) {
+	if grouping != nil && groupUsesHardlinkSignature(grouping.DefaultGroupID) {
 		return true
 	}
 
@@ -4557,7 +4554,21 @@ func ruleUsesHardlinkSignatureGrouping(rule *models.Automation) bool {
 		return true
 	}
 
-	return false
+	// Condition-level grouping IDs: scan all condition trees (including tag actions,
+	// external program, etc.) for IS_GROUPED/GROUP_SIZE referencing hardlink_signature.
+	var conditionTreeUsesHardlinkSignature func(cond *models.RuleCondition) bool
+	conditionTreeUsesHardlinkSignature = func(cond *models.RuleCondition) bool {
+		if cond == nil {
+			return false
+		}
+		if (cond.Field == models.FieldGroupSize || cond.Field == models.FieldIsGrouped) &&
+			groupUsesHardlinkSignature(cond.GroupID) {
+			return true
+		}
+		return slices.ContainsFunc(cond.Conditions, conditionTreeUsesHardlinkSignature)
+	}
+
+	return slices.ContainsFunc(conditionTreesForRule(rule), conditionTreeUsesHardlinkSignature)
 }
 
 // buildTrackerDisplayNameMap builds a map from lowercase domain to display name.

--- a/internal/services/automations/service.go
+++ b/internal/services/automations/service.go
@@ -1331,7 +1331,7 @@ func (s *Service) setupHardlinkSignatureContext(evalCtx *EvalContext, hardlinkIn
 	if !ConditionUsesField(cond, FieldFreeSpace) {
 		return
 	}
-	evalCtx.HardlinkSignatureByHash = hardlinkIndex.SignatureByHash
+	evalCtx.DeleteSafeHardlinkSignatureByHash = hardlinkIndex.DeleteSafeSignatureByHash
 	evalCtx.HardlinkSignaturesToClear = make(map[string]struct{})
 }
 
@@ -1997,7 +1997,7 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 		// Build hardlink signature map for FREE_SPACE dedupe if any rule needs it.
 		// Must happen BEFORE processTorrents() so SpaceToClear is correctly deduplicated.
 		if rulesNeedHardlinkSignatureMap(eligibleRules) && hardlinkIndex != nil {
-			evalCtx.HardlinkSignatureByHash = hardlinkIndex.SignatureByHash
+			evalCtx.DeleteSafeHardlinkSignatureByHash = hardlinkIndex.DeleteSafeSignatureByHash
 		}
 	}
 

--- a/internal/services/automations/service.go
+++ b/internal/services/automations/service.go
@@ -4520,7 +4520,7 @@ func rulesUseHardlinkSignatureGrouping(rules []*models.Automation) bool {
 }
 
 func ruleUsesHardlinkSignatureGrouping(rule *models.Automation) bool {
-	if rule == nil || !rule.Enabled || rule.Conditions == nil {
+	if rule == nil || rule.Conditions == nil {
 		return false
 	}
 

--- a/internal/services/automations/service_test.go
+++ b/internal/services/automations/service_test.go
@@ -1446,6 +1446,151 @@ func TestFindCrossSeedGroup(t *testing.T) {
 }
 
 // -----------------------------------------------------------------------------
+// ruleUsesHardlinkSignatureGrouping tests
+// -----------------------------------------------------------------------------
+
+func TestRuleUsesHardlinkSignatureGrouping(t *testing.T) {
+	tests := []struct {
+		name string
+		rule *models.Automation
+		want bool
+	}{
+		{
+			name: "nil rule",
+			rule: nil,
+			want: false,
+		},
+		{
+			name: "disabled rule",
+			rule: &models.Automation{Enabled: false},
+			want: false,
+		},
+		{
+			name: "default group is hardlink_signature",
+			rule: &models.Automation{
+				Enabled: true,
+				Conditions: &models.ActionConditions{
+					Grouping: &models.GroupingConfig{
+						DefaultGroupID: "hardlink_signature",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "delete action GroupID is hardlink_signature",
+			rule: &models.Automation{
+				Enabled: true,
+				Conditions: &models.ActionConditions{
+					Grouping: &models.GroupingConfig{},
+					Delete: &models.DeleteAction{
+						Enabled: true,
+						GroupID: "hardlink_signature",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "tag condition uses IS_GROUPED with hardlink_signature, no grouping config",
+			rule: &models.Automation{
+				Enabled: true,
+				Conditions: &models.ActionConditions{
+					Tags: []*models.TagAction{
+						{
+							Enabled: true,
+							Condition: &models.RuleCondition{
+								Field:   models.FieldIsGrouped,
+								GroupID: "hardlink_signature",
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "tag condition uses GROUP_SIZE with hardlink_signature",
+			rule: &models.Automation{
+				Enabled: true,
+				Conditions: &models.ActionConditions{
+					Tags: []*models.TagAction{
+						{
+							Enabled: true,
+							Condition: &models.RuleCondition{
+								Field:   models.FieldGroupSize,
+								GroupID: "hardlink_signature",
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "nested condition uses hardlink_signature",
+			rule: &models.Automation{
+				Enabled: true,
+				Conditions: &models.ActionConditions{
+					Tags: []*models.TagAction{
+						{
+							Enabled: true,
+							Condition: &models.RuleCondition{
+								Operator: "AND",
+								Conditions: []*models.RuleCondition{
+									{
+										Field:   models.FieldIsGrouped,
+										GroupID: "hardlink_signature",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "tag condition with unrelated groupId",
+			rule: &models.Automation{
+				Enabled: true,
+				Conditions: &models.ActionConditions{
+					Tags: []*models.TagAction{
+						{
+							Enabled: true,
+							Condition: &models.RuleCondition{
+								Field:   models.FieldIsGrouped,
+								GroupID: "cross_seed_content_path",
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "no grouping references at all",
+			rule: &models.Automation{
+				Enabled: true,
+				Conditions: &models.ActionConditions{
+					Delete: &models.DeleteAction{
+						Enabled: true,
+						Mode:    "delete",
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ruleUsesHardlinkSignatureGrouping(tc.rule)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
 // HardlinkIndex.GetHardlinkCopies tests
 // -----------------------------------------------------------------------------
 

--- a/internal/services/automations/service_test.go
+++ b/internal/services/automations/service_test.go
@@ -1466,6 +1466,24 @@ func TestRuleUsesHardlinkSignatureGrouping(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "disabled preview rule still detects hardlink_signature condition usage",
+			rule: &models.Automation{
+				Enabled: false,
+				Conditions: &models.ActionConditions{
+					Tags: []*models.TagAction{
+						{
+							Enabled: true,
+							Condition: &models.RuleCondition{
+								Field:   models.FieldIsGrouped,
+								GroupID: "hardlink_signature",
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
 			name: "default group is hardlink_signature",
 			rule: &models.Automation{
 				Enabled: true,

--- a/internal/services/automations/service_test.go
+++ b/internal/services/automations/service_test.go
@@ -1596,39 +1596,39 @@ func TestRuleUsesHardlinkSignatureGrouping(t *testing.T) {
 
 func TestHardlinkIndex_GetHardlinkCopies(t *testing.T) {
 	tests := []struct {
-		name             string
-		triggerHash      string
-		signatureByHash  map[string]string
-		groupBySignature map[string][]string
-		wantCopies       []string
+		name                      string
+		triggerHash               string
+		deleteSafeSignatureByHash map[string]string
+		deleteSafeGroupBySig      map[string][]string
+		wantCopies                []string
 	}{
 		{
 			name:        "trigger hash not in any group",
 			triggerHash: "not-found",
-			signatureByHash: map[string]string{
+			deleteSafeSignatureByHash: map[string]string{
 				"abc123": "sig1",
 				"def456": "sig1",
 			},
-			groupBySignature: map[string][]string{
+			deleteSafeGroupBySig: map[string][]string{
 				"sig1": {"abc123", "def456"},
 			},
 			wantCopies: nil,
 		},
 		{
-			name:             "trigger is only member of group (singleton filtered out)",
-			triggerHash:      "abc123",
-			signatureByHash:  map[string]string{}, // Singleton groups are filtered, so no entry
-			groupBySignature: map[string][]string{},
-			wantCopies:       nil,
+			name:                      "trigger is only member of group (singleton filtered out)",
+			triggerHash:               "abc123",
+			deleteSafeSignatureByHash: map[string]string{}, // Singleton groups are filtered, so no entry
+			deleteSafeGroupBySig:      map[string][]string{},
+			wantCopies:                nil,
 		},
 		{
 			name:        "trigger has one hardlink copy",
 			triggerHash: "abc123",
-			signatureByHash: map[string]string{
+			deleteSafeSignatureByHash: map[string]string{
 				"abc123": "sig1",
 				"def456": "sig1",
 			},
-			groupBySignature: map[string][]string{
+			deleteSafeGroupBySig: map[string][]string{
 				"sig1": {"abc123", "def456"},
 			},
 			wantCopies: []string{"def456"},
@@ -1636,12 +1636,12 @@ func TestHardlinkIndex_GetHardlinkCopies(t *testing.T) {
 		{
 			name:        "trigger has multiple hardlink copies",
 			triggerHash: "abc123",
-			signatureByHash: map[string]string{
+			deleteSafeSignatureByHash: map[string]string{
 				"abc123": "sig1",
 				"def456": "sig1",
 				"ghi789": "sig1",
 			},
-			groupBySignature: map[string][]string{
+			deleteSafeGroupBySig: map[string][]string{
 				"sig1": {"abc123", "def456", "ghi789"},
 			},
 			wantCopies: []string{"def456", "ghi789"},
@@ -1649,41 +1649,50 @@ func TestHardlinkIndex_GetHardlinkCopies(t *testing.T) {
 		{
 			name:        "multiple groups, trigger in second",
 			triggerHash: "xyz999",
-			signatureByHash: map[string]string{
+			deleteSafeSignatureByHash: map[string]string{
 				"abc123": "sig1",
 				"def456": "sig1",
 				"xyz999": "sig2",
 				"uvw888": "sig2",
 			},
-			groupBySignature: map[string][]string{
+			deleteSafeGroupBySig: map[string][]string{
 				"sig1": {"abc123", "def456"},
 				"sig2": {"xyz999", "uvw888"},
 			},
 			wantCopies: []string{"uvw888"},
 		},
 		{
-			name:             "nil index returns nil",
-			triggerHash:      "abc123",
-			signatureByHash:  nil,
-			groupBySignature: nil,
-			wantCopies:       nil,
+			name:                      "nil index returns nil",
+			triggerHash:               "abc123",
+			deleteSafeSignatureByHash: nil,
+			deleteSafeGroupBySig:      nil,
+			wantCopies:                nil,
 		},
 		{
-			name:             "empty index returns nil",
-			triggerHash:      "abc123",
-			signatureByHash:  map[string]string{},
-			groupBySignature: map[string][]string{},
-			wantCopies:       nil,
+			name:                      "empty index returns nil",
+			triggerHash:               "abc123",
+			deleteSafeSignatureByHash: map[string]string{},
+			deleteSafeGroupBySig:      map[string][]string{},
+			wantCopies:                nil,
+		},
+		{
+			name:                      "grouping-only signatures do not expand deletes",
+			triggerHash:               "abc123",
+			deleteSafeSignatureByHash: map[string]string{},
+			deleteSafeGroupBySig:      map[string][]string{},
+			wantCopies:                nil,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			var idx *HardlinkIndex
-			if tc.signatureByHash != nil || tc.groupBySignature != nil {
+			if tc.deleteSafeSignatureByHash != nil || tc.deleteSafeGroupBySig != nil {
 				idx = &HardlinkIndex{
-					SignatureByHash:  tc.signatureByHash,
-					GroupBySignature: tc.groupBySignature,
+					SignatureByHash:            map[string]string{"abc123": "sig1", "def456": "sig1"},
+					GroupBySignature:           map[string][]string{"sig1": {"abc123", "def456"}},
+					DeleteSafeSignatureByHash:  tc.deleteSafeSignatureByHash,
+					DeleteSafeGroupBySignature: tc.deleteSafeGroupBySig,
 				}
 			}
 			got := idx.GetHardlinkCopies(tc.triggerHash)
@@ -1694,6 +1703,24 @@ func TestHardlinkIndex_GetHardlinkCopies(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSetupHardlinkSignatureContext_UsesDeleteSafeSignatures(t *testing.T) {
+	svc := &Service{}
+	evalCtx := &EvalContext{
+		HardlinkSignatureByHash: map[string]string{"abc123": "grouping-sig"},
+	}
+	hardlinkIndex := &HardlinkIndex{
+		SignatureByHash:           map[string]string{"abc123": "grouping-sig"},
+		DeleteSafeSignatureByHash: map[string]string{"abc123": "delete-sig"},
+	}
+	cond := &RuleCondition{Field: FieldFreeSpace}
+
+	svc.setupHardlinkSignatureContext(evalCtx, hardlinkIndex, cond, false, true)
+
+	require.Equal(t, map[string]string{"abc123": "grouping-sig"}, evalCtx.HardlinkSignatureByHash)
+	require.Equal(t, map[string]string{"abc123": "delete-sig"}, evalCtx.DeleteSafeHardlinkSignatureByHash)
+	require.NotNil(t, evalCtx.HardlinkSignaturesToClear)
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
The automations "hardlink signature" group doesn't work as I expect it to. The description says it will "group torrents that share the same physical files via hardlinks", but if I make an automation to tag all hardlink signature groups, nothing is tagged. I would expect all of my torrents that share hardlinked files to be tagged.

It's possible that I have a misunderstanding about how the grouping is supposed to work—and from searching discord other users seem to as well. But assuming I'm not wrong, I think the issue was the following:

`ruleUsesHardlinkSignatureGrouping` only checked action-level GroupIDs (Delete, Category, Move) and the DefaultGroupID. It never scanned condition trees, so `IS_GROUPED`/`GROUP_SIZE` conditions referencing `hardlink_signature` (e.g. in tag actions) silently evaluated to false because `HardlinkSignatureByHash` was never populated.

Additionally, torrents with any outside hardlinks were excluded from signature grouping entirely, preventing grouping for the common case where files are also hardlinked to a media library.

Fix both issues:
- Scan all condition trees (via conditionTreesForRule) for IS_GROUPED/GROUP_SIZE referencing hardlink_signature
- Allow rules without an explicit Grouping config to use built-in group IDs like hardlink_signature
- Include torrents with outside links in signature grouping; the scope is still tracked in ScopeByHash for actions to check independently

I've tested this locally and it fixes my issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broad hardlink grouping now includes all torrents with hardlinks and consistently prunes singleton groups.
  * Hardlink expansion (delete/space calculations) now only counts delete-safe duplicates fully inside the client.
  * Rule evaluation properly detects hardlink-signature grouping even in nested or missing grouping configurations.

* **Tests**
  * Added and updated tests covering grouping detection, delete-safe signature behavior, dedupe logic, and context setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->