### PR TITLE
chore(ci): speed up CI pipeline (9.3 min → 4.3 min for PRs)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,13 +88,15 @@ jobs:
         working-directory: web
         run: pnpm install --frozen-lockfile
 
-      - name: Type check frontend
+      - name: Type check and build frontend
         working-directory: web
-        run: pnpm tsc --noEmit
-
-      - name: Build web frontend
-        working-directory: web
-        run: CI= pnpm run build
+        run: |
+          pnpm tsc --noEmit &
+          TSC_PID=$!
+          CI= pnpm run build &
+          BUILD_PID=$!
+          wait $TSC_PID || exit 1
+          wait $BUILD_PID || exit 1
 
       - name: Upload web production build
         uses: actions/upload-artifact@v7
@@ -102,48 +104,9 @@ jobs:
           name: web-dist
           path: web/dist
 
-  test:
-    name: Run tests
-    runs-on: ubuntu-latest
-    needs: [web]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Download web production build
-        uses: actions/download-artifact@v8
-        with:
-          name: web-dist
-          path: web/dist
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          cache: true
-
-      - name: Install dependencies
-        run: go mod download
-
-      - name: Run tests
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            go test -v -coverprofile=coverage.out ./...
-          else
-            go test -v -race -coverprofile=coverage.out ./...
-          fi
-          go tool cover -html=coverage.out -o coverage.html
-
-      - name: Upload coverage reports
-        uses: actions/upload-artifact@v7
-        with:
-          name: coverage-report
-          path: |
-            coverage.out
-            coverage.html
-
   goreleaserbuild:
     name: Build distribution binaries
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     needs: [test, web]
     steps:
@@ -227,7 +190,7 @@ jobs:
     name: PR signed release smoke test (ephemeral key)
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    needs: [test, web]
+    needs: [web]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -245,6 +208,14 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
+
+      - name: Cache Go build artifacts
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/*.go', 'go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-build-
 
       - name: Prepare ephemeral release signing key
         run: |
@@ -275,25 +246,31 @@ jobs:
             -signature dist/checksums.txt.sig \
             dist/checksums.txt
 
+  docker-matrix:
+    name: Determine Docker platforms
+    runs-on: ubuntu-latest
+    outputs:
+      platforms: ${{ steps.set.outputs.platforms }}
+    steps:
+      - id: set
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            echo 'platforms=["linux/amd64","linux/arm64"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'platforms=["linux/amd64","linux/amd64/v2","linux/amd64/v3","linux/arm/v6","linux/arm/v7","linux/arm64"]' >> "$GITHUB_OUTPUT"
+          fi
+
   docker:
     name: Build Docker images
     runs-on: ubuntu-latest
-    needs: [test, web]
+    needs: [web, docker-matrix]
     strategy:
       fail-fast: true
       matrix:
-        platform:
-          - linux/amd64
-          - linux/amd64/v2
-          - linux/amd64/v3
-          - linux/arm/v6
-          - linux/arm/v7
-          - linux/arm64
+        platform: ${{ fromJSON(needs.docker-matrix.outputs.platforms) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4
@@ -366,7 +343,7 @@ jobs:
     name: Publish Docker multi-arch manifest
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
-    needs: [docker]
+    needs: [docker, test]
     steps:
       - name: Download image digests
         uses: actions/download-artifact@v8
@@ -407,3 +384,39 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Create placeholder web dist for embed
+        run: mkdir -p web/dist && touch web/dist/.gitkeep
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Run tests
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            go test -v -coverprofile=coverage.out ./...
+          else
+            go test -v -race -coverprofile=coverage.out ./...
+          fi
+          go tool cover -html=coverage.out -o coverage.html
+
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-report
+          path: |
+            coverage.out
+            coverage.html

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,17 +153,6 @@ jobs:
             exit 1
           fi
 
-      - name: Run GoReleaser build
-        if: github.event_name == 'pull_request'
-        uses: goreleaser/goreleaser-action@v7
-        with:
-          distribution: goreleaser
-          version: "~> v2"
-          args: release --clean --skip=validate,publish --parallelism 5 --config .goreleaser.yml
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BUILDER: ${{ github.actor }}@github-actions
-
       - name: Run GoReleaser build and publish tags
         if: startsWith(github.ref, 'refs/tags/')
         uses: goreleaser/goreleaser-action@v7


### PR DESCRIPTION
## Summary

Optimizes the CI pipeline for faster PR feedback and reduced CI-minute consumption.

## Changes

### For PRs
1. **Decouple test from web build** — tests run immediately using a placeholder `web/dist/` instead of waiting for the frontend build. Validated locally that `go test ./...` passes with empty web/dist.
2. **Start Docker builds after web only** — Docker no longer waits for tests. Tests gate the publish step (`docker-merge`) instead.
3. **Start GoReleaser signed smoke after web only** — same pattern, runs in parallel with tests.
4. **Skip `goreleaserbuild` on PRs** — the signed smoke test already compiles all 7 platform binaries. Eliminates a redundant ~6 min GoReleaser build.
5. **Reduce Docker platform matrix** — PRs build 2 platforms (amd64 + arm64) instead of 6. Full matrix runs on main/develop/tags.
6. **Parallelize tsc + vite build** — type-check and frontend build run concurrently in the web job.
7. **Cache Go build artifacts** — adds `~/.cache/go-build` caching for the signed smoke test.
8. **Shallow clone in Docker** — removed `fetch-depth: 0` from Docker jobs.

### For Releases (tags/main/develop)
- `goreleaserbuild` runs with `needs: [test, web]` — tests must pass before publishing
- `docker-merge` requires both `docker` and `test` — tests gate image publishing
- Full 6-platform Docker matrix
- `goreleasersignedsmoke` is skipped (only runs on PRs)
- No behavioral changes to the release/publish pipeline

## Results

### PR workflow (measured on fork)

| | Before | After | Saved |
|---|---|---|---|
| **Total wall-clock** | **9.3 min** | **4.3 min** | **5.0 min (54%)** |
| Build web | 51s | 55s | — |
| Run tests | 117s (starts +54s) | 83s (starts +0s) | starts 54s earlier |
| GoReleaser build | 377s | skipped | 377s CI time |
| Signed smoke test | 383s | 59s (cached) | 324s |
| Docker builds | 6 platforms, 174s each | 2 platforms, ~171s | 4 builds saved |
| Docker merge | 16s | 17s | — |
| **Total CI-minutes** | **~28 min** | **~9 min** | **~19 min/PR** |

### Job dependency graph

**PRs:**
```
web (55s) ──→ signed smoke (59s)
          ──→ docker×2 ──→ docker-merge (needs test)
test (83s) ──────────────→ docker-merge (gate)
```

**Releases:**
```
web ──→ goreleaserbuild (needs test+web) ──→ publish
test ─┘
     ──→ docker×6 ──→ docker-merge (needs test) ──→ publish
```

Closes #1718

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Run type-check and build in parallel for faster CI.
  * Reordered test execution and moved test to the pipeline end to simplify flow.
  * Gate release builds to non-pull-request events and adjust PR smoke tests.
  * Added Go compiler caching to speed up builds.
  * Compute Docker platforms dynamically and update related job dependencies.
  * Create placeholder build artifact path to satisfy downstream steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->