### PR TITLE
test: fan out testdb helper to remaining database.New callers

### DIFF
--- a/internal/api/handlers/auth_setup_test.go
+++ b/internal/api/handlers/auth_setup_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -16,19 +15,14 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/autobrr/qui/internal/auth"
-	"github.com/autobrr/qui/internal/database"
 	"github.com/autobrr/qui/internal/domain"
+	"github.com/autobrr/qui/internal/testutil/testdb"
 )
 
 func TestSetupForbiddenWhenOIDCEnabled(t *testing.T) {
 	ctx := t.Context()
 
-	dbPath := filepath.Join(t.TempDir(), "test.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, db.Close())
-	})
+	db := testdb.NewMigratedSQLite(t, "auth-setup")
 
 	authService := auth.NewService(db)
 	sessionManager := scs.New()

--- a/internal/api/handlers/backups_test.go
+++ b/internal/api/handlers/backups_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/autobrr/qui/internal/backups"
 	"github.com/autobrr/qui/internal/database"
 	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/testutil/testdb"
 )
 
 func newRequestWithParams(method, path string, params map[string]string) *http.Request {
@@ -58,9 +59,7 @@ func setupTestBackupHandler(t *testing.T) (*BackupsHandler, *database.DB, string
 	t.Helper()
 
 	// Create test database
-	dbPath := filepath.Join(t.TempDir(), "test.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err)
+	db := testdb.NewMigratedSQLite(t, "backups-handler")
 
 	// Create test data directory
 	dataDir := t.TempDir()

--- a/internal/api/handlers/backups_test.go
+++ b/internal/api/handlers/backups_test.go
@@ -55,7 +55,7 @@ func newRequestWithParamsAndQuery(method, path string, params map[string]string,
 	return req
 }
 
-func setupTestBackupHandler(t *testing.T) (*BackupsHandler, *database.DB, string, func()) {
+func setupTestBackupHandler(t *testing.T) (*BackupsHandler, *database.DB, string) {
 	t.Helper()
 
 	// Create test database
@@ -75,11 +75,7 @@ func setupTestBackupHandler(t *testing.T) (*BackupsHandler, *database.DB, string
 
 	handler := NewBackupsHandler(service)
 
-	cleanup := func() {
-		require.NoError(t, db.Close())
-	}
-
-	return handler, db, dataDir, cleanup
+	return handler, db, dataDir
 }
 
 func createTestBackupRun(t *testing.T, db *database.DB, dataDir string, instanceID int) *models.BackupRun {
@@ -187,8 +183,7 @@ func createTestTorrentFiles(t *testing.T, dataDir string) {
 }
 
 func TestDownloadRun_InvalidInstanceID(t *testing.T) {
-	handler, _, _, cleanup := setupTestBackupHandler(t)
-	defer cleanup()
+	handler, _, _ := setupTestBackupHandler(t)
 
 	req := newRequestWithParams(http.MethodGet, "/api/instances/invalid/backups/runs/1/download", map[string]string{
 		"instanceID": "invalid",
@@ -203,8 +198,7 @@ func TestDownloadRun_InvalidInstanceID(t *testing.T) {
 }
 
 func TestDownloadRun_InvalidRunID(t *testing.T) {
-	handler, _, _, cleanup := setupTestBackupHandler(t)
-	defer cleanup()
+	handler, _, _ := setupTestBackupHandler(t)
 
 	req := newRequestWithParams(http.MethodGet, "/api/instances/1/backups/runs/invalid/download", map[string]string{
 		"instanceID": "1",
@@ -219,8 +213,7 @@ func TestDownloadRun_InvalidRunID(t *testing.T) {
 }
 
 func TestDownloadRun_BackupNotFound(t *testing.T) {
-	handler, _, _, cleanup := setupTestBackupHandler(t)
-	defer cleanup()
+	handler, _, _ := setupTestBackupHandler(t)
 
 	req := newRequestWithParams(http.MethodGet, "/api/instances/1/backups/runs/999/download", map[string]string{
 		"instanceID": "1",
@@ -235,8 +228,7 @@ func TestDownloadRun_BackupNotFound(t *testing.T) {
 }
 
 func TestDownloadRun_BackupNotAvailable(t *testing.T) {
-	handler, db, _, cleanup := setupTestBackupHandler(t)
-	defer cleanup()
+	handler, db, _ := setupTestBackupHandler(t)
 
 	// Create a test instance
 	ctx := context.Background()
@@ -273,8 +265,7 @@ func TestDownloadRun_BackupNotAvailable(t *testing.T) {
 }
 
 func TestDownloadRun_UnsupportedFormat(t *testing.T) {
-	handler, db, dataDir, cleanup := setupTestBackupHandler(t)
-	defer cleanup()
+	handler, db, dataDir := setupTestBackupHandler(t)
 
 	// Create a test instance and successful backup run
 	ctx := context.Background()
@@ -301,8 +292,7 @@ func TestDownloadRun_UnsupportedFormat(t *testing.T) {
 }
 
 func TestDownloadRun_ZIPFormat(t *testing.T) {
-	handler, db, dataDir, cleanup := setupTestBackupHandler(t)
-	defer cleanup()
+	handler, db, dataDir := setupTestBackupHandler(t)
 
 	// Create a test instance and successful backup run
 	ctx := context.Background()
@@ -346,8 +336,7 @@ func TestDownloadRun_ZIPFormat(t *testing.T) {
 }
 
 func TestDownloadRun_TarGzFormat(t *testing.T) {
-	handler, db, dataDir, cleanup := setupTestBackupHandler(t)
-	defer cleanup()
+	handler, db, dataDir := setupTestBackupHandler(t)
 
 	// Create a test instance and successful backup run
 	ctx := context.Background()
@@ -397,8 +386,7 @@ func TestDownloadRun_TarGzFormat(t *testing.T) {
 }
 
 func TestDownloadRun_TarZstFormat(t *testing.T) {
-	handler, db, dataDir, cleanup := setupTestBackupHandler(t)
-	defer cleanup()
+	handler, db, dataDir := setupTestBackupHandler(t)
 
 	// Create a test instance and successful backup run
 	ctx := context.Background()
@@ -448,8 +436,7 @@ func TestDownloadRun_TarZstFormat(t *testing.T) {
 }
 
 func TestDownloadRun_TarBrFormat(t *testing.T) {
-	handler, db, dataDir, cleanup := setupTestBackupHandler(t)
-	defer cleanup()
+	handler, db, dataDir := setupTestBackupHandler(t)
 
 	// Create a test instance and successful backup run
 	ctx := context.Background()
@@ -496,8 +483,7 @@ func TestDownloadRun_TarBrFormat(t *testing.T) {
 }
 
 func TestDownloadRun_TarXzFormat(t *testing.T) {
-	handler, db, dataDir, cleanup := setupTestBackupHandler(t)
-	defer cleanup()
+	handler, db, dataDir := setupTestBackupHandler(t)
 
 	// Create a test instance and successful backup run
 	ctx := context.Background()
@@ -546,8 +532,7 @@ func TestDownloadRun_TarXzFormat(t *testing.T) {
 }
 
 func TestDownloadRun_TarFormat(t *testing.T) {
-	handler, db, dataDir, cleanup := setupTestBackupHandler(t)
-	defer cleanup()
+	handler, db, dataDir := setupTestBackupHandler(t)
 
 	// Create a test instance and successful backup run
 	ctx := context.Background()
@@ -593,8 +578,7 @@ func TestDownloadRun_TarFormat(t *testing.T) {
 }
 
 func TestDownloadRun_DefaultFormat(t *testing.T) {
-	handler, db, dataDir, cleanup := setupTestBackupHandler(t)
-	defer cleanup()
+	handler, db, dataDir := setupTestBackupHandler(t)
 
 	// Create a test instance and successful backup run
 	ctx := context.Background()

--- a/internal/api/handlers/crossseed_blocklist_test.go
+++ b/internal/api/handlers/crossseed_blocklist_test.go
@@ -6,25 +6,19 @@ package handlers
 import (
 	"net/http"
 	"net/http/httptest"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/autobrr/qui/internal/database"
 	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/testutil/testdb"
 )
 
 func TestAddBlocklistEntryReturnsNotFoundWhenInstanceMissing(t *testing.T) {
 	ctx := t.Context()
 
-	dbPath := filepath.Join(t.TempDir(), "test.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, db.Close())
-	})
+	db := testdb.NewMigratedSQLite(t, "crossseed-blocklist")
 
 	instanceStore, err := models.NewInstanceStore(db, []byte("01234567890123456789012345678901"))
 	require.NoError(t, err)

--- a/internal/api/handlers/crossseed_put_test.go
+++ b/internal/api/handlers/crossseed_put_test.go
@@ -7,24 +7,20 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/autobrr/qui/internal/database"
 	"github.com/autobrr/qui/internal/models"
 	"github.com/autobrr/qui/internal/services/crossseed"
+	"github.com/autobrr/qui/internal/testutil/testdb"
 )
 
 func newTestCrossSeedStore(t *testing.T) *models.CrossSeedStore {
 	t.Helper()
 
-	dbPath := filepath.Join(t.TempDir(), "crossseed.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	db := testdb.NewMigratedSQLite(t, "crossseed-put")
 
 	key := make([]byte, 32)
 	for i := range key {

--- a/internal/api/handlers/crossseed_seasonpack_test.go
+++ b/internal/api/handlers/crossseed_seasonpack_test.go
@@ -7,22 +7,18 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/autobrr/qui/internal/database"
 	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/testutil/testdb"
 )
 
 func newTestSeasonPackRunStore(t *testing.T) *models.SeasonPackRunStore {
 	t.Helper()
-	dbPath := filepath.Join(t.TempDir(), "test.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	db := testdb.NewMigratedSQLite(t, "crossseed-seasonpack")
 	return models.NewSeasonPackRunStore(db)
 }
 

--- a/internal/api/handlers/dirscan_webhook_test.go
+++ b/internal/api/handlers/dirscan_webhook_test.go
@@ -18,9 +18,9 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/require"
 
-	"github.com/autobrr/qui/internal/database"
 	"github.com/autobrr/qui/internal/models"
 	"github.com/autobrr/qui/internal/services/dirscan"
+	"github.com/autobrr/qui/internal/testutil/testdb"
 )
 
 type webhookPayloadSimple struct {
@@ -144,12 +144,7 @@ func TestNormalizeAllowedDownloadClients(t *testing.T) {
 func TestTriggerScan_ReturnsMatchedDirectoryMetadata(t *testing.T) {
 	ctx := t.Context()
 
-	dbPath := filepath.Join(t.TempDir(), "test.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, db.Close())
-	})
+	db := testdb.NewMigratedSQLite(t, "dirscan-webhook")
 
 	instanceStore, err := models.NewInstanceStore(db, []byte("0123456789abcdef0123456789abcdef"))
 	require.NoError(t, err)
@@ -206,12 +201,7 @@ func TestTriggerScan_ReturnsMatchedDirectoryMetadata(t *testing.T) {
 func TestWebhookTriggerScan_RejectsAmbiguousDuplicateDirectoryPaths(t *testing.T) {
 	ctx := t.Context()
 
-	dbPath := filepath.Join(t.TempDir(), "test.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, db.Close())
-	})
+	db := testdb.NewMigratedSQLite(t, "dirscan-webhook")
 
 	instanceStore, err := models.NewInstanceStore(db, []byte("0123456789abcdef0123456789abcdef"))
 	require.NoError(t, err)
@@ -260,12 +250,7 @@ func TestWebhookTriggerScan_RejectsAmbiguousDuplicateDirectoryPaths(t *testing.T
 func TestWebhookTriggerScan_AcceptsArrTestPayloadWithoutScan(t *testing.T) {
 	ctx := t.Context()
 
-	dbPath := filepath.Join(t.TempDir(), "test.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, db.Close())
-	})
+	db := testdb.NewMigratedSQLite(t, "dirscan-webhook")
 
 	instanceStore, err := models.NewInstanceStore(db, []byte("0123456789abcdef0123456789abcdef"))
 	require.NoError(t, err)
@@ -309,12 +294,7 @@ func TestWebhookTriggerScan_AcceptsArrTestPayloadWithoutScan(t *testing.T) {
 func TestWebhookTriggerScan_ScansOnlyRequestedSubtree(t *testing.T) {
 	ctx := t.Context()
 
-	dbPath := filepath.Join(t.TempDir(), "test.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, db.Close())
-	})
+	db := testdb.NewMigratedSQLite(t, "dirscan-webhook")
 
 	instanceStore, err := models.NewInstanceStore(db, []byte("0123456789abcdef0123456789abcdef"))
 	require.NoError(t, err)
@@ -390,12 +370,7 @@ func TestWebhookTriggerScan_ScansOnlyRequestedSubtree(t *testing.T) {
 func TestWebhookTriggerScan_SkipsWhenDownloadClientNotAllowed(t *testing.T) {
 	ctx := t.Context()
 
-	dbPath := filepath.Join(t.TempDir(), "test.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, db.Close())
-	})
+	db := testdb.NewMigratedSQLite(t, "dirscan-webhook")
 
 	instanceStore, err := models.NewInstanceStore(db, []byte("0123456789abcdef0123456789abcdef"))
 	require.NoError(t, err)
@@ -455,12 +430,7 @@ func TestWebhookTriggerScan_SkipsWhenDownloadClientNotAllowed(t *testing.T) {
 func TestWebhookTriggerScan_SkipsWhenDownloadClientMissingButFilterExists(t *testing.T) {
 	ctx := t.Context()
 
-	dbPath := filepath.Join(t.TempDir(), "test.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, db.Close())
-	})
+	db := testdb.NewMigratedSQLite(t, "dirscan-webhook")
 
 	instanceStore, err := models.NewInstanceStore(db, []byte("0123456789abcdef0123456789abcdef"))
 	require.NoError(t, err)
@@ -519,12 +489,7 @@ func TestWebhookTriggerScan_SkipsWhenDownloadClientMissingButFilterExists(t *tes
 func TestWebhookTriggerScan_MatchesDownloadClientCaseInsensitively(t *testing.T) {
 	ctx := t.Context()
 
-	dbPath := filepath.Join(t.TempDir(), "test.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, db.Close())
-	})
+	db := testdb.NewMigratedSQLite(t, "dirscan-webhook")
 
 	instanceStore, err := models.NewInstanceStore(db, []byte("0123456789abcdef0123456789abcdef"))
 	require.NoError(t, err)
@@ -591,12 +556,7 @@ func TestWebhookTriggerScan_MatchesDownloadClientCaseInsensitively(t *testing.T)
 func TestWebhookTriggerScan_SimpleModeBypassesDownloadClientFilter(t *testing.T) {
 	ctx := t.Context()
 
-	dbPath := filepath.Join(t.TempDir(), "test.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, db.Close())
-	})
+	db := testdb.NewMigratedSQLite(t, "dirscan-webhook")
 
 	instanceStore, err := models.NewInstanceStore(db, []byte("0123456789abcdef0123456789abcdef"))
 	require.NoError(t, err)

--- a/internal/api/handlers/licenses_validate_test.go
+++ b/internal/api/handlers/licenses_validate_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -16,13 +15,11 @@ import (
 	"github.com/autobrr/qui/internal/api/ctxkeys"
 	"github.com/autobrr/qui/internal/database"
 	"github.com/autobrr/qui/internal/services/license"
+	"github.com/autobrr/qui/internal/testutil/testdb"
 )
 
 func TestValidateLicense_MissingStoredLicenseReturns404(t *testing.T) {
-	dbPath := filepath.Join(t.TempDir(), "licenses.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err)
-	defer db.Close()
+	db := testdb.NewMigratedSQLite(t, "licenses-validate-handler")
 
 	repo := database.NewLicenseRepo(db)
 	service := license.NewLicenseService(repo, nil, nil, t.TempDir())

--- a/internal/api/handlers/torrents_field_test.go
+++ b/internal/api/handlers/torrents_field_test.go
@@ -9,8 +9,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"reflect"
 	"strconv"
 	"testing"
@@ -21,9 +19,9 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/require"
 
-	"github.com/autobrr/qui/internal/database"
 	"github.com/autobrr/qui/internal/models"
 	quiqbt "github.com/autobrr/qui/internal/qbittorrent"
+	"github.com/autobrr/qui/internal/testutil/testdb"
 )
 
 func TestGetTorrentField_TagBaselineAcceptsFrontendMixedSelectionPayload(t *testing.T) {
@@ -119,17 +117,7 @@ func TestGetTorrentField_MagnetURIReturnsSelectedLinks(t *testing.T) {
 func createTorrentFieldTestHarness(t *testing.T, torrentsByInstanceName map[string][]qbt.Torrent) (*models.InstanceStore, *quiqbt.SyncManager, map[string]int) {
 	t.Helper()
 
-	tmpDir, err := os.MkdirTemp("", "qui-torrent-field-test-*")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = os.RemoveAll(tmpDir)
-	})
-
-	db, err := database.New(filepath.Join(tmpDir, "test.db"))
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = db.Close()
-	})
+	db := testdb.NewMigratedSQLite(t, "torrents-field")
 
 	instanceStore, err := models.NewInstanceStore(db, []byte("01234567890123456789012345678901"))
 	require.NoError(t, err)

--- a/internal/api/middleware/apikey_query_test.go
+++ b/internal/api/middleware/apikey_query_test.go
@@ -6,25 +6,19 @@ package middleware
 import (
 	"net/http"
 	"net/http/httptest"
-	"path/filepath"
 	"testing"
 
 	"github.com/alexedwards/scs/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/autobrr/qui/internal/auth"
-	"github.com/autobrr/qui/internal/database"
+	"github.com/autobrr/qui/internal/testutil/testdb"
 )
 
 func TestAPIKeyFromQuery_AllowsQueryParam(t *testing.T) {
 	ctx := t.Context()
 
-	dbPath := filepath.Join(t.TempDir(), "test.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, db.Close())
-	})
+	db := testdb.NewMigratedSQLite(t, "apikey-query")
 
 	authService := auth.NewService(db)
 	sessionManager := scs.New()

--- a/internal/api/middleware/auth_test.go
+++ b/internal/api/middleware/auth_test.go
@@ -6,7 +6,6 @@ package middleware
 import (
 	"net/http"
 	"net/http/httptest"
-	"path/filepath"
 	"testing"
 
 	"github.com/alexedwards/scs/v2"
@@ -15,19 +14,14 @@ import (
 
 	"github.com/autobrr/qui/internal/api/ctxkeys"
 	"github.com/autobrr/qui/internal/auth"
-	"github.com/autobrr/qui/internal/database"
 	"github.com/autobrr/qui/internal/domain"
+	"github.com/autobrr/qui/internal/testutil/testdb"
 )
 
 func TestIsAuthenticated_APIKeyHeaderAndSessionForbidden(t *testing.T) {
 	ctx := t.Context()
 
-	dbPath := filepath.Join(t.TempDir(), "test.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, db.Close())
-	})
+	db := testdb.NewMigratedSQLite(t, "middleware-auth")
 
 	authService := auth.NewService(db)
 	sessionManager := scs.New()
@@ -144,12 +138,7 @@ func TestIsAuthenticated_AuthDisabledWithoutConfirmation(t *testing.T) {
 	// AuthDisabled alone without IAcknowledgeThisIsABadIdea should NOT bypass auth
 	cfg := &domain.Config{AuthDisabled: true, IAcknowledgeThisIsABadIdea: false}
 
-	dbPath := filepath.Join(t.TempDir(), "test.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, db.Close())
-	})
+	db := testdb.NewMigratedSQLite(t, "middleware-auth")
 
 	authService := auth.NewService(db)
 	sessionManager := scs.New()

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
@@ -22,7 +21,6 @@ import (
 	"github.com/autobrr/qui/internal/auth"
 	"github.com/autobrr/qui/internal/backups"
 	"github.com/autobrr/qui/internal/config"
-	"github.com/autobrr/qui/internal/database"
 	"github.com/autobrr/qui/internal/domain"
 	"github.com/autobrr/qui/internal/models"
 	"github.com/autobrr/qui/internal/qbittorrent"
@@ -30,6 +28,7 @@ import (
 	"github.com/autobrr/qui/internal/services/license"
 	"github.com/autobrr/qui/internal/services/notifications"
 	"github.com/autobrr/qui/internal/services/trackericons"
+	"github.com/autobrr/qui/internal/testutil/testdb"
 	"github.com/autobrr/qui/internal/update"
 	"github.com/autobrr/qui/internal/web"
 	"github.com/autobrr/qui/internal/web/swagger"
@@ -97,15 +96,10 @@ func newTestDependencies(t *testing.T) *Dependencies {
 
 	sessionManager := scs.New()
 
-	dbPath := filepath.Join(t.TempDir(), "test.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, db.Close())
-	})
+	db := testdb.NewMigratedSQLite(t, "api-server")
 
 	authService := auth.NewService(db)
-	_, err = authService.SetupUser(context.Background(), "test-user", "password123")
+	_, err := authService.SetupUser(context.Background(), "test-user", "password123")
 	if err != nil && !errors.Is(err, models.ErrUserAlreadyExists) {
 		require.NoError(t, err)
 	}

--- a/internal/backups/service_test.go
+++ b/internal/backups/service_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/autobrr/qui/internal/database"
 	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/testutil/testdb"
 )
 
 // Helper function to insert a test instance with interned fields
@@ -46,18 +47,11 @@ func insertTestInstance(t *testing.T, db *database.DB, name string) int {
 func setupTestBackupDB(t *testing.T) *database.DB {
 	t.Helper()
 
-	// Create a unique database file for each test
-	dbPath := filepath.Join(t.TempDir(), "test.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err, "Failed to initialize test database with migrations")
+	db := testdb.NewMigratedSQLite(t, "backups-service")
 
 	// Allow multiple connections for tests that need concurrent access
 	db.Conn().SetMaxOpenConns(5)
 	db.Conn().SetMaxIdleConns(2)
-
-	t.Cleanup(func() {
-		require.NoError(t, db.Close())
-	})
 
 	return db
 }

--- a/internal/qbittorrent/pool_test.go
+++ b/internal/qbittorrent/pool_test.go
@@ -5,30 +5,18 @@ package qbittorrent
 
 import (
 	"errors"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/autobrr/qui/internal/database"
 	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/testutil/testdb"
 )
 
 // setupTestPool creates a new ClientPool for testing
 func setupTestPool(t *testing.T) *ClientPool {
-	// Create temp directory for test database
-	tmpDir, err := os.MkdirTemp("", "qui-pool-test-*")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(tmpDir) })
-
-	dbPath := filepath.Join(tmpDir, "test.db")
-
-	// Initialize test database
-	db, err := database.New(dbPath)
-	require.NoError(t, err, "Failed to initialize test database")
-	t.Cleanup(func() { db.Close() })
+	db := testdb.NewMigratedSQLite(t, "qbittorrent-pool")
 
 	// Use test encryption key
 	testKey := make([]byte, 32)

--- a/internal/services/arr/service_test.go
+++ b/internal/services/arr/service_test.go
@@ -8,7 +8,6 @@ import (
 	"database/sql"
 	"net/http"
 	"net/http/httptest"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -16,9 +15,9 @@ import (
 	"github.com/stretchr/testify/require"
 	_ "modernc.org/sqlite"
 
-	"github.com/autobrr/qui/internal/database"
 	"github.com/autobrr/qui/internal/dbinterface"
 	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/testutil/testdb"
 )
 
 type testQuerier struct {
@@ -302,12 +301,7 @@ func newArrLookupTestService(t *testing.T, instanceType models.ArrInstanceType, 
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
 
-	dbPath := filepath.Join(t.TempDir(), "arr-lookup.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, db.Close())
-	})
+	db := testdb.NewMigratedSQLite(t, "arr-service")
 
 	key := []byte("01234567890123456789012345678901")
 	instanceStore, err := models.NewArrInstanceStore(db, key)

--- a/internal/services/dirscan/cancel_scan_test.go
+++ b/internal/services/dirscan/cancel_scan_test.go
@@ -6,7 +6,6 @@ package dirscan
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -14,19 +13,13 @@ import (
 
 	"github.com/autobrr/qui/internal/database"
 	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/testutil/testdb"
 )
 
 func setupDirScanServiceTestDB(t *testing.T) *database.DB {
 	t.Helper()
 
-	dbPath := filepath.Join(t.TempDir(), "dirscan-service.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, db.Close())
-	})
-
-	return db
+	return testdb.NewMigratedSQLite(t, "dirscan-service")
 }
 
 func TestService_CancelScan_QueuedRunBumpsLastScanAt(t *testing.T) {

--- a/internal/services/dirscan/webhook_queue_test.go
+++ b/internal/services/dirscan/webhook_queue_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/autobrr/qui/internal/database"
 	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/testutil/testdb"
 )
 
 func TestMergeWebhookScanRoots(t *testing.T) {
@@ -34,12 +34,7 @@ func TestMergeWebhookScanRoots(t *testing.T) {
 func TestStartWebhookScan_QueuesAndMergesFollowUpRuns(t *testing.T) {
 	ctx := t.Context()
 
-	dbPath := filepath.Join(t.TempDir(), "webhook-queue.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, db.Close())
-	})
+	db := testdb.NewMigratedSQLite(t, "webhook-queue")
 
 	instanceStore, err := models.NewInstanceStore(db, []byte("0123456789abcdef0123456789abcdef"))
 	require.NoError(t, err)

--- a/internal/services/filesmanager/service_test.go
+++ b/internal/services/filesmanager/service_test.go
@@ -5,24 +5,19 @@ package filesmanager
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	qbt "github.com/autobrr/go-qbittorrent"
 	"github.com/stretchr/testify/require"
 
 	"github.com/autobrr/qui/internal/database"
+	"github.com/autobrr/qui/internal/testutil/testdb"
 )
 
 func setupFilesManagerDB(t *testing.T) (*database.DB, context.Context) {
 	t.Helper()
 	ctx := context.Background()
-	dbPath := filepath.Join(t.TempDir(), "test.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, db.Close())
-	})
+	db := testdb.NewMigratedSQLite(t, "filesmanager-service")
 
 	// Seed instance row to satisfy foreign key constraints for cache writes
 	var (
@@ -35,7 +30,7 @@ func setupFilesManagerDB(t *testing.T) (*database.DB, context.Context) {
 	require.NoError(t, db.QueryRowContext(ctx, "INSERT INTO string_pool (value) VALUES (?) RETURNING id", "instance-host").Scan(&hostID))
 	require.NoError(t, db.QueryRowContext(ctx, "INSERT INTO string_pool (value) VALUES (?) RETURNING id", "instance-username").Scan(&usernameID))
 
-	_, err = db.ExecContext(ctx, "INSERT INTO instances (id, name_id, host_id, username_id, password_encrypted) VALUES (?, ?, ?, ?, ?)", 1, instanceNameID, hostID, usernameID, "enc")
+	_, err := db.ExecContext(ctx, "INSERT INTO instances (id, name_id, host_id, username_id, password_encrypted) VALUES (?, ?, ?, ?, ?)", 1, instanceNameID, hostID, usernameID, "enc")
 	require.NoError(t, err)
 
 	return db, ctx

--- a/internal/services/license/license_service_dodo_regression_test.go
+++ b/internal/services/license/license_service_dodo_regression_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"io"
 	"net/http"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -18,15 +17,13 @@ import (
 	"github.com/autobrr/qui/internal/dodo"
 	"github.com/autobrr/qui/internal/models"
 	"github.com/autobrr/qui/internal/polar"
+	"github.com/autobrr/qui/internal/testutil/testdb"
 )
 
 func TestValidateLicenses_DoesNotAutoActivateInvalidDodoLicense(t *testing.T) {
 	ctx := context.Background()
 
-	dbPath := filepath.Join(t.TempDir(), "licenses.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err)
-	defer db.Close()
+	db := testdb.NewMigratedSQLite(t, "license-dodo-regression")
 
 	repo := database.NewLicenseRepo(db)
 
@@ -65,10 +62,7 @@ func TestValidateLicenses_DoesNotAutoActivateInvalidDodoLicense(t *testing.T) {
 func TestRefreshAllLicenses_UnknownProviderStoresDodoInstanceIDFromValidate(t *testing.T) {
 	ctx := context.Background()
 
-	dbPath := filepath.Join(t.TempDir(), "licenses.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err)
-	defer db.Close()
+	db := testdb.NewMigratedSQLite(t, "license-dodo-regression")
 
 	repo := database.NewLicenseRepo(db)
 
@@ -124,10 +118,7 @@ func TestRefreshAllLicenses_UnknownProviderStoresDodoInstanceIDFromValidate(t *t
 func TestValidateAndStoreLicense_UnknownProviderDodoInvalidDoesNotFallbackToPolar(t *testing.T) {
 	ctx := context.Background()
 
-	dbPath := filepath.Join(t.TempDir(), "licenses.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err)
-	defer db.Close()
+	db := testdb.NewMigratedSQLite(t, "license-dodo-regression")
 
 	repo := database.NewLicenseRepo(db)
 
@@ -177,7 +168,7 @@ func TestValidateAndStoreLicense_UnknownProviderDodoInvalidDoesNotFallbackToPola
 
 	service := NewLicenseService(repo, polarClient, dodoClient, t.TempDir())
 
-	_, err = service.ValidateAndStoreLicense(ctx, license.LicenseKey, "tester")
+	_, err := service.ValidateAndStoreLicense(ctx, license.LicenseKey, "tester")
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrLicenseNotActive)
 }
@@ -185,10 +176,7 @@ func TestValidateAndStoreLicense_UnknownProviderDodoInvalidDoesNotFallbackToPola
 func TestValidateLicenses_DodoProviderWithoutDodoClientDoesNotPanic(t *testing.T) {
 	ctx := context.Background()
 
-	dbPath := filepath.Join(t.TempDir(), "licenses.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err)
-	defer db.Close()
+	db := testdb.NewMigratedSQLite(t, "license-dodo-regression")
 
 	repo := database.NewLicenseRepo(db)
 
@@ -221,10 +209,7 @@ func TestValidateLicenses_DodoProviderWithoutDodoClientDoesNotPanic(t *testing.T
 func TestRefreshAllLicenses_ContinuesAfterDodoClientError(t *testing.T) {
 	ctx := context.Background()
 
-	dbPath := filepath.Join(t.TempDir(), "licenses.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err)
-	defer db.Close()
+	db := testdb.NewMigratedSQLite(t, "license-dodo-regression")
 
 	repo := database.NewLicenseRepo(db)
 
@@ -273,7 +258,7 @@ func TestRefreshAllLicenses_ContinuesAfterDodoClientError(t *testing.T) {
 
 	service := NewLicenseService(repo, polarClient, nil, t.TempDir())
 
-	err = service.RefreshAllLicenses(ctx)
+	err := service.RefreshAllLicenses(ctx)
 	require.ErrorIs(t, err, ErrDodoClientNotConfigured)
 
 	storedPolar, err := repo.GetLicenseByKey(ctx, polarLicense.LicenseKey)
@@ -284,10 +269,7 @@ func TestRefreshAllLicenses_ContinuesAfterDodoClientError(t *testing.T) {
 func TestDeleteLicense_DodoProviderWithoutDodoClientStillDeletesLocalLicense(t *testing.T) {
 	ctx := context.Background()
 
-	dbPath := filepath.Join(t.TempDir(), "licenses.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err)
-	defer db.Close()
+	db := testdb.NewMigratedSQLite(t, "license-dodo-regression")
 
 	repo := database.NewLicenseRepo(db)
 
@@ -309,6 +291,6 @@ func TestDeleteLicense_DodoProviderWithoutDodoClientStillDeletesLocalLicense(t *
 	service := NewLicenseService(repo, nil, nil, t.TempDir())
 	require.NoError(t, service.DeleteLicense(ctx, license.LicenseKey))
 
-	_, err = repo.GetLicenseByKey(ctx, license.LicenseKey)
+	_, err := repo.GetLicenseByKey(ctx, license.LicenseKey)
 	require.ErrorIs(t, err, models.ErrLicenseNotFound)
 }

--- a/internal/services/license/license_service_validation_test.go
+++ b/internal/services/license/license_service_validation_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"io"
 	"net/http"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -19,15 +18,13 @@ import (
 	"github.com/autobrr/qui/internal/database"
 	"github.com/autobrr/qui/internal/models"
 	"github.com/autobrr/qui/internal/polar"
+	"github.com/autobrr/qui/internal/testutil/testdb"
 )
 
 func TestValidateLicenses_NetworkTimeoutDoesNotInvalidate(t *testing.T) {
 	ctx := context.Background()
 
-	dbPath := filepath.Join(t.TempDir(), "licenses.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err)
-	defer db.Close()
+	db := testdb.NewMigratedSQLite(t, "license-validation")
 
 	repo := database.NewLicenseRepo(db)
 
@@ -72,10 +69,7 @@ func TestValidateLicenses_NetworkTimeoutDoesNotInvalidate(t *testing.T) {
 func TestValidateLicenses_OfflineBeyondGraceDoesNotInvalidate(t *testing.T) {
 	ctx := context.Background()
 
-	dbPath := filepath.Join(t.TempDir(), "licenses.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err)
-	defer db.Close()
+	db := testdb.NewMigratedSQLite(t, "license-validation")
 
 	repo := database.NewLicenseRepo(db)
 
@@ -120,10 +114,7 @@ func TestValidateLicenses_OfflineBeyondGraceDoesNotInvalidate(t *testing.T) {
 func TestValidateLicenses_InvalidThenTransientStillReturnsInvalid(t *testing.T) {
 	ctx := context.Background()
 
-	dbPath := filepath.Join(t.TempDir(), "licenses.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err)
-	defer db.Close()
+	db := testdb.NewMigratedSQLite(t, "license-validation")
 
 	repo := database.NewLicenseRepo(db)
 
@@ -192,10 +183,7 @@ func TestValidateLicenses_InvalidThenTransientStillReturnsInvalid(t *testing.T) 
 func TestValidateLicenses_InvalidStatusMarksLicenseInvalid(t *testing.T) {
 	ctx := context.Background()
 
-	dbPath := filepath.Join(t.TempDir(), "licenses.db")
-	db, err := database.New(dbPath)
-	require.NoError(t, err)
-	defer db.Close()
+	db := testdb.NewMigratedSQLite(t, "license-validation")
 
 	repo := database.NewLicenseRepo(db)
 


### PR DESCRIPTION
## Summary

Closes the testdb fan-out work started in #1938 (helper + `internal/models` + `internal/services/crossseed`). Converts the remaining 19 backend test files that still called `database.New` directly, replacing each migrate-from-scratch setup with `testdb.NewMigratedSQLite` (template-clone, sub-50ms per call).

Closes #1923 (completes the optimization track).

## Converted (19 files)

| Package | Files |
|---|---|
| `internal/backups` | 1 |
| `internal/services/license` | 2 |
| `internal/services/dirscan` | 2 |
| `internal/api` (incl. middleware) | 3 |
| `internal/api/handlers` | 8 |
| `internal/qbittorrent` | 1 |
| `internal/services/arr` | 1 |
| `internal/services/filesmanager` | 1 |

For `internal/backups/service_test.go`, the existing `SetMaxOpenConns(5)` / `SetMaxIdleConns(2)` calls are preserved inline after the helper returns (the original plan considered options for these but PR #1938 chose to let callers handle it directly — kept that pattern).

## Skipped (with reasons)

- **`internal/api/handlers/torrents_download_test.go`** — uses a `sync.Once` process-shared fixture, incompatible with `testdb.NewMigratedSQLite`'s `t.Cleanup`-based lifecycle. Would need a process-lived helper (e.g. `testdb.NewMigratedSQLiteAt(path string)`) to convert without breaking the shared-state semantics. Out of scope here.
- **`cmd/qui/user_commands_test.go`** — its `database.New` call reopens a DB the CLI command already migrated, so no migrations actually run. Not a meaningful contributor to test runtime.

## Observed wall-time improvements (`-race`, local, Apple Silicon)

| Package | Before | After | Saved |
|---|---|---|---|
| `internal/backups` | ~74s | ~9s | ~65s |
| `internal/api/handlers` | ~114s | ~12s | ~102s |
| `internal/api` | ~40s | ~13s | ~27s |
| `internal/services/license` | ~36s | ~6s | ~30s |
| `internal/api/middleware` | ~10s | ~5s | ~5s |
| `internal/services/dirscan` | ~19s | ~16s | ~3s |
| `internal/qbittorrent` | ~8s | ~7s | ~1s |
| **Total** | | | **~233s** |

`dirscan` and `qbittorrent` show small gains because most of their test runtime is in tests that don't use `database.New` (e.g. dirscan's filesystem-heavy `inject_test.go`); the converted files within each package still individually drop from ~3s migration overhead to ~50ms.

## Locally-only failures (not introduced by this PR)

Two tests in `internal/services/arr` fail locally in non-UTC timezones but **pass in CI** (GitHub Actions defaults to UTC). They exhibit a real production cache bug — tracked in **#1961**. Verified independent of this PR by stashing the changes and re-running against raw `develop`. Out of scope here.

- `TestService_LookupExternalIDsUsesNegativeCache`
- `TestService_LookupExternalIDsKeepsLegacyPositiveCacheWhenAliasHydrationMisses`

## Test plan

- [x] `go test -race -count=1 ./...` — all converted packages pass
- [x] `golangci-lint run --new-from-merge-base=develop` — 0 issues
- [x] `make build` — clean
- [x] CI green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Consolidated SQLite database setup across 15+ test files by introducing a unified initialization helper. Updates affect authentication, API handler, middleware, and service layer tests including backup, license validation, file management, directory scanning, and queue management. Manual database creation and temporary file cleanup patterns have been replaced with a standardized, reusable approach to improve test maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->