### PR TITLE
fix(web): Show collapsed folders when searching torrent contents

### DIFF
--- a/web/src/components/torrents/details/TorrentFileTable.tsx
+++ b/web/src/components/torrents/details/TorrentFileTable.tsx
@@ -47,6 +47,7 @@ interface FlatRow {
   depth: number
   isExpanded: boolean
   hasChildren: boolean
+  isVisible: boolean
 }
 
 function buildFileTree(
@@ -143,18 +144,27 @@ function buildFileTree(
 function flattenTree(
   nodes: FileTreeNode[],
   expandedFolders: Set<string>,
-  depth = 0
+  depth = 0,
+  visible = false
 ): FlatRow[] {
   const rows: FlatRow[] = []
 
   for (const node of nodes) {
     const hasChildren = node.kind === "folder" && Boolean(node.children?.length)
     const isExpanded = expandedFolders.has(node.id)
+    const isVisible = depth === 0 || visible
 
-    rows.push({ node, depth, isExpanded, hasChildren })
+    rows.push({ node, depth, isExpanded, hasChildren, isVisible })
 
-    if (hasChildren && isExpanded && node.children) {
-      rows.push(...flattenTree(node.children, expandedFolders, depth + 1))
+    if (hasChildren && node.children) {
+      rows.push(
+        ...flattenTree(
+          node.children,
+          expandedFolders,
+          depth + 1,
+          isVisible && isExpanded
+        )
+      )
     }
   }
 
@@ -210,7 +220,8 @@ export const TorrentFileTable = memo(function TorrentFileTable({
 
   // Filter rows based on search query
   const filteredRows = useMemo(() => {
-    if (!searchQuery.trim()) return flatRows
+    const visibleRows = flatRows.filter((row) => row.isVisible)
+    if (!searchQuery.trim()) return visibleRows
 
     const query = searchQuery.toLowerCase()
     const matchingIds = new Set<string>()
@@ -229,7 +240,7 @@ export const TorrentFileTable = memo(function TorrentFileTable({
       }
     }
 
-    return flatRows.filter(row => matchingIds.has(row.node.id))
+    return visibleRows.filter((row) => matchingIds.has(row.node.id))
   }, [flatRows, searchQuery])
 
   // Row height: 28px for file rows (with some padding)


### PR DESCRIPTION
This PR changes the behavior of `flattenTree` to keep nodes of collapsed folders inside the flattened tree to support searching inside folders that are collapsed. 

Previously, collapsed folders and their children would be ignored when searching and not show or fully disappear if you collapse them during one.


https://github.com/user-attachments/assets/d7a90ecd-28f1-4b7d-9f68-793ecf63fbd2




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced file tree visibility tracking to accurately reflect folder expansion states
  * Optimized file search functionality to filter only visible file entries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->