### PR TITLE
fix(web): restore unified actions in narrow menus

### DIFF
--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -4,6 +4,7 @@
  */
 
 import { InstancePreferencesDialog } from "@/components/instances/preferences/InstancePreferencesDialog"
+import { UnifiedActionMenuSection } from "@/components/layout/UnifiedActionMenuSection"
 import { UnifiedScopeDropdownSection } from "@/components/layout/UnifiedScopeDropdownSection"
 import { AddTorrentDialog } from "@/components/torrents/AddTorrentDialog"
 import { TorrentCreationTasks } from "@/components/torrents/TorrentCreationTasks"
@@ -12,7 +13,7 @@ import {
   Dialog,
   DialogContent,
   DialogHeader,
-  DialogTitle,
+  DialogTitle
 } from "@/components/ui/dialog"
 import { TorrentManagementBar } from "@/components/torrents/TorrentManagementBar"
 import { Badge } from "@/components/ui/badge"
@@ -45,6 +46,7 @@ import { usePersistedCompactViewState } from "@/hooks/usePersistedCompactViewSta
 import { usePersistedFilterSidebarState } from "@/hooks/usePersistedFilterSidebarState"
 import { usePersistedUnifiedInstanceFilter } from "@/hooks/usePersistedUnifiedInstanceFilter"
 import { useTheme } from "@/hooks/useTheme"
