### PR TITLE
docs: update release follow-up docs

### DIFF
--- a/documentation/docs/configuration/oidc.md
+++ b/documentation/docs/configuration/oidc.md
@@ -7,6 +7,8 @@ title: OIDC
 
 Set `QUI__OIDC_ENABLED=true` to hand authentication off to an external identity provider. The built-in login screen automatically offers a "Sign in with OIDC" button when the backend detects a valid OIDC configuration.
 
+If your provider advertises PKCE (`S256`) support, qui uses it automatically for the authorization flow. No extra qui setting is required.
+
 For the full mapping (TOML keys + environment variables + defaults), see [Configuration Reference](./reference).
 
 ## Configuration Options

--- a/documentation/docs/features/automations.md
+++ b/documentation/docs/features/automations.md
@@ -14,6 +14,7 @@ Automations are evaluated in **sort order** (first match wins for exclusive acti
 
 - **Automatic** - Background service scans torrents every 20 seconds
 - **Per-Rule Intervals** - Each rule can have its own interval (minimum 60 seconds, default 15 minutes)
+- **Per-Rule Notifications** - If notification targets are configured, each rule can opt in or out of sending automation notifications
 - **Manual** - Click "Apply Now" to trigger immediately (bypasses interval checks)
 - **Manual dry-run** - Run "Dry-run now" from the workflow dialog or "Run dry-run now" from the workflow menu
 - **Debouncing** - Same torrent won't be re-processed within 2 minutes
@@ -76,6 +77,19 @@ The query builder supports complex nested conditions with AND/OR groups. Drag co
 | Max Inactive Seeding Time | Configured max inactive seeding time |
 | Seeding Time Limit       | Torrent seeding time limit            |
 | Inactive Seeding Time Limit | Torrent inactive seeding time limit |
+
+#### System Time Fields
+
+These fields use qui's current system time when the rule is evaluated. They are useful for time-window automations such as "only run at night" or "apply different actions on weekends."
+
+| Field              | Description                               |
+| ------------------ | ----------------------------------------- |
+| System Hour        | Current hour (`0-23`)                     |
+| System Minute      | Current minute (`0-59`)                   |
+| System Day of Week | Current weekday (`0=Sun` to `6=Sat`)      |
+| System Day         | Current day of month (`1-31`)             |
+| System Month       | Current month (`1-12`)                    |
+| System Year        | Current year                              |
 
 #### Progress Fields
 

--- a/documentation/docs/features/backups.md
+++ b/documentation/docs/features/backups.md
@@ -8,6 +8,8 @@ description: Schedule and restore qBittorrent instance backups.
 
 qui can take scheduled or ad-hoc snapshots of a qBittorrent instance. Each snapshot includes the torrent archive, tags, categories (with save paths), and cached `.torrent` blobs so that you can recreate the original state later.
 
+If you manage multiple instances, the Backups page also includes **Save changes to all instances** so you can copy the current backup schedule/settings to every compatible instance in one step.
+
 ## Restore Modes
 
 Once backups are enabled for an instance the backlog UI exposes a **Restore** action for each run. Restores support three distinct modes:

--- a/documentation/docs/features/cross-seed/overview.md
+++ b/documentation/docs/features/cross-seed/overview.md
@@ -68,6 +68,8 @@ Triggers a cross-seed search when torrents finish downloading. Configure in the 
 - **Exclude categories/tags** - Skip torrents matching these filters
 - **Bypass Torznab cache** - When enabled for an instance, completion searches for that instance always perform a fresh Torznab search instead of using cached indexer results. Default: off. Does not affect Gazelle (OPS/RED) searches, which do not use the Torznab cache.
 
+If a torrent is still **checking** or **moving**, qui waits and runs the completion search afterward instead of searching immediately against an unstable path/state.
+
 ### Manual Search
 
 Right-click any torrent in the list to access cross-seed actions:


### PR DESCRIPTION
Update the release follow-up docs so the user-facing documentation matches the current behavior: document automatic PKCE in OIDC, add the automation system-time fields and per-rule notification toggle, mention the multi-instance backup save action, and note that completion searches wait until torrents finish checking or moving.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OIDC provider configuration documentation for PKCE support
  * Added per-rule notification options for automation rules
  * Introduced system time-based condition fields for automation rules (hour, minute, day of week, day of month, month, year)
  * Documented multi-instance backup schedule management feature
  * Enhanced cross-seed completion search handling for checking and moving torrent states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->