### PR TITLE
fix(ci): repair docs and release builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ package-lock.json
 web/build
 bin/
 dist/
+/web-dist.tar.gz
 .run/
 .dev/
 tmp/

--- a/documentation/netlify.toml
+++ b/documentation/netlify.toml
@@ -3,7 +3,7 @@
   command = "pnpm build"
 
 [build.environment]
-  NODE_VERSION = "20"
+  NODE_VERSION = "24"
 
 [[redirects]]
   from = "/chrome-extension"

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -20,14 +20,14 @@
     "@docusaurus/preset-classic": "3.10.1",
     "@docusaurus/theme-common": "3.10.1",
     "@easyops-cn/docusaurus-search-local": "0.52.2",
-    "@mdx-js/react": "^3.0.0",
+    "@mdx-js/react": "^3.1.1",
     "@tailwindcss/postcss": "^4.1.18",
-    "clsx": "^2.0.0",
+    "clsx": "^2.1.1",
     "docusaurus-plugin-llms": "^0.3.0",
     "postcss": "^8.5.14",
-    "prism-react-renderer": "^2.3.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "prism-react-renderer": "^2.4.1",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3",
     "redoc": "^2.5.2",
     "tailwindcss": "^4.1.18"
   },
@@ -36,7 +36,7 @@
     "@docusaurus/tsconfig": "3.10.1",
     "@docusaurus/types": "3.10.1",
     "raw-loader": "^4.0.2",
-    "typescript": "~5.6.2"
+    "typescript": "~5.6.3"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
Align the docs manifest with its lockfile and use Node 24 so Netlify's frozen pnpm install can resolve cleanly.

Ignore the workflow-generated GoReleaser web dist artifact so tagged releases do not fail the dirty worktree check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Node.js version in the documentation build environment to v24 for improved performance and stability.
  * Updated documentation dependencies (React, React DOM, MDX, Prism renderer, clsx) and TypeScript dev dependency for compatibility and reliability.
  * Added ignore rule to prevent a generated web archive from being committed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/autobrr/qui/pull/1932?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->