### PR TITLE
fix(torrents): validate creator output path

### DIFF
--- a/internal/api/handlers/torrents.go
+++ b/internal/api/handlers/torrents.go
@@ -68,6 +68,19 @@ func truncateExpr(expr string, maxLen int) string {
 	return expr[:maxLen-3] + "..."
 }
 
+func validateTorrentFilePath(path string) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil
+	}
+
+	if strings.HasSuffix(path, "/") || strings.HasSuffix(path, `\`) {
+		return errors.New("torrentFilePath must include a filename, not a directory")
+	}
+
+	return nil
+}
+
 const addTorrentMaxFormMemory int64 = 256 << 20 // 256 MiB cap for multi-file uploads
 
 // SortedPeer represents a peer with its key for sorting
@@ -2544,6 +2557,10 @@ func (h *TorrentsHandler) CreateTorrent(w http.ResponseWriter, r *http.Request) 
 
 	if req.SourcePath == "" {
 		RespondError(w, http.StatusBadRequest, "sourcePath is required")
+		return
+	}
+	if err := validateTorrentFilePath(req.TorrentFilePath); err != nil {
+		RespondError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 

--- a/internal/api/handlers/torrents_test.go
+++ b/internal/api/handlers/torrents_test.go
@@ -62,3 +62,42 @@ func TestSanitizeTorrentExportFilename_IgnoreSubdomain(t *testing.T) {
 		t.Fatalf("expected tracker tag to use registrable domain, got %q", filename)
 	}
 }
+
+func TestValidateTorrentFilePath(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{
+			name:    "empty path allowed",
+			path:    "",
+			wantErr: false,
+		},
+		{
+			name:    "full torrent file path allowed",
+			path:    "/downloads/output/movie.torrent",
+			wantErr: false,
+		},
+		{
+			name:    "unix directory path rejected",
+			path:    "/downloads/output/",
+			wantErr: true,
+		},
+		{
+			name:    "windows directory path rejected",
+			path:    `C:\Downloads\Output\`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		err := validateTorrentFilePath(tt.path)
+		if tt.wantErr && err == nil {
+			t.Fatalf("%s: expected error, got nil", tt.name)
+		}
+		if !tt.wantErr && err != nil {
+			t.Fatalf("%s: expected nil error, got %v", tt.name, err)
+		}
+	}
+}

--- a/web/src/components/torrents/TorrentCreatorDialog.tsx
+++ b/web/src/components/torrents/TorrentCreatorDialog.tsx
@@ -9,6 +9,7 @@ import { useForm } from "@tanstack/react-form"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { AlertCircle, ChevronDown, Info, Loader2 } from "lucide-react"
 import { toast } from "sonner"
+import { z } from "zod"
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
@@ -51,6 +52,13 @@ import { pieceSizeOptions, TorrentPieceSize } from "./piece-size"
 function parseLines(input: string): string[] {
   return input.split("\n").map((line) => line.trim()).filter(Boolean)
 }
+
+const torrentFilePathSchema = z.string().trim().refine(
+  (value) => value === "" || (!value.endsWith("/") && !value.endsWith("\\")),
+  {
+    message: "Enter a full .torrent file path, not a directory",
+  }
+)
 
 interface PathSuggestionsProps {
   suggestions: string[]
@@ -487,7 +495,15 @@ export function TorrentCreatorDialog({ instanceId, open, onOpenChange }: Torrent
                 </form.Field>
 
                 {/* Torrent File Path */}
-                <form.Field name="torrentFilePath">
+                <form.Field
+                  name="torrentFilePath"
+                  validators={{
+                    onChange: ({ value }) => {
+                      const result = torrentFilePathSchema.safeParse(value)
+                      return result.success ? undefined : result.error.issues[0]?.message
+                    },
+                  }}
+                >
                   {(field) => (
                     <div className="space-y-2">
                       <Label htmlFor="torrentFilePath">Save .torrent to (optional)</Label>
@@ -498,6 +514,7 @@ export function TorrentCreatorDialog({ instanceId, open, onOpenChange }: Torrent
                         autoComplete="off"
                         spellCheck={false}
                         value={field.state.value}
+                        aria-invalid={field.state.meta.isTouched && !!field.state.meta.errors[0]}
                         onBlur={field.handleBlur}
                         onKeyDown={supportsPathAutocomplete ? handleTorrentFilePathKeyDown : undefined}
                         onChange={(e) => {
@@ -517,7 +534,7 @@ export function TorrentCreatorDialog({ instanceId, open, onOpenChange }: Torrent
                       )}
 
                       <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                        <span>Where to save the .torrent file on the server</span>
+                        <span>Full .torrent file path on the server; directory alone is invalid</span>
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <Info className="h-4 w-4 cursor-help shrink-0" />
@@ -527,6 +544,9 @@ export function TorrentCreatorDialog({ instanceId, open, onOpenChange }: Torrent
                           </TooltipContent>
                         </Tooltip>
                       </div>
+                      {field.state.meta.isTouched && field.state.meta.errors[0] && (
+                        <p className="text-sm text-destructive">{field.state.meta.errors[0]}</p>
+                      )}
                     </div>
                   )}
                 </form.Field>


### PR DESCRIPTION
Prevent torrent creation failures when users enter a directory in the optional `.torrent` output field by validating the value in both the dialog and the API, surfacing a clearer error earlier, and clarifying that qBittorrent expects a full output path including the filename rather than a directory alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for torrent file paths to reject directory-only paths during form submission and input changes.
  * Enhanced error messaging in the UI to clearly indicate when a directory-only value is invalid.
  * Improved form field validation with real-time feedback and accessibility enhancements for error states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->