### PR TITLE
build(deps): add cooldown to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
       github:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: gomod
     directory: /
@@ -19,6 +21,11 @@ updates:
       golang:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
+      semver-patch-days: 3
+      semver-minor-days: 7
+      semver-major-days: 14
 
   - package-ecosystem: npm
     directory: /web
@@ -28,3 +35,8 @@ updates:
       npm:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
+      semver-patch-days: 3
+      semver-minor-days: 7
+      semver-major-days: 14


### PR DESCRIPTION
Enforce a minimum release age before Dependabot opens a PR.

- `github-actions`: 7-day default
- `gomod` / `npm`: patch=3d, minor=7d, major=14d

Security updates bypass cooldown by design (Dependabot behavior, not configurable). Cooldown is GA since July 2025.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dependabot configuration to introduce cooldown periods for dependency updates, spacing out patches, minor, and major version updates according to their severity level across GitHub Actions, Go, and npm packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->