### PR TITLE
fix(dirscan): tighten flexible matching and improve diagnostics

### DIFF
--- a/documentation/docs/features/cross-seed/dir-scan.md
+++ b/documentation/docs/features/cross-seed/dir-scan.md
@@ -169,8 +169,8 @@ Open **Dir Scan > Settings**:
 
 | Setting | Description |
 |---------|-------------|
-| Match Mode | `Strict` matches by filename + size. `Flexible` matches by size only. |
-| Size Tolerance (%) | Allows small size differences when matching. |
+| Match Mode | `Strict` matches by filename + exact file size. `Flexible` ignores filenames for primary matching, but matched files must still have the same exact file size. |
+| Size Tolerance (%) | Allows small differences in total torrent size when filtering candidates before file matching. |
 | Minimum Piece Ratio (%) | For partial matches, minimum percent of torrent data that must exist on disk. |
 | Max searchees per run | Limits how many eligible searchees are processed per run. `0` = unlimited. Useful for making progress across restarts. |
 | Only process items changed within the last (days) | Excludes stale work items before search. Uses video/audio mtimes only for manual/scheduled scans. Webhook-triggered scans ignore this cutoff. `0` = disabled. |
@@ -179,6 +179,13 @@ Open **Dir Scan > Settings**:
 | Skip piece boundary safety check | Allow partial matches where downloading missing files could modify pieces containing existing content. |
 | Start torrents paused | Add injected torrents in paused state. |
 | Default Category / Tags | Applied to all injected torrents. Directory-level settings add to these. |
+
+In practice:
+
+- **Strict** is best when filenames on disk are still close to the release layout.
+- **Flexible** is best for renamed libraries, but it still requires exact file-size matches for the files it pairs.
+- **Size Tolerance** only affects which search results are considered based on **total torrent size**. It does **not** allow per-file size mismatches.
+- Flexible single-file matches may still be rejected when the candidate lacks corroborating title or IMDb evidence. This prevents false positives when an indexer falls back from ID-based search to plain title search.
 
 ### "Max searchees per run" explained
 

--- a/documentation/docs/features/cross-seed/dir-scan.md
+++ b/documentation/docs/features/cross-seed/dir-scan.md
@@ -185,7 +185,7 @@ In practice:
 - **Strict** is best when filenames on disk are still close to the release layout.
 - **Flexible** is best for renamed libraries, but it still requires exact file-size matches for the files it pairs.
 - **Size Tolerance** only affects which search results are considered based on **total torrent size**. It does **not** allow per-file size mismatches.
-- Flexible single-file matches may still be rejected when the candidate lacks corroborating title or IMDb evidence. This prevents false positives when an indexer falls back from ID-based search to plain title search.
+- Flexible single-file matches may still be rejected when the candidate lacks corroborating title or external ID evidence. This prevents false positives when an indexer falls back from ID-based search to plain title search.
 
 ### "Max searchees per run" explained
 

--- a/internal/services/dirscan/acceptance_test.go
+++ b/internal/services/dirscan/acceptance_test.go
@@ -114,12 +114,13 @@ func TestRefineDirScanMatchDecision_RejectsFlexibleSingleFilePerfectWithoutCorro
 		MatchMode:    models.MatchModeFlexible,
 		AllowPartial: false,
 	}
+	searcheeMeta := NewParser(nil).Parse(searchee.Name)
 	baseDecision := shouldAcceptDirScanMatch(match, parsed, settings)
 	if !baseDecision.Accept {
 		t.Fatalf("expected base decision to accept perfect match")
 	}
 
