### PR TITLE
fix(crossseed): skip link-mode category path warnings

### DIFF
--- a/internal/services/crossseed/category_cache_test.go
+++ b/internal/services/crossseed/category_cache_test.go
@@ -74,22 +74,22 @@ func TestEnsureCrossCategory_RevalidatesWhenRequestedSavePathChanges(t *testing.
 
 	ctx := context.Background()
 
-	require.NoError(t, service.ensureCrossCategory(ctx, instanceID, categoryName, linkModePath))
+	require.NoError(t, service.ensureCrossCategory(ctx, instanceID, categoryName, linkModePath, true))
 	getCategoriesCalls, createCategoryCalls := syncManager.callCounts()
 	require.Equal(t, 1, getCategoriesCalls)
 	require.Equal(t, 1, createCategoryCalls)
 
-	require.NoError(t, service.ensureCrossCategory(ctx, instanceID, categoryName, regularPath))
+	require.NoError(t, service.ensureCrossCategory(ctx, instanceID, categoryName, regularPath, true))
 	getCategoriesCalls, createCategoryCalls = syncManager.callCounts()
 	require.Equal(t, 3, getCategoriesCalls)
 	require.Equal(t, 1, createCategoryCalls)
 
-	require.NoError(t, service.ensureCrossCategory(ctx, instanceID, categoryName, regularPath))
+	require.NoError(t, service.ensureCrossCategory(ctx, instanceID, categoryName, regularPath, true))
 	getCategoriesCalls, createCategoryCalls = syncManager.callCounts()
 	require.Equal(t, 5, getCategoriesCalls)
 	require.Equal(t, 1, createCategoryCalls)
 
-	require.NoError(t, service.ensureCrossCategory(ctx, instanceID, categoryName, linkModePath))
+	require.NoError(t, service.ensureCrossCategory(ctx, instanceID, categoryName, linkModePath, true))
 	getCategoriesCalls, createCategoryCalls = syncManager.callCounts()
 	require.Equal(t, 5, getCategoriesCalls)
 	require.Equal(t, 1, createCategoryCalls)
@@ -114,12 +114,12 @@ func TestEnsureCrossCategory_CacheMatchesPathCaseInsensitively(t *testing.T) {
 
 	ctx := context.Background()
 
-	require.NoError(t, service.ensureCrossCategory(ctx, instanceID, categoryName, initialPath))
+	require.NoError(t, service.ensureCrossCategory(ctx, instanceID, categoryName, initialPath, true))
 	getCategoriesCalls, createCategoryCalls := syncManager.callCounts()
 	require.Equal(t, 1, getCategoriesCalls)
 	require.Equal(t, 1, createCategoryCalls)
 
-	require.NoError(t, service.ensureCrossCategory(ctx, instanceID, categoryName, requestPath))
+	require.NoError(t, service.ensureCrossCategory(ctx, instanceID, categoryName, requestPath, true))
 	getCategoriesCalls, createCategoryCalls = syncManager.callCounts()
 	require.Equal(t, 1, getCategoriesCalls)
 	require.Equal(t, 1, createCategoryCalls)
@@ -148,13 +148,13 @@ func TestEnsureCrossCategory_ConcurrentDifferentRequestedPathsCreateOnce(t *test
 	errs := make(chan error, 2)
 
 	go func() {
-		errs <- service.ensureCrossCategory(ctx, instanceID, categoryName, linkModePath)
+		errs <- service.ensureCrossCategory(ctx, instanceID, categoryName, linkModePath, true)
 	}()
 
 	<-syncManager.getStarted
 
 	go func() {
-		errs <- service.ensureCrossCategory(ctx, instanceID, categoryName, regularPath)
+		errs <- service.ensureCrossCategory(ctx, instanceID, categoryName, regularPath, true)
 	}()
 
 	close(syncManager.releaseGet)
@@ -165,4 +165,53 @@ func TestEnsureCrossCategory_ConcurrentDifferentRequestedPathsCreateOnce(t *test
 	require.GreaterOrEqual(t, getCategoriesCalls, 2)
 	require.LessOrEqual(t, getCategoriesCalls, 3)
 	require.Equal(t, 1, createCategoryCalls)
+}
+
+func TestShouldWarnOnCategorySavePathMismatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                    string
+		compareExistingSavePath bool
+		requestedSavePath       string
+		existingSavePath        string
+		expectedWarn            bool
+	}{
+		{
+			name:                    "regular mode mismatch warns",
+			compareExistingSavePath: true,
+			requestedSavePath:       "/mnt/storage/torrents/cross-seeds/bhd",
+			existingSavePath:        "/mnt/storage/torrents/tv",
+			expectedWarn:            true,
+		},
+		{
+			name:                    "link mode mismatch does not warn",
+			compareExistingSavePath: false,
+			requestedSavePath:       "/mnt/storage/torrents/cross-seeds/bhd",
+			existingSavePath:        "/mnt/storage/torrents/tv",
+			expectedWarn:            false,
+		},
+		{
+			name:                    "matching paths do not warn",
+			compareExistingSavePath: true,
+			requestedSavePath:       "/mnt/storage/torrents/tv",
+			existingSavePath:        "/mnt/storage/torrents/tv",
+			expectedWarn:            false,
+		},
+		{
+			name:                    "missing requested path does not warn",
+			compareExistingSavePath: true,
+			existingSavePath:        "/mnt/storage/torrents/tv",
+			expectedWarn:            false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			warn := shouldWarnOnCategorySavePathMismatch(tt.compareExistingSavePath, tt.requestedSavePath, tt.existingSavePath)
+			require.Equal(t, tt.expectedWarn, warn)
+		})
+	}
 }

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -4452,7 +4452,7 @@ func (s *Service) processCrossSeedCandidate(
 		// the fallback to props.SavePath would produce the wrong path.
 		if !useReflinkMode && !useHardlinkMode {
 			// Ensure the cross-seed category exists with the correct SavePath
-			if err := s.ensureCrossCategory(ctx, candidate.InstanceID, crossCategory, categorySavePath); err != nil {
+			if err := s.ensureCrossCategory(ctx, candidate.InstanceID, crossCategory, categorySavePath, true); err != nil {
 				log.Warn().Err(err).
 					Str("category", crossCategory).
 					Str("savePath", categorySavePath).
@@ -10021,12 +10021,20 @@ func applyCategoryAffix(category, affixMode, affix string) string {
 }
 
 // ensureCrossCategory ensures a .cross suffixed category exists with the correct save_path.
-// If the category already exists, it verifies the save_path matches (logs warning if different).
+// If compareExistingSavePath is true and the category already exists, it verifies the save_path
+// matches (logs warning if different). Link modes pass false because they add torrents with an
+// explicit savepath and autoTMM disabled, so category save_path drift is not actionable there.
 // If it doesn't exist, it creates it with the provided save_path.
 //
 // This function uses singleflight to deduplicate concurrent creation attempts for the same
 // category, and maintains local state to avoid relying on potentially stale GetCategories responses.
-func (s *Service) ensureCrossCategory(ctx context.Context, instanceID int, crossCategory, savePath string) error {
+func (s *Service) ensureCrossCategory(
+	ctx context.Context,
+	instanceID int,
+	crossCategory,
+	savePath string,
+	compareExistingSavePath bool,
+) error {
 	if crossCategory == "" {
 		return nil
 	}
@@ -10035,6 +10043,9 @@ func (s *Service) ensureCrossCategory(ctx context.Context, instanceID int, cross
 	requestedSavePath := normalizePathForComparison(savePath)
 
 	cacheMatches := func(cached any) bool {
+		if !compareExistingSavePath {
+			return true
+		}
 		cachedSavePath, ok := cached.(string)
 		if !ok {
 			return false
@@ -10072,7 +10083,7 @@ func (s *Service) ensureCrossCategory(ctx context.Context, instanceID int, cross
 			actualSavePath := normalizePathForComparison(existing.SavePath)
 
 			// Category exists - check if save_path differs (informational warning only)
-			if savePath != "" && existing.SavePath != "" && actualSavePath != requestedSavePath {
+			if shouldWarnOnCategorySavePathMismatch(compareExistingSavePath, requestedSavePath, existing.SavePath) {
 				log.Warn().
 					Int("instanceID", instanceID).
 					Str("category", crossCategory).
@@ -10104,7 +10115,7 @@ func (s *Service) ensureCrossCategory(ctx context.Context, instanceID int, cross
 	}
 
 	actualSavePath, _ := actualSavePathValue.(string)
-	if requestedSavePath == "" || actualSavePath == requestedSavePath {
+	if !compareExistingSavePath || requestedSavePath == "" || actualSavePath == requestedSavePath {
 		return nil
 	}
 
@@ -10115,7 +10126,7 @@ func (s *Service) ensureCrossCategory(ctx context.Context, instanceID int, cross
 
 	if existing, exists := categories[crossCategory]; exists {
 		actualSavePath = normalizePathForComparison(existing.SavePath)
-		if savePath != "" && existing.SavePath != "" && actualSavePath != requestedSavePath {
+		if shouldWarnOnCategorySavePathMismatch(compareExistingSavePath, requestedSavePath, existing.SavePath) {
 			log.Warn().
 				Int("instanceID", instanceID).
 				Str("category", crossCategory).
@@ -10139,6 +10150,14 @@ func (s *Service) ensureCrossCategory(ctx context.Context, instanceID int, cross
 		Msg("[CROSSSEED] Created category for cross-seed after singleflight revalidation")
 
 	return nil
+}
+
+func shouldWarnOnCategorySavePathMismatch(compareExistingSavePath bool, requestedSavePath, existingSavePath string) bool {
+	if !compareExistingSavePath || requestedSavePath == "" || existingSavePath == "" {
+		return false
+	}
+
+	return normalizePathForComparison(existingSavePath) != requestedSavePath
 }
 
 // determineCrossSeedCategory selects the category to apply to a cross-seeded torrent.
@@ -11157,7 +11176,7 @@ func (s *Service) processHardlinkMode(
 	categoryCreationFailed := false
 	if crossCategory != "" {
 		categorySavePath := s.buildCategorySavePath(ctx, instance, selectedBaseDir, incomingTrackerDomain, candidate, req)
-		if err := s.ensureCrossCategory(ctx, candidate.InstanceID, crossCategory, categorySavePath); err != nil {
+		if err := s.ensureCrossCategory(ctx, candidate.InstanceID, crossCategory, categorySavePath, false); err != nil {
 			log.Warn().Err(err).
 				Str("category", crossCategory).
 				Str("savePath", categorySavePath).
@@ -11755,7 +11774,7 @@ func (s *Service) processReflinkMode(
 	categoryCreationFailed := false
 	if crossCategory != "" {
 		categorySavePath := s.buildCategorySavePath(ctx, instance, selectedBaseDir, incomingTrackerDomain, candidate, req)
-		if err := s.ensureCrossCategory(ctx, candidate.InstanceID, crossCategory, categorySavePath); err != nil {
+		if err := s.ensureCrossCategory(ctx, candidate.InstanceID, crossCategory, categorySavePath, false); err != nil {
 			log.Warn().Err(err).
 				Str("category", crossCategory).
 				Str("savePath", categorySavePath).


### PR DESCRIPTION
Hardlink and reflink cross-seeds are added with an explicit `savepath` and `autoTMM=false`, so an existing qBittorrent category `save_path` mismatch is not actionable there. This change keeps the regular-mode warning, but stops treating that mismatch as noteworthy in link modes.

It keeps the category existence check for link modes while limiting save-path mismatch warnings to the regular flow where the category path is still relevant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cross-seed category handling now validates save paths in regular mode to detect mismatches and prevent inconsistencies, while hardlink and reflink modes maintain flexible path configurations.

* **Tests**
  * Expanded test coverage for cross-seed category save path validation scenarios across different operational modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->