### PR TITLE
(fix) Fix case mismatch on orphan scan

### DIFF
--- a/internal/services/orphanscan/filemap.go
+++ b/internal/services/orphanscan/filemap.go
@@ -130,11 +130,12 @@ func canonicalizeHash(hash string) string {
 	return strings.ToLower(strings.TrimSpace(hash))
 }
 
-// resolvePathCase returns path with its final component corrected to the actual
-// on-disk casing. Uses cache to avoid repeated ReadDir calls on the same parent.
-// If the path already exists as-is, or no case-insensitive match is found in the
-// parent, the original cleaned path is returned.
-// No-op on Windows: normalizePath already case-folds all paths there.
+// resolvePathCase returns path with every component corrected to the actual
+// on-disk casing. Recurses into the parent when the parent itself does not
+// exist (e.g. "AITHER/subdir" where only "Aither/" is on disk).
+// Uses cache to avoid repeated ReadDir calls for the same parent.
+// If no case-insensitive match is found at any level, the original path is
+// returned. No-op on Windows: normalizePath already case-folds all paths.
 func resolvePathCase(path string, cache map[string]string) string {
 	if runtime.GOOS == goosWindows {
 		return path
@@ -142,26 +143,29 @@ func resolvePathCase(path string, cache map[string]string) string {
 	if v, ok := cache[path]; ok {
 		return v
 	}
-	// Fast path: the path exists with the exact casing given.
+	resolved := resolvePathCaseUncached(path, cache)
+	cache[path] = resolved
+	return resolved
+}
+
+func resolvePathCaseUncached(path string, cache map[string]string) string {
 	if _, err := os.Lstat(path); err == nil {
-		cache[path] = path
 		return path
 	}
-	// Slow path: list the parent and find the first case-insensitive match.
 	parent := filepath.Dir(path)
-	base := filepath.Base(path)
-	entries, err := os.ReadDir(parent)
-	if err != nil {
-		cache[path] = path
+	if parent == path {
 		return path
 	}
+	resolvedParent := resolvePathCase(parent, cache)
+	entries, err := os.ReadDir(resolvedParent)
+	if err != nil {
+		return path
+	}
+	base := filepath.Base(path)
 	for _, e := range entries {
 		if strings.EqualFold(e.Name(), base) {
-			resolved := filepath.Join(parent, e.Name())
-			cache[path] = resolved
-			return resolved
+			return filepath.Join(resolvedParent, e.Name())
 		}
 	}
-	cache[path] = path
 	return path
 }

--- a/internal/services/orphanscan/filemap.go
+++ b/internal/services/orphanscan/filemap.go
@@ -4,6 +4,7 @@
 package orphanscan
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -127,4 +128,40 @@ func normalizePath(path string) string {
 // canonicalizeHash matches SyncManager's internal hash normalization.
 func canonicalizeHash(hash string) string {
 	return strings.ToLower(strings.TrimSpace(hash))
+}
+
+// resolvePathCase returns path with its final component corrected to the actual
+// on-disk casing. Uses cache to avoid repeated ReadDir calls on the same parent.
+// If the path already exists as-is, or no case-insensitive match is found in the
+// parent, the original cleaned path is returned.
+// No-op on Windows: normalizePath already case-folds all paths there.
+func resolvePathCase(path string, cache map[string]string) string {
+	if runtime.GOOS == goosWindows {
+		return path
+	}
+	if v, ok := cache[path]; ok {
+		return v
+	}
+	// Fast path: the path exists with the exact casing given.
+	if _, err := os.Lstat(path); err == nil {
+		cache[path] = path
+		return path
+	}
+	// Slow path: list the parent and find the first case-insensitive match.
+	parent := filepath.Dir(path)
+	base := filepath.Base(path)
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		cache[path] = path
+		return path
+	}
+	for _, e := range entries {
+		if strings.EqualFold(e.Name(), base) {
+			resolved := filepath.Join(parent, e.Name())
+			cache[path] = resolved
+			return resolved
+		}
+	}
+	cache[path] = path
+	return path
 }

--- a/internal/services/orphanscan/service.go
+++ b/internal/services/orphanscan/service.go
@@ -1248,6 +1248,7 @@ func buildFileMapFromTorrents(torrents []qbt.Torrent, filesByHash map[string]qbt
 	scanRoots := make(map[string]struct{})
 	skippedRoots := make(map[string]struct{})
 	stableMissingFiles := 0
+	pathCache := make(map[string]string)
 
 	for i := range torrents {
 		torrent := torrents[i]
@@ -1259,7 +1260,7 @@ func buildFileMapFromTorrents(torrents []qbt.Torrent, filesByHash map[string]qbt
 		if !hasFiles {
 			if isTransientTorrentStateForOrphanScan(torrent.State) {
 				if hasAbsSavePath {
-					skippedRoots[savePath] = struct{}{}
+					skippedRoots[resolvePathCase(savePath, pathCache)] = struct{}{}
 				}
 				continue
 			}
@@ -1272,7 +1273,12 @@ func buildFileMapFromTorrents(torrents []qbt.Torrent, filesByHash map[string]qbt
 			continue
 		}
 
-		scanRoots[savePath] = struct{}{}
+		// qBittorrent stores the configured save_path, which may differ in case
+		// from the actual directory on disk (e.g. "tracker-one" vs "Tracker-ONE")
+		// on case-sensitive filesystems. Resolve to the real on-disk name so the
+		// file map and scan roots match what WalkDir reports.
+		resolvedSavePath := resolvePathCase(savePath, pathCache)
+		scanRoots[resolvedSavePath] = struct{}{}
 
 		// content_path reflects the real on-disk path; use it to correct any
 		// case differences between the torrent metadata root folder name and the
@@ -1284,6 +1290,9 @@ func buildFileMapFromTorrents(torrents []qbt.Torrent, filesByHash map[string]qbt
 
 		for _, f := range correctedFiles {
 			tfm.Add(normalizePath(filepath.Join(savePath, f.Name)))
+			if resolvedSavePath != savePath {
+				tfm.Add(normalizePath(filepath.Join(resolvedSavePath, f.Name)))
+			}
 		}
 
 		// Auto TMM can update save_path to the category root without moving the

--- a/internal/services/orphanscan/service.go
+++ b/internal/services/orphanscan/service.go
@@ -1138,6 +1138,45 @@ func torrentRootFolder(files qbt.TorrentFiles) string {
 	return rootFolder
 }
 
+// correctFileNamesCase corrects the root folder capitalization in file names
+// when the torrent metadata case differs from the actual on-disk name reported
+// by content_path. This prevents false orphans when qBittorrent returns file
+// paths using metadata casing (e.g. "Hawke-UNO/file.mkv") while the actual
+// folder on disk uses different casing (e.g. "hawke-uno").
+func correctFileNamesCase(contentPath string, files qbt.TorrentFiles) qbt.TorrentFiles {
+	if contentPath == "" || len(files) == 0 {
+		return files
+	}
+
+	rootFolderMeta := torrentRootFolder(files)
+	if rootFolderMeta == "" {
+		return files
+	}
+
+	contentBase := filepath.Base(filepath.Clean(contentPath))
+	if contentBase == "" || contentBase == "." || contentBase == rootFolderMeta {
+		return files
+	}
+
+	if !strings.EqualFold(contentBase, rootFolderMeta) {
+		return files
+	}
+
+	corrected := make(qbt.TorrentFiles, len(files))
+	copy(corrected, files)
+	prefix := rootFolderMeta + "/"
+	for i := range corrected {
+		normalized := strings.ReplaceAll(corrected[i].Name, "\\", "/")
+		switch {
+		case strings.HasPrefix(normalized, prefix):
+			corrected[i].Name = contentBase + "/" + normalized[len(prefix):]
+		case normalized == rootFolderMeta:
+			corrected[i].Name = contentBase
+		}
+	}
+	return corrected
+}
+
 func actualSavePathFromContentPath(savePath, contentPath string, files qbt.TorrentFiles) string {
 	savePath = filepath.Clean(savePath)
 	contentPath = filepath.Clean(contentPath)
@@ -1215,16 +1254,25 @@ func buildFileMapFromTorrents(torrents []qbt.Torrent, filesByHash map[string]qbt
 		}
 
 		scanRoots[savePath] = struct{}{}
-		for _, f := range files {
+
+		// content_path reflects the real on-disk path; use it to correct any
+		// case differences between the torrent metadata root folder name and the
+		// actual directory on disk (e.g. metadata says "Hawke-UNO" but disk has
+		// "hawke-uno"). Without this, the file map would have the metadata case
+		// while the filesystem walker finds the actual disk case, causing the
+		// files to be falsely reported as orphans.
+		correctedFiles := correctFileNamesCase(torrent.ContentPath, files)
+
+		for _, f := range correctedFiles {
 			tfm.Add(normalizePath(filepath.Join(savePath, f.Name)))
 		}
 
 		// Auto TMM can update save_path to the category root without moving the
 		// payload. content_path still reflects the real on-disk location.
-		actualSavePath := actualSavePathFromContentPath(savePath, torrent.ContentPath, files)
+		actualSavePath := actualSavePathFromContentPath(savePath, torrent.ContentPath, correctedFiles)
 		if actualSavePath != "" && actualSavePath != savePath {
 			scanRoots[actualSavePath] = struct{}{}
-			for _, f := range files {
+			for _, f := range correctedFiles {
 				tfm.Add(normalizePath(filepath.Join(actualSavePath, f.Name)))
 			}
 		}

--- a/internal/services/orphanscan/service.go
+++ b/internal/services/orphanscan/service.go
@@ -1141,9 +1141,14 @@ func torrentRootFolder(files qbt.TorrentFiles) string {
 // correctFileNamesCase corrects the root folder capitalization in file names
 // when the torrent metadata case differs from the actual on-disk name reported
 // by content_path. This prevents false orphans when qBittorrent returns file
-// paths using metadata casing (e.g. "Hawke-UNO/file.mkv") while the actual
-// folder on disk uses different casing (e.g. "hawke-uno").
-func correctFileNamesCase(contentPath string, files qbt.TorrentFiles) qbt.TorrentFiles {
+// paths using metadata casing (e.g. "Tracker/file.mkv") while the actual
+// folder on disk uses different casing (e.g. "tracker").
+//
+// The disk name is derived by taking the first path component of content_path
+// relative to save_path. This covers both:
+//   - Multi-file torrents: content_path = save_path/RootFolder
+//   - Single-file torrents with a root folder: content_path = save_path/RootFolder/file.ext
+func correctFileNamesCase(savePath, contentPath string, files qbt.TorrentFiles) qbt.TorrentFiles {
 	if contentPath == "" || len(files) == 0 {
 		return files
 	}
@@ -1153,25 +1158,39 @@ func correctFileNamesCase(contentPath string, files qbt.TorrentFiles) qbt.Torren
 		return files
 	}
 
-	contentBase := filepath.Base(filepath.Clean(contentPath))
-	if contentBase == "" || contentBase == "." || contentBase == rootFolderMeta {
+	cleanSave := filepath.Clean(savePath)
+	cleanContent := filepath.Clean(contentPath)
+
+	// Extract the first component of contentPath after savePath.
+	// That component is the on-disk name of the torrent's root folder.
+	sep := string(filepath.Separator)
+	prefix := cleanSave + sep
+	var diskRootFolder string
+	if strings.HasPrefix(cleanContent, prefix) {
+		rel := cleanContent[len(prefix):]
+		diskRootFolder, _, _ = strings.Cut(rel, sep)
+	} else {
+		diskRootFolder = filepath.Base(cleanContent)
+	}
+
+	if diskRootFolder == "" || diskRootFolder == rootFolderMeta {
 		return files
 	}
 
-	if !strings.EqualFold(contentBase, rootFolderMeta) {
+	if !strings.EqualFold(diskRootFolder, rootFolderMeta) {
 		return files
 	}
 
 	corrected := make(qbt.TorrentFiles, len(files))
 	copy(corrected, files)
-	prefix := rootFolderMeta + "/"
+	metaPrefix := rootFolderMeta + "/"
 	for i := range corrected {
 		normalized := strings.ReplaceAll(corrected[i].Name, "\\", "/")
 		switch {
-		case strings.HasPrefix(normalized, prefix):
-			corrected[i].Name = contentBase + "/" + normalized[len(prefix):]
+		case strings.HasPrefix(normalized, metaPrefix):
+			corrected[i].Name = diskRootFolder + "/" + normalized[len(metaPrefix):]
 		case normalized == rootFolderMeta:
-			corrected[i].Name = contentBase
+			corrected[i].Name = diskRootFolder
 		}
 	}
 	return corrected
@@ -1257,11 +1276,11 @@ func buildFileMapFromTorrents(torrents []qbt.Torrent, filesByHash map[string]qbt
 
 		// content_path reflects the real on-disk path; use it to correct any
 		// case differences between the torrent metadata root folder name and the
-		// actual directory on disk (e.g. metadata says "Hawke-UNO" but disk has
-		// "hawke-uno"). Without this, the file map would have the metadata case
+		// actual directory on disk (e.g. metadata says "Tracker" but disk has
+		// "tracker"). Without this, the file map would have the metadata case
 		// while the filesystem walker finds the actual disk case, causing the
 		// files to be falsely reported as orphans.
-		correctedFiles := correctFileNamesCase(torrent.ContentPath, files)
+		correctedFiles := correctFileNamesCase(savePath, torrent.ContentPath, files)
 
 		for _, f := range correctedFiles {
 			tfm.Add(normalizePath(filepath.Join(savePath, f.Name)))

--- a/internal/services/orphanscan/settling_test.go
+++ b/internal/services/orphanscan/settling_test.go
@@ -5,6 +5,7 @@ package orphanscan
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -296,6 +297,10 @@ func TestBuildFileMapFromTorrents_FlatMultiFileDivergentContentPathUsesContentRo
 func TestCorrectFileNamesCase(t *testing.T) {
 	t.Parallel()
 
+	// Use a real temp dir so paths are absolute and cross-platform.
+	// correctFileNamesCase does no I/O; it only needs a valid path string.
+	saveRoot := filepath.Join(t.TempDir(), "CrossSeed")
+
 	tests := []struct {
 		name        string
 		contentPath string
@@ -304,25 +309,34 @@ func TestCorrectFileNamesCase(t *testing.T) {
 	}{
 		{
 			name:        "no change when cases match",
-			contentPath: "/data/Torrents/ZZCrossSeed/hawke-uno",
-			files:       qbt.TorrentFiles{{Name: "hawke-uno/movie.mkv"}},
-			wantNames:   []string{"hawke-uno/movie.mkv"},
+			contentPath: filepath.Join(saveRoot, "tracker"),
+			files:       qbt.TorrentFiles{{Name: "tracker/movie.mkv"}},
+			wantNames:   []string{"tracker/movie.mkv"},
 		},
 		{
 			name:        "corrects metadata caps to disk lowercase",
-			contentPath: "/data/Torrents/ZZCrossSeed/hawke-uno",
-			files:       qbt.TorrentFiles{{Name: "Hawke-UNO/movie.mkv"}},
-			wantNames:   []string{"hawke-uno/movie.mkv"},
+			contentPath: filepath.Join(saveRoot, "tracker"),
+			files:       qbt.TorrentFiles{{Name: "Tracker/movie.mkv"}},
+			wantNames:   []string{"tracker/movie.mkv"},
 		},
 		{
 			name:        "corrects metadata lowercase to disk caps",
-			contentPath: "/data/Torrents/ZZCrossSeed/Hawke-UNO",
-			files:       qbt.TorrentFiles{{Name: "hawke-uno/movie.mkv"}},
-			wantNames:   []string{"Hawke-UNO/movie.mkv"},
+			contentPath: filepath.Join(saveRoot, "Tracker"),
+			files:       qbt.TorrentFiles{{Name: "tracker/movie.mkv"}},
+			wantNames:   []string{"Tracker/movie.mkv"},
+		},
+		{
+			// Single-file-in-subdir: content_path points to the file, not the root
+			// folder. Root folder name is the first component after save_path.
+			// Reproduces the TRACKER/Tracker mismatch.
+			name:        "corrects via relative path when content_path is a file inside root folder",
+			contentPath: filepath.Join(saveRoot, "TRACKER", "Movie.Title", "Movie.Title.mkv"),
+			files:       qbt.TorrentFiles{{Name: "Tracker/Movie.Title/Movie.Title.mkv"}},
+			wantNames:   []string{"TRACKER/Movie.Title/Movie.Title.mkv"},
 		},
 		{
 			name:        "no change when no common root folder",
-			contentPath: "/data/Torrents/ZZCrossSeed/hawke-uno",
+			contentPath: filepath.Join(saveRoot, "tracker"),
 			files: qbt.TorrentFiles{
 				{Name: "movie.mkv"},
 				{Name: "subs/en.srt"},
@@ -330,28 +344,25 @@ func TestCorrectFileNamesCase(t *testing.T) {
 			wantNames: []string{"movie.mkv", "subs/en.srt"},
 		},
 		{
-			name:        "no change when content_path base unrelated to root folder",
-			contentPath: "/data/Torrents/ZZCrossSeed/hawke-uno/movie.mkv",
-			files: qbt.TorrentFiles{
-				{Name: "Hawke-UNO/movie.mkv"},
-				{Name: "Hawke-UNO/subs.srt"},
-			},
-			wantNames: []string{"Hawke-UNO/movie.mkv", "Hawke-UNO/subs.srt"},
+			name:        "no change for flat single-file torrent",
+			contentPath: filepath.Join(saveRoot, "movie.mkv"),
+			files:       qbt.TorrentFiles{{Name: "movie.mkv"}},
+			wantNames:   []string{"movie.mkv"},
 		},
 		{
 			name:        "corrects multiple files with same root folder",
-			contentPath: "/data/Torrents/ZZCrossSeed/hawke-uno",
+			contentPath: filepath.Join(saveRoot, "tracker"),
 			files: qbt.TorrentFiles{
-				{Name: "Hawke-UNO/movie.mkv"},
-				{Name: "Hawke-UNO/subs/en.srt"},
+				{Name: "Tracker/movie.mkv"},
+				{Name: "Tracker/subs/en.srt"},
 			},
-			wantNames: []string{"hawke-uno/movie.mkv", "hawke-uno/subs/en.srt"},
+			wantNames: []string{"tracker/movie.mkv", "tracker/subs/en.srt"},
 		},
 		{
 			name:        "empty content_path returns files unchanged",
 			contentPath: "",
-			files:       qbt.TorrentFiles{{Name: "Hawke-UNO/movie.mkv"}},
-			wantNames:   []string{"Hawke-UNO/movie.mkv"},
+			files:       qbt.TorrentFiles{{Name: "Tracker/movie.mkv"}},
+			wantNames:   []string{"Tracker/movie.mkv"},
 		},
 	}
 
@@ -359,7 +370,7 @@ func TestCorrectFileNamesCase(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := correctFileNamesCase(tt.contentPath, tt.files)
+			got := correctFileNamesCase(saveRoot, tt.contentPath, tt.files)
 			require.Len(t, got, len(tt.wantNames))
 			for i, want := range tt.wantNames {
 				assert.Equal(t, want, got[i].Name)
@@ -369,41 +380,75 @@ func TestCorrectFileNamesCase(t *testing.T) {
 }
 
 // TestBuildFileMapFromTorrents_CaseMismatchBetweenMetadataAndDisk verifies that
-// when qBittorrent reports file names using torrent metadata casing (e.g. "Hawke-UNO")
-// but content_path reveals the actual on-disk casing is different (e.g. "hawke-uno"),
+// when qBittorrent reports file names using torrent metadata casing (e.g. "Tracker")
+// but content_path reveals the actual on-disk casing is different (e.g. "tracker"),
 // the file map is built with the actual on-disk paths so the walker can find them.
 func TestBuildFileMapFromTorrents_CaseMismatchBetweenMetadataAndDisk(t *testing.T) {
 	t.Parallel()
 
-	saveRoot := filepath.Join(t.TempDir(), "ZZCrossSeed")
-	// content_path uses the actual on-disk lowercase name
-	diskFolder := filepath.Join(saveRoot, "hawke-uno")
-	// but torrent metadata has a different capitalisation
-	result, err := buildFileMapFromTorrents(
-		[]qbt.Torrent{
-			{
-				Hash:        "crossseed1",
-				SavePath:    saveRoot,
-				ContentPath: diskFolder,
-				State:       qbt.TorrentStatePausedUp,
-			},
+	saveRoot := filepath.Join(t.TempDir(), "CrossSeed")
+
+	tests := []struct {
+		name          string
+		contentPath   string
+		metaFileNames []string
+		diskFolder    string
+	}{
+		{
+			name:          "multi-file: metadata caps, disk lowercase",
+			contentPath:   filepath.Join(saveRoot, "tracker"),
+			metaFileNames: []string{"Tracker/The.Hunger.Games.mkv", "Tracker/subs.srt"},
+			diskFolder:    "tracker",
 		},
-		map[string]qbt.TorrentFiles{
-			"crossseed1": {
-				{Name: "Hawke-UNO/The.Hunger.Games.mkv", Size: 1000},
-				{Name: "Hawke-UNO/subs.srt", Size: 50},
-			},
+		{
+			// content_path includes two path components after save_path (tracker dir + file),
+			// so filepath.Base alone would yield the filename, not the tracker dir.
+			name:          "single-file-in-subdir: metadata mixed case, disk all-caps",
+			contentPath:   filepath.Join(saveRoot, "TRACKER", "Movie.Title", "Movie.Title.mkv"),
+			metaFileNames: []string{"Tracker/Movie.Title/Movie.Title.mkv"},
+			diskFolder:    "TRACKER",
 		},
-	)
-	require.NoError(t, err)
+	}
 
-	// File map must use the actual on-disk case (from content_path), not metadata case.
-	assert.True(t, result.fileMap.Has(normalizePath(filepath.Join(saveRoot, "hawke-uno", "The.Hunger.Games.mkv"))))
-	assert.True(t, result.fileMap.Has(normalizePath(filepath.Join(saveRoot, "hawke-uno", "subs.srt"))))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	// Must NOT have the metadata-cased path (which doesn't exist on disk).
-	assert.False(t, result.fileMap.Has(normalizePath(filepath.Join(saveRoot, "Hawke-UNO", "The.Hunger.Games.mkv"))))
-	assert.False(t, result.fileMap.Has(normalizePath(filepath.Join(saveRoot, "Hawke-UNO", "subs.srt"))))
+			files := make(qbt.TorrentFiles, len(tt.metaFileNames))
+			for i, n := range tt.metaFileNames {
+				files[i].Name = n
+				files[i].Size = 1000
+			}
 
-	assert.Equal(t, []string{filepath.Clean(saveRoot)}, result.scanRoots)
+			result, err := buildFileMapFromTorrents(
+				[]qbt.Torrent{
+					{
+						Hash:        "cs1",
+						SavePath:    saveRoot,
+						ContentPath: tt.contentPath,
+						State:       qbt.TorrentStatePausedUp,
+					},
+				},
+				map[string]qbt.TorrentFiles{"cs1": files},
+			)
+			require.NoError(t, err)
+
+			// File map must use the actual on-disk case (from content_path).
+			for _, n := range tt.metaFileNames {
+				// Derive what the on-disk path should be by replacing the
+				// metadata root folder with the actual disk folder name.
+				parts := strings.SplitN(n, "/", 2)
+				diskPath := normalizePath(filepath.Join(saveRoot, tt.diskFolder, parts[1]))
+				assert.True(t, result.fileMap.Has(diskPath), "expected disk path in map: %s", diskPath)
+
+				// Metadata-cased path must not appear.
+				metaPath := normalizePath(filepath.Join(saveRoot, n))
+				if filepath.ToSlash(normalizePath(filepath.Join(saveRoot, tt.diskFolder))) !=
+					filepath.ToSlash(normalizePath(filepath.Join(saveRoot, parts[0]))) {
+					assert.False(t, result.fileMap.Has(metaPath), "unexpected metadata path in map: %s", metaPath)
+				}
+			}
+			assert.Equal(t, []string{filepath.Clean(saveRoot)}, result.scanRoots)
+		})
+	}
 }

--- a/internal/services/orphanscan/settling_test.go
+++ b/internal/services/orphanscan/settling_test.go
@@ -289,3 +289,121 @@ func TestBuildFileMapFromTorrents_FlatMultiFileDivergentContentPathUsesContentRo
 	assert.Contains(t, result.scanRoots, filepath.Clean(contentRoot))
 	assert.NotContains(t, result.scanRoots, filepath.Dir(categoryRoot))
 }
+
+// TestCorrectFileNamesCase verifies that case mismatches between torrent metadata
+// root folder names and actual on-disk names (as reported by content_path) are
+// corrected before building file map entries.
+func TestCorrectFileNamesCase(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		contentPath string
+		files       qbt.TorrentFiles
+		wantNames   []string
+	}{
+		{
+			name:        "no change when cases match",
+			contentPath: "/data/Torrents/ZZCrossSeed/hawke-uno",
+			files:       qbt.TorrentFiles{{Name: "hawke-uno/movie.mkv"}},
+			wantNames:   []string{"hawke-uno/movie.mkv"},
+		},
+		{
+			name:        "corrects metadata caps to disk lowercase",
+			contentPath: "/data/Torrents/ZZCrossSeed/hawke-uno",
+			files:       qbt.TorrentFiles{{Name: "Hawke-UNO/movie.mkv"}},
+			wantNames:   []string{"hawke-uno/movie.mkv"},
+		},
+		{
+			name:        "corrects metadata lowercase to disk caps",
+			contentPath: "/data/Torrents/ZZCrossSeed/Hawke-UNO",
+			files:       qbt.TorrentFiles{{Name: "hawke-uno/movie.mkv"}},
+			wantNames:   []string{"Hawke-UNO/movie.mkv"},
+		},
+		{
+			name:        "no change when no common root folder",
+			contentPath: "/data/Torrents/ZZCrossSeed/hawke-uno",
+			files: qbt.TorrentFiles{
+				{Name: "movie.mkv"},
+				{Name: "subs/en.srt"},
+			},
+			wantNames: []string{"movie.mkv", "subs/en.srt"},
+		},
+		{
+			name:        "no change when content_path base unrelated to root folder",
+			contentPath: "/data/Torrents/ZZCrossSeed/hawke-uno/movie.mkv",
+			files: qbt.TorrentFiles{
+				{Name: "Hawke-UNO/movie.mkv"},
+				{Name: "Hawke-UNO/subs.srt"},
+			},
+			wantNames: []string{"Hawke-UNO/movie.mkv", "Hawke-UNO/subs.srt"},
+		},
+		{
+			name:        "corrects multiple files with same root folder",
+			contentPath: "/data/Torrents/ZZCrossSeed/hawke-uno",
+			files: qbt.TorrentFiles{
+				{Name: "Hawke-UNO/movie.mkv"},
+				{Name: "Hawke-UNO/subs/en.srt"},
+			},
+			wantNames: []string{"hawke-uno/movie.mkv", "hawke-uno/subs/en.srt"},
+		},
+		{
+			name:        "empty content_path returns files unchanged",
+			contentPath: "",
+			files:       qbt.TorrentFiles{{Name: "Hawke-UNO/movie.mkv"}},
+			wantNames:   []string{"Hawke-UNO/movie.mkv"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := correctFileNamesCase(tt.contentPath, tt.files)
+			require.Len(t, got, len(tt.wantNames))
+			for i, want := range tt.wantNames {
+				assert.Equal(t, want, got[i].Name)
+			}
+		})
+	}
+}
+
+// TestBuildFileMapFromTorrents_CaseMismatchBetweenMetadataAndDisk verifies that
+// when qBittorrent reports file names using torrent metadata casing (e.g. "Hawke-UNO")
+// but content_path reveals the actual on-disk casing is different (e.g. "hawke-uno"),
+// the file map is built with the actual on-disk paths so the walker can find them.
+func TestBuildFileMapFromTorrents_CaseMismatchBetweenMetadataAndDisk(t *testing.T) {
+	t.Parallel()
+
+	saveRoot := filepath.Join(t.TempDir(), "ZZCrossSeed")
+	// content_path uses the actual on-disk lowercase name
+	diskFolder := filepath.Join(saveRoot, "hawke-uno")
+	// but torrent metadata has a different capitalisation
+	result, err := buildFileMapFromTorrents(
+		[]qbt.Torrent{
+			{
+				Hash:        "crossseed1",
+				SavePath:    saveRoot,
+				ContentPath: diskFolder,
+				State:       qbt.TorrentStatePausedUp,
+			},
+		},
+		map[string]qbt.TorrentFiles{
+			"crossseed1": {
+				{Name: "Hawke-UNO/The.Hunger.Games.mkv", Size: 1000},
+				{Name: "Hawke-UNO/subs.srt", Size: 50},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	// File map must use the actual on-disk case (from content_path), not metadata case.
+	assert.True(t, result.fileMap.Has(normalizePath(filepath.Join(saveRoot, "hawke-uno", "The.Hunger.Games.mkv"))))
+	assert.True(t, result.fileMap.Has(normalizePath(filepath.Join(saveRoot, "hawke-uno", "subs.srt"))))
+
+	// Must NOT have the metadata-cased path (which doesn't exist on disk).
+	assert.False(t, result.fileMap.Has(normalizePath(filepath.Join(saveRoot, "Hawke-UNO", "The.Hunger.Games.mkv"))))
+	assert.False(t, result.fileMap.Has(normalizePath(filepath.Join(saveRoot, "Hawke-UNO", "subs.srt"))))
+
+	assert.Equal(t, []string{filepath.Clean(saveRoot)}, result.scanRoots)
+}

--- a/internal/services/orphanscan/settling_test.go
+++ b/internal/services/orphanscan/settling_test.go
@@ -443,7 +443,10 @@ func TestBuildFileMapFromTorrents_CaseMismatchBetweenMetadataAndDisk(t *testing.
 				diskPath := normalizePath(filepath.Join(saveRoot, tt.diskFolder, parts[1]))
 				assert.True(t, result.fileMap.Has(diskPath), "expected disk path in map: %s", diskPath)
 
-				// Metadata-cased path must not appear.
+				// Metadata-cased path must not appear — but only assert this
+				// when the disk folder and metadata folder normalize to different
+				// keys. On case-insensitive filesystems they collapse to the same
+				// key, so both paths are valid and the assertion would be wrong.
 				metaPath := normalizePath(filepath.Join(saveRoot, n))
 				if filepath.ToSlash(normalizePath(filepath.Join(saveRoot, tt.diskFolder))) !=
 					filepath.ToSlash(normalizePath(filepath.Join(saveRoot, parts[0]))) {
@@ -456,9 +459,10 @@ func TestBuildFileMapFromTorrents_CaseMismatchBetweenMetadataAndDisk(t *testing.
 }
 
 // TestResolvePathCase verifies that resolvePathCase finds the actual on-disk
-// casing of a directory name when the caller supplies a different case.
-// Skipped on non-Linux because macOS uses a case-insensitive filesystem where
-// os.Lstat succeeds regardless of case, making the resolution path unreachable.
+// casing at every level of a path, including when the parent itself is
+// wrong-cased (e.g. "AITHER/subdir" where only "Aither/subdir" exists).
+// Skipped on non-Linux: macOS case-insensitive FS makes os.Lstat succeed
+// regardless of case, so the correction path is never reached there.
 func TestResolvePathCase(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("case-sensitive filesystem required")
@@ -466,22 +470,44 @@ func TestResolvePathCase(t *testing.T) {
 	t.Parallel()
 
 	parent := t.TempDir()
-	actual := filepath.Join(parent, "Tracker-ONE")
-	require.NoError(t, os.Mkdir(actual, 0o755))
-	cache := make(map[string]string)
+	trackerDir := filepath.Join(parent, "Tracker-ONE")
+	subDir := filepath.Join(trackerDir, "Movie.Dir")
+	require.NoError(t, os.MkdirAll(subDir, 0o755))
 
-	// Wrong case → returns actual on-disk name.
-	got := resolvePathCase(filepath.Join(parent, "tracker-one"), cache)
-	assert.Equal(t, actual, got)
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "wrong final component",
+			path: filepath.Join(parent, "tracker-one"),
+			want: trackerDir,
+		},
+		{
+			name: "correct path unchanged",
+			path: trackerDir,
+			want: trackerDir,
+		},
+		{
+			name: "no match returns original",
+			path: filepath.Join(parent, "zzz-nonexistent"),
+			want: filepath.Join(parent, "zzz-nonexistent"),
+		},
+		{
+			name: "wrong parent resolved recursively",
+			path: filepath.Join(parent, "tracker-one", "Movie.Dir"),
+			want: subDir,
+		},
+	}
 
-	// Correct case → returns unchanged.
-	got = resolvePathCase(actual, cache)
-	assert.Equal(t, actual, got)
-
-	// No match → returns original.
-	noMatch := filepath.Join(parent, "zzz-nonexistent")
-	got = resolvePathCase(noMatch, cache)
-	assert.Equal(t, noMatch, got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := resolvePathCase(tt.path, make(map[string]string))
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 // TestBuildFileMapFromTorrents_SavePathCaseMismatch verifies that when
@@ -517,4 +543,40 @@ func TestBuildFileMapFromTorrents_SavePathCaseMismatch(t *testing.T) {
 	diskPath := normalizePath(filepath.Join(actual, "Transformers.mkv"))
 	assert.True(t, result.fileMap.Has(diskPath), "expected disk path in map: %s", diskPath)
 	assert.Contains(t, result.scanRoots, filepath.Clean(actual))
+}
+
+// TestBuildFileMapFromTorrents_SavePathMultiLevelCaseMismatch verifies that
+// when multiple components of save_path have wrong case (e.g. qBittorrent
+// stores "AITHER/Roofman--hash" but disk has "Aither/Roofman--hash"),
+// resolvePathCase recurses through each component to find the actual path.
+func TestBuildFileMapFromTorrents_SavePathMultiLevelCaseMismatch(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("case-sensitive filesystem required")
+	}
+	t.Parallel()
+
+	parent := t.TempDir()
+	trackerDir := filepath.Join(parent, "Aither")
+	torrentDir := filepath.Join(trackerDir, "Roofman.mkv--hash")
+	require.NoError(t, os.MkdirAll(torrentDir, 0o755))
+
+	// qBittorrent configured with wrong-cased tracker dir and torrent dir.
+	wrongCaseSavePath := filepath.Join(parent, "AITHER", "Roofman.mkv--hash")
+	result, err := buildFileMapFromTorrents(
+		[]qbt.Torrent{
+			{
+				Hash:     "abc123",
+				SavePath: wrongCaseSavePath,
+				State:    qbt.TorrentStatePausedUp,
+			},
+		},
+		map[string]qbt.TorrentFiles{
+			"abc123": {{Name: "Roofman.mkv", Size: 1000}},
+		},
+	)
+	require.NoError(t, err)
+
+	diskPath := normalizePath(filepath.Join(torrentDir, "Roofman.mkv"))
+	assert.True(t, result.fileMap.Has(diskPath), "expected disk path in map: %s", diskPath)
+	assert.Contains(t, result.scanRoots, filepath.Clean(torrentDir))
 }

--- a/internal/services/orphanscan/settling_test.go
+++ b/internal/services/orphanscan/settling_test.go
@@ -4,7 +4,9 @@
 package orphanscan
 
 import (
+	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -451,4 +453,68 @@ func TestBuildFileMapFromTorrents_CaseMismatchBetweenMetadataAndDisk(t *testing.
 			assert.Equal(t, []string{filepath.Clean(saveRoot)}, result.scanRoots)
 		})
 	}
+}
+
+// TestResolvePathCase verifies that resolvePathCase finds the actual on-disk
+// casing of a directory name when the caller supplies a different case.
+// Skipped on non-Linux because macOS uses a case-insensitive filesystem where
+// os.Lstat succeeds regardless of case, making the resolution path unreachable.
+func TestResolvePathCase(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("case-sensitive filesystem required")
+	}
+	t.Parallel()
+
+	parent := t.TempDir()
+	actual := filepath.Join(parent, "Tracker-ONE")
+	require.NoError(t, os.Mkdir(actual, 0o755))
+	cache := make(map[string]string)
+
+	// Wrong case → returns actual on-disk name.
+	got := resolvePathCase(filepath.Join(parent, "tracker-one"), cache)
+	assert.Equal(t, actual, got)
+
+	// Correct case → returns unchanged.
+	got = resolvePathCase(actual, cache)
+	assert.Equal(t, actual, got)
+
+	// No match → returns original.
+	noMatch := filepath.Join(parent, "zzz-nonexistent")
+	got = resolvePathCase(noMatch, cache)
+	assert.Equal(t, noMatch, got)
+}
+
+// TestBuildFileMapFromTorrents_SavePathCaseMismatch verifies that when
+// qBittorrent's configured save_path uses different casing from the actual
+// on-disk directory (e.g. "tracker-one" vs "Tracker-ONE"), the file map is
+// built with the actual on-disk paths so the walker can find them.
+// Skipped on non-Linux (case-insensitive filesystem makes it a no-op there).
+func TestBuildFileMapFromTorrents_SavePathCaseMismatch(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("case-sensitive filesystem required")
+	}
+	t.Parallel()
+
+	parent := t.TempDir()
+	actual := filepath.Join(parent, "Tracker-ONE")
+	require.NoError(t, os.Mkdir(actual, 0o755))
+
+	wrongCaseSavePath := filepath.Join(parent, "tracker-one")
+	result, err := buildFileMapFromTorrents(
+		[]qbt.Torrent{
+			{
+				Hash:     "abc123",
+				SavePath: wrongCaseSavePath,
+				State:    qbt.TorrentStatePausedUp,
+			},
+		},
+		map[string]qbt.TorrentFiles{
+			"abc123": {{Name: "Transformers.mkv", Size: 1000}},
+		},
+	)
+	require.NoError(t, err)
+
+	diskPath := normalizePath(filepath.Join(actual, "Transformers.mkv"))
+	assert.True(t, result.fileMap.Has(diskPath), "expected disk path in map: %s", diskPath)
+	assert.Contains(t, result.scanRoots, filepath.Clean(actual))
 }


### PR DESCRIPTION
  Summary of the fix:

  Root cause: buildFileMapFromTorrents builds file map paths from filepath.Join(savePath, 
  f.Name) where f.Name comes from qBittorrent's files API using torrent metadata casing (e.g.
   Tracker-ONE/movie.mkv). But qBittorrent's content_path reflects the actual on-disk path
  which may have different casing (e.g. tracker-one). The filesystem walker finds the actual
  disk name → case-sensitive string comparison fails → false orphan.

  Fix: Added correctFileNamesCase(contentPath, files) in service.go that:
  - Extracts the metadata root folder from file names (via torrentRootFolder)
  - Gets the actual on-disk folder name from filepath.Base(contentPath)
  - If they're case-insensitively equal but case-sensitively different, replaces the prefix
  in all file names with the actual on-disk case
  
  This runs in buildFileMapFromTorrents before building file map entries AND before passing
  to actualSavePathFromContentPath (fixing scan root derivation too when TrimSuffix was
  failing due to the case mismatch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduce false orphan detections by aligning scan roots, saved paths, and file listings with the actual on-disk folder name casing (non-Windows platforms); path resolution is memoized to improve scan consistency.

* **Tests**
  * Added tests covering filename-casing reconciliation, scan-root normalization, and file-map construction using on-disk casing (includes platform-specific cases for Unix-like systems).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->