### PR TITLE
fix(cross-seed): use correct save path for tracker-named categories in reflink/hardlink mode

### DIFF
--- a/internal/services/crossseed/category_savepath_test.go
+++ b/internal/services/crossseed/category_savepath_test.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package crossseed
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/autobrr/qui/internal/models"
+)
+
+func TestBuildCategorySavePath(t *testing.T) {
+	tests := []struct {
+		name                  string
+		preset                string
+		baseDir               string
+		incomingTrackerDomain string
+		indexerName           string
+		instanceName          string
+		customizations        []*models.TrackerCustomization
+		expected              string
+	}{
+		{
+			name:                  "by-tracker with indexer name",
+			preset:                "by-tracker",
+			baseDir:               "/data/cross-seed",
+			incomingTrackerDomain: "tracker.example.com",
+			indexerName:           "FearNoPeer",
+			instanceName:          "Truenas",
+			expected:              "/data/cross-seed/FearNoPeer",
+		},
+		{
+			name:                  "by-tracker with tracker customization",
+			preset:                "by-tracker",
+			baseDir:               "/data/cross-seed",
+			incomingTrackerDomain: "tracker.lst.example.com",
+			indexerName:           "LST-Fallback",
+			instanceName:          "Truenas",
+			customizations: []*models.TrackerCustomization{
+				{DisplayName: "LST", Domains: []string{"tracker.lst.example.com"}},
+			},
+			expected: "/data/cross-seed/LST",
+		},
+		{
+			name:                  "by-tracker with special characters in name",
+			preset:                "by-tracker",
+			baseDir:               "/data/cross-seed",
+			incomingTrackerDomain: "tracker.oe.example.com",
+			indexerName:           "OnlyEncodes+ (API)",
+			instanceName:          "Truenas",
+			expected:              "/data/cross-seed/OnlyEncodes+ (API)",
+		},
+		{
+			name:                  "by-tracker with no tracker info falls back to Unknown",
+			preset:                "by-tracker",
+			baseDir:               "/data/cross-seed",
+			incomingTrackerDomain: "",
+			indexerName:           "",
+			instanceName:          "Truenas",
+			expected:              "/data/cross-seed/Unknown",
+		},
+		{
+			name:                  "by-instance uses instance name",
+			preset:                "by-instance",
+			baseDir:               "/data/cross-seed",
+			incomingTrackerDomain: "tracker.example.com",
+			indexerName:           "FearNoPeer",
+			instanceName:          "Seedhost-40gb",
+			expected:              "/data/cross-seed/Seedhost-40gb",
+		},
+		{
+			name:                  "flat returns base dir only",
+			preset:                "flat",
+			baseDir:               "/data/cross-seed",
+			incomingTrackerDomain: "tracker.example.com",
+			indexerName:           "FearNoPeer",
+			instanceName:          "Truenas",
+			expected:              "/data/cross-seed",
+		},
+		{
+			name:                  "unknown preset treated as flat",
+			preset:                "something-else",
+			baseDir:               "/data/cross-seed",
+			incomingTrackerDomain: "tracker.example.com",
+			indexerName:           "FearNoPeer",
+			instanceName:          "Truenas",
+			expected:              "/data/cross-seed",
+		},
+		{
+			name:                  "empty preset treated as flat",
+			preset:                "",
+			baseDir:               "/data/cross-seed",
+			incomingTrackerDomain: "tracker.example.com",
+			indexerName:           "FearNoPeer",
+			instanceName:          "Truenas",
+			expected:              "/data/cross-seed",
+		},
+		{
+			name:                  "by-tracker with trailing slash on baseDir",
+			preset:                "by-tracker",
+			baseDir:               "/data/cross-seed/",
+			incomingTrackerDomain: "tracker.example.com",
+			indexerName:           "LST",
+			instanceName:          "Truenas",
+			expected:              "/data/cross-seed/LST",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockStore := &mockTrackerCustomizationStore{
+				customizations: tt.customizations,
+			}
+			if tt.customizations == nil {
+				mockStore.customizations = []*models.TrackerCustomization{}
+			}
+
+			svc := &Service{
+				trackerCustomizationStore: mockStore,
+			}
+
+			instance := &models.Instance{
+				HardlinkDirPreset: tt.preset,
+			}
+
+			candidate := CrossSeedCandidate{
+				InstanceName: tt.instanceName,
+			}
+
+			req := &CrossSeedRequest{
+				IndexerName: tt.indexerName,
+			}
+
+			result := svc.buildCategorySavePath(context.Background(), instance, tt.baseDir, tt.incomingTrackerDomain, candidate, req)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestBuildCategorySavePathDoesNotIncludeIsolationFolder(t *testing.T) {
+	// Verify that buildCategorySavePath never includes torrent-specific isolation folders.
+	// This is the core bug fix — category save paths should be stable directory-level paths
+	// like /data/cross-seed/TrackerName, not torrent-specific paths like
+	// /data/cross-seed/TrackerName/Movie.Name--abc123
+	mockStore := &mockTrackerCustomizationStore{
+		customizations: []*models.TrackerCustomization{},
+	}
+
+	svc := &Service{
+		trackerCustomizationStore: mockStore,
+	}
+
+	instance := &models.Instance{
+		HardlinkDirPreset: "by-tracker",
+	}
+
+	candidate := CrossSeedCandidate{
+		InstanceName: "Truenas",
+	}
+
+	req := &CrossSeedRequest{
+		IndexerName: "TorrentLeech",
+	}
+
+	result := svc.buildCategorySavePath(context.Background(), instance, "/data/cross-seed", "tracker.tl.example.com", candidate, req)
+
+	// Should NOT contain any hash-like suffix or torrent name
+	assert.NotContains(t, result, "--")
+	assert.NotContains(t, result, ".mkv")
+	assert.NotContains(t, result, ".mp4")
+	// Should be exactly the tracker-level directory
+	assert.Equal(t, "/data/cross-seed/TorrentLeech", result)
+}

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -4445,14 +4445,20 @@ func (s *Service) processCrossSeedCandidate(
 			categorySavePath = props.SavePath
 		}
 
-		// Ensure the cross-seed category exists with the correct SavePath
-		if err := s.ensureCrossCategory(ctx, candidate.InstanceID, crossCategory, categorySavePath); err != nil {
-			log.Warn().Err(err).
-				Str("category", crossCategory).
-				Str("savePath", categorySavePath).
-				Msg("[CROSSSEED] Failed to ensure category exists, continuing without category")
-			crossCategory = ""            // Clear category to proceed without it
-			categoryCreationFailed = true // Track for result message
+		// Defer category creation for reflink/hardlink modes — they will create the category
+		// with the correct save path derived from the base directory and tracker/instance name.
+		// This avoids setting incorrect save paths when the category doesn't exist yet and
+		// the fallback to props.SavePath would produce the wrong path.
+		if !useReflinkMode && !useHardlinkMode {
+			// Ensure the cross-seed category exists with the correct SavePath
+			if err := s.ensureCrossCategory(ctx, candidate.InstanceID, crossCategory, categorySavePath); err != nil {
+				log.Warn().Err(err).
+					Str("category", crossCategory).
+					Str("savePath", categorySavePath).
+					Msg("[CROSSSEED] Failed to ensure category exists, continuing without category")
+				crossCategory = ""            // Clear category to proceed without it
+				categoryCreationFailed = true // Track for result message
+			}
 		}
 	}
 
@@ -4485,6 +4491,20 @@ func (s *Service) processCrossSeedCandidate(
 		if hlResult.Used {
 			// Hardlink mode was attempted (regardless of success/failure)
 			return hlResult.Result
+		}
+	}
+
+	// If reflink/hardlink modes were enabled but fell through (Used=false),
+	// the category was never created because we deferred it. Create it now
+	// before entering regular mode using the original categorySavePath.
+	if crossCategory != "" && (useReflinkMode || useHardlinkMode) {
+		if err := s.ensureCrossCategory(ctx, candidate.InstanceID, crossCategory, categorySavePath); err != nil {
+			log.Warn().Err(err).
+				Str("category", crossCategory).
+				Str("savePath", categorySavePath).
+				Msg("[CROSSSEED] Failed to ensure category exists on fallback to regular mode, continuing without category")
+			crossCategory = ""
+			categoryCreationFailed = true
 		}
 	}
 
@@ -11077,6 +11097,21 @@ func (s *Service) processHardlinkMode(
 	// Build destination directory based on preset and torrent structure
 	destDir := s.buildHardlinkDestDir(ctx, instance, selectedBaseDir, torrentHash, torrentName, candidate, incomingTrackerDomain, req, candidateTorrentFilesAll)
 
+	// Ensure cross-seed category exists with the correct save path derived from
+	// the base directory and directory preset, rather than the matched torrent's save path.
+	categoryCreationFailed := false
+	if crossCategory != "" {
+		categorySavePath := s.buildCategorySavePath(ctx, instance, selectedBaseDir, incomingTrackerDomain, candidate, req)
+		if err := s.ensureCrossCategory(ctx, candidate.InstanceID, crossCategory, categorySavePath); err != nil {
+			log.Warn().Err(err).
+				Str("category", crossCategory).
+				Str("savePath", categorySavePath).
+				Msg("[CROSSSEED] Hardlink mode: failed to ensure category exists, continuing without category")
+			crossCategory = ""
+			categoryCreationFailed = true
+		}
+	}
+
 	// Build existing files list (all files on disk from matched torrent).
 	// We pass all existing files to BuildPlan so it can use path/name matching
 	// to select the correct source file for each target.
@@ -11250,7 +11285,15 @@ func (s *Service) processHardlinkMode(
 	}
 
 	// Build result message
-	statusMsg := fmt.Sprintf("Added via hardlink mode (match: %s, files: %d/%d)", matchType, len(candidateTorrentFilesToLink), len(sourceFiles))
+	var statusMsg string
+	switch {
+	case categoryCreationFailed:
+		statusMsg = fmt.Sprintf("Added via hardlink mode WITHOUT category isolation (match: %s, files: %d/%d)", matchType, len(candidateTorrentFilesToLink), len(sourceFiles))
+	case crossCategory != "":
+		statusMsg = fmt.Sprintf("Added via hardlink mode (match: %s, category: %s, files: %d/%d)", matchType, crossCategory, len(candidateTorrentFilesToLink), len(sourceFiles))
+	default:
+		statusMsg = fmt.Sprintf("Added via hardlink mode (match: %s, files: %d/%d)", matchType, len(candidateTorrentFilesToLink), len(sourceFiles))
+	}
 	if addPolicy.DiscLayout {
 		statusMsg += addPolicy.StatusSuffix()
 	}
@@ -11375,6 +11418,29 @@ func (s *Service) buildHardlinkDestDir(
 	default: // "flat" or unknown
 		// For flat layout, always use isolation folder to keep torrents separated
 		return filepath.Join(baseDir, pathutil.IsolationFolderName(torrentHash, torrentName))
+	}
+}
+
+// buildCategorySavePath computes the correct save path for a cross-seed category
+// based on the instance's directory preset. This produces the tracker-level or
+// instance-level base directory (e.g., /data/cross-seed/TrackerName) rather than
+// a torrent-specific path with an isolation folder suffix.
+func (s *Service) buildCategorySavePath(
+	ctx context.Context,
+	instance *models.Instance,
+	baseDir string,
+	incomingTrackerDomain string,
+	candidate CrossSeedCandidate,
+	req *CrossSeedRequest,
+) string {
+	switch instance.HardlinkDirPreset {
+	case "by-tracker":
+		trackerDisplayName := s.resolveTrackerDisplayName(ctx, incomingTrackerDomain, req)
+		return filepath.Join(baseDir, pathutil.SanitizePathSegment(trackerDisplayName))
+	case "by-instance":
+		return filepath.Join(baseDir, pathutil.SanitizePathSegment(candidate.InstanceName))
+	default: // "flat" or unknown
+		return baseDir
 	}
 }
 
@@ -11629,6 +11695,21 @@ func (s *Service) processReflinkMode(
 	// Build destination directory based on preset and torrent structure
 	destDir := s.buildHardlinkDestDir(ctx, instance, selectedBaseDir, torrentHash, torrentName, candidate, incomingTrackerDomain, req, candidateTorrentFilesAll)
 
+	// Ensure cross-seed category exists with the correct save path derived from
+	// the base directory and directory preset, rather than the matched torrent's save path.
+	categoryCreationFailed := false
+	if crossCategory != "" {
+		categorySavePath := s.buildCategorySavePath(ctx, instance, selectedBaseDir, incomingTrackerDomain, candidate, req)
+		if err := s.ensureCrossCategory(ctx, candidate.InstanceID, crossCategory, categorySavePath); err != nil {
+			log.Warn().Err(err).
+				Str("category", crossCategory).
+				Str("savePath", categorySavePath).
+				Msg("[CROSSSEED] Reflink mode: failed to ensure category exists, continuing without category")
+			crossCategory = ""
+			categoryCreationFailed = true
+		}
+	}
+
 	// Build existing files list (all files on disk from matched torrent)
 	existingFiles := make([]hardlinktree.ExistingFile, 0, len(candidateFiles))
 	for _, f := range candidateFiles {
@@ -11804,7 +11885,15 @@ func (s *Service) processReflinkMode(
 	}
 
 	// Build result message
-	statusMsg := fmt.Sprintf("Added via reflink mode (match: %s, files: %d/%d)", matchType, clonedFiles, totalFiles)
+	var statusMsg string
+	switch {
+	case categoryCreationFailed:
+		statusMsg = fmt.Sprintf("Added via reflink mode WITHOUT category isolation (match: %s, files: %d/%d)", matchType, clonedFiles, totalFiles)
+	case crossCategory != "":
+		statusMsg = fmt.Sprintf("Added via reflink mode (match: %s, category: %s, files: %d/%d)", matchType, crossCategory, clonedFiles, totalFiles)
+	default:
+		statusMsg = fmt.Sprintf("Added via reflink mode (match: %s, files: %d/%d)", matchType, clonedFiles, totalFiles)
+	}
 	if addPolicy.DiscLayout {
 		statusMsg += addPolicy.StatusSuffix()
 	}


### PR DESCRIPTION
## Summary

- Defer category creation to reflink/hardlink processing functions where the correct base directory and tracker name are resolved
- Compute category save path as `{baseDir}/{trackerName}` instead of falling back to the matched torrent's save path
- Handle fallback to regular mode when reflink/hardlink handlers return `Used=false` — ensure category is created before proceeding
- Track and report category creation failures in hardlink/reflink result messages

## Test plan
- [x] New unit tests for `buildCategorySavePath` covering all presets (by-tracker, by-instance, flat, unknown, empty), edge cases (trailing slash, special characters, no tracker info), and isolation folder exclusion
- [ ] Manual test with reflink + by-tracker preset + `UseCategoryFromIndexer=true` across multiple trackers
- [ ] Verify categories get correct `{baseDir}/{trackerName}` save paths, not torrent-specific paths
- [ ] Verify concurrent cross-seeds don't shuffle save paths across categories

Fixes #1703

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved category save path handling based on hardlink directory preset configuration (by-tracker, by-instance, or flat mode).

* **Bug Fixes**
  * Enhanced category isolation status messaging to indicate when category isolation fails in hardlink/reflink operations.
  * Fixed category creation logic to properly defer and retry category creation in reflink and hardlink modes when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->