### PR TITLE
fix(automations): discard add torrent response

### DIFF
--- a/internal/services/automations/service.go
+++ b/internal/services/automations/service.go
@@ -6261,7 +6261,7 @@ func (s *Service) executeExportToInstance(_ context.Context, sourceInstanceID in
 			}
 
 			// 3. Add to target instance
-			if err := s.syncManager.AddTorrent(ctx, exec.action.TargetInstanceID, torrentBytes, options); err != nil {
+			if _, err := s.syncManager.AddTorrent(ctx, exec.action.TargetInstanceID, torrentBytes, options); err != nil {
 				log.Error().Err(err).
 					Int("sourceInstanceID", sourceInstanceID).
 					Int("targetInstanceID", exec.action.TargetInstanceID).


### PR DESCRIPTION
Updates the automation export path to match the current `AddTorrent` return values by discarding the response and preserving the existing error handling.

This fixes the migration-parity compile failure after `AddTorrent` started returning a response alongside the error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code maintenance and adjustments to automation service logic with no user-facing impact.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/autobrr/qui/pull/1904?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->