### PR TITLE
fix(cross-seed): suppress no-op RSS notifications

### DIFF
--- a/internal/services/crossseed/crossseed_test.go
+++ b/internal/services/crossseed/crossseed_test.go
@@ -2496,6 +2496,69 @@ func TestCheckWebhook_NotificationRequiresCompleteMatch(t *testing.T) {
 	}
 }
 
+func TestNotifyAutomationRun_SuccessRequiresMeaningfulChange(t *testing.T) {
+	t.Parallel()
+
+	completedAt := time.Now().UTC()
+
+	tests := []struct {
+		name      string
+		run       *models.CrossSeedRun
+		wantEvent bool
+	}{
+		{
+			name: "successful skipped-only run does not notify",
+			run: &models.CrossSeedRun{
+				ID:              42,
+				Mode:            models.CrossSeedRunModeAuto,
+				Status:          models.CrossSeedRunStatusSuccess,
+				StartedAt:       time.Now().UTC().Add(-2 * time.Minute),
+				CompletedAt:     &completedAt,
+				TotalFeedItems:  885,
+				CandidatesFound: 0,
+				TorrentsAdded:   0,
+				TorrentsFailed:  0,
+				TorrentsSkipped: 885,
+			},
+			wantEvent: false,
+		},
+		{
+			name: "successful run with additions still notifies",
+			run: &models.CrossSeedRun{
+				ID:              43,
+				Mode:            models.CrossSeedRunModeAuto,
+				Status:          models.CrossSeedRunStatusSuccess,
+				StartedAt:       time.Now().UTC().Add(-2 * time.Minute),
+				CompletedAt:     &completedAt,
+				TotalFeedItems:  10,
+				CandidatesFound: 2,
+				TorrentsAdded:   1,
+				TorrentsFailed:  0,
+				TorrentsSkipped: 9,
+			},
+			wantEvent: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			notifier := &recordingNotifier{}
+			svc := &Service{notifier: notifier}
+
+			svc.notifyAutomationRun(context.Background(), tt.run, nil)
+
+			events := notifier.Events()
+			if tt.wantEvent {
+				require.Len(t, events, 1)
+				assert.Equal(t, notifications.EventCrossSeedAutomationSucceeded, events[0].Type)
+				return
+			}
+
+			assert.Empty(t, events)
+		})
+	}
+}
+
 func TestCheckWebhook_NoInstancesAvailable(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/crossseed/crossseed_test.go
+++ b/internal/services/crossseed/crossseed_test.go
@@ -2502,9 +2502,10 @@ func TestNotifyAutomationRun_SuccessRequiresMeaningfulChange(t *testing.T) {
 	completedAt := time.Now().UTC()
 
 	tests := []struct {
-		name      string
-		run       *models.CrossSeedRun
-		wantEvent bool
+		name          string
+		run           *models.CrossSeedRun
+		wantEvent     bool
+		wantEventType notifications.EventType
 	}{
 		{
 			name: "successful skipped-only run does not notify",
@@ -2536,7 +2537,25 @@ func TestNotifyAutomationRun_SuccessRequiresMeaningfulChange(t *testing.T) {
 				TorrentsFailed:  0,
 				TorrentsSkipped: 9,
 			},
-			wantEvent: true,
+			wantEvent:     true,
+			wantEventType: notifications.EventCrossSeedAutomationSucceeded,
+		},
+		{
+			name: "failed run still notifies",
+			run: &models.CrossSeedRun{
+				ID:              44,
+				Mode:            models.CrossSeedRunModeAuto,
+				Status:          models.CrossSeedRunStatusFailed,
+				StartedAt:       time.Now().UTC().Add(-2 * time.Minute),
+				CompletedAt:     &completedAt,
+				TotalFeedItems:  10,
+				CandidatesFound: 3,
+				TorrentsAdded:   0,
+				TorrentsFailed:  2,
+				TorrentsSkipped: 8,
+			},
+			wantEvent:     true,
+			wantEventType: notifications.EventCrossSeedAutomationFailed,
 		},
 	}
 
@@ -2550,7 +2569,7 @@ func TestNotifyAutomationRun_SuccessRequiresMeaningfulChange(t *testing.T) {
 			events := notifier.Events()
 			if tt.wantEvent {
 				require.Len(t, events, 1)
-				assert.Equal(t, notifications.EventCrossSeedAutomationSucceeded, events[0].Type)
+				assert.Equal(t, tt.wantEventType, events[0].Type)
 				return
 			}
 

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -9179,6 +9179,8 @@ func (s *Service) notifyAutomationRun(ctx context.Context, run *models.CrossSeed
 	eventType := notifications.EventCrossSeedAutomationSucceeded
 	if run.Status == models.CrossSeedRunStatusFailed || run.Status == models.CrossSeedRunStatusPartial {
 		eventType = notifications.EventCrossSeedAutomationFailed
+	} else if run.TorrentsAdded == 0 && run.TorrentsFailed == 0 {
+		return
 	}
 
 	var errorMessage string


### PR DESCRIPTION
RSS automation currently emits success notifications for skipped-only runs, which creates downstream noise during routine polls. This change suppresses those no-op success notifications while keeping meaningful additions and failure notifications intact.

It also adds a regression test covering skipped-only and added-item RSS runs so the notifier behavior stays scoped to the RSS automation path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cross-Seed automation notifications now only fire for meaningful outcomes (torrents added or failures), reducing unnecessary notification noise from all-success/no-change runs.
* **Tests**
  * Added table-driven tests validating notification behavior across success-without-changes, success-with-additions, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->