### PR TITLE
fix(i18n): translate torrent state labels

### DIFF
--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -83,6 +83,7 @@ import {
   Trash2,
   X
 } from "lucide-react"
+import type { TFunction } from "i18next"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { AddTorrentDialog } from "./AddTorrentDialog"
@@ -486,28 +487,28 @@ function getStatusBadgeVariant(state: string): "default" | "secondary" | "destru
   }
 }
 
-function getStatusBadgeProps(torrent: Torrent, supportsTrackerHealth: boolean): {
+function getStatusBadgeProps(torrent: Torrent, supportsTrackerHealth: boolean, t: TFunction): {
   variant: "default" | "secondary" | "destructive" | "outline"
   label: string
   className: string
 } {
   const baseVariant = getStatusBadgeVariant(torrent.state)
   let variant = baseVariant
-  let label = getStateLabel(torrent.state)
+  let label = getStateLabel(torrent.state, t)
   let className = ""
 
   if (supportsTrackerHealth) {
     const trackerHealth = torrent.tracker_health ?? null
     if (trackerHealth === "tracker_down") {
-      label = "Tracker Down"
+      label = t("tableColumns.trackerDown")
       variant = "outline"
       className = "text-yellow-500 border-yellow-500/40 bg-yellow-500/10"
     } else if (trackerHealth === "tracker_error") {
-      label = "Tracker Error"
+      label = t("tableColumns.trackerError")
       variant = "outline"
       className = "text-orange-500 border-orange-500/40 bg-orange-500/10"
     } else if (trackerHealth === "unregistered") {
-      label = "Unregistered"
+      label = t("tableColumns.unregistered")
       variant = "outline"
       className = "text-destructive border-destructive/40 bg-destructive/10"
     }
@@ -712,8 +713,8 @@ function SwipeableCard({
   const displayTags = incognitoMode ? getLinuxTags(torrent.hash) : torrent.tags
   const displayRatio = incognitoMode ? getLinuxRatio(torrent.hash) : torrent.ratio
   const { variant: statusBadgeVariant, label: statusBadgeLabel, className: statusBadgeClass } = useMemo(
-    () => getStatusBadgeProps(torrent, supportsTrackerHealth),
-    [torrent, supportsTrackerHealth]
+    () => getStatusBadgeProps(torrent, supportsTrackerHealth, t),
+    [torrent, supportsTrackerHealth, t]
   )
   const trackerValue = incognitoMode ? getLinuxTracker(torrent.hash) : torrent.tracker
   const trackerMeta = useMemo(() => getTrackerDisplayMeta(trackerValue), [trackerValue])

--- a/web/src/components/torrents/TorrentDetailsPanel.tsx
+++ b/web/src/components/torrents/TorrentDetailsPanel.tsx
@@ -1669,7 +1669,7 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
 
                           // Get enriched status (tracker-aware)
                           const trackerHealth = match.tracker_health ?? null
-                          let statusLabel = getStateLabel(match.state)
+                          let statusLabel = getStateLabel(match.state, t)
                           let statusVariant: "default" | "secondary" | "destructive" | "outline" = "outline"
                           let statusClass = ""
 
@@ -1683,7 +1683,7 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
                             statusVariant = "outline"
                             statusClass = "text-yellow-500 border-yellow-500/40 bg-yellow-500/10"
                           } else if (trackerHealth === "tracker_error") {
-                            statusLabel = "Tracker Error"
+                            statusLabel = t("crossSeedTable.statusLabels.trackerError")
                             statusVariant = "outline"
                             statusClass = "text-orange-500 border-orange-500/40 bg-orange-500/10"
                           } else {

--- a/web/src/components/torrents/TorrentTableColumns.tsx
+++ b/web/src/components/torrents/TorrentTableColumns.tsx
@@ -197,7 +197,7 @@ const getTrackerAwareStatusLabel = (torrent: Torrent, supportsTrackerHealth: boo
     }
   }
 
-  return getStateLabel(torrent.state)
+  return getStateLabel(torrent.state, t)
 }
 
 const getTrackerAwareStatusSortMeta = (torrent: Torrent, supportsTrackerHealth: boolean, t?: TFunction) => {
@@ -230,7 +230,7 @@ const getTrackerAwareStatusSortMeta = (torrent: Torrent, supportsTrackerHealth: 
   return {
     priority: 10,
     statePriority,
-    label: getStateLabel(torrent.state),
+    label: getStateLabel(torrent.state, t),
   }
 }
 

--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -47,6 +47,7 @@ import {
   useReactTable
 } from "@tanstack/react-table"
 import { useVirtualizer } from "@tanstack/react-virtual"
+import type { TFunction } from "i18next"
 import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { InstancePreferencesDialog } from "../instances/preferences/InstancePreferencesDialog"
@@ -256,28 +257,28 @@ function getStatusBadgeVariant(state: string): "default" | "secondary" | "destru
   }
 }
 
-function getStatusBadgeProps(torrent: Torrent, supportsTrackerHealth: boolean): {
+function getStatusBadgeProps(torrent: Torrent, supportsTrackerHealth: boolean, t: TFunction): {
   variant: "default" | "secondary" | "destructive" | "outline"
   label: string
   className: string
 } {
   const baseVariant = getStatusBadgeVariant(torrent.state)
   let variant = baseVariant
-  let label = getStateLabel(torrent.state)
+  let label = getStateLabel(torrent.state, t)
   let className = ""
 
   if (supportsTrackerHealth) {
     const trackerHealth = torrent.tracker_health ?? null
     if (trackerHealth === "tracker_down") {
-      label = "Tracker Down"
+      label = t("tableColumns.trackerDown")
       variant = "outline"
       className = "text-yellow-500 border-yellow-500/40 bg-yellow-500/10"
     } else if (trackerHealth === "tracker_error") {
-      label = "Tracker Error"
+      label = t("tableColumns.trackerError")
       variant = "outline"
       className = "text-orange-500 border-orange-500/40 bg-orange-500/10"
     } else if (trackerHealth === "unregistered") {
-      label = "Unregistered"
+      label = t("tableColumns.unregistered")
       variant = "outline"
       className = "text-destructive border-destructive/40 bg-destructive/10"
     }
@@ -385,8 +386,8 @@ const CompactRow = memo(({
   const displayRatio = incognitoMode ? getLinuxRatio(torrent.hash) : torrent.ratio
 
   const { variant: statusBadgeVariant, label: statusBadgeLabel, className: statusBadgeClass } = useMemo(
-    () => getStatusBadgeProps(torrent, supportsTrackerHealth),
-    [torrent, supportsTrackerHealth]
+    () => getStatusBadgeProps(torrent, supportsTrackerHealth, t),
+    [torrent, supportsTrackerHealth, t]
   )
 
   // Resolve tracker display name and icon using customizations

--- a/web/src/components/torrents/details/CrossSeedTable.tsx
+++ b/web/src/components/torrents/details/CrossSeedTable.tsx
@@ -26,6 +26,7 @@ import {
   useReactTable,
   type SortingState
 } from "@tanstack/react-table"
+import type { TFunction } from "i18next"
 import { Copy, Loader2, Trash2 } from "lucide-react"
 import { memo, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
@@ -47,9 +48,9 @@ interface CrossSeedTableProps {
 
 const columnHelper = createColumnHelper<CrossSeedTorrent>()
 
-function getStatusInfo(match: CrossSeedTorrent, t: (key: string, options?: Record<string, unknown>) => string): { label: string; variant: "default" | "secondary" | "destructive" | "outline"; className: string } {
+function getStatusInfo(match: CrossSeedTorrent, t: TFunction): { label: string; variant: "default" | "secondary" | "destructive" | "outline"; className: string } {
   const trackerHealth = match.tracker_health ?? null
-  const label = getStateLabel(match.state)
+  const label = getStateLabel(match.state, t)
   let variant: "default" | "secondary" | "destructive" | "outline" = "outline"
   const className = ""
 

--- a/web/src/i18n/locales/en/torrents.json
+++ b/web/src/i18n/locales/en/torrents.json
@@ -1444,6 +1444,28 @@
     "yes": "Yes",
     "no": "No"
   },
+  "stateLabels": {
+    "downloading": "Downloading",
+    "metaDL": "Fetching Metadata",
+    "allocating": "Allocating",
+    "stalledDL": "Stalled",
+    "queuedDL": "Queued",
+    "checkingDL": "Checking",
+    "forcedDL": "(F) Downloading",
+    "uploading": "Seeding",
+    "stalledUP": "Seeding",
+    "queuedUP": "Queued",
+    "checkingUP": "Checking",
+    "forcedUP": "(F) Seeding",
+    "pausedDL": "Paused",
+    "pausedUP": "Completed",
+    "stoppedDL": "Stopped",
+    "stoppedUP": "Completed",
+    "error": "Error",
+    "missingFiles": "Missing Files",
+    "checkingResumeData": "Checking Resume Data",
+    "moving": "Moving"
+  },
   "details": {
     "failedToUpdatePriorities": "Failed to update file priorities",
     "failedToRenameFile": "Failed to rename file",

--- a/web/src/i18n/locales/zh-CN/torrents.json
+++ b/web/src/i18n/locales/zh-CN/torrents.json
@@ -1377,6 +1377,28 @@
     "yes": "是",
     "no": "否"
   },
+  "stateLabels": {
+    "downloading": "下载中",
+    "metaDL": "获取元数据中",
+    "allocating": "分配空间中",
+    "stalledDL": "停滞",
+    "queuedDL": "排队中",
+    "checkingDL": "校验中",
+    "forcedDL": "(强制) 下载中",
+    "uploading": "做种中",
+    "stalledUP": "做种中",
+    "queuedUP": "排队中",
+    "checkingUP": "校验中",
+    "forcedUP": "(强制) 做种中",
+    "pausedDL": "已暂停",
+    "pausedUP": "已完成",
+    "stoppedDL": "已停止",
+    "stoppedUP": "已完成",
+    "error": "错误",
+    "missingFiles": "文件丢失",
+    "checkingResumeData": "校验恢复数据中",
+    "moving": "移动中"
+  },
   "sort": {
     "label": "排序",
     "ascending": "升序",

--- a/web/src/lib/__tests__/torrent-state-utils.test.ts
+++ b/web/src/lib/__tests__/torrent-state-utils.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { getStateLabel } from "@/lib/torrent-state-utils"
+import type { TFunction } from "i18next"
+import { describe, expect, it, vi } from "vitest"
+
+describe("getStateLabel", () => {
+  it("returns the English fallback when no translator is provided", () => {
+    expect(getStateLabel("uploading")).toBe("Seeding")
+    expect(getStateLabel("stalledUP")).toBe("Seeding")
+    expect(getStateLabel("stoppedUP")).toBe("Completed")
+    expect(getStateLabel("stoppedDL")).toBe("Stopped")
+  })
+
+  it("passes through unknown states unchanged", () => {
+    expect(getStateLabel("someFutureState")).toBe("someFutureState")
+  })
+
+  it("translates known states through the i18n key with the English fallback as defaultValue", () => {
+    const t = vi.fn(() => "做种中") as unknown as TFunction
+
+    expect(getStateLabel("uploading", t)).toBe("做种中")
+    expect(t).toHaveBeenCalledWith("stateLabels.uploading", { defaultValue: "Seeding" })
+  })
+
+  it("uses the key derived from the raw qBittorrent state, not the friendly label", () => {
+    const t = vi.fn((_key: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? "") as unknown as TFunction
+
+    getStateLabel("stalledUP", t)
+    expect(t).toHaveBeenCalledWith("stateLabels.stalledUP", { defaultValue: "Seeding" })
+
+    getStateLabel("forcedDL", t)
+    expect(t).toHaveBeenCalledWith("stateLabels.forcedDL", { defaultValue: "(F) Downloading" })
+  })
+
+  it("falls back to the defaultValue for unknown states when a translator is provided", () => {
+    const t = vi.fn((_key: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? "") as unknown as TFunction
+
+    expect(getStateLabel("someFutureState", t)).toBe("someFutureState")
+    expect(t).toHaveBeenCalledWith("stateLabels.someFutureState", { defaultValue: "someFutureState" })
+  })
+})

--- a/web/src/lib/torrent-state-utils.ts
+++ b/web/src/lib/torrent-state-utils.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
+import type { TFunction } from "i18next"
+
 // Human-friendly labels for qBittorrent torrent states
 const TORRENT_STATE_LABELS: Record<string, string> = {
   // Downloading related
@@ -34,9 +36,10 @@ const TORRENT_STATE_LABELS: Record<string, string> = {
   moving: "Moving",
 }
 
-export function getStateLabel(state: string): string {
-  return TORRENT_STATE_LABELS[state] ?? state
+export function getStateLabel(state: string, t?: TFunction): string {
+  const fallback = TORRENT_STATE_LABELS[state] ?? state
+  if (t) {
+    return t(`stateLabels.${state}`, { defaultValue: fallback })
+  }
+  return fallback
 }
-
-
-


### PR DESCRIPTION
Torrent state labels (Seeding, Stopped, Completed, etc.) stayed in English in every locale because `getStateLabel` returned values from a hardcoded English map and was never wired to i18n — only the tracker-health overlay labels went through `t()`. This threads the translator through `getStateLabel` and all six call sites, adds a `stateLabels` group keyed by raw qBittorrent states for `en` and `zh-CN`, translates the remaining hardcoded tracker-health strings in the mobile/compact badges, and adds unit tests for `getStateLabel`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Internationalization**
  * Enhanced internationalization support for torrent status labels throughout the interface. Status indicators in torrent cards, tables, details panels, and cross-seed matches now display translated labels. Added comprehensive English and Chinese translations for all torrent states, error messages, and status indicators, improving localization for international users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/autobrr/qui/pull/1955?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->