+import { useUnifiedActionInstances } from "@/hooks/useUnifiedActionInstances"
 import { api } from "@/lib/api"
 import {
   ALL_INSTANCES_ID,
@@ -53,7 +55,7 @@ import {
 } from "@/lib/instances"
 import { cn } from "@/lib/utils"
 import type { InstanceCapabilities } from "@/types"
-import { useQueries, useQuery } from "@tanstack/react-query"
+import { useQuery } from "@tanstack/react-query"
 import { Link, useNavigate, useSearch } from "@tanstack/react-router"
 import { Archive, ChevronsUpDown, Cog, Download, FileEdit, FileText, FunnelPlus, FunnelX, GitBranch, HardDrive, Home, Info, ListTodo, Loader2, LogOut, Menu, Plus, Rss, Search, SearchCode, Server, Settings, X, Zap } from "lucide-react"
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react"
@@ -106,7 +108,7 @@ function UnifiedActionDropdown({ icon, tooltip, label, instances, onSelectInstan
             <span
               className={cn(
                 "ml-2 h-2 w-2 rounded-full flex-shrink-0",
-                instance.connected ? "bg-green-500" : "bg-red-500",
+                instance.connected ? "bg-green-500" : "bg-red-500"
               )}
             />
           </DropdownMenuItem>
@@ -162,28 +164,11 @@ export function Header({
     [persistedUnifiedFilter, activeInstanceIds]
   )
   const effectiveUnifiedInstanceIds = normalizedUnifiedInstanceIds.length > 0? normalizedUnifiedInstanceIds: activeInstanceIds
-  const unifiedScopeInstances = useMemo(
-    () => activeInstances.filter(instance => effectiveUnifiedInstanceIds.includes(instance.id)),
-    [activeInstances, effectiveUnifiedInstanceIds]
-  )
-  const unifiedManageableInstances = useMemo(
-    () => unifiedScopeInstances.filter((instance) => instance.id > 0),
-    [unifiedScopeInstances],
-  )
-  const unifiedCapabilitiesResults = useQueries({
-    queries: unifiedManageableInstances.map((instance) => ({
-      queryKey: ["instance-capabilities", instance.id],
-      queryFn: () => api.getInstanceCapabilities(instance.id),
-      staleTime: 60_000,
-      enabled: isAllInstancesRoute,
-    })),
+  const { unifiedManageableInstances, unifiedTorrentCreationInstances } = useUnifiedActionInstances({
+    activeInstances,
+    effectiveUnifiedInstanceIds,
+    enabled: isAllInstancesRoute,
   })
-  const unifiedTorrentCreationInstances = useMemo(
-    () => unifiedManageableInstances.filter((_instance, i) =>
-      unifiedCapabilitiesResults[i]?.data?.supportsTorrentCreation === true
-    ),
-    [unifiedManageableInstances, unifiedCapabilitiesResults],
-  )
   const applyUnifiedScope = useCallback((nextIds: number[]) => {
     const normalizedIds = normalizeUnifiedInstanceIds(nextIds, activeInstanceIds)
     saveUnifiedFilter(normalizedIds)
@@ -308,11 +293,11 @@ export function Header({
   // Derived at render time — avoids a cleanup Effect for stale IDs
   const validUnifiedIds = useMemo(
     () => new Set(unifiedManageableInstances.map((instance) => instance.id)),
-    [unifiedManageableInstances],
+    [unifiedManageableInstances]
   )
   const validUnifiedTorrentCreationIds = useMemo(
     () => new Set(unifiedTorrentCreationInstances.map((instance) => instance.id)),
-    [unifiedTorrentCreationInstances],
+    [unifiedTorrentCreationInstances]
   )
 
   useEffect(() => {
@@ -859,6 +844,14 @@ export function Header({
                       </DropdownMenuItem>
                     )
                   })}
+                  <UnifiedActionMenuSection
+                    manageableInstances={unifiedManageableInstances}
+                    torrentCreationInstances={unifiedTorrentCreationInstances}
+                    onSelectAddTorrentInstance={setUnifiedAddTorrentInstanceId}
+                    onSelectCreateTorrentInstance={setUnifiedCreateTorrentInstanceId}
+                    onSelectTasksInstance={setUnifiedTasksInstanceId}
+                    onSelectSettingsInstance={setUnifiedSettingsInstanceId}
+                  />
                 </>
               ) : (
                 <DropdownMenuItem disabled className="text-xs text-muted-foreground">

--- a/web/src/components/layout/MobileFooterNav.tsx
+++ b/web/src/components/layout/MobileFooterNav.tsx
@@ -3,7 +3,12 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
+import { InstancePreferencesDialog } from "@/components/instances/preferences/InstancePreferencesDialog"
+import { UnifiedActionMenuSection } from "@/components/layout/UnifiedActionMenuSection"
 import { UnifiedScopeDropdownSection } from "@/components/layout/UnifiedScopeDropdownSection"
+import { AddTorrentDialog } from "@/components/torrents/AddTorrentDialog"
+import { TorrentCreationTasks } from "@/components/torrents/TorrentCreationTasks"
+import { TorrentCreatorDialog } from "@/components/torrents/TorrentCreatorDialog"
 import { Badge } from "@/components/ui/badge"
 import {
   Dialog,
@@ -26,6 +31,7 @@ import { useAuth } from "@/hooks/useAuth"
 import { useCrossSeedInstanceState } from "@/hooks/useCrossSeedInstanceState"
 import { useHasPremiumAccess } from "@/hooks/useLicense"
 import { usePersistedUnifiedInstanceFilter } from "@/hooks/usePersistedUnifiedInstanceFilter"
+import { useUnifiedActionInstances } from "@/hooks/useUnifiedActionInstances"
 import { api } from "@/lib/api"
 import { getAppVersion } from "@/lib/build-info"
 import { canSwitchToPremiumTheme } from "@/lib/license-entitlement"
@@ -140,6 +146,11 @@ export function MobileFooterNav() {
     [persistedUnifiedFilter, activeInstanceIds]
   )
   const effectiveUnifiedInstanceIds = normalizedUnifiedInstanceIds.length > 0? normalizedUnifiedInstanceIds: activeInstanceIds
+  const { unifiedManageableInstances, unifiedTorrentCreationInstances } = useUnifiedActionInstances({
+    activeInstances,
+    effectiveUnifiedInstanceIds,
+    enabled: isOnAllInstancesPage,
+  })
   const hasMultipleActiveInstances = activeInstances.length > 1
   const applyUnifiedScope = useCallback((nextIds: number[]) => {
     const normalizedIds = normalizeUnifiedInstanceIds(nextIds, activeInstanceIds)
@@ -170,6 +181,18 @@ export function MobileFooterNav() {
   const currentInstanceId = !isOnAllInstancesPage && location.pathname.startsWith("/instances/") ? location.pathname.split("/")[2] : null
   const currentInstance = instances?.find(i => i.id.toString() === currentInstanceId)
   const currentInstanceLabel = isOnAllInstancesPage? (hasMultipleActiveInstances ? "Unified" : (activeInstances[0]?.name ?? null)): (currentInstance && currentInstance.isActive ? currentInstance.name : null)
+  const [unifiedAddTorrentInstanceId, setUnifiedAddTorrentInstanceId] = useState<number | null>(null)
+  const [unifiedCreateTorrentInstanceId, setUnifiedCreateTorrentInstanceId] = useState<number | null>(null)
+  const [unifiedTasksInstanceId, setUnifiedTasksInstanceId] = useState<number | null>(null)
+  const [unifiedSettingsInstanceId, setUnifiedSettingsInstanceId] = useState<number | null>(null)
+  const validUnifiedIds = useMemo(
+    () => new Set(unifiedManageableInstances.map((instance) => instance.id)),
+    [unifiedManageableInstances]
+  )
+  const validUnifiedTorrentCreationIds = useMemo(
+    () => new Set(unifiedTorrentCreationInstances.map((instance) => instance.id)),
+    [unifiedTorrentCreationInstances]
+  )
 
   const handleModeSelect = useCallback(async (mode: ThemeMode) => {
     await setThemeMode(mode)
@@ -351,6 +374,14 @@ export function MobileFooterNav() {
                       </DropdownMenuItem>
                     )
                   })}
+                  <UnifiedActionMenuSection
+                    manageableInstances={unifiedManageableInstances}
+                    torrentCreationInstances={unifiedTorrentCreationInstances}
+                    onSelectAddTorrentInstance={setUnifiedAddTorrentInstanceId}
+                    onSelectCreateTorrentInstance={setUnifiedCreateTorrentInstanceId}
+                    onSelectTasksInstance={setUnifiedTasksInstanceId}
+                    onSelectSettingsInstance={setUnifiedSettingsInstanceId}
+                  />
                 </>
               ) : (
                 <DropdownMenuItem disabled className="text-xs text-muted-foreground">
@@ -692,6 +723,53 @@ export function MobileFooterNav() {
           </div>
         </DialogContent>
       </Dialog>
+      {unifiedAddTorrentInstanceId !== null && validUnifiedIds.has(unifiedAddTorrentInstanceId) && (
+        <AddTorrentDialog
+          instanceId={unifiedAddTorrentInstanceId}
+          open={true}
+          onOpenChange={(open) => {
+            if (!open) setUnifiedAddTorrentInstanceId(null)
+          }}
+        />
+      )}
+      {unifiedCreateTorrentInstanceId !== null && validUnifiedTorrentCreationIds.has(unifiedCreateTorrentInstanceId) && (
+        <TorrentCreatorDialog
+          instanceId={unifiedCreateTorrentInstanceId}
+          open={true}
+          onOpenChange={(open) => {
+            if (!open) setUnifiedCreateTorrentInstanceId(null)
+          }}
+        />
+      )}
+      {unifiedTasksInstanceId !== null && validUnifiedTorrentCreationIds.has(unifiedTasksInstanceId) && (() => {
+        const instance = activeInstances.find(i => i.id === unifiedTasksInstanceId)
+        if (!instance) return null
+        return (
+          <Dialog open={true} onOpenChange={(open) => { if (!open) setUnifiedTasksInstanceId(null) }}>
+            <DialogContent className="w-full sm:max-w-screen-sm md:max-w-screen-md lg:max-w-screen-xl xl:max-w-screen-xl max-h-[85vh] overflow-hidden flex flex-col">
+              <DialogHeader>
+                <DialogTitle>Torrent Creation Tasks{instance ? ` — ${instance.name}` : ""}</DialogTitle>
+              </DialogHeader>
+              <div className="flex-1 overflow-auto">
+                <TorrentCreationTasks instanceId={unifiedTasksInstanceId} />
+              </div>
+            </DialogContent>
+          </Dialog>
+        )
+      })()}
+      {unifiedSettingsInstanceId !== null && validUnifiedIds.has(unifiedSettingsInstanceId) && (() => {
+        const instance = activeInstances.find(i => i.id === unifiedSettingsInstanceId)
+        if (!instance) return null
+        return (
+          <InstancePreferencesDialog
+            open={true}
+            onOpenChange={(open) => { if (!open) setUnifiedSettingsInstanceId(null) }}
+            instanceId={unifiedSettingsInstanceId}
+            instanceName={instance.name}
+            instance={instance}
+          />
+        )
+      })()}
     </nav>
   )
 }

--- a/web/src/components/layout/UnifiedActionMenuSection.tsx
+++ b/web/src/components/layout/UnifiedActionMenuSection.tsx
@@ -1,0 +1,113 @@
+import type { ReactNode } from "react"
+
+import {
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger
+} from "@/components/ui/dropdown-menu"
+import type { UnifiedActionInstance } from "@/hooks/useUnifiedActionInstances"
+import { cn } from "@/lib/utils"
+import { Cog, FileEdit, HardDrive, ListTodo, Plus } from "lucide-react"
+
+interface UnifiedActionMenuSectionProps {
+  manageableInstances: UnifiedActionInstance[]
+  torrentCreationInstances: UnifiedActionInstance[]
+  onSelectAddTorrentInstance: (id: number) => void
+  onSelectCreateTorrentInstance: (id: number) => void
+  onSelectTasksInstance: (id: number) => void
+  onSelectSettingsInstance: (id: number) => void
+}
+
+interface UnifiedActionSubmenuProps {
+  icon: ReactNode
+  label: string
+  instances: UnifiedActionInstance[]
+  onSelectInstance: (id: number) => void
+}
+
+function UnifiedActionSubmenu({
+  icon,
+  label,
+  instances,
+  onSelectInstance,
+}: UnifiedActionSubmenuProps) {
+  if (instances.length === 0) {
+    return null
+  }
+
+  return (
+    <DropdownMenuSub>
+      <DropdownMenuSubTrigger>
+        {icon}
+        {label}
+      </DropdownMenuSubTrigger>
+      <DropdownMenuSubContent className="min-w-56">
+        {instances.map((instance) => (
+          <DropdownMenuItem
+            key={instance.id}
+            onSelect={() => onSelectInstance(instance.id)}
+            className="cursor-pointer"
+          >
+            <HardDrive className="h-4 w-4 flex-shrink-0" />
+            <span className="flex-1 truncate">{instance.name}</span>
+            <span
+              className={cn(
+                "ml-2 h-2 w-2 rounded-full flex-shrink-0",
+                instance.connected ? "bg-green-500" : "bg-red-500"
+              )}
+            />
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
+  )
+}
+
+export function UnifiedActionMenuSection({
+  manageableInstances,
+  torrentCreationInstances,
+  onSelectAddTorrentInstance,
+  onSelectCreateTorrentInstance,
+  onSelectTasksInstance,
+  onSelectSettingsInstance,
+}: UnifiedActionMenuSectionProps) {
+  if (manageableInstances.length === 0) {
+    return null
+  }
+
+  return (
+    <>
+      <DropdownMenuSeparator />
+      <DropdownMenuLabel className="text-xs uppercase tracking-wide text-muted-foreground">
+        Actions
+      </DropdownMenuLabel>
+      <UnifiedActionSubmenu
+        icon={<Plus className="h-4 w-4" />}
+        label="Add torrent"
+        instances={manageableInstances}
+        onSelectInstance={onSelectAddTorrentInstance}
+      />
+      <UnifiedActionSubmenu
+        icon={<FileEdit className="h-4 w-4" />}
+        label="Create torrent"
+        instances={torrentCreationInstances}
+        onSelectInstance={onSelectCreateTorrentInstance}
+      />
+      <UnifiedActionSubmenu
+        icon={<ListTodo className="h-4 w-4" />}
+        label="Torrent creation tasks"
+        instances={torrentCreationInstances}
+        onSelectInstance={onSelectTasksInstance}
+      />
+      <UnifiedActionSubmenu
+        icon={<Cog className="h-4 w-4" />}
+        label="Instance settings"
+        instances={manageableInstances}
+        onSelectInstance={onSelectSettingsInstance}
+      />
+    </>
+  )
+}

--- a/web/src/hooks/useUnifiedActionInstances.ts
+++ b/web/src/hooks/useUnifiedActionInstances.ts
@@ -1,0 +1,49 @@
+import { api } from "@/lib/api"
+import { useQueries } from "@tanstack/react-query"
+import { useMemo } from "react"
+
+export interface UnifiedActionInstance {
+  id: number
+  name: string
+  connected: boolean
+}
+
+interface UseUnifiedActionInstancesProps {
+  activeInstances: UnifiedActionInstance[]
+  effectiveUnifiedInstanceIds: readonly number[]
+  enabled: boolean
+}
+
+export function useUnifiedActionInstances({
+  activeInstances,
+  effectiveUnifiedInstanceIds,
+  enabled,
+}: UseUnifiedActionInstancesProps) {
+  const unifiedScopeInstances = useMemo(
+    () => activeInstances.filter(instance => effectiveUnifiedInstanceIds.includes(instance.id)),
+    [activeInstances, effectiveUnifiedInstanceIds]
+  )
+  const unifiedManageableInstances = useMemo(
+    () => unifiedScopeInstances.filter(instance => instance.id > 0),
+    [unifiedScopeInstances]
+  )
+  const unifiedCapabilitiesResults = useQueries({
+    queries: unifiedManageableInstances.map((instance) => ({
+      queryKey: ["instance-capabilities", instance.id],
+      queryFn: () => api.getInstanceCapabilities(instance.id),
+      staleTime: 60_000,
+      enabled,
+    })),
+  })
+  const unifiedTorrentCreationInstances = useMemo(
+    () => unifiedManageableInstances.filter((_instance, i) =>
+      unifiedCapabilitiesResults[i]?.data?.supportsTorrentCreation === true
+    ),
+    [unifiedManageableInstances, unifiedCapabilitiesResults]
+  )
+
+  return {
+    unifiedManageableInstances,
+    unifiedTorrentCreationInstances,
+  }
+}


### PR DESCRIPTION
Adds the unified add/create/tasks/settings actions to the collapsed header menu and the mobile client menu.

Keeps the menu behavior shared so narrow layouts stay in sync with the desktop unified toolbar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unified "Actions" menu section to the header and mobile footer, enabling users to quickly perform operations (add torrents, create torrents, manage tasks, adjust settings) across multiple instances from a single dropdown menu with connection status indicators.

* **Refactor**
  * Optimized instance capability data retrieval for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->