### PR TITLE
fix(web): select-all bulk actions delete more torrents than visible when filters are stacked

### DIFF
--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -1657,7 +1657,13 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
       return undefined
     }
 
-    const combinedExpr = columnFiltersExpr ?? filters?.expr
+    // Combine both column filters and filter expressions (e.g. cross-seed hash filters)
+    // so select-all operations target exactly the visible set.
+    // Using ?? here would drop filters.expr when columnFiltersExpr is present,
+    // causing bulk actions to match more torrents than the user sees.
+    const combinedExpr = (columnFiltersExpr && filters?.expr)
+      ? `(${columnFiltersExpr}) && (${filters.expr})`
+      : (columnFiltersExpr || filters?.expr)
 
     if (filters) {
       return {


### PR DESCRIPTION
## Summary
- `selectAllFilters` used `??` to pick between `columnFiltersExpr` and `filters.expr`, dropping the cross-seed hash expression when a column filter (e.g. save path) was also present
- Bulk actions like delete then matched all torrents in the column filter instead of only the visible cross-seed subset
- Combines both expressions with `&&` when both are present, matching the pattern already used by `combinedFiltersExpr` for data fetching

## Test plan
- [x] Filter torrents by save path (column filter)
- [x] Right-click a torrent → filter cross seeds (narrows visible set)
- [x] Select all → delete → confirm only the visible cross-seed torrents are deleted, not all torrents at the save path

Fixes #1925

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the "select all" action in the torrents table would ignore active column filters, ensuring all filters are now properly applied when selecting items.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/autobrr/qui/pull/1926?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->