### PR TITLE
feat(torrents): filter for torrents with other tracker errors

### DIFF
--- a/internal/qbittorrent/integration_test.go
+++ b/internal/qbittorrent/integration_test.go
@@ -43,6 +43,11 @@ func TestSyncManager_FilteringAndSorting(t *testing.T) {
 		Message: "Tracker is down for maintenance",
 	}}
 
+	torrents[5].Trackers = []qbt.TorrentTracker{{
+		Status:  qbt.TrackerStatusNotWorking,
+		Message: "Invalid tracker response payload",
+	}}
+
 	t.Run("matchTorrentStatus filters correctly", func(t *testing.T) {
 		testCases := []struct {
 			status   string
@@ -56,6 +61,7 @@ func TestSyncManager_FilteringAndSorting(t *testing.T) {
 			{"errored", 1},
 			{"unregistered", 1},
 			{"tracker_down", 1},
+			{"tracker_error", 1},
 		}
 
 		for _, tc := range testCases {
@@ -174,6 +180,53 @@ func TestSyncManager_TorrentTrackerIsDown_TrackerUpdating(t *testing.T) {
 	})
 }
 
+func TestSyncManager_TorrentHasTrackerError(t *testing.T) {
+	sm := &SyncManager{}
+
+	t.Run("marks generic tracker errors when all trackers are errored", func(t *testing.T) {
+		torrent := qbt.Torrent{
+			Trackers: []qbt.TorrentTracker{
+				{Status: qbt.TrackerStatusNotWorking, Message: "Invalid tracker response payload"},
+				{Status: qbt.TrackerStatusTrackerError, Message: "Tracker reply failed checksum validation"},
+			},
+		}
+
+		assert.True(t, sm.torrentHasTrackerError(&torrent))
+	})
+
+	t.Run("ignores tracker errors when a working tracker is present", func(t *testing.T) {
+		torrent := qbt.Torrent{
+			Trackers: []qbt.TorrentTracker{
+				{Status: qbt.TrackerStatusNotWorking, Message: "Invalid tracker response payload"},
+				{Status: qbt.TrackerStatusOK, Message: ""},
+			},
+		}
+
+		assert.False(t, sm.torrentHasTrackerError(&torrent))
+	})
+
+	t.Run("ignores tracker errors classified as unregistered", func(t *testing.T) {
+		torrent := qbt.Torrent{
+			AddedOn: time.Now().Add(-2 * time.Hour).Unix(),
+			Trackers: []qbt.TorrentTracker{
+				{Status: qbt.TrackerStatusNotWorking, Message: "Torrent not registered on tracker"},
+			},
+		}
+
+		assert.False(t, sm.torrentHasTrackerError(&torrent))
+	})
+
+	t.Run("ignores tracker errors classified as tracker down", func(t *testing.T) {
+		torrent := qbt.Torrent{
+			Trackers: []qbt.TorrentTracker{
+				{Status: qbt.TrackerStatusUnreachable, Message: "Connection timed out"},
+			},
+		}
+
+		assert.False(t, sm.torrentHasTrackerError(&torrent))
+	})
+}
+
 func TestSyncManager_CountTorrentStatuses_TrackerHealthExclusive(t *testing.T) {
 	sm := &SyncManager{}
 	counts := map[string]int{}
@@ -194,6 +247,7 @@ func TestSyncManager_CountTorrentStatuses_TrackerHealthExclusive(t *testing.T) {
 	assert.Equal(t, 1, counts["all"])
 	assert.Equal(t, 1, counts["unregistered"])
 	assert.Zero(t, counts["tracker_down"])
+	assert.Zero(t, counts["tracker_error"])
 }
 
 func TestSyncManager_TorrentBelongsToTrackerDomain(t *testing.T) {
@@ -299,8 +353,10 @@ func TestSyncManager_GetTrackerHealthCounts_DeepCopy(t *testing.T) {
 	original := &TrackerHealthCounts{
 		Unregistered:    2,
 		TrackerDown:     1,
+		TrackerError:    3,
 		UnregisteredSet: map[string]struct{}{"hash1": {}, "hash2": {}},
 		TrackerDownSet:  map[string]struct{}{"hash3": {}},
+		TrackerErrorSet: map[string]struct{}{"hash4": {}, "hash5": {}, "hash6": {}},
 		UpdatedAt:       originalTime,
 	}
 	sm.trackerHealthCache[1] = original
@@ -312,22 +368,28 @@ func TestSyncManager_GetTrackerHealthCounts_DeepCopy(t *testing.T) {
 	assert.NotNil(t, returned)
 	assert.Equal(t, 2, returned.Unregistered)
 	assert.Equal(t, 1, returned.TrackerDown)
+	assert.Equal(t, 3, returned.TrackerError)
 
 	// Modify the returned copy
 	returned.Unregistered = 99
 	returned.TrackerDown = 88
+	returned.TrackerError = 77
 	returned.UnregisteredSet["modified"] = struct{}{}
 	delete(returned.UnregisteredSet, "hash1")
 	returned.TrackerDownSet["modified2"] = struct{}{}
+	returned.TrackerErrorSet["modified3"] = struct{}{}
 
 	// Verify original is unchanged
 	assert.Equal(t, 2, original.Unregistered, "Original Unregistered should be unchanged")
 	assert.Equal(t, 1, original.TrackerDown, "Original TrackerDown should be unchanged")
+	assert.Equal(t, 3, original.TrackerError, "Original TrackerError should be unchanged")
 	assert.Contains(t, original.UnregisteredSet, "hash1", "Original UnregisteredSet should still contain hash1")
 	assert.NotContains(t, original.UnregisteredSet, "modified", "Original UnregisteredSet should not contain modified")
 	assert.NotContains(t, original.TrackerDownSet, "modified2", "Original TrackerDownSet should not contain modified2")
+	assert.NotContains(t, original.TrackerErrorSet, "modified3", "Original TrackerErrorSet should not contain modified3")
 	assert.Len(t, original.UnregisteredSet, 2, "Original UnregisteredSet should still have 2 items")
 	assert.Len(t, original.TrackerDownSet, 1, "Original TrackerDownSet should still have 1 item")
+	assert.Len(t, original.TrackerErrorSet, 3, "Original TrackerErrorSet should still have 3 items")
 }
 
 func TestSyncManager_GetTrackerHealthCounts_NilWhenNoCache(t *testing.T) {
@@ -344,97 +406,145 @@ func TestSyncManager_RemoveHashesFromTrackerHealthCache(t *testing.T) {
 		name                string
 		initialUnregistered int
 		initialTrackerDown  int
+		initialTrackerError int
 		unregisteredSet     map[string]struct{}
 		trackerDownSet      map[string]struct{}
+		trackerErrorSet     map[string]struct{}
 		hashesToRemove      []string
 		expectedUnreg       int
 		expectedDown        int
+		expectedError       int
 		expectedUnregSet    map[string]struct{}
 		expectedDownSet     map[string]struct{}
+		expectedErrorSet    map[string]struct{}
 	}{
 		{
 			name:                "remove from UnregisteredSet only",
 			initialUnregistered: 2,
 			initialTrackerDown:  1,
+			initialTrackerError: 1,
 			unregisteredSet:     map[string]struct{}{"h1": {}, "h2": {}},
 			trackerDownSet:      map[string]struct{}{"h3": {}},
+			trackerErrorSet:     map[string]struct{}{"h4": {}},
 			hashesToRemove:      []string{"h1"},
 			expectedUnreg:       1,
 			expectedDown:        1,
+			expectedError:       1,
 			expectedUnregSet:    map[string]struct{}{"h2": {}},
 			expectedDownSet:     map[string]struct{}{"h3": {}},
+			expectedErrorSet:    map[string]struct{}{"h4": {}},
 		},
 		{
 			name:                "remove from TrackerDownSet only",
 			initialUnregistered: 2,
 			initialTrackerDown:  1,
+			initialTrackerError: 1,
 			unregisteredSet:     map[string]struct{}{"h1": {}, "h2": {}},
 			trackerDownSet:      map[string]struct{}{"h3": {}},
+			trackerErrorSet:     map[string]struct{}{"h4": {}},
 			hashesToRemove:      []string{"h3"},
 			expectedUnreg:       2,
 			expectedDown:        0,
+			expectedError:       1,
 			expectedUnregSet:    map[string]struct{}{"h1": {}, "h2": {}},
 			expectedDownSet:     map[string]struct{}{},
+			expectedErrorSet:    map[string]struct{}{"h4": {}},
+		},
+		{
+			name:                "remove from TrackerErrorSet only",
+			initialUnregistered: 2,
+			initialTrackerDown:  1,
+			initialTrackerError: 2,
+			unregisteredSet:     map[string]struct{}{"h1": {}, "h2": {}},
+			trackerDownSet:      map[string]struct{}{"h3": {}},
+			trackerErrorSet:     map[string]struct{}{"h4": {}, "h5": {}},
+			hashesToRemove:      []string{"h4"},
+			expectedUnreg:       2,
+			expectedDown:        1,
+			expectedError:       1,
+			expectedUnregSet:    map[string]struct{}{"h1": {}, "h2": {}},
+			expectedDownSet:     map[string]struct{}{"h3": {}},
+			expectedErrorSet:    map[string]struct{}{"h5": {}},
 		},
 		{
 			name:                "remove from both sets",
 			initialUnregistered: 2,
 			initialTrackerDown:  2,
+			initialTrackerError: 1,
 			unregisteredSet:     map[string]struct{}{"h1": {}, "h2": {}},
 			trackerDownSet:      map[string]struct{}{"h1": {}, "h3": {}},
+			trackerErrorSet:     map[string]struct{}{"h4": {}},
 			hashesToRemove:      []string{"h1"},
 			expectedUnreg:       1,
 			expectedDown:        1,
+			expectedError:       1,
 			expectedUnregSet:    map[string]struct{}{"h2": {}},
 			expectedDownSet:     map[string]struct{}{"h3": {}},
+			expectedErrorSet:    map[string]struct{}{"h4": {}},
 		},
 		{
 			name:                "remove non-existent hash - no change",
 			initialUnregistered: 2,
 			initialTrackerDown:  1,
+			initialTrackerError: 1,
 			unregisteredSet:     map[string]struct{}{"h1": {}, "h2": {}},
 			trackerDownSet:      map[string]struct{}{"h3": {}},
+			trackerErrorSet:     map[string]struct{}{"h4": {}},
 			hashesToRemove:      []string{"nonexistent"},
 			expectedUnreg:       2,
 			expectedDown:        1,
+			expectedError:       1,
 			expectedUnregSet:    map[string]struct{}{"h1": {}, "h2": {}},
 			expectedDownSet:     map[string]struct{}{"h3": {}},
+			expectedErrorSet:    map[string]struct{}{"h4": {}},
 		},
 		{
 			name:                "underflow protection - count stays at 0",
 			initialUnregistered: 0,
 			initialTrackerDown:  0,
+			initialTrackerError: 0,
 			unregisteredSet:     map[string]struct{}{"h1": {}},
 			trackerDownSet:      map[string]struct{}{"h2": {}},
-			hashesToRemove:      []string{"h1", "h2"},
+			trackerErrorSet:     map[string]struct{}{"h3": {}},
+			hashesToRemove:      []string{"h1", "h2", "h3"},
 			expectedUnreg:       0,
 			expectedDown:        0,
+			expectedError:       0,
 			expectedUnregSet:    map[string]struct{}{},
 			expectedDownSet:     map[string]struct{}{},
+			expectedErrorSet:    map[string]struct{}{},
 		},
 		{
 			name:                "empty hashes slice - no-op",
 			initialUnregistered: 2,
 			initialTrackerDown:  1,
+			initialTrackerError: 1,
 			unregisteredSet:     map[string]struct{}{"h1": {}, "h2": {}},
 			trackerDownSet:      map[string]struct{}{"h3": {}},
+			trackerErrorSet:     map[string]struct{}{"h4": {}},
 			hashesToRemove:      []string{},
 			expectedUnreg:       2,
 			expectedDown:        1,
+			expectedError:       1,
 			expectedUnregSet:    map[string]struct{}{"h1": {}, "h2": {}},
 			expectedDownSet:     map[string]struct{}{"h3": {}},
+			expectedErrorSet:    map[string]struct{}{"h4": {}},
 		},
 		{
 			name:                "remove multiple hashes",
 			initialUnregistered: 3,
 			initialTrackerDown:  2,
+			initialTrackerError: 2,
 			unregisteredSet:     map[string]struct{}{"h1": {}, "h2": {}, "h3": {}},
 			trackerDownSet:      map[string]struct{}{"h4": {}, "h5": {}},
-			hashesToRemove:      []string{"h1", "h2", "h4"},
+			trackerErrorSet:     map[string]struct{}{"h6": {}, "h7": {}},
+			hashesToRemove:      []string{"h1", "h2", "h4", "h6"},
 			expectedUnreg:       1,
 			expectedDown:        1,
+			expectedError:       1,
 			expectedUnregSet:    map[string]struct{}{"h3": {}},
 			expectedDownSet:     map[string]struct{}{"h5": {}},
+			expectedErrorSet:    map[string]struct{}{"h7": {}},
 		},
 	}
 
@@ -449,14 +559,20 @@ func TestSyncManager_RemoveHashesFromTrackerHealthCache(t *testing.T) {
 			for k := range tt.trackerDownSet {
 				downSet[k] = struct{}{}
 			}
+			errorSet := make(map[string]struct{}, len(tt.trackerErrorSet))
+			for k := range tt.trackerErrorSet {
+				errorSet[k] = struct{}{}
+			}
 
 			sm := &SyncManager{
 				trackerHealthCache: map[int]*TrackerHealthCounts{
 					1: {
 						Unregistered:    tt.initialUnregistered,
 						TrackerDown:     tt.initialTrackerDown,
+						TrackerError:    tt.initialTrackerError,
 						UnregisteredSet: unregSet,
 						TrackerDownSet:  downSet,
+						TrackerErrorSet: errorSet,
 					},
 				},
 			}
@@ -466,8 +582,10 @@ func TestSyncManager_RemoveHashesFromTrackerHealthCache(t *testing.T) {
 			counts := sm.trackerHealthCache[1]
 			assert.Equal(t, tt.expectedUnreg, counts.Unregistered, "Unregistered count")
 			assert.Equal(t, tt.expectedDown, counts.TrackerDown, "TrackerDown count")
+			assert.Equal(t, tt.expectedError, counts.TrackerError, "TrackerError count")
 			assert.Equal(t, tt.expectedUnregSet, counts.UnregisteredSet, "UnregisteredSet")
 			assert.Equal(t, tt.expectedDownSet, counts.TrackerDownSet, "TrackerDownSet")
+			assert.Equal(t, tt.expectedErrorSet, counts.TrackerErrorSet, "TrackerErrorSet")
 		})
 	}
 }
@@ -492,8 +610,10 @@ func TestSyncManager_TrackerHealthCache_ConcurrentAccess(t *testing.T) {
 			1: {
 				Unregistered:    100,
 				TrackerDown:     50,
+				TrackerError:    25,
 				UnregisteredSet: make(map[string]struct{}),
 				TrackerDownSet:  make(map[string]struct{}),
+				TrackerErrorSet: make(map[string]struct{}),
 			},
 		},
 	}
@@ -504,6 +624,9 @@ func TestSyncManager_TrackerHealthCache_ConcurrentAccess(t *testing.T) {
 	}
 	for i := range 50 {
 		sm.trackerHealthCache[1].TrackerDownSet[fmt.Sprintf("down%d", i)] = struct{}{}
+	}
+	for i := range 25 {
+		sm.trackerHealthCache[1].TrackerErrorSet[fmt.Sprintf("error%d", i)] = struct{}{}
 	}
 
 	var wg sync.WaitGroup
@@ -517,8 +640,10 @@ func TestSyncManager_TrackerHealthCache_ConcurrentAccess(t *testing.T) {
 					// Access the returned copy to ensure it's safe
 					_ = counts.Unregistered
 					_ = counts.TrackerDown
+					_ = counts.TrackerError
 					_ = len(counts.UnregisteredSet)
 					_ = len(counts.TrackerDownSet)
+					_ = len(counts.TrackerErrorSet)
 				}
 			}
 		})
