### PR TITLE
fix(web): sidebar element collisions

### DIFF
--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -159,8 +159,8 @@ export function Sidebar() {
   const appVersion = getAppVersion()
 
   return (
-    <div className="flex h-full w-64 flex-col border-r bg-sidebar border-sidebar-border">
-      <div className="p-6">
+    <div className="flex h-full w-64 flex-col overflow-hidden border-r bg-sidebar border-sidebar-border">
+      <div className="flex-shrink-0 p-6">
         <h2 className="flex items-center gap-2 text-lg font-semibold text-sidebar-foreground">
           {theme === "swizzin" ? (
             <SwizzinLogo className="h-5 w-5" />
@@ -173,7 +173,7 @@ export function Sidebar() {
         </h2>
       </div>
 
-      <nav className="flex flex-1 min-h-0 flex-col px-3">
+      <nav className="flex flex-1 min-h-0 flex-col overflow-y-auto px-3">
         <div className="space-y-1">
           {navigation.map((item) => {
             const Icon = item.icon
@@ -199,115 +199,113 @@ export function Sidebar() {
 
         <Separator className="my-4" />
 
-        <div className="flex-1 min-h-0">
-          <div className="flex h-full min-h-0 flex-col">
-            <p className="px-3 text-xs font-semibold uppercase tracking-wider text-sidebar-foreground/70">
-              Instances
-            </p>
-            <div className="mt-1 flex-1 overflow-y-auto space-y-1 pr-1">
-              {hasMultipleActiveInstances && (
-                <>
-                  <UnifiedScopeDropdownSection
-                    activeInstances={activeInstances}
-                    effectiveUnifiedInstanceIds={effectiveUnifiedInstanceIds}
-                    isAllInstancesRoute={isAllInstancesActive}
-                    onResetUnifiedScope={() => applyUnifiedScope(activeInstanceIds)}
-                    onToggleUnifiedScopeInstance={toggleUnifiedScopeInstance}
-                    scopeKeyPrefix="sidebar-scope"
-                    variant="sidebar"
-                  />
-                  <Separator className="my-2" />
-                </>
-              )}
-              {activeInstances.map((instance) => {
-                const instancePath = `/instances/${instance.id}`
-                const isActive = location.pathname === instancePath || location.pathname.startsWith(`${instancePath}/`)
-                const csState = crossSeedInstanceState[instance.id]
-                const hasRss = csState?.rssEnabled || csState?.rssRunning
-                const hasSearch = csState?.searchRunning
+        <p className="px-3 text-xs font-semibold uppercase tracking-wider text-sidebar-foreground/70">
+          Instances
+        </p>
+        <div className="mt-1 space-y-1 pr-1">
+          {hasMultipleActiveInstances && (
+            <>
+              <UnifiedScopeDropdownSection
+                activeInstances={activeInstances}
+                effectiveUnifiedInstanceIds={effectiveUnifiedInstanceIds}
+                isAllInstancesRoute={isAllInstancesActive}
+                onResetUnifiedScope={() => applyUnifiedScope(activeInstanceIds)}
+                onToggleUnifiedScopeInstance={toggleUnifiedScopeInstance}
+                scopeKeyPrefix="sidebar-scope"
+                variant="sidebar"
+              />
+              <Separator className="my-2" />
+            </>
+          )}
+          {activeInstances.map((instance) => {
+            const instancePath = `/instances/${instance.id}`
+            const isActive = location.pathname === instancePath || location.pathname.startsWith(`${instancePath}/`)
+            const csState = crossSeedInstanceState[instance.id]
+            const hasRss = csState?.rssEnabled || csState?.rssRunning
+            const hasSearch = csState?.searchRunning
 
-                return (
-                  <Link
-                    key={instance.id}
-                    to="/instances/$instanceId"
-                    params={{ instanceId: instance.id.toString() }}
+            return (
+              <Link
+                key={instance.id}
+                to="/instances/$instanceId"
+                params={{ instanceId: instance.id.toString() }}
+                className={cn(
+                  "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-all duration-200 ease-out",
+                  isActive? "bg-sidebar-primary text-sidebar-primary-foreground": "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+                )}
+              >
+                <HardDrive className="h-4 w-4 flex-shrink-0" />
+                <span className="truncate max-w-36" title={instance.name}>{instance.name}</span>
+                <span className="ml-auto flex items-center gap-1.5">
+                  {hasRss && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="flex items-center">
+                          {csState?.rssRunning ? (
+                            <Loader2 className={cn(
+                              "h-3 w-3 animate-spin",
+                              isActive ? "text-sidebar-primary-foreground/70" : "text-sidebar-foreground/70"
+                            )} />
+                          ) : (
+                            <Rss className={cn(
+                              "h-3 w-3",
+                              isActive ? "text-sidebar-primary-foreground/70" : "text-sidebar-foreground/70"
+                            )} />
+                          )}
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent side="right" className="text-xs">
+                        RSS {csState?.rssRunning ? "running" : "enabled"}
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+                  {hasSearch && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="flex items-center">
+                          <SearchCode className={cn(
+                            "h-3 w-3",
+                            isActive ? "text-sidebar-primary-foreground/70" : "text-sidebar-foreground/70"
+                          )} />
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent side="right" className="text-xs">
+                        Scan running
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+                  <span
                     className={cn(
-                      "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-all duration-200 ease-out",
-                      isActive? "bg-sidebar-primary text-sidebar-primary-foreground": "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+                      "h-2 w-2 rounded-full flex-shrink-0",
+                      instance.connected ? "bg-green-500" : "bg-red-500"
                     )}
-                  >
-                    <HardDrive className="h-4 w-4 flex-shrink-0" />
-                    <span className="truncate max-w-36" title={instance.name}>{instance.name}</span>
-                    <span className="ml-auto flex items-center gap-1.5">
-                      {hasRss && (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <span className="flex items-center">
-                              {csState?.rssRunning ? (
-                                <Loader2 className={cn(
-                                  "h-3 w-3 animate-spin",
-                                  isActive ? "text-sidebar-primary-foreground/70" : "text-sidebar-foreground/70"
-                                )} />
-                              ) : (
-                                <Rss className={cn(
-                                  "h-3 w-3",
-                                  isActive ? "text-sidebar-primary-foreground/70" : "text-sidebar-foreground/70"
-                                )} />
-                              )}
-                            </span>
-                          </TooltipTrigger>
-                          <TooltipContent side="right" className="text-xs">
-                            RSS {csState?.rssRunning ? "running" : "enabled"}
-                          </TooltipContent>
-                        </Tooltip>
-                      )}
-                      {hasSearch && (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <span className="flex items-center">
-                              <SearchCode className={cn(
-                                "h-3 w-3",
-                                isActive ? "text-sidebar-primary-foreground/70" : "text-sidebar-foreground/70"
-                              )} />
-                            </span>
-                          </TooltipTrigger>
-                          <TooltipContent side="right" className="text-xs">
-                            Scan running
-                          </TooltipContent>
-                        </Tooltip>
-                      )}
-                      <span
-                        className={cn(
-                          "h-2 w-2 rounded-full flex-shrink-0",
-                          instance.connected ? "bg-green-500" : "bg-red-500"
-                        )}
-                      />
-                    </span>
-                  </Link>
-                )
-              })}
-              {activeInstances.length === 0 && (
-                <p className="px-3 py-2 text-sm text-sidebar-foreground/50">
-                  {hasConfiguredInstances ? "All instances are disabled" : "No instances configured"}
-                </p>
-              )}
-            </div>
-          </div>
+                  />
+                </span>
+              </Link>
+            )
+          })}
+          {activeInstances.length === 0 && (
+            <p className="px-3 py-2 text-sm text-sidebar-foreground/50">
+              {hasConfiguredInstances ? "All instances are disabled" : "No instances configured"}
+            </p>
+          )}
+        </div>
+
+        <div className="mt-auto space-y-3 pt-3">
+          <UpdateBanner />
+
+          <Button
+            variant="ghost"
+            className="w-full justify-start"
+            onClick={() => logout()}
+          >
+            <LogOut className="mr-2 h-4 w-4" />
+            Logout
+          </Button>
         </div>
       </nav>
 
-      <div className="mt-auto space-y-3 p-3">
-        <UpdateBanner />
-
-        <Button
-          variant="ghost"
-          className="w-full justify-start"
-          onClick={() => logout()}
-        >
-          <LogOut className="mr-2 h-4 w-4" />
-          Logout
-        </Button>
-
+      <div className="flex-shrink-0 p-3">
         <Separator className="mx-3 mb-3" />
 
         <div className="flex items-center justify-between px-3 pb-3">


### PR DESCRIPTION
This PR fixes the element of the sidebar colliding, overflowing and/or overlapping.

The sidebar now has three sections:

- Logo - pinned to the top and will never be hidden.
- Scrollable navigation:
Contains Dashboard through Instances, then the UpdateBanner and Logout
UpdateBanner and Logout are pushed to the bottom via mt-auto. 
The whole region scrolls when content would otherwise collide, overflow or overlap.
- Version/copyright footer - pinned to the bottom and and will never be hidden.

This looks like a bigger PR, but it's really not, since the sidebar just got encased into some divs
and the lines of other elements got some more indentation.

ref https://discord.com/channels/881212911849209957/881967548143403058/1503676404980645958

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Restructured the sidebar layout to enhance scrolling behavior and improve content organization. Navigation items, instance management sections, and action buttons are now optimally arranged within a scrollable container. The sidebar footer, including version information and controls, remains fixed at the bottom for continuous accessibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/autobrr/qui/pull/1876)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->