### PR TITLE
fix(crossseed): reuse shared string normalizer to stop goroutine leak

### DIFF
--- a/internal/services/crossseed/matching.go
+++ b/internal/services/crossseed/matching.go
@@ -169,7 +169,13 @@ func normalizerForService(s *Service) *stringutils.Normalizer[string, string] {
 	if s != nil && s.stringNormalizer != nil {
 		return s.stringNormalizer
 	}
-	return stringutils.NewDefaultNormalizer()
+	// Reuse the process-wide singleton instead of allocating a fresh
+	// normalizer here. Every NewDefaultNormalizer() spins up a ttlcache
+	// whose startExpirations goroutine never terminates (the throwaway
+	// cache is never closed), and this is on the cross-seed matching hot
+	// path - one call per release pair - so a fresh allocation leaks a
+	// goroutine on every comparison.
+	return stringutils.DefaultNormalizer
 }
 
 func (s *Service) validateTitleArtistAndDates(source, candidate *rls.Release, sourceName, candidateName string, sourceExtraTitles, candidateExtraTitles []string, isTV bool) (bool, string) {

--- a/internal/services/crossseed/matching_normalizer_leak_test.go
+++ b/internal/services/crossseed/matching_normalizer_leak_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package crossseed
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/moistari/rls"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/pkg/stringutils"
+)
+
+// Regression test for the cross-seed RAM/goroutine explosion introduced in
+// #1687 (season pack support). The matching hot path used to call
+// stringutils.NewDefaultNormalizer() on every release comparison. Each call
+// builds a ttlcache whose startExpirations goroutine never terminates (the
+// throwaway cache is never closed), so cross-seed matching leaked one
+// goroutine per release pair and OOM'd containers overnight.
+
+func TestNormalizerForService_ReusesSharedSingleton(t *testing.T) {
+	// A Service without an explicit normalizer must fall back to the
+	// process-wide singleton, not allocate a fresh (leaking) one.
+	require.Same(t, stringutils.DefaultNormalizer, normalizerForService(nil))
+	require.Same(t, stringutils.DefaultNormalizer, normalizerForService(&Service{}))
+
+	// Explicit per-service normalizer is still honored.
+	custom := stringutils.NewDefaultNormalizer()
+	require.Same(t, custom, normalizerForService(&Service{stringNormalizer: custom}))
+}
+
+func TestReleasesMatch_DoesNotLeakGoroutines(t *testing.T) {
+	// Service with nil stringNormalizer: this is the path that previously
+	// allocated and leaked a ttlcache goroutine on every comparison.
+	s := &Service{}
+
+	source := rls.ParseString("Some.Show.S01.1080p.WEB-DL.DDP5.1.H.264-GROUP")
+	candidate := rls.ParseString("Some.Show.S01.1080p.WEB-DL.DDP5.1.H.264-GROUP")
+
+	// Warm up any one-time allocations before sampling.
+	for range 50 {
+		s.releasesMatch(&source, &candidate, false)
+	}
+	runtime.GC()
+	before := runtime.NumGoroutine()
+
+	const iterations = 5000
+	for range iterations {
+		s.releasesMatch(&source, &candidate, false)
+	}
+	runtime.GC()
+	after := runtime.NumGoroutine()
+
+	// Before the fix this grew by ~iterations (one leaked startExpirations
+	// goroutine per call). Allow a small slack for unrelated runtime/test
+	// goroutines.
+	require.LessOrEqualf(t, after-before, 10,
+		"goroutine count grew by %d over %d match calls - normalizer cache is leaking",
+		after-before, iterations)
+}

--- a/internal/services/crossseed/seasonpack.go
+++ b/internal/services/crossseed/seasonpack.go
@@ -667,7 +667,9 @@ func seasonPackNormalizer(s *Service) *stringutils.Normalizer[string, string] {
 	if s != nil && s.stringNormalizer != nil {
 		return s.stringNormalizer
 	}
-	return stringutils.NewDefaultNormalizer()
+	// Shared singleton: see normalizerForService - a fresh normalizer
+	// leaks a never-terminating ttlcache goroutine.
+	return stringutils.DefaultNormalizer
 }
 
 func parseSeasonPackEpisodePayload(
@@ -987,7 +989,7 @@ func (s *Service) matchEpisodeCandidatesDetailed(
 	candidates := make(map[episodeIdentity][]episodeMatch)
 	matcher := s
 	if matcher.stringNormalizer == nil {
-		matcher = &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
+		matcher = &Service{stringNormalizer: stringutils.DefaultNormalizer}
 	}
 
 	for i := range cached {

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -5341,7 +5341,7 @@ func (s *Service) selectContentDetectionRelease(torrentName string, sourceReleas
 
 	normalizer := s.stringNormalizer
 	if normalizer == nil {
-		normalizer = stringutils.NewDefaultNormalizer()
+		normalizer = stringutils.DefaultNormalizer
 	}
 
 	sourceTitle := normalizeLowerTrim(sourceRelease.Title)

--- a/internal/services/crossseed/source_release_inference.go
+++ b/internal/services/crossseed/source_release_inference.go
@@ -78,7 +78,7 @@ func mergeSeasonPackSearchStructure(sourceRelease, inferredRelease *rls.Release)
 func (s *Service) inferTVSeriesEpisodeFromFiles(torrentRelease *rls.Release, files qbt.TorrentFiles) (series, episode int, isPack, ok bool) {
 	normalizer := s.stringNormalizer
 	if normalizer == nil {
-		normalizer = stringutils.NewDefaultNormalizer()
+		normalizer = stringutils.DefaultNormalizer
 	}
 
 	type seriesInfo struct {


### PR DESCRIPTION
A likely cause of the recent high-RAM / OOM reports on `develop`. The cross-seed matching hot path (`releasesMatch` and friends) was calling `stringutils.NewDefaultNormalizer()` on every release comparison. Each call builds a `ttlcache` whose `startExpirations` goroutine never terminates because the throwaway cache is never closed, so a goroutine and its retained cache leak on every comparison. Since matching runs once per (source, candidate) pair across the whole library and cross-seed runs continuously, this accumulates fast and matches the symptoms reported (growth overnight, quick re-accumulation after restart, stable after reverting). The per-call allocation was introduced in #1687 (`feat(cross-seed): add season pack support`, commit `62bf1181f`), in `internal/services/crossseed/matching.go` — it shipped in the dev build and is absent from the previous tag users reverted to.

The fix reuses the existing process-wide `stringutils.DefaultNormalizer` singleton in the nil-fallback paths instead of allocating per call — same transform and TTL, no behavior change, no leak. A regression test asserts goroutine count stays flat across many match calls (it fails on the old code with ~7 leaked goroutines per comparison). This needs confirmation from affected users running a build of this branch before we can be sure it's the actual cause rather than a contributing one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized cross-seed matching and related string normalization operations to reduce memory allocation and initialization overhead on hot paths.

* **Tests**
  * Added regression tests to verify normalizer reuse and detect potential goroutine leaks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/autobrr/qui/pull/1909?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->