### PR TITLE
fix(settings): explain disabled API keys

### DIFF
--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -51,13 +51,13 @@ import { Switch } from "@/components/ui/switch"
 import { useDateTimeFormatters } from "@/hooks/useDateTimeFormatters"
 import { useInstances } from "@/hooks/useInstances"
 import { usePersistedTitleBarSpeeds } from "@/hooks/usePersistedTitleBarSpeeds"
-import { api } from "@/lib/api"
+import { APIError, api } from "@/lib/api"
 
 import { withBasePath } from "@/lib/base-url"
 import { canRegisterProtocolHandler, getMagnetHandlerRegistrationGuidance, registerMagnetHandler } from "@/lib/protocol-handler"
 import { copyTextToClipboard, formatBytes, formatDuration } from "@/lib/utils"
 import type { SettingsSearch } from "@/routes/_authenticated/settings"
-import type { Instance, TorznabSearchCacheStats, User } from "@/types"
+import type { ApplicationInfo, Instance, TorznabSearchCacheStats, User } from "@/types"
 import { useForm } from "@tanstack/react-form"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Bell, Clock, Copy, Database, ExternalLink, FileText, Info, Key, Layers, Link2, Loader2, Palette, Plus, RefreshCw, Server, Share2, Shield, Terminal, Trash2 } from "lucide-react"
@@ -68,6 +68,18 @@ import { toast } from "sonner"
 type SettingsTab = NonNullable<SettingsSearch["tab"]>
 
 const TORZNAB_CACHE_MIN_TTL_MINUTES = 1440
+
+function getApiErrorMessage(error: unknown, fallback: string) {
+  if (error instanceof APIError && error.message) {
+    return error.message
+  }
+
+  if (error instanceof Error && error.message) {
+    return error.message
+  }
+
+  return fallback
+}
 
 function ChangePasswordForm() {
   const mutation = useMutation({
@@ -199,17 +211,24 @@ function ChangePasswordForm() {
   )
 }
 
-function ApiKeysManager() {
+interface ApiKeysManagerProps {
+  authMode?: ApplicationInfo["authMode"]
+  authModeLoading: boolean
+}
+
+function ApiKeysManager({ authMode, authModeLoading }: ApiKeysManagerProps) {
   const [showCreateDialog, setShowCreateDialog] = useState(false)
   const [deleteKeyId, setDeleteKeyId] = useState<number | null>(null)
   const [newKey, setNewKey] = useState<{ name: string; key: string } | null>(null)
   const queryClient = useQueryClient()
   const { formatDate } = useDateTimeFormatters()
+  const authDisabled = authMode === "disabled"
 
   // Fetch API keys from backend
   const { data: apiKeys, isLoading } = useQuery({
     queryKey: ["apiKeys"],
     queryFn: () => api.getApiKeys(),
+    enabled: !authModeLoading && !authDisabled,
     staleTime: 30 * 1000, // 30 seconds
   })
 
@@ -225,8 +244,8 @@ function ApiKeysManager() {
       queryClient.invalidateQueries({ queryKey: ["apiKeys"] })
       toast.success("API key created successfully")
     },
-    onError: () => {
-      toast.error("Failed to create API key")
+    onError: (error) => {
+      toast.error(getApiErrorMessage(error, "Failed to create API key"))
     },
   })
 
@@ -239,8 +258,8 @@ function ApiKeysManager() {
       setDeleteKeyId(null)
       toast.success("API key deleted successfully")
     },
-    onError: () => {
-      toast.error("Failed to delete API key")
+    onError: (error) => {
+      toast.error(getApiErrorMessage(error, "Failed to delete API key"))
     },
   })
 
@@ -253,6 +272,25 @@ function ApiKeysManager() {
       form.reset()
     },
   })
+
+  if (authModeLoading) {
+    return (
+      <div className="rounded-md border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
+        Loading authentication mode...
+      </div>
+    )
+  }
+
+  if (authDisabled) {
+    return (
+      <div className="rounded-md border border-border bg-muted/30 p-4">
+        <h3 className="text-sm font-medium">API keys are unavailable while built-in auth is disabled</h3>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Requests that pass your reverse proxy and CIDR allowlist can use the qui API directly.
+        </p>
+      </div>
+    )
+  }
 
   return (
     <div className="space-y-4">
@@ -935,7 +973,7 @@ function ApplicationInfoPanel() {
     }
   }, [info])
 
-  let currentSessionAuth = "Unknown"
+  let currentSessionAuth: string
   if (currentUserQuery.isLoading) {
     currentSessionAuth = "Loading…"
   } else if (currentUserQuery.isError) {
@@ -1156,6 +1194,11 @@ function SettingsScrollPanel({ children, contentClassName }: SettingsScrollPanel
 export function Settings({ search, onSearchChange }: SettingsProps) {
   const activeTab: SettingsTab = search.tab ?? "application"
   const scrollPanelContentClassName = "space-y-4"
+  const appInfoQuery = useQuery({
+    queryKey: ["application-info"],
+    queryFn: () => api.getApplicationInfo(),
+    staleTime: 30 * 1000,
+  })
 
   const handleTabChange = (tab: SettingsTab) => {
     onSearchChange({ tab })
@@ -1478,7 +1521,7 @@ export function Settings({ search, onSearchChange }: SettingsProps) {
                   </div>
                 </CardHeader>
                 <CardContent>
-                  <ApiKeysManager />
+                  <ApiKeysManager authMode={appInfoQuery.data?.authMode} authModeLoading={appInfoQuery.isLoading} />
                 </CardContent>
               </Card>
             </SettingsScrollPanel>


### PR DESCRIPTION
When built-in auth is disabled, the normal API key endpoints intentionally reject requests. The Settings API Keys panel now detects that auth mode and explains direct proxy/CIDR API access instead of calling the disabled endpoint.

API key create/delete failures also surface the backend error message when one is available.

<img width="2144" height="1007" alt="CleanShot 2026-04-30 at 19 51 55@2x" src="https://github.com/user-attachments/assets/4ceff23f-cb0f-420c-933f-51665c8dbad4" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved API error handling to display server-provided error messages in toast notifications for better troubleshooting and guidance.

* **New Features**
  * Added visual loading indicators for authentication mode transitions.
  * Enhanced API keys management interface with dedicated states for loading and unavailable conditions, improving system status visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->