### PR TITLE
refactor(web): clean up 180 multiline-ternary warnings repo-wide

### DIFF
--- a/web/src/components/indexers/SearchHistoryPanel.tsx
+++ b/web/src/components/indexers/SearchHistoryPanel.tsx
@@ -8,7 +8,7 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/component
 import {
   Dialog,
   DialogContent,
-  DialogTitle,
+  DialogTitle
 } from "@/components/ui/dialog"
 import { useSearchHistory } from "@/hooks/useSearchHistory"
 import { formatRelativeTime, formatTimeHMS } from "@/lib/dateTimeUtils"
@@ -252,9 +252,7 @@ function HistoryRow({ entry, onClick }: HistoryRowProps) {
     rate_limited: <AlertCircle className="h-3 w-3 text-destructive shrink-0" />,
   }
 
-  const durationStr = entry.durationMs < 1000
-    ? `${entry.durationMs}ms`
-    : `${(entry.durationMs / 1000).toFixed(1)}s`
+  const durationStr = entry.durationMs < 1000? `${entry.durationMs}ms`: `${(entry.durationMs / 1000).toFixed(1)}s`
 
   // Hide "unknown" content type - it's noise for RSS searches
   const showContentType = entry.contentType && entry.contentType !== "unknown"
@@ -329,9 +327,7 @@ function SearchDetailDialog({ entry, open, onClose }: SearchDetailDialogProps) {
   const isSuccess = entry.status === "success"
   const isError = entry.status === "error" || entry.status === "rate_limited"
 
-  const durationStr = entry.durationMs < 1000
-    ? `${entry.durationMs}ms`
-    : `${(entry.durationMs / 1000).toFixed(2)}s`
+  const durationStr = entry.durationMs < 1000? `${entry.durationMs}ms`: `${(entry.durationMs / 1000).toFixed(2)}s`
 
   // Transform params into semantic badges
   const paramBadges = entry.params ? transformParams(entry.params) : []

--- a/web/src/components/instances/InstanceCard.tsx
+++ b/web/src/components/instances/InstanceCard.tsx
@@ -81,11 +81,7 @@ export function InstanceCard({
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
   const displayUrl = instance.host
 
-  const statusBadge = !instance.isActive
-    ? { label: "Disabled", variant: "secondary" as const }
-    : instance.connected
-      ? { label: "Connected", variant: "default" as const }
-      : { label: "Disconnected", variant: "destructive" as const }
+  const statusBadge = !instance.isActive? { label: "Disabled", variant: "secondary" as const }: instance.connected? { label: "Connected", variant: "default" as const }: { label: "Disconnected", variant: "destructive" as const }
 
   const handleTest = async () => {
     if (!instance.isActive) {
@@ -126,9 +122,7 @@ export function InstanceCard({
       onSuccess: () => {
         setTestResult(null)
         toast.success(nextState ? "Instance Enabled" : "Instance Disabled", {
-          description: nextState
-            ? "qui will resume connecting to this qBittorrent instance."
-            : "qui will stop attempting to reach this qBittorrent instance.",
+          description: nextState? "qui will resume connecting to this qBittorrent instance.": "qui will stop attempting to reach this qBittorrent instance.",
         })
       },
       onError: (error) => {

--- a/web/src/components/instances/preferences/CompletionOverview.tsx
+++ b/web/src/components/instances/preferences/CompletionOverview.tsx
@@ -420,9 +420,7 @@ export function CompletionOverview() {
                                 disabled={isSaving}
                               />
                               <p className="text-xs text-muted-foreground">
-                                {form.categories.length === 0
-                                  ? "All categories will be included."
-                                  : `Only ${form.categories.length} selected ${form.categories.length === 1 ? "category" : "categories"} will be matched.`}
+                                {form.categories.length === 0? "All categories will be included.": `Only ${form.categories.length} selected ${form.categories.length === 1 ? "category" : "categories"} will be matched.`}
                               </p>
                             </div>
                             <div className="space-y-2">
@@ -436,9 +434,7 @@ export function CompletionOverview() {
                                 disabled={isSaving}
                               />
                               <p className="text-xs text-muted-foreground">
-                                {form.tags.length === 0
-                                  ? "All tags will be included."
-                                  : `Only ${form.tags.length} selected ${form.tags.length === 1 ? "tag" : "tags"} will be matched.`}
+                                {form.tags.length === 0? "All tags will be included.": `Only ${form.tags.length} selected ${form.tags.length === 1 ? "tag" : "tags"} will be matched.`}
                               </p>
                             </div>
                             <div className="space-y-2">
@@ -451,9 +447,7 @@ export function CompletionOverview() {
                                 disabled={isSaving || indexersQuery.isPending || (!hasEnabledIndexers && !indexersQuery.isPending)}
                               />
                               <p className="text-xs text-muted-foreground">
-                                {form.indexerIds.length === 0
-                                  ? "All enabled indexers will be searched."
-                                  : `Only ${form.indexerIds.length} selected ${form.indexerIds.length === 1 ? "indexer" : "indexers"} will be queried.`}
+                                {form.indexerIds.length === 0? "All enabled indexers will be searched.": `Only ${form.indexerIds.length} selected ${form.indexerIds.length === 1 ? "indexer" : "indexers"} will be queried.`}
                               </p>
                             </div>
                           </div>

--- a/web/src/components/instances/preferences/FileManagementForm.tsx
+++ b/web/src/components/instances/preferences/FileManagementForm.tsx
@@ -107,11 +107,7 @@ function toScanDirs(watchFolders: WatchFolderConfig[]): Record<string, number | 
       return acc
     }
 
-    acc[path] = folder.destination === "default-save-location"
-      ? OVERRIDE_WATCH_FOLDER_SAVE_MODE
-      : folder.destination === "other"
-        ? folder.otherPath
-        : DEFAULT_WATCH_FOLDER_MODE
+    acc[path] = folder.destination === "default-save-location"? OVERRIDE_WATCH_FOLDER_SAVE_MODE: folder.destination === "other"? folder.otherPath: DEFAULT_WATCH_FOLDER_MODE
 
     return acc
   }, {})

--- a/web/src/components/instances/preferences/OrphanScanOverview.tsx
+++ b/web/src/components/instances/preferences/OrphanScanOverview.tsx
@@ -17,7 +17,7 @@ import {
   useOrphanScanRuns,
   useOrphanScanSettings,
   useTriggerOrphanScan,
-  useUpdateOrphanScanSettings,
+  useUpdateOrphanScanSettings
 } from "@/hooks/useOrphanScan"
 import { cn, copyTextToClipboard, formatBytes } from "@/lib/utils"
 import { formatRelativeTime } from "@/lib/dateTimeUtils"
@@ -223,14 +223,10 @@ function InstanceOrphanScanItem({
           <div className="flex items-center justify-between p-3 rounded-lg bg-muted/40 border">
             <div className="space-y-0.5">
               <p className="text-sm text-muted-foreground">
-                {settings
-                  ? `Grace ${settings.gracePeriodMinutes}min · Interval ${settings.scanIntervalHours}h · Max ${settings.maxFilesPerRun} files`
-                  : "Loading..."}
+                {settings? `Grace ${settings.gracePeriodMinutes}min · Interval ${settings.scanIntervalHours}h · Max ${settings.maxFilesPerRun} files`: "Loading..."}
               </p>
               <p className="text-xs text-muted-foreground/70">
-                {settings?.autoCleanupEnabled
-                  ? `Auto-cleanup enabled (≤${settings.autoCleanupMaxFiles} files)`
-                  : "Auto-cleanup disabled"}
+                {settings?.autoCleanupEnabled? `Auto-cleanup enabled (≤${settings.autoCleanupMaxFiles} files)`: "Auto-cleanup disabled"}
                 {settings?.ignorePaths && settings.ignorePaths.length > 0 && (
                   <> · {settings.ignorePaths.length} path{settings.ignorePaths.length !== 1 ? "s" : ""} ignored</>
                 )}
@@ -395,9 +391,7 @@ function InstanceOrphanScanItem({
                         <div className="px-3 pb-3 pt-0">
                           <div className={cn(
                             "relative p-3 rounded-md text-sm font-mono whitespace-pre-wrap break-all",
-                            run.status === "failed"
-                              ? "bg-destructive/10 text-destructive border border-destructive/20"
-                              : "bg-yellow-500/10 text-yellow-600 dark:text-yellow-400 border border-yellow-500/20"
+                            run.status === "failed"? "bg-destructive/10 text-destructive border border-destructive/20": "bg-yellow-500/10 text-yellow-600 dark:text-yellow-400 border border-yellow-500/20"
                           )}>
                             <Button
                               variant="ghost"

--- a/web/src/components/instances/preferences/PreferencesFormShell.tsx
+++ b/web/src/components/instances/preferences/PreferencesFormShell.tsx
@@ -46,11 +46,9 @@ export function PreferencesFormShell({
 
     updateFades()
 
-    const resizeObserver = typeof ResizeObserver === "undefined"
-      ? null
-      : new ResizeObserver(() => {
-        updateFades()
-      })
+    const resizeObserver = typeof ResizeObserver === "undefined"? null: new ResizeObserver(() => {
+      updateFades()
+    })
 
     scrollElement.addEventListener("scroll", updateFades, { passive: true })
     window.addEventListener("resize", updateFades)

--- a/web/src/components/instances/preferences/WorkflowDialog.tsx
+++ b/web/src/components/instances/preferences/WorkflowDialog.tsx
@@ -924,7 +924,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
 
   const nonSelfInstances = useMemo(
     () => instances ? instances.filter(i => i.id !== instanceId) : undefined,
-    [instances, instanceId],
+    [instances, instanceId]
   )
 
   const targetCategories = useMemo(() => {
@@ -1136,9 +1136,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
             exprExportPaused = conditions.exportToInstance.paused ?? false
             exprExportSkipChecking = conditions.exportToInstance.skipChecking ?? true
             const rawLayout = conditions.exportToInstance.contentLayout ?? ""
-            exprExportContentLayout = CONTENT_LAYOUT_VALUES.includes(rawLayout as typeof CONTENT_LAYOUT_VALUES[number])
-              ? rawLayout as FormState["exprExportContentLayout"]
-              : ""
+            exprExportContentLayout = CONTENT_LAYOUT_VALUES.includes(rawLayout as typeof CONTENT_LAYOUT_VALUES[number])? rawLayout as FormState["exprExportContentLayout"]: ""
           }
         }
 

--- a/web/src/components/instances/preferences/WorkflowPreviewDialog.tsx
+++ b/web/src/components/instances/preferences/WorkflowPreviewDialog.tsx
@@ -12,7 +12,7 @@ import {
   AlertDialogDescription,
   AlertDialogFooter,
   AlertDialogHeader,
-  AlertDialogTitle,
+  AlertDialogTitle
 } from "@/components/ui/alert-dialog"
 import { Button } from "@/components/ui/button"
 import { PathCell } from "@/components/ui/path-cell"
@@ -167,9 +167,7 @@ const DYNAMIC_COLUMNS: ColumnDef[] = [
     triggerFields: ["COMPLETION_ON", "COMPLETION_ON_AGE"],
     render: (t) => (
       <span className="font-mono text-muted-foreground whitespace-nowrap">
-        {t.completionOn > 0
-          ? formatDurationCompact(Math.floor(Date.now() / 1000) - t.completionOn)
-          : "-"}
+        {t.completionOn > 0? formatDurationCompact(Math.floor(Date.now() / 1000) - t.completionOn): "-"}
       </span>
     ),
   },
@@ -180,9 +178,7 @@ const DYNAMIC_COLUMNS: ColumnDef[] = [
     triggerFields: ["LAST_ACTIVITY", "LAST_ACTIVITY_AGE"],
     render: (t) => (
       <span className="font-mono text-muted-foreground whitespace-nowrap">
-        {t.lastActivity > 0
-          ? formatDurationCompact(Math.floor(Date.now() / 1000) - t.lastActivity)
-          : "-"}
+        {t.lastActivity > 0? formatDurationCompact(Math.floor(Date.now() / 1000) - t.lastActivity): "-"}
       </span>
     ),
   },
@@ -327,9 +323,7 @@ export function WorkflowPreviewDialog({
                     </TabsList>
                   </Tabs>
                   <p className="text-xs text-muted-foreground">
-                    {previewView === "needed"
-                      ? "These are the torrents that would be removed now to reach your free-space target."
-                      : "These are all torrents this rule could remove while free space is low."}
+                    {previewView === "needed"? "These are the torrents that would be removed now to reach your free-space target.": "These are all torrents this rule could remove while free space is low."}
                   </p>
                 </div>
               )}
@@ -392,9 +386,7 @@ export function WorkflowPreviewDialog({
                             {/* Single cross-seed badge with appropriate variant based on expansion type */}
                             {(t.isCrossSeed || t.isHardlinkCopy) && (
                               <span className={`shrink-0 text-[10px] px-1.5 py-0.5 rounded ${
-                                t.isHardlinkCopy
-                                  ? "bg-violet-500/10 text-violet-600"
-                                  : "bg-blue-500/10 text-blue-600"
+                                t.isHardlinkCopy? "bg-violet-500/10 text-violet-600": "bg-blue-500/10 text-blue-600"
                               }`}>
                                 {t.isHardlinkCopy ? "Cross-seed (hardlinked)" : "Cross-seed (same files)"}
                               </span>
@@ -481,11 +473,7 @@ export function WorkflowPreviewDialog({
               onClick={onConfirm}
               disabled={isConfirming}
               className={
-                destructive
-                  ? "bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                  : warning
-                    ? "bg-amber-600 text-white hover:bg-amber-700"
-                    : ""
+                destructive? "bg-destructive text-destructive-foreground hover:bg-destructive/90": warning? "bg-amber-600 text-white hover:bg-amber-700": ""
               }
             >
               {isConfirming && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}

--- a/web/src/components/instances/preferences/WorkflowsOverview.tsx
+++ b/web/src/components/instances/preferences/WorkflowsOverview.tsx
@@ -292,13 +292,7 @@ function formatExportedToInstanceSummary(details: AutomationActivity["details"],
 
 function formatDeleteDryRunSummary(details: AutomationActivity["details"], action: AutomationActivity["action"]): string {
   const count = details?.count ?? 0
-  const label = action === "deleted_ratio"
-    ? "ratio limit"
-    : action === "deleted_seeding"
-      ? "seeding limit"
-      : action === "deleted_unregistered"
-        ? "unregistered"
-        : "condition"
+  const label = action === "deleted_ratio"? "ratio limit": action === "deleted_seeding"? "seeding limit": action === "deleted_unregistered"? "unregistered": "condition"
   return `${count} torrent${count !== 1 ? "s" : ""} would be deleted (${label})`
 }
 
@@ -1285,13 +1279,7 @@ export function WorkflowsOverview({
                                               outcomeClasses[event.outcome]
                                             )}
                                           >
-                                            {event.outcome === "dry-run"
-                                              ? "Dry run"
-                                              : event.action === "external_program"
-                                                ? (event.outcome === "success" ? "Executed" : "Failed")
-                                                : event.action === "exported_to_instance"
-                                                  ? (event.outcome === "success" ? "Exported" : "Failed")
-                                                  : (event.outcome === "success" ? "Removed" : "Failed")}
+                                            {event.outcome === "dry-run"? "Dry run": event.action === "external_program"? (event.outcome === "success" ? "Executed" : "Failed"): event.action === "exported_to_instance"? (event.outcome === "success" ? "Exported" : "Failed"): (event.outcome === "success" ? "Removed" : "Failed")}
                                           </Badge>
                                         )}
                                       </div>

--- a/web/src/components/instances/preferences/WorkflowsOverview.tsx
+++ b/web/src/components/instances/preferences/WorkflowsOverview.tsx
@@ -200,6 +200,13 @@ function formatAction(action: AutomationActivity["action"]): string {
   }
 }
 
+function getOutcomeBadgeText(event: AutomationActivity): string {
+  if (event.outcome === "dry-run") return "Dry run"
+  if (event.action === "external_program") return event.outcome === "success" ? "Executed" : "Failed"
+  if (event.action === "exported_to_instance") return event.outcome === "success" ? "Exported" : "Failed"
+  return event.outcome === "success" ? "Removed" : "Failed"
+}
+
 function sumRecordValues(values: Record<string, number> | undefined): number {
   return Object.values(values ?? {}).reduce((sum, value) => {
     const asNumber = typeof value === "number" ? value : Number(value)
@@ -1279,7 +1286,7 @@ export function WorkflowsOverview({
                                               outcomeClasses[event.outcome]
                                             )}
                                           >
-                                            {event.outcome === "dry-run"? "Dry run": event.action === "external_program"? (event.outcome === "success" ? "Executed" : "Failed"): event.action === "exported_to_instance"? (event.outcome === "success" ? "Exported" : "Failed"): (event.outcome === "success" ? "Removed" : "Failed")}
+                                            {getOutcomeBadgeText(event)}
                                           </Badge>
                                         )}
                                       </div>

--- a/web/src/components/query-builder/ConditionGroup.tsx
+++ b/web/src/components/query-builder/ConditionGroup.tsx
@@ -9,7 +9,7 @@ import type { ConditionOperator, RuleCondition } from "@/types";
 import {
   SortableContext,
   useSortable,
-  verticalListSortingStrategy,
+  verticalListSortingStrategy
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { GripVertical, Plus, X } from "lucide-react";
@@ -169,9 +169,7 @@ export function ConditionGroup({
 
   // Generate unique IDs for children
   const childIds = children.map((child, index) => child.clientId ?? `${id}-${index}`);
-  const nestedColorClasses = depth % 2 === 1
-    ? "border-cyan-500/40 bg-cyan-500/10"
-    : "border-amber-500/45 bg-amber-500/10";
+  const nestedColorClasses = depth % 2 === 1? "border-cyan-500/40 bg-cyan-500/10": "border-amber-500/45 bg-amber-500/10";
 
   return (
     <div
@@ -204,9 +202,7 @@ export function ConditionGroup({
           size="sm"
           className={cn(
             "h-7 px-3 font-mono text-xs font-semibold",
-            condition.operator === "AND"
-              ? "border-blue-500/50 bg-blue-500/10 text-blue-500"
-              : "border-orange-500/50 bg-orange-500/10 text-orange-500"
+            condition.operator === "AND"? "border-blue-500/50 bg-blue-500/10 text-blue-500": "border-orange-500/50 bg-orange-500/10 text-orange-500"
           )}
           onClick={toggleOperator}
         >

--- a/web/src/components/query-builder/LeafCondition.tsx
+++ b/web/src/components/query-builder/LeafCondition.tsx
@@ -148,9 +148,7 @@ export function LeafCondition({
   const fieldType = condition.field ? getFieldType(condition.field) : "string";
   const operators = condition.field ? getOperatorsForField(condition.field) : [];
   const isGroupingField = isGroupingConditionField(condition.field);
-  const availableGroupOptions = (groupOptions && groupOptions.length > 0)
-    ? groupOptions
-    : [{ id: DEFAULT_GROUP_ID, label: "Cross-seed (content + save path)" }];
+  const availableGroupOptions = (groupOptions && groupOptions.length > 0)? groupOptions: [{ id: DEFAULT_GROUP_ID, label: "Cross-seed (content + save path)" }];
   const groupIdValue = condition.groupId || DEFAULT_GROUP_ID;
 
   // Track duration unit separately so it persists when value is empty

--- a/web/src/components/settings/LogSettingsPanel.tsx
+++ b/web/src/components/settings/LogSettingsPanel.tsx
@@ -13,14 +13,14 @@ import {
   DialogDescription,
   DialogFooter,
   DialogHeader,
-  DialogTitle,
+  DialogTitle
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import {
   Popover,
   PopoverContent,
-  PopoverTrigger,
+  PopoverTrigger
 } from "@/components/ui/popover"
 import {
   Select,
@@ -377,9 +377,7 @@ function LogEntry({
               <span className="text-muted-foreground/70">{key}</span>
               <span className="text-muted-foreground/40">=</span>
               <span className="text-muted-foreground/60">
-                {typeof entry.extra[key] === "string"
-                  ? entry.extra[key] as string
-                  : JSON.stringify(entry.extra[key])}
+                {typeof entry.extra[key] === "string"? entry.extra[key] as string: JSON.stringify(entry.extra[key])}
               </span>
             </span>
           ))}
@@ -720,11 +718,7 @@ function LiveLogViewer({ configPath }: { configPath?: string }) {
               <Button variant="outline" size="sm" className="h-8 gap-1">
                 <Filter className="h-3.5 w-3.5" />
                 <span className="text-xs">
-                  {selectedLevels.size === ALL_LOG_LEVELS.length
-                    ? "All Levels"
-                    : selectedLevels.size === 0
-                      ? "None"
-                      : `${selectedLevels.size} Level${selectedLevels.size > 1 ? "s" : ""}`}
+                  {selectedLevels.size === ALL_LOG_LEVELS.length? "All Levels": selectedLevels.size === 0? "None": `${selectedLevels.size} Level${selectedLevels.size > 1 ? "s" : ""}`}
                 </span>
                 <ChevronDown className="h-3.5 w-3.5 opacity-50" />
               </Button>
@@ -843,9 +837,7 @@ function LiveLogViewer({ configPath }: { configPath?: string }) {
             ))
           ) : (
             <span className="text-muted-foreground">
-              {lines.length > 0
-                ? "No entries match the current filter"
-                : "Waiting for log entries..."}
+              {lines.length > 0? "No entries match the current filter": "Waiting for log entries..."}
             </span>
           )}
         </div>

--- a/web/src/components/torrents/CategoryTree.tsx
+++ b/web/src/components/torrents/CategoryTree.tsx
@@ -164,9 +164,7 @@ const CategoryTreeNode = memo(({
   const itemPadding = viewMode === "dense" ? "px-1 py-0.5" : "px-1.5 py-1.5"
   const itemGap = viewMode === "dense" ? "gap-1.5" : "gap-2"
   const hasToggleSlot = useSubcategories && (hasChildren || node.level > 0)
-  const itemColumns = hasToggleSlot
-    ? "grid-cols-[auto_auto_minmax(0,1fr)_auto]"
-    : "grid-cols-[auto_minmax(0,1fr)_auto]"
+  const itemColumns = hasToggleSlot? "grid-cols-[auto_auto_minmax(0,1fr)_auto]": "grid-cols-[auto_minmax(0,1fr)_auto]"
 
   const handleToggleCollapse = useCallback((e: ReactMouseEvent<HTMLButtonElement>) => {
     e.stopPropagation()

--- a/web/src/components/torrents/ColumnFilterPopover.tsx
+++ b/web/src/components/torrents/ColumnFilterPopover.tsx
@@ -258,9 +258,7 @@ function ValueInput({
       const selectedValues = value ? value.split(",") : []
 
       const handleSelect = (optionValue: string) => {
-        const newSelected = selectedValues.includes(optionValue)
-          ? selectedValues.filter(v => v !== optionValue)
-          : [...selectedValues, optionValue]
+        const newSelected = selectedValues.includes(optionValue)? selectedValues.filter(v => v !== optionValue): [...selectedValues, optionValue]
         onChange(newSelected.join(","))
       }
 
@@ -281,9 +279,7 @@ function ValueInput({
                       <div
                         className={cn(
                           "mr-2 flex h-4 w-4 items-center justify-center rounded-sm border border-primary",
-                          isSelected
-                            ? "bg-primary text-primary-foreground"
-                            : "opacity-50 [&_svg]:invisible"
+                          isSelected? "bg-primary text-primary-foreground": "opacity-50 [&_svg]:invisible"
                         )}
                       >
                         <Check className={cn("h-4 w-4")} />

--- a/web/src/components/torrents/CrossSeedWarning.tsx
+++ b/web/src/components/torrents/CrossSeedWarning.tsx
@@ -64,9 +64,7 @@ export function CrossSeedWarning({
       <div
         className={cn(
           "group relative rounded-lg border py-2 px-3 transition-all duration-300",
-          isHighRisk
-            ? "border-amber-500/40 bg-amber-500/5 hover:border-amber-500/60 hover:bg-amber-500/10"
-            : "border-border/50 bg-muted/30 hover:border-border hover:bg-muted/50",
+          isHighRisk? "border-amber-500/40 bg-amber-500/5 hover:border-amber-500/60 hover:bg-amber-500/10": "border-border/50 bg-muted/30 hover:border-border hover:bg-muted/50",
           className
         )}
       >
@@ -92,9 +90,7 @@ export function CrossSeedWarning({
             onClick={onSearch}
             className={cn(
               "shrink-0 h-7 px-2 text-xs transition-all",
-              isHighRisk
-                ? "bg-amber-600 hover:bg-amber-700 text-white shadow-sm"
-                : "hover:bg-accent"
+              isHighRisk? "bg-amber-600 hover:bg-amber-700 text-white shadow-sm": "hover:bg-accent"
             )}
           >
             <Search className="h-3 w-3 mr-1" />
@@ -177,9 +173,7 @@ export function CrossSeedWarning({
     <div
       className={cn(
         "rounded-lg border py-3 px-4 overflow-hidden",
-        isDestructive
-          ? "border-destructive/40 bg-destructive/5"
-          : "border-blue-500/30 bg-blue-500/5",
+        isDestructive? "border-destructive/40 bg-destructive/5": "border-blue-500/30 bg-blue-500/5",
         className
       )}
     >
@@ -195,27 +189,17 @@ export function CrossSeedWarning({
             "text-sm font-medium",
             isDestructive ? "text-destructive" : "text-blue-600 dark:text-blue-400"
           )}>
-            {deleteCrossSeeds
-              ? "These cross-seeds will also be deleted"
-              : deleteFiles
-                ? "Deleting files will break these cross-seeds"
-                : "Cross-seeds detected — data will be preserved"}
+            {deleteCrossSeeds? "These cross-seeds will also be deleted": deleteFiles? "Deleting files will break these cross-seeds": "Cross-seeds detected — data will be preserved"}
           </p>
           <p className="mt-0.5 text-xs text-muted-foreground">
             {affectedTorrents.length} {affectedTorrents.length === 1 ? "torrent shares" : "torrents share"} these files
             {instanceCount > 1 && ` across ${instanceCount} instances`}
             {uniqueTrackers.size > 0 && (
               <span className="ml-1">
-                on {uniqueTrackers.size === 1
-                  ? Array.from(uniqueTrackers)[0]
-                  : `${uniqueTrackers.size} trackers`}
+                on {uniqueTrackers.size === 1? Array.from(uniqueTrackers)[0]: `${uniqueTrackers.size} trackers`}
               </span>
             )}
-            {deleteCrossSeeds
-              ? " — will be removed along with selection"
-              : deleteFiles
-                ? " — they will need to redownload"
-                : " — unaffected by this removal"}
+            {deleteCrossSeeds? " — will be removed along with selection": deleteFiles? " — they will need to redownload": " — unaffected by this removal"}
           </p>
         </div>
       </div>
@@ -269,9 +253,7 @@ export function CrossSeedWarning({
                         className="flex items-center gap-2 py-0.5 text-xs min-w-0"
                       >
                         <span className="truncate min-w-0 flex-1">
-                          {incognitoMode
-                            ? getLinuxIsoName(torrent.hash)
-                            : torrent.name}
+                          {incognitoMode? getLinuxIsoName(torrent.hash): torrent.name}
                         </span>
                         {trackerDomain && (
                           <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">

--- a/web/src/components/torrents/DeleteFilesPreference.tsx
+++ b/web/src/components/torrents/DeleteFilesPreference.tsx
@@ -46,9 +46,7 @@ export function DeleteFilesPreference({
               onClick={onToggleLock}
               aria-pressed={isLocked}
               aria-label={
-                isLocked
-                  ? "Stop remembering delete files preference"
-                  : "Remember delete files preference"
+                isLocked? "Stop remembering delete files preference": "Remember delete files preference"
               }
               className={cn(
                 "h-8 w-8 text-muted-foreground hover:text-accent-foreground",

--- a/web/src/components/torrents/FilterSidebar.tsx
+++ b/web/src/components/torrents/FilterSidebar.tsx
@@ -209,18 +209,14 @@ const FilterSidebarComponent = ({
   )
   const supportsTrackerHealth = supportsTrackerHealthProp ?? capabilities?.supportsTrackerHealth ?? false
   const supportsTrackerEditing = !isReadOnly && (capabilities?.supportsTrackerEditing ?? false)
-  const supportsSubcategories = isConcreteInstanceScope
-    ? (capabilities?.supportsSubcategories ?? false)
-    : Boolean(useSubcategories)
+  const supportsSubcategories = isConcreteInstanceScope? (capabilities?.supportsSubcategories ?? false): Boolean(useSubcategories)
   const subcategoriesAlwaysEnabled = capabilities?.subcategoriesAlwaysEnabled ?? false
   const { preferences } = useInstancePreferences(
     instanceId,
     { enabled: isConcreteInstanceScope && isInstanceActive }
   )
   const preferenceUseSubcategories = preferences?.use_subcategories
-  const subcategoriesEnabled = isConcreteInstanceScope
-    ? Boolean(supportsSubcategories && (subcategoriesAlwaysEnabled || (preferenceUseSubcategories ?? useSubcategories ?? false)))
-    : Boolean(useSubcategories)
+  const subcategoriesEnabled = isConcreteInstanceScope? Boolean(supportsSubcategories && (subcategoriesAlwaysEnabled || (preferenceUseSubcategories ?? useSubcategories ?? false))): Boolean(useSubcategories)
 
   // View mode syncs with the torrent list (table on desktop, cards on mobile).
   // Desktop supports all modes including "dense" (compact table rows).

--- a/web/src/components/torrents/GlobalStatusBar.tsx
+++ b/web/src/components/torrents/GlobalStatusBar.tsx
@@ -22,7 +22,7 @@ import {
   RefreshCcw,
   Rows3,
   Table as TableIcon,
-  Turtle,
+  Turtle
 } from "lucide-react"
 import { memo, useCallback, useEffect, useMemo, useState } from "react"
 
@@ -31,7 +31,7 @@ import { Button } from "@/components/ui/button"
 import {
   Tooltip,
   TooltipContent,
-  TooltipTrigger,
+  TooltipTrigger
 } from "@/components/ui/tooltip"
 import { usePersistedCompactViewState } from "@/hooks/usePersistedCompactViewState"
 import { api } from "@/lib/api"
@@ -189,9 +189,7 @@ export const GlobalStatusBar = memo(function GlobalStatusBar({
   const isConnectable = normalizedConnectionStatus === "connected"
   const isFirewalled = normalizedConnectionStatus === "firewalled"
   const ConnectionStatusIcon = isConnectable ? Globe : isFirewalled ? BrickWallFire : hasConnectionStatus ? Ban : Globe
-  const connectionStatusTooltip = hasConnectionStatus
-    ? `${isConnectable ? "Connectable" : connectionStatusDisplay}${listenPort ? `. Port: ${listenPort}` : ""}`
-    : "Connection status unknown"
+  const connectionStatusTooltip = hasConnectionStatus? `${isConnectable ? "Connectable" : connectionStatusDisplay}${listenPort ? `. Port: ${listenPort}` : ""}`: "Connection status unknown"
   const connectionStatusIconClass = hasConnectionStatus ? isConnectable ? "text-green-500" : isFirewalled ? "text-amber-500" : "text-destructive" : "text-muted-foreground"
   const connectionStatusAriaLabel = hasConnectionStatus ? `qBittorrent connection status: ${connectionStatusDisplay || formattedConnectionStatus}` : "qBittorrent connection status unknown"
 

--- a/web/src/components/torrents/SelectAllHotkey.tsx
+++ b/web/src/components/torrents/SelectAllHotkey.tsx
@@ -32,9 +32,7 @@ export function SelectAllHotkey({
     }
 
     const platformIsMac =
-      typeof isMac === "boolean"
-        ? isMac
-        : typeof window !== "undefined" &&
+      typeof isMac === "boolean"? isMac: typeof window !== "undefined" &&
           /Mac|iPhone|iPad|iPod/.test(window.navigator.userAgent)
 
     const handleSelectAllHotkey = (event: KeyboardEvent) => {

--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -29,7 +29,7 @@ import {
   SelectContent,
   SelectItem,
   SelectTrigger,
-  SelectValue,
+  SelectValue
 } from "@/components/ui/select"
 import { Progress } from "@/components/ui/progress"
 import { ScrollToTopButton } from "@/components/ui/scroll-to-top-button"
@@ -92,11 +92,11 @@ import {
   SetCategoryDialog,
   SetLocationDialog,
   TagEditorDialog,
-  TmmConfirmDialog,
+  TmmConfirmDialog
 } from "./TorrentDialogs"
 import {
   buildMobileShareLimitInitialState,
-  type MobileShareLimitFormState,
+  type MobileShareLimitFormState
 } from "./mobileShareLimitDialogState"
 import type { TorrentLimitSnapshot } from "./torrentLimitDialogHelpers"
 // import { createPortal } from 'react-dom'
@@ -187,7 +187,7 @@ function MobileShareLimitsDialog({
       seedingTimeEnabled ? seedingTimeLimit : -1,
       inactiveSeedingTimeEnabled ? inactiveSeedingTimeLimit : -1,
       supportsShareLimitsAction && shareLimitAction !== "default" ? shareLimitAction : undefined,
-      supportsShareLimitsMode && shareLimitsMode !== "default" ? shareLimitsMode : undefined,
+      supportsShareLimitsMode && shareLimitsMode !== "default" ? shareLimitsMode : undefined
     )
     resetForm()
   }
@@ -360,7 +360,7 @@ function MobileSpeedLimitsDialog({
   const handleSubmit = () => {
     onConfirm(
       uploadEnabled ? uploadLimit : 0,
-      downloadEnabled ? downloadLimit : 0,
+      downloadEnabled ? downloadLimit : 0
     )
     resetForm()
   }
@@ -1371,15 +1371,11 @@ export function TorrentCardsMobile({
     responseSupport: trackerHealthSupported,
   })
   const supportsTorrentCreation = isAllInstancesView ? false : (capabilities?.supportsTorrentCreation ?? true)
-  const supportsSubcategories = isAllInstancesView
-    ? Boolean(subcategoriesFromData)
-    : (capabilities?.supportsSubcategories ?? false)
+  const supportsSubcategories = isAllInstancesView? Boolean(subcategoriesFromData): (capabilities?.supportsSubcategories ?? false)
   const subcategoriesAlwaysEnabled = capabilities?.subcategoriesAlwaysEnabled ?? false
   // subcategoriesFromData reflects backend/server state; allowSubcategories
   // additionally respects user preferences for UI surfaces like dialogs.
-  const allowSubcategories = isAllInstancesView
-    ? Boolean(subcategoriesFromData)
-    : (supportsSubcategories && (subcategoriesAlwaysEnabled || (preferences?.use_subcategories ?? subcategoriesFromData ?? false)))
+  const allowSubcategories = isAllInstancesView? Boolean(subcategoriesFromData): (supportsSubcategories && (subcategoriesAlwaysEnabled || (preferences?.use_subcategories ?? subcategoriesFromData ?? false)))
 
   const getSelectionIdentity = useCallback((torrent: Torrent): string => {
     if (!isAllInstancesView) {
@@ -1777,9 +1773,7 @@ export function TorrentCardsMobile({
 
   const triggerSelectionAction = useCallback((action: TorrentAction, extra?: Parameters<typeof handleAction>[2]) => {
     const hashes = isAllSelected ? [] : selectedRequestHashes
-    const visibleHashes = isAllSelected
-      ? torrents.filter(t => !excludedFromSelectAll.has(getSelectionIdentity(t))).map(t => t.hash)
-      : selectedRequestHashes
+    const visibleHashes = isAllSelected? torrents.filter(t => !excludedFromSelectAll.has(getSelectionIdentity(t))).map(t => t.hash): selectedRequestHashes
     const clientCount = isAllSelected ? effectiveSelectionCount : selectedActionTargets.length || visibleHashes.length || 1
     const actionTargets = isAllSelected ? undefined : selectedActionTargets
     const excludedTargets = isAllSelected ? buildTorrentActionTargets(excludedTorrents, instanceId) : undefined
@@ -1803,9 +1797,7 @@ export function TorrentCardsMobile({
   }, [triggerSelectionAction])
 
   const handleDeleteWrapper = useCallback(async () => {
-    const deleteActionTargets = torrentToDelete
-      ? buildTorrentActionTargets([torrentToDelete], instanceId)
-      : (isAllSelected ? undefined : selectedActionTargets)
+    const deleteActionTargets = torrentToDelete? buildTorrentActionTargets([torrentToDelete], instanceId): (isAllSelected ? undefined : selectedActionTargets)
 
     const crossSeedTagHashesToBlock = deleteCrossSeeds ? getTorrentHashesWithTag(crossSeedWarning.affectedTorrents, "cross-seed") : []
 
@@ -1867,9 +1859,7 @@ export function TorrentCardsMobile({
         clientHashes: visibleHashesToDelete,
         totalSelected: totalToDelete,
         actionTargets: deleteActionTargets,
-        excludeTargets: !torrentToDelete && isAllSelected
-          ? buildTorrentActionTargets(excludedTorrents, instanceId)
-          : undefined,
+        excludeTargets: !torrentToDelete && isAllSelected? buildTorrentActionTargets(excludedTorrents, instanceId): undefined,
       }
     )
     setTorrentToDelete(null)
@@ -1910,9 +1900,7 @@ export function TorrentCardsMobile({
         clientHashes: visibleHashes,
         totalSelected,
         actionTargets: isAllSelected ? undefined : selectedActionTargets,
-        excludeTargets: isAllSelected
-          ? buildTorrentActionTargets(excludedTorrents, instanceId)
-          : undefined,
+        excludeTargets: isAllSelected? buildTorrentActionTargets(excludedTorrents, instanceId): undefined,
       }
     )
     setActionTorrents([])
@@ -1933,9 +1921,7 @@ export function TorrentCardsMobile({
         clientHashes: visibleHashes,
         totalSelected,
         actionTargets: isAllSelected ? undefined : selectedActionTargets,
-        excludeTargets: isAllSelected
-          ? buildTorrentActionTargets(excludedTorrents, instanceId)
-          : undefined,
+        excludeTargets: isAllSelected? buildTorrentActionTargets(excludedTorrents, instanceId): undefined,
       }
     )
     setActionTorrents([])
@@ -1956,9 +1942,7 @@ export function TorrentCardsMobile({
         clientHashes: visibleHashes,
         totalSelected,
         actionTargets: isAllSelected ? undefined : selectedActionTargets,
-        excludeTargets: isAllSelected
-          ? buildTorrentActionTargets(excludedTorrents, instanceId)
-          : undefined,
+        excludeTargets: isAllSelected? buildTorrentActionTargets(excludedTorrents, instanceId): undefined,
       }
     )
     setActionTorrents([])
@@ -1977,9 +1961,7 @@ export function TorrentCardsMobile({
         clientHashes: visibleHashes,
         totalSelected,
         actionTargets: isAllSelected ? undefined : selectedActionTargets,
-        excludeTargets: isAllSelected
-          ? buildTorrentActionTargets(excludedTorrents, instanceId)
-          : undefined,
+        excludeTargets: isAllSelected? buildTorrentActionTargets(excludedTorrents, instanceId): undefined,
       }
     )
   }, [isAllSelected, selectedRequestHashes, handleTmmConfirm, filters, effectiveSearch, excludedFromSelectAll, torrents, effectiveSelectionCount, instanceId, getSelectionIdentity, excludeHashesForRequest, excludedTorrents, selectedActionTargets])
@@ -2539,9 +2521,7 @@ export function TorrentCardsMobile({
           filters: isAllSelected ? effectiveFilters : undefined,
           search: isAllSelected ? effectiveSearch : undefined,
           excludeHashes: isAllSelected ? excludeHashesForRequest : undefined,
-          excludeTargets: isAllSelected
-            ? buildTorrentActionTargets(excludedTorrents, instanceId)
-            : undefined,
+          excludeTargets: isAllSelected? buildTorrentActionTargets(excludedTorrents, instanceId): undefined,
         }}
         onConfirm={handleTagsWrapper}
         isPending={isPending}
@@ -2584,9 +2564,7 @@ export function TorrentCardsMobile({
               clientHashes: visibleHashes,
               totalSelected,
               actionTargets: isAllSelected ? undefined : selectedActionTargets,
-              excludeTargets: isAllSelected
-                ? buildTorrentActionTargets(excludedTorrents, instanceId)
-                : undefined,
+              excludeTargets: isAllSelected? buildTorrentActionTargets(excludedTorrents, instanceId): undefined,
             },
             shareLimitAction,
             shareLimitsMode
@@ -2618,9 +2596,7 @@ export function TorrentCardsMobile({
               clientHashes: visibleHashes,
               totalSelected,
               actionTargets: isAllSelected ? undefined : selectedActionTargets,
-              excludeTargets: isAllSelected
-                ? buildTorrentActionTargets(excludedTorrents, instanceId)
-                : undefined,
+              excludeTargets: isAllSelected? buildTorrentActionTargets(excludedTorrents, instanceId): undefined,
             }
           )
           setShowSpeedLimitDialog(false)

--- a/web/src/components/torrents/TorrentFileTree.tsx
+++ b/web/src/components/torrents/TorrentFileTree.tsx
@@ -69,9 +69,7 @@ function buildFileTree(
       let node = nodeMap.get(currentPath)
 
       if (!node) {
-        const displayName = incognitoMode && isLeaf
-          ? getLinuxFileName(torrentHash, file.index).split("/").pop() || segment
-          : segment
+        const displayName = incognitoMode && isLeaf? getLinuxFileName(torrentHash, file.index).split("/").pop() || segment: segment
 
         node = {
           id: currentPath,
@@ -386,15 +384,9 @@ export const TorrentFileTree = memo(function TorrentFileTree({
           }
 
           // Folder row
-          const progressPercent = node.totalSize > 0
-            ? (node.totalProgress / node.totalSize) * 100
-            : 0
+          const progressPercent = node.totalSize > 0? (node.totalProgress / node.totalSize) * 100: 0
           const isFolderComplete = progressPercent === 100
-          const checkState: boolean | "indeterminate" = node.selectedCount === 0
-            ? false
-            : node.selectedCount === node.totalCount
-              ? true
-              : "indeterminate"
+          const checkState: boolean | "indeterminate" = node.selectedCount === 0? false: node.selectedCount === node.totalCount? true: "indeterminate"
           const indent = depth * 20 + 4
 
           const handleCheckChange = () => {

--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -1026,13 +1026,9 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
     capabilitySupport: capabilities?.supportsTrackerHealth,
     responseSupport: trackerHealthSupported,
   })
-  const supportsSubcategories = isAllInstancesView
-    ? Boolean(subcategoriesFromData)
-    : (capabilities?.supportsSubcategories ?? false)
+  const supportsSubcategories = isAllInstancesView? Boolean(subcategoriesFromData): (capabilities?.supportsSubcategories ?? false)
   const subcategoriesAlwaysEnabled = capabilities?.subcategoriesAlwaysEnabled ?? false
-  const allowSubcategories = isAllInstancesView
-    ? Boolean(subcategoriesFromData)
-    : (supportsSubcategories && (subcategoriesAlwaysEnabled || (preferences?.use_subcategories ?? subcategoriesFromData ?? false)))
+  const allowSubcategories = isAllInstancesView? Boolean(subcategoriesFromData): (supportsSubcategories && (subcategoriesAlwaysEnabled || (preferences?.use_subcategories ?? subcategoriesFromData ?? false)))
   const availableTags = isCrossInstanceEndpoint ? (tags ?? metadataTags) : metadataTags
   const availableCategories = isCrossInstanceEndpoint ? (categories ?? metadataCategories) : metadataCategories
   const isLoadingTags = isMetadataLoading && availableTags.length === 0

--- a/web/src/components/torrents/details/WebSeedsTable.tsx
+++ b/web/src/components/torrents/details/WebSeedsTable.tsx
@@ -13,7 +13,7 @@ import {
   createColumnHelper,
   flexRender,
   getCoreRowModel,
-  useReactTable,
+  useReactTable
 } from "@tanstack/react-table"
 import { Copy, Loader2, Search, X } from "lucide-react"
 import { memo, useMemo, useState } from "react"
@@ -118,9 +118,7 @@ export const WebSeedsTable = memo(function WebSeedsTable({
           )}
         </div>
         <span className="ml-auto text-muted-foreground">
-          {searchQuery
-            ? `${filteredData.length} of ${webseeds.length}`
-            : `${webseeds.length} HTTP source${webseeds.length !== 1 ? "s" : ""}`}
+          {searchQuery? `${filteredData.length} of ${webseeds.length}`: `${webseeds.length} HTTP source${webseeds.length !== 1 ? "s" : ""}`}
         </span>
       </div>
 

--- a/web/src/components/torrents/mobileShareLimitDialogState.ts
+++ b/web/src/components/torrents/mobileShareLimitDialogState.ts
@@ -8,7 +8,7 @@ import {
   LIMIT_UNLIMITED,
   LIMIT_USE_GLOBAL,
   shareLimitEnumFieldFromTorrents,
-  type TorrentLimitSnapshot,
+  type TorrentLimitSnapshot
 } from "./torrentLimitDialogHelpers"
 
 function numericShareLimitToMobile(
@@ -53,15 +53,9 @@ export function buildMobileShareLimitInitialState(
   const ratioCheck = checkFieldConsistency(torrents, t => t.ratio_limit)
   const seedTimeCheck = checkFieldConsistency(torrents, t => t.seeding_time_limit)
   const inactiveTimeCheck = checkFieldConsistency(torrents, t => t.inactive_seeding_time_limit)
-  const ratio = ratioCheck.isMixed
-    ? { enabled: defaults.ratioEnabled, limit: defaults.ratioLimit }
-    : numericShareLimitToMobile(ratioCheck.commonValue, defaults.ratioLimit)
-  const seedTime = seedTimeCheck.isMixed
-    ? { enabled: defaults.seedingTimeEnabled, limit: defaults.seedingTimeLimit }
-    : numericShareLimitToMobile(seedTimeCheck.commonValue, defaults.seedingTimeLimit)
-  const inactiveTime = inactiveTimeCheck.isMixed
-    ? { enabled: defaults.inactiveSeedingTimeEnabled, limit: defaults.inactiveSeedingTimeLimit }
-    : numericShareLimitToMobile(inactiveTimeCheck.commonValue, defaults.inactiveSeedingTimeLimit)
+  const ratio = ratioCheck.isMixed? { enabled: defaults.ratioEnabled, limit: defaults.ratioLimit }: numericShareLimitToMobile(ratioCheck.commonValue, defaults.ratioLimit)
+  const seedTime = seedTimeCheck.isMixed? { enabled: defaults.seedingTimeEnabled, limit: defaults.seedingTimeLimit }: numericShareLimitToMobile(seedTimeCheck.commonValue, defaults.seedingTimeLimit)
+  const inactiveTime = inactiveTimeCheck.isMixed? { enabled: defaults.inactiveSeedingTimeEnabled, limit: defaults.inactiveSeedingTimeLimit }: numericShareLimitToMobile(inactiveTimeCheck.commonValue, defaults.inactiveSeedingTimeLimit)
   const action = shareLimitEnumFieldFromTorrents(torrents, t => t.share_limit_action)
   const mode = shareLimitEnumFieldFromTorrents(torrents, t => t.share_limits_mode)
 

--- a/web/src/components/ui/calendar.tsx
+++ b/web/src/components/ui/calendar.tsx
@@ -7,7 +7,7 @@ import * as React from "react"
 import {
   ChevronDownIcon,
   ChevronLeftIcon,
-  ChevronRightIcon,
+  ChevronRightIcon
 } from "lucide-react"
 import { DayButton, DayPicker, getDefaultClassNames } from "react-day-picker"
 
@@ -82,9 +82,7 @@ function Calendar({
         ),
         caption_label: cn(
           "select-none font-medium",
-          captionLayout === "label"
-            ? "text-sm"
-            : "[&>svg]:text-muted-foreground flex h-8 items-center gap-1 rounded-md pl-2 pr-1 text-sm [&>svg]:size-3.5",
+          captionLayout === "label"? "text-sm": "[&>svg]:text-muted-foreground flex h-8 items-center gap-1 rounded-md pl-2 pr-1 text-sm [&>svg]:size-3.5",
           defaultClassNames.caption_label
         ),
         table: "w-full border-collapse",

--- a/web/src/components/ui/path-cell.tsx
+++ b/web/src/components/ui/path-cell.tsx
@@ -42,9 +42,7 @@ export function PathCell({ path, className }: PathCellProps) {
         disabled={!hasPath}
         className={cn(
           "flex-shrink-0 p-0.5 rounded transition-colors",
-          hasPath
-            ? "text-muted-foreground hover:text-foreground cursor-pointer"
-            : "text-muted-foreground/40 cursor-not-allowed"
+          hasPath? "text-muted-foreground hover:text-foreground cursor-pointer": "text-muted-foreground/40 cursor-not-allowed"
         )}
         aria-label="Copy path"
         title={hasPath ? "Copy path" : undefined}

--- a/web/src/components/ui/responsive-command-popover.tsx
+++ b/web/src/components/ui/responsive-command-popover.tsx
@@ -191,9 +191,7 @@ const ResponsiveCommandGroup = React.forwardRef<
       ref={ref}
       className={cn(
         "overflow-hidden text-foreground",
-        isMobile
-          ? "py-1 px-2 [&_[cmdk-group-heading]]:px-3 [&_[cmdk-group-heading]]:pt-4 [&_[cmdk-group-heading]]:pb-2 [&_[cmdk-group-heading]]:text-sm [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:text-foreground [&_[cmdk-group-heading]]:border-b [&_[cmdk-group-heading]]:border-border/50 [&_[cmdk-group-heading]]:mb-2"
-          : "p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+        isMobile? "py-1 px-2 [&_[cmdk-group-heading]]:px-3 [&_[cmdk-group-heading]]:pt-4 [&_[cmdk-group-heading]]:pb-2 [&_[cmdk-group-heading]]:text-sm [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:text-foreground [&_[cmdk-group-heading]]:border-b [&_[cmdk-group-heading]]:border-border/50 [&_[cmdk-group-heading]]:mb-2": "p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
         className
       )}
       {...props}
@@ -262,12 +260,8 @@ const ResponsiveCommandItem = React.forwardRef<
       ref={ref}
       className={cn(
         "relative flex cursor-default select-none items-center outline-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50",
-        isMobile
-          ? "min-h-[48px] px-4 py-2.5 text-[15px] rounded-lg"
-          : "px-2 py-1.5 text-sm rounded-sm",
-        disableHighlight
-          ? "data-[selected='true']:bg-transparent"
-          : "data-[selected='true']:bg-accent data-[selected='true']:text-accent-foreground",
+        isMobile? "min-h-[48px] px-4 py-2.5 text-[15px] rounded-lg": "px-2 py-1.5 text-sm rounded-sm",
+        disableHighlight? "data-[selected='true']:bg-transparent": "data-[selected='true']:bg-accent data-[selected='true']:text-accent-foreground",
         className
       )}
       onSelect={handleSelect}

--- a/web/src/hooks/useTitleBarSpeeds.ts
+++ b/web/src/hooks/useTitleBarSpeeds.ts
@@ -76,11 +76,7 @@ export function useTitleBarSpeeds({
   )
   const backgroundSpeeds = backgroundSpeedsOverride ?? backgroundSpeedsQuery
   const cachedBackgroundSpeeds = lastBackgroundSpeedsRef.current
-  const effectiveSpeeds = isHiddenDelayed
-    ? (backgroundSpeeds ?? cachedBackgroundSpeeds)
-    : (isForegroundStale
-      ? (cachedBackgroundSpeeds ?? backgroundSpeeds)
-      : (foregroundSpeeds ?? cachedBackgroundSpeeds ?? backgroundSpeeds))
+  const effectiveSpeeds = isHiddenDelayed? (backgroundSpeeds ?? cachedBackgroundSpeeds): (isForegroundStale? (cachedBackgroundSpeeds ?? backgroundSpeeds): (foregroundSpeeds ?? cachedBackgroundSpeeds ?? backgroundSpeeds))
   const shouldSetTitle = enabled && (isHiddenDelayed || isVisible)
 
   useEffect(() => {

--- a/web/src/hooks/useTorrentActions.ts
+++ b/web/src/hooks/useTorrentActions.ts
@@ -393,12 +393,8 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
         setContextTorrents([])
         const succeeded = error.results.filter(result => result.status === "success").map(result => result.action)
         const failed = error.results.filter(result => result.status === "failed")
-        const succeededLabel = succeeded.length > 0
-          ? `${succeeded.join(" and ")} ${succeeded.length === 1 ? "succeeded" : "succeeded"}`
-          : ""
-        const failedLabel = failed.length > 0
-          ? `${failed.map(result => result.action).join(" and ")} failed`
-          : "tag update failed"
+        const succeededLabel = succeeded.length > 0? `${succeeded.join(" and ")} ${succeeded.length === 1 ? "succeeded" : "succeeded"}`: ""
+        const failedLabel = failed.length > 0? `${failed.map(result => result.action).join(" and ")} failed`: "tag update failed"
         const description = failed
           .map(result => result.error?.message)
           .filter((message): message is string => Boolean(message))

--- a/web/src/hooks/useTorrentsList.ts
+++ b/web/src/hooks/useTorrentsList.ts
@@ -104,9 +104,7 @@ export function useTorrentsList(
     placeholderData: currentPage > 0 ? ((previousData) => previousData) : undefined,
     // Only poll the first page to get fresh data - don't poll pagination pages
     // Reduce polling frequency for cross-instance calls since they're more expensive
-    refetchInterval: currentPage === 0
-      ? (pollingEnabled ? (useCrossInstanceEndpoint ? 10000 : 3000) : false)
-      : false,
+    refetchInterval: currentPage === 0? (pollingEnabled ? (useCrossInstanceEndpoint ? 10000 : 3000) : false): false,
     refetchIntervalInBackground, // Controls background polling behavior
     refetchOnWindowFocus: currentPage === 0,
     enabled: shouldEnableQuery,
@@ -146,9 +144,7 @@ export function useTorrentsList(
     }
 
     // Handle both regular torrents and cross-instance torrents
-    const torrentsData = data.isCrossInstance
-      ? (data.crossInstanceTorrents || data.cross_instance_torrents)
-      : data.torrents
+    const torrentsData = data.isCrossInstance? (data.crossInstanceTorrents || data.cross_instance_torrents): data.torrents
 
     if (!torrentsData) {
       setIsLoadingMore(false)
@@ -249,9 +245,7 @@ export function useTorrentsList(
   const effectiveTotalCount = currentPage > 0 && !data?.total ? lastKnownTotal : (data?.total ?? 0)
 
   const responseUseSubcategories = data?.useSubcategories ?? data?.serverState?.use_subcategories ?? false
-  const supportsSubcategories = isAllInstancesView
-    ? responseUseSubcategories
-    : (capabilities?.supportsSubcategories ?? false)
+  const supportsSubcategories = isAllInstancesView? responseUseSubcategories: (capabilities?.supportsSubcategories ?? false)
 
   return {
     torrents: allTorrents,
@@ -264,9 +258,7 @@ export function useTorrentsList(
     supportsTorrentCreation: isAllInstancesView ? false : capabilities?.supportsTorrentCreation ?? true,
     capabilities: isAllInstancesView ? undefined : capabilities,
     serverState: data?.serverState ?? null,
-    useSubcategories: isAllInstancesView
-      ? responseUseSubcategories
-      : (supportsSubcategories ? responseUseSubcategories : false),
+    useSubcategories: isAllInstancesView? responseUseSubcategories: (supportsSubcategories ? responseUseSubcategories : false),
     isLoading: isLoading && currentPage === 0,
     isFetching,
     isLoadingMore,

--- a/web/src/lib/dodo-constants.ts
+++ b/web/src/lib/dodo-constants.ts
@@ -7,7 +7,5 @@
 // Test checkout URL can be provided via Vite env for local/dev builds:
 // `VITE_DODO_TEST_CHECKOUT_URL="https://test.checkout.dodopayments.com/buy/<product_id>?quantity=1"`
 export const DODO_CHECKOUT_URL =
-  import.meta.env.DEV && import.meta.env.VITE_DODO_TEST_CHECKOUT_URL
-    ? import.meta.env.VITE_DODO_TEST_CHECKOUT_URL
-    : "https://checkout.dodopayments.com/buy/pdt_0NWpVDU3kVcVuB10ycNiQ?quantity=1"
+  import.meta.env.DEV && import.meta.env.VITE_DODO_TEST_CHECKOUT_URL? import.meta.env.VITE_DODO_TEST_CHECKOUT_URL: "https://checkout.dodopayments.com/buy/pdt_0NWpVDU3kVcVuB10ycNiQ?quantity=1"
 export const DODO_PORTAL_URL = "https://customer.dodopayments.com"

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -458,7 +458,7 @@ function InstanceCard({
                       try {
                         localStorage.setItem("qui-filters-global", JSON.stringify({
                           status: ["unregistered"],
-                          excludeStatus: []
+                          excludeStatus: [],
                         }))
                       } catch (error) {
                         console.error("Failed to set filter state:", error)
@@ -479,7 +479,7 @@ function InstanceCard({
                       try {
                         localStorage.setItem("qui-filters-global", JSON.stringify({
                           status: ["tracker_down"],
-                          excludeStatus: []
+                          excludeStatus: [],
                         }))
                       } catch (error) {
                         console.error("Failed to set filter state:", error)
@@ -500,7 +500,7 @@ function InstanceCard({
                       try {
                         localStorage.setItem("qui-filters-global", JSON.stringify({
                           status: ["errored"],
-                          excludeStatus: []
+                          excludeStatus: [],
                         }))
                       } catch (error) {
                         console.error("Failed to set filter state:", error)
@@ -2419,18 +2419,14 @@ export function Dashboard() {
     },
     { dl: 0, up: 0, hasData: false }
   )
-  const backgroundSpeeds = backgroundSpeedsState.hasData
-    ? { dl: backgroundSpeedsState.dl, up: backgroundSpeedsState.up }
-    : undefined
+  const backgroundSpeeds = backgroundSpeedsState.hasData? { dl: backgroundSpeedsState.dl, up: backgroundSpeedsState.up }: undefined
   useTitleBarSpeeds({
     mode: "dashboard",
     enabled: titleBarSpeedsEnabled && hasActiveInstances,
-    foregroundSpeeds: hasActiveInstances
-      ? {
-        dl: globalStats.totalDownload ?? 0,
-        up: globalStats.totalUpload ?? 0,
-      }
-      : undefined,
+    foregroundSpeeds: hasActiveInstances? {
+      dl: globalStats.totalDownload ?? 0,
+      up: globalStats.totalUpload ?? 0,
+    }: undefined,
     backgroundSpeeds: isHiddenDelayed && hasActiveInstances ? backgroundSpeeds : undefined,
   })
 

--- a/web/src/utils/theme.ts
+++ b/web/src/utils/theme.ts
@@ -105,7 +105,7 @@ const applyTheme = async (theme: Theme, variation: string | null, isDark: boolea
 
   // Clean up all variation variables to prevent stale values
   Array.from(root.style)
-    .filter(prop => prop.startsWith('--variation'))
+    .filter(prop => prop.startsWith("--variation"))
     .forEach(prop => root.style.removeProperty(prop));
 
   // Apply theme CSS variables (lightOnly themes always use light vars)
@@ -285,9 +285,7 @@ export const setTheme = async (themeId: string, mode?: ThemeMode, variation?: st
   }
 
   // Validate and store variation
-  const currentVariation = (variation && theme.variations?.includes(variation))
-    ? variation
-    : getThemeVariation(theme.id);
+  const currentVariation = (variation && theme.variations?.includes(variation))? variation: getThemeVariation(theme.id);
 
   if (currentVariation) {
     setStoredVariation(theme.id, currentVariation);
@@ -387,8 +385,8 @@ export const getThemeVariation = (themeId?: string): string | null => {
 // When colorVar is provided, return string
 export function getThemeColors(
   theme: Theme,
-  colorVar: '--primary' | '--secondary' | '--accent',
-  mode?: 'light' | 'dark'
+  colorVar: "--primary" | "--secondary" | "--accent",
+  mode?: "light" | "dark"
 ): string;
 
 // When colorVar is not provided, return object
@@ -403,8 +401,8 @@ export function getThemeColors(
 
 export function getThemeColors(
   theme: Theme,
-  colorVar?: '--primary' | '--secondary' | '--accent',
-  mode?: 'light' | 'dark'
+  colorVar?: "--primary" | "--secondary" | "--accent",
+  mode?: "light" | "dark"
 ): string | {
   primary: string;
   secondary: string;
@@ -412,11 +410,11 @@ export function getThemeColors(
   variations?: Array<{ id: string; color: string }>;
 } {
   // Use passed mode if specified
-  const isDark = mode ? mode === 'dark' : document.documentElement.classList.contains("dark");
+  const isDark = mode ? mode === "dark" : document.documentElement.classList.contains("dark");
   const cssVars = isDark ? theme.cssVars.dark : theme.cssVars.light;
 
   // Helper to resolve variation colors
-  const resolveColor = (varName: '--primary' | '--secondary' | '--accent'): string => {
+  const resolveColor = (varName: "--primary" | "--secondary" | "--accent"): string => {
     const colorValue = cssVars[varName];
 
     if (colorValue === "var(--variation-color)") {
@@ -435,9 +433,9 @@ export function getThemeColors(
 
   // Otherwise return all
   return {
-    primary: resolveColor('--primary'),
-    secondary: resolveColor('--secondary'),
-    accent: resolveColor('--accent'),
+    primary: resolveColor("--primary"),
+    secondary: resolveColor("--secondary"),
+    accent: resolveColor("--accent"),
     variations: theme.variations?.map(varId => ({
       id: varId,
       color: cssVars[`--variation-${varId}`],


### PR DESCRIPTION
## Summary
- Fixes all 180 `@stylistic/multiline-ternary` warnings across 33 files in `web/src/`
- One commit per file, auto-fixed via `eslint --fix` scoped to affected files only
- No logic changes — purely stylistic (collapses multiline ternaries to single-line per the project's `"never"` rule config)
- `pnpm build` and `tsc --noEmit` verified clean after all changes

## Test plan
- [x] Smoke-test hot spot pages in browser (dashboard, instances, settings, cross-seed, search)
- [x] Verify `pnpm lint` shows no new warnings
- [x] Verify `pnpm build` succeeds

Closes #1901

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated conditional-expression formatting across many components and utilities for cleaner code.
  * Centralized outcome badge text generation for activity items.

* **Style**
  * Minor UI text and styling tweaks (cross-seed warning, instance card, various dialogs and controls).
  * Standardized import/list formatting across files.

* **Bug Fixes**
  * Dashboard issue links now set explicit status filters.
  * Improved speed selection logic driving the browser title updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/autobrr/qui/pull/1905?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->