### PR TITLE
docs: add migration PR guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ config.toml
 .mcp.json
 components.json
 .cache/
+.worktrees/
 tracker-icons/*
 .device-id-*
 backups/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,7 @@ Load secrets such as `THEMES_REPO_TOKEN` via `.env` so the Makefile can fetch pr
 ## API & Database Change Rules
 
 - Database schema changes must ship as migrations under `internal/database/migrations`, include matching model/store updates in the same PR, and add both SQLite and Postgres migrations.
+- For an open PR, keep schema work consolidated to at most one new SQLite migration and one new Postgres migration. If the PR needs more schema changes before merge, edit the draft migration files for that PR instead of adding more migration files.
 - API contract changes must update OpenAPI content under `internal/web/swagger` and pass `make test-openapi`.
 - Prefer minimal, reviewable diffs in high-churn areas (`internal/services/crossseed`, `internal/qbittorrent`, `internal/models`).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,11 @@
 
 ## Database Migrations
 
-Database schema changes must include both SQLite and Postgres migrations.
+Database schema changes must include:
+
+- a SQLite migration under `internal/database/migrations`
+- a Postgres migration under `internal/database/postgres_migrations`
+- matching model/store updates in the same PR so schema and code stay in sync
 
 For an open PR, keep schema work consolidated to at most one new migration file per driver:
 
@@ -10,3 +14,5 @@ For an open PR, keep schema work consolidated to at most one new migration file 
 - one file under `internal/database/postgres_migrations`
 
 If a PR needs more schema changes before merge, update the draft migration files for that PR instead of adding more migration files. Consolidate before merge.
+
+Do not land schema-only changes. The corresponding model/store files touched by the schema change must be updated in the same PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing
+
+## Database Migrations
+
+Database schema changes must include both SQLite and Postgres migrations.
+
+For an open PR, keep schema work consolidated to at most one new migration file per driver:
+
+- one file under `internal/database/migrations`
+- one file under `internal/database/postgres_migrations`
+
+If a PR needs more schema changes before merge, update the draft migration files for that PR instead of adding more migration files. Consolidate before merge.


### PR DESCRIPTION
Document the expectation that an open PR should keep schema work consolidated to one draft migration per driver and fold additional schema edits into those files before merge.

Add the same guidance to `CONTRIBUTING.md` and ignore `.worktrees/` so repo-local worktrees do not leak into git status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added contribution guidelines for database schema changes: require paired SQLite and Postgres migrations, matching model/store updates in the same PR, and consolidation of draft migrations so open PRs contain at most one new migration per driver.

* **Chores**
  * Updated repository ignore settings to exclude additional worktree directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->