### PR TITLE
feat: add support for monitored folders

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/andybalholm/brotli v1.2.1
 	github.com/autobrr/autobrr v1.77.0
 	github.com/autobrr/go-mediainfo v0.3.1
-	github.com/autobrr/go-qbittorrent v1.15.0
+	github.com/autobrr/go-qbittorrent v1.15.1-0.20260506110806-0f6206131e7a
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/coreos/go-oidc/v3 v3.18.0

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/autobrr/autobrr v1.77.0 h1:0SNa9g2mk5Qe92vHOt0eJJz7VHB515R/BZyy1fCzik
 github.com/autobrr/autobrr v1.77.0/go.mod h1:GstQT2UumxQE54ECtjl5jwdzenaGFzvWxVNEVoLWH4E=
 github.com/autobrr/go-mediainfo v0.3.1 h1:4gT1qoIKp4e+9X7PA/YO53lEkylY+GubFhCl8u8o1R4=
 github.com/autobrr/go-mediainfo v0.3.1/go.mod h1:xVXgHDAYYpIeGQCQCdTBpoiY/O3tojJfflK+rrbzclQ=
-github.com/autobrr/go-qbittorrent v1.15.0 h1:BiwqoXsxcTC5fm6nagJysR2hxUnynAzicrnOfB4Bbnw=
-github.com/autobrr/go-qbittorrent v1.15.0/go.mod h1:W/24JQyQI+u5KntK1qzkBC/7amOTBPpV+q5e3C+kCkY=
+github.com/autobrr/go-qbittorrent v1.15.1-0.20260506110806-0f6206131e7a h1:bWzZDGbwP72DxYSP9+ab68bmEYxf2FKV3LsklFrNt2s=
+github.com/autobrr/go-qbittorrent v1.15.1-0.20260506110806-0f6206131e7a/go.mod h1:W/24JQyQI+u5KntK1qzkBC/7amOTBPpV+q5e3C+kCkY=
 github.com/autobrr/rls v0.8.0 h1:Odz78o5nfrO4hsQ17qiuyKYtiG97+Cs5nrD9TFk8/lI=
 github.com/autobrr/rls v0.8.0/go.mod h1:11YJWgNe5H+UQrfFaNGjnkEy0OEsMFnmV4IL2tRKpPk=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=

--- a/internal/api/handlers/preferences.go
+++ b/internal/api/handlers/preferences.go
@@ -72,6 +72,11 @@ func (h *PreferencesHandler) UpdatePreferences(w http.ResponseWriter, r *http.Re
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
 	}
