### PR TITLE
feat(torrents): set comment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/andybalholm/brotli v1.2.1
 	github.com/autobrr/autobrr v1.77.0
 	github.com/autobrr/go-mediainfo v0.3.1
-	github.com/autobrr/go-qbittorrent v1.16.0
+	github.com/autobrr/go-qbittorrent v1.16.1-0.20260521092945-5b80e52f527d
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/coreos/go-oidc/v3 v3.18.0

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/autobrr/autobrr v1.77.0 h1:0SNa9g2mk5Qe92vHOt0eJJz7VHB515R/BZyy1fCzik
 github.com/autobrr/autobrr v1.77.0/go.mod h1:GstQT2UumxQE54ECtjl5jwdzenaGFzvWxVNEVoLWH4E=
 github.com/autobrr/go-mediainfo v0.3.1 h1:4gT1qoIKp4e+9X7PA/YO53lEkylY+GubFhCl8u8o1R4=
 github.com/autobrr/go-mediainfo v0.3.1/go.mod h1:xVXgHDAYYpIeGQCQCdTBpoiY/O3tojJfflK+rrbzclQ=
-github.com/autobrr/go-qbittorrent v1.16.0 h1:H0zwzLOaCxvJTxJ3xe4+hV3rFSuxucsgKQxsGHydXCU=
-github.com/autobrr/go-qbittorrent v1.16.0/go.mod h1:s36a75VlatWPpHI+pNg4Ta6eB3fRxQvTZPfgMtOsQfY=
+github.com/autobrr/go-qbittorrent v1.16.1-0.20260521092945-5b80e52f527d h1:P3KMTh8FwTGgzr1dSxezDFniJWmNQ1RcKWSaBaPYSI4=
+github.com/autobrr/go-qbittorrent v1.16.1-0.20260521092945-5b80e52f527d/go.mod h1:s36a75VlatWPpHI+pNg4Ta6eB3fRxQvTZPfgMtOsQfY=
 github.com/autobrr/rls v0.8.0 h1:Odz78o5nfrO4hsQ17qiuyKYtiG97+Cs5nrD9TFk8/lI=
 github.com/autobrr/rls v0.8.0/go.mod h1:11YJWgNe5H+UQrfFaNGjnkEy0OEsMFnmV4IL2tRKpPk=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=