@@ -628,6 +753,11 @@ func TestFiltersRequireTrackerData(t *testing.T) {
 		{
 			name:    "exclude tracker health statuses",
 			filters: FilterOptions{ExcludeStatus: []string{"tracker_down"}},
+			want:    true,
+		},
+		{
+			name:    "include tracker error status",
+			filters: FilterOptions{Status: []string{"tracker_error"}},
 			want:    true,
 		},
 		{

--- a/internal/qbittorrent/integration_test.go
+++ b/internal/qbittorrent/integration_test.go
@@ -192,6 +192,7 @@ func TestSyncManager_TorrentHasTrackerError(t *testing.T) {
 		}
 
 		assert.True(t, sm.torrentHasTrackerError(&torrent))
+		assert.Equal(t, TrackerHealthError, sm.determineTrackerHealth(&torrent))
 	})
 
 	t.Run("ignores tracker errors when a working tracker is present", func(t *testing.T) {

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -91,6 +91,7 @@ type TrackerHealth string
 const (
 	TrackerHealthUnregistered TrackerHealth = "unregistered"
 	TrackerHealthDown         TrackerHealth = "tracker_down"
+	TrackerHealthError        TrackerHealth = "tracker_error"
 )
 
 // TorrentView extends qBittorrent's torrent with UI-specific metadata.
@@ -450,11 +451,9 @@ func (sm *SyncManager) refreshTrackerHealthCounts(ctx context.Context, instanceI
 		case TrackerHealthDown:
 			counts.TrackerDown++
 			counts.TrackerDownSet[t.Hash] = struct{}{}
-		default:
-			if sm.torrentHasTrackerError(&t) {
-				counts.TrackerError++
-				counts.TrackerErrorSet[t.Hash] = struct{}{}
-			}
+		case TrackerHealthError:
+			counts.TrackerError++
+			counts.TrackerErrorSet[t.Hash] = struct{}{}
 		}
 
 		// Tracker domain mapping
@@ -1223,6 +1222,8 @@ func (sm *SyncManager) GetTorrentsWithFilters(ctx context.Context, instanceID in
 					view.TrackerHealth = TrackerHealthUnregistered
 				} else if _, ok := cachedHealth.TrackerDownSet[torrent.Hash]; ok {
 					view.TrackerHealth = TrackerHealthDown
+				} else if _, ok := cachedHealth.TrackerErrorSet[torrent.Hash]; ok {
+					view.TrackerHealth = TrackerHealthError
 				}
 			}
 			paginatedViews[i] = view
@@ -1459,6 +1460,8 @@ func (sm *SyncManager) GetCachedInstanceTorrents(ctx context.Context, instanceID
 				view.TrackerHealth = TrackerHealthUnregistered
 			} else if _, ok := cachedHealth.TrackerDownSet[torrent.Hash]; ok {
 				view.TrackerHealth = TrackerHealthDown
+			} else if _, ok := cachedHealth.TrackerErrorSet[torrent.Hash]; ok {
+				view.TrackerHealth = TrackerHealthError
 			}
 		}
 		views[i] = CrossInstanceTorrentView{
@@ -2703,6 +2706,10 @@ func (sm *SyncManager) determineTrackerHealth(torrent *qbt.Torrent) TrackerHealt
 		return TrackerHealthDown
 	}
 
