### PR TITLE
fix(cross-seed): log skipped RSS notifications

### DIFF
--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -9060,6 +9060,15 @@ func (s *Service) notifyAutomationRun(ctx context.Context, run *models.CrossSeed
 	if run.Status == models.CrossSeedRunStatusFailed || run.Status == models.CrossSeedRunStatusPartial {
 		eventType = notifications.EventCrossSeedAutomationFailed
 	} else if run.TorrentsAdded == 0 && run.TorrentsFailed == 0 {
+		log.Info().
+			Int64("runID", run.ID).
+			Str("status", string(run.Status)).
+			Int("feedItems", run.TotalFeedItems).
+			Int("candidates", run.CandidatesFound).
+			Int("added", run.TorrentsAdded).
+			Int("failed", run.TorrentsFailed).
+			Int("skipped", run.TorrentsSkipped).
+			Msg("Skipping cross-seed RSS success notification")
 		return
 	}
 


### PR DESCRIPTION
This follow-up keeps the RSS no-op notification hush behavior unchanged and adds an info log when qui skips sending the success notification. The log includes the run id and summary counts so future support questions have an explicit explanation in the app logs.

The behavior stays scoped to the RSS automation notifier path only. It does not change seeded search, completion search, or webhook notification handling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved diagnostics for background automation runs. When an operation completes successfully without adding or failing any torrents, the system now logs detailed information including run status, feed metrics, candidate counts, and action results for better visibility into operation outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->