--- a/internal/api/handlers/capabilities.go
+++ b/internal/api/handlers/capabilities.go
@@ -14,6 +14,7 @@ type InstanceCapabilitiesResponse struct {
 	SupportsTorrentCreation     bool   `json:"supportsTorrentCreation"`
 	SupportsTorrentExport       bool   `json:"supportsTorrentExport"`
 	SupportsSetTags             bool   `json:"supportsSetTags"`
+	SupportsSetComment          bool   `json:"supportsSetComment"`
 	SupportsTrackerHealth       bool   `json:"supportsTrackerHealth"`
 	SupportsTrackerEditing      bool   `json:"supportsTrackerEditing"`
 	SupportsRenameTorrent       bool   `json:"supportsRenameTorrent"`
@@ -37,6 +38,7 @@ func NewInstanceCapabilitiesResponse(client *internalqbittorrent.Client) Instanc
 		SupportsTorrentCreation:     client.SupportsTorrentCreation(),
 		SupportsTorrentExport:       client.SupportsTorrentExport(),
 		SupportsSetTags:             client.SupportsSetTags(),
+		SupportsSetComment:          client.SupportsSetComment(),
 		SupportsTrackerHealth:       client.SupportsTrackerHealth(),
 		SupportsTrackerEditing:      client.SupportsTrackerEditing(),
 		SupportsRenameTorrent:       client.SupportsRenameTorrent(),

--- a/internal/api/handlers/torrents.go
+++ b/internal/api/handlers/torrents.go
@@ -1120,6 +1120,7 @@ type BulkActionRequest struct {
 	Action                   string                     `json:"action"`
 	DeleteFiles              bool                       `json:"deleteFiles,omitempty"`              // For delete action
 	Tags                     string                     `json:"tags,omitempty"`                     // For tag operations (comma-separated)
+	Comment                  string                     `json:"comment,omitempty"`                  // For setComment action
 	Category                 string                     `json:"category,omitempty"`                 // For category operations
 	Enable                   bool                       `json:"enable,omitempty"`                   // For toggleAutoTMM action
 	SelectAll                bool                       `json:"selectAll,omitempty"`                // When true, apply to all torrents matching filters
@@ -1368,7 +1369,7 @@ func (h *TorrentsHandler) BulkAction(w http.ResponseWriter, r *http.Request) {
 	validActions := []string{
 		"pause", "resume", "delete", "deleteWithFiles",
 		"recheck", "reannounce", "increasePriority", "decreasePriority",
-		"topPriority", "bottomPriority", "addTags", "removeTags", "setTags", "setCategory",
+		"topPriority", "bottomPriority", "addTags", "removeTags", "setTags", "setComment", "setCategory",
 		"toggleAutoTMM", "forceStart", "setShareLimit", "setUploadLimit", "setDownloadLimit", "setLocation",
 		"editTrackers", "addTrackers", "removeTrackers", "toggleSequentialDownload",
 	}
@@ -1646,6 +1647,8 @@ func (h *TorrentsHandler) executeBulkActionForInstance(ctx context.Context, inst
 	case "setTags":
 		// allow empty tags to clear all tags from torrents
 		return h.syncManager.SetTags(ctx, instanceID, hashes, req.Tags)
+	case "setComment":
+		return h.syncManager.SetComment(ctx, instanceID, hashes, req.Comment)
 	case "setCategory":
 		return h.syncManager.SetCategory(ctx, instanceID, hashes, req.Category)
 	case "toggleAutoTMM":

--- a/internal/qbittorrent/client.go
+++ b/internal/qbittorrent/client.go
@@ -19,6 +19,7 @@ import (
 
 var (
 	setTagsMinVersion                    = semver.MustParse("2.11.4")
+	setCommentMinVersion                 = semver.MustParse("2.12.1")
 	torrentCreationMinVersion            = semver.MustParse("2.11.2")
 	exportTorrentMinVersion              = semver.MustParse("2.8.11")
 	trackerEditingMinVersion             = semver.MustParse("2.2.0")
@@ -41,6 +42,7 @@ type Client struct {
 	instanceID                 int
 	webAPIVersion              string
 	supportsSetTags            bool
+	supportsSetComment         bool
 	supportsTorrentCreation    bool
 	supportsTorrentExport      bool
 	supportsTrackerEditing     bool
@@ -153,6 +155,7 @@ func NewClientWithTimeout(instanceID int, instanceHost, username, password, apiK
 		Str("host", instanceHost).
 		Str("webAPIVersion", client.GetWebAPIVersion()).
 		Bool("supportsSetTags", client.SupportsSetTags()).
+		Bool("supportsSetComment", client.SupportsSetComment()).
 		Bool("supportsTorrentCreation", client.SupportsTorrentCreation()).
 		Bool("supportsTorrentExport", client.SupportsTorrentExport()).
 		Bool("supportsTrackerEditing", client.SupportsTrackerEditing()).
@@ -263,6 +266,7 @@ func (c *Client) applyCapabilitiesLocked(version string) {
 	}
 
 	c.supportsSetTags = !v.LessThan(setTagsMinVersion)
+	c.supportsSetComment = !v.LessThan(setCommentMinVersion)
 	c.supportsTorrentCreation = !v.LessThan(torrentCreationMinVersion)
 	c.supportsTorrentExport = !v.LessThan(exportTorrentMinVersion)
 	c.supportsTrackerEditing = !v.LessThan(trackerEditingMinVersion)
@@ -388,6 +392,12 @@ func (c *Client) SupportsSetTags() bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.supportsSetTags
+}
+
+func (c *Client) SupportsSetComment() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.supportsSetComment
 }
 
 func (c *Client) SupportsTrackerHealth() bool {

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -5310,6 +5310,29 @@ func (sm *SyncManager) SetTags(ctx context.Context, instanceID int, hashes []str
 	return nil
 }
 
+// SetComment sets the comment on the specified torrents (qBittorrent 5.2+, Web API 2.12.1+).
+func (sm *SyncManager) SetComment(ctx context.Context, instanceID int, hashes []string, comment string) error {
+	client, err := sm.clientPool.GetClient(ctx, instanceID)
+	if err != nil {
+		return fmt.Errorf("failed to get client: %w", err)
+	}
+
+	if !client.SupportsSetComment() {
+		return fmt.Errorf("set comment requires qBittorrent 5.2 and Web API 2.12.1 or newer (current: %s)", client.GetWebAPIVersion())
+	}
+
+	if err := sm.validateTorrentsExist(client, hashes, "set comment"); err != nil {
+		return err
+	}
+
+	if err := client.SetCommentCtx(ctx, hashes, comment); err != nil {
+		return err
+	}
+
+	sm.syncAfterModification(instanceID, client, "set_comment")
+	return nil
+}
+
 // SetCategory sets the category for the specified torrents
 func (sm *SyncManager) SetCategory(ctx context.Context, instanceID int, hashes []string, category string) error {
 	// Get client and sync manager

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -1566,6 +1566,7 @@ paths:
                     - addTags
                     - removeTags
                     - setTags
+                    - setComment
                     - setCategory
                     - toggleAutoTMM
                     - setShareLimit
@@ -1582,6 +1583,9 @@ paths:
                 tags:
                   type: string
                   description: Comma-separated list of tags for tag-related actions.
+                comment:
+                  type: string
+                  description: Comment text for setComment action (empty clears the comment).
                 category:
                   type: string
                   description: Category name for setCategory action.
@@ -5770,6 +5774,9 @@ components:
         supportsSetTags:
           type: boolean
           description: Whether the instance supports replacing tags on torrents.
+        supportsSetComment:
+          type: boolean
+          description: Whether the instance supports setting torrent comments (Web API 2.12.1+, qBittorrent 5.2+).
         supportsTrackerHealth:
           type: boolean
           description: Whether the instance exposes tracker health metadata (unregistered/tracker down states).

--- a/web/src/components/torrents/TorrentContextMenu.tsx
+++ b/web/src/components/torrents/TorrentContextMenu.tsx
@@ -22,7 +22,7 @@ import { buildTorrentActionTargets } from "@/lib/torrent-action-targets"
 import { getTorrentDisplayHash } from "@/lib/torrent-utils"
 import { copyTextToClipboard } from "@/lib/utils"
 import type { Category, ExternalProgram, InstanceCapabilities, Torrent, TorrentFilters } from "@/types"
-import { useMutation, useQuery } from "@tanstack/react-query"
+import { useMutation, useQueries, useQuery } from "@tanstack/react-query"
 import {
   Blocks,
   CheckCircle,
@@ -139,6 +139,26 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
   [useSelection, selectedTorrents, torrent]
   )
   const actionTargets = useMemo(() => buildTorrentActionTargets(torrents, _instanceId), [torrents, _instanceId])
+
+  const targetInstanceIds = useMemo(() => {
+    const ids = new Set<number>()
+    for (const target of actionTargets) {
+      if (target.instanceId > 0) {
+        ids.add(target.instanceId)
+      }
+    }
+    return Array.from(ids).sort((a, b) => a - b)
+  }, [actionTargets])
+
+  const shouldResolveSetCommentSupport = capabilities === undefined && _instanceId <= 0 && targetInstanceIds.length > 0
+  const setCommentCapabilityQueries = useQueries({
+    queries: targetInstanceIds.map(id => ({
+      queryKey: ["instance-capabilities", id],
+      queryFn: () => api.getInstanceCapabilities(id),
+      staleTime: 60_000,
+      enabled: shouldResolveSetCommentSupport,
+    })),
+  })
 
   const count = isAllSelected ? effectiveSelectionCount : hashes.length
 
@@ -351,7 +371,11 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
   }, [onPrepareLocation, hashes, torrents, count])
 
   const supportsTorrentExport = capabilities?.supportsTorrentExport ?? true
-  const supportsSetComment = capabilities?.supportsSetComment ?? false
+  const supportsSetComment = capabilities?.supportsSetComment ?? (
+    shouldResolveSetCommentSupport
+      ? setCommentCapabilityQueries.some(query => query.data?.supportsSetComment === true)
+      : false
+  )
   const supportsInstanceScopedActions = _instanceId > 0
 
   return (

--- a/web/src/components/torrents/TorrentContextMenu.tsx
+++ b/web/src/components/torrents/TorrentContextMenu.tsx
@@ -32,6 +32,7 @@ import {
   FolderOpen,
   Gauge,
   GitBranch,
+  MessageSquare,
   Pause,
   Play,
   Radio,
@@ -63,6 +64,7 @@ interface TorrentContextMenuProps {
   onAction: (action: TorrentAction, hashes: string[], options?: { enable?: boolean; targets?: Array<{ instanceId: number; hash: string }> }) => void
   onPrepareDelete: (hashes: string[], torrents?: Torrent[]) => void
   onPrepareTags: (hashes: string[], torrents?: Torrent[]) => void
+  onPrepareComment?: (hashes: string[], torrents?: Torrent[]) => void
   onPrepareCategory: (hashes: string[], torrents?: Torrent[]) => void
   onPrepareCreateCategory: (hashes: string[], torrents?: Torrent[]) => void
   onPrepareShareLimit: (hashes: string[], torrents?: Torrent[]) => void
@@ -100,6 +102,7 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
   onAction,
   onPrepareDelete,
   onPrepareTags,
+  onPrepareComment,
   onPrepareShareLimit,
   onPrepareSpeedLimits,
   onPrepareRecheck,
@@ -348,6 +351,7 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
   }, [onPrepareLocation, hashes, torrents, count])
 
   const supportsTorrentExport = capabilities?.supportsTorrentExport ?? true
+  const supportsSetComment = capabilities?.supportsSetComment ?? false
   const supportsInstanceScopedActions = _instanceId > 0
 
   return (
@@ -531,6 +535,15 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
                 isPending={isPending}
                 capabilities={capabilities}
               />
+            )}
+            {supportsSetComment && onPrepareComment && (
+              <ContextMenuItem
+                onClick={() => onPrepareComment(hashes, torrents)}
+                disabled={isPending}
+              >
+                <MessageSquare className="mr-2 h-4 w-4" />
+                Set Comment {count > 1 ? `(${count})` : ""}
+              </ContextMenuItem>
             )}
             <ContextMenuSeparator />
             <ContextMenuItem

--- a/web/src/components/torrents/TorrentDetailsPanel.tsx
+++ b/web/src/components/torrents/TorrentDetailsPanel.tsx
@@ -920,7 +920,7 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
                             {displayCreatedBy && (
                               <div className="space-y-1">
                                 <p className="text-xs text-muted-foreground">Created By</p>
-                                <div className="text-xs">{renderTextWithLinks(displayCreatedBy)}</div>
+                                <p className="text-xs">{renderTextWithLinks(displayCreatedBy)}</p>
                               </div>
                             )}
 
@@ -928,7 +928,7 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
                             {displayComment && (
                               <div className="space-y-1">
                                 <p className="text-xs text-muted-foreground">Comment</p>
-                                <div className="text-xs">{renderTextWithLinks(displayComment)}</div>
+                                <p className="font-mono text-xs whitespace-pre-wrap break-words">{renderTextWithLinks(displayComment)}</p>
                               </div>
                             )}
                           </div>

--- a/web/src/components/torrents/TorrentDialogs.tsx
+++ b/web/src/components/torrents/TorrentDialogs.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Switch } from "@/components/ui/switch"
 import { api } from "@/lib/api"
@@ -633,6 +634,131 @@ interface RenameTorrentDialogProps {
   onConfirm: (name: string) => void | Promise<void>
   isPending?: boolean
 }
+
+interface SetCommentDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  hashCount: number
+  instanceId: number
+  torrentHash?: string
+  onConfirm: (comment: string) => void | Promise<void>
+  isPending?: boolean
+}
+
+export const SetCommentDialog = memo(function SetCommentDialog({
+  open,
+  onOpenChange,
+  hashCount,
+  instanceId,
+  torrentHash,
+  onConfirm,
+  isPending = false,
+}: SetCommentDialogProps) {
+  const [comment, setComment] = useState("")
+  const [isLoadingComment, setIsLoadingComment] = useState(false)
+  const wasOpen = useRef(false)
+
+  const focusCommentField = useCallback(() => {
+    setTimeout(() => document.getElementById("torrentComment")?.focus({ preventScroll: true }), 0)
+  }, [])
+
+  useEffect(() => {
+    if (!open) {
+      setComment("")
+      setIsLoadingComment(false)
+      wasOpen.current = false
+      return
+    }
+
+    const didOpen = !wasOpen.current
+    wasOpen.current = true
+
+    if (!didOpen || hashCount !== 1 || !torrentHash) {
+      setComment("")
+      setIsLoadingComment(false)
+      if (didOpen) {
+        focusCommentField()
+      }
+      return
+    }
+
+    let cancelled = false
+    setIsLoadingComment(true)
+
+    void api.getTorrentProperties(instanceId, torrentHash).then((properties) => {
+      if (cancelled) {
+        return
+      }
+      setComment(properties.comment ?? "")
+      setIsLoadingComment(false)
+      focusCommentField()
+    }).catch(() => {
+      if (cancelled) {
+        return
+      }
+      setComment("")
+      setIsLoadingComment(false)
+      focusCommentField()
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [open, hashCount, instanceId, torrentHash, focusCommentField])
+
+  const handleConfirm = useCallback(() => {
+    onConfirm(comment)
+  }, [comment, onConfirm])
+
+  const handleClose = useCallback((nextOpen: boolean) => {
+    if (!nextOpen) {
+      setComment("")
+    }
+    onOpenChange(nextOpen)
+  }, [onOpenChange])
+
+  const countLabel = hashCount > 1 ? ` (${hashCount})` : ""
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Set Comment{countLabel}</DialogTitle>
+          <DialogDescription>
+            {hashCount > 1
+              ? "Apply the same comment to all selected torrents. Leave empty to clear comments."
+              : "Set the torrent comment shown in qBittorrent. Leave empty to clear the comment."}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="py-4 space-y-2">
+          <Label htmlFor="torrentComment">Comment</Label>
+          <Textarea
+            id="torrentComment"
+            value={comment}
+            onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setComment(e.target.value)}
+            placeholder={isLoadingComment ? "Loading current comment..." : "Enter comment"}
+            disabled={isPending || isLoadingComment}
+          />
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => handleClose(false)} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button onClick={handleConfirm} disabled={isPending || isLoadingComment}>
+            {isPending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Saving...
+              </>
+            ) : (
+              "Save"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+})
 
 export const RenameTorrentDialog = memo(function RenameTorrentDialog({
   open,

--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -125,6 +125,7 @@ import {
   SetCategoryDialog,
   SetLocationDialog,
   TagEditorDialog,
+  SetCommentDialog,
   ShareLimitDialog,
   SpeedLimitsDialog,
   TmmConfirmDialog
@@ -768,6 +769,8 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
     setDeleteCrossSeeds,
     showTagsDialog,
     setShowTagsDialog,
+    showCommentDialog,
+    setShowCommentDialog,
     showCategoryDialog,
     setShowCategoryDialog,
     showCreateCategoryDialog,
@@ -799,6 +802,7 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
     handleAction,
     handleDelete,
     handleUpdateTags,
+    handleSetComment,
     handleSetCategory,
     handleSetLocation,
     handleRenameTorrent,
@@ -812,6 +816,7 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
     proceedToLocationDialog,
     prepareDeleteAction,
     prepareTagsAction,
+    prepareCommentAction,
     prepareCategoryAction,
     prepareCreateCategoryAction,
     prepareShareLimitAction,
@@ -2157,6 +2162,18 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
     shouldBlockCrossSeeds,
   ])
 
+  const handleSetCommentWrapper = useCallback((comment: string) => {
+    handleSetComment(
+      comment,
+      contextHashes,
+      isAllSelected,
+      normalizedSelectionFilters ?? selectAllFilters ?? filters,
+      effectiveSearch,
+      selectAllExcludeHashes,
+      contextClientMeta
+    )
+  }, [handleSetComment, contextHashes, isAllSelected, normalizedSelectionFilters, selectAllFilters, filters, effectiveSearch, selectAllExcludeHashes, contextClientMeta])
+
   const handleTagsWrapper = useCallback((plan: Parameters<typeof handleUpdateTags>[0]) => {
     handleUpdateTags(
       plan,
@@ -2697,6 +2714,7 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
                         onAction={runAction}
                         onPrepareDelete={prepareDeleteAction}
                         onPrepareTags={prepareTagsAction}
+                        onPrepareComment={prepareCommentAction}
                         onPrepareCategory={prepareCategoryAction}
                         onPrepareCreateCategory={prepareCreateCategoryAction}
                         onPrepareShareLimit={prepareShareLimitAction}
@@ -2847,6 +2865,7 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
                       onAction={runAction}
                       onPrepareDelete={prepareDeleteAction}
                       onPrepareTags={prepareTagsAction}
+                      onPrepareComment={prepareCommentAction}
                       onPrepareCategory={prepareCategoryAction}
                       onPrepareCreateCategory={prepareCreateCategoryAction}
                       onPrepareShareLimit={prepareShareLimitAction}
@@ -3031,6 +3050,20 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
           onDeleteCrossSeedsChange={setDeleteCrossSeeds}
           crossSeedWarning={crossSeedWarning}
           onConfirm={handleDeleteWrapper}
+        />
+
+        <SetCommentDialog
+          open={showCommentDialog}
+          onOpenChange={setShowCommentDialog}
+          hashCount={isAllSelected ? effectiveSelectionCount : contextHashes.length}
+          instanceId={
+            contextTorrents.length === 1
+              ? ((contextTorrents[0] as CrossInstanceTorrent).instanceId ?? instanceId)
+              : instanceId
+          }
+          torrentHash={contextHashes.length === 1 ? contextHashes[0] : undefined}
+          onConfirm={handleSetCommentWrapper}
+          isPending={isPending}
         />
 
         <TagEditorDialog

--- a/web/src/components/torrents/details/GeneralTabHorizontal.tsx
+++ b/web/src/components/torrents/details/GeneralTabHorizontal.tsx
@@ -140,7 +140,7 @@ export const GeneralTabHorizontal = memo(function GeneralTabHorizontal({
       <div className="p-3">
         {/* Row 1: Name + Size */}
         <div className="grid grid-cols-2 gap-6 h-5">
-          <div className="flex items-center gap-2 min-w-0">
+          <div className="flex items-start gap-2 min-w-0">
             <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground shrink-0 whitespace-nowrap">
               Name:
             </span>
@@ -158,7 +158,7 @@ export const GeneralTabHorizontal = memo(function GeneralTabHorizontal({
               </Button>
             )}
           </div>
-          <div className="flex items-center gap-2 min-w-0">
+          <div className="flex items-start gap-2 min-w-0">
             <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground shrink-0 whitespace-nowrap">
               Size:
             </span>
@@ -170,7 +170,7 @@ export const GeneralTabHorizontal = memo(function GeneralTabHorizontal({
 
         {/* Row 2: Hash v1 + Hash v2 */}
         <div className="grid grid-cols-2 gap-6 h-5">
-          <div className="flex items-center gap-2 min-w-0">
+          <div className="flex items-start gap-2 min-w-0">
             <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground shrink-0 whitespace-nowrap">
               Hash v1:
             </span>
@@ -189,7 +189,7 @@ export const GeneralTabHorizontal = memo(function GeneralTabHorizontal({
             )}
           </div>
           {displayInfohashV2 && (
-            <div className="flex items-center gap-2 min-w-0">
+            <div className="flex items-start gap-2 min-w-0">
               <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground shrink-0 whitespace-nowrap">
                 Hash v2:
               </span>
@@ -210,7 +210,7 @@ export const GeneralTabHorizontal = memo(function GeneralTabHorizontal({
 
         {/* Row 3: Save Path + Temp Path (if enabled) */}
         <div className="grid grid-cols-2 gap-6 h-5">
-          <div className="flex items-center gap-2 min-w-0">
+          <div className="flex items-start gap-2 min-w-0">
             <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground shrink-0 whitespace-nowrap">
               Save Path:
             </span>
@@ -229,7 +229,7 @@ export const GeneralTabHorizontal = memo(function GeneralTabHorizontal({
             )}
           </div>
           {tempPathEnabled && displayTempPath ? (
-            <div className="flex items-center gap-2 min-w-0">
+            <div className="flex items-start gap-2 min-w-0">
               <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground shrink-0 whitespace-nowrap">
                 Temp Path:
               </span>
@@ -251,23 +251,23 @@ export const GeneralTabHorizontal = memo(function GeneralTabHorizontal({
 
         {/* Row 4: Comment & Created By */}
         {(displayComment) && (
-          <div className="grid grid-cols-2 gap-6 h-5">
+          <div className="grid grid-cols-2 gap-6">
             {displayComment && (
-              <div className="flex items-center gap-2 min-w-0">
+              <div className="flex items-start gap-2 min-w-0">
                 <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground shrink-0 whitespace-nowrap">
                   Comment:
                 </span>
-                <span className="text-xs text-muted-foreground truncate" title={displayComment}>
+                <span className="min-w-0 flex-1 font-mono text-xs text-muted-foreground whitespace-pre-wrap break-words">
                   {renderTextWithLinks(displayComment)}
                 </span>
               </div>
             )}
             {displayCreatedBy && (
-              <div className="flex items-center gap-2 min-w-0">
+              <div className="flex items-start gap-2 min-w-0">
                 <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground shrink-0 whitespace-nowrap">
                   Created By:
                 </span>
-                <span className="text-xs text-muted-foreground truncate" title={displayCreatedBy}>
+                <span className="min-w-0 flex-1 text-xs text-muted-foreground truncate" title={displayCreatedBy}>
                   {renderTextWithLinks(displayCreatedBy)}
                 </span>
               </div>

--- a/web/src/hooks/useTorrentActions.ts
+++ b/web/src/hooks/useTorrentActions.ts
@@ -26,6 +26,7 @@ export const TORRENT_ACTIONS = {
   ADD_TAGS: "addTags",
   REMOVE_TAGS: "removeTags",
   SET_TAGS: "setTags",
+  SET_COMMENT: "setComment",
   SET_CATEGORY: "setCategory",
   TOGGLE_AUTO_TMM: "toggleAutoTMM",
   FORCE_START: "forceStart",
@@ -58,6 +59,7 @@ interface TorrentActionData {
   targets?: Array<{ instanceId: number; hash: string }>
   deleteFiles?: boolean
   tags?: string
+  comment?: string
   category?: string
   enable?: boolean
   ratioLimit?: number
@@ -138,6 +140,7 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
   const { blockCrossSeeds, setBlockCrossSeeds } = usePersistedCrossSeedBlocklist(instanceId, false)
   const [deleteCrossSeeds, setDeleteCrossSeeds] = useState(false)
   const [showTagsDialog, setShowTagsDialog] = useState(false)
+  const [showCommentDialog, setShowCommentDialog] = useState(false)
   const [showCategoryDialog, setShowCategoryDialog] = useState(false)
   const [showCreateCategoryDialog, setShowCreateCategoryDialog] = useState(false)
   const [showShareLimitDialog, setShowShareLimitDialog] = useState(false)
@@ -174,6 +177,7 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
         action: payload.action,
         deleteFiles: payload.deleteFiles,
         tags: payload.tags,
+        comment: payload.comment,
         category: payload.category,
         enable: payload.enable,
         ratioLimit: payload.ratioLimit,
@@ -276,6 +280,8 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
       if (variables.action === "delete") {
         setShowDeleteDialog(false)
         setDeleteCrossSeeds(false)
+      } else if (variables.action === "setComment") {
+        setShowCommentDialog(false)
       } else if (variables.action === "setCategory") {
         setShowCategoryDialog(false)
         setShowCreateCategoryDialog(false)
@@ -602,6 +608,37 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
     })
   }, [updateTagsMutation, instanceIds])
 
+  const handleSetComment = useCallback(async (
+    comment: string,
+    hashes: string[],
+    isAllSelected?: boolean,
+    filters?: TorrentActionData["filters"],
+    search?: string,
+    excludeHashes?: string[],
+    clientMeta?: ClientMeta
+  ) => {
+    const clientHashes = clientMeta?.clientHashes ?? hashes
+    const clientCount = clientMeta?.totalSelected
+      ?? (clientHashes?.length ?? hashes.length)
+    await mutation.mutateAsync({
+      action: "setComment",
+      instanceIds,
+      targets: isAllSelected ? undefined : clientMeta?.actionTargets,
+      comment,
+      hashes: isAllSelected ? [] : hashes,
+      selectAll: isAllSelected,
+      filters: isAllSelected ? filters : undefined,
+      search: isAllSelected ? search : undefined,
+      excludeHashes: isAllSelected ? excludeHashes : undefined,
+      excludeTargets: isAllSelected ? clientMeta?.excludeTargets : undefined,
+      clientHashes,
+      clientCount,
+    })
+    setShowCommentDialog(false)
+    setContextHashes([])
+    setContextTorrents([])
+  }, [mutation, instanceIds])
+
   const handleSetCategory = useCallback(async (
     category: string,
     hashes: string[],
@@ -869,6 +906,12 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
     setShowTagsDialog(true)
   }, [])
 
+  const prepareCommentAction = useCallback((hashes: string[], torrents?: Torrent[]) => {
+    setContextHashes(hashes)
+    if (torrents) setContextTorrents(torrents)
+    setShowCommentDialog(true)
+  }, [])
+
   const prepareCategoryAction = useCallback((hashes: string[], torrents?: Torrent[]) => {
     setContextHashes(hashes)
     if (torrents) setContextTorrents(torrents)
@@ -997,6 +1040,8 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
     setDeleteCrossSeeds,
     showTagsDialog,
     setShowTagsDialog,
+    showCommentDialog,
+    setShowCommentDialog,
     showCategoryDialog,
     setShowCategoryDialog,
     showCreateCategoryDialog,
@@ -1032,6 +1077,7 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
     handleAction,
     handleDelete,
     handleUpdateTags,
+    handleSetComment,
     handleSetCategory,
     handleSetShareLimit,
     handleSetSpeedLimits,
@@ -1045,6 +1091,7 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
     // Preparation handlers (for showing dialogs)
     prepareDeleteAction,
     prepareTagsAction,
+    prepareCommentAction,
     prepareCategoryAction,
     prepareCreateCategoryAction,
     prepareShareLimitAction,
@@ -1101,6 +1148,9 @@ function showSuccessToast(action: TorrentAction, count: number, deleteFiles?: bo
       break
     case "setTags":
       toast.success(`Replaced tags for ${count} ${torrentText}`)
+      break
+    case "setComment":
+      toast.success(`Updated comment for ${count} ${torrentText}`)
       break
     case "setCategory":
       toast.success(`Set category for ${count} ${torrentText}`)

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1042,10 +1042,11 @@ class ApiClient {
     data: {
       hashes: string[]
       targets?: Array<{ instanceId: number; hash: string }>
-      action: "pause" | "resume" | "delete" | "recheck" | "reannounce" | "increasePriority" | "decreasePriority" | "topPriority" | "bottomPriority" | "setCategory" | "addTags" | "removeTags" | "setTags" | "toggleAutoTMM" | "forceStart" | "setShareLimit" | "setUploadLimit" | "setDownloadLimit" | "setLocation" | "editTrackers" | "addTrackers" | "removeTrackers" | "toggleSequentialDownload"
+      action: "pause" | "resume" | "delete" | "recheck" | "reannounce" | "increasePriority" | "decreasePriority" | "topPriority" | "bottomPriority" | "setCategory" | "addTags" | "removeTags" | "setTags" | "setComment" | "toggleAutoTMM" | "forceStart" | "setShareLimit" | "setUploadLimit" | "setDownloadLimit" | "setLocation" | "editTrackers" | "addTrackers" | "removeTrackers" | "toggleSequentialDownload"
       deleteFiles?: boolean
       category?: string
       tags?: string  // Comma-separated tags string
+      comment?: string  // For setComment action
       enable?: boolean  // For toggleAutoTMM
       selectAll?: boolean  // When true, apply to all torrents matching filters
       filters?: TorrentFilters

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -649,6 +649,7 @@ export interface InstanceCapabilities {
   supportsTorrentCreation: boolean
   supportsTorrentExport: boolean
   supportsSetTags: boolean
+  supportsSetComment: boolean
   supportsTrackerHealth: boolean
   supportsTrackerEditing: boolean
   supportsRenameTorrent: boolean


### PR DESCRIPTION
This PR adds support for setting and editing comments of torrents via qui.

Depends on https://github.com/autobrr/go-qbittorrent/pull/123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add ability to set torrent comments via a new context-menu item, dialog, and bulk action (includes comment field).
  * UI: dedicated Set Comment dialog, comment editing, loading state, and success toast.

* **Compatibility**
  * Automatic detection of instance support for comment-setting; feature enabled only on supported instances (qBittorrent 5.2+/Web API 2.12.1+).

* **UX**
  * Improved comment rendering in details views for better wrapping and readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/autobrr/qui/pull/1928?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->