### PR TITLE
chore(refactor): remove explicit any and enable no-explicit-any rule

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -40,6 +40,7 @@ export default tseslint.config([
       '@stylistic/no-trailing-spaces': ['warn'],
       '@stylistic/object-curly-spacing': ['error', 'always'],
       '@typescript-eslint/no-unused-vars': ['warn'],
+      '@typescript-eslint/no-explicit-any': 'error',
       'linebreak-style': ['error', 'unix'],
       'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
       'react-hooks/rules-of-hooks': 'error',

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -58,6 +58,7 @@ import { cn } from "@/lib/utils"
 import type { InstanceCapabilities } from "@/types"
 import { useQueries, useQuery } from "@tanstack/react-query"
 import { Link, useNavigate, useSearch } from "@tanstack/react-router"
+import { navigateWithSearch } from "@/lib/router-search"
 import { changeLanguage, languageNames, supportedLanguages } from "@/i18n"
 import { Archive, Check, ChevronsUpDown, Cog, Download, FileEdit, FileText, FunnelPlus, FunnelX, GitBranch, Globe, HardDrive, Home, Info, ListTodo, Loader2, LogOut, Menu, Plus, Rss, Search, SearchCode, Server, Settings, X, Zap } from "lucide-react"
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react"
@@ -195,9 +196,10 @@ export function Header({
     saveUnifiedFilter(normalizedIds)
     const nextSearch: Record<string, unknown> = isAllInstancesRoute ? { ...(routeSearch || {}) } : {}
 
-    navigate({
+    navigateWithSearch({
+      navigate,
       to: "/instances",
-      search: nextSearch as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      search: nextSearch,
       replace: isAllInstancesRoute,
     })
   }, [activeInstanceIds, isAllInstancesRoute, navigate, routeSearch, saveUnifiedFilter])
@@ -236,7 +238,7 @@ export function Header({
     const next = { ...(routeSearch || {}) }
     if (trimmedSearch) next.q = trimmedSearch
     else delete next.q
-    navigate({ search: next as any, replace: true }) // eslint-disable-line @typescript-eslint/no-explicit-any
+    navigateWithSearch({ navigate, search: next, replace: true })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [debouncedSearch, shouldShowInstanceControls])
 
@@ -503,7 +505,7 @@ export function Header({
                       className="hidden md:inline-flex"
                       onClick={() => {
                         const next = { ...(routeSearch || {}), modal: "add-torrent" }
-                        navigate({ search: next as any, replace: true }) // eslint-disable-line @typescript-eslint/no-explicit-any
+                        navigateWithSearch({ navigate, search: next, replace: true })
                       }}
                     >
                       <Plus className="h-4 w-4" />
@@ -521,7 +523,7 @@ export function Header({
                         className="hidden md:inline-flex"
                         onClick={() => {
                           const next = { ...(routeSearch || {}), modal: "create-torrent" }
-                          navigate({ search: next as any, replace: true }) // eslint-disable-line @typescript-eslint/no-explicit-any
+                          navigateWithSearch({ navigate, search: next, replace: true })
                         }}
                       >
                         <FileEdit className="h-4 w-4" />
@@ -540,7 +542,7 @@ export function Header({
                         className="hidden md:inline-flex relative"
                         onClick={() => {
                           const next = { ...(routeSearch || {}), modal: "tasks" }
-                          navigate({ search: next as any, replace: true }) // eslint-disable-line @typescript-eslint/no-explicit-any
+                          navigateWithSearch({ navigate, search: next, replace: true })
                         }}
                       >
                         <ListTodo className="h-4 w-4" />
@@ -615,7 +617,7 @@ export function Header({
                     const trimmedValue = searchValue.trim()
                     if (trimmedValue) next.q = trimmedValue
                     else delete next.q
-                    navigate({ search: next as any, replace: true }) // eslint-disable-line @typescript-eslint/no-explicit-any
+                    navigateWithSearch({ navigate, search: next, replace: true })
                   } else if (e.key === "Escape") {
                     // Clear search and blur the input
                     e.preventDefault()
@@ -644,7 +646,7 @@ export function Header({
                           setSearchValue("")
                           const next = { ...(routeSearch || {}) }
                           delete next.q
-                          navigate({ search: next as any, replace: true }) // eslint-disable-line @typescript-eslint/no-explicit-any
+                          navigateWithSearch({ navigate, search: next, replace: true })
                         }}
                       >
                         <X className="h-3.5 w-3.5 text-muted-foreground" />

--- a/web/src/components/layout/MobileFooterNav.tsx
+++ b/web/src/components/layout/MobileFooterNav.tsx
@@ -47,6 +47,7 @@ import {
 } from "@/utils/theme"
 import { useQuery } from "@tanstack/react-query"
 import { Link, useLocation, useNavigate, useSearch } from "@tanstack/react-router"
+import { navigateWithSearch } from "@/lib/router-search"
 import {
   Archive,
   Check,
@@ -153,9 +154,10 @@ export function MobileFooterNav() {
     saveUnifiedFilter(normalizedIds)
     const nextSearch: Record<string, unknown> = isOnAllInstancesPage ? { ...(routeSearch || {}) } : {}
 
-    navigate({
+    navigateWithSearch({
+      navigate,
       to: "/instances",
-      search: nextSearch as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      search: nextSearch,
       replace: isOnAllInstancesPage,
     })
   }, [activeInstanceIds, isOnAllInstancesPage, navigate, routeSearch, saveUnifiedFilter])

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -28,6 +28,7 @@ import { normalizeUnifiedInstanceIds } from "@/lib/instances"
 import { cn } from "@/lib/utils"
 import { useQuery } from "@tanstack/react-query"
 import { Link, useLocation, useNavigate, useSearch } from "@tanstack/react-router"
+import { navigateWithSearch } from "@/lib/router-search"
 import {
   Archive,
   Check,
@@ -147,9 +148,10 @@ export function Sidebar() {
     saveUnifiedFilter(normalizedIds)
     const nextSearch: Record<string, unknown> = isAllInstancesActive ? { ...(routeSearch || {}) } : {}
 
-    navigate({
+    navigateWithSearch({
+      navigate,
       to: "/instances",
-      search: nextSearch as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      search: nextSearch,
       replace: isAllInstancesActive,
     })
   }, [activeInstanceIds, isAllInstancesActive, navigate, routeSearch, saveUnifiedFilter])

--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -52,6 +52,7 @@ import { buildTorrentActionTargets } from "@/lib/torrent-action-targets"
 import { anyTorrentHasTag, getCommonCategory, getCommonSavePath, getTorrentHashesWithTag } from "@/lib/torrent-utils"
 import { isAllInstancesScope } from "@/lib/instances"
 import { useNavigate, useSearch } from "@tanstack/react-router"
+import { navigateWithSearch } from "@/lib/router-search"
 import { useVirtualizer } from "@tanstack/react-virtual"
 import {
   ArrowUpDown,
@@ -1999,7 +2000,7 @@ export function TorrentCardsMobile({
     if (routeSearch && Object.prototype.hasOwnProperty.call(routeSearch, "q")) {
       const next = { ...(routeSearch || {}) }
       delete next.q
-      navigate({ search: next as any, replace: true }) // eslint-disable-line @typescript-eslint/no-explicit-any
+      navigateWithSearch({ navigate, search: next, replace: true })
     }
   }, [navigate, routeSearch])
 
@@ -2768,7 +2769,7 @@ export function TorrentCardsMobile({
               <button
                 onClick={() => {
                   const next = { ...(routeSearch || {}), modal: "create-torrent" }
-                  navigate({ search: next as any, replace: true }) // eslint-disable-line @typescript-eslint/no-explicit-any
+                  navigateWithSearch({ navigate, search: next, replace: true })
                 }}
                 className="flex flex-col items-center justify-center gap-0.5 px-2 py-1.5 text-xs font-medium transition-colors min-w-0 flex-1 text-muted-foreground hover:text-foreground active:scale-95"
               >
@@ -2781,7 +2782,7 @@ export function TorrentCardsMobile({
               <button
                 onClick={() => {
                   const next = { ...(routeSearch || {}), modal: "tasks" }
-                  navigate({ search: next as any, replace: true }) // eslint-disable-line @typescript-eslint/no-explicit-any
+                  navigateWithSearch({ navigate, search: next, replace: true })
                 }}
                 className="flex flex-col items-center justify-center gap-0.5 px-2 py-1.5 text-xs font-medium transition-colors min-w-0 flex-1 text-muted-foreground hover:text-foreground active:scale-95 relative"
               >

--- a/web/src/components/ui/multi-select.tsx
+++ b/web/src/components/ui/multi-select.tsx
@@ -190,12 +190,12 @@ function MultiSelectContent({
   const displayOptions = isMobile ? options : options.filter((option) => !selectedSet.has(option.value))
 
   return (
-      <ResponsiveCommand>
-        <ResponsiveCommandInput
-          placeholder={t("placeholders.search")}
-          value={inputValue}
-          onValueChange={setInputValue}
-        />
+    <ResponsiveCommand>
+      <ResponsiveCommandInput
+        placeholder={t("placeholders.search")}
+        value={inputValue}
+        onValueChange={setInputValue}
+      />
       <ResponsiveCommandList>
         <ResponsiveCommandEmpty>
           {creatable && inputValue.trim() ? (

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -420,11 +420,9 @@ async function ssoSafeFetch(url: string, options: RequestInit): Promise<Response
 // Custom error class for API errors with status and additional data
 export class APIError extends Error {
   status: number
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  data?: any
+  data?: unknown
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  constructor(message: string, status: number, data?: any) {
+  constructor(message: string, status: number, data?: unknown) {
     super(message)
     this.name = "APIError"
     this.status = status
@@ -459,8 +457,7 @@ class ApiClient {
     return response.json()
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private async extractErrorData(response: Response): Promise<{ message: string; data?: any }> {
+  private async extractErrorData(response: Response): Promise<{ message: string; data?: unknown }> {
     const fallbackMessage = `HTTP error! status: ${response.status}`
 
     try {
@@ -473,8 +470,7 @@ class ApiClient {
 
       // Try to parse as JSON first
       try {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const errorData = JSON.parse(rawBody) as { error?: string; message?: string; [key: string]: any }
+        const errorData = JSON.parse(rawBody) as { error?: string; message?: string; [key: string]: unknown }
         const parsedMessage = errorData?.error ?? errorData?.message
         if (typeof parsedMessage === "string" && parsedMessage.trim().length > 0) {
           // Return both the message and the full data (for 409 conflicts with automations, etc.)

--- a/web/src/lib/router-search.ts
+++ b/web/src/lib/router-search.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import type { useNavigate } from "@tanstack/react-router"
+
+// The concrete navigate function returned by useNavigate().
+type NavigateFn = ReturnType<typeof useNavigate>
+
+// Loose, structurally-correct shape for dynamically-built search params.
+// Router search params come from useSearch({ strict: false }) and are spread
+// into new objects, so values are effectively unknown at the call site.
+type DynamicSearch = Record<string, unknown>
+
+interface NavigateSearchOptions {
+  navigate: NavigateFn
+  to?: string
+  search: DynamicSearch
+  replace?: boolean
+}
+
+/**
+ * Navigate while replacing search params with a dynamically-built object.
+ *
+ * TanStack Router's navigate() requires `search` to match the destination
+ * route's generated SearchSchema. We build search objects dynamically
+ * (spread current params + set/delete one key), which the compiler cannot
+ * narrow to a specific route schema. The single cast below is the ONLY place
+ * that bridge happens; every call site passes a DynamicSearch and stays
+ * cast-free. Each route validates at runtime via its Zod validateSearch
+ * (with .catch(undefined)), so the typed boundary is centralized, not weakened.
+ */
+export function navigateWithSearch({ navigate, to, search, replace }: NavigateSearchOptions): void {
+  navigate({
+    ...(to !== undefined ? { to } : {}),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- router navigate() expects a per-route SearchSchema; dynamic search objects are validated by each route's Zod validateSearch at runtime, so this single cast centralizes the unavoidable TanStack typing boundary.
+    search: search as any,
+    ...(replace !== undefined ? { replace } : {}),
+  })
+}


### PR DESCRIPTION
## Summary

Tightens frontend type safety by eliminating explicit `any` from `web/src` and turning on `@typescript-eslint/no-explicit-any` as an `error` so new `any` can't slip back in. Implements **1930-a** of #1930. No runtime behavior changes — type-level hygiene only.

## Changes

**Clean up explicit `any`**
- New `web/src/lib/router-search.ts` exporting `navigateWithSearch()`, a typed wrapper around TanStack Router's `navigate()`. Dynamically-built search params can't be statically narrowed to a route's generated `SearchSchema`, but each route validates them at runtime via its Zod `validateSearch`. The single unavoidable `as any` lives here behind one `eslint-disable-next-line` with a rationale; every call site is now cast-free.
- `Header.tsx`, `Sidebar.tsx`, `MobileFooterNav.tsx`, `TorrentCardsMobile.tsx`: all `navigate({ search: … as any })` calls routed through the helper.
- `api.ts`: remaining `any`s replaced with real types — `APIError.data`, its constructor parameter, `extractErrorData`'s return value, and the `JSON.parse` index signature all become `unknown` — removing four bare `eslint-disable` comments.

**Enable the rule**
- `eslint.config.js`: `@typescript-eslint/no-explicit-any` set to `error`. With the cleanup done it flags nothing today, but pins the bar going forward.

**Pre-existing lint fix**
- `multi-select.tsx`: dedent a JSX block to satisfy `@stylistic/indent`. These 6 errors pre-date this branch and are unrelated, but surface only under a full-tree lint (`make lint` checks changed files only). Indentation-only; no logic change.

## Out of scope

- **1930-b** — splitting the 2578-line `types/index.ts` by domain — is a separate follow-up; this PR leaves it open.

## Testing

- `tsc -b` → clean (exit 0)
- `pnpm lint` → 0 errors, 0 `no-explicit-any` violations (110 pre-existing warnings remain, non-failing)
- `vitest run` → 8 files, 291 tests pass
- `pnpm build` → passes

No visual/UI changes, so no screenshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactoring**
  * Consolidated navigation logic throughout the application for improved consistency
  * Enhanced codebase type safety by eliminating unsafe type assertions
  * Updated development standards with stricter type checking to improve code reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->