### PR TITLE
fix(openapi): document dirscan downloadMissingFiles

### DIFF
--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -7352,6 +7352,8 @@ components:
           type: boolean
         startPaused:
           type: boolean
+        downloadMissingFiles:
+          type: boolean
         category:
           type: string
         tags:
@@ -7375,6 +7377,7 @@ components:
         - allowPartial
         - skipPieceBoundarySafetyCheck
         - startPaused
+        - downloadMissingFiles
         - category
         - tags
         - createdAt
@@ -7402,6 +7405,8 @@ components:
         skipPieceBoundarySafetyCheck:
           type: boolean
         startPaused:
+          type: boolean
+        downloadMissingFiles:
           type: boolean
         category:
           type: string


### PR DESCRIPTION
Adds the missing `downloadMissingFiles` property to the dirscan OpenAPI schemas so the documented contract matches the implemented API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * A new configuration option has been added to directory scan settings, allowing users to enable or disable file downloads during scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->