-	decision := refineDirScanMatchDecision(searchee, parsed, &jackett.SearchResult{
+	decision := refineDirScanMatchDecision(searchee, searcheeMeta, parsed, &jackett.SearchResult{
 		Title: "Totally Different Movie 2023 1080p BluRay x264-GROUP",
 	}, settings, match, baseDecision)
 
@@ -161,12 +162,13 @@ func TestRefineDirScanMatchDecision_AcceptsFlexibleSingleFilePerfectWithIMDbCorr
 		MatchMode:    models.MatchModeFlexible,
 		AllowPartial: false,
 	}
+	searcheeMeta := NewParser(nil).Parse(searchee.Name)
 	baseDecision := shouldAcceptDirScanMatch(match, parsed, settings)
 	if !baseDecision.Accept {
 		t.Fatalf("expected base decision to accept perfect match")
 	}
 
-	decision := refineDirScanMatchDecision(searchee, parsed, &jackett.SearchResult{
+	decision := refineDirScanMatchDecision(searchee, searcheeMeta, parsed, &jackett.SearchResult{
 		Title:  "John Wick Chapter 4 2023 1080p WEB-DL DDP5 1 Atmos H 264-WDYM",
 		IMDbID: "tt10366206",
 	}, settings, match, baseDecision)
@@ -178,7 +180,7 @@ func TestRefineDirScanMatchDecision_AcceptsFlexibleSingleFilePerfectWithIMDbCorr
 
 func TestRefineDirScanMatchDecision_AcceptsFlexibleSingleFilePerfectWithSearchIMDbContext(t *testing.T) {
 	searchee := &Searchee{
-		Name: "Le Comte de Monte-Cristo (2024) {imdb-tt26446278}",
+		Name: "Le Comte de Monte-Cristo (2024)",
 		Files: []*ScannedFile{{
 			Path:    "/media/movies/Le Comte de Monte-Cristo (2024)/Le Comte de Monte-Cristo (2024).mkv",
 			RelPath: "Le Comte de Monte-Cristo (2024).mkv",
@@ -206,8 +208,10 @@ func TestRefineDirScanMatchDecision_AcceptsFlexibleSingleFilePerfectWithSearchIM
 		MatchMode:    models.MatchModeFlexible,
 		AllowPartial: false,
 	}
+	searcheeMeta := NewParser(nil).Parse(searchee.Name)
+	searcheeMeta.SetExternalIDs("tt26446278", 0, 0)
 	baseDecision := shouldAcceptDirScanMatch(match, parsed, settings)
-	decision := refineDirScanMatchDecision(searchee, parsed, &jackett.SearchResult{
+	decision := refineDirScanMatchDecision(searchee, searcheeMeta, parsed, &jackett.SearchResult{
 		Title:        "The Count of Monte Cristo 2024 1080p WEB-DL x264-GROUP",
 		SearchIMDbID: "26446278",
 	}, settings, match, baseDecision)
@@ -247,8 +251,9 @@ func TestRefineDirScanMatchDecision_AcceptsFlexibleSingleFilePerfectWithTVDbCorr
 		MatchMode:    models.MatchModeFlexible,
 		AllowPartial: false,
 	}
+	searcheeMeta := NewParser(nil).Parse(searchee.Name)
 	baseDecision := shouldAcceptDirScanMatch(match, parsed, settings)
-	decision := refineDirScanMatchDecision(searchee, parsed, &jackett.SearchResult{
+	decision := refineDirScanMatchDecision(searchee, searcheeMeta, parsed, &jackett.SearchResult{
 		Title:        "The Bureau S01E01 1080p WEB-DL x264-GROUP",
 		SearchTVDbID: "295770",
 	}, settings, match, baseDecision)
@@ -288,14 +293,63 @@ func TestRefineDirScanMatchDecision_AcceptsFlexibleSingleFilePerfectWithTMDbCorr
 		MatchMode:    models.MatchModeFlexible,
 		AllowPartial: false,
 	}
+	searcheeMeta := NewParser(nil).Parse(searchee.Name)
 	baseDecision := shouldAcceptDirScanMatch(match, parsed, settings)
-	decision := refineDirScanMatchDecision(searchee, parsed, &jackett.SearchResult{
+	decision := refineDirScanMatchDecision(searchee, searcheeMeta, parsed, &jackett.SearchResult{
 		Title:        "Avatar Fire and Ash 2025 2160p WEB-DL x265-GROUP",
 		SearchTMDbID: 83533,
 	}, settings, match, baseDecision)
 
 	if !decision.Accept {
 		t.Fatalf("expected TMDb corroboration to be accepted, got reason %q", decision.Reason)
+	}
+}
+
+func TestRefineDirScanMatchDecision_RejectsFlexibleSingleFilePerfectForWrongEpisode(t *testing.T) {
+	searchee := &Searchee{
+		Name: "The Office S01E01",
+		Files: []*ScannedFile{{
+			Path:    "/media/tv/The Office/Season 01/The Office - S01E01.mkv",
+			RelPath: "The Office - S01E01.mkv",
+			Size:    1000,
+		}},
+	}
+	parsed := &ParsedTorrent{
+		Name:        "The.Office.S01E02.1080p.WEB-DL.x264-GROUP",
+		InfoHash:    "deadbeef",
+		PieceLength: 4,
+		Files: []TorrentFile{
+			{Path: "The.Office.S01E02.1080p.WEB-DL.x264-GROUP.mkv", Size: 1000, Offset: 0},
+		},
+		TotalSize: 1000,
+	}
+	match := &MatchResult{
+		MatchedFiles: []MatchedFilePair{{
+			SearcheeFile: searchee.Files[0],
+			TorrentFile:  parsed.Files[0],
+		}},
+		IsPerfectMatch: true,
+		IsMatch:        true,
+	}
+	settings := &models.DirScanSettings{
+		MatchMode:    models.MatchModeFlexible,
+		AllowPartial: false,
+	}
+	searcheeMeta := NewParser(nil).Parse(searchee.Name)
+	baseDecision := shouldAcceptDirScanMatch(match, parsed, settings)
+	if !baseDecision.Accept {
+		t.Fatalf("expected base decision to accept perfect match")
+	}
+
+	decision := refineDirScanMatchDecision(searchee, searcheeMeta, parsed, &jackett.SearchResult{
+		Title: "The Office S01E02 1080p WEB-DL x264-GROUP",
+	}, settings, match, baseDecision)
+
+	if decision.Accept {
+		t.Fatalf("expected wrong-episode title corroboration to be rejected")
+	}
+	if decision.Reason != "flexible size-only match lacks title or ID corroboration" {
+		t.Fatalf("unexpected reason: %q", decision.Reason)
 	}
 }
 

--- a/internal/services/dirscan/acceptance_test.go
+++ b/internal/services/dirscan/acceptance_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/services/jackett"
 )
 
 func TestShouldAcceptDirScanMatch_PiecePercentThreshold(t *testing.T) {
@@ -80,5 +81,233 @@ func TestShouldAcceptDirScanMatch_NoFilesMatched(t *testing.T) {
 	}
 	if decision.Reason != "no files matched" {
 		t.Fatalf("expected reason %q, got %q", "no files matched", decision.Reason)
+	}
+}
+
+func TestRefineDirScanMatchDecision_RejectsFlexibleSingleFilePerfectWithoutCorroboration(t *testing.T) {
+	searchee := &Searchee{
+		Name: "John Wick Chapter 4 (2023) {imdb-tt10366206}",
+		Files: []*ScannedFile{{
+			Path:    "/media/movies/John Wick Chapter 4 (2023) {imdb-tt10366206}/John Wick Chapter 4 (2023).mkv",
+			RelPath: "John Wick Chapter 4 (2023).mkv",
+			Size:    1000,
+		}},
+	}
+	parsed := &ParsedTorrent{
+		Name:        "Totally.Different.Movie.2023.1080p.BluRay.x264-GROUP",
+		InfoHash:    "deadbeef",
+		PieceLength: 4,
+		Files: []TorrentFile{
+			{Path: "Totally.Different.Movie.2023.1080p.BluRay.x264-GROUP.mkv", Size: 1000, Offset: 0},
+		},
+		TotalSize: 1000,
+	}
+	match := &MatchResult{
+		MatchedFiles: []MatchedFilePair{{
+			SearcheeFile: searchee.Files[0],
+			TorrentFile:  parsed.Files[0],
+		}},
+		IsPerfectMatch: true,
+		IsMatch:        true,
+	}
+	settings := &models.DirScanSettings{
+		MatchMode:    models.MatchModeFlexible,
+		AllowPartial: false,
+	}
+	baseDecision := shouldAcceptDirScanMatch(match, parsed, settings)
+	if !baseDecision.Accept {
+		t.Fatalf("expected base decision to accept perfect match")
+	}
+
+	decision := refineDirScanMatchDecision(searchee, parsed, &jackett.SearchResult{
+		Title: "Totally Different Movie 2023 1080p BluRay x264-GROUP",
+	}, settings, match, baseDecision)
+
+	if decision.Accept {
+		t.Fatalf("expected flexible size-only mismatch to be rejected")
+	}
+	if decision.Reason != "flexible size-only match lacks title or ID corroboration" {
+		t.Fatalf("unexpected reason: %q", decision.Reason)
+	}
+}
+
+func TestRefineDirScanMatchDecision_AcceptsFlexibleSingleFilePerfectWithIMDbCorroboration(t *testing.T) {
+	searchee := &Searchee{
+		Name: "John Wick Chapter 4 (2023) {imdb-tt10366206}",
+		Files: []*ScannedFile{{
+			Path:    "/media/movies/John Wick Chapter 4 (2023) {imdb-tt10366206}/John Wick Chapter 4 (2023).mkv",
+			RelPath: "John Wick Chapter 4 (2023).mkv",
+			Size:    1000,
+		}},
+	}
+	parsed := &ParsedTorrent{
+		Name:        "John.Wick.Chapter.4.2023.1080p.WEB-DL.DDP5.1.Atmos.H.264-WDYM",
+		InfoHash:    "deadbeef",
+		PieceLength: 4,
+		Files: []TorrentFile{
+			{Path: "John.Wick.Chapter.4.2023.1080p.WEB-DL.DDP5.1.Atmos.H.264-WDYM.mkv", Size: 1000, Offset: 0},
+		},
+		TotalSize: 1000,
+	}
+	match := &MatchResult{
+		MatchedFiles: []MatchedFilePair{{
+			SearcheeFile: searchee.Files[0],
+			TorrentFile:  parsed.Files[0],
+		}},
+		IsPerfectMatch: true,
+		IsMatch:        true,
+	}
+	settings := &models.DirScanSettings{
+		MatchMode:    models.MatchModeFlexible,
+		AllowPartial: false,
+	}
+	baseDecision := shouldAcceptDirScanMatch(match, parsed, settings)
+	if !baseDecision.Accept {
+		t.Fatalf("expected base decision to accept perfect match")
+	}
+
+	decision := refineDirScanMatchDecision(searchee, parsed, &jackett.SearchResult{
+		Title:  "John Wick Chapter 4 2023 1080p WEB-DL DDP5 1 Atmos H 264-WDYM",
+		IMDbID: "tt10366206",
+	}, settings, match, baseDecision)
+
+	if !decision.Accept {
+		t.Fatalf("expected corroborated flexible match to be accepted, got reason %q", decision.Reason)
+	}
+}
+
+func TestRefineDirScanMatchDecision_AcceptsFlexibleSingleFilePerfectWithSearchIMDbContext(t *testing.T) {
+	searchee := &Searchee{
+		Name: "Le Comte de Monte-Cristo (2024) {imdb-tt26446278}",
+		Files: []*ScannedFile{{
+			Path:    "/media/movies/Le Comte de Monte-Cristo (2024)/Le Comte de Monte-Cristo (2024).mkv",
+			RelPath: "Le Comte de Monte-Cristo (2024).mkv",
+			Size:    1000,
+		}},
+	}
+	parsed := &ParsedTorrent{
+		Name:        "The.Count.of.Monte.Cristo.2024.1080p.WEB-DL.x264-GROUP",
+		InfoHash:    "deadbeef",
+		PieceLength: 4,
+		Files: []TorrentFile{
+			{Path: "The.Count.of.Monte.Cristo.2024.1080p.WEB-DL.x264-GROUP.mkv", Size: 1000, Offset: 0},
+		},
+		TotalSize: 1000,
+	}
+	match := &MatchResult{
+		MatchedFiles: []MatchedFilePair{{
+			SearcheeFile: searchee.Files[0],
+			TorrentFile:  parsed.Files[0],
+		}},
+		IsPerfectMatch: true,
+		IsMatch:        true,
+	}
+	settings := &models.DirScanSettings{
+		MatchMode:    models.MatchModeFlexible,
+		AllowPartial: false,
+	}
+	baseDecision := shouldAcceptDirScanMatch(match, parsed, settings)
+	decision := refineDirScanMatchDecision(searchee, parsed, &jackett.SearchResult{
+		Title:        "The Count of Monte Cristo 2024 1080p WEB-DL x264-GROUP",
+		SearchIMDbID: "26446278",
+	}, settings, match, baseDecision)
+
+	if !decision.Accept {
+		t.Fatalf("expected search-context IMDb corroboration to be accepted, got reason %q", decision.Reason)
+	}
+}
+
+func TestRefineDirScanMatchDecision_AcceptsFlexibleSingleFilePerfectWithTVDbCorroboration(t *testing.T) {
+	searchee := &Searchee{
+		Name: "Le Bureau des Légendes - S01E01 [tvdb-295770]",
+		Files: []*ScannedFile{{
+			Path:    "/media/tv/Le Bureau des Légendes/S01E01.mkv",
+			RelPath: "Le Bureau des Légendes - S01E01.mkv",
+			Size:    1000,
+		}},
+	}
+	parsed := &ParsedTorrent{
+		Name:        "The.Bureau.S01E01.1080p.WEB-DL.x264-GROUP",
+		InfoHash:    "deadbeef",
+		PieceLength: 4,
+		Files: []TorrentFile{
+			{Path: "The.Bureau.S01E01.1080p.WEB-DL.x264-GROUP.mkv", Size: 1000, Offset: 0},
+		},
+		TotalSize: 1000,
+	}
+	match := &MatchResult{
+		MatchedFiles: []MatchedFilePair{{
+			SearcheeFile: searchee.Files[0],
+			TorrentFile:  parsed.Files[0],
+		}},
+		IsPerfectMatch: true,
+		IsMatch:        true,
+	}
+	settings := &models.DirScanSettings{
+		MatchMode:    models.MatchModeFlexible,
+		AllowPartial: false,
+	}
+	baseDecision := shouldAcceptDirScanMatch(match, parsed, settings)
+	decision := refineDirScanMatchDecision(searchee, parsed, &jackett.SearchResult{
+		Title:        "The Bureau S01E01 1080p WEB-DL x264-GROUP",
+		SearchTVDbID: "295770",
+	}, settings, match, baseDecision)
+
+	if !decision.Accept {
+		t.Fatalf("expected TVDb corroboration to be accepted, got reason %q", decision.Reason)
+	}
+}
+
+func TestRefineDirScanMatchDecision_AcceptsFlexibleSingleFilePerfectWithTMDbCorroboration(t *testing.T) {
+	searchee := &Searchee{
+		Name: "Avatar - De feu et de cendres (2025) {tmdb-83533}",
+		Files: []*ScannedFile{{
+			Path:    "/media/movies/Avatar - De feu et de cendres (2025)/Avatar - De feu et de cendres (2025).mkv",
+			RelPath: "Avatar - De feu et de cendres (2025).mkv",
+			Size:    1000,
+		}},
+	}
+	parsed := &ParsedTorrent{
+		Name:        "Avatar.Fire.and.Ash.2025.2160p.WEB-DL.x265-GROUP",
+		InfoHash:    "deadbeef",
+		PieceLength: 4,
+		Files: []TorrentFile{
+			{Path: "Avatar.Fire.and.Ash.2025.2160p.WEB-DL.x265-GROUP.mkv", Size: 1000, Offset: 0},
+		},
+		TotalSize: 1000,
+	}
+	match := &MatchResult{
+		MatchedFiles: []MatchedFilePair{{
+			SearcheeFile: searchee.Files[0],
+			TorrentFile:  parsed.Files[0],
+		}},
+		IsPerfectMatch: true,
+		IsMatch:        true,
+	}
+	settings := &models.DirScanSettings{
+		MatchMode:    models.MatchModeFlexible,
+		AllowPartial: false,
+	}
+	baseDecision := shouldAcceptDirScanMatch(match, parsed, settings)
+	decision := refineDirScanMatchDecision(searchee, parsed, &jackett.SearchResult{
+		Title:        "Avatar Fire and Ash 2025 2160p WEB-DL x265-GROUP",
+		SearchTMDbID: 83533,
+	}, settings, match, baseDecision)
+
+	if !decision.Accept {
+		t.Fatalf("expected TMDb corroboration to be accepted, got reason %q", decision.Reason)
+	}
+}
+
+func TestDescribeDirScanDecisionHints_FlexibleCorroborationFailure(t *testing.T) {
+	hint, hints := describeDirScanDecisionHints(dirScanMatchDecision{
+		Reason: "flexible size-only match lacks title or ID corroboration",
+	})
+
+	if hint != "size-only match rejected" {
+		t.Fatalf("expected hint %q, got %q", "size-only match rejected", hint)
+	}
+	if len(hints) == 0 {
+		t.Fatal("expected at least one hint")
 	}
 }

--- a/internal/services/dirscan/acceptance_test.go
+++ b/internal/services/dirscan/acceptance_test.go
@@ -305,6 +305,48 @@ func TestRefineDirScanMatchDecision_AcceptsFlexibleSingleFilePerfectWithTMDbCorr
 	}
 }
 
+func TestRefineDirScanMatchDecision_AcceptsFlexibleSingleFilePerfectWithResultTMDbCorroboration(t *testing.T) {
+	searchee := &Searchee{
+		Name: "Avatar - De feu et de cendres (2025) {tmdb-83533}",
+		Files: []*ScannedFile{{
+			Path:    "/media/movies/Avatar - De feu et de cendres (2025)/Avatar - De feu et de cendres (2025).mkv",
+			RelPath: "Avatar - De feu et de cendres (2025).mkv",
+			Size:    1000,
+		}},
+	}
+	parsed := &ParsedTorrent{
+		Name:        "Avatar.Fire.and.Ash.2025.2160p.WEB-DL.x265-GROUP",
+		InfoHash:    "deadbeef",
+		PieceLength: 4,
+		Files: []TorrentFile{
+			{Path: "Avatar.Fire.and.Ash.2025.2160p.WEB-DL.x265-GROUP.mkv", Size: 1000, Offset: 0},
+		},
+		TotalSize: 1000,
+	}
+	match := &MatchResult{
+		MatchedFiles: []MatchedFilePair{{
+			SearcheeFile: searchee.Files[0],
+			TorrentFile:  parsed.Files[0],
+		}},
+		IsPerfectMatch: true,
+		IsMatch:        true,
+	}
+	settings := &models.DirScanSettings{
+		MatchMode:    models.MatchModeFlexible,
+		AllowPartial: false,
+	}
+	searcheeMeta := NewParser(nil).Parse(searchee.Name)
+	baseDecision := shouldAcceptDirScanMatch(match, parsed, settings)
+	decision := refineDirScanMatchDecision(searchee, searcheeMeta, parsed, &jackett.SearchResult{
+		Title:  "Avatar Fire and Ash 2025 2160p WEB-DL x265-GROUP",
+		TMDbID: "83533",
+	}, settings, match, baseDecision)
+
+	if !decision.Accept {
+		t.Fatalf("expected result TMDb corroboration to be accepted, got reason %q", decision.Reason)
+	}
+}
+
 func TestRefineDirScanMatchDecision_RejectsFlexibleSingleFilePerfectForWrongEpisode(t *testing.T) {
 	searchee := &Searchee{
 		Name: "The Office S01E01",

--- a/internal/services/dirscan/inject_test.go
+++ b/internal/services/dirscan/inject_test.go
@@ -160,9 +160,7 @@ func TestHumanizeLinkPlanError(t *testing.T) {
 	}
 }
 
-func TestBuildLinkTreeMatchedFiles_SizeToleranceMismatch(t *testing.T) {
-	// Simulate flexible-mode match where sizes differ within tolerance:
-	// torrent file is 1000 bytes, searchee file is 1040 bytes (4% diff).
+func TestBuildLinkTreeMatchedFiles_UsesTorrentFileSize(t *testing.T) {
 	match := &MatchResult{
 		MatchedFiles: []MatchedFilePair{
 			{
@@ -173,7 +171,7 @@ func TestBuildLinkTreeMatchedFiles_SizeToleranceMismatch(t *testing.T) {
 				SearcheeFile: &ScannedFile{
 					Path:    "/media/tv/Show (2024)/Season 01/Show (2024) - S01E07 - Title [CR][WEBDL-1080p]-Group.mkv",
 					RelPath: "Show (2024) - S01E07 - Title [CR][WEBDL-1080p]-Group.mkv",
-					Size:    1040,
+					Size:    1000,
 				},
 			},
 		},
@@ -184,13 +182,11 @@ func TestBuildLinkTreeMatchedFiles_SizeToleranceMismatch(t *testing.T) {
 		t.Fatalf("buildLinkTreeMatchedFiles: %v", err)
 	}
 
-	// The bug: existing[0].Size was set to SearcheeFile.Size (1040),
-	// but linkable[0].Size is TorrentFile.Size (1000).
-	// BuildPlan indexes by existing size and looks up by candidate size,
-	// so mismatched sizes cause "no matching file" error.
+	// The bug was that existing[0].Size used the searchee file size instead of the
+	// torrent file size. Exact file-size matching means these should now be equal.
 	_, err = hardlinktree.BuildPlan(linkable, existing, hardlinktree.LayoutOriginal, "Show", t.TempDir())
 	if err != nil {
-		t.Fatalf("BuildPlan should succeed with tolerance-matched sizes, got: %v", err)
+		t.Fatalf("BuildPlan should succeed with exact matched sizes, got: %v", err)
 	}
 }
 

--- a/internal/services/dirscan/matching.go
+++ b/internal/services/dirscan/matching.go
@@ -66,21 +66,16 @@ type TorrentFile struct {
 
 // Matcher handles matching searchees against torrent file lists.
 type Matcher struct {
-	mode             MatchMode
-	sizeTolerancePct float64
+	mode MatchMode
 }
 
 // NewMatcher creates a new matcher.
-func NewMatcher(mode MatchMode, sizeTolerancePct float64) *Matcher {
+func NewMatcher(mode MatchMode, _ float64) *Matcher {
 	if mode == "" {
 		mode = MatchModeStrict
 	}
-	if sizeTolerancePct <= 0 {
-		sizeTolerancePct = 0 // Exact size match
-	}
 	return &Matcher{
-		mode:             mode,
-		sizeTolerancePct: sizeTolerancePct,
+		mode: mode,
 	}
 }
 
@@ -167,8 +162,9 @@ func (m *Matcher) matchStrict(searchee *Searchee, torrentFiles []TorrentFile, re
 				continue
 			}
 
-			// Check size match
-			if m.sizesMatch(sf.Size, tf.Size) {
+			// File-level matching requires exact sizes. Tolerance only applies when
+			// prefiltering candidate torrents by total size before matching starts.
+			if sizesMatchExactly(sf.Size, tf.Size) {
 				result.MatchedFiles = append(result.MatchedFiles, MatchedFilePair{
 					SearcheeFile: sf,
 					TorrentFile:  tf,
@@ -254,7 +250,7 @@ func (m *Matcher) findSizeCandidates(
 ) []TorrentFile {
 	var candidates []TorrentFile
 	for size, files := range torrentBySize {
-		if !m.sizesMatch(sf.Size, size) {
+		if !sizesMatchExactly(sf.Size, size) {
 			continue
 		}
 		for _, tf := range files {
@@ -294,22 +290,8 @@ func collectUnmatchedTorrentFiles(torrentFiles []TorrentFile, matched map[int]bo
 	}
 }
 
-// sizesMatch checks if two sizes match within the configured tolerance.
-func (m *Matcher) sizesMatch(size1, size2 int64) bool {
-	if m.sizeTolerancePct <= 0 {
-		return size1 == size2
-	}
-
-	// Calculate tolerance based on the larger size
-	larger := max(size1, size2)
-
-	tolerance := float64(larger) * (m.sizeTolerancePct / 100.0)
-	diff := size1 - size2
-	if diff < 0 {
-		diff = -diff
-	}
-
-	return float64(diff) <= tolerance
+func sizesMatchExactly(size1, size2 int64) bool {
+	return size1 == size2
 }
 
 // normalizeFileName normalizes a file path for comparison.

--- a/internal/services/dirscan/matching_test.go
+++ b/internal/services/dirscan/matching_test.go
@@ -107,3 +107,26 @@ func TestMatcher_Strict_NormalizesFilenames(t *testing.T) {
 		})
 	}
 }
+
+func TestMatcher_Flexible_RequiresExactFileSize(t *testing.T) {
+	matcher := NewMatcher(MatchModeFlexible, 5)
+
+	searchee := &Searchee{
+		Name: "EPiC.Elvis.Presley.in.Concert.2025",
+		Files: []*ScannedFile{{
+			RelPath: "EPiC.Elvis.Presley.in.Concert.2025.NORDiC.1080p.AMZN.WEB-DL.H.264-NORViNE.mkv",
+			Size:    1040,
+		}},
+	}
+	torrentFiles := []TorrentFile{{
+		Path: "EPiC.Elvis.Presley.in.Concert.2025.1080p.AMZN.WEB-DL.H.264-NTb.mkv",
+		Size: 1000,
+	}}
+
+	res := matcher.Match(searchee, torrentFiles)
+	require.False(t, res.IsMatch)
+	require.False(t, res.IsPerfectMatch)
+	require.Empty(t, res.MatchedFiles)
+	require.Len(t, res.UnmatchedSearcheeFiles, 1)
+	require.Len(t, res.UnmatchedTorrentFiles, 1)
+}

--- a/internal/services/dirscan/service.go
+++ b/internal/services/dirscan/service.go
@@ -2099,7 +2099,7 @@ func hasCorroboratingExternalID(searcheeMeta *SearcheeMetadata, result *jackett.
 	}
 
 	if searcheeMeta.GetTMDbID() > 0 {
-		if numericIDsMatch(strconv.Itoa(searcheeMeta.GetTMDbID()), strconv.Itoa(result.SearchTMDbID)) {
+		if numericIDsMatch(strconv.Itoa(searcheeMeta.GetTMDbID()), result.TMDbID, strconv.Itoa(result.SearchTMDbID)) {
 			return true
 		}
 	}

--- a/internal/services/dirscan/service.go
+++ b/internal/services/dirscan/service.go
@@ -1499,7 +1499,7 @@ func (s *Service) processSearchee(
 		Msg("dirscan: got search results")
 
 	// Try to match and inject
-	return s.tryMatchResults(ctx, dir, searchee, response, minSize, maxSize, contentType, settings, matcher, runID, l), searcheeOutcome{searched: true}
+	return s.tryMatchResults(ctx, dir, searchee, meta, response, minSize, maxSize, contentType, settings, matcher, runID, l), searcheeOutcome{searched: true}
 }
 
 func (s *Service) buildSearcheeMetadata(searchee *Searchee) (meta *SearcheeMetadata, arrLookupName string) {
@@ -1643,6 +1643,7 @@ func (s *Service) tryMatchResults(
 	ctx context.Context,
 	dir *models.DirScanDirectory,
 	searchee *Searchee,
+	searcheeMeta *SearcheeMetadata,
 	response *jackett.SearchResponse,
 	minSize, maxSize int64,
 	contentType string,
@@ -1662,7 +1663,7 @@ func (s *Service) tryMatchResults(
 			return false
 		},
 		func(result *jackett.SearchResult) *searcheeMatch {
-			return s.tryMatchAndInject(ctx, dir, searchee, result, contentType, settings, matcher, runID, l)
+			return s.tryMatchAndInject(ctx, dir, searchee, searcheeMeta, result, contentType, settings, matcher, runID, l)
 		},
 	)
 
@@ -1728,6 +1729,7 @@ func (s *Service) tryMatchAndInject(
 	ctx context.Context,
 	dir *models.DirScanDirectory,
 	searchee *Searchee,
+	searcheeMeta *SearcheeMetadata,
 	result *jackett.SearchResult,
 	contentType string,
 	settings *models.DirScanSettings,
@@ -1742,7 +1744,7 @@ func (s *Service) tryMatchAndInject(
 
 	matchResult := matcher.Match(searchee, parsed.Files)
 	decision := shouldAcceptDirScanMatch(matchResult, parsed, settings)
-	decision = refineDirScanMatchDecision(searchee, parsed, result, settings, matchResult, decision)
+	decision = refineDirScanMatchDecision(searchee, searcheeMeta, parsed, result, settings, matchResult, decision)
 	if !decision.Accept {
 		logDirScanMatchRejection(l, searchee, result, parsed, contentType, settings, matchResult, decision, matcher)
 		return nil
@@ -2021,6 +2023,7 @@ func shouldAcceptDirScanMatch(match *MatchResult, parsed *ParsedTorrent, setting
 
 func refineDirScanMatchDecision(
 	searchee *Searchee,
+	searcheeMeta *SearcheeMetadata,
 	parsed *ParsedTorrent,
 	result *jackett.SearchResult,
 	settings *models.DirScanSettings,
@@ -2046,7 +2049,6 @@ func refineDirScanMatchDecision(
 		return decision
 	}
 
-	searcheeMeta := NewParser(nil).Parse(searchee.Name)
 	candidateMetas := candidateMetadataVariants(parsed, result)
 
 	if hasCorroboratingExternalID(searcheeMeta, result) {
@@ -2198,7 +2200,35 @@ func titlesCorroborate(searcheeMeta, candidateMeta *SearcheeMetadata) bool {
 		return false
 	}
 
+	if episodicMarkersConflict(searcheeMeta, candidateMeta) {
+		return false
+	}
+
 	return searcheeTitle == candidateTitle
+}
+
+func episodicMarkersConflict(searcheeMeta, candidateMeta *SearcheeMetadata) bool {
+	if !hasEpisodicMarkers(searcheeMeta) || !hasEpisodicMarkers(candidateMeta) {
+		return false
+	}
+
+	if searcheeMeta.Season != nil && candidateMeta.Season != nil && *searcheeMeta.Season != *candidateMeta.Season {
+		return true
+	}
+
+	if searcheeMeta.Episode != nil && candidateMeta.Episode != nil && *searcheeMeta.Episode != *candidateMeta.Episode {
+		return true
+	}
+
+	return false
+}
+
+func hasEpisodicMarkers(meta *SearcheeMetadata) bool {
+	if meta == nil {
+		return false
+	}
+
+	return meta.Season != nil || meta.Episode != nil
 }
 
 func normalizedTitleIdentity(title string) string {

--- a/internal/services/dirscan/service.go
+++ b/internal/services/dirscan/service.go
@@ -2465,7 +2465,7 @@ func describeDirScanNoMatchHints(
 func describeDirScanDecisionHints(decision dirScanMatchDecision) (hint string, hints []string) {
 	if decision.Reason == "flexible size-only match lacks title or ID corroboration" {
 		hints = append(hints, "size matched, but the candidate release title/ID did not corroborate the searchee")
-		hints = append(hints, "this often happens when an indexer falls back from IMDb/TMDb lookup to plain title search")
+		hints = append(hints, "this often happens when an indexer falls back from IMDb/TMDb/TVDb lookup to plain title search")
 		hints = append(hints, "tighten total size tolerance or use strict mode when scanning renamed library folders")
 		return "size-only match rejected", hints
 	}

--- a/internal/services/dirscan/service.go
+++ b/internal/services/dirscan/service.go
@@ -13,6 +13,7 @@ import (
 	"math/big"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -28,6 +29,7 @@ import (
 	"github.com/autobrr/qui/internal/services/crossseed"
 	"github.com/autobrr/qui/internal/services/jackett"
 	"github.com/autobrr/qui/internal/services/notifications"
+	"github.com/autobrr/qui/pkg/stringutils"
 )
 
 // Config holds configuration for the directory scanner service.
@@ -1740,6 +1742,7 @@ func (s *Service) tryMatchAndInject(
 
 	matchResult := matcher.Match(searchee, parsed.Files)
 	decision := shouldAcceptDirScanMatch(matchResult, parsed, settings)
+	decision = refineDirScanMatchDecision(searchee, parsed, result, settings, matchResult, decision)
 	if !decision.Accept {
 		logDirScanMatchRejection(l, searchee, result, parsed, contentType, settings, matchResult, decision, matcher)
 		return nil
@@ -1763,15 +1766,7 @@ func (s *Service) tryMatchAndInject(
 		}
 	}
 
-	l.Info().
-		Str("name", searchee.Name).
-		Str("torrent", parsed.Name).
-		Str("hash", parsed.InfoHash).
-		Bool("perfect", matchResult.IsPerfectMatch).
-		Bool("partial", matchResult.IsPartialMatch).
-		Float64("matchRatio", matchResult.MatchRatio).
-		Float64("pieceMatchPercent", decision.PieceMatchPercent).
-		Msg("dirscan: found match")
+	logDirScanAcceptedMatch(l, searchee, parsed, matchResult, decision)
 
 	category := settings.Category
 	if dir.Category != "" {
@@ -1865,6 +1860,9 @@ func logDirScanMatchRejection(
 		Strs("unmatchedSearcheeExts", summarizeDirScanExtensions(matchResult.UnmatchedSearcheeFiles, 5)).
 		Float64("pieceMatchPercent", decision.PieceMatchPercent).
 		Bool("pieceBoundaryUnsafe", decision.PieceBoundaryUnsafe).
+		Bool("nameCorroborated", decision.NameCorroborated).
+		Bool("titleCorroborated", decision.TitleCorroborated).
+		Bool("idCorroborated", decision.IDCorroborated).
 		Str("reason", decision.Reason).
 		Str("hint", hint).
 		Strs("hints", hints).
@@ -1969,6 +1967,9 @@ type dirScanMatchDecision struct {
 	Reason              string
 	PieceMatchPercent   float64
 	PieceBoundaryUnsafe bool
+	NameCorroborated    bool
+	TitleCorroborated   bool
+	IDCorroborated      bool
 }
 
 func shouldAcceptDirScanMatch(match *MatchResult, parsed *ParsedTorrent, settings *models.DirScanSettings) dirScanMatchDecision {
@@ -2018,6 +2019,196 @@ func shouldAcceptDirScanMatch(match *MatchResult, parsed *ParsedTorrent, setting
 	return decision
 }
 
+func refineDirScanMatchDecision(
+	searchee *Searchee,
+	parsed *ParsedTorrent,
+	result *jackett.SearchResult,
+	settings *models.DirScanSettings,
+	match *MatchResult,
+	decision dirScanMatchDecision,
+) dirScanMatchDecision {
+	if !decision.Accept || searchee == nil || parsed == nil || settings == nil || match == nil {
+		return decision
+	}
+
+	if settings.MatchMode != models.MatchModeFlexible || !match.IsPerfectMatch {
+		return decision
+	}
+
+	// Size-only single-file matches are the riskiest false positives when scanning
+	// renamed movie libraries. Require corroborating title or ID evidence before inject.
+	if len(searchee.Files) != 1 || len(parsed.Files) != 1 {
+		return decision
+	}
+
+	if hasMatchedNameEvidence(match) {
+		decision.NameCorroborated = true
+		return decision
+	}
+
+	searcheeMeta := NewParser(nil).Parse(searchee.Name)
+	candidateMetas := candidateMetadataVariants(parsed, result)
+
+	if hasCorroboratingExternalID(searcheeMeta, result) {
+		decision.IDCorroborated = true
+		return decision
+	}
+
+	for _, candidateMeta := range candidateMetas {
+		if titlesCorroborate(searcheeMeta, candidateMeta) {
+			decision.TitleCorroborated = true
+			return decision
+		}
+	}
+
+	decision.Accept = false
+	decision.Reason = "flexible size-only match lacks title or ID corroboration"
+	return decision
+}
+
+func hasMatchedNameEvidence(match *MatchResult) bool {
+	if match == nil {
+		return false
+	}
+
+	for _, pair := range match.MatchedFiles {
+		if pair.SearcheeFile == nil {
+			continue
+		}
+		if normalizeFileName(pair.SearcheeFile.RelPath) == normalizeFileName(pair.TorrentFile.Path) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasCorroboratingExternalID(searcheeMeta *SearcheeMetadata, result *jackett.SearchResult) bool {
+	if searcheeMeta == nil || result == nil {
+		return false
+	}
+
+	if imdbIDsMatch(searcheeMeta.GetIMDbID(), result.IMDbID, result.SearchIMDbID) {
+		return true
+	}
+
+	if numericIDsMatch(strconv.Itoa(searcheeMeta.GetTVDbID()), result.TVDbID, result.SearchTVDbID) {
+		return true
+	}
+
+	if searcheeMeta.GetTMDbID() > 0 {
+		if numericIDsMatch(strconv.Itoa(searcheeMeta.GetTMDbID()), strconv.Itoa(result.SearchTMDbID)) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func imdbIDsMatch(expected string, candidates ...string) bool {
+	expected = strings.TrimSpace(expected)
+	if expected == "" {
+		return false
+	}
+	expected = normalizeIMDbIDForComparison(expected)
+
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" || candidate == "0" {
+			continue
+		}
+		if normalizeIMDbIDForComparison(candidate) == expected {
+			return true
+		}
+	}
+
+	return false
+}
+
+func numericIDsMatch(expected string, candidates ...string) bool {
+	expected = normalizeNumericIDForComparison(expected)
+	if expected == "" {
+		return false
+	}
+
+	for _, candidate := range candidates {
+		if normalizeNumericIDForComparison(candidate) == expected {
+			return true
+		}
+	}
+
+	return false
+}
+
+func normalizeIMDbIDForComparison(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if digitsOnly(value) {
+		return "tt" + value
+	}
+	return strings.ToLower(value)
+}
+
+func normalizeNumericIDForComparison(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" || value == "0" {
+		return ""
+	}
+	if !digitsOnly(value) {
+		return ""
+	}
+	return value
+}
+
+func digitsOnly(value string) bool {
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return value != ""
+}
+
+func candidateMetadataVariants(parsed *ParsedTorrent, result *jackett.SearchResult) []*SearcheeMetadata {
+	parser := NewParser(nil)
+	metas := make([]*SearcheeMetadata, 0, 2)
+	if parsed != nil && strings.TrimSpace(parsed.Name) != "" {
+		metas = append(metas, parser.Parse(parsed.Name))
+	}
+	if result != nil && strings.TrimSpace(result.Title) != "" && (parsed == nil || result.Title != parsed.Name) {
+		metas = append(metas, parser.Parse(result.Title))
+	}
+	return metas
+}
+
+func titlesCorroborate(searcheeMeta, candidateMeta *SearcheeMetadata) bool {
+	if searcheeMeta == nil || candidateMeta == nil {
+		return false
+	}
+
+	searcheeTitle := normalizedTitleIdentity(searcheeMeta.Title)
+	candidateTitle := normalizedTitleIdentity(candidateMeta.Title)
+	if searcheeTitle == "" || candidateTitle == "" {
+		return false
+	}
+
+	if searcheeMeta.Year > 0 && candidateMeta.Year > 0 && searcheeMeta.Year != candidateMeta.Year {
+		return false
+	}
+
+	return searcheeTitle == candidateTitle
+}
+
+func normalizedTitleIdentity(title string) string {
+	title = cleanForSearch(title)
+	if title == "" {
+		return ""
+	}
+	return stringutils.NormalizeForMatching(title)
+}
+
 func sampleDirScanSearcheeFiles(files []*ScannedFile, limit int) []string {
 	if limit <= 0 || len(files) == 0 {
 		return nil
@@ -2049,6 +2240,38 @@ func sampleDirScanTorrentFiles(files []TorrentFile, limit int) []string {
 		out = append(out, fmt.Sprintf("%s (%d bytes)", f.Path, f.Size))
 	}
 	return out
+}
+
+func logDirScanAcceptedMatch(
+	l *zerolog.Logger,
+	searchee *Searchee,
+	parsed *ParsedTorrent,
+	matchResult *MatchResult,
+	decision dirScanMatchDecision,
+) {
+	if l == nil || searchee == nil || parsed == nil || matchResult == nil {
+		return
+	}
+
+	ev := l.Info().
+		Str("name", searchee.Name).
+		Str("torrent", parsed.Name).
+		Str("hash", parsed.InfoHash).
+		Bool("perfect", matchResult.IsPerfectMatch).
+		Bool("partial", matchResult.IsPartialMatch).
+		Float64("matchRatio", matchResult.MatchRatio).
+		Float64("pieceMatchPercent", decision.PieceMatchPercent)
+
+	if matchResult.IsPartialMatch {
+		ev = ev.
+			Int("matchedFiles", len(matchResult.MatchedFiles)).
+			Int("unmatchedSearcheeFiles", len(matchResult.UnmatchedSearcheeFiles)).
+			Int("unmatchedTorrentFiles", len(matchResult.UnmatchedTorrentFiles)).
+			Strs("unmatchedSearcheeSample", sampleDirScanSearcheeFiles(matchResult.UnmatchedSearcheeFiles, 3)).
+			Strs("unmatchedTorrentSample", sampleDirScanTorrentFiles(matchResult.UnmatchedTorrentFiles, 3))
+	}
+
+	ev.Msg("dirscan: found match")
 }
 
 func summarizeDirScanExtensions(files []*ScannedFile, limit int) []string {
@@ -2168,7 +2391,7 @@ func updateDirScanMatchSignals(
 		return
 	}
 
-	sizeMatch := matcher.sizesMatch(searcheeSize, torrentFile.Size)
+	sizeMatch := sizesMatchExactly(searcheeSize, torrentFile.Size)
 	if sizeMatch {
 		signals.HasAnySizeMatch = true
 	}
@@ -2210,6 +2433,13 @@ func describeDirScanNoMatchHints(
 }
 
 func describeDirScanDecisionHints(decision dirScanMatchDecision) (hint string, hints []string) {
+	if decision.Reason == "flexible size-only match lacks title or ID corroboration" {
+		hints = append(hints, "size matched, but the candidate release title/ID did not corroborate the searchee")
+		hints = append(hints, "this often happens when an indexer falls back from IMDb/TMDb lookup to plain title search")
+		hints = append(hints, "tighten total size tolerance or use strict mode when scanning renamed library folders")
+		return "size-only match rejected", hints
+	}
+
 	if strings.Contains(decision.Reason, "below minimum") {
 		hints = append(hints, "matched pieces below threshold; lower minPieceRatio or disable partial matching")
 		return "piece ratio too low", hints

--- a/internal/services/dirscan/service_logging_test.go
+++ b/internal/services/dirscan/service_logging_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package dirscan
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogDirScanAcceptedMatch_PartialIncludesUnmatchedSamples(t *testing.T) {
+	var buf bytes.Buffer
+	logger := zerolog.New(&buf)
+
+	logDirScanAcceptedMatch(
+		&logger,
+		&Searchee{Name: "Avatar - De feu et de cendres (2025)"},
+		&ParsedTorrent{Name: "Avatar.Fire.and.Ash.2025.2160p.WEB-DL.mkv", InfoHash: "deadbeef"},
+		&MatchResult{
+			IsPartialMatch: true,
+			MatchRatio:     0.5,
+			MatchedFiles: []MatchedFilePair{
+				{TorrentFile: TorrentFile{Path: "Avatar.Fire.and.Ash.2025.2160p.WEB-DL.mkv", Size: 100}},
+			},
+			UnmatchedSearcheeFiles: []*ScannedFile{
+				{RelPath: "Avatar - De feu et de cendres (2025).nfo", Size: 12},
+			},
+			UnmatchedTorrentFiles: []TorrentFile{
+				{Path: "Avatar.Fire.and.Ash.2025.2160p.WEB-DL/Proof/sample.txt", Size: 8},
+			},
+		},
+		dirScanMatchDecision{PieceMatchPercent: 99.98},
+	)
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
+	require.Equal(t, "dirscan: found match", entry["message"])
+	require.Equal(t, true, entry["partial"])
+	require.EqualValues(t, 1, entry["matchedFiles"])
+	require.EqualValues(t, 1, entry["unmatchedSearcheeFiles"])
+	require.EqualValues(t, 1, entry["unmatchedTorrentFiles"])
+
+	searcheeSamples, ok := entry["unmatchedSearcheeSample"].([]any)
+	require.True(t, ok)
+	require.Len(t, searcheeSamples, 1)
+
+	torrentSamples, ok := entry["unmatchedTorrentSample"].([]any)
+	require.True(t, ok)
+	require.Len(t, torrentSamples, 1)
+}

--- a/internal/services/jackett/client.go
+++ b/internal/services/jackett/client.go
@@ -144,6 +144,9 @@ type Result struct {
 	DownloadVolumeFactor float64
 	UploadVolumeFactor   float64
 	Imdb                 string
+	SearchIMDbID         string
+	SearchTVDbID         string
+	SearchTMDbID         int
 	// Attributes stores every Torznab attribute with lowercase keys from RSS item attr entries (see convertRssToResults normalization).
 	Attributes map[string]string
 }

--- a/internal/services/jackett/models.go
+++ b/internal/services/jackett/models.go
@@ -107,6 +107,8 @@ type SearchResult struct {
 	IMDbID string `json:"imdb_id,omitempty"`
 	// TVDb ID if available
 	TVDbID string `json:"tvdb_id,omitempty"`
+	// TMDb ID if available
+	TMDbID string `json:"tmdb_id,omitempty"`
 	// SearchIMDbID is the IMDb ID actually used in the per-indexer search request, if any.
 	SearchIMDbID string `json:"search_imdb_id,omitempty"`
 	// SearchTVDbID is the TVDb ID actually used in the per-indexer search request, if any.

--- a/internal/services/jackett/models.go
+++ b/internal/services/jackett/models.go
@@ -107,6 +107,12 @@ type SearchResult struct {
 	IMDbID string `json:"imdb_id,omitempty"`
 	// TVDb ID if available
 	TVDbID string `json:"tvdb_id,omitempty"`
+	// SearchIMDbID is the IMDb ID actually used in the per-indexer search request, if any.
+	SearchIMDbID string `json:"search_imdb_id,omitempty"`
+	// SearchTVDbID is the TVDb ID actually used in the per-indexer search request, if any.
+	SearchTVDbID string `json:"search_tvdb_id,omitempty"`
+	// SearchTMDbID is the TMDb ID actually used in the per-indexer search request, if any.
+	SearchTMDbID int `json:"search_tmdb_id,omitempty"`
 	// Source parsed from release name (e.g., "WEB-DL", "BluRay", "HDTV")
 	Source string `json:"source,omitempty"`
 	// Collection/streaming service parsed from release name (e.g., "AMZN", "NF", "HULU", "MAX")

--- a/internal/services/jackett/service.go
+++ b/internal/services/jackett/service.go
@@ -2035,6 +2035,7 @@ func (s *Service) executeIndexerSearch(ctx context.Context, idx *models.TorznabI
 			results[i].Tracker = idx.Name
 		}
 	}
+	annotateResultsWithSearchIDs(results, paramsMap)
 
 	// Reset escalation on successful request
 	s.rateLimiter.RecordSuccess(idx.ID)
@@ -2043,6 +2044,47 @@ func (s *Service) executeIndexerSearch(ctx context.Context, idx *models.TorznabI
 		results: results,
 		id:      idx.ID,
 	}
+}
+
+func annotateResultsWithSearchIDs(results []Result, params map[string]string) {
+	if len(results) == 0 || len(params) == 0 {
+		return
+	}
+
+	imdbID := normalizeSearchIMDbID(params["imdbid"])
+	tvdbID := strings.TrimSpace(params["tvdbid"])
+	tmdbID := 0
+	if rawTMDbID := strings.TrimSpace(params["tmdbid"]); rawTMDbID != "" {
+		if parsedTMDbID, err := strconv.Atoi(rawTMDbID); err == nil {
+			tmdbID = parsedTMDbID
+		}
+	}
+
+	for i := range results {
+		results[i].SearchIMDbID = imdbID
+		results[i].SearchTVDbID = tvdbID
+		results[i].SearchTMDbID = tmdbID
+	}
+}
+
+func normalizeSearchIMDbID(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if digitsOnlyString(value) {
+		return "tt" + value
+	}
+	return strings.ToLower(value)
+}
+
+func digitsOnlyString(value string) bool {
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return value != ""
 }
 
 // searchMultipleIndexers searches multiple indexers in parallel and aggregates results.
@@ -3195,6 +3237,9 @@ func (s *Service) convertResults(results []Result) []SearchResult {
 			InfoHashV2:           "", // InfoHashV2 not typically in extended attributes
 			IMDbID:               r.Imdb,
 			TVDbID:               s.parseTVDbID(r),
+			SearchIMDbID:         r.SearchIMDbID,
+			SearchTVDbID:         r.SearchTVDbID,
+			SearchTMDbID:         r.SearchTMDbID,
 			Source:               source,
 			Collection:           collection,
 			Group:                group,

--- a/internal/services/jackett/service.go
+++ b/internal/services/jackett/service.go
@@ -111,6 +111,7 @@ const (
 	searchCacheScopeCrossSeed = "cross_seed"
 	searchCacheScopeGeneral   = "general"
 	searchCacheScopeDirScan   = "dir-scan"
+	searchCacheSchemaVersion  = 2
 
 	searchCacheSourceNetwork = "network"
 	searchCacheSourceCache   = "cache"
@@ -236,21 +237,22 @@ type searchCacheSignature struct {
 }
 
 type searchCacheKeyPayload struct {
-	Scope       string      `json:"scope"`
-	Query       string      `json:"query"`
-	Categories  []int       `json:"categories,omitempty"`
-	IndexerIDs  []int       `json:"indexer_ids,omitempty"`
-	IMDbID      string      `json:"imdb_id,omitempty"`
-	TVDbID      string      `json:"tvdb_id,omitempty"`
-	TMDbID      int         `json:"tmdb_id,omitempty"`
-	TVMazeID    int         `json:"tvmaze_id,omitempty"`
-	Year        int         `json:"year,omitempty"`
-	Season      *int        `json:"season,omitempty"`
-	Episode     *int        `json:"episode,omitempty"`
-	Artist      string      `json:"artist,omitempty"`
-	Album       string      `json:"album,omitempty"`
-	SearchMode  string      `json:"search_mode,omitempty"`
-	ContentType contentType `json:"content_type"`
+	SchemaVersion int         `json:"schema_version"`
+	Scope         string      `json:"scope"`
+	Query         string      `json:"query"`
+	Categories    []int       `json:"categories,omitempty"`
+	IndexerIDs    []int       `json:"indexer_ids,omitempty"`
+	IMDbID        string      `json:"imdb_id,omitempty"`
+	TVDbID        string      `json:"tvdb_id,omitempty"`
+	TMDbID        int         `json:"tmdb_id,omitempty"`
+	TVMazeID      int         `json:"tvmaze_id,omitempty"`
+	Year          int         `json:"year,omitempty"`
+	Season        *int        `json:"season,omitempty"`
+	Episode       *int        `json:"episode,omitempty"`
+	Artist        string      `json:"artist,omitempty"`
+	Album         string      `json:"album,omitempty"`
+	SearchMode    string      `json:"search_mode,omitempty"`
+	ContentType   contentType `json:"content_type"`
 }
 
 // TorrentDownloadRequest captures the metadata required to download (and cache) a torrent payload.
@@ -1183,21 +1185,22 @@ func (s *Service) buildSearchCacheSignature(scope string, req *TorznabSearchRequ
 	query := canonicalizeQuery(req.Query)
 
 	payload := searchCacheKeyPayload{
-		Scope:       scope,
-		Query:       query,
-		Categories:  categories,
-		IndexerIDs:  normalizedIndexerIDs,
-		IMDbID:      strings.TrimSpace(req.IMDbID),
-		TVDbID:      strings.TrimSpace(req.TVDbID),
-		TMDbID:      req.TMDbID,
-		TVMazeID:    req.TVMazeID,
-		Year:        req.Year,
-		Season:      req.Season,
-		Episode:     req.Episode,
-		Artist:      strings.TrimSpace(req.Artist),
-		Album:       strings.TrimSpace(req.Album),
-		SearchMode:  searchMode,
-		ContentType: detectedType,
+		SchemaVersion: searchCacheSchemaVersion,
+		Scope:         scope,
+		Query:         query,
+		Categories:    categories,
+		IndexerIDs:    normalizedIndexerIDs,
+		IMDbID:        strings.TrimSpace(req.IMDbID),
+		TVDbID:        strings.TrimSpace(req.TVDbID),
+		TMDbID:        req.TMDbID,
+		TVMazeID:      req.TVMazeID,
+		Year:          req.Year,
+		Season:        req.Season,
+		Episode:       req.Episode,
+		Artist:        strings.TrimSpace(req.Artist),
+		Album:         strings.TrimSpace(req.Album),
+		SearchMode:    searchMode,
+		ContentType:   detectedType,
 	}
 
 	fullFingerprint, baseFingerprint, err := buildSearchCacheFingerprints(payload)

--- a/internal/services/jackett/service.go
+++ b/internal/services/jackett/service.go
@@ -3237,6 +3237,7 @@ func (s *Service) convertResults(results []Result) []SearchResult {
 			InfoHashV2:           "", // InfoHashV2 not typically in extended attributes
 			IMDbID:               r.Imdb,
 			TVDbID:               s.parseTVDbID(r),
+			TMDbID:               s.parseTMDbID(r),
 			SearchIMDbID:         r.SearchIMDbID,
 			SearchTVDbID:         r.SearchTVDbID,
 			SearchTMDbID:         r.SearchTMDbID,
@@ -3307,6 +3308,9 @@ var (
 	tvdbIdentifierPattern = regexp.MustCompile(`(?i)(?:tvdb|thetvdb|tvdb:)[^\d]*([0-9]+)`)
 	tvdbAttributeKeys     = []string{"tvdb", "tvdbid", "tvdb_id"}
 	tvdbDigitsOnlyPattern = regexp.MustCompile(`\A[0-9]+\z`)
+	tmdbIdentifierPattern = regexp.MustCompile(`(?i)(?:tmdb|themoviedb|tmdb:)[^\d]*([0-9]+)`)
+	tmdbAttributeKeys     = []string{"tmdb", "tmdbid", "tmdb_id"}
+	tmdbDigitsOnlyPattern = regexp.MustCompile(`\A[0-9]+\z`)
 	infohashAttributeKeys = []string{"infohash", "info_hash", "hash"}
 )
 
@@ -3350,6 +3354,53 @@ func extractTVDbIDFromAttributes(attrs map[string]string) string {
 	for _, key := range tvdbAttributeKeys {
 		if value, ok := attrs[key]; ok {
 			if id := parseTVDbNumericIDFromString(value); id != "" {
+				return id
+			}
+		}
+	}
+
+	return ""
+}
+
+func parseTMDbNumericIDFromString(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+
+	if tmdbDigitsOnlyPattern.MatchString(value) {
+		return value
+	}
+
+	if matches := tmdbIdentifierPattern.FindStringSubmatch(value); len(matches) == 2 {
+		if tmdbDigitsOnlyPattern.MatchString(matches[1]) {
+			return matches[1]
+		}
+	}
+
+	return ""
+}
+
+func (s *Service) parseTMDbID(r Result) string {
+	if id := parseTMDbNumericIDFromString(r.GUID); id != "" {
+		return id
+	}
+
+	if id := extractTMDbIDFromAttributes(r.Attributes); id != "" {
+		return id
+	}
+
+	return ""
+}
+
+func extractTMDbIDFromAttributes(attrs map[string]string) string {
+	if len(attrs) == 0 {
+		return ""
+	}
+
+	for _, key := range tmdbAttributeKeys {
+		if value, ok := attrs[key]; ok {
+			if id := parseTMDbNumericIDFromString(value); id != "" {
 				return id
 			}
 		}

--- a/internal/services/jackett/service_test.go
+++ b/internal/services/jackett/service_test.go
@@ -1031,11 +1031,14 @@ func TestConvertResults(t *testing.T) {
 			name: "preserves executed search id context",
 			input: []Result{
 				{
-					Tracker:      "Tracker1",
-					Title:        "Example",
-					Seeders:      10,
-					Peers:        10,
-					Size:         1024,
+					Tracker: "Tracker1",
+					Title:   "Example",
+					Seeders: 10,
+					Peers:   10,
+					Size:    1024,
+					Attributes: map[string]string{
+						"tmdbid": "42",
+					},
 					SearchIMDbID: "tt1234567",
 					SearchTVDbID: "7654321",
 					SearchTMDbID: 42,
@@ -1048,6 +1051,9 @@ func TestConvertResults(t *testing.T) {
 				}
 				if results[0].SearchTVDbID != "7654321" {
 					t.Fatalf("SearchTVDbID = %q, want %q", results[0].SearchTVDbID, "7654321")
+				}
+				if results[0].TMDbID != "42" {
+					t.Fatalf("TMDbID = %q, want %q", results[0].TMDbID, "42")
 				}
 				if results[0].SearchTMDbID != 42 {
 					t.Fatalf("SearchTMDbID = %d, want %d", results[0].SearchTMDbID, 42)

--- a/internal/services/jackett/service_test.go
+++ b/internal/services/jackett/service_test.go
@@ -1027,6 +1027,33 @@ func TestConvertResults(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "preserves executed search id context",
+			input: []Result{
+				{
+					Tracker:      "Tracker1",
+					Title:        "Example",
+					Seeders:      10,
+					Peers:        10,
+					Size:         1024,
+					SearchIMDbID: "tt1234567",
+					SearchTVDbID: "7654321",
+					SearchTMDbID: 42,
+				},
+			},
+			expected: 1,
+			checkFn: func(t *testing.T, results []SearchResult) {
+				if results[0].SearchIMDbID != "tt1234567" {
+					t.Fatalf("SearchIMDbID = %q, want %q", results[0].SearchIMDbID, "tt1234567")
+				}
+				if results[0].SearchTVDbID != "7654321" {
+					t.Fatalf("SearchTVDbID = %q, want %q", results[0].SearchTVDbID, "7654321")
+				}
+				if results[0].SearchTMDbID != 42 {
+					t.Fatalf("SearchTMDbID = %d, want %d", results[0].SearchTMDbID, 42)
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1039,6 +1066,27 @@ func TestConvertResults(t *testing.T) {
 				tt.checkFn(t, result)
 			}
 		})
+	}
+}
+
+func TestAnnotateResultsWithSearchIDs(t *testing.T) {
+	results := []Result{{Title: "Example"}}
+	params := map[string]string{
+		"imdbid": "1234567",
+		"tvdbid": "7654321",
+		"tmdbid": "42",
+	}
+
+	annotateResultsWithSearchIDs(results, params)
+
+	if results[0].SearchIMDbID != "tt1234567" {
+		t.Fatalf("SearchIMDbID = %q, want %q", results[0].SearchIMDbID, "tt1234567")
+	}
+	if results[0].SearchTVDbID != "7654321" {
+		t.Fatalf("SearchTVDbID = %q, want %q", results[0].SearchTVDbID, "7654321")
+	}
+	if results[0].SearchTMDbID != 42 {
+		t.Fatalf("SearchTMDbID = %d, want %d", results[0].SearchTMDbID, 42)
 	}
 }
 

--- a/internal/services/jackett/service_test.go
+++ b/internal/services/jackett/service_test.go
@@ -334,10 +334,11 @@ func TestLoadCachedSearchPortionReturnsPartialCoverage(t *testing.T) {
 	}
 	req := &TorznabSearchRequest{Query: "My Query"}
 	payload := searchCacheKeyPayload{
-		Scope:       searchCacheScopeCrossSeed,
-		Query:       canonicalizeQuery(req.Query),
-		IndexerIDs:  []int{1, 2},
-		ContentType: contentTypeTVShow,
+		SchemaVersion: searchCacheSchemaVersion,
+		Scope:         searchCacheScopeCrossSeed,
+		Query:         canonicalizeQuery(req.Query),
+		IndexerIDs:    []int{1, 2},
+		ContentType:   contentTypeTVShow,
 	}
 	full, base, err := buildSearchCacheFingerprints(payload)
 	if err != nil {
@@ -395,9 +396,10 @@ func TestLoadCachedSearchPortionReturnsPartialCoverage(t *testing.T) {
 
 func TestSelectCacheEntryForCoveragePrefersMostCoverage(t *testing.T) {
 	payload := searchCacheKeyPayload{
-		Scope:       searchCacheScopeCrossSeed,
-		Query:       "query",
-		ContentType: contentTypeTVShow,
+		SchemaVersion: searchCacheSchemaVersion,
+		Scope:         searchCacheScopeCrossSeed,
+		Query:         "query",
+		ContentType:   contentTypeTVShow,
 	}
 	firstFull, base, err := buildSearchCacheFingerprints(payload)
 	if err != nil {
@@ -419,6 +421,30 @@ func TestSelectCacheEntryForCoveragePrefersMostCoverage(t *testing.T) {
 	}
 	if entry, coverage := selectCacheEntryForCoverage([]*models.TorznabSearchCacheEntry{first}, []int{1, 3}, base, true); entry != nil || coverage != nil {
 		t.Fatalf("expected nil when full coverage unavailable")
+	}
+}
+
+func TestBuildBaseFingerprintFromRaw_LegacyPayloadDoesNotMatchCurrentSchema(t *testing.T) {
+	legacyRaw := `{"scope":"dir-scan","query":"query","content_type":1}`
+
+	base, err := buildBaseFingerprintFromRaw(legacyRaw)
+	if err != nil {
+		t.Fatalf("buildBaseFingerprintFromRaw: %v", err)
+	}
+
+	currentPayload := searchCacheKeyPayload{
+		SchemaVersion: searchCacheSchemaVersion,
+		Scope:         searchCacheScopeDirScan,
+		Query:         "query",
+		ContentType:   contentTypeMovie,
+	}
+	_, currentBase, err := buildSearchCacheFingerprints(currentPayload)
+	if err != nil {
+		t.Fatalf("buildSearchCacheFingerprints: %v", err)
+	}
+
+	if base == currentBase {
+		t.Fatal("expected legacy cache fingerprint to differ from current schema fingerprint")
 	}
 }
 

--- a/web/src/components/cross-seed/DirScanTab.tsx
+++ b/web/src/components/cross-seed/DirScanTab.tsx
@@ -921,7 +921,7 @@ function SettingsDialog({ open, onOpenChange, settings, instances }: SettingsDia
               </SelectContent>
             </Select>
             <p className="text-xs text-muted-foreground">
-              Strict mode matches files by name and size. Flexible mode matches by size only.
+              Strict mode matches by filename plus exact file size. Flexible mode ignores filenames for primary matching, but file sizes must still match exactly.
             </p>
           </div>
 
@@ -942,7 +942,7 @@ function SettingsDialog({ open, onOpenChange, settings, instances }: SettingsDia
               }
             />
             <p className="text-xs text-muted-foreground">
-              Allows small size differences when comparing files (useful for minor repacks). Keep low for best accuracy.
+              Allows small differences in total torrent size before file matching. File sizes must still match exactly. Keep low for best accuracy.
             </p>
           </div>
 


### PR DESCRIPTION
Dir scan now requires exact per-file size matches while keeping size tolerance limited to total torrent candidate filtering. It also tightens ambiguous flexible single-file matches by requiring corroborating title or external ID evidence, including preserving IMDb/TVDb/TMDb search context when indexers omit those fields in results.

This prevents fallback title-search false positives from being injected as valid matches and adds clearer match and rejection logging, partial-match unmatched-file samples, and updated dir-scan docs and UI copy so the behavior is easier to understand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Dir Scan Match Mode semantics and Size Tolerance behavior.

* **New Features**
  * Flexible single-file matches now require corroborating title or external-ID evidence to be accepted.

* **Improvements**
  * Enforced exact per-file size matching across modes; size tolerance now only filters by total torrent size.
  * Search results now include per-search identifier metadata to support corroboration.

* **UI**
  * Updated help text for Match Mode and Size Tolerance controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->