### PR TITLE
docs(dirscan): clarify re-identification after torrent removal

### DIFF
--- a/documentation/docs/features/cross-seed/dir-scan.md
+++ b/documentation/docs/features/cross-seed/dir-scan.md
@@ -133,6 +133,8 @@ Dir Scan maintains a FileID index (inode + device on Unix) to track files alread
 
 This avoids redundant searches and duplicate additions.
 
+If a torrent is removed from qBittorrent (for example, by an automation rule that removes torrents with missing files), its files are no longer tracked in the index. The next scan of whichever directory contains those files will treat them as new searchees and search indexers for them again.
+
 ### Recheck Behavior
 
 - **Full matches**: Torrent is added with "skip hash check" enabled. Seeding starts immediately.


### PR DESCRIPTION
Adds a sentence to the already-seeding detection section clarifying that files from a removed torrent will be picked up again on the next scan. This came up as a support question on Discord.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify Dir Scan behavior with removed torrents. Files previously tracked from torrents removed in qBittorrent are no longer indexed. Subsequent directory scans will treat them as new entries and trigger re-indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->