### PR TITLE
fix(auth): harden OIDC PKCE flow

### DIFF
--- a/documentation/docs/configuration/oidc.md
+++ b/documentation/docs/configuration/oidc.md
@@ -8,6 +8,8 @@ title: OIDC
 Set `QUI__OIDC_ENABLED=true` to hand authentication off to an external identity provider. The built-in login screen automatically offers a "Sign in with OIDC" button when the backend detects a valid OIDC configuration.
 
 If your provider advertises PKCE (`S256`) support, qui uses it automatically for the authorization flow. No extra qui setting is required.
+To confirm it is active, inspect `/api/auth/oidc/config` and verify `authorizationUrl` includes both `code_challenge=` and `code_challenge_method=S256`.
+qui does not currently emit a dedicated "PKCE enabled" log line, so the authorize URL is the easiest check.
 
 For the full mapping (TOML keys + environment variables + defaults), see [Configuration Reference](./reference).
 

--- a/internal/api/handlers/oidc.go
+++ b/internal/api/handlers/oidc.go
@@ -58,7 +58,6 @@ type OIDCConfigResponse struct {
 	Enabled             bool   `json:"enabled"`
 	AuthorizationURL    string `json:"authorizationUrl"`
 	State               string `json:"state"`
-	PKCEVerifier        string `json:"pkceVerifier"`
 	DisableBuiltInLogin bool   `json:"disableBuiltInLogin"`
 	IssuerURL           string `json:"issuerUrl"`
 }