+	if sm.torrentHasTrackerError(torrent) {
+		return TrackerHealthError
+	}
+
 	return ""
 }
 
@@ -2935,10 +2942,8 @@ func (sm *SyncManager) countTorrentStatuses(torrent qbt.Torrent, counts map[stri
 		counts["unregistered"]++
 	case TrackerHealthDown:
 		counts["tracker_down"]++
-	default:
-		if sm.torrentHasTrackerError(&torrent) {
-			counts["tracker_error"]++
-		}
+	case TrackerHealthError:
+		counts["tracker_error"]++
 	}
 
 	// Count "completed"
@@ -4464,7 +4469,7 @@ func (sm *SyncManager) matchTorrentStatus(torrent qbt.Torrent, status string) bo
 	case "tracker_down":
 		return sm.determineTrackerHealth(&torrent) == TrackerHealthDown
 	case "tracker_error":
-		return sm.torrentHasTrackerError(&torrent)
+		return sm.determineTrackerHealth(&torrent) == TrackerHealthError
 	}
 
 	// Handle special cases first
@@ -4507,6 +4512,8 @@ func (sm *SyncManager) trackerHealthPriority(torrent qbt.Torrent, trackerHealthS
 		return 0
 	case TrackerHealthDown:
 		return 1
+	case TrackerHealthError:
+		return 2
 	default:
 		return 10
 	}
