### PR TITLE
feat(automations): add AutoTMM condition and action

### DIFF
--- a/documentation/docs/features/automations.md
+++ b/documentation/docs/features/automations.md
@@ -570,6 +570,19 @@ The move path is evaluated as a **Go template** for each torrent. You can use a 
 - By isolation folder: `/data/{{.IsolationFolderName}}`
 - By tracker: `/data/{{.Tracker}}` (when tracker display name is configured)
 
+### Auto Management
+
+Enable or disable qBittorrent's Automatic Torrent Management (AutoTMM) on matching torrents.
+
+| Mode      | Description                                      |
+| --------- | ------------------------------------------------ |
+| `enable`  | Enable automatic torrent management on matches   |
+| `disable` | Disable automatic torrent management on matches  |
+
+When AutoTMM is enabled, qBittorrent automatically moves torrents to the save path configured for their category. Disabling it allows manual control of save paths.
+
+If multiple rules match the same torrent with Auto Management actions, the **last matching rule** (by sort order) wins.
+
 ### External Program
 
 Run a pre-configured external program when torrents match the automation rule. Uses the same programs configured in **Settings → External Programs**.

--- a/internal/models/automation.go
+++ b/internal/models/automation.go
@@ -856,7 +856,8 @@ type ActionConditions struct {
 	Tags            []*TagAction           `json:"tags,omitempty"` // Preferred multi-tag actions
 	Category        *CategoryAction        `json:"category,omitempty"`
 	Move            *MoveAction            `json:"move,omitempty"`
-	ExternalProgram *ExternalProgramAction `json:"externalProgram,omitempty"`
+	ExternalProgram  *ExternalProgramAction  `json:"externalProgram,omitempty"`
+	AutoManagement   *AutoManagementAction   `json:"autoManagement,omitempty"`
 }
 
 // SpeedLimitAction configures speed limit application with optional conditions.
