### PR TITLE
fix(web): keep showing torrent column filter icons on touch devices

### DIFF
--- a/web/src/components/torrents/DraggableTableHeader.tsx
+++ b/web/src/components/torrents/DraggableTableHeader.tsx
@@ -10,6 +10,7 @@ import { CSS } from "@dnd-kit/utilities"
 import { flexRender, type Header } from "@tanstack/react-table"
 import { ChevronDown, ChevronUp } from "lucide-react"
 import { ColumnFilterPopover } from "./ColumnFilterPopover"
+import { useMediaQuery } from "@/hooks/useMediaQuery"
 import type { ViewMode } from "@/hooks/usePersistedCompactViewState"
 
 {/* Auto-fit width for column headers on double-click*/}
@@ -92,7 +93,9 @@ export function DraggableTableHeader({ header, columnFilters = [], viewMode = "n
   const toggleSortingHandler = column.getToggleSortingHandler()
   const trackerToggleHandler = trackerColumn?.getToggleSortingHandler()
   const columnHasActiveFilter = columnFilters.some(f => f.columnId === column.id)
-  const columnFilterIconVisibilityClassName = columnHasActiveFilter ? undefined : "hidden group-hover:block focus-within:block [&:has(button[data-state=open])]:block"
+  const primaryInputCanHover = useMediaQuery("(hover: hover)")
+  const hideFilterUntilHover = primaryInputCanHover && !columnHasActiveFilter
+  const columnFilterIconVisibilityClassName = hideFilterUntilHover ? "hidden group-hover:block focus-within:block [&:has(button[data-state=open])]:block" : undefined
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,


### PR DESCRIPTION
This PR fixes a regression caused by changes in #1869 where wider viewpoints (especially for tablets)
were not able to access the filter icons anymore.

The frontend now checks if the primary input type is touch and still shows the icons if that is the case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved filter icon visibility in table headers. The filter icon now intelligently appears based on hover capability and active filter status, showing on hover when applicable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/autobrr/qui/pull/1881)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->