### PR TITLE
fix(api): remove WriteTimeout that aborted downloads and SSE at 120s

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -133,8 +133,14 @@ func NewServer(deps *Dependencies) *Server {
 		server: &http.Server{
 			ReadHeaderTimeout: time.Second * 15,
 			ReadTimeout:       60 * time.Second,
-			WriteTimeout:      120 * time.Second,
-			IdleTimeout:       180 * time.Second,
+			// No WriteTimeout: it is an absolute deadline on the whole response,
+			// so it aborts large file downloads (DownloadTorrentContentFile) and
+			// long-lived SSE streams once they run past a fixed bound, regardless
+			// of any reverse proxy. ReadHeaderTimeout/ReadTimeout/IdleTimeout still
+			// bound slow-header and idle connections; on a single-user self-hosted
+			// instance the response-side slow-client protection is not worth the cost.
+			WriteTimeout: 0,
+			IdleTimeout:  180 * time.Second,
 		},
 		logger:                           log.Logger.With().Str("module", "api").Logger(),
 		config:                           deps.Config,


### PR DESCRIPTION
`http.Server.WriteTimeout` is an absolute deadline on the whole response, set when the request headers are read, so any response still streaming past 120s gets its socket killed. That aborts large file downloads (`DownloadTorrentContentFile`) at exactly the 2-minute mark and silently severs long-lived SSE streams (masked by EventSource auto-reconnect). It reproduces even against `localhost` from inside the pod, which rules out the reverse proxy.

There is no clean per-route escape here: `http.ResponseController.SetWriteDeadline` can't reach the socket because the gzip middleware (`CAFxX/httpcompression` v0.0.9, latest) doesn't implement `Unwrap()`. Since qui is single-user self-hosted, response-side slow-client protection isn't worth permanently breaking streaming, so this drops `WriteTimeout` while keeping `ReadHeaderTimeout`/`ReadTimeout`/`IdleTimeout` to bound slow-header and idle connections.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated HTTP server write timeout configuration to allow unlimited response writing time, removing the previous deadline enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->