### PR TITLE
fix(web): improve duplicate torrent state and check another field.state.value type in AddTorrentDialog

### DIFF
--- a/web/src/components/torrents/AddTorrentDialog.tsx
+++ b/web/src/components/torrents/AddTorrentDialog.tsx
@@ -222,7 +222,6 @@ export function AddTorrentDialog({ instanceId, open: controlledOpen, onOpenChang
   const checkForDuplicates = useCallback(async (files: File[] | null, urls: string) => {
     duplicateCheckRequestRef.current += 1
     const requestId = duplicateCheckRequestRef.current
-    setDuplicateSummary(createEmptyDuplicateSummary())
     setDuplicateCheckStatus("pending")
     if (duplicateCheckIndicatorTimeoutRef.current !== null) {
       window.clearTimeout(duplicateCheckIndicatorTimeoutRef.current)
@@ -674,7 +673,7 @@ export function AddTorrentDialog({ instanceId, open: controlledOpen, onOpenChang
 
     // Check for duplicates when files are dropped
     if (allFiles.length > 0) {
-      checkForDuplicates(allFiles, "")
+      checkForDuplicates(allFiles, form.getFieldValue("urls"))
     }
   }, [form, checkForDuplicates])
 
@@ -1039,7 +1038,7 @@ export function AddTorrentDialog({ instanceId, open: controlledOpen, onOpenChang
                           onChange={(e) => {
                             field.handleChange(e.target.value)
                             // Check for duplicates when URLs are entered
-                            checkForDuplicates(null, e.target.value)
+                            checkForDuplicates(form.getFieldValue("torrentFiles"), e.target.value)
                           }}
                         />
                         {duplicateUrlKeys.length > 0 && (

--- a/web/src/components/torrents/AddTorrentDialog.tsx
+++ b/web/src/components/torrents/AddTorrentDialog.tsx
@@ -975,7 +975,7 @@ export function AddTorrentDialog({ instanceId, open: controlledOpen, onOpenChang
                         {showFileList && field.state.value && field.state.value.length > 0 && (
                           <div className="max-h-24 overflow-y-auto border rounded-md p-2">
                             <div className="space-y-1 text-xs">
-                              {field.state.value.map((file, index) => {
+                              {Array.isArray(field.state.value) && field.state.value.map((file, index) => {
                                 const fileKey = createFileKey(file)
                                 const duplicateInfo = duplicateFileEntries[fileKey]
                                 const isDuplicate = Boolean(duplicateInfo)


### PR DESCRIPTION
In the `AddTorrentDialog` component adding a new torrent either through a file or a URL, the previous torrents are not passed to `checkForDuplicates`, so the state is not correct after adding a new torrent of the opposite type.

The `checkForDuplicates` function sets the `duplicateSummary` state to an empty summary every time it is called, this causes unnecessary UI changes and flashing, removing the function call does not seem to have an impact on the UI or state since the `duplicateSummary` state is initialized with an empty state and set to empty when the dialog is open. Removing this function call prevents the flickering from state changes.

This also includes a check like in #1613 for another line, CodeRabbit suggested this change and while testing the duplicate torrent issue I ran into a crash that can be fixed with the type check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate detection to properly consider both torrent files and URLs when checking for duplicates in the Add Torrent dialog.
  * Improved stability of the dropped-file list rendering to prevent errors with invalid data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->