### PR TITLE
fix(qbittorrent): avoid tracker health URL false positives

### DIFF
--- a/internal/qbittorrent/integration_test.go
+++ b/internal/qbittorrent/integration_test.go
@@ -156,6 +156,44 @@ func TestSyncManager_TorrentTrackerIsDown_TrackerUpdating(t *testing.T) {
 
 		assert.False(t, sm.torrentTrackerIsDown(&torrent))
 	})
+
+	t.Run("does not mark tracker down from down keyword inside URL", func(t *testing.T) {
+		torrent := qbt.Torrent{
+			AddedOn: time.Now().Add(-2 * time.Hour).Unix(),
+			Trackers: []qbt.TorrentTracker{
+				{
+					Status:  qbt.TrackerStatusNotWorking,
+					Message: "Trumped: https://beyond-hd.me/torrents/paradise-2025-s02e07-the-final-countdown-1080p",
+				},
+			},
+		}
+
+		assert.True(t, sm.torrentIsUnregistered(&torrent))
+		assert.False(t, sm.torrentTrackerIsDown(&torrent))
+		assert.Equal(t, TrackerHealthUnregistered, sm.determineTrackerHealth(&torrent))
+	})
+}
+
+func TestSyncManager_CountTorrentStatuses_TrackerHealthExclusive(t *testing.T) {
+	sm := &SyncManager{}
+	counts := map[string]int{}
+
+	torrent := qbt.Torrent{
+		Hash:    "hash1",
+		AddedOn: time.Now().Add(-2 * time.Hour).Unix(),
+		Trackers: []qbt.TorrentTracker{
+			{
+				Status:  qbt.TrackerStatusNotWorking,
+				Message: "Trumped: https://beyond-hd.me/torrents/paradise-2025-s02e07-the-final-countdown-1080p",
+			},
+		},
+	}
+
+	sm.countTorrentStatuses(torrent, counts)
+
+	assert.Equal(t, 1, counts["all"])
+	assert.Equal(t, 1, counts["unregistered"])
+	assert.Zero(t, counts["tracker_down"])
 }
 
 func TestSyncManager_TorrentBelongsToTrackerDomain(t *testing.T) {

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -437,12 +437,12 @@ func (sm *SyncManager) refreshTrackerHealthCounts(ctx context.Context, instanceI
 	}
 
 	for _, t := range enriched {
-		// Health counts
-		if sm.torrentIsUnregistered(&t) {
+		// Health counts are mutually exclusive.
+		switch sm.determineTrackerHealth(&t) {
+		case TrackerHealthUnregistered:
 			counts.Unregistered++
 			counts.UnregisteredSet[t.Hash] = struct{}{}
-		}
-		if sm.torrentTrackerIsDown(&t) {
+		case TrackerHealthDown:
 			counts.TrackerDown++
 			counts.TrackerDownSet[t.Hash] = struct{}{}
 		}
@@ -2624,7 +2624,7 @@ func (sm *SyncManager) torrentTrackerIsDown(torrent *qbt.Torrent) bool {
 		case qbt.TrackerStatusOK, qbt.TrackerStatusUpdating:
 			hasWorking = true
 		case qbt.TrackerStatusNotWorking:
-			if trackerMessageMatches(tracker.Message, trackerDownStatuses) {
+			if TrackerMessageMatchesDown(tracker.Message) {
 				hasDown = true
 			}
 		default:
@@ -2875,11 +2875,10 @@ func (sm *SyncManager) countTorrentStatuses(torrent qbt.Torrent, counts map[stri
 	// Count "all"
 	counts["all"]++
 
-	if sm.torrentIsUnregistered(&torrent) {
+	switch sm.determineTrackerHealth(&torrent) {
+	case TrackerHealthUnregistered:
 		counts["unregistered"]++
-	}
-
-	if sm.torrentTrackerIsDown(&torrent) {
+	case TrackerHealthDown:
 		counts["tracker_down"]++
 	}
 
@@ -4404,9 +4403,9 @@ func (sm *SyncManager) shouldClearOptimisticUpdate(currentState qbt.TorrentState
 func (sm *SyncManager) matchTorrentStatus(torrent qbt.Torrent, status string) bool {
 	switch strings.ToLower(status) {
 	case "unregistered":
-		return sm.torrentIsUnregistered(&torrent)
+		return sm.determineTrackerHealth(&torrent) == TrackerHealthUnregistered
 	case "tracker_down":
-		return sm.torrentTrackerIsDown(&torrent)
+		return sm.determineTrackerHealth(&torrent) == TrackerHealthDown
 	}
 
 	// Handle special cases first


### PR DESCRIPTION
Fix tracker health classification so tracker URLs in status messages do not trigger `tracker_down` matches. This routes filtering and cached counts through the exclusive tracker-health decision, so unregistered torrents no longer also show up as tracker-down because of words inside URLs like `countdown`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracker health status classification to accurately distinguish between unregistered torrents and offline trackers, ensuring robust categorization and preventing misclassification when tracker-related information appears in URLs.

* **Tests**
  * Added integration tests validating accurate tracker health status classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->