### PR TITLE
fix(qbittorrent): handle forced subcategories

### DIFF
--- a/internal/api/handlers/capabilities.go
+++ b/internal/api/handlers/capabilities.go
@@ -21,6 +21,7 @@ type InstanceCapabilitiesResponse struct {
 	SupportsRenameFolder        bool   `json:"supportsRenameFolder"`
 	SupportsFilePriority        bool   `json:"supportsFilePriority"`
 	SupportsSubcategories       bool   `json:"supportsSubcategories"`
+	SubcategoriesAlwaysEnabled  bool   `json:"subcategoriesAlwaysEnabled"`
 	SupportsTorrentTmpPath      bool   `json:"supportsTorrentTmpPath"`
 	SupportsPathAutocomplete    bool   `json:"supportsPathAutocomplete"`
 	SupportsFreeSpacePathSource bool   `json:"supportsFreeSpacePathSource"`
@@ -41,6 +42,7 @@ func NewInstanceCapabilitiesResponse(client *internalqbittorrent.Client) Instanc
 		SupportsRenameFolder:        client.SupportsRenameFolder(),
 		SupportsFilePriority:        client.SupportsFilePriority(),
 		SupportsSubcategories:       client.SupportsSubcategories(),
+		SubcategoriesAlwaysEnabled:  client.SubcategoriesAlwaysEnabled(),
 		SupportsTorrentTmpPath:      client.SupportsTorrentTmpPath(),
 		SupportsPathAutocomplete:    client.SupportsPathAutocomplete(),
 		SupportsFreeSpacePathSource: runtime.GOOS != osWindows,

--- a/internal/qbittorrent/client.go
+++ b/internal/qbittorrent/client.go
@@ -18,42 +18,44 @@ import (
 )
 
 var (
-	setTagsMinVersion          = semver.MustParse("2.11.4")
-	torrentCreationMinVersion  = semver.MustParse("2.11.2")
-	exportTorrentMinVersion    = semver.MustParse("2.8.11")
-	trackerEditingMinVersion   = semver.MustParse("2.2.0")
-	trackerIncludeMinVersion   = semver.MustParse("2.11.4")
-	filePriorityMinVersion     = semver.MustParse("2.2.0")
-	renameTorrentMinVersion    = semver.MustParse("2.0.0")
-	renameFileMinVersion       = semver.MustParse("2.4.0")
-	renameFolderMinVersion     = semver.MustParse("2.7.0")
-	subcategoriesMinVersion    = semver.MustParse("2.9.0")
-	torrentTmpPathMinVersion   = semver.MustParse("2.8.4")
-	pathAutocompleteMinVersion = semver.MustParse("2.11.2")
-	rssSetFeedURLMinVersion    = semver.MustParse("2.9.1")
+	setTagsMinVersion                    = semver.MustParse("2.11.4")
+	torrentCreationMinVersion            = semver.MustParse("2.11.2")
+	exportTorrentMinVersion              = semver.MustParse("2.8.11")
+	trackerEditingMinVersion             = semver.MustParse("2.2.0")
+	trackerIncludeMinVersion             = semver.MustParse("2.11.4")
+	filePriorityMinVersion               = semver.MustParse("2.2.0")
+	renameTorrentMinVersion              = semver.MustParse("2.0.0")
+	renameFileMinVersion                 = semver.MustParse("2.4.0")
+	renameFolderMinVersion               = semver.MustParse("2.7.0")
+	subcategoriesMinVersion              = semver.MustParse("2.9.0")
+	subcategoriesAlwaysEnabledMinVersion = semver.MustParse("2.15.0")
+	torrentTmpPathMinVersion             = semver.MustParse("2.8.4")
+	pathAutocompleteMinVersion           = semver.MustParse("2.11.2")
+	rssSetFeedURLMinVersion              = semver.MustParse("2.9.1")
 )
 
 type Client struct {
 	*qbt.Client
-	instanceID               int
-	webAPIVersion            string
-	supportsSetTags          bool
-	supportsTorrentCreation  bool
-	supportsTorrentExport    bool
-	supportsTrackerEditing   bool
-	supportsRenameTorrent    bool
-	supportsRenameFile       bool
-	supportsRenameFolder     bool
-	supportsFilePriority     bool
-	supportsSubcategories    bool
-	supportsTorrentTmpPath   bool
-	supportsPathAutocomplete bool
-	trackerIncludeSupported  bool
-	supportsSetRSSFeedURL    bool
-	lastHealthCheck          time.Time
-	isHealthy                bool
-	syncManager              *qbt.SyncManager
-	peerSyncManager          map[string]*qbt.PeerSyncManager // Map of torrent hash to PeerSyncManager
+	instanceID                 int
+	webAPIVersion              string
+	supportsSetTags            bool
+	supportsTorrentCreation    bool
+	supportsTorrentExport      bool
+	supportsTrackerEditing     bool
+	supportsRenameTorrent      bool
+	supportsRenameFile         bool
+	supportsRenameFolder       bool
+	supportsFilePriority       bool
+	supportsSubcategories      bool
+	subcategoriesAlwaysEnabled bool
+	supportsTorrentTmpPath     bool
+	supportsPathAutocomplete   bool
+	trackerIncludeSupported    bool
+	supportsSetRSSFeedURL      bool
+	lastHealthCheck            time.Time
+	isHealthy                  bool
+	syncManager                *qbt.SyncManager
+	peerSyncManager            map[string]*qbt.PeerSyncManager // Map of torrent hash to PeerSyncManager
 	// optimisticUpdates stores temporary optimistic state changes for this instance
 	optimisticUpdates *ttlcache.Cache[string, *OptimisticTorrentUpdate]
 	trackerExclusions map[string]map[string]struct{} // Domains to hide hashes from until fresh sync arrives
@@ -265,6 +267,7 @@ func (c *Client) applyCapabilitiesLocked(version string) {
 	c.supportsRenameFile = !v.LessThan(renameFileMinVersion)
 	c.supportsRenameFolder = !v.LessThan(renameFolderMinVersion)
 	c.supportsSubcategories = !v.LessThan(subcategoriesMinVersion)
+	c.subcategoriesAlwaysEnabled = !v.LessThan(subcategoriesAlwaysEnabledMinVersion)
 	c.supportsTorrentTmpPath = !v.LessThan(torrentTmpPathMinVersion)
 	c.supportsPathAutocomplete = !v.LessThan(pathAutocompleteMinVersion)
 	c.supportsSetRSSFeedURL = !v.LessThan(rssSetFeedURLMinVersion)
@@ -328,6 +331,12 @@ func (c *Client) SupportsSubcategories() bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.supportsSubcategories
+}
+
+func (c *Client) SubcategoriesAlwaysEnabled() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.subcategoriesAlwaysEnabled
 }
 
 func (c *Client) SupportsTorrentTmpPath() bool {

--- a/internal/qbittorrent/client_test.go
+++ b/internal/qbittorrent/client_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package qbittorrent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientSubcategoriesAlwaysEnabledCapability(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		version  string
+		expected bool
+	}{
+		{
+			name:     "legacy optional setting",
+			version:  "2.14.1",
+			expected: false,
+		},
+		{
+			name:     "subcategories unconditional",
+			version:  "2.15.0",
+			expected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := &Client{}
+			client.applyCapabilitiesLocked(tc.version)
+
+			require.Equal(t, tc.expected, client.SubcategoriesAlwaysEnabled())
+		})
+	}
+}

