### PR TITLE
fix(web): remove deprecated tsconfig baseUrl

### DIFF
--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { Github } from "lucide-react";
+import { Code } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 export const Footer = () => {
@@ -24,7 +24,7 @@ export const Footer = () => {
           rel="noopener noreferrer"
           aria-label="View on GitHub"
         >
-          <Github className="h-3 w-3" />
+          <Code className="h-3 w-3" />
         </a>
       </Button>
     </div>

--- a/web/src/components/layout/MobileFooterNav.tsx
+++ b/web/src/components/layout/MobileFooterNav.tsx
@@ -46,12 +46,12 @@ import { Link, useLocation, useNavigate, useSearch } from "@tanstack/react-route
 import {
   Archive,
   Check,
+  Code,
   Copyright,
   CornerDownRight,
   Download,
   FileText,
   GitBranch,
-  Github,
   HardDrive,
   Home,
   Loader2,
@@ -525,7 +525,7 @@ export function MobileFooterNav() {
                 aria-label="View on GitHub"
                 className="h-6 w-6 flex items-center justify-center text-muted-foreground/60 hover:text-foreground transition-colors"
               >
-                <Github className="h-3.5 w-3.5" />
+                <Code className="h-3.5 w-3.5" />
               </a>
             </div>
             <DropdownMenuSeparator />

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -23,10 +23,10 @@ import { useQuery } from "@tanstack/react-query"
 import { Link, useLocation, useNavigate, useSearch } from "@tanstack/react-router"
 import {
   Archive,
+  Code,
   Copyright,
   FileText,
   GitBranch,
-  Github,
   HardDrive,
   Home,
   Loader2,
@@ -330,7 +330,7 @@ export function Sidebar() {
               rel="noopener noreferrer"
               aria-label="View on GitHub"
             >
-              <Github className="h-3.5 w-3.5" />
+              <Code className="h-3.5 w-3.5" />
             </a>
           </Button>
         </div>

--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -7,7 +7,6 @@
     "module": "ESNext",
     "skipLibCheck": true,
 
-    /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
@@ -15,7 +14,6 @@
     "noEmit": true,
     "jsx": "react-jsx",
 
-    /* Linting */
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
@@ -23,8 +21,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
 
-    /* Import alias */
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
Removes the deprecated `baseUrl` option from the web app TypeScript config so TypeScript 6 no longer fails with TS5101 during frontend builds.

Also swaps the removed lucide GitHub brand icon for lucide’s `Code` icon so the UI builds against lucide-react 1.x.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted TypeScript configuration formatting and removed inline explanatory comments.
* **Style / UI**
  * Updated footer and navigation link icons: GitHub links now display a generic code icon across desktop and mobile views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->