@@ -895,6 +896,12 @@ type RecheckAction struct {
 
 // ReannounceAction configures force reannounce action with optional conditions.
 type ReannounceAction struct {
+	Enabled   bool           `json:"enabled"`
+	Condition *RuleCondition `json:"condition,omitempty"`
+}
+
+// AutoManagementAction configures automatic torrent management (ATM) with optional conditions.
+type AutoManagementAction struct {
 	Enabled   bool           `json:"enabled"`
 	Condition *RuleCondition `json:"condition,omitempty"`
 }
@@ -995,7 +1002,8 @@ func (ac *ActionConditions) IsEmpty() bool {
 		len(ac.TagActions()) == 0 &&
 		ac.Category == nil &&
 		ac.Move == nil &&
-		ac.ExternalProgram == nil
+		ac.ExternalProgram == nil &&
+		ac.AutoManagement == nil
 }
 
 // Normalize normalizes legacy/new action fields for in-memory use.

--- a/internal/models/automation.go
+++ b/internal/models/automation.go
@@ -856,8 +856,8 @@ type ActionConditions struct {
 	Tags            []*TagAction           `json:"tags,omitempty"` // Preferred multi-tag actions
 	Category        *CategoryAction        `json:"category,omitempty"`
 	Move            *MoveAction            `json:"move,omitempty"`
-	ExternalProgram  *ExternalProgramAction  `json:"externalProgram,omitempty"`
-	AutoManagement   *AutoManagementAction   `json:"autoManagement,omitempty"`
+	ExternalProgram *ExternalProgramAction `json:"externalProgram,omitempty"`
+	AutoManagement  *AutoManagementAction  `json:"autoManagement,omitempty"`
 }
 
 // SpeedLimitAction configures speed limit application with optional conditions.

--- a/internal/models/automation_activity.go
+++ b/internal/models/automation_activity.go
@@ -29,6 +29,7 @@ const (
 	ActivityActionRechecked           = "rechecked"            // Batch force recheck operation
 	ActivityActionReannounced         = "reannounced"          // Batch force reannounce operation
 	ActivityActionMoved               = "moved"                // Batch move operation
+	ActivityActionAutoManaged         = "auto_managed"         // Batch auto management operation
 	ActivityActionDryRunNoMatch       = "dry_run_no_match"     // Manual dry-run completed with no matching actions
 )
 

--- a/internal/services/automations/processor.go
+++ b/internal/services/automations/processor.go
@@ -56,6 +56,7 @@ type torrentDesiredState struct {
 
 	// Auto management (last rule wins)
 	shouldAutoManage bool
+	autoManageValue  bool // true = enable ATM, false = disable ATM
 	autoManageRule   ruleRef
 
 	// Tags (accumulated, last action per tag wins)
@@ -390,7 +391,7 @@ func processRuleForTorrent(rule *models.Automation, torrent qbt.Torrent, state *
 	}
 
 	// Auto management (last rule wins)
-	if conditions.AutoManagement != nil && conditions.AutoManagement.Enabled {
+	if conditions.AutoManagement != nil {
 		shouldApply := conditions.AutoManagement.Condition == nil ||
 			EvaluateConditionWithContext(conditions.AutoManagement.Condition, torrent, evalCtx, 0)
 
@@ -398,9 +399,10 @@ func processRuleForTorrent(rule *models.Automation, torrent qbt.Torrent, state *
 			if stats != nil {
 				stats.AutoManageApplied++
 			}
-			// Only enable if not already auto-managed
-			if !torrent.AutoManaged {
+			// Only act if the current state differs from the desired state
+			if torrent.AutoManaged != conditions.AutoManagement.Enabled {
 				state.shouldAutoManage = true
+				state.autoManageValue = conditions.AutoManagement.Enabled
 				state.autoManageRule = ruleRef{id: rule.ID, name: rule.Name}
 			}
 		} else if stats != nil {

--- a/internal/services/automations/processor.go
+++ b/internal/services/automations/processor.go
@@ -54,7 +54,7 @@ type torrentDesiredState struct {
 	shouldReannounce bool
 	reannounceRule   ruleRef
 
-	// Auto management (OR - any rule can trigger)
+	// Auto management (last rule wins)
 	shouldAutoManage bool
 	autoManageRule   ruleRef
 
@@ -398,8 +398,11 @@ func processRuleForTorrent(rule *models.Automation, torrent qbt.Torrent, state *
 			if stats != nil {
 				stats.AutoManageApplied++
 			}
-			state.shouldAutoManage = true
-			state.autoManageRule = ruleRef{id: rule.ID, name: rule.Name}
+			// Only enable if not already auto-managed
+			if !torrent.AutoManaged {
+				state.shouldAutoManage = true
+				state.autoManageRule = ruleRef{id: rule.ID, name: rule.Name}
+			}
 		} else if stats != nil {
 			stats.AutoManageConditionNotMet++
 		}

--- a/internal/services/automations/processor.go
+++ b/internal/services/automations/processor.go
@@ -399,12 +399,12 @@ func processRuleForTorrent(rule *models.Automation, torrent qbt.Torrent, state *
 			if stats != nil {
 				stats.AutoManageApplied++
 			}
-			// Only act if the current state differs from the desired state
-			if torrent.AutoManaged != conditions.AutoManagement.Enabled {
-				state.shouldAutoManage = true
-				state.autoManageValue = conditions.AutoManagement.Enabled
-				state.autoManageRule = ruleRef{id: rule.ID, name: rule.Name}
-			}
+			// Always record the last matching rule's desired state so later
+			// rules can override earlier ones (last rule wins). The actual
+			// API call is skipped when the torrent already has the desired state.
+			state.autoManageValue = conditions.AutoManagement.Enabled
+			state.autoManageRule = ruleRef{id: rule.ID, name: rule.Name}
+			state.shouldAutoManage = torrent.AutoManaged != state.autoManageValue
 		} else if stats != nil {
 			stats.AutoManageConditionNotMet++
 		}

--- a/internal/services/automations/processor.go
+++ b/internal/services/automations/processor.go
@@ -54,6 +54,10 @@ type torrentDesiredState struct {
 	shouldReannounce bool
 	reannounceRule   ruleRef
 
+	// Auto management (OR - any rule can trigger)
+	shouldAutoManage bool
+	autoManageRule   ruleRef
+
 	// Tags (accumulated, last action per tag wins)
 	currentTags  map[string]struct{}
 	tagActions   map[string]string // tag -> "add" | "remove"
@@ -112,6 +116,8 @@ type ruleRunStats struct {
 	RecheckConditionNotMet           int
 	ReannounceApplied                int
 	ReannounceConditionNotMet        int
+	AutoManageApplied                int
+	AutoManageConditionNotMet        int
 	TagConditionMet                  int
 	TagConditionNotMet               int
 	TagSkippedMissingUnregisteredSet int
@@ -131,7 +137,7 @@ func (s *ruleRunStats) totalApplied() int {
 	if s == nil {
 		return 0
 	}
-	return s.SpeedApplied + s.ShareApplied + s.PauseApplied + s.ResumeApplied + s.RecheckApplied + s.ReannounceApplied + s.TagConditionMet + s.CategoryApplied + s.DeleteApplied + s.MoveApplied + s.ExternalProgramApplied
+	return s.SpeedApplied + s.ShareApplied + s.PauseApplied + s.ResumeApplied + s.RecheckApplied + s.ReannounceApplied + s.AutoManageApplied + s.TagConditionMet + s.CategoryApplied + s.DeleteApplied + s.MoveApplied + s.ExternalProgramApplied
 }
 
 func getOrCreateRuleStats(m map[int]*ruleRunStats, rule *models.Automation) *ruleRunStats {
@@ -380,6 +386,22 @@ func processRuleForTorrent(rule *models.Automation, torrent qbt.Torrent, state *
 			state.reannounceRule = ruleRef{id: rule.ID, name: rule.Name}
 		} else if stats != nil {
 			stats.ReannounceConditionNotMet++
+		}
+	}
+
+	// Auto management (last rule wins)
+	if conditions.AutoManagement != nil && conditions.AutoManagement.Enabled {
+		shouldApply := conditions.AutoManagement.Condition == nil ||
+			EvaluateConditionWithContext(conditions.AutoManagement.Condition, torrent, evalCtx, 0)
+
+		if shouldApply {
+			if stats != nil {
+				stats.AutoManageApplied++
+			}
+			state.shouldAutoManage = true
+			state.autoManageRule = ruleRef{id: rule.ID, name: rule.Name}
+		} else if stats != nil {
+			stats.AutoManageConditionNotMet++
 		}
 	}
 
@@ -757,6 +779,7 @@ func hasActions(state *torrentDesiredState) bool {
 		state.shouldResume ||
 		state.shouldRecheck ||
 		state.shouldReannounce ||
+		state.shouldAutoManage ||
 		len(state.tagActions) > 0 ||
 		state.category != nil ||
 		state.shouldDelete ||

--- a/internal/services/automations/service.go
+++ b/internal/services/automations/service.go
@@ -2168,6 +2168,7 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 	resumeHashes := make([]string, 0)
 	recheckHashes := make([]string, 0)
 	reannounceHashes := make([]string, 0)
+	autoManageHashes := make([]string, 0)
 	uploadRuleByHash := make(map[string]ruleRef)
 	downloadRuleByHash := make(map[string]ruleRef)
 	shareRatioRuleByHash := make(map[string]ruleRef)
@@ -2176,6 +2177,7 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 	resumeRuleByHash := make(map[string]ruleRef)
 	recheckRuleByHash := make(map[string]ruleRef)
 	reannounceRuleByHash := make(map[string]ruleRef)
+	autoManageRuleByHash := make(map[string]ruleRef)
 	categoryRuleByHash := make(map[string]ruleRef)
 	moveRuleByHash := make(map[string]ruleRef)
 
@@ -2545,6 +2547,12 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 			reannounceRuleByHash[hash] = state.reannounceRule
 		}
 
+		// Auto management
+		if state.shouldAutoManage {
+			autoManageHashes = append(autoManageHashes, hash)
+			autoManageRuleByHash[hash] = state.autoManageRule
+		}
+
 		// Tags
 		if len(state.tagActions) > 0 {
 			var toAdd, toRemove []string
@@ -2608,6 +2616,7 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 			resumeHashes,
 			recheckHashes,
 			reannounceHashes,
+			autoManageHashes,
 			tagChanges,
 			categoryBatches,
 			moveBatches,
@@ -2931,6 +2940,52 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 				log.Warn().Err(err).Int("instanceID", instanceID).Msg("automations: failed to record reannounce activity")
 			} else if s.activityRuns != nil {
 				items := buildRunItemsFromHashes(reannouncedHashesSuccess, torrentByHash, s.syncManager)
+				if len(items) > 0 {
+					s.activityRuns.Put(activityID, instanceID, items)
+				}
+			}
+		}
+	}
+
+	// Execute auto management actions
+	autoManagedCount := 0
+	autoManagedHashesSuccess := make([]string, 0)
+	if len(autoManageHashes) > 0 {
+		limited := limitHashBatch(autoManageHashes, s.cfg.MaxBatchHashes)
+		for _, batch := range limited {
+			if err := s.syncManager.SetAutoTMM(ctx, instanceID, batch, true); err != nil {
+				log.Warn().Err(err).Int("instanceID", instanceID).Int("count", len(batch)).Msg("automations: auto management action failed")
+			} else {
+				log.Info().Int("instanceID", instanceID).Int("count", len(batch)).Msg("automations: enabled auto management for torrents")
+				autoManagedCount += len(batch)
+				autoManagedHashesSuccess = append(autoManagedHashesSuccess, batch...)
+			}
+		}
+	}
+
+	// Record aggregated auto management activity
+	if autoManagedCount > 0 {
+		detailsJSON, _ := json.Marshal(map[string]any{"count": autoManagedCount})
+		activity := &models.AutomationActivity{
+			InstanceID: instanceID,
+			Hash:       "",
+			Action:     models.ActivityActionAutoManaged,
+			Outcome:    models.ActivityOutcomeSuccess,
+			Details:    detailsJSON,
+		}
+		summary.recordActivity(activity, autoManagedCount)
+		summary.recordRuleCounts(
+			models.ActivityActionAutoManaged,
+			models.ActivityOutcomeSuccess,
+			buildRuleCountsFromHashes(autoManagedHashesSuccess, autoManageRuleByHash),
+		)
+		summary.addTorrentSamples(collectTorrentNamesForHashes(autoManagedHashesSuccess, torrentByHash), 3)
+		if s.activityStore != nil {
+			activityID, err := s.activityStore.CreateWithID(ctx, activity)
+			if err != nil {
+				log.Warn().Err(err).Int("instanceID", instanceID).Msg("automations: failed to record auto management activity")
+			} else if s.activityRuns != nil {
+				items := buildRunItemsFromHashes(autoManagedHashesSuccess, torrentByHash, s.syncManager)
 				if len(items) > 0 {
 					s.activityRuns.Put(activityID, instanceID, items)
 				}
@@ -4878,6 +4933,7 @@ func (s *Service) recordDryRunActivities(
 	resumeHashes []string,
 	recheckHashes []string,
 	reannounceHashes []string,
+	autoManageHashes []string,
 	tagChanges map[string]*tagChange,
 	categoryBatches map[string][]string,
 	moveBatches map[string][]string,
@@ -4985,6 +5041,7 @@ func (s *Service) recordDryRunActivities(
 		{action: models.ActivityActionResumed, hashes: resumeHashes},
 		{action: models.ActivityActionRechecked, hashes: recheckHashes},
 		{action: models.ActivityActionReannounced, hashes: reannounceHashes},
+		{action: models.ActivityActionAutoManaged, hashes: autoManageHashes},
 	} {
 		if len(a.hashes) == 0 {
 			continue

--- a/internal/services/automations/service.go
+++ b/internal/services/automations/service.go
@@ -2168,7 +2168,8 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 	resumeHashes := make([]string, 0)
 	recheckHashes := make([]string, 0)
 	reannounceHashes := make([]string, 0)
-	autoManageHashes := make([]string, 0)
+	autoManageEnableHashes := make([]string, 0)
+	autoManageDisableHashes := make([]string, 0)
 	uploadRuleByHash := make(map[string]ruleRef)
 	downloadRuleByHash := make(map[string]ruleRef)
 	shareRatioRuleByHash := make(map[string]ruleRef)
@@ -2549,7 +2550,11 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 
 		// Auto management
 		if state.shouldAutoManage {
-			autoManageHashes = append(autoManageHashes, hash)
+			if state.autoManageValue {
+				autoManageEnableHashes = append(autoManageEnableHashes, hash)
+			} else {
+				autoManageDisableHashes = append(autoManageDisableHashes, hash)
+			}
 			autoManageRuleByHash[hash] = state.autoManageRule
 		}
 
@@ -2616,7 +2621,7 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 			resumeHashes,
 			recheckHashes,
 			reannounceHashes,
-			autoManageHashes,
+			append(autoManageEnableHashes, autoManageDisableHashes...),
 			tagChanges,
 			categoryBatches,
 			moveBatches,
@@ -2950,13 +2955,23 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 	// Execute auto management actions
 	autoManagedCount := 0
 	autoManagedHashesSuccess := make([]string, 0)
-	if len(autoManageHashes) > 0 {
-		limited := limitHashBatch(autoManageHashes, s.cfg.MaxBatchHashes)
+	for _, group := range []struct {
+		hashes []string
+		enable bool
+		verb   string
+	}{
+		{autoManageEnableHashes, true, "enabled"},
+		{autoManageDisableHashes, false, "disabled"},
+	} {
+		if len(group.hashes) == 0 {
+			continue
+		}
+		limited := limitHashBatch(group.hashes, s.cfg.MaxBatchHashes)
 		for _, batch := range limited {
-			if err := s.syncManager.SetAutoTMM(ctx, instanceID, batch, true); err != nil {
+			if err := s.syncManager.SetAutoTMM(ctx, instanceID, batch, group.enable); err != nil {
 				log.Warn().Err(err).Int("instanceID", instanceID).Int("count", len(batch)).Msg("automations: auto management action failed")
 			} else {
-				log.Info().Int("instanceID", instanceID).Int("count", len(batch)).Msg("automations: enabled auto management for torrents")
+				log.Info().Int("instanceID", instanceID).Int("count", len(batch)).Str("mode", group.verb).Msg("automations: auto management for torrents")
 				autoManagedCount += len(batch)
 				autoManagedHashesSuccess = append(autoManagedHashesSuccess, batch...)
 			}

--- a/internal/services/automations/service.go
+++ b/internal/services/automations/service.go
@@ -4628,6 +4628,9 @@ func actionConditionsUseField(ac *models.ActionConditions, field ConditionField)
 	if ac.Reannounce != nil && ac.Reannounce.Enabled {
 		conds = append(conds, ac.Reannounce.Condition)
 	}
+	if ac.AutoManagement != nil {
+		conds = append(conds, ac.AutoManagement.Condition)
+	}
 	if ac.Delete != nil && ac.Delete.Enabled {
 		conds = append(conds, ac.Delete.Condition)
 	}

--- a/internal/services/automations/service_test.go
+++ b/internal/services/automations/service_test.go
@@ -2205,6 +2205,7 @@ func TestRecordDryRunActivities_Categories_IncludeCrossSeeds_DoesNotRequireCondi
 		nil,
 		nil,
 		nil,
+		nil,
 		categoryBatches,
 		nil,
 		nil,

--- a/internal/services/automations/service_test.go
+++ b/internal/services/automations/service_test.go
@@ -2064,6 +2064,7 @@ func TestRecordDryRunActivities_Deletes(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 		pending,
 		nil,
 		map[string]qbt.Torrent{"abc123": torrent},
@@ -2107,6 +2108,7 @@ func TestRecordDryRunActivities_Resumes(t *testing.T) {
 		nil,
 		nil,
 		[]string{"abc123", "abc123"},
+		nil,
 		nil,
 		nil,
 		nil,
@@ -2259,6 +2261,7 @@ func TestRecordDryRunActivities_NoMatches_LogsSummary(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 		true,
 	)
 
@@ -2309,6 +2312,7 @@ func TestRecordDryRunActivities_CategoryUnknownGroupID_DoesNotPanicAndSkips(t *t
 		_ = s.recordDryRunActivities(
 			context.Background(),
 			1,
+			nil,
 			nil,
 			nil,
 			nil,
@@ -2418,6 +2422,7 @@ func TestRecordDryRunActivities_MoveGroupRequiresAllMembersMatchCondition(t *tes
 		nil,
 		nil,
 		nil,
+		nil,
 		map[string][]string{"/data/moved": {"a"}},
 		nil,
 		nil,
@@ -2449,6 +2454,7 @@ func TestRecordDryRunActivities_NoMatches_DoesNotLogSummaryWhenDisabled(t *testi
 	activities := s.recordDryRunActivities(
 		context.Background(),
 		1,
+		nil,
 		nil,
 		nil,
 		nil,

--- a/web/src/components/instances/preferences/AutomationActivityRunDialog.tsx
+++ b/web/src/components/instances/preferences/AutomationActivityRunDialog.tsx
@@ -48,6 +48,7 @@ const actionLabels: Record<AutomationActivity["action"], string> = {
   reannounced: "Reannounced",
   moved: "Moved",
   external_program: "External program",
+  auto_managed: "Auto managed",
   dry_run_no_match: "Dry-run (no match)",
 }
 

--- a/web/src/components/instances/preferences/WorkflowDialog.tsx
+++ b/web/src/components/instances/preferences/WorkflowDialog.tsx
@@ -202,6 +202,7 @@ function formatDryRunEventSummary(event: AutomationActivity): string {
     case "resumed":
     case "rechecked":
     case "reannounced":
+    case "auto_managed":
     case "external_program":
     case "deleted_ratio":
     case "deleted_seeding":

--- a/web/src/components/instances/preferences/WorkflowDialog.tsx
+++ b/web/src/components/instances/preferences/WorkflowDialog.tsx
@@ -1084,7 +1084,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
           recheckEnabled,
           reannounceEnabled,
           autoManagementEnabled,
-          autoManageMode: conditions.autoManagement?.enabled !== false ? "enable" : "disable",
+          autoManageMode: conditions?.autoManagement?.enabled !== false ? "enable" : "disable",
           deleteEnabled,
           tagEnabled,
           categoryEnabled,

--- a/web/src/components/instances/preferences/WorkflowDialog.tsx
+++ b/web/src/components/instances/preferences/WorkflowDialog.tsx
@@ -105,10 +105,10 @@ const SPEED_LIMIT_UNITS = [
   { value: 1024, label: "MiB/s" },
 ]
 
-type ActionType = "speedLimits" | "shareLimits" | "pause" | "resume" | "recheck" | "reannounce" | "delete" | "tag" | "category" | "move" | "externalProgram"
+type ActionType = "speedLimits" | "shareLimits" | "pause" | "resume" | "recheck" | "reannounce" | "autoManagement" | "delete" | "tag" | "category" | "move" | "externalProgram"
 
 // Actions that can be combined (Delete must be standalone)
-const COMBINABLE_ACTIONS: ActionType[] = ["speedLimits", "shareLimits", "pause", "resume", "recheck", "reannounce", "tag", "category", "move", "externalProgram"]
+const COMBINABLE_ACTIONS: ActionType[] = ["speedLimits", "shareLimits", "pause", "resume", "recheck", "reannounce", "autoManagement", "tag", "category", "move", "externalProgram"]
 
 const ACTION_LABELS: Record<ActionType, string> = {
   speedLimits: "Speed limits",
@@ -117,6 +117,7 @@ const ACTION_LABELS: Record<ActionType, string> = {
   resume: "Resume",
   recheck: "Force recheck",
   reannounce: "Force reannounce",
+  autoManagement: "Auto management",
   delete: "Delete",
   tag: "Tag",
   category: "Category",
@@ -139,6 +140,7 @@ const DRY_RUN_ACTION_LABELS: Record<AutomationActivity["action"], string> = {
   resumed: "Resume",
   rechecked: "Recheck",
   reannounced: "Reannounce",
+  auto_managed: "Auto management",
   moved: "Move",
   external_program: "External program",
   dry_run_no_match: "No matches",
@@ -432,6 +434,7 @@ type FormState = {
   resumeEnabled: boolean
   recheckEnabled: boolean
   reannounceEnabled: boolean
+  autoManagementEnabled: boolean
   deleteEnabled: boolean
   tagEnabled: boolean
   categoryEnabled: boolean
@@ -493,6 +496,7 @@ const emptyFormState: FormState = {
   resumeEnabled: false,
   recheckEnabled: false,
   reannounceEnabled: false,
+  autoManagementEnabled: false,
   deleteEnabled: false,
   tagEnabled: false,
   categoryEnabled: false,
@@ -537,6 +541,7 @@ function getEnabledActions(state: FormState): ActionType[] {
   if (state.resumeEnabled) actions.push("resume")
   if (state.recheckEnabled) actions.push("recheck")
   if (state.reannounceEnabled) actions.push("reannounce")
+  if (state.autoManagementEnabled) actions.push("autoManagement")
   if (state.deleteEnabled) actions.push("delete")
   if (state.tagEnabled) actions.push("tag")
   if (state.categoryEnabled) actions.push("category")
@@ -899,6 +904,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
         let resumeEnabled = false
         let recheckEnabled = false
         let reannounceEnabled = false
+        let autoManagementEnabled = false
         let deleteEnabled = false
         let tagEnabled = false
         let categoryEnabled = false
@@ -971,6 +977,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
             ?? conditions.resume?.condition
             ?? conditions.recheck?.condition
             ?? conditions.reannounce?.condition
+            ?? conditions.autoManagement?.condition
             ?? conditions.delete?.condition
             ?? conditions.tags?.[0]?.condition
             ?? conditions.tag?.condition
@@ -1012,6 +1019,9 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
           }
           if (conditions.reannounce?.enabled) {
             reannounceEnabled = true
+          }
+          if (conditions.autoManagement?.enabled) {
+            autoManagementEnabled = true
           }
           if (conditions.delete?.enabled) {
             deleteEnabled = true
@@ -1070,6 +1080,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
           resumeEnabled,
           recheckEnabled,
           reannounceEnabled,
+          autoManagementEnabled,
           deleteEnabled,
           tagEnabled,
           categoryEnabled,
@@ -1317,6 +1328,12 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
         condition: input.actionCondition ?? undefined,
       }
     }
+    if (input.autoManagementEnabled) {
+      conditions.autoManagement = {
+        enabled: true,
+        condition: input.actionCondition ?? undefined,
+      }
+    }
     if (input.deleteEnabled) {
       conditions.delete = {
         enabled: true,
@@ -1467,6 +1484,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
     formState.resumeEnabled,
     formState.recheckEnabled,
     formState.reannounceEnabled,
+    formState.autoManagementEnabled,
     formState.deleteEnabled,
     formState.tagEnabled,
     formState.categoryEnabled,
@@ -2504,6 +2522,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
                             resumeEnabled: false,
                             recheckEnabled: false,
                             reannounceEnabled: false,
+                            autoManagementEnabled: false,
                             deleteEnabled: true,
                             tagEnabled: false,
                             categoryEnabled: false,
@@ -2877,6 +2896,23 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
                             size="icon"
                             className="h-6 w-6"
                             onClick={() => setFormState(prev => ({ ...prev, reannounceEnabled: false }))}
+                          >
+                            <X className="h-3.5 w-3.5" />
+                          </Button>
+                        </div>
+                      </div>
+                    )}
+                    {/* Auto management */}
+                    {formState.autoManagementEnabled && (
+                      <div className="rounded-lg border p-3">
+                        <div className="flex items-center justify-between">
+                          <Label className="text-sm font-medium">Auto management</Label>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="h-6 w-6"
+                            onClick={() => setFormState(prev => ({ ...prev, autoManagementEnabled: false }))}
                           >
                             <X className="h-3.5 w-3.5" />
                           </Button>

--- a/web/src/components/instances/preferences/WorkflowDialog.tsx
+++ b/web/src/components/instances/preferences/WorkflowDialog.tsx
@@ -435,6 +435,7 @@ type FormState = {
   recheckEnabled: boolean
   reannounceEnabled: boolean
   autoManagementEnabled: boolean
+  autoManageMode: "enable" | "disable"
   deleteEnabled: boolean
   tagEnabled: boolean
   categoryEnabled: boolean
@@ -497,6 +498,7 @@ const emptyFormState: FormState = {
   recheckEnabled: false,
   reannounceEnabled: false,
   autoManagementEnabled: false,
+  autoManageMode: "enable",
   deleteEnabled: false,
   tagEnabled: false,
   categoryEnabled: false,
@@ -1020,7 +1022,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
           if (conditions.reannounce?.enabled) {
             reannounceEnabled = true
           }
-          if (conditions.autoManagement?.enabled) {
+          if (conditions.autoManagement != null) {
             autoManagementEnabled = true
           }
           if (conditions.delete?.enabled) {
@@ -1081,6 +1083,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
           recheckEnabled,
           reannounceEnabled,
           autoManagementEnabled,
+          autoManageMode: conditions.autoManagement?.enabled !== false ? "enable" : "disable",
           deleteEnabled,
           tagEnabled,
           categoryEnabled,
@@ -1330,7 +1333,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
     }
     if (input.autoManagementEnabled) {
       conditions.autoManagement = {
-        enabled: true,
+        enabled: input.autoManageMode === "enable",
         condition: input.actionCondition ?? undefined,
       }
     }
@@ -2905,7 +2908,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
                     )}
                     {/* Auto management */}
                     {formState.autoManagementEnabled && (
-                      <div className="rounded-lg border p-3">
+                      <div className="rounded-lg border p-3 space-y-3">
                         <div className="flex items-center justify-between">
                           <Label className="text-sm font-medium">Auto management</Label>
                           <Button
@@ -2918,6 +2921,18 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
                             <X className="h-3.5 w-3.5" />
                           </Button>
                         </div>
+                        <Select
+                          value={formState.autoManageMode}
+                          onValueChange={(v) => setFormState(prev => ({ ...prev, autoManageMode: v as "enable" | "disable" }))}
+                        >
+                          <SelectTrigger>
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="enable">Enable automatic torrent management</SelectItem>
+                            <SelectItem value="disable">Disable automatic torrent management</SelectItem>
+                          </SelectContent>
+                        </Select>
                       </div>
                     )}
                     {/* Tag */}

--- a/web/src/components/instances/preferences/WorkflowDialog.tsx
+++ b/web/src/components/instances/preferences/WorkflowDialog.tsx
@@ -2556,6 +2556,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
                         <SelectItem value="category">Category</SelectItem>
                         <SelectItem value="move">Move</SelectItem>
                         <SelectItem value="externalProgram">Run external program</SelectItem>
+                        <SelectItem value="autoManagement">Auto management</SelectItem>
                         <SelectItem value="delete" className="text-destructive focus:text-destructive">Delete (standalone only)</SelectItem>
                       </SelectContent>
                     </Select>

--- a/web/src/components/instances/preferences/WorkflowsOverview.tsx
+++ b/web/src/components/instances/preferences/WorkflowsOverview.tsx
@@ -802,6 +802,7 @@ export function WorkflowsOverview({
     reannounced: "bg-fuchsia-500/10 text-fuchsia-500 border-fuchsia-500/20",
     moved: "bg-green-500/10 text-green-500 border-green-500/20",
     external_program: "bg-teal-500/10 text-teal-500 border-teal-500/20",
+    auto_managed: "bg-rose-500/10 text-rose-500 border-rose-500/20",
     dry_run_no_match: "bg-slate-500/10 text-slate-500 border-slate-500/20",
   }
 

--- a/web/src/components/instances/preferences/WorkflowsOverview.tsx
+++ b/web/src/components/instances/preferences/WorkflowsOverview.tsx
@@ -184,6 +184,8 @@ function formatAction(action: AutomationActivity["action"]): string {
       return "Recheck"
     case "reannounced":
       return "Reannounce"
+    case "auto_managed":
+      return "Auto management"
     case "moved":
       return "Move"
     case "external_program":
@@ -297,6 +299,7 @@ const runSummaryActions = new Set<AutomationActivity["action"]>([
   "resumed",
   "rechecked",
   "reannounced",
+  "auto_managed",
   "moved",
 ])
 

--- a/web/src/components/instances/preferences/WorkflowsPanel.tsx
+++ b/web/src/components/instances/preferences/WorkflowsPanel.tsx
@@ -428,6 +428,14 @@ function RuleSummary({ rule }: { rule: Automation }) {
         </Badge>
       )}
 
+      {/* Auto management */}
+      {conditions?.autoManagement?.enabled && (
+        <Badge variant="outline" className="text-[10px] px-1.5 h-5 gap-1 font-normal text-cyan-600 border-cyan-600/50 cursor-default">
+          <Folder className="h-3 w-3" />
+          Auto management
+        </Badge>
+      )}
+
       {/* Delete */}
       {conditions?.delete?.enabled && (
         <Tooltip>

--- a/web/src/components/instances/preferences/WorkflowsPanel.tsx
+++ b/web/src/components/instances/preferences/WorkflowsPanel.tsx
@@ -429,10 +429,10 @@ function RuleSummary({ rule }: { rule: Automation }) {
       )}
 
       {/* Auto management */}
-      {conditions?.autoManagement?.enabled && (
+      {conditions?.autoManagement != null && (
         <Badge variant="outline" className="text-[10px] px-1.5 h-5 gap-1 font-normal text-cyan-600 border-cyan-600/50 cursor-default">
           <Folder className="h-3 w-3" />
-          Auto management
+          {conditions.autoManagement.enabled ? "AutoTMM on" : "AutoTMM off"}
         </Badge>
       )}
 

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -338,6 +338,11 @@ export interface ReannounceAction {
   condition?: RuleCondition
 }
 
+export interface AutoManagementAction {
+  enabled: boolean
+  condition?: RuleCondition
+}
+
 export interface GroupDefinition {
   id: string
   keys: string[]
@@ -410,6 +415,7 @@ export interface ActionConditions {
   category?: CategoryAction
   move?: MoveAction
   externalProgram?: ExternalProgramAction
+  autoManagement?: AutoManagementAction
 }
 
 export type FreeSpaceSource =
@@ -500,7 +506,7 @@ export interface AutomationActivity {
   hash: string
   torrentName?: string
   trackerDomain?: string
-  action: "deleted_ratio" | "deleted_seeding" | "deleted_unregistered" | "deleted_condition" | "delete_failed" | "limit_failed" | "tags_changed" | "category_changed" | "speed_limits_changed" | "share_limits_changed" | "paused" | "resumed" | "rechecked" | "reannounced" | "moved" | "external_program" | "dry_run_no_match"
+  action: "deleted_ratio" | "deleted_seeding" | "deleted_unregistered" | "deleted_condition" | "delete_failed" | "limit_failed" | "tags_changed" | "category_changed" | "speed_limits_changed" | "share_limits_changed" | "paused" | "resumed" | "rechecked" | "reannounced" | "auto_managed" | "moved" | "external_program" | "dry_run_no_match"
   ruleId?: number
   ruleName?: string
   outcome: "success" | "failed" | "dry-run"


### PR DESCRIPTION
## Summary
- Adds a new `auto_managed` automation action that enables or disables qBittorrent's Automatic Torrent Management (AutoTMM) on matching torrents
- Adds an `auto_managed` condition to filter torrents by their current AutoTMM state
- Skips redundant API calls when a torrent already has the desired AutoTMM state

## Test plan
- [x] Unit tests added for evaluator, processor, service, and summary
- [x] All automation tests pass (`go test -race -count=1`)
- [x] Tested on live instance with 10k+ torrents across multiple qBit instances
- [x] Verified enable and disable modes work correctly
- [x] Confirmed redundant API calls are skipped when state already matches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-management added as a configurable rule action (enable/disable) with optional condition and last-rule-wins resolution.
  * Backend applies auto-management in batched executions and records aggregated success/failure stats; dry-run and activity reporting include auto-management.

* **UI**
  * Dry-run summaries, activity logs, dialogs and rule panels show “Auto management” / “Auto managed” labels and badges.

* **Documentation**
  * Docs updated with Auto Management details and precedence rules.

* **Tests**
  * Dry-run tests updated to include the auto-management parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->