### PR TITLE
fix(license): unblock stale polar license migration

### DIFF
--- a/internal/services/license/license_service.go
+++ b/internal/services/license/license_service.go
@@ -897,10 +897,11 @@ func (s *Service) DeleteLicense(ctx context.Context, licenseKey string) error {
 				LicenseKeyInstanceID: license.DodoInstanceID,
 				InstanceID:           license.DodoInstanceID,
 			})
-			if err != nil {
-				if !errors.Is(err, dodo.ErrInstanceNotFound) && !errors.Is(err, dodo.ErrLicenseNotFound) {
-					return fmt.Errorf("failed to deactivate license: %w", err)
-				}
+			if err != nil && !errors.Is(err, dodo.ErrInstanceNotFound) && !errors.Is(err, dodo.ErrLicenseNotFound) {
+				log.Warn().
+					Err(err).
+					Str("licenseKey", maskLicenseKey(license.LicenseKey)).
+					Msg("Failed to deactivate Dodo license remotely, deleting local license anyway")
 			}
 		}
 	case models.LicenseProviderPolar:
@@ -910,7 +911,10 @@ func (s *Service) DeleteLicense(ctx context.Context, licenseKey string) error {
 				ActivationID: license.PolarActivationID,
 			})
 			if err != nil && !errors.Is(err, polar.ErrLicenseNotActivated) && !errors.Is(err, polar.ErrInvalidLicenseKey) {
-				return fmt.Errorf("failed to deactivate license: %w", err)
+				log.Warn().
+					Err(err).
+					Str("licenseKey", maskLicenseKey(license.LicenseKey)).
+					Msg("Failed to deactivate Polar license remotely, deleting local license anyway")
 			}
 		}
 	}

--- a/internal/services/license/license_service.go
+++ b/internal/services/license/license_service.go
@@ -919,7 +919,10 @@ func (s *Service) DeleteLicense(ctx context.Context, licenseKey string) error {
 		}
 	}
 
-	return s.licenseRepo.DeleteLicense(context.WithoutCancel(ctx), licenseKey)
+	deleteCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+
+	return s.licenseRepo.DeleteLicense(deleteCtx, licenseKey)
 }
 
 // Helper function to mask license keys in logs

--- a/internal/services/license/license_service.go
+++ b/internal/services/license/license_service.go
@@ -919,7 +919,7 @@ func (s *Service) DeleteLicense(ctx context.Context, licenseKey string) error {
 		}
 	}
 
-	return s.licenseRepo.DeleteLicense(ctx, licenseKey)
+	return s.licenseRepo.DeleteLicense(context.WithoutCancel(ctx), licenseKey)
 }
 
 // Helper function to mask license keys in logs

--- a/web/src/components/themes/LicenseManager.tsx
+++ b/web/src/components/themes/LicenseManager.tsx
@@ -88,6 +88,7 @@ export function LicenseManager({ checkoutStatus, checkoutPaymentStatus, onChecko
     accessTitle = "License Activation Required"
     accessDescription = "Your license needs to be activated on this machine"
   }
+  const canAddLicense = !hasStoredLicense || hasInvalidLicense
   const checkoutUrl = useMemo(() => {
     const returnPath = withBasePath("settings?tab=themes&checkout=success")
     const returnUrl = new URL(returnPath, window.location.origin).toString()
@@ -177,7 +178,7 @@ export function LicenseManager({ checkoutStatus, checkoutPaymentStatus, onChecko
               </CardDescription>
             </div>
             <div className="flex gap-2">
-              {!hasStoredLicense && (
+              {canAddLicense && (
                 <Button
                   size="sm"
                   onClick={() => setShowAddLicense(true)}
@@ -336,7 +337,7 @@ export function LicenseManager({ checkoutStatus, checkoutPaymentStatus, onChecko
           <DialogHeader>
             <DialogTitle>Remove license?</DialogTitle>
             <DialogDescription>
-              Are you sure you want to remove this license from this machine? This will deactivate it here to free up an activation slot.
+              Are you sure you want to remove this license from this machine? qui will try to free the remote activation slot too, but local removal will still finish if that request fails.
             </DialogDescription>
           </DialogHeader>
 


### PR DESCRIPTION
This updates license removal to always clear the local row even when remote deactivation fails, which unblocks stale Polar migrations.

It also keeps Add License available when the stored license is invalid so users can activate a new Dodo license without first getting stuck on removal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * License removal now completes locally even if remote deactivation fails; such remote failures are logged as warnings and no longer block local deletion.

* **New Features**
  * You can add or activate a license when a stored license exists but is inactive.
  * The delete-license confirmation dialog now explains an extra remote deactivation attempt and clarifies that local removal still completes if remote release fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->