### PR TITLE
fix(torrents): clear filters in unified-view empty state

### DIFF
--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -2198,7 +2198,7 @@ export function TorrentCardsMobile({
                 </Button>
               )
             })()}
-            {onFilterChange && (
+            {onFilterChange && !isAllInstancesView && (
               <Button
                 variant="outline"
                 onClick={() => {

--- a/web/src/components/torrents/TorrentContextMenu.tsx
+++ b/web/src/components/torrents/TorrentContextMenu.tsx
@@ -486,7 +486,7 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
                 Search Cross-Seeds
               </ContextMenuItem>
             )}
-            {onFilterChange && (
+            {onFilterChange && supportsInstanceScopedActions && (
               <ContextMenuItem
                 onClick={handleFilterCrossSeeds}
                 disabled={isPending || isFilteringCrossSeeds || count > 1}
@@ -501,7 +501,7 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
                 {isFilteringCrossSeeds && <span className="ml-1 text-xs text-muted-foreground">...</span>}
               </ContextMenuItem>
             )}
-            {(canCrossSeedSearch || onFilterChange) && <ContextMenuSeparator />}
+            {(canCrossSeedSearch || (onFilterChange && supportsInstanceScopedActions)) && <ContextMenuSeparator />}
             <ContextMenuItem
               onClick={() => onPrepareTags(hashes, torrents)}
               disabled={isPending}

--- a/web/src/components/torrents/TorrentTableResponsive.tsx
+++ b/web/src/components/torrents/TorrentTableResponsive.tsx
@@ -57,7 +57,6 @@ export function TorrentTableResponsive(props: TorrentTableResponsiveProps) {
       <>
         <TorrentCardsMobile
           {...memoizedProps}
-          onFilterChange={allowCrossSeedSearch ? props.onFilterChange : undefined}
           canCrossSeedSearch={allowCrossSeedSearch ? crossSeed.canCrossSeedSearch : false}
           onCrossSeedSearch={allowCrossSeedSearch ? crossSeed.openCrossSeedSearch : undefined}
           isCrossSeedSearching={allowCrossSeedSearch ? crossSeed.isCrossSeedSearching : false}
@@ -73,7 +72,6 @@ export function TorrentTableResponsive(props: TorrentTableResponsiveProps) {
         readOnly={readOnly}
         onSelectionChange={updateSelection}
         onResetSelection={setResetHandler}
-        onFilterChange={allowCrossSeedSearch ? props.onFilterChange : undefined}
         canCrossSeedSearch={allowCrossSeedSearch ? crossSeed.canCrossSeedSearch : false}
         onCrossSeedSearch={allowCrossSeedSearch ? crossSeed.openCrossSeedSearch : undefined}
         isCrossSeedSearching={allowCrossSeedSearch ? crossSeed.isCrossSeedSearching : false}


### PR DESCRIPTION
## Summary

The empty-state "Clear filters" button on **Dashboard → All Instances** was a no-op. `TorrentTableResponsive` was passing `onFilterChange={allowCrossSeedSearch ? props.onFilterChange : undefined}`, and in unified view `allowCrossSeedSearch` is `false`, so the parent filter setter was `undefined`. The atomic clear in `TorrentTableOptimized` cleared local column filters but the parent's `status` / `categories` / `tags` / `trackers` state stayed applied — so the empty state never went away.

`onFilterChange` is the generic parent filter callback (`setFilters` in `pages/Torrents.tsx`), not a cross-seed concern. It got conflated with the cross-seed-search props in the same ternary in #1481.

Closes #1852.

## Changes

- **`TorrentTableResponsive.tsx`** — drop the two `onFilterChange={allowCrossSeedSearch ? ... : undefined}` overrides. It now flows through `{...memoizedProps}` to both mobile cards and desktop table unconditionally. Cross-seed-search props remain gated.
- **`TorrentContextMenu.tsx`** — the "Filter Cross-Seeds" item was incidentally hidden by the `onFilterChange` gate. Now that `onFilterChange` is defined in unified view, gate it explicitly on the existing `supportsInstanceScopedActions` check (`_instanceId > 0`) so it stays hidden where it can't work.
- **`TorrentCardsMobile.tsx`** — same fix for the mobile actions sheet's "Filter Cross-Seeds" button: gate on the existing `!isAllInstancesView`.

The "Filter Cross-Seeds" feature calls `api.getLocalCrossSeedMatches(instanceId, hash)`, which needs a real instance — in unified view `instanceId` is the all-instances sentinel `0`, so keeping it hidden there preserves prior behavior.

Side benefit: right-click "filter by this tracker / category / tag" actions in `TorrentContextMenu` (which also use `onFilterChange`) were broken in unified view for the same reason. This restores them.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec eslint` on the three changed files — 0 errors (26 pre-existing warnings unrelated to this change)
- [x] `pnpm build` — clean (889 ms, PWA generated)
- [x] `golangci-lint run --new-from-merge-base=develop` — 0 issues

## User-acceptance tests

1. **Dashboard → All Instances**, apply enough filters (category + tag + tracker) to produce zero results.
2. Empty-state "Clear filters" button appears in the torrents pane — click it.
3. **Expect:** filters reset, full torrent list returns.
4. Repeat on a single-instance dashboard — no regression.
5. Bonus: right-click a row in unified view → "Filter by this tracker" should now apply.
6. **Filter Cross-Seeds** option in row context menu / mobile actions sheet should still be **hidden** in unified view (correct — it needs a single instance) and **visible** in single-instance views.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined the display logic for cross-seed filtering options across all views and interfaces. The filter now appears conditionally, displayed only when fully supported in the current context. This targeted approach eliminates unnecessary menu items and improves overall UI consistency and clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/autobrr/qui/pull/1898?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->