### PR TITLE
fix(automations): include AutoManagement in delete standalone check

### DIFF
--- a/internal/api/handlers/automations.go
+++ b/internal/api/handlers/automations.go
@@ -355,7 +355,8 @@ func (h *AutomationHandler) validatePayload(ctx context.Context, instanceID int,
 			(len(payload.Conditions.TagActions()) > 0) ||
 			(payload.Conditions.Category != nil && payload.Conditions.Category.Enabled) ||
 			(payload.Conditions.Move != nil && payload.Conditions.Move.Enabled) ||
-			(payload.Conditions.ExternalProgram != nil && payload.Conditions.ExternalProgram.Enabled)
+			(payload.Conditions.ExternalProgram != nil && payload.Conditions.ExternalProgram.Enabled) ||
+			(payload.Conditions.AutoManagement != nil && payload.Conditions.AutoManagement.Enabled)
 		if hasOtherAction {
 			return http.StatusBadRequest, "Delete action cannot be combined with other actions", errors.New("delete must be standalone")
 		}

--- a/internal/api/handlers/automations.go
+++ b/internal/api/handlers/automations.go
@@ -356,7 +356,7 @@ func (h *AutomationHandler) validatePayload(ctx context.Context, instanceID int,
 			(payload.Conditions.Category != nil && payload.Conditions.Category.Enabled) ||
 			(payload.Conditions.Move != nil && payload.Conditions.Move.Enabled) ||
 			(payload.Conditions.ExternalProgram != nil && payload.Conditions.ExternalProgram.Enabled) ||
-			(payload.Conditions.AutoManagement != nil && payload.Conditions.AutoManagement.Enabled)
+			(payload.Conditions.AutoManagement != nil)
 		if hasOtherAction {
 			return http.StatusBadRequest, "Delete action cannot be combined with other actions", errors.New("delete must be standalone")
 		}


### PR DESCRIPTION
## Summary
- Adds AutoManagement to the `hasOtherAction` check in `validatePayload` so that Delete + AutoManagement is rejected as invalid

The delete-is-standalone validation already checks SpeedLimits, ShareLimits, Pause, Resume, Recheck, Reannounce, Tags, Category, Move, and ExternalProgram — but AutoManagement was missed when it was added in ba3d5d97.

#1726 fixed the other three validation functions (`conditionsUseField`, `conditionTreesForValidation`, `collectConditionRegexErrors`) but this one was still missing.

## Test plan
- [x] `go test -race -count=1 -v ./internal/api/handlers/...` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automation validation updated: Auto Management options can no longer be combined with an enabled Delete action. This prevents conflicting automation setups and reduces risk of unintended deletions; users configuring automations will now see the validation enforced when attempting such combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->