+	if err := h.syncManager.NormalizeScanDirsPreference(prefs); err != nil {
+		log.Error().Err(err).Int("instanceID", instanceID).Msg("Invalid scan_dirs value")
+		http.Error(w, "Invalid scan_dirs value", http.StatusBadRequest)
+		return
+	}
 
 	// NOTE: qBittorrent's app/setPreferences API does not properly support all preferences.
 	// Specifically, start_paused_enabled gets rejected/ignored. The frontend now handles

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -6,6 +6,7 @@ package qbittorrent
 import (
 	"cmp"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
@@ -5492,6 +5493,28 @@ func (sm *SyncManager) SetAppPreferences(ctx context.Context, instanceID int, pr
 	// Sync after modification
 	sm.syncAfterModification(instanceID, client, "set_app_preferences")
 
+	return nil
+}
+
+// NormalizeScanDirsPreference validates and normalizes the scan_dirs preference
+// using go-qbittorrent's typed monitored folder support.
+func (sm *SyncManager) NormalizeScanDirsPreference(prefs map[string]any) error {
+	rawScanDirs, ok := prefs["scan_dirs"]
+	if !ok {
+		return nil
+	}
+
+	encoded, err := json.Marshal(rawScanDirs)
+	if err != nil {
+		return err
+	}
+
+	var scanDirs qbt.MonitoredFolders
+	if err := json.Unmarshal(encoded, &scanDirs); err != nil {
+		return err
+	}
+
+	prefs["scan_dirs"] = scanDirs
 	return nil
 }
 

--- a/web/src/components/instances/preferences/FileManagementForm.tsx
+++ b/web/src/components/instances/preferences/FileManagementForm.tsx
@@ -57,6 +57,14 @@ const LEGACY_AUTORUN_PROGRAM_PLACEHOLDER = "/path/to/script \"%N\" \"%I\""
 const MODERN_AUTORUN_PROGRAM_PLACEHOLDER = "/path/to/script \"%N\" \"%K\""
 const AUTORUN_PROGRAM_TIP = "Tip: wrap placeholders in quotes, e.g. \"%N\", to preserve spaces."
 const AUTORUN_ON_ADDED_MIN_WEBAPI_VERSION = "2.8.18" // qBittorrent 4.5.0+
+const DEFAULT_WATCH_FOLDER_MODE = 0
+const OVERRIDE_WATCH_FOLDER_SAVE_MODE = 1
+type WatchFolderDestination = "monitored-folder" | "default-save-location" | "other"
+type WatchFolderConfig = {
+  path: string
+  destination: WatchFolderDestination
+  otherPath: string
+}
 
 function isWebAPIVersionAtLeast(version: string, minimum: string): boolean {
   // WebAPI versions are "x.y.z". Compare each numeric part.
@@ -76,16 +84,51 @@ function isWebAPIVersionAtLeast(version: string, minimum: string): boolean {
   return true
 }
 
+function getWatchFolders(scanDirs: Record<string, unknown> | undefined): WatchFolderConfig[] {
+  if (!scanDirs || typeof scanDirs !== "object") {
+    return []
+  }
+
+  return Object.entries(scanDirs).map(([path, value]) => {
+    if (typeof value === "string") {
+      return { path, destination: "other", otherPath: value }
+    }
+    if (typeof value === "number" && value === OVERRIDE_WATCH_FOLDER_SAVE_MODE) {
+      return { path, destination: "default-save-location", otherPath: "" }
+    }
+    return { path, destination: "monitored-folder", otherPath: "" }
+  })
+}
+
+function toScanDirs(watchFolders: WatchFolderConfig[]): Record<string, number | string> {
+  return watchFolders.reduce<Record<string, number | string>>((acc, folder) => {
+    const path = folder.path.trim()
+    if (!path) {
+      return acc
+    }
+
+    acc[path] = folder.destination === "default-save-location"
+      ? OVERRIDE_WATCH_FOLDER_SAVE_MODE
+      : folder.destination === "other"
+        ? folder.otherPath
+        : DEFAULT_WATCH_FOLDER_MODE
+
+    return acc
+  }, {})
+}
+
 function SwitchSetting({
   label,
   checked,
   onCheckedChange,
   description,
+  disabled,
 }: {
   label: string
   checked: boolean
   onCheckedChange: (checked: boolean) => void
   description?: string
+  disabled?: boolean
 }) {
   const switchId = React.useId()
   const descriptionId = description ? `${switchId}-desc` : undefined
@@ -100,6 +143,7 @@ function SwitchSetting({
         checked={checked}
         onCheckedChange={onCheckedChange}
         aria-describedby={descriptionId}
+        disabled={disabled}
       />
       <div className="space-y-0.5">
         <span className="text-sm font-medium">{label}</span>
@@ -143,6 +187,7 @@ export function FileManagementForm({ instanceId, onSuccess }: FileManagementForm
       autorun_on_torrent_added_program: "",
       autorun_enabled: false,
       autorun_program: "",
+      watch_folders: [] as WatchFolderConfig[],
     },
     onSubmit: async ({ value }) => {
       try {
@@ -162,6 +207,7 @@ export function FileManagementForm({ instanceId, onSuccess }: FileManagementForm
           torrent_content_layout: value.torrent_content_layout ?? "Original",
           autorun_enabled: value.autorun_enabled,
           autorun_program: value.autorun_program,
+          scan_dirs: toScanDirs(value.watch_folders),
         }
         if (supportsAutorunOnTorrentAdded) {
           qbittorrentPrefs.autorun_on_torrent_added_enabled = value.autorun_on_torrent_added_enabled
@@ -199,6 +245,7 @@ export function FileManagementForm({ instanceId, onSuccess }: FileManagementForm
       form.setFieldValue("autorun_on_torrent_added_program", preferences.autorun_on_torrent_added_program ?? "")
       form.setFieldValue("autorun_enabled", preferences.autorun_enabled ?? false)
       form.setFieldValue("autorun_program", preferences.autorun_program ?? "")
+      form.setFieldValue("watch_folders", getWatchFolders(preferences.scan_dirs))
     }
   }, [preferences, form, supportsSubcategories])
 
@@ -396,6 +443,106 @@ export function FileManagementForm({ instanceId, onSuccess }: FileManagementForm
               </div>
             )}
           </form.Field>
+
+          <form.Subscribe selector={(state) => state.values.watch_folders}>
+            {(watchFolders) => (
+              <div className="space-y-3">
+                <div className="flex items-center justify-between gap-2">
+                  <div>
+                    <Label className="text-sm font-medium">Watch Folders</Label>
+                    <p className="text-xs text-muted-foreground">
+                      Add one or more monitored folders and choose where discovered torrents should be saved.
+                    </p>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => form.setFieldValue("watch_folders", [
+                      ...watchFolders,
+                      { path: "", destination: "default-save-location", otherPath: "" },
+                    ])}
+                  >
+                    Add Folder
+                  </Button>
+                </div>
+
+                {watchFolders.length === 0 && (
+                  <p className="text-xs text-muted-foreground">
+                    No watch folders configured.
+                  </p>
+                )}
+
+                {watchFolders.map((watchFolder, index) => (
+                  <div key={`watch-folder-${index}`} className="rounded-md border p-3 space-y-3">
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-3 items-start">
+                      <div className="space-y-2">
+                        <Label className="text-sm font-medium">Monitored Folder</Label>
+                        <Input
+                          value={watchFolder.path}
+                          onChange={(e) => {
+                            const next = [...watchFolders]
+                            next[index] = { ...next[index], path: e.target.value }
+                            form.setFieldValue("watch_folders", next)
+                          }}
+                          placeholder="/watchfolder"
+                          className={incognitoMode ? "blur-sm select-none" : ""}
+                        />
+                      </div>
+
+                      <div className="space-y-2">
+                        <Label className="text-sm font-medium">Torrent Destination</Label>
+                        <Select
+                          value={watchFolder.destination}
+                          onValueChange={(value) => {
+                            const next = [...watchFolders]
+                            next[index] = { ...next[index], destination: value as WatchFolderDestination }
+                            form.setFieldValue("watch_folders", next)
+                          }}
+                          disabled={!watchFolder.path}
+                        >
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select destination" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="monitored-folder">Monitored folder</SelectItem>
+                            <SelectItem value="default-save-location">Default save location</SelectItem>
+                            <SelectItem value="other">Other</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    </div>
+
+                    {watchFolder.destination === "other" && (
+                      <div className="space-y-2">
+                        <Label className="text-sm font-medium">Custom Save Path</Label>
+                        <Input
+                          value={watchFolder.otherPath}
+                          onChange={(e) => {
+                            const next = [...watchFolders]
+                            next[index] = { ...next[index], otherPath: e.target.value }
+                            form.setFieldValue("watch_folders", next)
+                          }}
+                          placeholder="foldername"
+                          disabled={!watchFolder.path}
+                          className={incognitoMode ? "blur-sm select-none" : ""}
+                        />
+                      </div>
+                    )}
+
+                    <div className="flex justify-end">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        onClick={() => form.setFieldValue("watch_folders", watchFolders.filter((_, i) => i !== index))}
+                      >
+                        Remove
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </form.Subscribe>
 
           <Card className="bg-muted/20 border-muted/60">
             <CardHeader className="pb-3">


### PR DESCRIPTION
This PR adds support for managing monitored folders / watch folders in qui.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive support for configuring multiple watch folders in File Management settings
  * Introduced dynamic list management for watch folders with add/remove capabilities
  * Added per-folder destination and custom save path configuration options
  * Enhanced validation for watch folder configurations to ensure data integrity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->