### PR TITLE
fix(crossseed): tone down async cache reuse log

### DIFF
--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -8550,13 +8550,13 @@ func (s *Service) filterIndexerIDsForTorrentAsync(ctx context.Context, instanceI
 		if existing, found := s.asyncFilteringCache.Get(cacheKey); found {
 			existingSnapshot := existing.Clone()
 			if existingSnapshot != nil && existingSnapshot.ContentCompleted {
-				log.Warn().
+				log.Trace().
 					Str("torrentHash", hash).
 					Int("instanceID", instanceID).
 					Str("cacheKey", cacheKey).
 					Bool("existingContentCompleted", existingSnapshot.ContentCompleted).
 					Int("existingFilteredCount", len(existingSnapshot.FilteredIndexers)).
-					Msg("[CROSSSEED-ASYNC] WARNING: Avoiding overwrite of completed content filtering")
+					Msg("[crossseed-async] Reusing completed content-filtering cache entry")
 
 				var torrentInfo *TorrentInfo
 				asyncAnalysis, err := s.AnalyzeTorrentForSearchAsync(ctx, instanceID, hash, false)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted internal logging level for cache entry reuse detection, improving diagnostic output clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->