--- a/internal/qbittorrent/maindata_test.go
+++ b/internal/qbittorrent/maindata_test.go
@@ -121,3 +121,31 @@ func TestResolveServerStateFallsBackToUncheckedProvider(t *testing.T) {
 	require.Equal(t, int64(4096), got.DlInfoSpeed)
 	require.Equal(t, int64(8192), got.UpInfoSpeed)
 }
+
+func TestResolveUseSubcategoriesAlwaysEnabled(t *testing.T) {
+	t.Parallel()
+
+	got := resolveUseSubcategories(true, true, &qbt.MainData{
+		ServerState: qbt.ServerState{
+			ConnectionStatus: "connected",
+			UseSubcategories: false,
+		},
+	}, nil)
+
+	require.True(t, got)
+}
+
+func TestResolveUseSubcategoriesKeepsLegacyDisabledState(t *testing.T) {
+	t.Parallel()
+
+	got := resolveUseSubcategories(true, false, &qbt.MainData{
+		ServerState: qbt.ServerState{
+			ConnectionStatus: "connected",
+			UseSubcategories: false,
+		},
+	}, map[string]qbt.Category{
+		"Movies/HD": {Name: "Movies/HD"},
+	})
+
+	require.False(t, got)
+}

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -954,7 +954,8 @@ func (sm *SyncManager) GetTorrentsWithFilters(ctx context.Context, instanceID in
 	}
 
 	supportsSubcategories := client.SupportsSubcategories()
