### PR TITLE
fix(crossseed): run external programs after link-mode injection

### DIFF
--- a/internal/services/crossseed/hardlink_mode_test.go
+++ b/internal/services/crossseed/hardlink_mode_test.go
@@ -537,6 +537,55 @@ func (m *mockInstanceStore) List(ctx context.Context) ([]*models.Instance, error
 	return result, nil
 }
 
+func TestProcessHardlinkMode_ExecutesExternalProgramAfterSuccessfulAdd(t *testing.T) {
+	tempDir := t.TempDir()
+	downloadsDir := filepath.Join(tempDir, "downloads")
+	require.NoError(t, os.MkdirAll(filepath.Join(downloadsDir, "Movie"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(downloadsDir, "Movie", "movie.mkv"), []byte("movie"), 0o600))
+
+	hookCallCount := 0
+	s := &Service{
+		instanceStore: &mockInstanceStore{
+			instances: map[int]*models.Instance{
+				1: {
+					ID:                       1,
+					Name:                     "qbt1",
+					HasLocalFilesystemAccess: true,
+					UseHardlinks:             true,
+					HardlinkBaseDir:          filepath.Join(tempDir, "hardlinks"),
+				},
+			},
+		},
+		syncManager: &rootlessSavePathSyncManager{},
+		postInjectionHook: func(_ context.Context, instanceID int, torrentHash string) {
+			if instanceID == 1 && torrentHash == "hash123" {
+				hookCallCount++
+			}
+		},
+	}
+
+	result := s.processHardlinkMode(
+		context.Background(),
+		CrossSeedCandidate{InstanceID: 1, InstanceName: "qbt1"},
+		[]byte("torrent"),
+		"hash123",
+		"",
+		"TorrentName",
+		&CrossSeedRequest{},
+		&qbt.Torrent{Hash: "matched", ContentPath: filepath.Join(downloadsDir, "Movie")},
+		"exact",
+		qbt.TorrentFiles{{Name: "Movie/movie.mkv", Size: 5}},
+		qbt.TorrentFiles{{Name: "Movie/movie.mkv", Size: 5}},
+		&qbt.TorrentProperties{SavePath: downloadsDir},
+		"category",
+		"category.cross",
+	)
+
+	require.True(t, result.Success)
+	require.Equal(t, "added_hardlink", result.Result.Status)
+	require.Equal(t, 1, hookCallCount, "expected successful hardlink injection to run post-injection hooks once")
+}
+
 func TestProcessHardlinkMode_FailsWhenNoLocalAccess(t *testing.T) {
 	mockInstances := &mockInstanceStore{
 		instances: map[int]*models.Instance{

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -355,6 +355,7 @@ type Service struct {
 	crossSeedInvoker        func(ctx context.Context, req *CrossSeedRequest) (*CrossSeedResponse, error)
 	torrentDownloadFunc     func(ctx context.Context, req jackett.TorrentDownloadRequest) ([]byte, error)
 	completionSearchInvoker func(context.Context, int, *qbt.Torrent, *models.CrossSeedAutomationSettings, *models.InstanceCrossSeedCompletionSettings) error
+	postInjectionHook       func(context.Context, int, string)
 
 	// Recheck resume worker
 	recheckResumeChan   chan *pendingResume
@@ -4902,7 +4903,7 @@ func (s *Service) processCrossSeedCandidate(
 	}
 
 	// Execute external program if configured (async, non-blocking)
-	s.executeExternalProgram(ctx, candidate.InstanceID, torrentHash)
+	s.runPostInjectionHooks(ctx, candidate.InstanceID, torrentHash)
 
 	logEvent := log.Info().
 		Int("instanceID", candidate.InstanceID).
@@ -10665,6 +10666,15 @@ func (s *Service) CheckWebhook(ctx context.Context, req *WebhookCheckRequest) (*
 	}, nil
 }
 
+func (s *Service) runPostInjectionHooks(ctx context.Context, instanceID int, torrentHash string) {
+	if s.postInjectionHook != nil {
+		s.postInjectionHook(ctx, instanceID, torrentHash)
+		return
+	}
+
+	s.executeExternalProgram(ctx, instanceID, torrentHash)
+}
+
 // executeExternalProgram runs the configured external program for a successfully injected torrent.
 //
 // WARNING: No rate limiting is applied. Rapid injections can spawn many concurrent processes.
@@ -11506,6 +11516,8 @@ func (s *Service) processHardlinkMode(
 		statusMsg += addPolicy.StatusSuffix()
 	}
 
+	s.runPostInjectionHooks(ctx, candidate.InstanceID, torrentHash)
+
 	return hardlinkModeResult{
 		Used:    true,
 		Success: true,
@@ -12110,6 +12122,8 @@ func (s *Service) processReflinkMode(
 	if hasExtras && clonedFiles < totalFiles {
 		statusMsg += " (below threshold = remains paused for manual review)"
 	}
+
+	s.runPostInjectionHooks(ctx, candidate.InstanceID, torrentHash)
 
 	return reflinkModeResult{
 		Used:    true,


### PR DESCRIPTION
Hardlink and reflink cross-seed injections now run the same post-injection hook as regular cross-seed adds, so configured external programs are executed after successful link-mode injection.

Previously those paths returned from their own success flow before the external program hook was reached, which made the UI setting appear enabled without taking effect for hardlink/reflink automation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a unit test verifying post-injection behavior in hardlink mode: successful add reports the expected status and triggers the post-injection hook exactly once.

* **Refactor**
  * Centralized post-injection handling via a hook mechanism used across hardlink and reflink flows to improve testability and extensibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/autobrr/qui/pull/1874)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->