### PR TITLE
refactor(search): table & cards cleanup

### DIFF
--- a/web/src/components/search/SearchResultCard.tsx
+++ b/web/src/components/search/SearchResultCard.tsx
@@ -43,13 +43,21 @@ export function SearchResultCard({
 }: SearchResultCardProps) {
   const primaryAddLabel = targetInstanceName ? `Add to ${targetInstanceName}` : "Add to instance"
   const menuCooldownRef = useRef(false)
+  const menuCooldownTimerRef = useRef<number | null>(null)
 
   const handleMenuOpenChange = useCallback((open: boolean) => {
+    if (menuCooldownTimerRef.current !== null) {
+      clearTimeout(menuCooldownTimerRef.current)
+      menuCooldownTimerRef.current = null
+    }
     if (open) {
       menuCooldownRef.current = true
     } else {
       // Brief cooldown so the phantom tap after menu close doesn't reach the card
-      setTimeout(() => { menuCooldownRef.current = false }, 300)
+      menuCooldownTimerRef.current = window.setTimeout(() => {
+        menuCooldownRef.current = false
+        menuCooldownTimerRef.current = null
+      }, 300)
     }
   }, [])
 
@@ -70,6 +78,10 @@ export function SearchResultCard({
       aria-selected={isSelected}
       onClick={handleCardClick}
       onKeyDown={(event) => {
+        if (event.currentTarget !== event.target) {
+          return
+        }
+
         if (event.key === "Enter" || event.key === " ") {
           event.preventDefault()
           onSelect()

--- a/web/src/components/search/SearchResultCard.tsx
+++ b/web/src/components/search/SearchResultCard.tsx
@@ -3,13 +3,14 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
-import { Card } from '@/components/ui/card'
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuSub, DropdownMenuSubContent, DropdownMenuSubTrigger, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
-import { cn } from '@/lib/utils'
-import type { InstanceResponse, TorznabSearchResult } from '@/types'
-import { Download, ExternalLink, MoreVertical, Plus } from 'lucide-react'
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card } from "@/components/ui/card"
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSub, DropdownMenuSubContent, DropdownMenuSubTrigger, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
+import { cn } from "@/lib/utils"
+import type { InstanceResponse, TorznabSearchResult } from "@/types"
+import { Download, ExternalLink, MoreVertical, Plus } from "lucide-react"
+import { useCallback, useRef } from "react"
 
 type SearchResultCardProps = {
   result: TorznabSearchResult
@@ -38,24 +39,38 @@ export function SearchResultCard({
   formatDate,
   instances,
   hasInstances,
-  targetInstanceName
+  targetInstanceName,
 }: SearchResultCardProps) {
-  const primaryAddLabel = targetInstanceName ? `Add to ${targetInstanceName}` : 'Add to instance'
+  const primaryAddLabel = targetInstanceName ? `Add to ${targetInstanceName}` : "Add to instance"
+  const menuCooldownRef = useRef(false)
+
+  const handleMenuOpenChange = useCallback((open: boolean) => {
+    if (open) {
+      menuCooldownRef.current = true
+    } else {
+      // Brief cooldown so the phantom tap after menu close doesn't reach the card
+      setTimeout(() => { menuCooldownRef.current = false }, 300)
+    }
+  }, [])
+
+  const handleCardClick = useCallback(() => {
+    if (!menuCooldownRef.current) {
+      onSelect()
+    }
+  }, [onSelect])
 
   return (
     <Card
       className={cn(
-        'p-3 transition-colors cursor-pointer',
-        isSelected
-          ? 'bg-accent text-accent-foreground ring-2 ring-accent'
-          : 'hover:bg-muted/60'
+        "p-3 transition-colors cursor-pointer",
+        isSelected? "bg-accent text-accent-foreground ring-2 ring-inset ring-accent": "hover:bg-muted/60"
       )}
       role="button"
       tabIndex={0}
       aria-selected={isSelected}
-      onClick={onSelect}
+      onClick={handleCardClick}
       onKeyDown={(event) => {
-        if (event.key === 'Enter' || event.key === ' ') {
+        if (event.key === "Enter" || event.key === " ") {
           event.preventDefault()
           onSelect()
         }
@@ -67,27 +82,21 @@ export function SearchResultCard({
           <h3 className="text-sm font-medium leading-tight line-clamp-2">
             {result.title}
           </h3>
-          <DropdownMenu>
+          <DropdownMenu onOpenChange={handleMenuOpenChange}>
             <DropdownMenuTrigger asChild>
               <Button
                 type="button"
                 variant="ghost"
                 size="icon"
-                className="h-7 w-7 flex-shrink-0"
+                className="h-7 w-7 shrink-0"
                 onClick={(e) => e.stopPropagation()}
               >
                 <MoreVertical className="h-4 w-4" />
                 <span className="sr-only">Actions</span>
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem
-                onSelect={(event) => {
-                  event.preventDefault()
-                  onAddTorrent()
-                }}
-                disabled={!hasInstances}
-              >
+            <DropdownMenuContent align="end" onCloseAutoFocus={(e) => e.preventDefault()}>
+              <DropdownMenuItem onSelect={() => onAddTorrent()} disabled={!hasInstances}>
                 <Plus className="mr-2 h-4 w-4" /> {primaryAddLabel}
               </DropdownMenuItem>
               {hasInstances && instances && instances.length > 1 && (
@@ -99,48 +108,20 @@ export function SearchResultCard({
                     {instances.map(instance => (
                       <DropdownMenuItem
                         key={instance.id}
-                        onSelect={(event) => {
-                          event.preventDefault()
-                          onAddTorrent(instance.id)
-                        }}
+                        onSelect={() => onAddTorrent(instance.id)}
                       >
-                        {instance.name}{!instance.connected ? ' (offline)' : ''}
+                        {instance.name}{!instance.connected ? " (offline)" : ""}
                       </DropdownMenuItem>
                     ))}
                   </DropdownMenuSubContent>
                 </DropdownMenuSub>
               )}
-              <DropdownMenuItem
-                onSelect={(event) => {
-                  event.preventDefault()
-                  onDownload()
-                }}
-                disabled={!result.downloadUrl}
-              >
+              <DropdownMenuItem onSelect={() => onDownload()} disabled={!result.downloadUrl}>
                 <Download className="mr-2 h-4 w-4" /> Download
               </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={(event) => {
-                  event.preventDefault()
-                  onViewDetails()
-                }}
-                disabled={!result.infoUrl}
-              >
+              <DropdownMenuItem onSelect={() => onViewDetails()} disabled={!result.infoUrl}>
                 <ExternalLink className="mr-2 h-4 w-4" /> View details
               </DropdownMenuItem>
-              {isSelected && (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    onSelect={(event) => {
-                      event.preventDefault()
-                      onSelect()
-                    }}
-                  >
-                    Clear selection
-                  </DropdownMenuItem>
-                </>
-              )}
             </DropdownMenuContent>
           </DropdownMenu>
         </div>
@@ -149,7 +130,7 @@ export function SearchResultCard({
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
           <span className="font-medium text-foreground">{result.indexer}</span>
           <span>{formatSize(result.size)}</span>
-          <Badge variant={result.seeders > 0 ? 'default' : 'secondary'} className="text-[10px]">
+          <Badge variant={result.seeders > 0 ? "default" : "secondary"} className="text-[10px]">
             {result.seeders} seeders
           </Badge>
         </div>

--- a/web/src/pages/Search.tsx
+++ b/web/src/pages/Search.tsx
@@ -1247,9 +1247,24 @@ export function Search() {
                                 </DropdownMenuSubContent>
                               </DropdownMenuSub>
                             )}
-                            <DropdownMenuSeparator />
-                            <DropdownMenuItem onSelect={() => handleClearSelection()}>
-                              Clear selection
+                            <DropdownMenuItem
+                              onSelect={(event) => {
+                                event.preventDefault()
+                                handleDownload(selectedResult)
+                              }}
+                            >
+                              <Download className="mr-2 h-4 w-4" /> Download
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              onSelect={(event) => {
+                                event.preventDefault()
+                                if (selectedResult.infoUrl) {
+                                  handleViewDetails(selectedResult)
+                                }
+                              }}
+                              disabled={!selectedResult.infoUrl}
+                            >
+                              <ExternalLink className="mr-2 h-4 w-4" /> View details
                             </DropdownMenuItem>
                           </DropdownMenuContent>
                         </DropdownMenu>
@@ -1631,7 +1646,7 @@ export function Search() {
                             <TableCell className={cn("text-sm text-muted-foreground", isSelected && "text-accent-foreground")}>
                               {formatCacheTimestamp(result.publishDate)}
                             </TableCell>
-                            <TableCell className="w-20" onClick={(e) => e.stopPropagation()}>
+                            <TableCell className="w-20 py-1" onClick={(e) => e.stopPropagation()}>
                               <div className="flex items-center gap-1">
                                 <Tooltip>
                                   <TooltipTrigger asChild>

--- a/web/src/pages/Search.tsx
+++ b/web/src/pages/Search.tsx
@@ -1593,6 +1593,10 @@ export function Search() {
                             aria-selected={isSelected}
                             onClick={() => handleToggleResultSelection(result)}
                             onKeyDown={(event) => {
+                              if (event.currentTarget !== event.target) {
+                                return
+                              }
+
                               if (event.key === "Enter" || event.key === " ") {
                                 event.preventDefault()
                                 handleToggleResultSelection(result)

--- a/web/src/pages/Search.tsx
+++ b/web/src/pages/Search.tsx
@@ -573,7 +573,7 @@ export function Search() {
   const getSortIcon = (column: Exclude<typeof sortColumn, null>) => {
     if (sortColumn !== column) return null
 
-    return sortOrder === "asc" ? <ChevronUp className="h-4 w-4 flex-shrink-0" /> : <ChevronDown className="h-4 w-4 flex-shrink-0" />
+    return sortOrder === "asc" ? <ChevronUp className="h-4 w-4 shrink-0" /> : <ChevronDown className="h-4 w-4 shrink-0" />
   }
 
   // Filter and sort results
@@ -765,7 +765,7 @@ export function Search() {
     window.open(result.infoUrl, "_blank")
   }
 
-  const toggleResultSelection = (result: TorznabSearchResult) => {
+  const handleToggleResultSelection = (result: TorznabSearchResult) => {
     setSelectedResultGuid(prev => prev === result.guid ? null : result.guid)
   }
 
@@ -804,7 +804,7 @@ export function Search() {
                 </Button>
               </SheetTrigger>
 
-              <SheetContent side="right" className="flex h-full max-h-[100dvh] max-w-xl flex-col overflow-hidden p-0">
+              <SheetContent side="right" className="flex h-full max-h-dvh max-w-xl flex-col overflow-hidden p-0">
                 <SheetHeader>
                   <SheetTitle>Indexer selection</SheetTitle>
                   <SheetDescription>Pick which indexers to include in searches.</SheetDescription>
@@ -951,7 +951,7 @@ export function Search() {
             <form onSubmit={handleSearch} className="space-y-4">
               <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:gap-2">
                 <div className="flex items-center gap-2">
-                  <div className="flex-shrink-0 min-w-[120px] max-w-[180px]">
+                  <div className="shrink-0 min-w-30 max-w-45">
                     <Label htmlFor="search-type" className="sr-only">Search type</Label>
                     <Select value={searchType} onValueChange={(value) => setSearchType(value as SearchType)}>
                       <SelectTrigger id="search-type" className="w-full">
@@ -966,13 +966,13 @@ export function Search() {
                       </SelectContent>
                     </Select>
                   </div>
-                  <div className="flex flex-shrink-0 items-center gap-2">
+                  <div className="flex shrink-0 items-center gap-2">
                     <Button
                       type="button"
                       variant={showAdvancedParams ? "default" : "outline"}
                       size="default"
                       className={cn(
-                        "!border !px-4 !py-2.5 h-9",
+                        "border! px-4! py-2.5! h-9",
                         showAdvancedParams? "border-primary bg-primary text-primary-foreground shadow-xs hover:bg-primary/90": "border-input dark:border-input"
                       )}
                       onClick={() => setShowAdvancedParams(prev => !prev)}
@@ -1056,7 +1056,7 @@ export function Search() {
                   <Button
                     type="submit"
                     disabled={loading || (!query.trim() && !hasAdvancedParams) || selectedIndexers.size === 0}
-                    className="flex-shrink-0"
+                    className="shrink-0"
                   >
                     <SearchIcon className="mr-2 h-4 w-4" />
                     {loading ? "Searching..." : "Search"}
@@ -1108,7 +1108,7 @@ export function Search() {
                   Showing {filteredAndSortedResults.length} of {total} results
                 </div>
                 <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:gap-2">
-                  <div className="w-full sm:min-w-[200px] sm:flex-1 min-w-0 relative">
+                  <div className="w-full sm:min-w-50 sm:flex-1 min-w-0 relative">
                     <Input
                       type="text"
                       placeholder="Filter results..."
@@ -1203,28 +1203,6 @@ export function Search() {
                         </div>
                         <Button
                           type="button"
-                          variant="outline"
-                          size="sm"
-                          onClick={() => handleDownload(selectedResult)}
-                          disabled={!selectedResult.downloadUrl}
-                          title="Download"
-                          className="h-9"
-                        >
-                          <Download className="h-4 w-4" />
-                        </Button>
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="sm"
-                          onClick={() => handleViewDetails(selectedResult)}
-                          disabled={!selectedResult.infoUrl}
-                          title={selectedResult.infoUrl ? "View details" : "No info URL available"}
-                          className="h-9"
-                        >
-                          <ExternalLink className="h-4 w-4" />
-                        </Button>
-                        <Button
-                          type="button"
                           variant="ghost"
                           size="sm"
                           onClick={handleClearSelection}
@@ -1269,32 +1247,8 @@ export function Search() {
                                 </DropdownMenuSubContent>
                               </DropdownMenuSub>
                             )}
-                            <DropdownMenuItem
-                              onSelect={(event) => {
-                                event.preventDefault()
-                                handleDownload(selectedResult)
-                              }}
-                            >
-                              <Download className="mr-2 h-4 w-4" /> Download
-                            </DropdownMenuItem>
-                            <DropdownMenuItem
-                              onSelect={(event) => {
-                                event.preventDefault()
-                                if (selectedResult.infoUrl) {
-                                  handleViewDetails(selectedResult)
-                                }
-                              }}
-                              disabled={!selectedResult.infoUrl}
-                            >
-                              <ExternalLink className="mr-2 h-4 w-4" /> View details
-                            </DropdownMenuItem>
                             <DropdownMenuSeparator />
-                            <DropdownMenuItem
-                              onSelect={(event) => {
-                                event.preventDefault()
-                                handleClearSelection()
-                              }}
-                            >
+                            <DropdownMenuItem onSelect={() => handleClearSelection()}>
                               Clear selection
                             </DropdownMenuItem>
                           </DropdownMenuContent>
@@ -1336,13 +1290,13 @@ export function Search() {
                   </div>
                 </div>
                 {/* Mobile: Card-based view */}
-                <div className="sm:hidden space-y-2 max-h-[600px] overflow-auto">
+                <div className="sm:hidden space-y-2 max-h-150 overflow-auto">
                   {filteredAndSortedResults.map((result) => (
                     <SearchResultCard
                       key={result.guid}
                       result={result}
                       isSelected={selectedResultGuid === result.guid}
-                      onSelect={() => toggleResultSelection(result)}
+                      onSelect={() => handleToggleResultSelection(result)}
                       onAddTorrent={(overrideInstanceId) => handleAddTorrent(result, overrideInstanceId)}
                       onDownload={() => handleDownload(result)}
                       onViewDetails={() => handleViewDetails(result)}
@@ -1357,7 +1311,7 @@ export function Search() {
                 </div>
 
                 {/* Desktop: Full table view */}
-                <div className="hidden sm:block max-h-[600px] overflow-auto border rounded-md">
+                <div className="hidden sm:block max-h-150 overflow-auto border rounded-md">
                   <Table>
                     <TableHeader className="sticky top-0 z-20 bg-card">
                       <TableRow className="bg-card">
@@ -1604,6 +1558,9 @@ export function Search() {
                             </div>
                           </div>
                         </TableHead>
+                        <TableHead className="w-20">
+                          <span className="sr-only">Actions</span>
+                        </TableHead>
                       </TableRow>
                     </TableHeader>
                     <TableBody>
@@ -1613,17 +1570,17 @@ export function Search() {
                           <TableRow
                             key={result.guid}
                             className={cn(
-                              "cursor-pointer transition-colors",
+                              "cursor-pointer select-none transition-colors",
                               isSelected? "bg-accent text-accent-foreground hover:bg-accent/90": "hover:bg-muted/60 odd:bg-background/70 even:bg-card/90 dark:odd:bg-background/30 dark:even:bg-card/80"
                             )}
                             role="button"
                             tabIndex={0}
                             aria-selected={isSelected}
-                            onClick={() => toggleResultSelection(result)}
+                            onClick={() => handleToggleResultSelection(result)}
                             onKeyDown={(event) => {
                               if (event.key === "Enter" || event.key === " ") {
                                 event.preventDefault()
-                                toggleResultSelection(result)
+                                handleToggleResultSelection(result)
                               }
                             }}
                           >
@@ -1673,6 +1630,42 @@ export function Search() {
                             </TableCell>
                             <TableCell className={cn("text-sm text-muted-foreground", isSelected && "text-accent-foreground")}>
                               {formatCacheTimestamp(result.publishDate)}
+                            </TableCell>
+                            <TableCell className="w-20" onClick={(e) => e.stopPropagation()}>
+                              <div className="flex items-center gap-1">
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <Button
+                                      type="button"
+                                      variant="ghost"
+                                      size="icon"
+                                      className="h-7 w-7"
+                                      onClick={() => handleDownload(result)}
+                                      disabled={!result.downloadUrl}
+                                    >
+                                      <Download className="h-3.5 w-3.5" />
+                                      <span className="sr-only">Download</span>
+                                    </Button>
+                                  </TooltipTrigger>
+                                  <TooltipContent>Download .torrent</TooltipContent>
+                                </Tooltip>
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <Button
+                                      type="button"
+                                      variant="ghost"
+                                      size="icon"
+                                      className="h-7 w-7"
+                                      onClick={() => handleViewDetails(result)}
+                                      disabled={!result.infoUrl}
+                                    >
+                                      <ExternalLink className="h-3.5 w-3.5" />
+                                      <span className="sr-only">View details</span>
+                                    </Button>
+                                  </TooltipTrigger>
+                                  <TooltipContent>{result.infoUrl ? "View details" : "No info URL"}</TooltipContent>
+                                </Tooltip>
+                              </div>
                             </TableCell>
                           </TableRow>
                         )


### PR DESCRIPTION
This change moves the action buttons for downloading a .torrent file and viewing the details of a torrent into the table row. This also fixes a bug with the mobile view where the selection indicator was bigger than the actual card.
And last but not least, this fixes a bug in the mobile view with 3 dot menu when you were trying to tap on any actions, it would tap through and deselect or select the result behind it.

Before:
<img width="1512" height="835" alt="Screenshot 2026-04-12 at 11 11 27" src="https://github.com/user-attachments/assets/40f45c7e-e6d7-40bd-b577-829be92e1fb9" />

After:
<img width="1512" height="835" alt="Screenshot 2026-04-12 at 11 11 06" src="https://github.com/user-attachments/assets/cf632db0-8154-4797-8b15-c772ccf83639" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented accidental selections from dropdown interactions and bubbled keyboard events.
  * Strengthened row/card keyboard handling to avoid unintended actions.

* **New Features**
  * Added an "Actions" column to the desktop results table with inline Download and View details icon buttons and tooltips.

* **Improvements**
  * Removed "Clear selection" from mobile/compact actions.
  * Adjusted layout, sizing, and scroll behavior for improved UX.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->