### PR TITLE
fix(cross-seed): remove unreachable ctx.Done branches (#1817)

### DIFF
--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -1667,7 +1667,7 @@ func (s *Service) waitForCompletionTorrentReady(ctx context.Context, instanceID 
 }
 
 func (s *Service) waitForCompletionTorrentReadyLocked(
-	ctx context.Context,
+	_ context.Context,
 	instanceID int,
 	lane *completionLane,
 	eventTorrent qbt.Torrent,
@@ -1676,28 +1676,17 @@ func (s *Service) waitForCompletionTorrentReadyLocked(
 	done := wait.done
 
 	lane.mu.Unlock()
-
-	var result *qbt.Torrent
-	var err error
-
-	select {
-	case <-ctx.Done():
-		err = ctx.Err()
-	case <-done:
-		err = wait.err
-		if wait.result != nil {
-			torrent := *wait.result
-			result = &torrent
-		}
-	}
-
+	<-done
 	lane.mu.Lock()
 
-	if err != nil {
-		return nil, err
+	if wait.err != nil {
+		return nil, wait.err
 	}
-
-	return result, nil
+	if wait.result == nil {
+		return nil, nil
+	}
+	torrent := *wait.result
+	return &torrent, nil
 }
 
 func (s *Service) registerCompletionWaitLocked(
@@ -2138,13 +2127,7 @@ func (s *Service) executeCompletionSearchWithRetry(
 			Dur("retryAfter", retryAfter).
 			Msg("[CROSSSEED-COMPLETION] Rate-limited completion search, retrying")
 
-		timer := time.NewTimer(retryAfter)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
-			return ctx.Err()
-		case <-timer.C:
-		}
+		time.Sleep(retryAfter)
 	}
 	return lastErr
 }
@@ -2220,12 +2203,7 @@ func (s *Service) updateSearchRunWithRetry(ctx context.Context, run *models.Cros
 
 	for attempt := range maxRetries {
 		if attempt > 0 {
-			// Wait before retry
-			select {
-			case <-ctx.Done():
-				return run, ctx.Err()
-			case <-time.After(time.Duration(attempt) * 100 * time.Millisecond):
-			}
+			time.Sleep(time.Duration(attempt) * 100 * time.Millisecond)
 		}
 
 		updated, err := s.automationStore.UpdateSearchRun(ctx, run)


### PR DESCRIPTION
## Summary

Removes three `case <-ctx.Done()` branches in `internal/services/crossseed/service.go` that could never fire because the controlling ctx had a nil `Done()` channel at the point the select ran (either via an upstream `context.WithoutCancel` or because the only caller passed `context.Background()`). The selects are replaced with their actually-equivalent direct receive or `time.Sleep`, matching what the code does at runtime.

Closes #1817.

## Verification of each site

Traced every `case <-ctx.Done()` in the file and categorized by ctx provenance:

| Line | Function | Status | Action |
| --- | --- | --- | --- |
| 1684 | `waitForCompletionTorrentReadyLocked` | dead — caller chain detaches via `context.WithoutCancel` in `HandleTorrentCompletion` | replaced select with `<-done` |
| 2143 | `executeCompletionSearchWithRetry` | dead — same caller chain | replaced timer/select with `time.Sleep` |
| 2225 | `updateSearchRunWithRetry` | dead — sole caller passes `context.Background()` | replaced select with `time.Sleep` |
| 2197 | `updateAutomationRunWithRetry` | **mixed** — some callers pass cancellable ctx, others detach (e.g. L3058) | **left alone** — removing would silently break cancellation for the live callers |
| 2847 | `automationLoop` | live — `loopCtx = context.WithCancel(ctx)` at L1331 | untouched |
| 2918 | `waitTimer` | live — only called from `automationLoop` with the same loopCtx | untouched |
| 3061 | `executeAutomationRun` | live — `runCtx = context.WithCancel(ctx)` at L1378 | untouched |
| 7548 | `searchRunLoop` | live — started with `runCtx = context.WithCancel(context.Background())` at L2747 | untouched |
| 11002 | `recoverErroredTorrents` | live — called from `executeAutomationRun` / `searchRunLoop` with their cancellable runCtx | untouched |

## Notes

- `waitForCompletionTorrentReadyLocked`'s ctx parameter is now unused (renamed to `_`) since the function's only meaningful wait was the dead select. Signature kept for API consistency with sibling helpers; future cleanup can drop the parameter and propagate to `waitForCompletionTorrentReady` if desired.
- This is option 1 from the issue (honest minimal surgery). Option 2 — threading a real service-lifecycle ctx into `HandleTorrentCompletion` so shutdown cancellation actually fires — is the larger correct fix but out of scope here.

## Test plan

- [x] `go build ./...` — clean.
- [x] `go test -race -count=3 ./internal/services/crossseed/` — passes (`ok 242s`).
- [x] `make lint` — backend `--new-from-merge-base=develop` reports 0 issues.

## User-acceptance tests

These exercise the three touched code paths end-to-end from a user's perspective. The fix is a no-op refactor — every UA check below should produce **identical** behavior to develop. Any divergence is a regression.

### UA1 — Completion search fires when a torrent finishes (`waitForCompletionTorrentReadyLocked`)

1. In Settings → Cross-Seed, enable completion search for an instance and pick at least one Torznab indexer.
2. In qBittorrent, add a small torrent that will finish quickly (or force-recheck a complete torrent so it transitions to `pausedUP`/`uploading`).
3. **Expect:** within a few seconds of completion, the cross-seed log emits `[CROSSSEED-COMPLETION] Completion search starting` for that hash, followed by per-indexer search results. No log line stalls indefinitely waiting on a "ready" signal.
4. Repeat with the per-instance completion delay > 0 and with `Skip recheck` toggled both ways — completion still proceeds in every case.

### UA2 — Rate-limited completion search retries on its own schedule (`executeCompletionSearchWithRetry`)

1. Point one of the configured indexers at a Torznab endpoint that returns HTTP 429 / "rate limit" on the first call. (Easiest: temporarily lower a Jackett indexer's rate limit, or use a mock Torznab returning 429.)
2. Trigger a completion search (UA1) so it routes through this indexer.
3. **Expect:** the log shows `[CROSSSEED-COMPLETION] Rate-limited completion search, retrying` followed by a wait of the server-advertised `Retry-After`, then a second attempt. The retry must run even if the user is concurrently restarting the service — the retry is intentionally non-cancellable here (it was already non-cancellable before this PR; this just makes that explicit).

### UA3 — Search run DB update survives a transient SQLite write contention (`updateSearchRunWithRetry`)

1. Kick off a manual cross-seed search run (Cross-Seed page → Run Search) against a large library so multiple result batches are persisted.
2. While the run is recording results, induce brief DB contention (e.g., run `make backups` or any other operation that opens a write txn).
3. **Expect:** the search run completes; per-result rows land in the DB; no `[CROSSSEED] update search run failed` errors leak through. The backoff between retries is 100ms × attempt, sleeping rather than selecting.

### UA4 — Cancellation paths that *were* live still cancel cleanly (regression guard)

This PR explicitly leaves `automationLoop`, `waitTimer`, `executeAutomationRun`, `searchRunLoop`, `recoverErroredTorrents`, and `updateAutomationRunWithRetry` untouched. Confirm none regressed:

1. Start a long-running automation run (e.g., a Cross-Seed automation against a large instance).
2. From the UI, toggle the automation **off** mid-run, or `SIGTERM` the `qui` process.
3. **Expect:** the automation run exits promptly (≤ a few seconds), the `searchRunLoop` shuts down, and the process exits without a hang or "context deadline exceeded" stack dump. Log should show the automation/run ctx being cancelled and loops returning.

### UA5 — Shutdown during an in-flight completion search no longer hangs the *service* but never did cancel the *search* (documented behavior)

1. Trigger a completion search (UA1) against an indexer that takes several seconds to respond.
2. Mid-search, stop the `qui` process (`Ctrl+C` / `systemctl stop qui`).
3. **Expect:** the process exits cleanly within the normal shutdown window. The in-flight completion search may still log a final result after the listener stops — this is the same behavior as develop (the search ctx was already detached via `context.WithoutCancel` upstream). No new hang is introduced; no panic on shutdown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Cross-seed completion waiting and retry backoff processes have been restructured to improve reliability. Note: cancellation requests may now require longer to take effect during these operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/autobrr/qui/pull/1897?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
