### PR TITLE
fix(web): cross-seed warning in unified view

### DIFF
--- a/web/src/components/torrents/TorrentManagementBar.tsx
+++ b/web/src/components/torrents/TorrentManagementBar.tsx
@@ -94,7 +94,7 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
   const hasActionScope = typeof instanceId === "number" && instanceId >= 0
   const actionInstanceId = hasActionScope ? instanceId : -1
   const metadataInstanceId = actionInstanceId > 0 ? actionInstanceId : 0
-  const supportsCrossSeedDeleteTools = actionInstanceId > 0
+  const supportsCrossSeedDeleteTools = actionInstanceId >= 0
   const supportsCrossSeedBlocklist = actionInstanceId >= 0
 
   // Use shared metadata hook to leverage cache from table and filter sidebar

--- a/web/src/hooks/useCrossSeedWarning.ts
+++ b/web/src/hooks/useCrossSeedWarning.ts
@@ -8,7 +8,8 @@ import { useCallback, useMemo, useState } from "react"
 
 import { api } from "@/lib/api"
 import { toCompatibleMatch, type CrossSeedTorrent } from "@/lib/cross-seed-utils"
-import type { Torrent } from "@/types"
+import { isAllInstancesScope } from "@/lib/instances"
+import type { CrossInstanceTorrent, Torrent } from "@/types"
 
 interface UseCrossSeedWarningOptions {
   instanceId: number
@@ -35,12 +36,18 @@ export interface CrossSeedWarningResult {
   reset: () => void
 }
 
+function isCrossInstanceTorrent(t: Torrent): t is CrossInstanceTorrent {
+  return "instanceId" in t && typeof (t as CrossInstanceTorrent).instanceId === "number"
+}
+
 /**
- * Hook to detect cross-seeded torrents on the current instance that would be
- * affected when deleting files.
+ * Hook to detect cross-seeded torrents that would be affected when deleting files.
  *
  * Search is opt-in - call `search()` to check for cross-seeds.
  * Checks ALL selected torrents, not just the first one.
+ *
+ * In unified (all-instances) view, resolves each torrent's instance from its
+ * own instanceId field (CrossInstanceTorrent) and checks per-instance.
  */
 export function useCrossSeedWarning({
   instanceId,
@@ -50,6 +57,8 @@ export function useCrossSeedWarning({
   const [searchState, setSearchState] = useState<CrossSeedSearchState>("idle")
   const [affectedTorrents, setAffectedTorrents] = useState<CrossSeedTorrent[]>([])
   const [checkedCount, setCheckedCount] = useState(0)
+
+  const isUnified = isAllInstancesScope(instanceId)
 
   const hashesBeingDeleted = useMemo(
     () => new Set(torrents.map(t => t.hash)),
@@ -69,39 +78,62 @@ export function useCrossSeedWarning({
   )
 
   const search = useCallback(async () => {
-    if (!instance || torrents.length === 0) return
+    if (torrents.length === 0) return
+
+    // In single-instance view, we need the instance to exist.
+    // In unified view, we resolve per torrent.
+    if (!isUnified && !instance) return
 
     setSearchState("searching")
     setCheckedCount(0)
     setAffectedTorrents([])
 
     const allMatches: CrossSeedTorrent[] = []
-    const seenHashes = new Set<string>()
+    const seenKeys = new Set<string>()
+
+    // Build a lookup for instance names when in unified view
+    const instanceNameLookup = new Map<number, string>()
+    if (isUnified && instances) {
+      for (const inst of instances) {
+        instanceNameLookup.set(inst.id, inst.name)
+      }
+    }
 
     try {
-      // Check each torrent for cross-seeds using backend API
       for (let i = 0; i < torrents.length; i++) {
         const torrent = torrents[i]
 
-        // Use backend API for proper release matching (rls library)
-        // strict=true ensures we fail if overlap checks can't complete (delete safety)
-        const matches = await api.getLocalCrossSeedMatches(instanceId, torrent.hash, true)
+        // Resolve the instance ID and name for this specific torrent
+        let torrentInstanceId: number
+        let torrentInstanceName: string
 
-        // Filter and dedupe matches - only include matches that share the same content_path
+        if (isUnified && isCrossInstanceTorrent(torrent)) {
+          torrentInstanceId = torrent.instanceId
+          torrentInstanceName = instanceNameLookup.get(torrent.instanceId)
+            ?? torrent.instanceName
+            ?? `Instance ${torrent.instanceId}`
+        } else {
+          torrentInstanceId = instanceId
+          torrentInstanceName = instanceName
+        }
+
+        const matches = await api.getLocalCrossSeedMatches(torrentInstanceId, torrent.hash, true)
+
         for (const match of matches) {
-          // Skip if not on this instance
-          if (match.instanceId !== instanceId) continue
+          // Skip if not on the same instance as the torrent being deleted
+          if (match.instanceId !== torrentInstanceId) continue
           // Skip torrents being deleted
           if (hashesBeingDeleted.has(match.hash)) continue
           // Only include matches that share the same on-disk location
           if (match.matchType !== "content_path") continue
-          // Skip duplicates
-          if (seenHashes.has(match.hash)) continue
+          // Skip duplicates (instance-aware to handle same hash on multiple instances)
+          const dedupeKey = isUnified ? `${match.instanceId}:${match.hash}` : match.hash
+          if (seenKeys.has(dedupeKey)) continue
 
-          seenHashes.add(match.hash)
+          seenKeys.add(dedupeKey)
           allMatches.push({
             ...toCompatibleMatch(match),
-            instanceName,
+            instanceName: torrentInstanceName,
           })
         }
 
@@ -114,7 +146,7 @@ export function useCrossSeedWarning({
       console.error("[CrossSeedWarning] Search failed:", error)
       setSearchState("error")
     }
-  }, [instance, torrents, instanceId, instanceName, hashesBeingDeleted])
+  }, [instance, instances, isUnified, torrents, instanceId, instanceName, hashesBeingDeleted])
 
   const reset = useCallback(() => {
     setSearchState("idle")


### PR DESCRIPTION
The cross-seed "Check" button in the delete dialog was dead in unified view. The hook only supported single-instance mode and silently bailed when passed instanceId=0. Now resolves each torrent's instance individually, deduplicates with instance-aware keys, and enables the warning in the management bar for unified scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended cross-seed detection and delete functionality to support multiple torrent instances
  * Enabled cross-seed operations in additional application scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->