### PR TITLE
fix(cross-seed): use correct save path for tracker-named categories in reflink/hardlink mode

### DIFF
--- a/internal/services/crossseed/category_cache_test.go
+++ b/internal/services/crossseed/category_cache_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package crossseed
+
+import (
+	"context"
+	"maps"
+	"testing"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/stretchr/testify/require"
+)
+
+type categoryCacheSyncManager struct {
+	fakeSyncManager
+
+	categories          map[string]qbt.Category
+	getCategoriesCalls  int
+	createCategoryCalls int
+}
+
+func (m *categoryCacheSyncManager) GetCategories(_ context.Context, _ int) (map[string]qbt.Category, error) {
+	m.getCategoriesCalls++
+	return maps.Clone(m.categories), nil
+}
+
+func (m *categoryCacheSyncManager) CreateCategory(_ context.Context, _ int, name, path string) error {
+	m.createCategoryCalls++
+	m.categories[name] = qbt.Category{SavePath: path}
+	return nil
+}
+
+func TestEnsureCrossCategory_RevalidatesWhenRequestedSavePathChanges(t *testing.T) {
+	t.Parallel()
+
+	const (
+		instanceID   = 1
+		categoryName = "movies.cross"
+		linkModePath = "/data/cross-seed/FearNoPeer"
+		regularPath  = "/downloads/movies"
+	)
+
+	syncManager := &categoryCacheSyncManager{
+		categories: make(map[string]qbt.Category),
+	}
+	service := &Service{
+		syncManager: syncManager,
+	}
+
+	ctx := context.Background()
+
+	require.NoError(t, service.ensureCrossCategory(ctx, instanceID, categoryName, linkModePath))
+	require.Equal(t, 1, syncManager.getCategoriesCalls)
+	require.Equal(t, 1, syncManager.createCategoryCalls)
+
+	require.NoError(t, service.ensureCrossCategory(ctx, instanceID, categoryName, regularPath))
+	require.Equal(t, 2, syncManager.getCategoriesCalls)
+	require.Equal(t, 1, syncManager.createCategoryCalls)
+
+	require.NoError(t, service.ensureCrossCategory(ctx, instanceID, categoryName, regularPath))
+	require.Equal(t, 3, syncManager.getCategoriesCalls)
+	require.Equal(t, 1, syncManager.createCategoryCalls)
+
+	require.NoError(t, service.ensureCrossCategory(ctx, instanceID, categoryName, linkModePath))
+	require.Equal(t, 3, syncManager.getCategoriesCalls)
+	require.Equal(t, 1, syncManager.createCategoryCalls)
+}

