### PR TITLE
fix(backups): gate bulk save on resolved instance capabilities

### DIFF
--- a/web/src/pages/InstanceBackups.tsx
+++ b/web/src/pages/InstanceBackups.tsx
@@ -153,13 +153,15 @@ export function InstanceBackups() {
     })),
   })
 
+  const instanceCapabilitiesPending = (instances?.length ?? 0) > 0
+    && instanceCapabilitiesQueries.some(query => query.isPending)
+
   // Filter instances to only show those that support backups
   const supportedInstances = useMemo(() => {
     if (!instances) return []
     return instances.filter((_inst, index) => {
       const capabilitiesData = instanceCapabilitiesQueries[index]?.data
-      // If capabilities haven't loaded yet, assume supported to avoid flickering
-      return capabilitiesData?.supportsTorrentExport ?? true
+      return capabilitiesData?.supportsTorrentExport === true
     })
   }, [instances, instanceCapabilitiesQueries])
 
@@ -173,12 +175,15 @@ export function InstanceBackups() {
     if (!instances) {
       return
     }
+    if (instanceCapabilitiesPending) {
+      return
+    }
 
     const stillSupported = supportedInstances.some(inst => inst.id === selectedInstanceId)
     if (!stillSupported) {
       setSelectedInstanceId(undefined)
     }
-  }, [selectedInstanceId, setSelectedInstanceId, supportedInstances, instances])
+  }, [selectedInstanceId, setSelectedInstanceId, supportedInstances, instances, instanceCapabilitiesPending])
 
   const instanceId = selectedInstanceId
 
@@ -213,7 +218,7 @@ export function InstanceBackups() {
     offset: backupsOffset,
     enabled: shouldLoadData,
   })
-  const runs = runsResponse?.runs ?? []
+  const runs = useMemo(() => runsResponse?.runs ?? [], [runsResponse?.runs])
   const queryClient = useQueryClient()
   const { data: firstPageResponse } = useBackupRuns(instanceId ?? 0, {
     limit: BACKUPS_PER_PAGE,
@@ -581,12 +586,13 @@ export function InstanceBackups() {
   }
 
   const [savingAll, setSavingAll] = useState(false)
+  const saveAllDisabled = saveDisabled || savingAll || instanceCapabilitiesPending
 
   const handleSaveAll = async () => {
     if (!formState) return
     setSavingAll(true)
     const results = await Promise.allSettled(
-      (supportedInstances ?? []).map(inst => api.updateBackupSettings(inst.id, formState)),
+      (supportedInstances ?? []).map(inst => api.updateBackupSettings(inst.id, formState))
     )
     const failed = results.filter((result): result is PromiseRejectedResult => result.status === "rejected")
 
@@ -759,9 +765,9 @@ export function InstanceBackups() {
 
   // Show instance selector when no instance is selected
   if (!instanceId) {
-    const selectionHeading = hasSupportedInstances? "Select an instance to manage backups": hasInstances? "No compatible instances found": "Connect a qBittorrent instance"
+    const selectionHeading = instanceCapabilitiesPending? "Checking instance compatibility": hasSupportedInstances? "Select an instance to manage backups": hasInstances? "No compatible instances found": "Connect a qBittorrent instance"
 
-    const selectionMessage = !hasInstances? "No qBittorrent instances configured. Add an instance first to use the backup feature.": hasSupportedInstances? "Choose a qBittorrent instance from the dropdown above to view and manage its backups.": "None of your qBittorrent instances support torrent backups yet. Upgrade to qBittorrent 4.5.0+ (Web API 2.8.11+) to enable this feature."
+    const selectionMessage = !hasInstances? "No qBittorrent instances configured. Add an instance first to use the backup feature.": instanceCapabilitiesPending? "Checking which instances support torrent backups.": hasSupportedInstances? "Choose a qBittorrent instance from the dropdown above to view and manage its backups.": "None of your qBittorrent instances support torrent backups yet. Upgrade to qBittorrent 4.5.0+ (Web API 2.8.11+) to enable this feature."
 
     return (
       <TooltipProvider>
@@ -812,7 +818,7 @@ export function InstanceBackups() {
                 <p className="text-lg font-medium">{selectionHeading}</p>
                 <p className="text-sm text-muted-foreground max-w-md">{selectionMessage}</p>
               </div>
-              {!hasSupportedInstances && (
+              {!hasSupportedInstances && !instanceCapabilitiesPending && (
                 <Button variant="outline" asChild>
                   <Link to="/instances">
                     Go to Instances
@@ -1078,7 +1084,8 @@ export function InstanceBackups() {
                     <Button
                       variant="outline"
                       onClick={handleSaveAll}
-                      disabled={saveDisabled || savingAll}
+                      disabled={saveAllDisabled}
+                      title={instanceCapabilitiesPending ? "Wait for instance capability checks to finish before saving to all instances." : undefined}
                     >
                       <Save className="mr-2 h-4 w-4" /> Save changes to all instances
                     </Button>


### PR DESCRIPTION
Bulk backup save treated unresolved capability checks as supported, so mixed-capability setups could briefly send backup-settings updates to unsupported instances.

This only treats explicit backup support as eligible for bulk save and keeps the bulk-save action disabled until instance capability checks finish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time compatibility checking with improved UI feedback during instance capability verification.

* **Bug Fixes**
  * Fixed instance filtering to accurately reflect supported instances based on capability data.
  * Improved instance selection to prevent unintended changes while compatibility checks are in progress.

* **Refactor**
  * Enhanced empty-state messaging and button visibility to reflect compatibility checking status.
  * Updated "Save changes to all instances" button with appropriate disabled state and contextual messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->