### PR TITLE
fix(automations): clarify cross-seed condition labels

### DIFF
--- a/web/src/components/query-builder/constants.ts
+++ b/web/src/components/query-builder/constants.ts
@@ -102,10 +102,10 @@ export const CONDITION_FIELDS = {
   IS_UNREGISTERED: { label: "Unregistered", type: "boolean" as const, description: "Tracker reports torrent as unregistered" },
   HAS_MISSING_FILES: { label: "Has Missing Files", type: "boolean" as const, description: "Completed torrent has files missing on disk. Requires Local Filesystem Access." },
   IS_GROUPED: { label: "Is Grouped", type: "boolean" as const, description: "True when group size > 1 for the selected group in this condition" },
-  EXISTS_ON_OTHER_INSTANCE: { label: "Exists on Other Instance", type: "boolean" as const, description: "A matching torrent exists on at least one other active instance" },
-  SEEDING_ON_OTHER_INSTANCE: { label: "Seeding on Other Instance", type: "boolean" as const, description: "A matching torrent is actively seeding on at least one other active instance" },
-  EXISTS_ON_SAME_INSTANCE: { label: "Cross-seed Exists on Same Instance", type: "boolean" as const, description: "A cross-seed (same content, different hash) exists on this instance" },
-  SEEDING_ON_SAME_INSTANCE: { label: "Cross-seed Seeding on Same Instance", type: "boolean" as const, description: "A cross-seed is actively seeding on this instance" },
+  EXISTS_ON_OTHER_INSTANCE: { label: "Cross-seed(s) Exists on Other Instance", type: "boolean" as const, description: "A matching torrent exists on at least one other active instance" },
+  SEEDING_ON_OTHER_INSTANCE: { label: "Cross-seed(s) Seeding on Other Instance", type: "boolean" as const, description: "A matching torrent is actively seeding on at least one other active instance" },
+  EXISTS_ON_SAME_INSTANCE: { label: "Cross-seed(s) Exists on Same Instance", type: "boolean" as const, description: "A cross-seed (same content, different hash) exists on this instance" },
+  SEEDING_ON_SAME_INSTANCE: { label: "Cross-seed(s) Seeding on Same Instance", type: "boolean" as const, description: "A cross-seed is actively seeding on this instance" },
 
   // Enum-like fields
   HARDLINK_SCOPE: { label: "Hardlink scope", type: "hardlinkScope" as const, description: "Where hardlinks for this torrent's files exist. Requires Local Filesystem Access." },


### PR DESCRIPTION
## Summary
- Prefixed all four cross-seed automation condition fields with "Cross-seed(s)" in the query builder dropdown
- Previously the "Other Instance" conditions didn't mention cross-seed at all, making them confusing to end-users

Ref: #1648

## Test plan
- [x] Open automations query builder, verify all four cross-seed conditions show the "Cross-seed(s)" prefix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated UI labels for cross-seed condition fields to use consistent pluralized wording ("Cross-seed(s)") across the query builder interface for improved clarity and uniformity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->