### PR TITLE
feat(web): Add option to copy magnet link from the context menu

### DIFF
--- a/internal/api/handlers/torrents.go
+++ b/internal/api/handlers/torrents.go
@@ -298,8 +298,8 @@ func (h *TorrentsHandler) GetTorrentField(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if req.Field != "name" && req.Field != "hash" && req.Field != "full_path" && req.Field != "tags" {
-		RespondError(w, http.StatusBadRequest, "Invalid field: must be name, hash, full_path, or tags")
+	if req.Field != "name" && req.Field != "hash" && req.Field != "full_path" && req.Field != "tags" && req.Field != "magnet_uri" {
+		RespondError(w, http.StatusBadRequest, "Invalid field: must be name, hash, full_path, tags, or magnet_uri")
 		return
 	}
 
@@ -406,7 +406,7 @@ func (h *TorrentsHandler) GetTorrentField(w http.ResponseWriter, r *http.Request
 					continue
 				}
 
-				value := torrentFieldValue(req.Field, torrent.Name, torrent.Hash, torrent.InfohashV1, torrent.InfohashV2, torrent.SavePath, torrent.Tags)
+				value := torrentFieldValue(req.Field, torrent.Name, torrent.Hash, torrent.InfohashV1, torrent.InfohashV2, torrent.SavePath, torrent.Tags, torrent.MagnetURI)
 				if shouldIncludeTorrentFieldValue(req.Field, value) {
 					values = append(values, value)
 					resolvedCount++
@@ -464,7 +464,7 @@ func (h *TorrentsHandler) GetTorrentField(w http.ResponseWriter, r *http.Request
 				continue
 			}
 
-			value := torrentFieldValue(req.Field, torrent.Name, torrent.Hash, torrent.InfohashV1, torrent.InfohashV2, torrent.SavePath, torrent.Tags)
+			value := torrentFieldValue(req.Field, torrent.Name, torrent.Hash, torrent.InfohashV1, torrent.InfohashV2, torrent.SavePath, torrent.Tags, torrent.MagnetURI)
 			if shouldIncludeTorrentFieldValue(req.Field, value) {
 				values = append(values, value)
 			}
@@ -500,7 +500,7 @@ func (h *TorrentsHandler) GetTorrentField(w http.ResponseWriter, r *http.Request
 	RespondJSON(w, http.StatusOK, fieldResponse)
 }
 
-func torrentFieldValue(field, name, hash, infohashV1, infohashV2, savePath, tags string) string {
+func torrentFieldValue(field, name, hash, infohashV1, infohashV2, savePath, tags, magnetURI string) string {
 	switch field {
 	case "name":
 		return strings.TrimSpace(name)
@@ -514,6 +514,8 @@ func torrentFieldValue(field, name, hash, infohashV1, infohashV2, savePath, tags
 		return fullPathValue(savePath, name)
 	case "tags":
 		return tags
+	case "magnet_uri":
+		return strings.TrimSpace(magnetURI)
 	default:
 		return ""
 	}

--- a/internal/api/handlers/torrents_field_test.go
+++ b/internal/api/handlers/torrents_field_test.go
@@ -85,6 +85,37 @@ func TestGetTorrentField_TagBaselineHandlesDuplicateCrossInstanceHashesWithoutTa
 	require.ElementsMatch(t, []string{"movies", "hdr"}, response.Values)
 }
 
+func TestGetTorrentField_MagnetURIReturnsSelectedLinks(t *testing.T) {
+	t.Parallel()
+
+	instanceStore, syncManager, instanceIDs := createTorrentFieldTestHarness(t, map[string][]qbt.Torrent{
+		"alpha": {
+			{Name: "Alpha", Hash: "aaa", MagnetURI: "magnet:?xt=urn:btih:aaa"},
+			{Name: "Beta", Hash: "bbb"},
+			{Name: "Gamma", Hash: "ccc", MagnetURI: "magnet:?xt=urn:btih:ccc"},
+		},
+	})
+
+	handler := NewTorrentsHandler(syncManager, nil, instanceStore)
+	req := newTorrentFieldRequest(t, instanceIDs["alpha"], map[string]any{
+		"field": "magnet_uri",
+		"sort":  "name",
+		"order": "asc",
+	})
+
+	rec := httptest.NewRecorder()
+	handler.GetTorrentField(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var response quiqbt.TorrentFieldResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+	require.Equal(t, []string{
+		"magnet:?xt=urn:btih:aaa",
+		"magnet:?xt=urn:btih:ccc",
+	}, response.Values)
+}
+
 func createTorrentFieldTestHarness(t *testing.T, torrentsByInstanceName map[string][]qbt.Torrent) (*models.InstanceStore, *quiqbt.SyncManager, map[string]int) {
 	t.Helper()
 

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -1267,7 +1267,7 @@ type TorrentFieldResponse struct {
 }
 
 // GetTorrentField returns field values for torrents matching the given filters.
-// Supported fields: "name", "hash", "full_path" (save_path/name), "tags".
+// Supported fields: "name", "hash", "full_path" (save_path/name), "tags", "magnet_uri".
 // excludeHashes and excludeTargets remove specific torrents from the result.
 func (sm *SyncManager) GetTorrentField(
 	ctx context.Context,
@@ -1341,6 +1341,8 @@ func (sm *SyncManager) GetTorrentField(
 			}
 		case "tags":
 			v = t.Tags
+		case "magnet_uri":
+			v = strings.TrimSpace(t.MagnetURI)
 		}
 		if field == "tags" || v != "" {
 			values = append(values, v)

--- a/web/src/components/torrents/TorrentContextMenu.tsx
+++ b/web/src/components/torrents/TorrentContextMenu.tsx
@@ -379,6 +379,9 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
             <ContextMenuItem onClick={handleCopyFullPaths}>
               Copy Full Path
             </ContextMenuItem>
+            <ContextMenuItem onClick={handleCopyMagnetLinks}>
+              Copy Magnet Link
+            </ContextMenuItem>
           </>
         ) : (
           <>

--- a/web/src/components/torrents/TorrentContextMenu.tsx
+++ b/web/src/components/torrents/TorrentContextMenu.tsx
@@ -153,13 +153,14 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
     filterCrossSeeds(torrents)
   }, [filterCrossSeeds, torrents])
 
-  const copyToClipboard = useCallback(async (text: string, type: "name" | "hash" | "full path", itemCount: number) => {
+  const copyToClipboard = useCallback(async (text: string, type: "name" | "hash" | "full path" | "magnet link", itemCount: number) => {
     try {
       await copyTextToClipboard(text)
-      const pluralTypes: Record<"name" | "hash" | "full path", string> = {
+      const pluralTypes: Record<"name" | "hash" | "full path" | "magnet link", string> = {
         name: "names",
         hash: "hashes",
         "full path": "full paths",
+        "magnet link": "magnet links",
       }
       const label = itemCount > 1 ? pluralTypes[type] : type
       toast.success(`Torrent ${label} copied to clipboard`)
@@ -270,6 +271,19 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
 
     void copyToClipboard(values.join("\n"), "full path", values.length)
   }, [copyToClipboard, incognitoMode, torrents, isAllSelected, effectiveSelectionCount, onFetchAllField])
+
+  const handleCopyMagnetLinks = useCallback(() => {
+    const values = torrents
+      .map(t => t.magnet_uri)
+      .filter(Boolean)
+
+    if (values.length === 0) {
+      toast.error("Magnet link not available")
+      return
+    }
+
+    void copyToClipboard(values.join("\n"), "magnet link", values.length)
+  }, [copyToClipboard, torrents])
 
   const handleExport = useCallback(() => {
     if (!onExport) {
@@ -583,6 +597,9 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
                 </ContextMenuItem>
                 <ContextMenuItem onClick={handleCopyFullPaths}>
                   Copy Full Path
+                </ContextMenuItem>
+                <ContextMenuItem onClick={handleCopyMagnetLinks}>
+                  Copy Magnet Link
                 </ContextMenuItem>
               </ContextMenuSubContent>
             </ContextMenuSub>

--- a/web/src/components/torrents/TorrentContextMenu.tsx
+++ b/web/src/components/torrents/TorrentContextMenu.tsx
@@ -85,7 +85,7 @@ interface TorrentContextMenuProps {
   onCrossSeedSearch?: (torrent: Torrent) => void
   isCrossSeedSearching?: boolean
   onFilterChange?: (filters: TorrentFilters) => void
-  onFetchAllField?: (field: "name" | "hash" | "full_path") => Promise<string[]>
+  onFetchAllField?: (field: "name" | "hash" | "full_path" | "magnet_uri") => Promise<string[]>
 }
 
 export const TorrentContextMenu = memo(function TorrentContextMenu({
@@ -272,9 +272,21 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
     void copyToClipboard(values.join("\n"), "full path", values.length)
   }, [copyToClipboard, incognitoMode, torrents, isAllSelected, effectiveSelectionCount, onFetchAllField])
 
-  const handleCopyMagnetLinks = useCallback(() => {
+  const handleCopyMagnetLinks = useCallback(async () => {
+    if (isAllSelected && onFetchAllField && torrents.length < effectiveSelectionCount) {
+      try {
+        const values = await onFetchAllField("magnet_uri")
+        if (values.length === 0) { toast.error("Magnet link not available"); return }
+        void copyToClipboard(values.join("\n"), "magnet link", values.length)
+      } catch (error) {
+        console.error("Failed to fetch torrent magnet links:", error)
+        toast.error("Failed to fetch torrent magnet links")
+      }
+      return
+    }
+
     const values = torrents
-      .map(t => t.magnet_uri)
+      .map(t => (t.magnet_uri ?? "").trim())
       .filter(Boolean)
 
     if (values.length === 0) {
@@ -283,7 +295,7 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
     }
 
     void copyToClipboard(values.join("\n"), "magnet link", values.length)
-  }, [copyToClipboard, torrents])
+  }, [copyToClipboard, torrents, isAllSelected, effectiveSelectionCount, onFetchAllField])
 
   const handleExport = useCallback(() => {
     if (!onExport) {

--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -1717,7 +1717,7 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
   }, [onSelectionChange, selectedHashes, selectedTorrents, isAllSelected, effectiveSelectionCount, selectAllExcludeHashes, selectAllExcludedTargets, selectedTotalSize, selectAllFilters, filters])
 
   // Callback for context menu to fetch field for matching torrents
-  const fetchAllTorrentField = useCallback(async (field: "name" | "hash" | "full_path"): Promise<string[]> => {
+  const fetchAllTorrentField = useCallback(async (field: "name" | "hash" | "full_path" | "magnet_uri"): Promise<string[]> => {
     const response = await api.getTorrentField(instanceId, field, {
       sort: activeSortField,
       order: activeSortOrder,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -834,7 +834,7 @@ class ApiClient {
 
   async getTorrentField(
     instanceId: number,
-    field: "name" | "hash" | "full_path" | "tags",
+    field: "name" | "hash" | "full_path" | "tags" | "magnet_uri",
     params: {
       sort?: string
       order?: "asc" | "desc"


### PR DESCRIPTION
This pull request introduces a new option in the "Copy" context menu to copy the torrent magnet link to the clipboard, as shown in the following screenshot

<img width="1920" height="1080" alt="Captura de tela 2026-05-02 105137" src="https://github.com/user-attachments/assets/bc31c50e-d784-496f-a39d-c5186bb1d127" />

This should fulfill the request from the discussion https://github.com/autobrr/qui/discussions/998

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Copy Magnet Link" to the torrent context menu (also available under read-only copy actions). Copies magnet links for selected torrents—including "all selected"—with validation and success/error toasts and improved pluralization/labels.
* **Tests**
  * Added backend test to verify magnet link fetching and selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->