### PR TITLE
feat(ci): build binaries for develop branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,12 +161,12 @@ jobs:
           fi
 
       - name: Run GoReleaser build and publish tags
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/develop'
         uses: goreleaser/goreleaser-action@v7.2.2
         with:
           distribution: goreleaser
           version: "~> v2"
-          args: release --clean --config .goreleaser.release.yml
+          args: ${{ startsWith(github.ref, 'refs/tags/') && 'release --clean --config .goreleaser.release.yml' || 'release --skip=publish,sign --snapshot --clean --config .goreleaser.release.yml' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BUILDER: ${{ github.actor }}@github-actions
@@ -181,6 +181,7 @@ jobs:
             dist/*.zip
             dist/*.deb
             dist/*.rpm
+          if-no-files-found: error
 
   goreleasersignedsmoke:
     name: PR signed release smoke test (ephemeral key)


### PR DESCRIPTION
This PR adds a condition to the existing `Run GoReleaser build and publish tags` step 
to also build binaries for the develop branch and not just for tags.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to build snapshot releases from the develop branch in addition to tag-based releases.
  * Improved release process reliability by enforcing strict artifact validation, ensuring all expected files are present before publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->