### PR TITLE
fix(cross-seed): defer completion search while moving

### DIFF
--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -2065,7 +2065,8 @@ func (s *Service) getCompletionTorrents(ctx context.Context, instanceID int, has
 func isCompletionCheckingState(state qbt.TorrentState) bool {
 	return state == qbt.TorrentStateCheckingDl ||
 		state == qbt.TorrentStateCheckingUp ||
-		state == qbt.TorrentStateCheckingResumeData
+		state == qbt.TorrentStateCheckingResumeData ||
+		state == qbt.TorrentStateMoving
 }
 
 func (s *Service) executeCompletionSearchWithRetry(

--- a/internal/services/crossseed/service_completion_queue_test.go
+++ b/internal/services/crossseed/service_completion_queue_test.go
@@ -516,6 +516,68 @@ func TestHandleTorrentCompletion_DefersWhileChecking(t *testing.T) {
 	}
 }
 
+func TestHandleTorrentCompletion_DefersWhileMoving(t *testing.T) {
+	completionStore := setupCompletionStoreForQueueTests(t)
+
+	hash := "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+	syncMock := newCompletionPollingSyncMock(map[string][]qbt.Torrent{
+		hash: {
+			{
+				Hash:         hash,
+				Name:         "moving",
+				Progress:     1.0,
+				State:        qbt.TorrentStateMoving,
+				CompletionOn: 210,
+			},
+			{
+				Hash:         hash,
+				Name:         "moving",
+				Progress:     1.0,
+				State:        qbt.TorrentStateMoving,
+				CompletionOn: 210,
+			},
+			{
+				Hash:         hash,
+				Name:         "moving",
+				Progress:     1.0,
+				State:        qbt.TorrentStateUploading,
+				CompletionOn: 210,
+			},
+		},
+	})
+
+	invoked := make(chan qbt.Torrent, 1)
+	svc := &Service{
+		completionStore: completionStore,
+		syncManager:     syncMock,
+		automationSettingsLoader: func(context.Context) (*models.CrossSeedAutomationSettings, error) {
+			return models.DefaultCrossSeedAutomationSettings(), nil
+		},
+		completionSearchInvoker: func(_ context.Context, _ int, torrent *qbt.Torrent, _ *models.CrossSeedAutomationSettings, _ *models.InstanceCrossSeedCompletionSettings) error {
+			invoked <- *torrent
+			return nil
+		},
+	}
+	setCompletionCheckingTimings(svc, 5*time.Millisecond, 50*time.Millisecond)
+
+	svc.HandleTorrentCompletion(context.Background(), 1, qbt.Torrent{
+		Hash:         hash,
+		Name:         "moving",
+		Progress:     1.0,
+		State:        qbt.TorrentStateMoving,
+		CompletionOn: 210,
+	})
+
+	select {
+	case torrent := <-invoked:
+		require.Equal(t, qbt.TorrentStateUploading, torrent.State)
+	case <-time.After(time.Second):
+		t.Fatal("completion search was not invoked after moving finished")
+	}
+
+	require.GreaterOrEqual(t, syncMock.hitCount(hash), 3)
+}
+
 func TestHandleTorrentCompletion_RetriesAfterCheckingTimeout(t *testing.T) {
 	completionStore := setupCompletionStoreForQueueTests(t)
 


### PR DESCRIPTION
Treat qBittorrent's moving state as a transient completion state so completion-triggered cross-seed searches wait for temp-dir moves to finish before reading source paths for hardlink/reflink injection. Adds a regression test covering moving-to-uploading before search execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced torrent state handling to properly defer completion checks when torrents are being moved in qBittorrent, improving reliability during file relocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->