### PR TITLE
refactor(torrents): drop unused rename props from TorrentContextMenu

### DIFF
--- a/web/src/components/torrents/TorrentContextMenu.tsx
+++ b/web/src/components/torrents/TorrentContextMenu.tsx
@@ -72,8 +72,6 @@ interface TorrentContextMenuProps {
   onPrepareLocation: (hashes: string[], torrents?: Torrent[], count?: number) => void
   onPrepareTmm?: (hashes: string[], count: number, enable: boolean) => void
   onPrepareRenameTorrent: (hashes: string[], torrents?: Torrent[]) => void
-  onPrepareRenameFile: (hashes: string[], torrents?: Torrent[]) => void
-  onPrepareRenameFolder: (hashes: string[], torrents?: Torrent[]) => void
   availableCategories?: Record<string, Category>
   onSetCategory?: (category: string, hashes: string[], targets?: Array<{ instanceId: number; hash: string }>) => void
   isPending?: boolean
@@ -108,8 +106,6 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
   onPrepareReannounce,
   onPrepareLocation,
   onPrepareRenameTorrent,
-  onPrepareRenameFile: _onPrepareRenameFile,
-  onPrepareRenameFolder: _onPrepareRenameFolder,
   onPrepareTmm,
   availableCategories = {},
   onSetCategory,

--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -818,8 +818,6 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
     prepareSpeedLimitAction,
     prepareLocationAction,
     prepareRenameTorrentAction,
-    prepareRenameFileAction,
-    prepareRenameFolderAction,
     prepareRecheckAction,
     prepareReannounceAction,
     prepareTmmAction,
@@ -2699,8 +2697,6 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
                         onPrepareSpeedLimits={prepareSpeedLimitAction}
                         onPrepareLocation={prepareLocationAction}
                         onPrepareRenameTorrent={prepareRenameTorrentAction}
-                        onPrepareRenameFile={prepareRenameFileAction}
-                        onPrepareRenameFolder={prepareRenameFolderAction}
                         onPrepareRecheck={prepareRecheckAction}
                         onPrepareReannounce={prepareReannounceAction}
                         onPrepareTmm={prepareTmmAction}
@@ -2851,8 +2847,6 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
                       onPrepareSpeedLimits={prepareSpeedLimitAction}
                       onPrepareLocation={prepareLocationAction}
                       onPrepareRenameTorrent={prepareRenameTorrentAction}
-                      onPrepareRenameFile={prepareRenameFileAction}
-                      onPrepareRenameFolder={prepareRenameFolderAction}
                       onPrepareRecheck={prepareRecheckAction}
                       onPrepareReannounce={prepareReannounceAction}
                       onPrepareTmm={prepareTmmAction}


### PR DESCRIPTION
## Summary

Drops `onPrepareRenameFile` / `onPrepareRenameFolder` from `TorrentContextMenu` — the props were declared, destructured as `_`-prefixed, and never used. The pass-through plumbing in `TorrentTableOptimized` is gone too. Underlying file/folder rename flows (`handleRenameFile` / `handleRenameFolder`) are still alive and triggered from torrent-details file lists, not the row context menu.

Closes #1899.

## Changes

- `TorrentContextMenu.tsx` — remove the two props from `TorrentContextMenuProps` and the destructure.
- `TorrentTableOptimized.tsx` — remove the two destructures from `useTorrentActions` and the four pass-through sites (two desktop variants).

10 lines deleted, 0 added. Zero behavior change.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec eslint` on changed files — 0 errors; the two `@typescript-eslint/no-unused-vars` warnings for `_onPrepareRenameFile` / `_onPrepareRenameFolder` are gone
- [x] Right-click on a torrent row → context menu still renders all expected items (Rename Torrent stays, file/folder rename items were never there)
- [x] Rename a file from the torrent-details file list — still works (separate code path)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added torrent export functionality
  * Enhanced category and subcategory management
  * Introduced cross-seed search capability
  * Added advanced filtering options

* **Changes**
  * Reorganized context menu actions for improved usability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/autobrr/qui/pull/1900?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->