### PR TITLE
fix(rss): populate legacy assignedCategory for qBittorrent < 5.0 comp…

### DIFF
--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -6348,6 +6348,13 @@ func (sm *SyncManager) SetRSSRule(ctx context.Context, instanceID int, ruleName 
 		return fmt.Errorf("failed to get client: %w", err)
 	}
 
+	// qBittorrent < 5.0 ignores torrentParams and uses legacy flat fields instead.
+	// Mirror the values so category/savePath persist on older instances.
+	if rule.TorrentParams != nil {
+		rule.AssignedCategory = rule.TorrentParams.Category
+		rule.SavePath = rule.TorrentParams.SavePath
+	}
+
 	return client.SetRSSRuleCtx(ctx, ruleName, rule)
 }
 


### PR DESCRIPTION
## Summary

- qBittorrent versions before 5.0 use flat fields (`assignedCategory`, `savePath`) on RSS auto-download rules and silently ignore the `torrentParams` nested object
- When a user sets a category in the RSS rules editor, the frontend sends `torrentParams.category` but older qBittorrent instances discard it, causing the save to silently fail
- Fix: in `SetRSSRule`, mirror `TorrentParams.Category` → `AssignedCategory` and `TorrentParams.SavePath` → `SavePath` before forwarding to qBittorrent, so both old and new instances receive the data in a format they understand


discussion about bug:  https://github.com/autobrr/qui/discussions/1707

## Testing

Like I mentioned in the discussion, I have simulated this fix by editing the curl and verifying that it works for me, but I haven't actually run patch. Also have not verified it doesn't cause issues with more recent qbittorrent versions.


_Generated by [Claude Code](https://claude.ai/code/session_01FreQeoTMEhnZ12d1Jk1sP6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with older qBittorrent versions when setting RSS rules. Category and save path assignments now properly persist across qBittorrent instances that use legacy configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->