### PR TITLE
fix(orphanscan): align content path root detection

### DIFF
--- a/internal/services/orphanscan/service.go
+++ b/internal/services/orphanscan/service.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -1116,16 +1117,58 @@ func addAbsoluteScanRoot(scanRoots map[string]struct{}, root string) {
 	scanRoots[root] = struct{}{}
 }
 
-func actualSavePathFromContentPath(contentPath string, files qbt.TorrentFiles) string {
+func torrentRootFolder(files qbt.TorrentFiles) string {
+	rootFolder := ""
+
+	for _, f := range files {
+		name := path.Clean(strings.ReplaceAll(f.Name, "\\", "/"))
+		parts := strings.Split(name, "/")
+		if len(parts) <= 1 {
+			return ""
+		}
+		if rootFolder == "" {
+			rootFolder = parts[0]
+			continue
+		}
+		if rootFolder != parts[0] {
+			return ""
+		}
+	}
+
+	return rootFolder
+}
+
+func actualSavePathFromContentPath(savePath, contentPath string, files qbt.TorrentFiles) string {
+	savePath = filepath.Clean(savePath)
 	contentPath = filepath.Clean(contentPath)
 	if contentPath == "" || !filepath.IsAbs(contentPath) || len(files) == 0 {
 		return ""
 	}
+	if savePath != "" && filepath.IsAbs(savePath) && contentPath == savePath {
+		return savePath
+	}
 
-	firstFileName := filepath.Clean(files[0].Name)
-	actualSavePath := strings.TrimSuffix(contentPath, string(filepath.Separator)+firstFileName)
-	if actualSavePath == "" || actualSavePath == contentPath {
-		actualSavePath = filepath.Dir(contentPath)
+	var actualSavePath string
+	if len(files) == 1 {
+		firstFileName := filepath.Clean(filepath.FromSlash(files[0].Name))
+		actualSavePath = strings.TrimSuffix(contentPath, string(filepath.Separator)+firstFileName)
+		if actualSavePath == "" || actualSavePath == contentPath {
+			actualSavePath = filepath.Dir(contentPath)
+		}
+	} else {
+		rootFolder := torrentRootFolder(files)
+		if rootFolder == "" {
+			actualSavePath = contentPath
+		} else {
+			actualSavePath = strings.TrimSuffix(contentPath, string(filepath.Separator)+filepath.FromSlash(rootFolder))
+			if actualSavePath == "" || actualSavePath == contentPath {
+				firstFileName := filepath.Clean(filepath.FromSlash(files[0].Name))
+				actualSavePath = strings.TrimSuffix(contentPath, string(filepath.Separator)+firstFileName)
+				if actualSavePath == "" || actualSavePath == contentPath {
+					actualSavePath = filepath.Dir(contentPath)
+				}
+			}
+		}
 	}
 	if actualSavePath == "" || !filepath.IsAbs(actualSavePath) {
 		return ""
@@ -1178,7 +1221,7 @@ func buildFileMapFromTorrents(torrents []qbt.Torrent, filesByHash map[string]qbt
 
 		// Auto TMM can update save_path to the category root without moving the
 		// payload. content_path still reflects the real on-disk location.
-		actualSavePath := actualSavePathFromContentPath(torrent.ContentPath, files)
+		actualSavePath := actualSavePathFromContentPath(savePath, torrent.ContentPath, files)
 		if actualSavePath != "" && actualSavePath != savePath {
 			scanRoots[actualSavePath] = struct{}{}
 			for _, f := range files {

--- a/internal/services/orphanscan/settling_test.go
+++ b/internal/services/orphanscan/settling_test.go
@@ -229,3 +229,63 @@ func TestBuildFileMapFromTorrents_ContentPathDivergesFromSavePath(t *testing.T) 
 	assert.Contains(t, result.scanRoots, filepath.Clean(categoryRoot))
 	assert.Contains(t, result.scanRoots, filepath.Clean(trackerDir))
 }
+
+func TestBuildFileMapFromTorrents_FlatMultiFileContentPathStaysWithinSavePath(t *testing.T) {
+	t.Parallel()
+
+	saveRoot := filepath.Join(t.TempDir(), "downloads")
+	result, err := buildFileMapFromTorrents(
+		[]qbt.Torrent{
+			{
+				Hash:        "flat123",
+				SavePath:    saveRoot,
+				ContentPath: saveRoot,
+				State:       qbt.TorrentStatePausedUp,
+			},
+		},
+		map[string]qbt.TorrentFiles{
+			"flat123": {
+				{Name: "movie.mkv", Size: 1000},
+				{Name: "subs/file.srt", Size: 100},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	assert.True(t, result.fileMap.Has(normalizePath(filepath.Join(saveRoot, "movie.mkv"))))
+	assert.True(t, result.fileMap.Has(normalizePath(filepath.Join(saveRoot, "subs", "file.srt"))))
+	assert.Equal(t, []string{filepath.Clean(saveRoot)}, result.scanRoots)
+	assert.NotContains(t, result.scanRoots, filepath.Dir(saveRoot))
+}
+
+func TestBuildFileMapFromTorrents_FlatMultiFileDivergentContentPathUsesContentRoot(t *testing.T) {
+	t.Parallel()
+
+	categoryRoot := filepath.Join(t.TempDir(), "cross-seed")
+	contentRoot := filepath.Join(categoryRoot, "tracker-name")
+	result, err := buildFileMapFromTorrents(
+		[]qbt.Torrent{
+			{
+				Hash:        "flat-divergent",
+				SavePath:    categoryRoot,
+				ContentPath: contentRoot,
+				State:       qbt.TorrentStatePausedUp,
+			},
+		},
+		map[string]qbt.TorrentFiles{
+			"flat-divergent": {
+				{Name: "extras/poster.jpg", Size: 100},
+				{Name: "movie.mkv", Size: 1000},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	assert.True(t, result.fileMap.Has(normalizePath(filepath.Join(categoryRoot, "extras", "poster.jpg"))))
+	assert.True(t, result.fileMap.Has(normalizePath(filepath.Join(categoryRoot, "movie.mkv"))))
+	assert.True(t, result.fileMap.Has(normalizePath(filepath.Join(contentRoot, "extras", "poster.jpg"))))
+	assert.True(t, result.fileMap.Has(normalizePath(filepath.Join(contentRoot, "movie.mkv"))))
+	assert.Contains(t, result.scanRoots, filepath.Clean(categoryRoot))
+	assert.Contains(t, result.scanRoots, filepath.Clean(contentRoot))
+	assert.NotContains(t, result.scanRoots, filepath.Dir(categoryRoot))
+}


### PR DESCRIPTION
This fixes a regression introduced in #1712, where orphan scan started deriving extra scan roots from `content_path` using fallback logic that did not match qBittorrent's root-folder semantics. In flat multi-file layouts that could broaden scan roots beyond the real torrent content and surface container/runtime files as orphans.

The fix keeps the Auto TMM protection added in #1712, but updates root derivation to follow qBittorrent's actual `content_path` behavior for single-file torrents, rooted multi-file torrents, and flat multi-file torrents. It also adds regression coverage for the reported orphan-scan behavior in discussion #1770.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined torrent path resolution in orphan scan service to correctly identify root folders in multi-file torrents and improve accuracy of file tracking when content paths differ from save paths.

* **Tests**
  * Added test coverage for multi-file torrent scenarios with varying content and save path configurations to ensure robust path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->