### PR TITLE
fix(crossseed): normalize empty qbit metadata

### DIFF
--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -2020,6 +2020,9 @@ func (sm *SyncManager) GetCategories(ctx context.Context, instanceID int) (map[s
 
 	// Get categories from sync manager (real-time)
 	categories := syncManager.GetCategories()
+	if categories == nil {
+		categories = make(map[string]qbt.Category)
+	}
 
 	return categories, nil
 }
@@ -2034,6 +2037,9 @@ func (sm *SyncManager) GetTags(ctx context.Context, instanceID int) ([]string, e
 
 	// Get tags from sync manager (real-time)
 	tags := syncManager.GetTags()
+	if tags == nil {
+		tags = []string{}
+	}
 
 	slices.SortFunc(tags, func(a, b string) int {
 		return strings.Compare(strings.ToLower(a), strings.ToLower(b))


### PR DESCRIPTION
Normalizes empty qBittorrent category and tag metadata responses so API clients always receive object/array shapes. This fixes RSS Automation target metadata loading when an instance has no tags.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Categories and tags are now properly initialized, ensuring more reliable data handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/autobrr/qui/pull/1887)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->