### PR TITLE
fix(orphanscan): use content_path to prevent false positives when Auto TMM changes save_path

### DIFF
--- a/internal/services/orphanscan/service.go
+++ b/internal/services/orphanscan/service.go
@@ -1151,16 +1151,22 @@ func buildFileMapFromTorrents(torrents []qbt.Torrent, filesByHash map[string]qbt
 
 		// When Auto TMM updates save_path without moving files, content_path
 		// still reflects the real location on disk. Derive the actual save path
-		// by stripping the first file's name from content_path. For single-file
-		// torrents, content_path = actualSavePath/filename. For folder torrents,
-		// content_path = actualSavePath/folder/filename and f.Name = folder/filename.
-		// In both cases, trimming the file's Name suffix from content_path yields
-		// the real save path.
+		// from content_path so files at the original location are not falsely
+		// flagged as orphans.
+		//
+		// For single-file(-in-folder) torrents, content_path ends with the file
+		// name: strip the first file's Name suffix to get the actual save path.
+		// For multi-file torrents, content_path IS the torrent folder and file
+		// names already include the folder prefix: use filepath.Dir.
 		contentPath := filepath.Clean(torrent.ContentPath)
 		if contentPath != "" && filepath.IsAbs(contentPath) && len(files) > 0 {
 			firstFileName := filepath.Clean(files[0].Name)
 			actualSavePath := strings.TrimSuffix(contentPath, string(filepath.Separator)+firstFileName)
-			if actualSavePath != "" && filepath.IsAbs(actualSavePath) && actualSavePath != contentPath && actualSavePath != savePath {
+			if actualSavePath == contentPath {
+				// Multi-file torrent: content_path is the folder itself.
+				actualSavePath = filepath.Dir(contentPath)
+			}
+			if actualSavePath != "" && filepath.IsAbs(actualSavePath) && actualSavePath != savePath {
 				scanRoots[actualSavePath] = struct{}{}
 				for _, f := range files {
 					tfm.Add(normalizePath(filepath.Join(actualSavePath, f.Name)))

--- a/internal/services/orphanscan/service.go
+++ b/internal/services/orphanscan/service.go
@@ -137,11 +137,12 @@ func (s *Service) getLastCompletedRun(ctx context.Context, instanceID int) (*mod
 func scanRootsFromTorrents(torrents []qbt.Torrent) []string {
 	scanRoots := make(map[string]struct{})
 	for i := range torrents {
-		savePath := filepath.Clean(torrents[i].SavePath)
-		if savePath == "" || !filepath.IsAbs(savePath) {
-			continue
-		}
-		scanRoots[savePath] = struct{}{}
+		addAbsoluteScanRoot(scanRoots, torrents[i].SavePath)
+
+		// Auto TMM can rewrite save_path to a category root without moving the
+		// payload. content_path still points at the real file/folder on disk, and
+		// using it directly is enough for conservative overlap detection.
+		addAbsoluteScanRoot(scanRoots, torrents[i].ContentPath)
 	}
 
 	roots := make([]string, 0, len(scanRoots))
@@ -1107,6 +1108,32 @@ func filterScanRootsCoveredBySkippedRoots(scanRoots, skippedRoots []string) []st
 	return filtered
 }
 
+func addAbsoluteScanRoot(scanRoots map[string]struct{}, root string) {
+	root = filepath.Clean(root)
+	if root == "" || !filepath.IsAbs(root) {
+		return
+	}
+	scanRoots[root] = struct{}{}
+}
+
+func actualSavePathFromContentPath(contentPath string, files qbt.TorrentFiles) string {
+	contentPath = filepath.Clean(contentPath)
+	if contentPath == "" || !filepath.IsAbs(contentPath) || len(files) == 0 {
+		return ""
+	}
+
+	firstFileName := filepath.Clean(files[0].Name)
+	actualSavePath := strings.TrimSuffix(contentPath, string(filepath.Separator)+firstFileName)
+	if actualSavePath == "" || actualSavePath == contentPath {
+		actualSavePath = filepath.Dir(contentPath)
+	}
+	if actualSavePath == "" || !filepath.IsAbs(actualSavePath) {
+		return ""
+	}
+
+	return filepath.Clean(actualSavePath)
+}
+
 // buildFileMapResult contains the file map plus metadata for storage
 type buildFileMapResult struct {
 	fileMap      *TorrentFileMap
@@ -1149,28 +1176,13 @@ func buildFileMapFromTorrents(torrents []qbt.Torrent, filesByHash map[string]qbt
 			tfm.Add(normalizePath(filepath.Join(savePath, f.Name)))
 		}
 
-		// When Auto TMM updates save_path without moving files, content_path
-		// still reflects the real location on disk. Derive the actual save path
-		// from content_path so files at the original location are not falsely
-		// flagged as orphans.
-		//
-		// For single-file(-in-folder) torrents, content_path ends with the file
-		// name: strip the first file's Name suffix to get the actual save path.
-		// For multi-file torrents, content_path IS the torrent folder and file
-		// names already include the folder prefix: use filepath.Dir.
-		contentPath := filepath.Clean(torrent.ContentPath)
-		if contentPath != "" && filepath.IsAbs(contentPath) && len(files) > 0 {
-			firstFileName := filepath.Clean(files[0].Name)
-			actualSavePath := strings.TrimSuffix(contentPath, string(filepath.Separator)+firstFileName)
-			if actualSavePath == contentPath {
-				// Multi-file torrent: content_path is the folder itself.
-				actualSavePath = filepath.Dir(contentPath)
-			}
-			if actualSavePath != "" && filepath.IsAbs(actualSavePath) && actualSavePath != savePath {
-				scanRoots[actualSavePath] = struct{}{}
-				for _, f := range files {
-					tfm.Add(normalizePath(filepath.Join(actualSavePath, f.Name)))
-				}
+		// Auto TMM can update save_path to the category root without moving the
+		// payload. content_path still reflects the real on-disk location.
+		actualSavePath := actualSavePathFromContentPath(torrent.ContentPath, files)
+		if actualSavePath != "" && actualSavePath != savePath {
+			scanRoots[actualSavePath] = struct{}{}
+			for _, f := range files {
+				tfm.Add(normalizePath(filepath.Join(actualSavePath, f.Name)))
 			}
 		}
 	}

--- a/internal/services/orphanscan/service.go
+++ b/internal/services/orphanscan/service.go
@@ -1148,6 +1148,25 @@ func buildFileMapFromTorrents(torrents []qbt.Torrent, filesByHash map[string]qbt
 		for _, f := range files {
 			tfm.Add(normalizePath(filepath.Join(savePath, f.Name)))
 		}
+
+		// When Auto TMM updates save_path without moving files, content_path
+		// still reflects the real location on disk. Derive the actual save path
+		// by stripping the first file's name from content_path. For single-file
+		// torrents, content_path = actualSavePath/filename. For folder torrents,
+		// content_path = actualSavePath/folder/filename and f.Name = folder/filename.
+		// In both cases, trimming the file's Name suffix from content_path yields
+		// the real save path.
+		contentPath := filepath.Clean(torrent.ContentPath)
+		if contentPath != "" && filepath.IsAbs(contentPath) && len(files) > 0 {
+			firstFileName := filepath.Clean(files[0].Name)
+			actualSavePath := strings.TrimSuffix(contentPath, string(filepath.Separator)+firstFileName)
+			if actualSavePath != "" && filepath.IsAbs(actualSavePath) && actualSavePath != contentPath && actualSavePath != savePath {
+				scanRoots[actualSavePath] = struct{}{}
+				for _, f := range files {
+					tfm.Add(normalizePath(filepath.Join(actualSavePath, f.Name)))
+				}
+			}
+		}
 	}
 
 	if stableMissingFiles > 0 {

--- a/internal/services/orphanscan/service_cross_instance_test.go
+++ b/internal/services/orphanscan/service_cross_instance_test.go
@@ -116,6 +116,82 @@ func TestBuildFileMap_CrossInstance(t *testing.T) {
 	}
 }
 
+func TestBuildFileMap_MergesOtherInstanceWhenOnlyContentPathsOverlap(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	instanceOneSaveRoot := filepath.Join(root, "qb1", "cross-seed")
+	instanceTwoSaveRoot := filepath.Join(root, "qb2", "cross-seed")
+	sharedContentRoot := filepath.Join(root, "shared", "tracker-name")
+
+	svc := NewService(DefaultConfig(), nil, nil, nil, nil)
+
+	now := time.Now()
+	lastSync := now.Add(-10 * time.Second)
+
+	svc.getClientProvider = func(_ context.Context, _ int) (healthChecker, error) {
+		return stubHealthChecker{
+			healthy:  true,
+			lastSync: lastSync,
+		}, nil
+	}
+
+	svc.listInstancesProvider = func(_ context.Context) ([]*models.Instance, error) {
+		return []*models.Instance{
+			{ID: 1, Name: "one", IsActive: true, HasLocalFilesystemAccess: true},
+			{ID: 2, Name: "two", IsActive: true, HasLocalFilesystemAccess: true},
+		}, nil
+	}
+
+	svc.getAllTorrentsProvider = func(_ context.Context, instanceID int) ([]qbt.Torrent, error) {
+		switch instanceID {
+		case 1:
+			return []qbt.Torrent{{
+				Hash:        "A",
+				SavePath:    instanceOneSaveRoot,
+				ContentPath: filepath.Join(sharedContentRoot, "Movie.One", "file1.mkv"),
+				State:       qbt.TorrentStatePausedUp,
+			}}, nil
+		case 2:
+			return []qbt.Torrent{{
+				Hash:        "B",
+				SavePath:    instanceTwoSaveRoot,
+				ContentPath: filepath.Join(sharedContentRoot, "Movie.Two", "file1.mkv"),
+				State:       qbt.TorrentStatePausedUp,
+			}}, nil
+		default:
+			return nil, nil
+		}
+	}
+
+	svc.getTorrentFilesBatchProvider = func(_ context.Context, instanceID int, _ []string) (map[string]qbt.TorrentFiles, error) {
+		switch instanceID {
+		case 1:
+			return map[string]qbt.TorrentFiles{
+				"a": {{Name: "Movie.One/file1.mkv", Size: 1}},
+			}, nil
+		case 2:
+			return map[string]qbt.TorrentFiles{
+				"b": {{Name: "Movie.Two/file1.mkv", Size: 1}},
+			}, nil
+		default:
+			return map[string]qbt.TorrentFiles{}, nil
+		}
+	}
+
+	result, err := svc.buildFileMap(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("buildFileMap: %v", err)
+	}
+
+	if !result.fileMap.Has(normalizePath(filepath.Join(sharedContentRoot, "Movie.One", "file1.mkv"))) {
+		t.Fatalf("expected instance 1 actual content path to be protected")
+	}
+	if !result.fileMap.Has(normalizePath(filepath.Join(sharedContentRoot, "Movie.Two", "file1.mkv"))) {
+		t.Fatalf("expected instance 2 actual content path to be merged when content paths overlap")
+	}
+}
+
 func TestBuildFileMap_BailsWhenOtherLocalInstanceUnavailable(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/orphanscan/settling_test.go
+++ b/internal/services/orphanscan/settling_test.go
@@ -202,15 +202,8 @@ func TestFilterScanRootsCoveredBySkippedRoots(t *testing.T) {
 func TestBuildFileMapFromTorrents_ContentPathDivergesFromSavePath(t *testing.T) {
 	t.Parallel()
 
-	// Simulates Auto TMM updating save_path to category default without
-	// moving files. content_path still points to the real location.
 	categoryRoot := filepath.Join(t.TempDir(), "cross-seed")
 	trackerDir := filepath.Join(categoryRoot, "tracker-name")
-
-	// Folder torrent: content_path points to folder, file names include folder prefix.
-	// content_path = .../tracker-name/My.Torrent/file1.mkv (first file in folder torrent)
-	// but qBittorrent reports content_path as the folder for multi-file torrents.
-	// For single-file-in-folder, content_path = folder/filename.
 	result, err := buildFileMapFromTorrents(
 		[]qbt.Torrent{
 			{
@@ -229,15 +222,10 @@ func TestBuildFileMapFromTorrents_ContentPathDivergesFromSavePath(t *testing.T) 
 	)
 	require.NoError(t, err)
 
-	// Files at the reported save_path should be in the map.
-	assert.True(t, result.fileMap.Has(normalizePath(filepath.Join(categoryRoot, "My.Torrent/file1.mkv"))))
-	assert.True(t, result.fileMap.Has(normalizePath(filepath.Join(categoryRoot, "My.Torrent/file2.srt"))))
-
-	// Files at the actual location (derived from content_path) should also be in the map.
-	assert.True(t, result.fileMap.Has(normalizePath(filepath.Join(trackerDir, "My.Torrent/file1.mkv"))))
-	assert.True(t, result.fileMap.Has(normalizePath(filepath.Join(trackerDir, "My.Torrent/file2.srt"))))
-
-	// Both roots should be scan roots.
+	assert.True(t, result.fileMap.Has(normalizePath(filepath.Join(categoryRoot, "My.Torrent", "file1.mkv"))))
+	assert.True(t, result.fileMap.Has(normalizePath(filepath.Join(categoryRoot, "My.Torrent", "file2.srt"))))
+	assert.True(t, result.fileMap.Has(normalizePath(filepath.Join(trackerDir, "My.Torrent", "file1.mkv"))))
+	assert.True(t, result.fileMap.Has(normalizePath(filepath.Join(trackerDir, "My.Torrent", "file2.srt"))))
 	assert.Contains(t, result.scanRoots, filepath.Clean(categoryRoot))
 	assert.Contains(t, result.scanRoots, filepath.Clean(trackerDir))
 }

--- a/internal/services/orphanscan/settling_test.go
+++ b/internal/services/orphanscan/settling_test.go
@@ -198,3 +198,46 @@ func TestFilterScanRootsCoveredBySkippedRoots(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildFileMapFromTorrents_ContentPathDivergesFromSavePath(t *testing.T) {
+	t.Parallel()
+
+	// Simulates Auto TMM updating save_path to category default without
+	// moving files. content_path still points to the real location.
+	categoryRoot := filepath.Join(t.TempDir(), "cross-seed")
+	trackerDir := filepath.Join(categoryRoot, "tracker-name")
+
+	// Folder torrent: content_path points to folder, file names include folder prefix.
+	// content_path = .../tracker-name/My.Torrent/file1.mkv (first file in folder torrent)
+	// but qBittorrent reports content_path as the folder for multi-file torrents.
+	// For single-file-in-folder, content_path = folder/filename.
+	result, err := buildFileMapFromTorrents(
+		[]qbt.Torrent{
+			{
+				Hash:        "abc123",
+				SavePath:    categoryRoot,
+				ContentPath: filepath.Join(trackerDir, "My.Torrent", "file1.mkv"),
+				State:       qbt.TorrentStatePausedUp,
+			},
+		},
+		map[string]qbt.TorrentFiles{
+			"abc123": {
+				{Name: "My.Torrent/file1.mkv", Size: 1000},
+				{Name: "My.Torrent/file2.srt", Size: 100},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	// Files at the reported save_path should be in the map.
+	assert.True(t, result.fileMap.Has(normalizePath(filepath.Join(categoryRoot, "My.Torrent/file1.mkv"))))
+	assert.True(t, result.fileMap.Has(normalizePath(filepath.Join(categoryRoot, "My.Torrent/file2.srt"))))
+
+	// Files at the actual location (derived from content_path) should also be in the map.
+	assert.True(t, result.fileMap.Has(normalizePath(filepath.Join(trackerDir, "My.Torrent/file1.mkv"))))
+	assert.True(t, result.fileMap.Has(normalizePath(filepath.Join(trackerDir, "My.Torrent/file2.srt"))))
+
+	// Both roots should be scan roots.
+	assert.Contains(t, result.scanRoots, filepath.Clean(categoryRoot))
+	assert.Contains(t, result.scanRoots, filepath.Clean(trackerDir))
+}


### PR DESCRIPTION
## Summary
- When Auto TMM updates `save_path` to the category default without moving files, `content_path` still reflects the real location on disk
- Orphan scan now derives the actual save path by stripping the file name suffix from `content_path`, registering file entries for both paths
- Handles both single-file and folder torrents correctly (folder torrents include the folder prefix in the file name from qBittorrent's API)
- Aligns with the approach already used in `managedDeleteCleanupDir` for delete cleanup

## Test plan
- [x] Added `TestBuildFileMapFromTorrents_ContentPathDivergesFromSavePath`
- [x] Verified with 60TB cross-seed setup — Auto TMM torrents with diverging save_path/content_path no longer flagged as orphans
- [x] Both single-file (hash-suffixed folders) and folder torrents (tracker-name subdirs) confirmed working

Closes #1699

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file scanning accuracy for torrents with alternate content paths. The system now correctly identifies files when torrent content is organized in tracker-specific directories separate from the category root.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->