### PR TITLE
chore(deps): update go-qbittorrent for new qbt 5.2.x webAPI version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,9 @@ require (
 	github.com/alexedwards/scs/v2 v2.9.0
 	github.com/anacrolix/torrent v1.61.0
 	github.com/andybalholm/brotli v1.2.1
-	github.com/autobrr/autobrr v1.76.0
+	github.com/autobrr/autobrr v1.77.0
 	github.com/autobrr/go-mediainfo v0.3.1
-	github.com/autobrr/go-qbittorrent v1.15.0-rc1.0.20260221205148-5cc22ac80d42
+	github.com/autobrr/go-qbittorrent v1.15.0-rc1.0.20260504155815-c211e84d3742
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/coreos/go-oidc/v3 v3.18.0

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/andybalholm/brotli v1.2.1
 	github.com/autobrr/autobrr v1.77.0
 	github.com/autobrr/go-mediainfo v0.3.1
-	github.com/autobrr/go-qbittorrent v1.15.0-rc1.0.20260504155815-c211e84d3742
+	github.com/autobrr/go-qbittorrent v1.15.0
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/coreos/go-oidc/v3 v3.18.0

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/autobrr/autobrr v1.77.0 h1:0SNa9g2mk5Qe92vHOt0eJJz7VHB515R/BZyy1fCzik
 github.com/autobrr/autobrr v1.77.0/go.mod h1:GstQT2UumxQE54ECtjl5jwdzenaGFzvWxVNEVoLWH4E=
 github.com/autobrr/go-mediainfo v0.3.1 h1:4gT1qoIKp4e+9X7PA/YO53lEkylY+GubFhCl8u8o1R4=
 github.com/autobrr/go-mediainfo v0.3.1/go.mod h1:xVXgHDAYYpIeGQCQCdTBpoiY/O3tojJfflK+rrbzclQ=
-github.com/autobrr/go-qbittorrent v1.15.0-rc1.0.20260504155815-c211e84d3742 h1:POUfnyRKL4uRPUAdJgz3YJ0aJfBvQbYnlTTJLmUR44w=
-github.com/autobrr/go-qbittorrent v1.15.0-rc1.0.20260504155815-c211e84d3742/go.mod h1:W/24JQyQI+u5KntK1qzkBC/7amOTBPpV+q5e3C+kCkY=
+github.com/autobrr/go-qbittorrent v1.15.0 h1:BiwqoXsxcTC5fm6nagJysR2hxUnynAzicrnOfB4Bbnw=
+github.com/autobrr/go-qbittorrent v1.15.0/go.mod h1:W/24JQyQI+u5KntK1qzkBC/7amOTBPpV+q5e3C+kCkY=
 github.com/autobrr/rls v0.8.0 h1:Odz78o5nfrO4hsQ17qiuyKYtiG97+Cs5nrD9TFk8/lI=
 github.com/autobrr/rls v0.8.0/go.mod h1:11YJWgNe5H+UQrfFaNGjnkEy0OEsMFnmV4IL2tRKpPk=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=

--- a/go.sum
+++ b/go.sum
@@ -57,12 +57,12 @@ github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHG
 github.com/andybalholm/brotli v1.2.1 h1:R+f5xP285VArJDRgowrfb9DqL18yVK0gKAW/F+eTWro=
 github.com/andybalholm/brotli v1.2.1/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
-github.com/autobrr/autobrr v1.76.0 h1:HxX/bAcj7qdoo0qv+OhOTAyJhPa76cY0g4HIHGErlx8=
-github.com/autobrr/autobrr v1.76.0/go.mod h1:GstQT2UumxQE54ECtjl5jwdzenaGFzvWxVNEVoLWH4E=
+github.com/autobrr/autobrr v1.77.0 h1:0SNa9g2mk5Qe92vHOt0eJJz7VHB515R/BZyy1fCzikA=
+github.com/autobrr/autobrr v1.77.0/go.mod h1:GstQT2UumxQE54ECtjl5jwdzenaGFzvWxVNEVoLWH4E=
 github.com/autobrr/go-mediainfo v0.3.1 h1:4gT1qoIKp4e+9X7PA/YO53lEkylY+GubFhCl8u8o1R4=
 github.com/autobrr/go-mediainfo v0.3.1/go.mod h1:xVXgHDAYYpIeGQCQCdTBpoiY/O3tojJfflK+rrbzclQ=
-github.com/autobrr/go-qbittorrent v1.15.0-rc1.0.20260221205148-5cc22ac80d42 h1:NWveC89mG3g4O5wrynalUF8JOxHEx68RFh6l/dkGt7U=
-github.com/autobrr/go-qbittorrent v1.15.0-rc1.0.20260221205148-5cc22ac80d42/go.mod h1:oqvAaTbjH/6RoE5D5qaZg6JZ5TqDMMl+rYnMuyXDgAg=
+github.com/autobrr/go-qbittorrent v1.15.0-rc1.0.20260504155815-c211e84d3742 h1:POUfnyRKL4uRPUAdJgz3YJ0aJfBvQbYnlTTJLmUR44w=
+github.com/autobrr/go-qbittorrent v1.15.0-rc1.0.20260504155815-c211e84d3742/go.mod h1:W/24JQyQI+u5KntK1qzkBC/7amOTBPpV+q5e3C+kCkY=
 github.com/autobrr/rls v0.8.0 h1:Odz78o5nfrO4hsQ17qiuyKYtiG97+Cs5nrD9TFk8/lI=
 github.com/autobrr/rls v0.8.0/go.mod h1:11YJWgNe5H+UQrfFaNGjnkEy0OEsMFnmV4IL2tRKpPk=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=

--- a/internal/services/crossseed/parsing.go
+++ b/internal/services/crossseed/parsing.go
@@ -684,16 +684,7 @@ func extractDomainFromAnnounce(announceURL string) string {
 
 // FindLargestFile returns the file with the largest size from a list of torrent files.
 // This is useful for content type detection as the largest file usually represents the main content.
-func FindLargestFile(files qbt.TorrentFiles) *struct {
-	Availability float32 `json:"availability"`
-	Index        int     `json:"index"`
-	IsSeed       bool    `json:"is_seed,omitempty"`
-	Name         string  `json:"name"`
-	PieceRange   []int   `json:"piece_range"`
-	Priority     int     `json:"priority"`
-	Progress     float32 `json:"progress"`
-	Size         int64   `json:"size"`
-} {
+func FindLargestFile(files qbt.TorrentFiles) *qbt.TorrentFile {
 	if len(files) == 0 {
 		return nil
 	}


### PR DESCRIPTION
This PR adds support for the new webAPI version coming with qBittorrent 5.2.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to newer releases.

* **Bug Fixes / Internal Improvements**
  * Improved largest-file selection in cross-seed handling, making file choice more reliable and reducing edge-case mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->