### PR TITLE
fix(automations): add AutoTMM to condition validation

### DIFF
--- a/internal/api/handlers/automations.go
+++ b/internal/api/handlers/automations.go
@@ -486,7 +486,8 @@ func conditionsUseField(conditions *models.ActionConditions, field automations.C
 		anyEnabledTagActionUsesField(c.TagActions(), field) ||
 		(c.Category != nil && check(c.Category.Enabled, c.Category.Condition)) ||
 		(c.Move != nil && check(c.Move.Enabled, c.Move.Condition)) ||
-		(c.ExternalProgram != nil && check(c.ExternalProgram.Enabled, c.ExternalProgram.Condition))
+		(c.ExternalProgram != nil && check(c.ExternalProgram.Enabled, c.ExternalProgram.Condition)) ||
+		(c.AutoManagement != nil && check(c.AutoManagement.Enabled, c.AutoManagement.Condition))
 }
 
 func anyEnabledTagActionUsesField(actions []*models.TagAction, field automations.ConditionField) bool {
@@ -629,6 +630,9 @@ func conditionTreesForValidation(conditions *models.ActionConditions) []*models.
 	}
 	if conditions.ExternalProgram != nil && conditions.ExternalProgram.Enabled {
 		trees = append(trees, conditions.ExternalProgram.Condition)
+	}
+	if conditions.AutoManagement != nil && conditions.AutoManagement.Enabled {
+		trees = append(trees, conditions.AutoManagement.Condition)
 	}
 	return trees
 }
@@ -1034,6 +1038,9 @@ func collectConditionRegexErrors(conditions *models.ActionConditions) []RegexVal
 	}
 	if conditions.ExternalProgram != nil {
 		validateConditionRegex(conditions.ExternalProgram.Condition, "/conditions/externalProgram/condition", &result)
+	}
+	if conditions.AutoManagement != nil {
+		validateConditionRegex(conditions.AutoManagement.Condition, "/conditions/autoManagement/condition", &result)
 	}
 
 	return result

