### PR TITLE
feat(auth): add PKCE support to OIDC implementation

### DIFF
--- a/internal/api/handlers/oidc.go
+++ b/internal/api/handlers/oidc.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 
@@ -441,12 +442,7 @@ func (h *OIDCHandler) supportsPKCE() bool {
 	if err := h.provider.Claims(&claims); err != nil {
 		return false
 	}
-	for _, method := range claims.CodeChallenges {
-		if method == "S256" {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(claims.CodeChallenges, "S256")
 }
 
 func (h *OIDCHandler) GetConfigResponse() OIDCConfigResponse {

--- a/internal/api/handlers/oidc.go
+++ b/internal/api/handlers/oidc.go
@@ -57,6 +57,7 @@ type OIDCConfigResponse struct {
 	Enabled             bool   `json:"enabled"`
 	AuthorizationURL    string `json:"authorizationUrl"`
 	State               string `json:"state"`
+	PKCEVerifier        string `json:"pkceVerifier"`
 	DisableBuiltInLogin bool   `json:"disableBuiltInLogin"`
 	IssuerURL           string `json:"issuerUrl"`
 }
@@ -194,9 +195,12 @@ func (h *OIDCHandler) getConfig(w http.ResponseWriter, r *http.Request) {
 	// Get the config first
 	config := h.GetConfigResponse()
 
-	// Store state in session for later validation
+	// Store state and PKCE verifier in session for later validation
 	// This is needed even if user is already authenticated, in case they're re-authenticating
 	h.sessionManager.Put(r.Context(), "oidc_state", config.State)
+	if config.PKCEVerifier != "" {
+		h.sessionManager.Put(r.Context(), "oidc_pkce_verifier", config.PKCEVerifier)
+	}
 
 	RespondJSON(w, http.StatusOK, config)
 }
@@ -225,6 +229,10 @@ func (h *OIDCHandler) handleCallback(w http.ResponseWriter, r *http.Request) {
 	// Clear the state from session after successful validation
 	h.sessionManager.Remove(r.Context(), "oidc_state")
 
+	// Retrieve and clear the PKCE verifier stored during the authorization request
+	pkceVerifier := h.sessionManager.GetString(r.Context(), "oidc_pkce_verifier")
+	h.sessionManager.Remove(r.Context(), "oidc_pkce_verifier")
+
 	code := r.URL.Query().Get("code")
 	if code == "" {
 		log.Error().Msg("authorization code is missing from callback request")
@@ -232,7 +240,12 @@ func (h *OIDCHandler) handleCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	oauth2Token, err := h.oauthConfig.Exchange(r.Context(), code)
+	var exchangeOpts []oauth2.AuthCodeOption
+	if pkceVerifier != "" {
+		exchangeOpts = append(exchangeOpts, oauth2.VerifierOption(pkceVerifier))
+	}
+
+	oauth2Token, err := h.oauthConfig.Exchange(r.Context(), code, exchangeOpts...)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to exchange token")
 		RespondError(w, http.StatusInternalServerError, fmt.Sprintf("failed to exchange token: %v", err))
@@ -421,14 +434,37 @@ func generateRandomState() string {
 	return hex.EncodeToString(b)
 }
 
+func (h *OIDCHandler) supportsPKCE() bool {
+	var claims struct {
+		CodeChallenges []string `json:"code_challenge_methods_supported"`
+	}
+	if err := h.provider.Claims(&claims); err != nil {
+		return false
+	}
+	for _, method := range claims.CodeChallenges {
+		if method == "S256" {
+			return true
+		}
+	}
+	return false
+}
+
 func (h *OIDCHandler) GetConfigResponse() OIDCConfigResponse {
 	state := generateRandomState()
-	authURL := h.oauthConfig.AuthCodeURL(state)
+
+	var authURL, verifier string
+	if h.supportsPKCE() {
+		verifier = oauth2.GenerateVerifier()
+		authURL = h.oauthConfig.AuthCodeURL(state, oauth2.S256ChallengeOption(verifier))
+	} else {
+		authURL = h.oauthConfig.AuthCodeURL(state)
+	}
 
 	return OIDCConfigResponse{
 		Enabled:             h.config.OIDCEnabled,
 		AuthorizationURL:    authURL,
 		State:               state,
+		PKCEVerifier:        verifier,
 		DisableBuiltInLogin: h.config.OIDCDisableBuiltInLogin,
 		IssuerURL:           h.config.OIDCIssuer,
 	}


### PR DESCRIPTION
This PR adds PKCE support to the OIDC implementation, which is by default required by some IDPs like kanidm. The used oauth2 library already has support for PKCE, it just had to be wired up. See https://github.com/autobrr/autobrr/pull/2421 for equivalent changes in autobrr.

I tested this using a production NixOS deployment of qui and the kanidm IDP, with PKCE both enabled and disabled on the IDP side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced authentication with PKCE (S256) support when the identity provider advertises it.
  * Authorization flow now includes a PKCE verifier for improved security, persists it during login, and cleans it up after callback to ensure safe validation.
  * Better compatibility and more secure sign-in experience with providers that support PKCE.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->