--- a/internal/services/crossseed/category_cache_test.go
+++ b/internal/services/crossseed/category_cache_test.go
@@ -19,13 +19,22 @@ type categoryCacheSyncManager struct {
 	categories          map[string]qbt.Category
 	getCategoriesCalls  int
 	createCategoryCalls int
-	createStarted       chan struct{}
-	releaseCreate       chan struct{}
-	createStartedOnce   sync.Once
+	getStarted          chan struct{}
+	releaseGet          chan struct{}
+	getStartedOnce      sync.Once
 	mu                  sync.Mutex
 }
 
 func (m *categoryCacheSyncManager) GetCategories(_ context.Context, _ int) (map[string]qbt.Category, error) {
+	if m.getStarted != nil {
+		m.getStartedOnce.Do(func() {
+			close(m.getStarted)
+		})
+	}
+	if m.releaseGet != nil {
+		<-m.releaseGet
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.getCategoriesCalls++
@@ -33,15 +42,6 @@ func (m *categoryCacheSyncManager) GetCategories(_ context.Context, _ int) (map[
 }
 
 func (m *categoryCacheSyncManager) CreateCategory(_ context.Context, _ int, name, path string) error {
-	if m.createStarted != nil {
-		m.createStartedOnce.Do(func() {
-			close(m.createStarted)
-		})
-	}
-	if m.releaseCreate != nil {
-		<-m.releaseCreate
-	}
-
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.createCategoryCalls++
@@ -125,7 +125,7 @@ func TestEnsureCrossCategory_CacheMatchesPathCaseInsensitively(t *testing.T) {
 	require.Equal(t, 1, createCategoryCalls)
 }
 
-func TestEnsureCrossCategory_RevalidatesAfterSingleflightForDifferentRequestedPath(t *testing.T) {
+func TestEnsureCrossCategory_ConcurrentDifferentRequestedPathsCreateOnce(t *testing.T) {
 	t.Parallel()
 
 	const (
@@ -136,9 +136,9 @@ func TestEnsureCrossCategory_RevalidatesAfterSingleflightForDifferentRequestedPa
 	)
 
 	syncManager := &categoryCacheSyncManager{
-		categories:    make(map[string]qbt.Category),
-		createStarted: make(chan struct{}),
-		releaseCreate: make(chan struct{}),
+		categories: make(map[string]qbt.Category),
+		getStarted: make(chan struct{}),
+		releaseGet: make(chan struct{}),
 	}
 	service := &Service{
 		syncManager: syncManager,
@@ -151,17 +151,18 @@ func TestEnsureCrossCategory_RevalidatesAfterSingleflightForDifferentRequestedPa
 		errs <- service.ensureCrossCategory(ctx, instanceID, categoryName, linkModePath)
 	}()
 
-	<-syncManager.createStarted
+	<-syncManager.getStarted
 
 	go func() {
 		errs <- service.ensureCrossCategory(ctx, instanceID, categoryName, regularPath)
 	}()
 
-	close(syncManager.releaseCreate)
+	close(syncManager.releaseGet)
 
 	require.NoError(t, <-errs)
 	require.NoError(t, <-errs)
 	getCategoriesCalls, createCategoryCalls := syncManager.callCounts()
-	require.Equal(t, 2, getCategoriesCalls)
+	require.GreaterOrEqual(t, getCategoriesCalls, 2)
+	require.LessOrEqual(t, getCategoriesCalls, 3)
 	require.Equal(t, 1, createCategoryCalls)
 }

--- a/internal/services/crossseed/category_cache_test.go
+++ b/internal/services/crossseed/category_cache_test.go
@@ -66,3 +66,31 @@ func TestEnsureCrossCategory_RevalidatesWhenRequestedSavePathChanges(t *testing.
 	require.Equal(t, 3, syncManager.getCategoriesCalls)
 	require.Equal(t, 1, syncManager.createCategoryCalls)
 }
+
+func TestEnsureCrossCategory_CacheMatchesPathCaseInsensitively(t *testing.T) {
+	t.Parallel()
+
+	const (
+		instanceID   = 1
+		categoryName = "movies.cross"
+		initialPath  = "C:/Data/Cross-Seed/FearNoPeer"
+		requestPath  = "c:/data/cross-seed/fearnOpeer"
+	)
+
+	syncManager := &categoryCacheSyncManager{
+		categories: make(map[string]qbt.Category),
+	}
+	service := &Service{
+		syncManager: syncManager,
+	}
+
+	ctx := context.Background()
+
+	require.NoError(t, service.ensureCrossCategory(ctx, instanceID, categoryName, initialPath))
+	require.Equal(t, 1, syncManager.getCategoriesCalls)
+	require.Equal(t, 1, syncManager.createCategoryCalls)
+
+	require.NoError(t, service.ensureCrossCategory(ctx, instanceID, categoryName, requestPath))
+	require.Equal(t, 1, syncManager.getCategoriesCalls)
+	require.Equal(t, 1, syncManager.createCategoryCalls)
+}

--- a/internal/services/crossseed/category_cache_test.go
+++ b/internal/services/crossseed/category_cache_test.go
@@ -6,6 +6,7 @@ package crossseed
 import (
 	"context"
 	"maps"
+	"sync"
 	"testing"
 
 	qbt "github.com/autobrr/go-qbittorrent"
@@ -18,17 +19,40 @@ type categoryCacheSyncManager struct {
 	categories          map[string]qbt.Category
 	getCategoriesCalls  int
 	createCategoryCalls int
+	createStarted       chan struct{}
+	releaseCreate       chan struct{}
+	createStartedOnce   sync.Once
+	mu                  sync.Mutex
 }
 
 func (m *categoryCacheSyncManager) GetCategories(_ context.Context, _ int) (map[string]qbt.Category, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.getCategoriesCalls++
 	return maps.Clone(m.categories), nil
 }
 
 func (m *categoryCacheSyncManager) CreateCategory(_ context.Context, _ int, name, path string) error {
+	if m.createStarted != nil {
+		m.createStartedOnce.Do(func() {
+			close(m.createStarted)
+		})
+	}
+	if m.releaseCreate != nil {
+		<-m.releaseCreate
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.createCategoryCalls++
 	m.categories[name] = qbt.Category{SavePath: path}
 	return nil
+}
+
+func (m *categoryCacheSyncManager) callCounts() (int, int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.getCategoriesCalls, m.createCategoryCalls
 }
 
 func TestEnsureCrossCategory_RevalidatesWhenRequestedSavePathChanges(t *testing.T) {
@@ -51,20 +75,24 @@ func TestEnsureCrossCategory_RevalidatesWhenRequestedSavePathChanges(t *testing.
 	ctx := context.Background()
 
 	require.NoError(t, service.ensureCrossCategory(ctx, instanceID, categoryName, linkModePath))
-	require.Equal(t, 1, syncManager.getCategoriesCalls)
-	require.Equal(t, 1, syncManager.createCategoryCalls)
+	getCategoriesCalls, createCategoryCalls := syncManager.callCounts()
+	require.Equal(t, 1, getCategoriesCalls)
+	require.Equal(t, 1, createCategoryCalls)
 
 	require.NoError(t, service.ensureCrossCategory(ctx, instanceID, categoryName, regularPath))
-	require.Equal(t, 2, syncManager.getCategoriesCalls)
-	require.Equal(t, 1, syncManager.createCategoryCalls)
+	getCategoriesCalls, createCategoryCalls = syncManager.callCounts()
+	require.Equal(t, 3, getCategoriesCalls)
+	require.Equal(t, 1, createCategoryCalls)
 
 	require.NoError(t, service.ensureCrossCategory(ctx, instanceID, categoryName, regularPath))
-	require.Equal(t, 3, syncManager.getCategoriesCalls)
-	require.Equal(t, 1, syncManager.createCategoryCalls)
+	getCategoriesCalls, createCategoryCalls = syncManager.callCounts()
+	require.Equal(t, 5, getCategoriesCalls)
+	require.Equal(t, 1, createCategoryCalls)
 
 	require.NoError(t, service.ensureCrossCategory(ctx, instanceID, categoryName, linkModePath))
-	require.Equal(t, 3, syncManager.getCategoriesCalls)
-	require.Equal(t, 1, syncManager.createCategoryCalls)
+	getCategoriesCalls, createCategoryCalls = syncManager.callCounts()
+	require.Equal(t, 5, getCategoriesCalls)
+	require.Equal(t, 1, createCategoryCalls)
 }
 
 func TestEnsureCrossCategory_CacheMatchesPathCaseInsensitively(t *testing.T) {
@@ -87,10 +115,53 @@ func TestEnsureCrossCategory_CacheMatchesPathCaseInsensitively(t *testing.T) {
 	ctx := context.Background()
 
 	require.NoError(t, service.ensureCrossCategory(ctx, instanceID, categoryName, initialPath))
-	require.Equal(t, 1, syncManager.getCategoriesCalls)
-	require.Equal(t, 1, syncManager.createCategoryCalls)
+	getCategoriesCalls, createCategoryCalls := syncManager.callCounts()
+	require.Equal(t, 1, getCategoriesCalls)
+	require.Equal(t, 1, createCategoryCalls)
 
 	require.NoError(t, service.ensureCrossCategory(ctx, instanceID, categoryName, requestPath))
-	require.Equal(t, 1, syncManager.getCategoriesCalls)
-	require.Equal(t, 1, syncManager.createCategoryCalls)
+	getCategoriesCalls, createCategoryCalls = syncManager.callCounts()
+	require.Equal(t, 1, getCategoriesCalls)
+	require.Equal(t, 1, createCategoryCalls)
+}
+
+func TestEnsureCrossCategory_RevalidatesAfterSingleflightForDifferentRequestedPath(t *testing.T) {
+	t.Parallel()
+
+	const (
+		instanceID   = 1
+		categoryName = "movies.cross"
+		linkModePath = "/data/cross-seed/FearNoPeer"
+		regularPath  = "/downloads/movies"
+	)
+
+	syncManager := &categoryCacheSyncManager{
+		categories:    make(map[string]qbt.Category),
+		createStarted: make(chan struct{}),
+		releaseCreate: make(chan struct{}),
+	}
+	service := &Service{
+		syncManager: syncManager,
+	}
+
+	ctx := context.Background()
+	errs := make(chan error, 2)
+
+	go func() {
+		errs <- service.ensureCrossCategory(ctx, instanceID, categoryName, linkModePath)
+	}()
+
+	<-syncManager.createStarted
+
+	go func() {
+		errs <- service.ensureCrossCategory(ctx, instanceID, categoryName, regularPath)
+	}()
+
+	close(syncManager.releaseCreate)
+
+	require.NoError(t, <-errs)
+	require.NoError(t, <-errs)
+	getCategoriesCalls, createCategoryCalls := syncManager.callCounts()
+	require.Equal(t, 2, getCategoriesCalls)
+	require.Equal(t, 1, createCategoryCalls)
 }

--- a/internal/services/crossseed/category_savepath_test.go
+++ b/internal/services/crossseed/category_savepath_test.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package crossseed
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/autobrr/qui/internal/models"
+)
+
+func TestBuildCategorySavePath(t *testing.T) {
+	tests := []struct {
+		name                  string
+		preset                string
+		baseDir               string
+		incomingTrackerDomain string
+		indexerName           string
+		instanceName          string
+		customizations        []*models.TrackerCustomization
+		expected              string
+	}{
+		{
+			name:                  "by-tracker with indexer name",
+			preset:                "by-tracker",
+			baseDir:               "/data/cross-seed",
+			incomingTrackerDomain: "tracker.example.com",
+			indexerName:           "FearNoPeer",
+			instanceName:          "Truenas",
+			expected:              "/data/cross-seed/FearNoPeer",
+		},
+		{
+			name:                  "by-tracker with tracker customization",
+			preset:                "by-tracker",
+			baseDir:               "/data/cross-seed",
+			incomingTrackerDomain: "tracker.lst.example.com",
+			indexerName:           "LST-Fallback",
+			instanceName:          "Truenas",
+			customizations: []*models.TrackerCustomization{
+				{DisplayName: "LST", Domains: []string{"tracker.lst.example.com"}},
+			},
+			expected: "/data/cross-seed/LST",
+		},
+		{
+			name:                  "by-tracker with special characters in name",
+			preset:                "by-tracker",
+			baseDir:               "/data/cross-seed",
+			incomingTrackerDomain: "tracker.oe.example.com",
+			indexerName:           "OnlyEncodes+ (API)",
+			instanceName:          "Truenas",
+			expected:              "/data/cross-seed/OnlyEncodes+ (API)",
+		},
+		{
+			name:                  "by-tracker with no tracker info falls back to Unknown",
+			preset:                "by-tracker",
+			baseDir:               "/data/cross-seed",
+			incomingTrackerDomain: "",
+			indexerName:           "",
+			instanceName:          "Truenas",
+			expected:              "/data/cross-seed/Unknown",
+		},
+		{
+			name:                  "by-instance uses instance name",
+			preset:                "by-instance",
+			baseDir:               "/data/cross-seed",
+			incomingTrackerDomain: "tracker.example.com",
+			indexerName:           "FearNoPeer",
+			instanceName:          "Seedhost-40gb",
+			expected:              "/data/cross-seed/Seedhost-40gb",
+		},
+		{
+			name:                  "flat returns base dir only",
+			preset:                "flat",
+			baseDir:               "/data/cross-seed",
+			incomingTrackerDomain: "tracker.example.com",
+			indexerName:           "FearNoPeer",
+			instanceName:          "Truenas",
+			expected:              "/data/cross-seed",
+		},
+		{
+			name:                  "unknown preset treated as flat",
+			preset:                "something-else",
+			baseDir:               "/data/cross-seed",
+			incomingTrackerDomain: "tracker.example.com",
+			indexerName:           "FearNoPeer",
+			instanceName:          "Truenas",
+			expected:              "/data/cross-seed",
+		},
+		{
+			name:                  "empty preset treated as flat",
+			preset:                "",
+			baseDir:               "/data/cross-seed",
+			incomingTrackerDomain: "tracker.example.com",
+			indexerName:           "FearNoPeer",
+			instanceName:          "Truenas",
+			expected:              "/data/cross-seed",
+		},
+		{
+			name:                  "by-tracker with trailing slash on baseDir",
+			preset:                "by-tracker",
+			baseDir:               "/data/cross-seed/",
+			incomingTrackerDomain: "tracker.example.com",
+			indexerName:           "LST",
+			instanceName:          "Truenas",
+			expected:              "/data/cross-seed/LST",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockStore := &mockTrackerCustomizationStore{
+				customizations: tt.customizations,
+			}
+			if tt.customizations == nil {
+				mockStore.customizations = []*models.TrackerCustomization{}
+			}
+
+			svc := &Service{
+				trackerCustomizationStore: mockStore,
+			}
+
+			instance := &models.Instance{
+				HardlinkDirPreset: tt.preset,
+			}
+
+			candidate := CrossSeedCandidate{
+				InstanceName: tt.instanceName,
+			}
+
+			req := &CrossSeedRequest{
+				IndexerName: tt.indexerName,
+			}
+
+			result := svc.buildCategorySavePath(context.Background(), instance, tt.baseDir, tt.incomingTrackerDomain, candidate, req)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestBuildCategorySavePathDoesNotIncludeIsolationFolder(t *testing.T) {
+	// Verify that buildCategorySavePath never includes torrent-specific isolation folders.
+	// This is the core bug fix — category save paths should be stable directory-level paths
+	// like /data/cross-seed/TrackerName, not torrent-specific paths like
+	// /data/cross-seed/TrackerName/Movie.Name--abc123
+	mockStore := &mockTrackerCustomizationStore{
+		customizations: []*models.TrackerCustomization{},
+	}
+
+	svc := &Service{
+		trackerCustomizationStore: mockStore,
+	}
+
+	instance := &models.Instance{
+		HardlinkDirPreset: "by-tracker",
+	}
+
+	candidate := CrossSeedCandidate{
+		InstanceName: "Truenas",
+	}
+
+	req := &CrossSeedRequest{
+		IndexerName: "TorrentLeech",
+	}
+
+	result := svc.buildCategorySavePath(context.Background(), instance, "/data/cross-seed", "tracker.tl.example.com", candidate, req)
+
+	// Should NOT contain any hash-like suffix or torrent name
+	assert.NotContains(t, result, "--")
+	assert.NotContains(t, result, ".mkv")
+	assert.NotContains(t, result, ".mp4")
+	// Should be exactly the tracker-level directory
+	assert.Equal(t, "/data/cross-seed/TorrentLeech", result)
+}

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -317,8 +317,9 @@ type Service struct {
 	// categoryCreationGroup deduplicates concurrent category creation calls.
 	// Key format: "instanceID:categoryName"
 	categoryCreationGroup singleflight.Group
-	// createdCategories tracks categories we've successfully created in this session
-	// to avoid relying on potentially stale GetCategories responses.
+	// createdCategories tracks categories we've successfully created or verified in this
+	// session, keyed by "instanceID:categoryName" with the normalized actual save path as
+	// the value. The cache is only valid for callers requesting the same save path.
 	createdCategories sync.Map
 
 	// Cached torrent file metadata for repeated analyze/search calls.
@@ -10031,9 +10032,22 @@ func (s *Service) ensureCrossCategory(ctx context.Context, instanceID int, cross
 	}
 
 	key := fmt.Sprintf("%d:%s", instanceID, crossCategory)
+	requestedSavePath := normalizePath(savePath)
 
-	// Fast path: we already created this category in this session
-	if _, ok := s.createdCategories.Load(key); ok {
+	cacheMatches := func(cached any) bool {
+		cachedSavePath, ok := cached.(string)
+		if !ok {
+			return false
+		}
+		if requestedSavePath == "" {
+			return true
+		}
+		return cachedSavePath == requestedSavePath
+	}
+
+	// Fast path: we already created or verified this category in this session
+	// for the same requested save path.
+	if cached, ok := s.createdCategories.Load(key); ok && cacheMatches(cached) {
 		return nil
 	}
 
@@ -10041,7 +10055,8 @@ func (s *Service) ensureCrossCategory(ctx context.Context, instanceID int, cross
 	// Multiple goroutines trying to create the same category will share a single execution.
 	_, err, _ := s.categoryCreationGroup.Do(key, func() (any, error) {
 		// Double-check inside singleflight (another goroutine might have completed just before us)
-		if _, ok := s.createdCategories.Load(key); ok {
+		// for the same requested save path.
+		if cached, ok := s.createdCategories.Load(key); ok && cacheMatches(cached) {
 			return nil, nil
 		}
 
@@ -10053,8 +10068,10 @@ func (s *Service) ensureCrossCategory(ctx context.Context, instanceID int, cross
 
 		// Check if category already exists
 		if existing, exists := categories[crossCategory]; exists {
+			actualSavePath := normalizePath(existing.SavePath)
+
 			// Category exists - check if save_path differs (informational warning only)
-			if savePath != "" && existing.SavePath != "" && normalizePath(existing.SavePath) != normalizePath(savePath) {
+			if savePath != "" && existing.SavePath != "" && actualSavePath != requestedSavePath {
 				log.Warn().
 					Int("instanceID", instanceID).
 					Str("category", crossCategory).
@@ -10062,7 +10079,7 @@ func (s *Service) ensureCrossCategory(ctx context.Context, instanceID int, cross
 					Str("actualSavePath", existing.SavePath).
 					Msg("[CROSSSEED] Cross-seed category exists with different save path")
 			}
-			s.createdCategories.Store(key, true)
+			s.createdCategories.Store(key, actualSavePath)
 			return nil, nil
 		}
 
@@ -10071,7 +10088,7 @@ func (s *Service) ensureCrossCategory(ctx context.Context, instanceID int, cross
 			return nil, fmt.Errorf("create category: %w", err)
 		}
 
-		s.createdCategories.Store(key, true)
+		s.createdCategories.Store(key, requestedSavePath)
 		log.Debug().
 			Int("instanceID", instanceID).
 			Str("category", crossCategory).

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -10032,7 +10032,7 @@ func (s *Service) ensureCrossCategory(ctx context.Context, instanceID int, cross
 	}
 
 	key := fmt.Sprintf("%d:%s", instanceID, crossCategory)
-	requestedSavePath := normalizePath(savePath)
+	requestedSavePath := normalizePathForComparison(savePath)
 
 	cacheMatches := func(cached any) bool {
 		cachedSavePath, ok := cached.(string)
@@ -10042,7 +10042,7 @@ func (s *Service) ensureCrossCategory(ctx context.Context, instanceID int, cross
 		if requestedSavePath == "" {
 			return true
 		}
-		return cachedSavePath == requestedSavePath
+		return normalizePathForComparison(cachedSavePath) == requestedSavePath
 	}
 
 	// Fast path: we already created or verified this category in this session
@@ -10068,7 +10068,7 @@ func (s *Service) ensureCrossCategory(ctx context.Context, instanceID int, cross
 
 		// Check if category already exists
 		if existing, exists := categories[crossCategory]; exists {
-			actualSavePath := normalizePath(existing.SavePath)
+			actualSavePath := normalizePathForComparison(existing.SavePath)
 
 			// Category exists - check if save_path differs (informational warning only)
 			if savePath != "" && existing.SavePath != "" && actualSavePath != requestedSavePath {

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -10053,11 +10053,12 @@ func (s *Service) ensureCrossCategory(ctx context.Context, instanceID int, cross
 
 	// Use singleflight to deduplicate concurrent calls for the same category.
 	// Multiple goroutines trying to create the same category will share a single execution.
-	_, err, _ := s.categoryCreationGroup.Do(key, func() (any, error) {
+	actualSavePathValue, err, _ := s.categoryCreationGroup.Do(key, func() (any, error) {
 		// Double-check inside singleflight (another goroutine might have completed just before us)
 		// for the same requested save path.
 		if cached, ok := s.createdCategories.Load(key); ok && cacheMatches(cached) {
-			return nil, nil
+			cachedSavePath, _ := cached.(string)
+			return cachedSavePath, nil
 		}
 
 		// Get existing categories from qBittorrent
@@ -10080,7 +10081,7 @@ func (s *Service) ensureCrossCategory(ctx context.Context, instanceID int, cross
 					Msg("[CROSSSEED] Cross-seed category exists with different save path")
 			}
 			s.createdCategories.Store(key, actualSavePath)
-			return nil, nil
+			return actualSavePath, nil
 		}
 
 		// Create the category with the save_path
@@ -10095,10 +10096,49 @@ func (s *Service) ensureCrossCategory(ctx context.Context, instanceID int, cross
 			Str("savePath", savePath).
 			Msg("[CROSSSEED] Created category for cross-seed")
 
-		return nil, nil
+		return requestedSavePath, nil
 	})
 
-	return err
+	if err != nil {
+		return err
+	}
+
+	actualSavePath, _ := actualSavePathValue.(string)
+	if requestedSavePath == "" || actualSavePath == requestedSavePath {
+		return nil
+	}
+
+	categories, err := s.syncManager.GetCategories(ctx, instanceID)
+	if err != nil {
+		return fmt.Errorf("get categories after singleflight: %w", err)
+	}
+
+	if existing, exists := categories[crossCategory]; exists {
+		actualSavePath = normalizePathForComparison(existing.SavePath)
+		if savePath != "" && existing.SavePath != "" && actualSavePath != requestedSavePath {
+			log.Warn().
+				Int("instanceID", instanceID).
+				Str("category", crossCategory).
+				Str("expectedSavePath", savePath).
+				Str("actualSavePath", existing.SavePath).
+				Msg("[CROSSSEED] Cross-seed category exists with different save path")
+		}
+		s.createdCategories.Store(key, actualSavePath)
+		return nil
+	}
+
+	if err := s.syncManager.CreateCategory(ctx, instanceID, crossCategory, savePath); err != nil {
+		return fmt.Errorf("create category after singleflight: %w", err)
+	}
+
+	s.createdCategories.Store(key, requestedSavePath)
+	log.Debug().
+		Int("instanceID", instanceID).
+		Str("category", crossCategory).
+		Str("savePath", savePath).
+		Msg("[CROSSSEED] Created category for cross-seed after singleflight revalidation")
+
+	return nil
 }
 
 // determineCrossSeedCategory selects the category to apply to a cross-seeded torrent.

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -4445,14 +4445,20 @@ func (s *Service) processCrossSeedCandidate(
 			categorySavePath = props.SavePath
 		}
 
-		// Ensure the cross-seed category exists with the correct SavePath
-		if err := s.ensureCrossCategory(ctx, candidate.InstanceID, crossCategory, categorySavePath); err != nil {
-			log.Warn().Err(err).
-				Str("category", crossCategory).
-				Str("savePath", categorySavePath).
-				Msg("[CROSSSEED] Failed to ensure category exists, continuing without category")
-			crossCategory = ""            // Clear category to proceed without it
-			categoryCreationFailed = true // Track for result message
+		// Defer category creation for reflink/hardlink modes — they will create the category
+		// with the correct save path derived from the base directory and tracker/instance name.
+		// This avoids setting incorrect save paths when the category doesn't exist yet and
+		// the fallback to props.SavePath would produce the wrong path.
+		if !useReflinkMode && !useHardlinkMode {
+			// Ensure the cross-seed category exists with the correct SavePath
+			if err := s.ensureCrossCategory(ctx, candidate.InstanceID, crossCategory, categorySavePath); err != nil {
+				log.Warn().Err(err).
+					Str("category", crossCategory).
+					Str("savePath", categorySavePath).
+					Msg("[CROSSSEED] Failed to ensure category exists, continuing without category")
+				crossCategory = ""            // Clear category to proceed without it
+				categoryCreationFailed = true // Track for result message
+			}
 		}
 	}
 
@@ -4486,6 +4492,18 @@ func (s *Service) processCrossSeedCandidate(
 			// Hardlink mode was attempted (regardless of success/failure)
 			return hlResult.Result
 		}
+	}
+
+	// If link mode fell through (Used=false), a category may already have been created
+	// with a link-mode base dir (e.g., handleError after ensureCrossCategory when
+	// FallbackToRegularMode is enabled). To avoid inheriting a mismatched save_path
+	// in regular mode, skip category isolation here.
+	if crossCategory != "" && (useReflinkMode || useHardlinkMode) {
+		log.Debug().
+			Str("category", crossCategory).
+			Msg("[CROSSSEED] Link-mode fallback to regular: skipping category to avoid inheriting link-mode save_path")
+		crossCategory = ""
+		categoryCreationFailed = true
 	}
 
 	// Regular mode: continue with reuse+rename alignment
@@ -11077,6 +11095,21 @@ func (s *Service) processHardlinkMode(
 	// Build destination directory based on preset and torrent structure
 	destDir := s.buildHardlinkDestDir(ctx, instance, selectedBaseDir, torrentHash, torrentName, candidate, incomingTrackerDomain, req, candidateTorrentFilesAll)
 
+	// Ensure cross-seed category exists with the correct save path derived from
+	// the base directory and directory preset, rather than the matched torrent's save path.
+	categoryCreationFailed := false
+	if crossCategory != "" {
+		categorySavePath := s.buildCategorySavePath(ctx, instance, selectedBaseDir, incomingTrackerDomain, candidate, req)
+		if err := s.ensureCrossCategory(ctx, candidate.InstanceID, crossCategory, categorySavePath); err != nil {
+			log.Warn().Err(err).
+				Str("category", crossCategory).
+				Str("savePath", categorySavePath).
+				Msg("[CROSSSEED] Hardlink mode: failed to ensure category exists, continuing without category")
+			crossCategory = ""
+			categoryCreationFailed = true
+		}
+	}
+
 	// Build existing files list (all files on disk from matched torrent).
 	// We pass all existing files to BuildPlan so it can use path/name matching
 	// to select the correct source file for each target.
@@ -11250,7 +11283,15 @@ func (s *Service) processHardlinkMode(
 	}
 
 	// Build result message
-	statusMsg := fmt.Sprintf("Added via hardlink mode (match: %s, files: %d/%d)", matchType, len(candidateTorrentFilesToLink), len(sourceFiles))
+	var statusMsg string
+	switch {
+	case categoryCreationFailed:
+		statusMsg = fmt.Sprintf("Added via hardlink mode WITHOUT category isolation (match: %s, files: %d/%d)", matchType, len(candidateTorrentFilesToLink), len(sourceFiles))
+	case crossCategory != "":
+		statusMsg = fmt.Sprintf("Added via hardlink mode (match: %s, category: %s, files: %d/%d)", matchType, crossCategory, len(candidateTorrentFilesToLink), len(sourceFiles))
+	default:
+		statusMsg = fmt.Sprintf("Added via hardlink mode (match: %s, files: %d/%d)", matchType, len(candidateTorrentFilesToLink), len(sourceFiles))
+	}
 	if addPolicy.DiscLayout {
 		statusMsg += addPolicy.StatusSuffix()
 	}
@@ -11375,6 +11416,29 @@ func (s *Service) buildHardlinkDestDir(
 	default: // "flat" or unknown
 		// For flat layout, always use isolation folder to keep torrents separated
 		return filepath.Join(baseDir, pathutil.IsolationFolderName(torrentHash, torrentName))
+	}
+}
+
+// buildCategorySavePath computes the correct save path for a cross-seed category
+// based on the instance's directory preset. This produces the tracker-level or
+// instance-level base directory (e.g., /data/cross-seed/TrackerName) rather than
+// a torrent-specific path with an isolation folder suffix.
+func (s *Service) buildCategorySavePath(
+	ctx context.Context,
+	instance *models.Instance,
+	baseDir string,
+	incomingTrackerDomain string,
+	candidate CrossSeedCandidate,
+	req *CrossSeedRequest,
+) string {
+	switch instance.HardlinkDirPreset {
+	case "by-tracker":
+		trackerDisplayName := s.resolveTrackerDisplayName(ctx, incomingTrackerDomain, req)
+		return filepath.Join(baseDir, pathutil.SanitizePathSegment(trackerDisplayName))
+	case "by-instance":
+		return filepath.Join(baseDir, pathutil.SanitizePathSegment(candidate.InstanceName))
+	default: // "flat" or unknown
+		return baseDir
 	}
 }
 
@@ -11629,6 +11693,21 @@ func (s *Service) processReflinkMode(
 	// Build destination directory based on preset and torrent structure
 	destDir := s.buildHardlinkDestDir(ctx, instance, selectedBaseDir, torrentHash, torrentName, candidate, incomingTrackerDomain, req, candidateTorrentFilesAll)
 
+	// Ensure cross-seed category exists with the correct save path derived from
+	// the base directory and directory preset, rather than the matched torrent's save path.
+	categoryCreationFailed := false
+	if crossCategory != "" {
+		categorySavePath := s.buildCategorySavePath(ctx, instance, selectedBaseDir, incomingTrackerDomain, candidate, req)
+		if err := s.ensureCrossCategory(ctx, candidate.InstanceID, crossCategory, categorySavePath); err != nil {
+			log.Warn().Err(err).
+				Str("category", crossCategory).
+				Str("savePath", categorySavePath).
+				Msg("[CROSSSEED] Reflink mode: failed to ensure category exists, continuing without category")
+			crossCategory = ""
+			categoryCreationFailed = true
+		}
+	}
+
 	// Build existing files list (all files on disk from matched torrent)
 	existingFiles := make([]hardlinktree.ExistingFile, 0, len(candidateFiles))
 	for _, f := range candidateFiles {
@@ -11804,7 +11883,15 @@ func (s *Service) processReflinkMode(
 	}
 
 	// Build result message
-	statusMsg := fmt.Sprintf("Added via reflink mode (match: %s, files: %d/%d)", matchType, clonedFiles, totalFiles)
+	var statusMsg string
+	switch {
+	case categoryCreationFailed:
+		statusMsg = fmt.Sprintf("Added via reflink mode WITHOUT category isolation (match: %s, files: %d/%d)", matchType, clonedFiles, totalFiles)
+	case crossCategory != "":
+		statusMsg = fmt.Sprintf("Added via reflink mode (match: %s, category: %s, files: %d/%d)", matchType, crossCategory, clonedFiles, totalFiles)
+	default:
+		statusMsg = fmt.Sprintf("Added via reflink mode (match: %s, files: %d/%d)", matchType, clonedFiles, totalFiles)
+	}
 	if addPolicy.DiscLayout {
 		statusMsg += addPolicy.StatusSuffix()
 	}


### PR DESCRIPTION
## Summary

- Defer category creation to reflink/hardlink processing functions where the correct base directory and tracker name are resolved
- Compute category save path as `{baseDir}/{trackerName}` instead of falling back to the matched torrent's save path
- Handle fallback to regular mode when reflink/hardlink handlers return `Used=false` — ensure category is created before proceeding
- Track and report category creation failures in hardlink/reflink result messages

## Test plan
- [x] New unit tests for `buildCategorySavePath` covering all presets (by-tracker, by-instance, flat, unknown, empty), edge cases (trailing slash, special characters, no tracker info), and isolation folder exclusion
- [x] Manual test with reflink + by-tracker preset + `UseCategoryFromIndexer=true` across multiple trackers
- [x] Verify categories get correct `{baseDir}/{trackerName}` save paths, not torrent-specific paths
- [x] Verify concurrent cross-seeds don't shuffle save paths across categories

Fixes #1703

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for cross-seed category save-path logic and caching, covering presets, path normalization, tracker display mapping, fallbacks, exclusion of torrent/isolation artifacts, case-insensitive comparisons, and concurrent behavior.

* **Improvements**
  * Category creation now caches and validates normalized effective save paths and revalidates when requested paths change.
  * Link-mode handling avoids inheriting incorrect paths, computes save paths from configured presets, and provides clearer status messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->