### PR TITLE
refactor(web): extract torrent-table display helpers and row components

### DIFF
--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -22,10 +22,11 @@ import { TORRENT_STREAM_POLL_INTERVAL_SECONDS, useTorrentsList } from "@/hooks/u
 import { useTrackerCustomizations } from "@/hooks/useTrackerCustomizations"
 import { useTrackerIcons } from "@/hooks/useTrackerIcons"
 import { columnFiltersToExpr } from "@/lib/column-filter-utils"
-import { buildTrackerCustomizationLookup, extractTrackerHost, getTrackerCustomizationsCacheKey, resolveTrackerDisplay, type TrackerCustomizationLookup } from "@/lib/tracker-customizations"
+import { getRowBackgroundClass } from "@/lib/torrent-table/row-display"
+import { shallowEqualTrackerIcons } from "@/lib/torrent-table/tracker-icon-equality"
+import { buildTrackerCustomizationLookup, getTrackerCustomizationsCacheKey, type TrackerCustomizationLookup } from "@/lib/tracker-customizations"
 import { resolveTrackerHealthSupport } from "@/lib/tracker-health-support"
-import { resolveTrackerIconSrc } from "@/lib/tracker-icons"
-import { formatBytes, getRatioColor } from "@/lib/utils"
+import { formatBytes } from "@/lib/utils"
 import {
   DndContext,
   MouseSensor,
@@ -48,7 +49,6 @@ import {
   useReactTable
 } from "@tanstack/react-table"
 import { useVirtualizer } from "@tanstack/react-virtual"
-import type { TFunction } from "i18next"
 import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { InstancePreferencesDialog } from "../instances/preferences/InstancePreferencesDialog"
@@ -57,7 +57,6 @@ import { TORRENT_SORT_OPTIONS, getDefaultSortOrder, type TorrentSortOptionValue 
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Checkbox } from "@/components/ui/checkbox"
 import {
   Dialog,
   DialogContent,
@@ -87,12 +86,11 @@ import { useInstanceMetadata } from "@/hooks/useInstanceMetadata"
 import { useInstancePreferences } from "@/hooks/useInstancePreferences.ts"
 import { useInstances } from "@/hooks/useInstances"
 import { api } from "@/lib/api"
-import { getLinuxCategory, getLinuxIsoName, getLinuxRatio, getLinuxTags, getLinuxTracker, useIncognitoMode } from "@/lib/incognito"
+import { useIncognitoMode } from "@/lib/incognito"
 import { isAllInstancesScope } from "@/lib/instances"
 import { resolveFooterSpeeds } from "@/lib/scoped-speeds"
 import { formatSpeedWithUnit, useSpeedUnits } from "@/lib/speedUnits"
 import { buildTorrentActionTargets } from "@/lib/torrent-action-targets"
-import { getStateLabel } from "@/lib/torrent-state-utils"
 import { anyTorrentHasTag, getCommonCategory, getCommonSavePath, getTorrentHashesWithTag, getTotalSize } from "@/lib/torrent-utils"
 import { cn } from "@/lib/utils"
 import type {
@@ -115,7 +113,6 @@ import {
   EthernetPort,
   Eye,
   EyeOff,
-  Folder,
   Globe,
   HardDrive,
   LayoutGrid,
@@ -124,7 +121,6 @@ import {
   RefreshCcw,
   Rows3,
   Table as TableIcon,
-  Tag,
   Turtle,
   X
 } from "lucide-react"
@@ -149,6 +145,7 @@ import {
 } from "./TorrentDialogs"
 import { TorrentDropZone } from "./TorrentDropZone"
 import { createColumns, type TableViewMode } from "./TorrentTableColumns"
+import { CompactRow } from "./table/CompactRow"
 
 const TABLE_ALLOWED_VIEW_MODES = ["normal", "dense", "compact"] as const
 
@@ -216,357 +213,6 @@ function getDefaultColumnOrder(): string[] {
 
   return order
 }
-
-function shallowEqualTrackerIcons(
-  prev?: Record<string, string>,
-  next?: Record<string, string>
-): boolean {
-  if (prev === next) {
-    return true
-  }
-
-  if (!prev || !next) {
-    return false
-  }
-
-  const prevKeys = Object.keys(prev)
-  const nextKeys = Object.keys(next)
-
-  if (prevKeys.length !== nextKeys.length) {
-    return false
-  }
-
-  for (const key of prevKeys) {
-    if (prev[key] !== next[key]) {
-      return false
-    }
-  }
-
-  return true
-}
-
-// Compact view helper functions and components
-
-// Returns the background class for a row based on selection state and zebra striping
-function getRowBackgroundClass(isRowSelected: boolean, isSelected: boolean, rowIndex: number): string {
-  if (isRowSelected || isSelected) return "bg-accent"
-  if (rowIndex % 2 === 1) return "bg-muted/40"
-  return ""
-}
-
-function getStatusBadgeVariant(state: string): "default" | "secondary" | "destructive" | "outline" {
-  switch (state) {
-    case "downloading":
-      return "default"
-    case "stalledDL":
-      return "secondary"
-    case "uploading":
-      return "default"
-    case "stalledUP":
-      return "secondary"
-    case "pausedDL":
-    case "pausedUP":
-      return "secondary"
-    case "error":
-    case "missingFiles":
-      return "destructive"
-    default:
-      return "outline"
-  }
-}
-
-function getStatusBadgeProps(torrent: Torrent, supportsTrackerHealth: boolean, t: TFunction): {
-  variant: "default" | "secondary" | "destructive" | "outline"
-  label: string
-  className: string
-} {
-  const baseVariant = getStatusBadgeVariant(torrent.state)
-  let variant = baseVariant
-  let label = getStateLabel(torrent.state, t)
-  let className = ""
-
-  if (supportsTrackerHealth) {
-    const trackerHealth = torrent.tracker_health ?? null
-    if (trackerHealth === "tracker_down") {
-      label = t("tableColumns.trackerDown")
-      variant = "outline"
-      className = "text-yellow-500 border-yellow-500/40 bg-yellow-500/10"
-    } else if (trackerHealth === "tracker_error") {
-      label = t("tableColumns.trackerError")
-      variant = "outline"
-      className = "text-orange-500 border-orange-500/40 bg-orange-500/10"
-    } else if (trackerHealth === "unregistered") {
-      label = t("tableColumns.unregistered")
-      variant = "outline"
-      className = "text-destructive border-destructive/40 bg-destructive/10"
-    }
-  }
-
-  return { variant, label, className }
-}
-
-const trackerIconSizeClasses = {
-  xs: "h-3 w-3 text-[8px]",
-  sm: "h-[14px] w-[14px] text-[9px]",
-  md: "h-4 w-4 text-[10px]",
-} as const
-
-type TrackerIconSize = keyof typeof trackerIconSizeClasses
-
-interface TrackerIconProps {
-  title: string
-  fallback: string
-  src: string | null
-  size?: TrackerIconSize
-  className?: string
-}
-
-const TrackerIcon = memo(({ title, fallback, src, size = "md", className }: TrackerIconProps) => {
-  const [hasError, setHasError] = useState(false)
-
-  useEffect(() => {
-    setHasError(false)
-  }, [src])
-
-  return (
-    <div className={cn("flex items-center justify-center", className)} title={title}>
-      <div
-        className={cn(
-          "flex items-center justify-center rounded-sm border border-border/40 bg-muted font-medium uppercase leading-none select-none",
-          trackerIconSizeClasses[size]
-        )}
-      >
-        {src && !hasError ? (
-          <img
-            src={src}
-            alt=""
-            className="h-full w-full rounded-[2px] object-cover"
-            loading="lazy"
-            draggable={false}
-            onError={() => setHasError(true)}
-          />
-        ) : (
-          <span aria-hidden="true">{fallback}</span>
-        )}
-      </div>
-    </div>
-  )
-}, (prev, next) =>
-  prev.title === next.title &&
-  prev.fallback === next.fallback &&
-  prev.src === next.src &&
-  prev.size === next.size &&
-  prev.className === next.className
-)
-
-// Compact row component for desktop
-interface CompactRowProps {
-  torrent: Torrent
-  rowId: string
-  rowIndex: number
-  isSelected: boolean
-  isRowSelected: boolean
-  showCheckbox: boolean
-  onClick: (e: React.MouseEvent) => void
-  onContextMenu: () => void
-  onCheckboxPointerDown: (event: React.PointerEvent<HTMLDivElement>) => void
-  onCheckboxChange: (torrent: Torrent, rowId: string, checked: boolean) => void
-  incognitoMode: boolean
-  speedUnit: "bytes" | "bits"
-  supportsTrackerHealth: boolean
-  trackerIcons?: Record<string, string>
-  trackerCustomizationLookup: TrackerCustomizationLookup
-  style: React.CSSProperties
-}
-
-const CompactRow = memo(({
-  torrent,
-  rowId,
-  rowIndex,
-  isSelected,
-  isRowSelected,
-  showCheckbox,
-  onClick,
-  onContextMenu,
-  onCheckboxPointerDown,
-  onCheckboxChange,
-  incognitoMode,
-  speedUnit,
-  supportsTrackerHealth,
-  trackerIcons,
-  trackerCustomizationLookup,
-  style,
-}: CompactRowProps) => {
-  const { t } = useTranslation("torrents")
-  const displayName = incognitoMode ? getLinuxIsoName(torrent.hash) : torrent.name
-  const displayCategory = incognitoMode ? getLinuxCategory(torrent.hash) : torrent.category
-  const displayTags = incognitoMode ? getLinuxTags(torrent.hash) : torrent.tags
-  const displayRatio = incognitoMode ? getLinuxRatio(torrent.hash) : torrent.ratio
-
-  const { variant: statusBadgeVariant, label: statusBadgeLabel, className: statusBadgeClass } = useMemo(
-    () => getStatusBadgeProps(torrent, supportsTrackerHealth, t),
-    [torrent, supportsTrackerHealth, t]
-  )
-
-  // Resolve tracker display name and icon using customizations
-  const trackerRaw = incognitoMode ? getLinuxTracker(torrent.hash) : torrent.tracker
-  const trackerHost = useMemo(() => extractTrackerHost(trackerRaw), [trackerRaw])
-  const trackerDisplayInfo = useMemo(
-    () => resolveTrackerDisplay(trackerHost, trackerCustomizationLookup),
-    [trackerHost, trackerCustomizationLookup]
-  )
-  const trackerLabel = trackerDisplayInfo.displayName || ""
-  const trackerIconSrc = resolveTrackerIconSrc(trackerIcons, trackerDisplayInfo.primaryDomain, trackerHost)
-  const trackerTitle = trackerDisplayInfo.isCustomized ? `${trackerDisplayInfo.displayName} (${trackerHost})` : trackerHost
-
-  // Compact view
-  return (
-    <div
-      className={cn(
-        "relative flex flex-col gap-1 px-3 py-2 cursor-pointer hover:bg-accent/40 overflow-hidden",
-        getRowBackgroundClass(isRowSelected, isSelected, rowIndex)
-      )}
-      style={style}
-      onClick={(e) => onClick(e)}
-      onContextMenu={onContextMenu}
-    >
-      {/* Progress background overlay - only show when downloading */}
-      {torrent.progress < 1 && (
-        <div
-          className="absolute inset-0 -z-10 bg-primary/10 transition-all duration-300"
-          style={{
-            width: `${Math.min(100, Math.max(0, torrent.progress * 100))}%`,
-          }}
-          aria-hidden="true"
-        />
-      )}
-      {/* Name with progress inline */}
-      <div className="flex items-center gap-2">
-        {showCheckbox && (
-          <div
-            className="flex items-center justify-center flex-shrink-0"
-            data-slot="checkbox"
-            onPointerDown={onCheckboxPointerDown}
-          >
-            <Checkbox
-              checked={isRowSelected}
-              onCheckedChange={(checked) => onCheckboxChange(torrent, rowId, checked === true)}
-              aria-label={t("tableColumns.selectAll")}
-              className="h-4 w-4"
-            />
-          </div>
-        )}
-        <div className="flex items-center gap-1 flex-shrink-0" title={trackerTitle}>
-          <TrackerIcon
-            title={trackerTitle}
-            fallback={trackerHost ? trackerHost.charAt(0).toUpperCase() : "?"}
-            src={trackerIconSrc}
-            size="sm"
-          />
-          {trackerLabel && (
-            <span className="text-xs text-muted-foreground whitespace-nowrap">
-              {trackerLabel}
-            </span>
-          )}
-        </div>
-        <h3 className="flex-1 font-medium text-sm truncate min-w-0" title={displayName}>
-          {displayName}
-        </h3>
-        <Badge variant={statusBadgeVariant} className={cn("text-xs flex-shrink-0", statusBadgeClass)}>
-          {statusBadgeLabel}
-        </Badge>
-      </div>
-
-      {/* Downloaded/Size and Ratio */}
-      <div className="flex items-center justify-between text-xs">
-        <span className="text-muted-foreground">
-          {formatBytes(torrent.downloaded)} / {formatBytes(torrent.size)}
-        </span>
-        <div className="flex items-center gap-1">
-          <span className="text-muted-foreground">{t("mobileCards.ratio")}</span>
-          <span
-            className="font-medium"
-            style={{ color: getRatioColor(displayRatio) }}
-          >
-            {displayRatio === -1 ? "∞" : displayRatio.toFixed(2)}
-          </span>
-        </div>
-      </div>
-
-      {/* Bottom row: Category/tags and percentage/speeds */}
-      <div className="flex items-center justify-between gap-2 text-xs">
-        {/* Left side: Category and Tags */}
-        <div className="flex items-center gap-2 text-muted-foreground min-w-0 overflow-hidden">
-          {displayCategory && (
-            <span className="flex items-center gap-1 flex-shrink-0">
-              <Folder className="h-3 w-3" />
-              {displayCategory}
-            </span>
-          )}
-          {displayTags && (
-            <div className="flex items-center gap-1 min-w-0 overflow-hidden">
-              <Tag className="h-3 w-3 flex-shrink-0" />
-              <span className="truncate">
-                {Array.isArray(displayTags) ? displayTags.join(", ") : displayTags}
-              </span>
-            </div>
-          )}
-        </div>
-
-        {/* Right side: Percentage and Speeds */}
-        <div className="flex items-center gap-2 flex-shrink-0">
-          <span className="text-muted-foreground">
-            {torrent.progress >= 0.99 && torrent.progress < 1 ? (
-              (Math.floor(torrent.progress * 1000) / 10).toFixed(1)
-            ) : (
-              Math.round(torrent.progress * 100)
-            )}%
-          </span>
-          {/* Speeds */}
-          {(torrent.dlspeed > 0 || torrent.upspeed > 0) && (
-            <div className="flex items-center gap-1">
-              {torrent.dlspeed > 0 && (
-                <span className="text-chart-2 font-medium">
-                  ↓{formatSpeedWithUnit(torrent.dlspeed, speedUnit)}
-                </span>
-              )}
-              {torrent.upspeed > 0 && (
-                <span className="text-chart-3 font-medium">
-                  ↑{formatSpeedWithUnit(torrent.upspeed, speedUnit)}
-                </span>
-              )}
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
-  )
-}, (prev, next) =>
-  prev.torrent.hash === next.torrent.hash &&
-  prev.rowId === next.rowId &&
-  prev.rowIndex === next.rowIndex &&
-  prev.torrent.name === next.torrent.name &&
-  prev.torrent.category === next.torrent.category &&
-  prev.torrent.tags === next.torrent.tags &&
-  prev.torrent.tracker === next.torrent.tracker &&
-  prev.torrent.tracker_health === next.torrent.tracker_health &&
-  prev.torrent.state === next.torrent.state &&
-  prev.torrent.progress === next.torrent.progress &&
-  prev.torrent.dlspeed === next.torrent.dlspeed &&
-  prev.torrent.upspeed === next.torrent.upspeed &&
-  prev.torrent.downloaded === next.torrent.downloaded &&
-  prev.torrent.size === next.torrent.size &&
-  prev.torrent.ratio === next.torrent.ratio &&
-  prev.isSelected === next.isSelected &&
-  prev.isRowSelected === next.isRowSelected &&
-  prev.showCheckbox === next.showCheckbox &&
-  prev.incognitoMode === next.incognitoMode &&
-  prev.speedUnit === next.speedUnit &&
-  prev.supportsTrackerHealth === next.supportsTrackerHealth &&
-  prev.trackerIcons === next.trackerIcons &&
-  prev.trackerCustomizationLookup === next.trackerCustomizationLookup &&
-  prev.style === next.style
-)
 
 interface ExternalIPAddressProps {
   address?: string | null

--- a/web/src/components/torrents/table/CompactRow.tsx
+++ b/web/src/components/torrents/table/CompactRow.tsx
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { Badge } from "@/components/ui/badge"
+import { Checkbox } from "@/components/ui/checkbox"
+import { getLinuxCategory, getLinuxIsoName, getLinuxRatio, getLinuxTags, getLinuxTracker } from "@/lib/incognito"
+import { formatSpeedWithUnit } from "@/lib/speedUnits"
+import { getRowBackgroundClass, getStatusBadgeProps } from "@/lib/torrent-table/row-display"
+import { extractTrackerHost, resolveTrackerDisplay, type TrackerCustomizationLookup } from "@/lib/tracker-customizations"
+import { resolveTrackerIconSrc } from "@/lib/tracker-icons"
+import { cn, formatBytes, getRatioColor } from "@/lib/utils"
+import type { Torrent } from "@/types"
+import { Folder, Tag } from "lucide-react"
+import { memo, useMemo } from "react"
+import { useTranslation } from "react-i18next"
+import { TrackerIcon } from "./TrackerIcon"
+
+// Compact row component for desktop
+interface CompactRowProps {
+  torrent: Torrent
+  rowId: string
+  rowIndex: number
+  isSelected: boolean
+  isRowSelected: boolean
+  showCheckbox: boolean
+  onClick: (e: React.MouseEvent) => void
+  onContextMenu: () => void
+  onCheckboxPointerDown: (event: React.PointerEvent<HTMLDivElement>) => void
+  onCheckboxChange: (torrent: Torrent, rowId: string, checked: boolean) => void
+  incognitoMode: boolean
+  speedUnit: "bytes" | "bits"
+  supportsTrackerHealth: boolean
+  trackerIcons?: Record<string, string>
+  trackerCustomizationLookup: TrackerCustomizationLookup
+  style: React.CSSProperties
+}
+
+export const CompactRow = memo(({
+  torrent,
+  rowId,
+  rowIndex,
+  isSelected,
+  isRowSelected,
+  showCheckbox,
+  onClick,
+  onContextMenu,
+  onCheckboxPointerDown,
+  onCheckboxChange,
+  incognitoMode,
+  speedUnit,
+  supportsTrackerHealth,
+  trackerIcons,
+  trackerCustomizationLookup,
+  style,
+}: CompactRowProps) => {
+  const { t } = useTranslation("torrents")
+  const displayName = incognitoMode ? getLinuxIsoName(torrent.hash) : torrent.name
+  const displayCategory = incognitoMode ? getLinuxCategory(torrent.hash) : torrent.category
+  const displayTags = incognitoMode ? getLinuxTags(torrent.hash) : torrent.tags
+  const displayRatio = incognitoMode ? getLinuxRatio(torrent.hash) : torrent.ratio
+
+  const { variant: statusBadgeVariant, label: statusBadgeLabel, className: statusBadgeClass } = useMemo(
+    () => getStatusBadgeProps(torrent, supportsTrackerHealth, t),
+    [torrent, supportsTrackerHealth, t]
+  )
+
+  // Resolve tracker display name and icon using customizations
+  const trackerRaw = incognitoMode ? getLinuxTracker(torrent.hash) : torrent.tracker
+  const trackerHost = useMemo(() => extractTrackerHost(trackerRaw), [trackerRaw])
+  const trackerDisplayInfo = useMemo(
+    () => resolveTrackerDisplay(trackerHost, trackerCustomizationLookup),
+    [trackerHost, trackerCustomizationLookup]
+  )
+  const trackerLabel = trackerDisplayInfo.displayName || ""
+  const trackerIconSrc = resolveTrackerIconSrc(trackerIcons, trackerDisplayInfo.primaryDomain, trackerHost)
+  const trackerTitle = trackerDisplayInfo.isCustomized ? `${trackerDisplayInfo.displayName} (${trackerHost})` : trackerHost
+
+  // Compact view
+  return (
+    <div
+      className={cn(
+        "relative flex flex-col gap-1 px-3 py-2 cursor-pointer hover:bg-accent/40 overflow-hidden",
+        getRowBackgroundClass(isRowSelected, isSelected, rowIndex)
+      )}
+      style={style}
+      onClick={(e) => onClick(e)}
+      onContextMenu={onContextMenu}
+    >
+      {/* Progress background overlay - only show when downloading */}
+      {torrent.progress < 1 && (
+        <div
+          className="absolute inset-0 -z-10 bg-primary/10 transition-all duration-300"
+          style={{
+            width: `${Math.min(100, Math.max(0, torrent.progress * 100))}%`,
+          }}
+          aria-hidden="true"
+        />
+      )}
+      {/* Name with progress inline */}
+      <div className="flex items-center gap-2">
+        {showCheckbox && (
+          <div
+            className="flex items-center justify-center flex-shrink-0"
+            data-slot="checkbox"
+            onPointerDown={onCheckboxPointerDown}
+          >
+            <Checkbox
+              checked={isRowSelected}
+              onCheckedChange={(checked) => onCheckboxChange(torrent, rowId, checked === true)}
+              aria-label={t("tableColumns.selectAll")}
+              className="h-4 w-4"
+            />
+          </div>
+        )}
+        <div className="flex items-center gap-1 flex-shrink-0" title={trackerTitle}>
+          <TrackerIcon
+            title={trackerTitle}
+            fallback={trackerHost ? trackerHost.charAt(0).toUpperCase() : "?"}
+            src={trackerIconSrc}
+            size="sm"
+          />
+          {trackerLabel && (
+            <span className="text-xs text-muted-foreground whitespace-nowrap">
+              {trackerLabel}
+            </span>
+          )}
+        </div>
+        <h3 className="flex-1 font-medium text-sm truncate min-w-0" title={displayName}>
+          {displayName}
+        </h3>
+        <Badge variant={statusBadgeVariant} className={cn("text-xs flex-shrink-0", statusBadgeClass)}>
+          {statusBadgeLabel}
+        </Badge>
+      </div>
+
+      {/* Downloaded/Size and Ratio */}
+      <div className="flex items-center justify-between text-xs">
+        <span className="text-muted-foreground">
+          {formatBytes(torrent.downloaded)} / {formatBytes(torrent.size)}
+        </span>
+        <div className="flex items-center gap-1">
+          <span className="text-muted-foreground">{t("mobileCards.ratio")}</span>
+          <span
+            className="font-medium"
+            style={{ color: getRatioColor(displayRatio) }}
+          >
+            {displayRatio === -1 ? "∞" : displayRatio.toFixed(2)}
+          </span>
+        </div>
+      </div>
+
+      {/* Bottom row: Category/tags and percentage/speeds */}
+      <div className="flex items-center justify-between gap-2 text-xs">
+        {/* Left side: Category and Tags */}
+        <div className="flex items-center gap-2 text-muted-foreground min-w-0 overflow-hidden">
+          {displayCategory && (
+            <span className="flex items-center gap-1 flex-shrink-0">
+              <Folder className="h-3 w-3" />
+              {displayCategory}
+            </span>
+          )}
+          {displayTags && (
+            <div className="flex items-center gap-1 min-w-0 overflow-hidden">
+              <Tag className="h-3 w-3 flex-shrink-0" />
+              <span className="truncate">
+                {Array.isArray(displayTags) ? displayTags.join(", ") : displayTags}
+              </span>
+            </div>
+          )}
+        </div>
+
+        {/* Right side: Percentage and Speeds */}
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <span className="text-muted-foreground">
+            {torrent.progress >= 0.99 && torrent.progress < 1 ? (
+              (Math.floor(torrent.progress * 1000) / 10).toFixed(1)
+            ) : (
+              Math.round(torrent.progress * 100)
+            )}%
+          </span>
+          {/* Speeds */}
+          {(torrent.dlspeed > 0 || torrent.upspeed > 0) && (
+            <div className="flex items-center gap-1">
+              {torrent.dlspeed > 0 && (
+                <span className="text-chart-2 font-medium">
+                  ↓{formatSpeedWithUnit(torrent.dlspeed, speedUnit)}
+                </span>
+              )}
+              {torrent.upspeed > 0 && (
+                <span className="text-chart-3 font-medium">
+                  ↑{formatSpeedWithUnit(torrent.upspeed, speedUnit)}
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}, (prev, next) =>
+  prev.torrent.hash === next.torrent.hash &&
+  prev.rowId === next.rowId &&
+  prev.rowIndex === next.rowIndex &&
+  prev.torrent.name === next.torrent.name &&
+  prev.torrent.category === next.torrent.category &&
+  prev.torrent.tags === next.torrent.tags &&
+  prev.torrent.tracker === next.torrent.tracker &&
+  prev.torrent.tracker_health === next.torrent.tracker_health &&
+  prev.torrent.state === next.torrent.state &&
+  prev.torrent.progress === next.torrent.progress &&
+  prev.torrent.dlspeed === next.torrent.dlspeed &&
+  prev.torrent.upspeed === next.torrent.upspeed &&
+  prev.torrent.downloaded === next.torrent.downloaded &&
+  prev.torrent.size === next.torrent.size &&
+  prev.torrent.ratio === next.torrent.ratio &&
+  prev.isSelected === next.isSelected &&
+  prev.isRowSelected === next.isRowSelected &&
+  prev.showCheckbox === next.showCheckbox &&
+  prev.incognitoMode === next.incognitoMode &&
+  prev.speedUnit === next.speedUnit &&
+  prev.supportsTrackerHealth === next.supportsTrackerHealth &&
+  prev.trackerIcons === next.trackerIcons &&
+  prev.trackerCustomizationLookup === next.trackerCustomizationLookup &&
+  prev.style === next.style
+)

--- a/web/src/components/torrents/table/CompactRow.tsx
+++ b/web/src/components/torrents/table/CompactRow.tsx
@@ -200,6 +200,10 @@ export const CompactRow = memo(({
     </div>
   )
 }, (prev, next) =>
+  // Handler props (onClick/onContextMenu/onCheckbox*) are intentionally excluded:
+  // the parent passes fresh inline lambdas every render, so comparing them would
+  // defeat row memoization (every row would re-render on every poll/stream tick).
+  // The state those handlers act on is reflected in the compared props below.
   prev.torrent.hash === next.torrent.hash &&
   prev.rowId === next.rowId &&
   prev.rowIndex === next.rowIndex &&

--- a/web/src/components/torrents/table/TrackerIcon.tsx
+++ b/web/src/components/torrents/table/TrackerIcon.tsx
@@ -4,7 +4,7 @@
  */
 
 import { cn } from "@/lib/utils"
-import { memo, useEffect, useState } from "react"
+import { memo, useState } from "react"
 
 const trackerIconSizeClasses = {
   xs: "h-3 w-3 text-[8px]",
@@ -23,11 +23,10 @@ export interface TrackerIconProps {
 }
 
 export const TrackerIcon = memo(({ title, fallback, src, size = "md", className }: TrackerIconProps) => {
-  const [hasError, setHasError] = useState(false)
-
-  useEffect(() => {
-    setHasError(false)
-  }, [src])
+  // Track the specific src that failed to load. Keying error state to the src
+  // value (rather than resetting a boolean in an effect) means a new src renders
+  // its image immediately, with no one-frame fallback flash.
+  const [failedSrc, setFailedSrc] = useState<string | null>(null)
 
   return (
     <div className={cn("flex items-center justify-center", className)} title={title}>
@@ -37,14 +36,14 @@ export const TrackerIcon = memo(({ title, fallback, src, size = "md", className 
           trackerIconSizeClasses[size]
         )}
       >
-        {src && !hasError ? (
+        {src && failedSrc !== src ? (
           <img
             src={src}
             alt=""
             className="h-full w-full rounded-[2px] object-cover"
             loading="lazy"
             draggable={false}
-            onError={() => setHasError(true)}
+            onError={() => setFailedSrc(src)}
           />
         ) : (
           <span aria-hidden="true">{fallback}</span>

--- a/web/src/components/torrents/table/TrackerIcon.tsx
+++ b/web/src/components/torrents/table/TrackerIcon.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { cn } from "@/lib/utils"
+import { memo, useEffect, useState } from "react"
+
+const trackerIconSizeClasses = {
+  xs: "h-3 w-3 text-[8px]",
+  sm: "h-[14px] w-[14px] text-[9px]",
+  md: "h-4 w-4 text-[10px]",
+} as const
+
+export type TrackerIconSize = keyof typeof trackerIconSizeClasses
+
+export interface TrackerIconProps {
+  title: string
+  fallback: string
+  src: string | null
+  size?: TrackerIconSize
+  className?: string
+}
+
+export const TrackerIcon = memo(({ title, fallback, src, size = "md", className }: TrackerIconProps) => {
+  const [hasError, setHasError] = useState(false)
+
+  useEffect(() => {
+    setHasError(false)
+  }, [src])
+
+  return (
+    <div className={cn("flex items-center justify-center", className)} title={title}>
+      <div
+        className={cn(
+          "flex items-center justify-center rounded-sm border border-border/40 bg-muted font-medium uppercase leading-none select-none",
+          trackerIconSizeClasses[size]
+        )}
+      >
+        {src && !hasError ? (
+          <img
+            src={src}
+            alt=""
+            className="h-full w-full rounded-[2px] object-cover"
+            loading="lazy"
+            draggable={false}
+            onError={() => setHasError(true)}
+          />
+        ) : (
+          <span aria-hidden="true">{fallback}</span>
+        )}
+      </div>
+    </div>
+  )
+}, (prev, next) =>
+  prev.title === next.title &&
+  prev.fallback === next.fallback &&
+  prev.src === next.src &&
+  prev.size === next.size &&
+  prev.className === next.className
+)

--- a/web/src/components/torrents/table/__tests__/CompactRow.test.tsx
+++ b/web/src/components/torrents/table/__tests__/CompactRow.test.tsx
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { CompactRow } from "@/components/torrents/table/CompactRow"
+import { getLinuxIsoName } from "@/lib/incognito"
+import type { TrackerCustomizationLookup } from "@/lib/tracker-customizations"
+import { makeTorrent } from "@/test/mockTorrent"
+import { cleanup, fireEvent, render } from "@testing-library/react"
+import type { Torrent } from "@/types"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+// Presentational component: stub i18n with a passthrough translator so we can
+// render without bootstrapping the real i18next instance.
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? key,
+  }),
+}))
+
+afterEach(cleanup)
+
+const emptyLookup: TrackerCustomizationLookup = new Map()
+
+function renderCompactRow(overrides: {
+  torrent?: Torrent
+  incognitoMode?: boolean
+  showCheckbox?: boolean
+  onCheckboxChange?: (torrent: Torrent, rowId: string, checked: boolean) => void
+} = {}) {
+  const torrent = overrides.torrent ?? makeTorrent({ name: "My Torrent", hash: "hash-1" })
+  return render(
+    <CompactRow
+      torrent={torrent}
+      rowId="row-0"
+      rowIndex={0}
+      isSelected={false}
+      isRowSelected={false}
+      showCheckbox={overrides.showCheckbox ?? true}
+      onClick={vi.fn()}
+      onContextMenu={vi.fn()}
+      onCheckboxPointerDown={vi.fn()}
+      onCheckboxChange={overrides.onCheckboxChange ?? vi.fn()}
+      incognitoMode={overrides.incognitoMode ?? false}
+      speedUnit="bytes"
+      supportsTrackerHealth={false}
+      trackerIcons={undefined}
+      trackerCustomizationLookup={emptyLookup}
+      style={{}}
+    />
+  )
+}
+
+describe("CompactRow", () => {
+  it("renders the torrent name when not in incognito mode", () => {
+    const { container } = renderCompactRow({
+      torrent: makeTorrent({ name: "Ubuntu 24.04 ISO", hash: "hash-1" }),
+    })
+    expect(container.textContent).toContain("Ubuntu 24.04 ISO")
+  })
+
+  it("masks the name with a Linux ISO alias in incognito mode", () => {
+    const torrent = makeTorrent({ name: "Ubuntu 24.04 ISO", hash: "hash-xyz" })
+    const { container } = renderCompactRow({ torrent, incognitoMode: true })
+    expect(container.textContent).not.toContain("Ubuntu 24.04 ISO")
+    expect(container.textContent).toContain(getLinuxIsoName(torrent.hash))
+  })
+
+  it("renders the progress percentage", () => {
+    const { container } = renderCompactRow({
+      torrent: makeTorrent({ name: "t", hash: "h", progress: 0.5 }),
+    })
+    expect(container.textContent).toContain("50%")
+  })
+
+  it("renders an infinite ratio as the infinity glyph", () => {
+    const { container } = renderCompactRow({
+      torrent: makeTorrent({ name: "t", hash: "h", ratio: -1 }),
+    })
+    expect(container.textContent).toContain("∞")
+  })
+
+  it("shows a download-speed indicator when downloading", () => {
+    const { container } = renderCompactRow({
+      torrent: makeTorrent({ name: "t", hash: "h", dlspeed: 1024 }),
+    })
+    expect(container.textContent).toContain("↓")
+  })
+
+  it("omits speed indicators when idle", () => {
+    const { container } = renderCompactRow({
+      torrent: makeTorrent({ name: "t", hash: "h", dlspeed: 0, upspeed: 0 }),
+    })
+    expect(container.textContent).not.toContain("↓")
+    expect(container.textContent).not.toContain("↑")
+  })
+
+  it("renders a checkbox and forwards toggles to onCheckboxChange", () => {
+    const onCheckboxChange = vi.fn()
+    const torrent = makeTorrent({ name: "t", hash: "hash-1" })
+    const { container } = renderCompactRow({ torrent, onCheckboxChange })
+    const checkbox = container.querySelector("[role=\"checkbox\"]")
+    expect(checkbox).not.toBeNull()
+    fireEvent.click(checkbox!)
+    expect(onCheckboxChange).toHaveBeenCalledWith(torrent, "row-0", true)
+  })
+
+  it("hides the checkbox when showCheckbox is false", () => {
+    const { container } = renderCompactRow({ showCheckbox: false })
+    expect(container.querySelector("[role=\"checkbox\"]")).toBeNull()
+  })
+})

--- a/web/src/components/torrents/table/__tests__/TorrentTableOptimized.smoke.test.tsx
+++ b/web/src/components/torrents/table/__tests__/TorrentTableOptimized.smoke.test.tsx
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+/**
+ * Whole-table mount smoke test — the cross-PR regression tripwire for the
+ * TorrentTableOptimized decomposition (issue #1963).
+ *
+ * It mounts the REAL component with the network/router/stream boundaries
+ * mocked and a deterministic virtualizer, then asserts the behaviours most
+ * likely to break while extracting seams: rows render, and the header
+ * select-all toggles row selection. The external data/action hooks mocked
+ * here are NOT what the decomposition refactors, so this harness stays stable
+ * across the 10 PRs it guards. Real virtualized scrolling and column-filter
+ * UI are intentionally left to per-seam unit tests + the manual smoke per PR.
+ *
+ * IMPORTANT: every mocked hook returns a STABLE singleton reference. Returning
+ * fresh objects per render makes the table's effects re-fire forever (OOM).
+ */
+
+import { TorrentTableOptimized } from "@/components/torrents/TorrentTableOptimized"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { cleanup, fireEvent, render, within } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { makeTorrent } from "@/test/mockTorrent"
+
+const torrents = [
+  makeTorrent({ hash: "hash-aaa", name: "Alpha Release", state: "downloading", progress: 0.5 }),
+  makeTorrent({ hash: "hash-bbb", name: "Bravo Release", state: "uploading", progress: 1 }),
+  makeTorrent({ hash: "hash-ccc", name: "Charlie Release", state: "stalledUP", progress: 1 }),
+]
+
+// i18n: keep the real exports (i18n bootstrap needs initReactI18next), but
+// override useTranslation with a stable passthrough translator.
+vi.mock("react-i18next", async (importOriginal) => {
+  const translation = {
+    t: (key: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? key,
+    i18n: { resolvedLanguage: "en", language: "en" },
+  }
+  return {
+    ...(await importOriginal<typeof import("react-i18next")>()),
+    useTranslation: () => translation,
+  }
+})
+
+// Router: avoid needing a real router tree.
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const search = {}
+  const navigate = vi.fn()
+  return {
+    ...(await importOriginal<typeof import("@tanstack/react-router")>()),
+    useSearch: () => search,
+    useNavigate: () => navigate,
+  }
+})
+
+// SyncStream: keep the pure error-code helper, stub the live connection.
+vi.mock("@/contexts/SyncStreamContext", async (importOriginal) => {
+  const streamState = {
+    connected: false,
+    error: null,
+    lastMeta: undefined,
+    retrying: false,
+    nextRetryAt: undefined,
+    retryAttempt: 0,
+  }
+  return {
+    ...(await importOriginal<typeof import("@/contexts/SyncStreamContext")>()),
+    useSyncStream: () => streamState,
+  }
+})
+
+// Deterministic virtualizer: render all rows regardless of jsdom layout.
+// Built lazily (on first call) so it reads `torrents` after module init, while
+// still returning a stable singleton across renders.
+vi.mock("@tanstack/react-virtual", () => {
+  let virtualizer: Record<string, unknown> | undefined
+  return {
+    useVirtualizer: () => {
+      if (!virtualizer) {
+        const items = torrents.map((_, index) => ({ index, key: index, start: index * 40, size: 40 }))
+        virtualizer = {
+          getVirtualItems: () => items,
+          getTotalSize: () => torrents.length * 40,
+          measure: vi.fn(),
+          scrollToOffset: vi.fn(),
+          scrollToIndex: vi.fn(),
+        }
+      }
+      return virtualizer
+    },
+  }
+})
+
+// Network boundary: any api.* call resolves to undefined (real hooks degrade
+// gracefully via their ?? fallbacks).
+vi.mock("@/lib/api", () => ({
+  api: new Proxy({}, { get: () => vi.fn(() => Promise.resolve(undefined)) }),
+}))
+
+// Tracker query hooks subscribe to the activity stream (needs a provider);
+// the table only reads their `.data`, so stub that directly with stable refs.
+vi.mock("@/hooks/useTrackerIcons", () => {
+  const result = { data: {} as Record<string, string> }
+  return { useTrackerIcons: () => result }
+})
+vi.mock("@/hooks/useTrackerCustomizations", () => {
+  const result = { data: [] as unknown[] }
+  return { useTrackerCustomizations: () => result }
+})
+
+// The data hook that drives the table body. Built lazily (reads `torrents`
+// after init) and cached so the reference is stable across renders.
+vi.mock("@/hooks/useTorrentsList", () => {
+  let result: Record<string, unknown> | undefined
+  return {
+    TORRENT_STREAM_POLL_INTERVAL_SECONDS: 2,
+    useTorrentsList: () => {
+      result ??= {
+        torrents,
+        totalCount: torrents.length,
+        stats: {
+          total: torrents.length,
+          downloading: 1,
+          seeding: 2,
+          paused: 0,
+          error: 0,
+          totalDownloadSpeed: 0,
+          totalUploadSpeed: 0,
+          totalSize: 0,
+        },
+        counts: { status: {}, categories: {}, tags: {}, trackers: {} },
+        categories: {},
+        tags: [] as string[],
+        trackerHealthSupported: false,
+        serverState: null,
+        capabilities: undefined,
+        useSubcategories: false,
+        isLoading: false,
+        isCachedData: false,
+        isStaleData: false,
+        isLoadingMore: false,
+        hasLoadedAll: true,
+        loadMore: vi.fn(),
+        streamConnected: false,
+        streamMeta: undefined,
+        isStreaming: false,
+        streamError: null,
+        streamRetrying: false,
+        streamNextRetryAt: undefined,
+        streamRetryAttempt: 0,
+        isCrossSeedFiltering: false,
+        isCrossInstanceEndpoint: false,
+      }
+      return result
+    },
+  }
+})
+
+// The action hook that drives dialog state (all dialogs closed).
+vi.mock("@/hooks/useTorrentActions", () => {
+  const noop = vi.fn()
+  const actions = new Proxy(
+    {
+      blockCrossSeeds: false,
+      deleteCrossSeeds: false,
+      deleteFiles: false,
+      isDeleteFilesLocked: false,
+      pendingTmmEnable: false,
+      isPending: false,
+      contextHashes: [],
+      contextTorrents: [],
+    } as Record<string, unknown>,
+    {
+      // Unknown dialog flags read as falsy; unknown handlers read as no-ops.
+      get(target, prop: string) {
+        if (prop in target) return target[prop]
+        if (prop.startsWith("show")) return false
+        return noop
+      },
+    }
+  )
+  return {
+    TORRENT_ACTIONS: { DELETE: "delete" },
+    useTorrentActions: () => actions,
+  }
+})
+
+afterEach(cleanup)
+
+function renderTable() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>{children}</TooltipProvider>
+    </QueryClientProvider>
+  )
+  return render(<TorrentTableOptimized instanceId={1} />, { wrapper })
+}
+
+describe("TorrentTableOptimized smoke", () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it("renders a row for each torrent", () => {
+    const { container } = renderTable()
+    expect(container.textContent).toContain("Alpha Release")
+    expect(container.textContent).toContain("Bravo Release")
+    expect(container.textContent).toContain("Charlie Release")
+  })
+
+  it("toggles row selection via the header select-all checkbox", () => {
+    const { container } = renderTable()
+    const checkboxes = container.querySelectorAll("[role=\"checkbox\"]")
+    expect(checkboxes.length).toBeGreaterThan(0)
+    const header = checkboxes[0]
+    expect(header.getAttribute("aria-checked")).not.toBe("true")
+    fireEvent.click(header)
+    const checkedAfter = within(container).getAllByRole("checkbox").filter(
+      (cb) => cb.getAttribute("aria-checked") === "true"
+    )
+    expect(checkedAfter.length).toBeGreaterThan(0)
+  })
+})

--- a/web/src/components/torrents/table/__tests__/TorrentTableOptimized.smoke.test.tsx
+++ b/web/src/components/torrents/table/__tests__/TorrentTableOptimized.smoke.test.tsx
@@ -220,9 +220,11 @@ describe("TorrentTableOptimized smoke", () => {
     const header = checkboxes[0]
     expect(header.getAttribute("aria-checked")).not.toBe("true")
     fireEvent.click(header)
-    const checkedAfter = within(container).getAllByRole("checkbox").filter(
-      (cb) => cb.getAttribute("aria-checked") === "true"
+    // Exclude the header itself so this asserts ROW checkboxes became checked,
+    // not just the select-all control reflecting its own click.
+    const checkedRowsAfter = within(container).getAllByRole("checkbox").filter(
+      (cb) => cb !== header && cb.getAttribute("aria-checked") === "true"
     )
-    expect(checkedAfter.length).toBeGreaterThan(0)
+    expect(checkedRowsAfter.length).toBeGreaterThan(0)
   })
 })

--- a/web/src/components/torrents/table/__tests__/TrackerIcon.test.tsx
+++ b/web/src/components/torrents/table/__tests__/TrackerIcon.test.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { TrackerIcon } from "@/components/torrents/table/TrackerIcon"
+import { cleanup, fireEvent, render } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+
+afterEach(cleanup)
+
+describe("TrackerIcon", () => {
+  it("renders the favicon image when a src is provided", () => {
+    const { container } = render(
+      <TrackerIcon title="Example" fallback="E" src="https://icons.example/e.png" />
+    )
+    const img = container.querySelector("img")
+    expect(img).not.toBeNull()
+    expect(img?.getAttribute("src")).toBe("https://icons.example/e.png")
+  })
+
+  it("renders the fallback glyph when src is null", () => {
+    const { container } = render(
+      <TrackerIcon title="Example" fallback="E" src={null} />
+    )
+    expect(container.querySelector("img")).toBeNull()
+    expect(container.textContent).toContain("E")
+  })
+
+  it("falls back to the glyph when the image errors", () => {
+    const { container } = render(
+      <TrackerIcon title="Example" fallback="E" src="https://icons.example/e.png" />
+    )
+    const img = container.querySelector("img")
+    expect(img).not.toBeNull()
+    fireEvent.error(img!)
+    expect(container.querySelector("img")).toBeNull()
+    expect(container.textContent).toContain("E")
+  })
+
+  it("resets the error state when src changes", () => {
+    const { container, rerender } = render(
+      <TrackerIcon title="Example" fallback="E" src="https://icons.example/e.png" />
+    )
+    fireEvent.error(container.querySelector("img")!)
+    expect(container.querySelector("img")).toBeNull()
+
+    rerender(<TrackerIcon title="Example" fallback="E" src="https://icons.example/e2.png" />)
+    const img = container.querySelector("img")
+    expect(img).not.toBeNull()
+    expect(img?.getAttribute("src")).toBe("https://icons.example/e2.png")
+  })
+
+  it("applies the glyph size class for the requested size", () => {
+    const { container } = render(
+      <TrackerIcon title="Example" fallback="E" src={null} size="xs" />
+    )
+    const glyphBox = container.querySelector("[title=\"Example\"]")?.firstElementChild
+    expect(glyphBox?.className).toContain("h-3 w-3")
+  })
+
+  it("defaults to the medium size class", () => {
+    const { container } = render(
+      <TrackerIcon title="Example" fallback="E" src={null} />
+    )
+    const glyphBox = container.querySelector("[title=\"Example\"]")?.firstElementChild
+    expect(glyphBox?.className).toContain("h-4 w-4")
+  })
+})

--- a/web/src/lib/torrent-table/__tests__/row-display.test.ts
+++ b/web/src/lib/torrent-table/__tests__/row-display.test.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { getRowBackgroundClass, getStatusBadgeProps, getStatusBadgeVariant } from "@/lib/torrent-table/row-display"
+import { makeTorrent } from "@/test/mockTorrent"
+import type { TFunction } from "i18next"
+import { describe, expect, it } from "vitest"
+
+// Passthrough translator: honors an explicit defaultValue (as getStateLabel
+// uses), otherwise echoes the key so assertions can match on the key string.
+const t = ((key: string, opts?: { defaultValue?: string }) =>
+  opts?.defaultValue ?? key) as unknown as TFunction
+
+describe("getRowBackgroundClass", () => {
+  it("uses the accent background when the row is selected, regardless of zebra parity", () => {
+    expect(getRowBackgroundClass(true, false, 0)).toBe("bg-accent")
+    expect(getRowBackgroundClass(true, false, 1)).toBe("bg-accent")
+    expect(getRowBackgroundClass(false, true, 0)).toBe("bg-accent")
+  })
+
+  it("selection takes precedence over the zebra stripe", () => {
+    // Odd index would normally be muted, but selection wins.
+    expect(getRowBackgroundClass(true, false, 1)).toBe("bg-accent")
+  })
+
+  it("applies the zebra stripe to odd rows when unselected", () => {
+    expect(getRowBackgroundClass(false, false, 1)).toBe("bg-muted/40")
+    expect(getRowBackgroundClass(false, false, 3)).toBe("bg-muted/40")
+  })
+
+  it("returns no background for unselected even rows", () => {
+    expect(getRowBackgroundClass(false, false, 0)).toBe("")
+    expect(getRowBackgroundClass(false, false, 2)).toBe("")
+  })
+})
+
+describe("getStatusBadgeVariant", () => {
+  it("maps active transfer states to the default variant", () => {
+    expect(getStatusBadgeVariant("downloading")).toBe("default")
+    expect(getStatusBadgeVariant("uploading")).toBe("default")
+  })
+
+  it("maps stalled and paused states to the secondary variant", () => {
+    expect(getStatusBadgeVariant("stalledDL")).toBe("secondary")
+    expect(getStatusBadgeVariant("stalledUP")).toBe("secondary")
+    expect(getStatusBadgeVariant("pausedDL")).toBe("secondary")
+    expect(getStatusBadgeVariant("pausedUP")).toBe("secondary")
+  })
+
+  it("maps error states to the destructive variant", () => {
+    expect(getStatusBadgeVariant("error")).toBe("destructive")
+    expect(getStatusBadgeVariant("missingFiles")).toBe("destructive")
+  })
+
+  it("falls back to the outline variant for unknown states", () => {
+    expect(getStatusBadgeVariant("stoppedUP")).toBe("outline")
+    expect(getStatusBadgeVariant("someFutureState")).toBe("outline")
+  })
+})
+
+describe("getStatusBadgeProps", () => {
+  it("derives variant from state and leaves className empty when tracker health is unsupported", () => {
+    const torrent = makeTorrent({ state: "downloading", tracker_health: "tracker_down" })
+    const props = getStatusBadgeProps(torrent, false, t)
+    expect(props.variant).toBe("default")
+    expect(props.className).toBe("")
+    // Label comes from getStateLabel's English fallback (not a tracker-health override).
+    expect(props.label).toBe("Downloading")
+  })
+
+  it("overrides label/variant/className for tracker_down when tracker health is supported", () => {
+    const torrent = makeTorrent({ state: "downloading", tracker_health: "tracker_down" })
+    const props = getStatusBadgeProps(torrent, true, t)
+    expect(props.label).toBe("tableColumns.trackerDown")
+    expect(props.variant).toBe("outline")
+    expect(props.className).toContain("text-yellow-500")
+  })
+
+  it("overrides for tracker_error", () => {
+    const torrent = makeTorrent({ state: "stalledUP", tracker_health: "tracker_error" })
+    const props = getStatusBadgeProps(torrent, true, t)
+    expect(props.label).toBe("tableColumns.trackerError")
+    expect(props.variant).toBe("outline")
+    expect(props.className).toContain("text-orange-500")
+  })
+
+  it("overrides for unregistered", () => {
+    const torrent = makeTorrent({ state: "uploading", tracker_health: "unregistered" })
+    const props = getStatusBadgeProps(torrent, true, t)
+    expect(props.label).toBe("tableColumns.unregistered")
+    expect(props.variant).toBe("outline")
+    expect(props.className).toContain("text-destructive")
+  })
+
+  it("ignores a healthy tracker_health value and keeps the state-derived badge", () => {
+    const torrent = makeTorrent({ state: "uploading" })
+    const props = getStatusBadgeProps(torrent, true, t)
+    expect(props.variant).toBe("default")
+    expect(props.className).toBe("")
+  })
+})

--- a/web/src/lib/torrent-table/__tests__/tracker-icon-equality.test.ts
+++ b/web/src/lib/torrent-table/__tests__/tracker-icon-equality.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { shallowEqualTrackerIcons } from "@/lib/torrent-table/tracker-icon-equality"
+import { describe, expect, it } from "vitest"
+
+describe("shallowEqualTrackerIcons", () => {
+  it("returns true for the same reference", () => {
+    const map = { "a.com": "iconA" }
+    expect(shallowEqualTrackerIcons(map, map)).toBe(true)
+  })
+
+  it("treats two undefined inputs as equal (same reference)", () => {
+    expect(shallowEqualTrackerIcons(undefined, undefined)).toBe(true)
+  })
+
+  it("returns false when exactly one side is undefined", () => {
+    expect(shallowEqualTrackerIcons({ "a.com": "iconA" }, undefined)).toBe(false)
+    expect(shallowEqualTrackerIcons(undefined, { "a.com": "iconA" })).toBe(false)
+  })
+
+  it("returns true for distinct objects with identical contents", () => {
+    const prev = { "a.com": "iconA", "b.com": "iconB" }
+    const next = { "a.com": "iconA", "b.com": "iconB" }
+    expect(prev).not.toBe(next)
+    expect(shallowEqualTrackerIcons(prev, next)).toBe(true)
+  })
+
+  it("returns false when a value differs", () => {
+    expect(
+      shallowEqualTrackerIcons({ "a.com": "iconA" }, { "a.com": "iconA-v2" })
+    ).toBe(false)
+  })
+
+  it("returns false when key counts differ", () => {
+    expect(
+      shallowEqualTrackerIcons({ "a.com": "iconA" }, { "a.com": "iconA", "b.com": "iconB" })
+    ).toBe(false)
+  })
+
+  it("returns false when keys differ but counts match", () => {
+    expect(
+      shallowEqualTrackerIcons({ "a.com": "iconA" }, { "b.com": "iconA" })
+    ).toBe(false)
+  })
+})

--- a/web/src/lib/torrent-table/row-display.ts
+++ b/web/src/lib/torrent-table/row-display.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { getStateLabel } from "@/lib/torrent-state-utils"
+import type { Torrent } from "@/types"
+import type { TFunction } from "i18next"
+
+// Returns the background class for a row based on selection state and zebra striping
+export function getRowBackgroundClass(isRowSelected: boolean, isSelected: boolean, rowIndex: number): string {
+  if (isRowSelected || isSelected) return "bg-accent"
+  if (rowIndex % 2 === 1) return "bg-muted/40"
+  return ""
+}
+
+export function getStatusBadgeVariant(state: string): "default" | "secondary" | "destructive" | "outline" {
+  switch (state) {
+    case "downloading":
+      return "default"
+    case "stalledDL":
+      return "secondary"
+    case "uploading":
+      return "default"
+    case "stalledUP":
+      return "secondary"
+    case "pausedDL":
+    case "pausedUP":
+      return "secondary"
+    case "error":
+    case "missingFiles":
+      return "destructive"
+    default:
+      return "outline"
+  }
+}
+
+export function getStatusBadgeProps(torrent: Torrent, supportsTrackerHealth: boolean, t: TFunction): {
+  variant: "default" | "secondary" | "destructive" | "outline"
+  label: string
+  className: string
+} {
+  const baseVariant = getStatusBadgeVariant(torrent.state)
+  let variant = baseVariant
+  let label = getStateLabel(torrent.state, t)
+  let className = ""
+
+  if (supportsTrackerHealth) {
+    const trackerHealth = torrent.tracker_health ?? null
+    if (trackerHealth === "tracker_down") {
+      label = t("tableColumns.trackerDown")
+      variant = "outline"
+      className = "text-yellow-500 border-yellow-500/40 bg-yellow-500/10"
+    } else if (trackerHealth === "tracker_error") {
+      label = t("tableColumns.trackerError")
+      variant = "outline"
+      className = "text-orange-500 border-orange-500/40 bg-orange-500/10"
+    } else if (trackerHealth === "unregistered") {
+      label = t("tableColumns.unregistered")
+      variant = "outline"
+      className = "text-destructive border-destructive/40 bg-destructive/10"
+    }
+  }
+
+  return { variant, label, className }
+}

--- a/web/src/lib/torrent-table/tracker-icon-equality.ts
+++ b/web/src/lib/torrent-table/tracker-icon-equality.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+/**
+ * Shallow-compares two tracker-icon maps (host -> icon URL) for equality.
+ *
+ * Used to keep a stable reference for the tracker-icon cache so the table
+ * doesn't re-render rows when a poll returns icon data with the same contents
+ * but a new object identity.
+ */
+export function shallowEqualTrackerIcons(
+  prev?: Record<string, string>,
+  next?: Record<string, string>
+): boolean {
+  if (prev === next) {
+    return true
+  }
+
+  if (!prev || !next) {
+    return false
+  }
+
+  const prevKeys = Object.keys(prev)
+  const nextKeys = Object.keys(next)
+
+  if (prevKeys.length !== nextKeys.length) {
+    return false
+  }
+
+  for (const key of prevKeys) {
+    if (prev[key] !== next[key]) {
+      return false
+    }
+  }
+
+  return true
+}


### PR DESCRIPTION
> ## ⚠️ Strict merge order — #1963 decomposition stack
>
> These PRs edit `TorrentTableOptimized.tsx` sequentially and **must be merged strictly in order**. Merging out of order will cause conflicts and force rebases of every downstream PR.
>
> **Order:** #1970 → #1971 → #1973 → #1974 → #1975 → #1976 → #1977 → #1978 → #1980 → #1982
>
> **This is PR-01 (position 1).** ✅ Safe to merge first — land this before #1971.

---

## Summary

First extraction in the `TorrentTableOptimized.tsx` decomposition (#1963). Moves the display-only layer out of the ~3.6k-line component into dedicated, independently testable modules, with colocated tests and a whole-table mount smoke test that serves as a regression tripwire for the rest of the decomposition series.

**No behavior change** — code is relocated verbatim; only import wiring changes in the host component.

### Extracted
- `lib/torrent-table/row-display.ts` — `getRowBackgroundClass`, `getStatusBadgeVariant`, `getStatusBadgeProps`
- `lib/torrent-table/tracker-icon-equality.ts` — `shallowEqualTrackerIcons`
- `components/torrents/table/TrackerIcon.tsx`
- `components/torrents/table/CompactRow.tsx`

`TorrentTableOptimized.tsx` shrinks from **3656 → 3302 lines**: it re-imports the three still-referenced symbols (`getRowBackgroundClass`, `shallowEqualTrackerIcons`, `CompactRow`) and drops imports left unused by the move.

### Tests
- Unit tests for each helper and component (36 tests; first RTL component tests in the suite).
- `TorrentTableOptimized.smoke.test.tsx` — mounts the real table with the network/router/stream boundaries mocked and a deterministic virtualizer, then asserts rows render and the header select-all toggles row selection. It stays green across every PR in the series as an integration tripwire.

## Testing
- [x] `pnpm test` — 384/384 pass
- [x] `tsc -b` clean; test-config typecheck clean
- [x] `pnpm lint` — new files report 0 problems; no new warnings in the touched component
- [x] `pnpm build` succeeds

Part of #1963.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New compact-row display for torrents with tracker icon, status badge, progress, speeds, and checkbox support.

* **Refactor**
  * Streamlined torrent table by extracting compact-row and tracker-icon logic into reusable components/utilities.

* **Tests**
  * Added unit and smoke tests covering compact rows, tracker icon behavior, and row display logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->