@@ -4562,6 +4569,8 @@ func (sm *SyncManager) sortTorrentsByStatus(torrents []qbt.Torrent, desc bool, t
 				label = "unregistered"
 			case TrackerHealthDown:
 				label = "tracker_down"
+			case TrackerHealthError:
+				label = "tracker_error"
 			}
 		}
 		meta := statusSortMeta{

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -2679,6 +2679,8 @@ func (sm *SyncManager) torrentHasTrackerError(torrent *qbt.Torrent) bool {
 			continue
 		case qbt.TrackerStatusNotWorking, qbt.TrackerStatusTrackerError, qbt.TrackerStatusUnreachable:
 			erroredTrackers++
+		case qbt.TrackerStatusNotContacted, qbt.TrackerStatusOK, qbt.TrackerStatusUpdating:
+			return false
 		default:
 			// Any non-disabled tracker that is not in an error state means the torrent
 			// does not belong in the "all trackers errored" bucket.

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -162,8 +162,10 @@ type DuplicateTorrentMatch struct {
 type TrackerHealthCounts struct {
 	Unregistered    int                 // count for sidebar
 	TrackerDown     int                 // count for sidebar
+	TrackerError    int                 // count for sidebar
 	UnregisteredSet map[string]struct{} // hashes of unregistered torrents
 	TrackerDownSet  map[string]struct{} // hashes of tracker_down torrents
+	TrackerErrorSet map[string]struct{} // hashes of tracker_error torrents
 	UpdatedAt       time.Time
 }
 
@@ -407,6 +409,7 @@ func (sm *SyncManager) refreshTrackerHealthCounts(ctx context.Context, instanceI
 		sm.trackerHealthCache[instanceID] = &TrackerHealthCounts{
 			UnregisteredSet: make(map[string]struct{}),
 			TrackerDownSet:  make(map[string]struct{}),
+			TrackerErrorSet: make(map[string]struct{}),
 			UpdatedAt:       time.Now(),
 		}
 		sm.trackerHealthMu.Unlock()
@@ -426,6 +429,7 @@ func (sm *SyncManager) refreshTrackerHealthCounts(ctx context.Context, instanceI
 	counts := &TrackerHealthCounts{
 		UnregisteredSet: make(map[string]struct{}),
 		TrackerDownSet:  make(map[string]struct{}),
+		TrackerErrorSet: make(map[string]struct{}),
 		UpdatedAt:       time.Now(),
 	}
 
@@ -446,6 +450,11 @@ func (sm *SyncManager) refreshTrackerHealthCounts(ctx context.Context, instanceI
 		case TrackerHealthDown:
 			counts.TrackerDown++
 			counts.TrackerDownSet[t.Hash] = struct{}{}
+		default:
+			if sm.torrentHasTrackerError(&t) {
+				counts.TrackerError++
+				counts.TrackerErrorSet[t.Hash] = struct{}{}
+			}
 		}
 
 		// Tracker domain mapping
@@ -478,6 +487,7 @@ func (sm *SyncManager) refreshTrackerHealthCounts(ctx context.Context, instanceI
 		Int("instanceID", instanceID).
 		Int("unregistered", counts.Unregistered).
 		Int("trackerDown", counts.TrackerDown).
+		Int("trackerError", counts.TrackerError).
 		Int("trackerDomains", len(mapping.DomainToHashes)).
 		Int("totalTorrents", len(torrents)).
 		Msg("Refreshed tracker health counts and validated tracker mapping")
@@ -504,12 +514,18 @@ func (sm *SyncManager) GetTrackerHealthCounts(instanceID int) *TrackerHealthCoun
 	for k := range cached.TrackerDownSet {
 		trackerDownSet[k] = struct{}{}
 	}
+	trackerErrorSet := make(map[string]struct{}, len(cached.TrackerErrorSet))
+	for k := range cached.TrackerErrorSet {
+		trackerErrorSet[k] = struct{}{}
+	}
 
 	return &TrackerHealthCounts{
 		Unregistered:    cached.Unregistered,
 		TrackerDown:     cached.TrackerDown,
+		TrackerError:    cached.TrackerError,
 		UnregisteredSet: unregisteredSet,
 		TrackerDownSet:  trackerDownSet,
+		TrackerErrorSet: trackerErrorSet,
 		UpdatedAt:       cached.UpdatedAt,
 	}
 }
@@ -536,6 +552,12 @@ func (sm *SyncManager) RemoveHashesFromTrackerHealthCache(instanceID int, hashes
 			delete(counts.TrackerDownSet, hash)
 			if counts.TrackerDown > 0 {
 				counts.TrackerDown--
+			}
+		}
+		if _, exists := counts.TrackerErrorSet[hash]; exists {
+			delete(counts.TrackerErrorSet, hash)
+			if counts.TrackerError > 0 {
+				counts.TrackerError--
 			}
 		}
 	}
@@ -2565,7 +2587,7 @@ func trackerMessageMatches(message string, patterns []string) bool {
 func statusFiltersRequireTrackerData(statuses []string) bool {
 	for _, status := range statuses {
 		switch status {
-		case "unregistered", "tracker_down":
+		case "unregistered", "tracker_down", "tracker_error":
 			return true
 		}
 	}
@@ -2573,7 +2595,7 @@ func statusFiltersRequireTrackerData(statuses []string) bool {
 	return false
 }
 
-// helper to make it possible to do filterExclude by "tracker_down" and "unregistered" in FilterSidebar
+// helper to make it possible to filter by tracker-derived states in FilterSidebar
 func filtersRequireTrackerData(filters FilterOptions) bool {
 	return statusFiltersRequireTrackerData(filters.Status) ||
 		statusFiltersRequireTrackerData(filters.ExcludeStatus)
@@ -2637,6 +2659,34 @@ func (sm *SyncManager) torrentTrackerIsDown(torrent *qbt.Torrent) bool {
 	}
 
 	return hasDown && !hasWorking
+}
+
+func (sm *SyncManager) torrentHasTrackerError(torrent *qbt.Torrent) bool {
+	if torrent == nil {
+		return false
+	}
+
+	if sm.torrentIsUnregistered(torrent) || sm.torrentTrackerIsDown(torrent) {
+		return false
+	}
+
+	var erroredTrackers int
+
+	for _, tracker := range torrent.Trackers {
+		switch tracker.Status {
+		case qbt.TrackerStatusDisabled:
+			// Skip DHT/PeX entries
+			continue
+		case qbt.TrackerStatusNotWorking, qbt.TrackerStatusTrackerError, qbt.TrackerStatusUnreachable:
+			erroredTrackers++
+		default:
+			// Any non-disabled tracker that is not in an error state means the torrent
+			// does not belong in the "all trackers errored" bucket.
+			return false
+		}
+	}
+
+	return erroredTrackers > 0
 }
 
 func (sm *SyncManager) determineTrackerHealth(torrent *qbt.Torrent) TrackerHealth {
@@ -2883,6 +2933,10 @@ func (sm *SyncManager) countTorrentStatuses(torrent qbt.Torrent, counts map[stri
 		counts["unregistered"]++
 	case TrackerHealthDown:
 		counts["tracker_down"]++
+	default:
+		if sm.torrentHasTrackerError(&torrent) {
+			counts["tracker_error"]++
+		}
 	}
 
 	// Count "completed"
@@ -2940,7 +2994,7 @@ func (sm *SyncManager) calculateCountsFromTorrentsWithTrackers(_ context.Context
 			"all": 0, "downloading": 0, "seeding": 0, "completed": 0, "paused": 0,
 			"active": 0, "inactive": 0, "resumed": 0, "running": 0, "stopped": 0, "stalled": 0,
 			"stalled_uploading": 0, "stalled_downloading": 0, "errored": 0,
-			"checking": 0, "moving": 0, "unregistered": 0, "tracker_down": 0,
+			"checking": 0, "moving": 0, "unregistered": 0, "tracker_down": 0, "tracker_error": 0,
 		},
 		Categories:    make(map[string]int),
 		CategorySizes: make(map[string]int64),
@@ -3259,6 +3313,7 @@ func (sm *SyncManager) calculateCountsFromTorrentsWithTrackers(_ context.Context
 		if cached := sm.GetTrackerHealthCounts(client.instanceID); cached != nil {
 			counts.Status["unregistered"] = cached.Unregistered
 			counts.Status["tracker_down"] = cached.TrackerDown
+			counts.Status["tracker_error"] = cached.TrackerError
 		}
 	}
 
@@ -4406,6 +4461,8 @@ func (sm *SyncManager) matchTorrentStatus(torrent qbt.Torrent, status string) bo
 		return sm.determineTrackerHealth(&torrent) == TrackerHealthUnregistered
 	case "tracker_down":
 		return sm.determineTrackerHealth(&torrent) == TrackerHealthDown
+	case "tracker_error":
+		return sm.torrentHasTrackerError(&torrent)
 	}
 
 	// Handle special cases first

--- a/internal/services/automations/evaluator.go
+++ b/internal/services/automations/evaluator.go
@@ -53,6 +53,8 @@ type EvalContext struct {
 	UnregisteredSet map[string]struct{}
 	// TrackerDownSet contains hashes of torrents whose trackers are down (from SyncManager health counts)
 	TrackerDownSet map[string]struct{}
+	// TrackerErrorSet contains hashes of torrents with tracker errors (from SyncManager health counts)
+	TrackerErrorSet map[string]struct{}
 	// HardlinkScopeByHash maps torrent hash to its hardlink scope (none, torrents_only, outside_qbittorrent)
 	HardlinkScopeByHash map[string]string
 	// HardlinkCrossScopeByHash maps torrent hash to its cross-instance hardlink scope.
@@ -747,6 +749,12 @@ func matchesStateValue(torrent qbt.Torrent, value string, ctx *EvalContext) bool
 			return false
 		}
 		_, ok := ctx.TrackerDownSet[torrent.Hash]
+		return ok
+	case "tracker_error":
+		if ctx == nil || ctx.TrackerErrorSet == nil {
+			return false
+		}
+		_, ok := ctx.TrackerErrorSet[torrent.Hash]
 		return ok
 	}
 

--- a/internal/services/automations/evaluator_test.go
+++ b/internal/services/automations/evaluator_test.go
@@ -1165,6 +1165,36 @@ func TestEvaluateCondition_StateTrackerDown_WithContext(t *testing.T) {
 	})
 }
 
+func TestEvaluateCondition_StateTrackerError_WithContext(t *testing.T) {
+	cond := &RuleCondition{
+		Field:    FieldState,
+		Operator: OperatorEqual,
+		Value:    "tracker_error",
+	}
+
+	torrent := qbt.Torrent{
+		Hash:  "hash1",
+		State: qbt.TorrentStateUploading,
+	}
+
+	t.Run("matches when in TrackerErrorSet", func(t *testing.T) {
+		ctx := &EvalContext{
+			TrackerErrorSet: map[string]struct{}{"hash1": {}},
+		}
+		got := EvaluateConditionWithContext(cond, torrent, ctx, 0)
+		if !got {
+			t.Fatalf("expected true, got false")
+		}
+	})
+
+	t.Run("does not match without TrackerErrorSet", func(t *testing.T) {
+		got := EvaluateConditionWithContext(cond, torrent, &EvalContext{}, 0)
+		if got {
+			t.Fatalf("expected false, got true")
+		}
+	})
+}
+
 //go:fix inline
 func float64Ptr(v float64) *float64 {
 	return new(v)

--- a/internal/services/automations/service.go
+++ b/internal/services/automations/service.go
@@ -884,6 +884,9 @@ func (s *Service) initPreviewEvalContext(ctx context.Context, instanceID int, to
 		if len(healthCounts.TrackerDownSet) > 0 {
 			evalCtx.TrackerDownSet = healthCounts.TrackerDownSet
 		}
+		if len(healthCounts.TrackerErrorSet) > 0 {
+			evalCtx.TrackerErrorSet = healthCounts.TrackerErrorSet
+		}
 	}
 
 	return evalCtx, instance
@@ -2019,6 +2022,7 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 	if healthCounts := s.syncManager.GetTrackerHealthCounts(instanceID); healthCounts != nil {
 		evalCtx.UnregisteredSet = healthCounts.UnregisteredSet
 		evalCtx.TrackerDownSet = healthCounts.TrackerDownSet
+		evalCtx.TrackerErrorSet = healthCounts.TrackerErrorSet
 	}
 
 	// On-demand hardlink index (if rules use HARDLINK_SCOPE condition OR includeHardlinks)

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -7199,7 +7199,7 @@ components:
           description: Primary tracker URL
         trackerHealth:
           type: string
-          enum: [unregistered, tracker_down]
+          enum: [unregistered, tracker_down, tracker_error]
           description: Tracker health status (only present if unhealthy)
         matchType:
           type: string

--- a/web/src/components/query-builder/constants.ts
+++ b/web/src/components/query-builder/constants.ts
@@ -216,6 +216,7 @@ export const TORRENT_STATES = [
   { value: "stalled_downloading", label: "Stalled Down" },
   { value: "errored", label: "Error" },
   { value: "tracker_down", label: "Tracker Down" },
+  { value: "tracker_error", label: "Tracker Error" },
   { value: "checking", label: "Checking" },
   { value: "checkingResumeData", label: "Checking Resume Data" },
   { value: "moving", label: "Moving" },
@@ -369,6 +370,7 @@ export const FIELD_REQUIREMENTS = {
 
 export const STATE_VALUE_REQUIREMENTS = {
   tracker_down: "trackerHealth",
+  tracker_error: "trackerHealth",
 } as const;
 
 // Uncategorized sentinel (Radix Select requires non-empty values)

--- a/web/src/components/torrents/FilterSidebar.tsx
+++ b/web/src/components/torrents/FilterSidebar.tsx
@@ -298,11 +298,12 @@ const FilterSidebarComponent = ({
   const [isConvertingScheme, setIsConvertingScheme] = useState(false)
 
   const visibleTorrentStates = useMemo(() => {
-    let states = supportsTrackerHealth
-      ? TORRENT_STATES
-      : TORRENT_STATES.filter(
-          state => state.value !== "unregistered" && state.value !== "tracker_down" && state.value !== "tracker_error"
-        )
+    let states = TORRENT_STATES
+    if (!supportsTrackerHealth) {
+      states = TORRENT_STATES.filter(
+        state => state.value !== "unregistered" && state.value !== "tracker_down" && state.value !== "tracker_error"
+      )
+    }
 
     // Only show cross-seeds when there's an active cross-seed filter
     if (!selectedFilters.expr) {

--- a/web/src/components/torrents/FilterSidebar.tsx
+++ b/web/src/components/torrents/FilterSidebar.tsx
@@ -172,6 +172,7 @@ const TORRENT_STATES: Array<{ value: string; label: string; icon: LucideIcon }> 
   { value: "moving", label: "Moving", icon: MoveRight },
   { value: "unregistered", label: "Unregistered", icon: XCircle },
   { value: "tracker_down", label: "Tracker Down", icon: AlertCircle },
+  { value: "tracker_error", label: "Tracker Error", icon: XCircle },
   { value: "cross-seeds", label: "Cross Seeds", icon: GitBranch },
 ]
 
@@ -297,7 +298,11 @@ const FilterSidebarComponent = ({
   const [isConvertingScheme, setIsConvertingScheme] = useState(false)
 
   const visibleTorrentStates = useMemo(() => {
-    let states = supportsTrackerHealth ? TORRENT_STATES : TORRENT_STATES.filter(state => state.value !== "unregistered" && state.value !== "tracker_down")
+    let states = supportsTrackerHealth
+      ? TORRENT_STATES
+      : TORRENT_STATES.filter(
+          state => state.value !== "unregistered" && state.value !== "tracker_down" && state.value !== "tracker_error"
+        )
 
     // Only show cross-seeds when there's an active cross-seed filter
     if (!selectedFilters.expr) {

--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -499,6 +499,10 @@ function getStatusBadgeProps(torrent: Torrent, supportsTrackerHealth: boolean): 
       label = "Tracker Down"
       variant = "outline"
       className = "text-yellow-500 border-yellow-500/40 bg-yellow-500/10"
+    } else if (trackerHealth === "tracker_error") {
+      label = "Tracker Error"
+      variant = "outline"
+      className = "text-orange-500 border-orange-500/40 bg-orange-500/10"
     } else if (trackerHealth === "unregistered") {
       label = "Unregistered"
       variant = "outline"

--- a/web/src/components/torrents/TorrentDetailsPanel.tsx
+++ b/web/src/components/torrents/TorrentDetailsPanel.tsx
@@ -1687,6 +1687,10 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
                             statusLabel = "Tracker Down"
                             statusVariant = "outline"
                             statusClass = "text-yellow-500 border-yellow-500/40 bg-yellow-500/10"
+                          } else if (trackerHealth === "tracker_error") {
+                            statusLabel = "Tracker Error"
+                            statusVariant = "outline"
+                            statusClass = "text-orange-500 border-orange-500/40 bg-orange-500/10"
                           } else {
                             // Normal state-based styling
                             if (match.state === "downloading" || match.state === "uploading") {

--- a/web/src/components/torrents/TorrentTableColumns.tsx
+++ b/web/src/components/torrents/TorrentTableColumns.tsx
@@ -191,6 +191,9 @@ const getTrackerAwareStatusLabel = (torrent: Torrent, supportsTrackerHealth: boo
     if (torrent.tracker_health === "tracker_down") {
       return "Tracker Down"
     }
+    if (torrent.tracker_health === "tracker_error") {
+      return "Tracker Error"
+    }
   }
 
   return getStateLabel(torrent.state)
@@ -212,6 +215,13 @@ const getTrackerAwareStatusSortMeta = (torrent: Torrent, supportsTrackerHealth: 
         label: "Tracker Down",
       }
     }
+    if (torrent.tracker_health === "tracker_error") {
+      return {
+        priority: 2,
+        statePriority: -1,
+        label: "Tracker Error",
+      }
+    }
   }
 
   const statePriority = STATUS_SORT_ORDER[torrent.state] ?? 1000
@@ -231,6 +241,9 @@ const getStatusIcon = (state: string, trackerHealth?: string | null, supportsTra
     }
     if (trackerHealth === "tracker_down") {
       return AlertCircle
+    }
+    if (trackerHealth === "tracker_error") {
+      return XCircle
     }
   }
 

--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -271,6 +271,10 @@ function getStatusBadgeProps(torrent: Torrent, supportsTrackerHealth: boolean): 
       label = "Tracker Down"
       variant = "outline"
       className = "text-yellow-500 border-yellow-500/40 bg-yellow-500/10"
+    } else if (trackerHealth === "tracker_error") {
+      label = "Tracker Error"
+      variant = "outline"
+      className = "text-orange-500 border-orange-500/40 bg-orange-500/10"
     } else if (trackerHealth === "unregistered") {
       label = "Unregistered"
       variant = "outline"

--- a/web/src/components/torrents/details/CrossSeedTable.tsx
+++ b/web/src/components/torrents/details/CrossSeedTable.tsx
@@ -56,6 +56,8 @@ function getStatusInfo(match: CrossSeedTorrent): { label: string; variant: "defa
     return { label: "Unregistered", variant: "outline", className: "text-destructive border-destructive/40 bg-destructive/10" }
   } else if (trackerHealth === "tracker_down") {
     return { label: "Tracker Down", variant: "outline", className: "text-yellow-500 border-yellow-500/40 bg-yellow-500/10" }
+  } else if (trackerHealth === "tracker_error") {
+    return { label: "Tracker Error", variant: "outline", className: "text-orange-500 border-orange-500/40 bg-orange-500/10" }
   }
 
   if (match.state === "downloading" || match.state === "uploading") {

--- a/web/src/lib/cross-seed-utils.ts
+++ b/web/src/lib/cross-seed-utils.ts
@@ -101,7 +101,7 @@ export function toCompatibleMatch(m: LocalCrossSeedMatch): CrossSeedTorrent {
     tags: m.tags,
     state: m.state,
     tracker: m.tracker,
-    tracker_health: m.trackerHealth as "unregistered" | "tracker_down" | undefined,
+    tracker_health: m.trackerHealth as "unregistered" | "tracker_down" | "tracker_error" | undefined,
     instanceId: m.instanceId,
     instanceName: m.instanceName,
     matchType: m.matchType,

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -801,7 +801,7 @@ export interface Torrent {
   tracker: string
   trackers_count: number
   trackers?: TorrentTracker[]
-  tracker_health?: "unregistered" | "tracker_down"
+  tracker_health?: "unregistered" | "tracker_down" | "tracker_error"
   up_limit: number
   uploaded: number
   uploaded_session: number


### PR DESCRIPTION
This PR adds a new `Tracker Error` status which matches torrents only when all non-disabled trackers are in error states,
while explicitly excluding torrents already classified as unregistered or tracker_down.
This new status shows up under Unregistered and Tracker Down, and it stays hidden when tracker-health support is unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Tracker Error" status so torrents with tracker connectivity problems are visible, filterable, counted, and sorted; filters now require tracker-derived data when selected.
  * UI updates: sidebar counts, status badges, table/mobile cards, details and cross-seed views show a distinct orange "Tracker Error" badge/icon.
  * Automation/query builder support: rules and query options now recognize and require tracker-health capability for "Tracker Error".

* **Tests**
  * Added integration and unit tests covering detection, counts, caching, concurrent access, and filter behavior for tracker-error.

* **API**
  * OpenAPI/types updated to include the new tracker_error value.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/autobrr/qui/pull/1945?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->