--- a/internal/api/handlers/automations.go
+++ b/internal/api/handlers/automations.go
@@ -487,7 +487,7 @@ func conditionsUseField(conditions *models.ActionConditions, field automations.C
 		(c.Category != nil && check(c.Category.Enabled, c.Category.Condition)) ||
 		(c.Move != nil && check(c.Move.Enabled, c.Move.Condition)) ||
 		(c.ExternalProgram != nil && check(c.ExternalProgram.Enabled, c.ExternalProgram.Condition)) ||
-		(c.AutoManagement != nil && check(c.AutoManagement.Enabled, c.AutoManagement.Condition))
+		(c.AutoManagement != nil && automations.ConditionUsesField(c.AutoManagement.Condition, field))
 }
 
 func anyEnabledTagActionUsesField(actions []*models.TagAction, field automations.ConditionField) bool {
@@ -631,7 +631,7 @@ func conditionTreesForValidation(conditions *models.ActionConditions) []*models.
 	if conditions.ExternalProgram != nil && conditions.ExternalProgram.Enabled {
 		trees = append(trees, conditions.ExternalProgram.Condition)
 	}
-	if conditions.AutoManagement != nil && conditions.AutoManagement.Enabled {
+	if conditions.AutoManagement != nil {
 		trees = append(trees, conditions.AutoManagement.Condition)
 	}
 	return trees

--- a/internal/api/handlers/automations_validation_test.go
+++ b/internal/api/handlers/automations_validation_test.go
@@ -370,6 +370,42 @@ func TestConditionsUseFreeSpace(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "autoManagement enabled with FREE_SPACE returns true",
+			conditions: &models.ActionConditions{
+				AutoManagement: &models.AutoManagementAction{
+					Enabled: true,
+					Condition: &automations.RuleCondition{
+						Field: automations.FieldFreeSpace,
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "autoManagement disabled with FREE_SPACE returns true (presence semantics)",
+			conditions: &models.ActionConditions{
+				AutoManagement: &models.AutoManagementAction{
+					Enabled: false,
+					Condition: &automations.RuleCondition{
+						Field: automations.FieldFreeSpace,
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "autoManagement enabled without FREE_SPACE returns false",
+			conditions: &models.ActionConditions{
+				AutoManagement: &models.AutoManagementAction{
+					Enabled: true,
+					Condition: &automations.RuleCondition{
+						Field: automations.FieldSize,
+					},
+				},
+			},
+			want: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -377,6 +413,111 @@ func TestConditionsUseFreeSpace(t *testing.T) {
 			got := conditionsUseFreeSpace(tt.conditions)
 			if got != tt.want {
 				t.Errorf("conditionsUseFreeSpace() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConditionTreesForValidation_AutoManagement(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions *models.ActionConditions
+		wantCount  int
+	}{
+		{
+			name: "autoManagement enabled is included",
+			conditions: &models.ActionConditions{
+				AutoManagement: &models.AutoManagementAction{
+					Enabled:   true,
+					Condition: &automations.RuleCondition{Field: automations.FieldSize},
+				},
+			},
+			wantCount: 1,
+		},
+		{
+			name: "autoManagement disabled is included (presence semantics)",
+			conditions: &models.ActionConditions{
+				AutoManagement: &models.AutoManagementAction{
+					Enabled:   false,
+					Condition: &automations.RuleCondition{Field: automations.FieldSize},
+				},
+			},
+			wantCount: 1,
+		},
+		{
+			name: "autoManagement nil is excluded",
+			conditions: &models.ActionConditions{
+				AutoManagement: nil,
+			},
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			trees := conditionTreesForValidation(tt.conditions)
+			if len(trees) != tt.wantCount {
+				t.Errorf("conditionTreesForValidation() returned %d trees, want %d", len(trees), tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestCollectConditionRegexErrors_AutoManagement(t *testing.T) {
+	tests := []struct {
+		name      string
+		conditions *models.ActionConditions
+		wantErrs  int
+	}{
+		{
+			name: "autoManagement with invalid regex returns error",
+			conditions: &models.ActionConditions{
+				AutoManagement: &models.AutoManagementAction{
+					Enabled: true,
+					Condition: &automations.RuleCondition{
+						Field:    automations.FieldTracker,
+						Operator: models.OperatorMatches,
+						Value:    "[invalid",
+					},
+				},
+			},
+			wantErrs: 1,
+		},
+		{
+			name: "autoManagement disabled with invalid regex still returns error",
+			conditions: &models.ActionConditions{
+				AutoManagement: &models.AutoManagementAction{
+					Enabled: false,
+					Condition: &automations.RuleCondition{
+						Field:    automations.FieldTracker,
+						Operator: models.OperatorMatches,
+						Value:    "[invalid",
+					},
+				},
+			},
+			wantErrs: 1,
+		},
+		{
+			name: "autoManagement with valid regex returns no errors",
+			conditions: &models.ActionConditions{
+				AutoManagement: &models.AutoManagementAction{
+					Enabled: true,
+					Condition: &automations.RuleCondition{
+						Field:    automations.FieldTracker,
+						Operator: models.OperatorMatches,
+						Value:    "^tracker\\.example\\.com$",
+					},
+				},
+			},
+			wantErrs: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := collectConditionRegexErrors(tt.conditions)
+			if len(errs) != tt.wantErrs {
+				t.Errorf("collectConditionRegexErrors() returned %d errors, want %d", len(errs), tt.wantErrs)
 			}
 		})
 	}

--- a/internal/api/handlers/automations_validation_test.go
+++ b/internal/api/handlers/automations_validation_test.go
@@ -465,9 +465,9 @@ func TestConditionTreesForValidation_AutoManagement(t *testing.T) {
 
 func TestCollectConditionRegexErrors_AutoManagement(t *testing.T) {
 	tests := []struct {
-		name      string
+		name       string
 		conditions *models.ActionConditions
-		wantErrs  int
+		wantErrs   int
 	}{
 		{
 			name: "autoManagement with invalid regex returns error",


### PR DESCRIPTION
AutoManagement was added to the runtime evaluator in ba3d5d97 but the three API validation functions in the handler were not updated. This meant invalid AutoTMM rules (bad regex, unknown group IDs, references to fields requiring local access) could be saved without error, then silently never match at runtime.

Adds AutoManagement to `conditionsUseField`, `conditionTreesForValidation`, and `collectConditionRegexErrors`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for AutoManagement conditions in automation validation and grouping checks.
* **Bug Fixes / Improvements**
  * Expanded validation to include AutoManagement condition trees when present.
  * Improved regex validation and error reporting for AutoManagement conditions to surface invalid patterns.
* **Tests**
  * Added unit tests covering AutoManagement inclusion semantics, condition-tree validation, and regex error detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->