@@ -194,13 +193,13 @@ func discoverOIDCProvider(ctx context.Context, issuer string) (*oidc.Provider, s
 
 func (h *OIDCHandler) getConfig(w http.ResponseWriter, r *http.Request) {
 	// Get the config first
-	config := h.GetConfigResponse()
+	config, pkceVerifier := h.GetConfigResponse()
 
 	// Store state and PKCE verifier in session for later validation
 	// This is needed even if user is already authenticated, in case they're re-authenticating
 	h.sessionManager.Put(r.Context(), "oidc_state", config.State)
-	if config.PKCEVerifier != "" {
-		h.sessionManager.Put(r.Context(), "oidc_pkce_verifier", config.PKCEVerifier)
+	if pkceVerifier != "" {
+		h.sessionManager.Put(r.Context(), "oidc_pkce_verifier", pkceVerifier)
 	}
 
 	RespondJSON(w, http.StatusOK, config)
@@ -445,7 +444,7 @@ func (h *OIDCHandler) supportsPKCE() bool {
 	return slices.Contains(claims.CodeChallenges, "S256")
 }
 
-func (h *OIDCHandler) GetConfigResponse() OIDCConfigResponse {
+func (h *OIDCHandler) GetConfigResponse() (OIDCConfigResponse, string) {
 	state := generateRandomState()
 
 	var authURL, verifier string
@@ -460,8 +459,7 @@ func (h *OIDCHandler) GetConfigResponse() OIDCConfigResponse {
 		Enabled:             h.config.OIDCEnabled,
 		AuthorizationURL:    authURL,
 		State:               state,
-		PKCEVerifier:        verifier,
 		DisableBuiltInLogin: h.config.OIDCDisableBuiltInLogin,
 		IssuerURL:           h.config.OIDCIssuer,
-	}
+	}, verifier
 }

--- a/internal/api/handlers/oidc.go
+++ b/internal/api/handlers/oidc.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"slices"
@@ -32,6 +33,10 @@ const (
 var (
 	oidcNewProvider = oidc.NewProvider
 	oidcSleep       = time.Sleep
+	oidcReadRandom  = func(b []byte) error {
+		_, err := io.ReadFull(rand.Reader, b)
+		return err
+	}
 )
 
 type OIDCHandler struct {
@@ -193,7 +198,12 @@ func discoverOIDCProvider(ctx context.Context, issuer string) (*oidc.Provider, s
 
 func (h *OIDCHandler) getConfig(w http.ResponseWriter, r *http.Request) {
 	// Get the config first
-	config, pkceVerifier := h.GetConfigResponse()
+	config, pkceVerifier, err := h.GetConfigResponse()
+	if err != nil {
+		log.Error().Err(err).Msg("failed to build OIDC config response")
+		RespondError(w, http.StatusInternalServerError, "failed to generate OIDC state")
+		return
+	}
 
 	// Store state and PKCE verifier in session for later validation
 	// This is needed even if user is already authenticated, in case they're re-authenticating
@@ -424,14 +434,12 @@ func isValidRedirectURL(candidateURL, configuredURL string) bool {
 	return candidate.Host == configured.Host
 }
 
-func generateRandomState() string {
+func generateRandomState() (string, error) {
 	b := make([]byte, 32)
-	if _, err := rand.Read(b); err != nil {
-		// Fallback to a less secure random state
-		b = make([]byte, 32)
-		_, _ = rand.Read(b)
+	if err := oidcReadRandom(b); err != nil {
+		return "", err
 	}
-	return hex.EncodeToString(b)
+	return hex.EncodeToString(b), nil
 }
 
 func (h *OIDCHandler) supportsPKCE() bool {
@@ -444,8 +452,11 @@ func (h *OIDCHandler) supportsPKCE() bool {
 	return slices.Contains(claims.CodeChallenges, "S256")
 }
 
-func (h *OIDCHandler) GetConfigResponse() (OIDCConfigResponse, string) {
-	state := generateRandomState()
+func (h *OIDCHandler) GetConfigResponse() (OIDCConfigResponse, string, error) {
+	state, err := generateRandomState()
+	if err != nil {
+		return OIDCConfigResponse{}, "", err
+	}
 
 	var authURL, verifier string
 	if h.supportsPKCE() {
@@ -461,5 +472,5 @@ func (h *OIDCHandler) GetConfigResponse() (OIDCConfigResponse, string) {
 		State:               state,
 		DisableBuiltInLogin: h.config.OIDCDisableBuiltInLogin,
 		IssuerURL:           h.config.OIDCIssuer,
-	}, verifier
+	}, verifier, nil
 }

--- a/internal/api/handlers/oidc.go
+++ b/internal/api/handlers/oidc.go
@@ -63,7 +63,6 @@ type OIDCClaims struct {
 type OIDCConfigResponse struct {
 	Enabled             bool   `json:"enabled"`
 	AuthorizationURL    string `json:"authorizationUrl"`
-	State               string `json:"state"`
 	DisableBuiltInLogin bool   `json:"disableBuiltInLogin"`
 	IssuerURL           string `json:"issuerUrl"`
 }
@@ -203,7 +202,7 @@ func (h *OIDCHandler) getConfig(w http.ResponseWriter, r *http.Request) {
 	h.sessionManager.Remove(r.Context(), "oidc_pkce_verifier")
 
 	// Get the config first
-	config, pkceVerifier, err := h.GetConfigResponse()
+	config, state, pkceVerifier, err := h.GetConfigResponse()
 	if err != nil {
 		log.Error().Err(err).Msg("failed to build OIDC config response")
 		RespondError(w, http.StatusInternalServerError, "failed to build OIDC config response")
@@ -212,7 +211,7 @@ func (h *OIDCHandler) getConfig(w http.ResponseWriter, r *http.Request) {
 
 	// Store state and PKCE verifier in session for later validation
 	// This is needed even if user is already authenticated, in case they're re-authenticating
-	h.sessionManager.Put(r.Context(), "oidc_state", config.State)
+	h.sessionManager.Put(r.Context(), "oidc_state", state)
 	if pkceVerifier != "" {
 		h.sessionManager.Put(r.Context(), "oidc_pkce_verifier", pkceVerifier)
 	}
@@ -465,17 +464,17 @@ func (h *OIDCHandler) supportsPKCE() bool {
 	return slices.Contains(claims.CodeChallenges, "S256")
 }
 
-func (h *OIDCHandler) GetConfigResponse() (OIDCConfigResponse, string, error) {
+func (h *OIDCHandler) GetConfigResponse() (OIDCConfigResponse, string, string, error) {
 	state, err := generateRandomState()
 	if err != nil {
-		return OIDCConfigResponse{}, "", err
+		return OIDCConfigResponse{}, "", "", err
 	}
 
 	var authURL, verifier string
 	if h.supportsPKCE() {
 		verifier, err = generatePKCEVerifier()
 		if err != nil {
-			return OIDCConfigResponse{}, "", err
+			return OIDCConfigResponse{}, "", "", err
 		}
 		authURL = h.oauthConfig.AuthCodeURL(state, oauth2.S256ChallengeOption(verifier))
 	} else {
@@ -485,8 +484,7 @@ func (h *OIDCHandler) GetConfigResponse() (OIDCConfigResponse, string, error) {
 	return OIDCConfigResponse{
 		Enabled:             h.config.OIDCEnabled,
 		AuthorizationURL:    authURL,
-		State:               state,
 		DisableBuiltInLogin: h.config.OIDCDisableBuiltInLogin,
 		IssuerURL:           h.config.OIDCIssuer,
-	}, verifier, nil
+	}, state, verifier, nil
 }

--- a/internal/api/handlers/oidc.go
+++ b/internal/api/handlers/oidc.go
@@ -6,6 +6,7 @@ package handlers
 import (
 	"context"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -205,7 +206,7 @@ func (h *OIDCHandler) getConfig(w http.ResponseWriter, r *http.Request) {
 	config, pkceVerifier, err := h.GetConfigResponse()
 	if err != nil {
 		log.Error().Err(err).Msg("failed to build OIDC config response")
-		RespondError(w, http.StatusInternalServerError, "failed to generate OIDC state")
+		RespondError(w, http.StatusInternalServerError, "failed to build OIDC config response")
 		return
 	}
 
@@ -446,6 +447,14 @@ func generateRandomState() (string, error) {
 	return hex.EncodeToString(b), nil
 }
 
+func generatePKCEVerifier() (string, error) {
+	b := make([]byte, 32)
+	if err := oidcReadRandom(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
 func (h *OIDCHandler) supportsPKCE() bool {
 	var claims struct {
 		CodeChallenges []string `json:"code_challenge_methods_supported"`
@@ -464,7 +473,10 @@ func (h *OIDCHandler) GetConfigResponse() (OIDCConfigResponse, string, error) {
 
 	var authURL, verifier string
 	if h.supportsPKCE() {
-		verifier = oauth2.GenerateVerifier()
+		verifier, err = generatePKCEVerifier()
+		if err != nil {
+			return OIDCConfigResponse{}, "", err
+		}
 		authURL = h.oauthConfig.AuthCodeURL(state, oauth2.S256ChallengeOption(verifier))
 	} else {
 		authURL = h.oauthConfig.AuthCodeURL(state)

--- a/internal/api/handlers/oidc.go
+++ b/internal/api/handlers/oidc.go
@@ -197,6 +197,10 @@ func discoverOIDCProvider(ctx context.Context, issuer string) (*oidc.Provider, s
 }
 
 func (h *OIDCHandler) getConfig(w http.ResponseWriter, r *http.Request) {
+	// Clear any prior authorization state before generating a new config response.
+	h.sessionManager.Remove(r.Context(), "oidc_state")
+	h.sessionManager.Remove(r.Context(), "oidc_pkce_verifier")
+
 	// Get the config first
 	config, pkceVerifier, err := h.GetConfigResponse()
 	if err != nil {

--- a/internal/api/handlers/oidc_test.go
+++ b/internal/api/handlers/oidc_test.go
@@ -18,6 +18,15 @@ import (
 	"github.com/autobrr/qui/internal/domain"
 )
 
+type discoveryDocument struct {
+	Issuer                        string   `json:"issuer"`
+	AuthorizationEndpoint         string   `json:"authorization_endpoint"`
+	TokenEndpoint                 string   `json:"token_endpoint"`
+	UserInfoEndpoint              string   `json:"userinfo_endpoint"`
+	JWKSURI                       string   `json:"jwks_uri"`
+	CodeChallengeMethodsSupported []string `json:"code_challenge_methods_supported,omitempty"`
+}
+
 func newOIDCDiscoveryServer(t *testing.T, codeChallenges []string) *httptest.Server {
 	var discovery *httptest.Server
 	discovery = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -26,17 +35,17 @@ func newOIDCDiscoveryServer(t *testing.T, codeChallenges []string) *httptest.Ser
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		payload := map[string]any{
-			"issuer":                 discovery.URL,
-			"authorization_endpoint": discovery.URL + "/authorize",
-			"token_endpoint":         discovery.URL + "/token",
-			"userinfo_endpoint":      discovery.URL + "/userinfo",
-			"jwks_uri":               discovery.URL + "/jwks",
+		doc := discoveryDocument{
+			Issuer:                discovery.URL,
+			AuthorizationEndpoint: discovery.URL + "/authorize",
+			TokenEndpoint:         discovery.URL + "/token",
+			UserInfoEndpoint:      discovery.URL + "/userinfo",
+			JWKSURI:               discovery.URL + "/jwks",
 		}
 		if codeChallenges != nil {
-			payload["code_challenge_methods_supported"] = codeChallenges
+			doc.CodeChallengeMethodsSupported = codeChallenges
 		}
-		if err := json.NewEncoder(w).Encode(payload); err != nil {
+		if err := json.NewEncoder(w).Encode(doc); err != nil {
 			t.Errorf("encode OIDC discovery response: %v", err)
 			http.Error(w, "failed to encode discovery response", http.StatusInternalServerError)
 		}
@@ -69,28 +78,35 @@ func TestOIDCConfigDoesNotExposePKCEVerifier(t *testing.T) {
 	handler := newTestOIDCHandler(t, discovery.URL)
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/auth/oidc/config", nil)
-	ctx, err := handler.sessionManager.Load(req.Context(), "")
-	require.NoError(t, err)
-	req = req.WithContext(ctx)
-
 	rec := httptest.NewRecorder()
-	handler.getConfig(rec, req)
+	handler.sessionManager.LoadAndSave(http.HandlerFunc(handler.getConfig)).ServeHTTP(rec, req)
 
 	require.Equal(t, http.StatusOK, rec.Code)
 
-	var body map[string]any
+	var body OIDCConfigResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.NotEmpty(t, body.State)
 
-	_, leakedVerifier := body["pkceVerifier"]
-	assert.False(t, leakedVerifier)
+	var sessionCookie *http.Cookie
+	for _, cookie := range rec.Result().Cookies() {
+		if cookie.Name == handler.sessionManager.Cookie.Name {
+			sessionCookie = cookie
+			break
+		}
+	}
+	require.NotNil(t, sessionCookie)
 
-	storedVerifier := handler.sessionManager.GetString(req.Context(), "oidc_pkce_verifier")
+	secondReq := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/auth/oidc/config", nil)
+	secondReq.AddCookie(sessionCookie)
+	ctx, err := handler.sessionManager.Load(secondReq.Context(), sessionCookie.Value)
+	require.NoError(t, err)
+
+	storedVerifier := handler.sessionManager.GetString(ctx, "oidc_pkce_verifier")
 	assert.NotEmpty(t, storedVerifier)
+	assert.Equal(t, body.State, handler.sessionManager.GetString(ctx, "oidc_state"))
 
-	authURL, ok := body["authorizationUrl"].(string)
-	require.True(t, ok)
-	assert.Contains(t, authURL, "code_challenge=")
-	assert.NotContains(t, authURL, storedVerifier)
+	assert.Contains(t, body.AuthorizationURL, "code_challenge=")
+	assert.NotContains(t, body.AuthorizationURL, storedVerifier)
 	assert.NotContains(t, rec.Body.String(), `"pkceVerifier"`)
 }
 

--- a/internal/api/handlers/oidc_test.go
+++ b/internal/api/handlers/oidc_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/alexedwards/scs/v2"
@@ -85,7 +86,7 @@ func TestOIDCConfigDoesNotExposePKCEVerifier(t *testing.T) {
 
 	var body OIDCConfigResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
-	assert.NotEmpty(t, body.State)
+	assert.NotContains(t, rec.Body.String(), `"state"`)
 
 	var sessionCookie *http.Cookie
 	for _, cookie := range rec.Result().Cookies() {
@@ -103,7 +104,12 @@ func TestOIDCConfigDoesNotExposePKCEVerifier(t *testing.T) {
 
 	storedVerifier := handler.sessionManager.GetString(ctx, "oidc_pkce_verifier")
 	assert.NotEmpty(t, storedVerifier)
-	assert.Equal(t, body.State, handler.sessionManager.GetString(ctx, "oidc_state"))
+	storedState := handler.sessionManager.GetString(ctx, "oidc_state")
+	assert.NotEmpty(t, storedState)
+
+	authURL, err := url.Parse(body.AuthorizationURL)
+	require.NoError(t, err)
+	assert.Equal(t, storedState, authURL.Query().Get("state"))
 
 	assert.Contains(t, body.AuthorizationURL, "code_challenge=")
 	assert.NotContains(t, body.AuthorizationURL, storedVerifier)

--- a/internal/api/handlers/oidc_test.go
+++ b/internal/api/handlers/oidc_test.go
@@ -5,6 +5,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -17,7 +18,7 @@ import (
 	"github.com/autobrr/qui/internal/domain"
 )
 
-func TestOIDCConfigDoesNotExposePKCEVerifier(t *testing.T) {
+func newOIDCDiscoveryServer(t *testing.T, codeChallenges []string) *httptest.Server {
 	var discovery *httptest.Server
 	discovery = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/.well-known/openid-configuration" {
@@ -25,17 +26,27 @@ func TestOIDCConfigDoesNotExposePKCEVerifier(t *testing.T) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+		payload := map[string]any{
 			"issuer":                           discovery.URL,
 			"authorization_endpoint":           discovery.URL + "/authorize",
 			"token_endpoint":                   discovery.URL + "/token",
 			"userinfo_endpoint":                discovery.URL + "/userinfo",
 			"jwks_uri":                         discovery.URL + "/jwks",
-			"code_challenge_methods_supported": []string{"S256"},
-		}))
+		}
+		if codeChallenges != nil {
+			payload["code_challenge_methods_supported"] = codeChallenges
+		}
+		if err := json.NewEncoder(w).Encode(payload); err != nil {
+			t.Errorf("encode OIDC discovery response: %v", err)
+			http.Error(w, "failed to encode discovery response", http.StatusInternalServerError)
+		}
 	}))
 	t.Cleanup(discovery.Close)
+	return discovery
+}
 
+func TestOIDCConfigDoesNotExposePKCEVerifier(t *testing.T) {
+	discovery := newOIDCDiscoveryServer(t, []string{"S256"})
 	handler, err := NewOIDCHandler(&domain.Config{
 		OIDCEnabled:      true,
 		OIDCIssuer:       discovery.URL,
@@ -69,4 +80,36 @@ func TestOIDCConfigDoesNotExposePKCEVerifier(t *testing.T) {
 	assert.Contains(t, authURL, "code_challenge=")
 	assert.NotContains(t, authURL, storedVerifier)
 	assert.False(t, strings.Contains(rec.Body.String(), `"pkceVerifier"`))
+}
+
+func TestOIDCConfigReturnsInternalServerErrorWhenStateGenerationFails(t *testing.T) {
+	discovery := newOIDCDiscoveryServer(t, nil)
+	handler, err := NewOIDCHandler(&domain.Config{
+		OIDCEnabled:      true,
+		OIDCIssuer:       discovery.URL,
+		OIDCClientID:     "client-id",
+		OIDCClientSecret: "client-secret",
+		OIDCRedirectURL:  "http://localhost/callback",
+	}, scs.New())
+	require.NoError(t, err)
+
+	originalReadRandom := oidcReadRandom
+	oidcReadRandom = func(_ []byte) error {
+		return errors.New("entropy unavailable")
+	}
+	t.Cleanup(func() {
+		oidcReadRandom = originalReadRandom
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/oidc/config", nil)
+	ctx, err := handler.sessionManager.Load(req.Context(), "")
+	require.NoError(t, err)
+	req = req.WithContext(ctx)
+
+	rec := httptest.NewRecorder()
+	handler.getConfig(rec, req)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Contains(t, rec.Body.String(), "failed to generate OIDC state")
+	assert.Empty(t, handler.sessionManager.GetString(req.Context(), "oidc_state"))
 }

--- a/internal/api/handlers/oidc_test.go
+++ b/internal/api/handlers/oidc_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/alexedwards/scs/v2"
@@ -27,11 +26,11 @@ func newOIDCDiscoveryServer(t *testing.T, codeChallenges []string) *httptest.Ser
 		}
 		w.Header().Set("Content-Type", "application/json")
 		payload := map[string]any{
-			"issuer":                           discovery.URL,
-			"authorization_endpoint":           discovery.URL + "/authorize",
-			"token_endpoint":                   discovery.URL + "/token",
-			"userinfo_endpoint":                discovery.URL + "/userinfo",
-			"jwks_uri":                         discovery.URL + "/jwks",
+			"issuer":                 discovery.URL,
+			"authorization_endpoint": discovery.URL + "/authorize",
+			"token_endpoint":         discovery.URL + "/token",
+			"userinfo_endpoint":      discovery.URL + "/userinfo",
+			"jwks_uri":               discovery.URL + "/jwks",
 		}
 		if codeChallenges != nil {
 			payload["code_challenge_methods_supported"] = codeChallenges
@@ -45,18 +44,30 @@ func newOIDCDiscoveryServer(t *testing.T, codeChallenges []string) *httptest.Ser
 	return discovery
 }
 
-func TestOIDCConfigDoesNotExposePKCEVerifier(t *testing.T) {
-	discovery := newOIDCDiscoveryServer(t, []string{"S256"})
-	handler, err := NewOIDCHandler(&domain.Config{
-		OIDCEnabled:      true,
-		OIDCIssuer:       discovery.URL,
-		OIDCClientID:     "client-id",
-		OIDCClientSecret: "client-secret",
-		OIDCRedirectURL:  "http://localhost/callback",
-	}, scs.New())
+func newTestOIDCHandler(t *testing.T, issuer string) *OIDCHandler {
+	t.Helper()
+
+	// #nosec G101 -- test-only OIDC client config values.
+	cfg := &domain.Config{
+		OIDCEnabled:     true,
+		OIDCIssuer:      issuer,
+		OIDCClientID:    "client-id",
+		OIDCRedirectURL: "http://localhost/callback",
+	}
+	// #nosec G101 -- test-only placeholder used to satisfy OIDC config validation.
+	cfg.OIDCClientSecret = "placeholder"
+
+	handler, err := NewOIDCHandler(cfg, scs.New())
 	require.NoError(t, err)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/auth/oidc/config", nil)
+	return handler
+}
+
+func TestOIDCConfigDoesNotExposePKCEVerifier(t *testing.T) {
+	discovery := newOIDCDiscoveryServer(t, []string{"S256"})
+	handler := newTestOIDCHandler(t, discovery.URL)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/auth/oidc/config", nil)
 	ctx, err := handler.sessionManager.Load(req.Context(), "")
 	require.NoError(t, err)
 	req = req.WithContext(ctx)
@@ -79,19 +90,12 @@ func TestOIDCConfigDoesNotExposePKCEVerifier(t *testing.T) {
 	require.True(t, ok)
 	assert.Contains(t, authURL, "code_challenge=")
 	assert.NotContains(t, authURL, storedVerifier)
-	assert.False(t, strings.Contains(rec.Body.String(), `"pkceVerifier"`))
+	assert.NotContains(t, rec.Body.String(), `"pkceVerifier"`)
 }
 
 func TestOIDCConfigReturnsInternalServerErrorWhenStateGenerationFails(t *testing.T) {
 	discovery := newOIDCDiscoveryServer(t, nil)
-	handler, err := NewOIDCHandler(&domain.Config{
-		OIDCEnabled:      true,
-		OIDCIssuer:       discovery.URL,
-		OIDCClientID:     "client-id",
-		OIDCClientSecret: "client-secret",
-		OIDCRedirectURL:  "http://localhost/callback",
-	}, scs.New())
-	require.NoError(t, err)
+	handler := newTestOIDCHandler(t, discovery.URL)
 
 	originalReadRandom := oidcReadRandom
 	oidcReadRandom = func(_ []byte) error {
@@ -101,7 +105,7 @@ func TestOIDCConfigReturnsInternalServerErrorWhenStateGenerationFails(t *testing
 		oidcReadRandom = originalReadRandom
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/api/auth/oidc/config", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/auth/oidc/config", nil)
 	ctx, err := handler.sessionManager.Load(req.Context(), "")
 	require.NoError(t, err)
 	req = req.WithContext(ctx)

--- a/internal/api/handlers/oidc_test.go
+++ b/internal/api/handlers/oidc_test.go
@@ -4,6 +4,7 @@
 package handlers
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -116,7 +117,80 @@ func TestOIDCConfigReturnsInternalServerErrorWhenStateGenerationFails(t *testing
 	handler.getConfig(rec, req)
 
 	require.Equal(t, http.StatusInternalServerError, rec.Code)
-	assert.Contains(t, rec.Body.String(), "failed to generate OIDC state")
+	assert.Contains(t, rec.Body.String(), "failed to build OIDC config response")
+	assert.Empty(t, handler.sessionManager.GetString(req.Context(), "oidc_state"))
+	assert.Empty(t, handler.sessionManager.GetString(req.Context(), "oidc_pkce_verifier"))
+}
+
+func TestGeneratePKCEVerifierReturnsErrorWhenRandomReadFails(t *testing.T) {
+	originalReadRandom := oidcReadRandom
+	oidcReadRandom = func(_ []byte) error {
+		return errors.New("entropy unavailable")
+	}
+	t.Cleanup(func() {
+		oidcReadRandom = originalReadRandom
+	})
+
+	verifier, err := generatePKCEVerifier()
+	require.Error(t, err)
+	assert.Empty(t, verifier)
+}
+
+func TestGeneratePKCEVerifierEncodesRandomBytes(t *testing.T) {
+	originalReadRandom := oidcReadRandom
+	oidcReadRandom = func(b []byte) error {
+		for i := range b {
+			b[i] = byte(i)
+		}
+		return nil
+	}
+	t.Cleanup(func() {
+		oidcReadRandom = originalReadRandom
+	})
+
+	verifier, err := generatePKCEVerifier()
+	require.NoError(t, err)
+	assert.Equal(t, base64.RawURLEncoding.EncodeToString(func() []byte {
+		b := make([]byte, 32)
+		for i := range b {
+			b[i] = byte(i)
+		}
+		return b
+	}()), verifier)
+}
+
+func TestOIDCConfigReturnsInternalServerErrorWhenPKCEVerifierGenerationFails(t *testing.T) {
+	discovery := newOIDCDiscoveryServer(t, []string{"S256"})
+	handler := newTestOIDCHandler(t, discovery.URL)
+
+	originalReadRandom := oidcReadRandom
+	readCalls := 0
+	oidcReadRandom = func(b []byte) error {
+		readCalls++
+		if readCalls == 1 {
+			for i := range b {
+				b[i] = byte(i)
+			}
+			return nil
+		}
+		return errors.New("entropy unavailable")
+	}
+	t.Cleanup(func() {
+		oidcReadRandom = originalReadRandom
+	})
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/auth/oidc/config", nil)
+	ctx, err := handler.sessionManager.Load(req.Context(), "")
+	require.NoError(t, err)
+	req = req.WithContext(ctx)
+	handler.sessionManager.Put(req.Context(), "oidc_state", "stale-state")
+	handler.sessionManager.Put(req.Context(), "oidc_pkce_verifier", "stale-verifier")
+
+	rec := httptest.NewRecorder()
+	handler.getConfig(rec, req)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Contains(t, rec.Body.String(), "failed to build OIDC config response")
 	assert.Empty(t, handler.sessionManager.GetString(req.Context(), "oidc_state"))
 	assert.Empty(t, handler.sessionManager.GetString(req.Context(), "oidc_pkce_verifier"))
 }

--- a/internal/api/handlers/oidc_test.go
+++ b/internal/api/handlers/oidc_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/alexedwards/scs/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/domain"
+)
+
+func TestOIDCConfigDoesNotExposePKCEVerifier(t *testing.T) {
+	var discovery *httptest.Server
+	discovery = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/openid-configuration" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                           discovery.URL,
+			"authorization_endpoint":           discovery.URL + "/authorize",
+			"token_endpoint":                   discovery.URL + "/token",
+			"userinfo_endpoint":                discovery.URL + "/userinfo",
+			"jwks_uri":                         discovery.URL + "/jwks",
+			"code_challenge_methods_supported": []string{"S256"},
+		}))
+	}))
+	t.Cleanup(discovery.Close)
+
+	handler, err := NewOIDCHandler(&domain.Config{
+		OIDCEnabled:      true,
+		OIDCIssuer:       discovery.URL,
+		OIDCClientID:     "client-id",
+		OIDCClientSecret: "client-secret",
+		OIDCRedirectURL:  "http://localhost/callback",
+	}, scs.New())
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/oidc/config", nil)
+	ctx, err := handler.sessionManager.Load(req.Context(), "")
+	require.NoError(t, err)
+	req = req.WithContext(ctx)
+
+	rec := httptest.NewRecorder()
+	handler.getConfig(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+
+	_, leakedVerifier := body["pkceVerifier"]
+	assert.False(t, leakedVerifier)
+
+	storedVerifier := handler.sessionManager.GetString(req.Context(), "oidc_pkce_verifier")
+	assert.NotEmpty(t, storedVerifier)
+
+	authURL, ok := body["authorizationUrl"].(string)
+	require.True(t, ok)
+	assert.Contains(t, authURL, "code_challenge=")
+	assert.NotContains(t, authURL, storedVerifier)
+	assert.False(t, strings.Contains(rec.Body.String(), `"pkceVerifier"`))
+}

--- a/internal/api/handlers/oidc_test.go
+++ b/internal/api/handlers/oidc_test.go
@@ -109,6 +109,8 @@ func TestOIDCConfigReturnsInternalServerErrorWhenStateGenerationFails(t *testing
 	ctx, err := handler.sessionManager.Load(req.Context(), "")
 	require.NoError(t, err)
 	req = req.WithContext(ctx)
+	handler.sessionManager.Put(req.Context(), "oidc_state", "stale-state")
+	handler.sessionManager.Put(req.Context(), "oidc_pkce_verifier", "stale-verifier")
 
 	rec := httptest.NewRecorder()
 	handler.getConfig(rec, req)
@@ -116,4 +118,5 @@ func TestOIDCConfigReturnsInternalServerErrorWhenStateGenerationFails(t *testing
 	require.Equal(t, http.StatusInternalServerError, rec.Code)
 	assert.Contains(t, rec.Body.String(), "failed to generate OIDC state")
 	assert.Empty(t, handler.sessionManager.GetString(req.Context(), "oidc_state"))
+	assert.Empty(t, handler.sessionManager.GetString(req.Context(), "oidc_pkce_verifier"))
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -587,7 +587,6 @@ class ApiClient {
   async getOIDCConfig(): Promise<{
     enabled: boolean
     authorizationUrl: string
-    state: string
     disableBuiltInLogin: boolean
     issuerUrl: string
   }> {
@@ -598,7 +597,6 @@ class ApiClient {
       return {
         enabled: false,
         authorizationUrl: "",
-        state: "",
         disableBuiltInLogin: false,
         issuerUrl: "",
       }


### PR DESCRIPTION
Keeps the OIDC PKCE verifier server-side and tightens the OIDC config flow. State and PKCE verifier generation now fail closed, stale OIDC session values are cleared before issuing a new config, and the unused state field was removed from the config response.

Adds regression coverage for the OIDC config/session round-trip and a short docs note on how to confirm PKCE is active.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced OIDC authentication flow with improved security handling for authorization parameters.

* **Bug Fixes**
  * Improved error handling during OIDC configuration generation with clear error messages.

* **Documentation**
  * Added guidance on verifying PKCE support in OIDC authorization flow.

* **Tests**
  * Added comprehensive tests for OIDC handler configuration and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->