-	useSubcategories := resolveUseSubcategories(supportsSubcategories, mainData, categories)
+	subcategoriesAlwaysEnabled := client.SubcategoriesAlwaysEnabled()
+	useSubcategories := resolveUseSubcategories(supportsSubcategories, subcategoriesAlwaysEnabled, mainData, categories)
 
 	if useManualFiltering {
 		// Use manual filtering - get all torrents and filter manually
@@ -1140,7 +1141,7 @@ func (sm *SyncManager) GetTorrentsWithFilters(ctx context.Context, instanceID in
 		allTorrents = syncManager.GetTorrents(qbt.TorrentFilterOptions{})
 	}
 
-	useSubcategories = resolveUseSubcategories(supportsSubcategories, mainData, categories)
+	useSubcategories = resolveUseSubcategories(supportsSubcategories, subcategoriesAlwaysEnabled, mainData, categories)
 
 	var enrichedAll []qbt.Torrent
 
@@ -3281,14 +3282,8 @@ func (sm *SyncManager) GetTorrentCounts(ctx context.Context, instanceID int) (*T
 	// Calculate counts using the shared function - pass mainData for tracker information
 	trackerHealthSupported := client != nil && client.supportsTrackerInclude()
 	supportsSubcategories := client.SupportsSubcategories()
-	useSubcategories := false
-	if supportsSubcategories {
-		if mainData != nil && mainData.ServerState != (qbt.ServerState{}) {
-			useSubcategories = mainData.ServerState.UseSubcategories
-		} else if mainData != nil && mainData.Categories != nil {
-			useSubcategories = hasNestedCategories(mainData.Categories)
-		}
-	}
+	subcategoriesAlwaysEnabled := client.SubcategoriesAlwaysEnabled()
+	useSubcategories := resolveUseSubcategories(supportsSubcategories, subcategoriesAlwaysEnabled, mainData, nil)
 	counts, _, _ := sm.calculateCountsFromTorrentsWithTrackers(ctx, client, allTorrents, mainData, nil, trackerHealthSupported, useSubcategories)
 
 	// Don't cache counts separately - they're always derived from the cached torrent data
@@ -4247,9 +4242,13 @@ func hasNestedCategories(categories map[string]qbt.Category) bool {
 	return false
 }
 
-func resolveUseSubcategories(supports bool, mainData *qbt.MainData, categories map[string]qbt.Category) bool {
+func resolveUseSubcategories(supports bool, alwaysEnabled bool, mainData *qbt.MainData, categories map[string]qbt.Category) bool {
 	if !supports {
 		return false
+	}
+
+	if alwaysEnabled {
+		return true
 	}
 
 	if mainData != nil && mainData.ServerState != (qbt.ServerState{}) {

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -1141,8 +1141,6 @@ func (sm *SyncManager) GetTorrentsWithFilters(ctx context.Context, instanceID in
 		allTorrents = syncManager.GetTorrents(qbt.TorrentFilterOptions{})
 	}
 
-	useSubcategories = resolveUseSubcategories(supportsSubcategories, subcategoriesAlwaysEnabled, mainData, categories)
-
 	var enrichedAll []qbt.Torrent
 
 	if skipTrackerHydration {

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -5668,6 +5668,9 @@ components:
         supportsSubcategories:
           type: boolean
           description: Whether the instance supports nested torrent categories (requires WebAPI 2.9.0+, qBittorrent 4.6.0+).
+        subcategoriesAlwaysEnabled:
+          type: boolean
+          description: Whether nested torrent categories are always enabled by qBittorrent (WebAPI 2.15.0+).
         webAPIVersion:
           type: string
           nullable: true

--- a/web/src/components/instances/preferences/FileManagementForm.tsx
+++ b/web/src/components/instances/preferences/FileManagementForm.tsx
@@ -166,6 +166,8 @@ export function FileManagementForm({ instanceId, onSuccess }: FileManagementForm
   const { data: capabilities } = useInstanceCapabilities(instanceId)
   const [incognitoMode] = useIncognitoMode()
   const supportsSubcategories = capabilities?.supportsSubcategories ?? false
+  const subcategoriesAlwaysEnabled = capabilities?.subcategoriesAlwaysEnabled ?? false
+  const canToggleSubcategories = supportsSubcategories && !subcategoriesAlwaysEnabled
   const webAPIVersion = capabilities?.webAPIVersion?.trim() ?? ""
   const supportsAutorunOnTorrentAdded = isWebAPIVersionAtLeast(webAPIVersion, AUTORUN_ON_ADDED_MIN_WEBAPI_VERSION)
   const autorunPlaceholders = supportsAutorunOnTorrentAdded ? MODERN_AUTORUN_PLACEHOLDERS : LEGACY_AUTORUN_PLACEHOLDERS
@@ -213,7 +215,7 @@ export function FileManagementForm({ instanceId, onSuccess }: FileManagementForm
           qbittorrentPrefs.autorun_on_torrent_added_enabled = value.autorun_on_torrent_added_enabled
           qbittorrentPrefs.autorun_on_torrent_added_program = value.autorun_on_torrent_added_program
         }
-        if (supportsSubcategories) {
+        if (canToggleSubcategories) {
           qbittorrentPrefs.use_subcategories = Boolean(value.use_subcategories)
         }
         updatePreferences(qbittorrentPrefs)
@@ -232,7 +234,9 @@ export function FileManagementForm({ instanceId, onSuccess }: FileManagementForm
       form.setFieldValue("torrent_changed_tmm_enabled", preferences.torrent_changed_tmm_enabled ?? true)
       form.setFieldValue("save_path_changed_tmm_enabled", preferences.save_path_changed_tmm_enabled ?? true)
       form.setFieldValue("category_changed_tmm_enabled", preferences.category_changed_tmm_enabled ?? true)
-      if (supportsSubcategories) {
+      if (subcategoriesAlwaysEnabled) {
+        form.setFieldValue("use_subcategories", true)
+      } else if (supportsSubcategories) {
         form.setFieldValue("use_subcategories", Boolean(preferences.use_subcategories))
       } else {
         form.setFieldValue("use_subcategories", false)
@@ -247,7 +251,7 @@ export function FileManagementForm({ instanceId, onSuccess }: FileManagementForm
       form.setFieldValue("autorun_program", preferences.autorun_program ?? "")
       form.setFieldValue("watch_folders", getWatchFolders(preferences.scan_dirs))
     }
-  }, [preferences, form, supportsSubcategories])
+  }, [preferences, form, supportsSubcategories, subcategoriesAlwaysEnabled])
 
   // Update form when localStorage start_paused_enabled changes
   React.useEffect(() => {
@@ -346,7 +350,7 @@ export function FileManagementForm({ instanceId, onSuccess }: FileManagementForm
             }
           </form.Subscribe>
 
-          {supportsSubcategories && (
+          {canToggleSubcategories && (
             <form.Field name="use_subcategories">
               {(field) => (
                 <SwitchSetting

--- a/web/src/components/torrents/FilterSidebar.tsx
+++ b/web/src/components/torrents/FilterSidebar.tsx
@@ -212,13 +212,14 @@ const FilterSidebarComponent = ({
   const supportsSubcategories = isConcreteInstanceScope
     ? (capabilities?.supportsSubcategories ?? false)
     : Boolean(useSubcategories)
+  const subcategoriesAlwaysEnabled = capabilities?.subcategoriesAlwaysEnabled ?? false
   const { preferences } = useInstancePreferences(
     instanceId,
     { enabled: isConcreteInstanceScope && isInstanceActive }
   )
   const preferenceUseSubcategories = preferences?.use_subcategories
   const subcategoriesEnabled = isConcreteInstanceScope
-    ? Boolean(supportsSubcategories && (preferenceUseSubcategories ?? useSubcategories ?? false))
+    ? Boolean(supportsSubcategories && (subcategoriesAlwaysEnabled || (preferenceUseSubcategories ?? useSubcategories ?? false)))
     : Boolean(useSubcategories)
 
   // View mode syncs with the torrent list (table on desktop, cards on mobile).

--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -1255,11 +1255,12 @@ export function TorrentCardsMobile({
   const supportsSubcategories = isAllInstancesView
     ? Boolean(subcategoriesFromData)
     : (capabilities?.supportsSubcategories ?? false)
+  const subcategoriesAlwaysEnabled = capabilities?.subcategoriesAlwaysEnabled ?? false
   // subcategoriesFromData reflects backend/server state; allowSubcategories
   // additionally respects user preferences for UI surfaces like dialogs.
   const allowSubcategories = isAllInstancesView
     ? Boolean(subcategoriesFromData)
-    : (supportsSubcategories && (preferences?.use_subcategories ?? subcategoriesFromData ?? false))
+    : (supportsSubcategories && (subcategoriesAlwaysEnabled || (preferences?.use_subcategories ?? subcategoriesFromData ?? false)))
 
   const getSelectionIdentity = useCallback((torrent: Torrent): string => {
     if (!isAllInstancesView) {

--- a/web/src/components/torrents/TorrentManagementBar.tsx
+++ b/web/src/components/torrents/TorrentManagementBar.tsx
@@ -136,8 +136,9 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
   // Get capabilities to check subcategory support
   const { data: capabilities } = useInstanceCapabilities(metadataInstanceId, { enabled: metadataInstanceId > 0 })
   const supportsSubcategories = capabilities?.supportsSubcategories ?? false
+  const subcategoriesAlwaysEnabled = capabilities?.subcategoriesAlwaysEnabled ?? false
   const allowSubcategories =
-    supportsSubcategories && (preferences?.use_subcategories ?? false)
+    supportsSubcategories && (subcategoriesAlwaysEnabled || (preferences?.use_subcategories ?? false))
 
   // Get instance name for cross-seed warning
   const { instances } = useInstances()
@@ -243,13 +244,13 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
       const separatorIndex = trimmed.indexOf(":")
       const target = separatorIndex > 0
         ? {
-            instanceId: Number(trimmed.slice(0, separatorIndex)),
-            hash: trimmed.slice(separatorIndex + 1),
-          }
+          instanceId: Number(trimmed.slice(0, separatorIndex)),
+          hash: trimmed.slice(separatorIndex + 1),
+        }
         : {
-            instanceId: actionInstanceId,
-            hash: trimmed,
-          }
+          instanceId: actionInstanceId,
+          hash: trimmed,
+        }
 
       if (target.instanceId <= 0 || !target.hash) {
         continue

--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -1031,9 +1031,10 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
   const supportsSubcategories = isAllInstancesView
     ? Boolean(subcategoriesFromData)
     : (capabilities?.supportsSubcategories ?? false)
+  const subcategoriesAlwaysEnabled = capabilities?.subcategoriesAlwaysEnabled ?? false
   const allowSubcategories = isAllInstancesView
     ? Boolean(subcategoriesFromData)
-    : (supportsSubcategories && (preferences?.use_subcategories ?? subcategoriesFromData ?? false))
+    : (supportsSubcategories && (subcategoriesAlwaysEnabled || (preferences?.use_subcategories ?? subcategoriesFromData ?? false)))
   const availableTags = isCrossInstanceEndpoint ? (tags ?? metadataTags) : metadataTags
   const availableCategories = isCrossInstanceEndpoint ? (categories ?? metadataCategories) : metadataCategories
   const isLoadingTags = isMetadataLoading && availableTags.length === 0

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -639,6 +639,7 @@ export interface InstanceCapabilities {
   supportsRenameFolder: boolean
   supportsFilePriority: boolean
   supportsSubcategories: boolean
+  subcategoriesAlwaysEnabled: boolean
   supportsTorrentTmpPath: boolean
   supportsPathAutocomplete: boolean
   supportsFreeSpacePathSource: boolean


### PR DESCRIPTION
qBittorrent WebAPI 2.15.0 removed `use_subcategories` because subcategories are always enabled. This adds a version-derived capability and keeps backend/frontend category handling enabled for 5.2+ clients while preserving optional behavior for older clients.

Closes #1862


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects qBittorrent 2.15.0+ instances where nested categories are always enabled and adapts UI behavior (forms, filters, lists, and management controls) accordingly.
  * Exposes a capability flag so interfaces automatically treat subcategories as forced-on when applicable.

* **Tests**
  * Added unit tests for capability detection and category-resolution logic.

* **Documentation**
  * OpenAPI schema updated to include the new capability flag.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/autobrr/qui/pull/1863)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->