### PR TITLE
feat(crossseed): route season packs to categories by resolution and source

### DIFF
--- a/documentation/docs/features/cross-seed/season-packs.md
+++ b/documentation/docs/features/cross-seed/season-packs.md
@@ -240,7 +240,7 @@ When qui applies a season pack, it:
 - Applies the tags configured in **Cross-Seed > Rules > Season packs**
 - Adds incomplete packs paused, then best-effort attempts automatic recheck and queues automatic resume. After recheck, qui resumes at or above the configured season-pack coverage threshold; below that threshold, the torrent stays paused for manual review.
 - Resolves the category in this order:
-  - The category from the first matching **Category routing** rule under **Cross-Seed > Rules > Season packs** (recommended for Sonarr integration so the pack lands in Sonarr's download-client category and inherits hardlink-aware imports)
+  - The category from the matching **Category routing** rule under **Cross-Seed > Rules > Season packs**, choosing the most specific rule when several apply (an explicit-source rule beats an Any-source rule at the same resolution). Recommended for Sonarr integration so the pack lands in Sonarr's download-client category and inherits hardlink-aware imports
   - Otherwise the **Anything else** fallback category, if set
   - Otherwise the global cross-seed category rules: custom category if enabled, otherwise category affix mode if enabled, otherwise indexer-name category if enabled, otherwise inheriting the matched episode's category
 - Creates the resolved category on the target instance if it does not already exist

--- a/documentation/docs/features/cross-seed/season-packs.md
+++ b/documentation/docs/features/cross-seed/season-packs.md
@@ -112,7 +112,23 @@ See [Hardlink Mode](hardlink-mode) for setup instructions.
 - Enable the feature
 - Set the coverage threshold (default 75%)
 - Optionally, add a TVDB API key for improved episode count accuracy. TVMaze is used automatically as a free fallback without any configuration.
-- Optionally, set a **Category override** for season pack injects. If you use Sonarr, set this to the same category Sonarr is watching on its qBittorrent download client (for example `tv-hd` or `tv-uhd`). Sonarr will pick up the assembled pack and hardlink-import its files into your library, so the same on-disk bytes back both the library and every seeded episode. If left empty, season packs use the global Category Mode configured under **Cross-Seed > Rules > Categories**.
+- Optionally, configure **Category routing** for season pack injects. Add rules that map a resolution (and optionally a source) to a qBittorrent category, then set an **Anything else** fallback category for packs that match no rule. If you run multiple Sonarr instances, point each rule at the category that Sonarr watches on its qBittorrent download client: route `1080p` to `tv-hd` and `2160p` to `tv-uhd`, for example. Sonarr will pick up the assembled pack and hardlink-import its files into your library, so the same on-disk bytes back both the library and every seeded episode. Categories are created on demand when they do not exist yet, and existing categories are used untouched. If no rule matches and no fallback is set, season packs use the global Category Mode configured under **Cross-Seed > Rules > Categories**.
+
+#### Category routing
+
+Each routing rule matches on a resolution and an optional source:
+
+| Field | Values | Effect |
+| --- | --- | --- |
+| Resolution | `2160p`, `1080p`, `720p`, `576p`, `480p` | Required. The pack resolution the rule applies to. |
+| Source | Any, `WEB`, `BluRay`, `Remux`, `HDTV` | Optional. Restricts the rule to a single source, or leave as **Any** to match every source at that resolution. |
+| Category | A qBittorrent category | Where matching packs are filed. Created on demand if it does not exist. |
+
+When more than one rule could match a pack, the most specific rule wins: a rule with an explicit source beats an **Any**-source rule at the same resolution. If no rule matches, qui uses the **Anything else** fallback category.
+
+:::tip
+**Remux** is detected from the release tags, not the source field. A BluRay remux carries the remux tag, so it routes under the **Remux** option rather than the **BluRay** option. Add a separate `Remux` rule when you want remuxes filed away from regular BluRay packs.
+:::
 
 ### 2. Create an API Key
 
@@ -223,11 +239,11 @@ When qui applies a season pack, it:
 - Always adds the torrent with an explicit `savepath` pointing at the linked tree
 - Applies the tags configured in **Cross-Seed > Rules > Season packs**
 - Adds incomplete packs paused, then best-effort attempts automatic recheck and queues automatic resume. After recheck, qui resumes at or above the configured season-pack coverage threshold; below that threshold, the torrent stays paused for manual review.
-- Uses the **Category override** from **Cross-Seed > Rules > Season packs** when set (recommended for Sonarr integration so the pack lands in Sonarr's download-client category and inherits hardlink-aware imports)
-- Otherwise uses the global cross-seed category rules:
-  - Custom category, if enabled
-  - Otherwise category affix mode, if enabled
-  - Otherwise indexer-name category, if enabled
+- Resolves the category in this order:
+  - The category from the first matching **Category routing** rule under **Cross-Seed > Rules > Season packs** (recommended for Sonarr integration so the pack lands in Sonarr's download-client category and inherits hardlink-aware imports)
+  - Otherwise the **Anything else** fallback category, if set
+  - Otherwise the global cross-seed category rules: custom category if enabled, otherwise category affix mode if enabled, otherwise indexer-name category if enabled, otherwise inheriting the matched episode's category
+- Creates the resolved category on the target instance if it does not already exist
 
 ## Instance Selection
 

--- a/internal/api/handlers/crossseed.go
+++ b/internal/api/handlers/crossseed.go
@@ -406,9 +406,11 @@ var validSeasonPackRuleSources = map[string]struct{}{
 }
 
 // normalizeSeasonPackCategoryRules cleans up incoming category routing rules:
-// it trims fields, lowercases the resolution, coerces the source to a known
-// uppercase value (unknown -> "" meaning any), drops rules missing a resolution
-// or category, and dedupes on (resolution, source) keeping the first match.
+// it trims fields, lowercases the resolution, uppercases the source, drops rules
+// missing a resolution or category or carrying an unrecognized source, and
+// dedupes on (resolution, source) keeping the first match. An empty source means
+// "any"; an unrecognized non-empty source drops the rule rather than silently
+// widening it to "any".
 func normalizeSeasonPackCategoryRules(rules []models.SeasonPackCategoryRule) []models.SeasonPackCategoryRule {
 	normalized := make([]models.SeasonPackCategoryRule, 0, len(rules))
 	seen := make(map[string]struct{}, len(rules))
@@ -420,8 +422,10 @@ func normalizeSeasonPackCategoryRules(rules []models.SeasonPackCategoryRule) []m
 		}
 
 		source := strings.ToUpper(strings.TrimSpace(rule.Source))
-		if _, ok := validSeasonPackRuleSources[source]; !ok {
-			source = ""
+		if source != "" {
+			if _, ok := validSeasonPackRuleSources[source]; !ok {
+				continue
+			}
 		}
 
 		key := resolution + "|" + source

--- a/internal/api/handlers/crossseed.go
+++ b/internal/api/handlers/crossseed.go
@@ -34,31 +34,32 @@ type CrossSeedHandler struct {
 var infoHashRegex = regexp.MustCompile(`^[a-fA-F0-9]{40}$|^[a-fA-F0-9]{64}$`)
 
 type automationSettingsRequest struct {
-	Enabled                      bool     `json:"enabled"`
-	RunIntervalMinutes           int      `json:"runIntervalMinutes"`
-	StartPaused                  bool     `json:"startPaused"`
-	Category                     *string  `json:"category"`
-	TargetInstanceIDs            []int    `json:"targetInstanceIds"`
-	TargetIndexerIDs             []int    `json:"targetIndexerIds"`
-	MaxResultsPerRun             int      `json:"maxResultsPerRun"` // Deprecated: automation now processes full feeds and ignores this value
-	FindIndividualEpisodes       bool     `json:"findIndividualEpisodes"`
-	SizeMismatchTolerancePercent float64  `json:"sizeMismatchTolerancePercent"`
-	UseCategoryFromIndexer       bool     `json:"useCategoryFromIndexer"`
-	UseCrossCategoryAffix        bool     `json:"useCrossCategoryAffix"`
-	CategoryAffixMode            string   `json:"categoryAffixMode"`
-	CategoryAffix                string   `json:"categoryAffix"`
-	UseCustomCategory            bool     `json:"useCustomCategory"`
-	CustomCategory               string   `json:"customCategory"`
-	RunExternalProgramID         *int     `json:"runExternalProgramId"`
-	SkipRecheck                  bool     `json:"skipRecheck"`
-	SeasonPackEnabled            bool     `json:"seasonPackEnabled"`
-	SeasonPackSkipRepackCompare  bool     `json:"seasonPackSkipRepackCompare"`
-	SeasonPackSimplifyHDRCompare bool     `json:"seasonPackSimplifyHdrCompare"`
-	SeasonPackSimplifyWEBCompare bool     `json:"seasonPackSimplifyWebCompare"`
-	SeasonPackSkipYearCompare    bool     `json:"seasonPackSkipYearCompare"`
-	SeasonPackCoverageThreshold  float64  `json:"seasonPackCoverageThreshold"`
-	SeasonPackTags               []string `json:"seasonPackTags"`
-	SeasonPackCategory           string   `json:"seasonPackCategory"`
+	Enabled                      bool                            `json:"enabled"`
+	RunIntervalMinutes           int                             `json:"runIntervalMinutes"`
+	StartPaused                  bool                            `json:"startPaused"`
+	Category                     *string                         `json:"category"`
+	TargetInstanceIDs            []int                           `json:"targetInstanceIds"`
+	TargetIndexerIDs             []int                           `json:"targetIndexerIds"`
+	MaxResultsPerRun             int                             `json:"maxResultsPerRun"` // Deprecated: automation now processes full feeds and ignores this value
+	FindIndividualEpisodes       bool                            `json:"findIndividualEpisodes"`
+	SizeMismatchTolerancePercent float64                         `json:"sizeMismatchTolerancePercent"`
+	UseCategoryFromIndexer       bool                            `json:"useCategoryFromIndexer"`
+	UseCrossCategoryAffix        bool                            `json:"useCrossCategoryAffix"`
+	CategoryAffixMode            string                          `json:"categoryAffixMode"`
+	CategoryAffix                string                          `json:"categoryAffix"`
+	UseCustomCategory            bool                            `json:"useCustomCategory"`
+	CustomCategory               string                          `json:"customCategory"`
+	RunExternalProgramID         *int                            `json:"runExternalProgramId"`
+	SkipRecheck                  bool                            `json:"skipRecheck"`
+	SeasonPackEnabled            bool                            `json:"seasonPackEnabled"`
+	SeasonPackSkipRepackCompare  bool                            `json:"seasonPackSkipRepackCompare"`
+	SeasonPackSimplifyHDRCompare bool                            `json:"seasonPackSimplifyHdrCompare"`
+	SeasonPackSimplifyWEBCompare bool                            `json:"seasonPackSimplifyWebCompare"`
+	SeasonPackSkipYearCompare    bool                            `json:"seasonPackSkipYearCompare"`
+	SeasonPackCoverageThreshold  float64                         `json:"seasonPackCoverageThreshold"`
+	SeasonPackTags               []string                        `json:"seasonPackTags"`
+	SeasonPackCategory           string                          `json:"seasonPackCategory"`
+	SeasonPackCategoryRules      []models.SeasonPackCategoryRule `json:"seasonPackCategoryRules"`
 	// Gazelle (OPS/RED) cross-seed settings.
 	GazelleEnabled       bool   `json:"gazelleEnabled"`
 	RedactedAPIKey       string `json:"redactedApiKey"`
@@ -109,19 +110,20 @@ type automationSettingsPatchRequest struct {
 	SkipPieceBoundarySafetyCheck *bool `json:"skipPieceBoundarySafetyCheck,omitempty"`
 	// Gazelle (OPS/RED) cross-seed settings.
 	// Season pack settings
-	SeasonPackEnabled            *bool     `json:"seasonPackEnabled,omitempty"`
-	SeasonPackSkipRepackCompare  *bool     `json:"seasonPackSkipRepackCompare,omitempty"`
-	SeasonPackSimplifyHDRCompare *bool     `json:"seasonPackSimplifyHdrCompare,omitempty"`
-	SeasonPackSimplifyWEBCompare *bool     `json:"seasonPackSimplifyWebCompare,omitempty"`
-	SeasonPackSkipYearCompare    *bool     `json:"seasonPackSkipYearCompare,omitempty"`
-	SeasonPackCoverageThreshold  *float64  `json:"seasonPackCoverageThreshold,omitempty"`
-	SeasonPackTags               *[]string `json:"seasonPackTags,omitempty"`
-	SeasonPackCategory           *string   `json:"seasonPackCategory,omitempty"`
-	GazelleEnabled               *bool     `json:"gazelleEnabled,omitempty"`
-	RedactedAPIKey               *string   `json:"redactedApiKey,omitempty"`
-	OrpheusAPIKey                *string   `json:"orpheusApiKey,omitempty"`
-	SeasonPackTVDBAPIKey         *string   `json:"seasonPackTvdbApiKey,omitempty"`
-	SeasonPackTVDBPIN            *string   `json:"seasonPackTvdbPin,omitempty"`
+	SeasonPackEnabled            *bool                            `json:"seasonPackEnabled,omitempty"`
+	SeasonPackSkipRepackCompare  *bool                            `json:"seasonPackSkipRepackCompare,omitempty"`
+	SeasonPackSimplifyHDRCompare *bool                            `json:"seasonPackSimplifyHdrCompare,omitempty"`
+	SeasonPackSimplifyWEBCompare *bool                            `json:"seasonPackSimplifyWebCompare,omitempty"`
+	SeasonPackSkipYearCompare    *bool                            `json:"seasonPackSkipYearCompare,omitempty"`
+	SeasonPackCoverageThreshold  *float64                         `json:"seasonPackCoverageThreshold,omitempty"`
+	SeasonPackTags               *[]string                        `json:"seasonPackTags,omitempty"`
+	SeasonPackCategory           *string                          `json:"seasonPackCategory,omitempty"`
+	SeasonPackCategoryRules      *[]models.SeasonPackCategoryRule `json:"seasonPackCategoryRules,omitempty"`
+	GazelleEnabled               *bool                            `json:"gazelleEnabled,omitempty"`
+	RedactedAPIKey               *string                          `json:"redactedApiKey,omitempty"`
+	OrpheusAPIKey                *string                          `json:"orpheusApiKey,omitempty"`
+	SeasonPackTVDBAPIKey         *string                          `json:"seasonPackTvdbApiKey,omitempty"`
+	SeasonPackTVDBPIN            *string                          `json:"seasonPackTvdbPin,omitempty"`
 }
 
 type optionalString struct {
@@ -224,6 +226,7 @@ func (r automationSettingsPatchRequest) isEmpty() bool {
 		r.SeasonPackCoverageThreshold == nil &&
 		r.SeasonPackTags == nil &&
 		r.SeasonPackCategory == nil &&
+		r.SeasonPackCategoryRules == nil &&
 		r.GazelleEnabled == nil &&
 		r.RedactedAPIKey == nil &&
 		r.OrpheusAPIKey == nil &&
@@ -375,6 +378,9 @@ func applyAutomationSettingsPatch(settings *models.CrossSeedAutomationSettings, 
 	if patch.SeasonPackCategory != nil {
 		settings.SeasonPackCategory = strings.TrimSpace(*patch.SeasonPackCategory)
 	}
+	if patch.SeasonPackCategoryRules != nil {
+		settings.SeasonPackCategoryRules = normalizeSeasonPackCategoryRules(*patch.SeasonPackCategoryRules)
+	}
 	if patch.GazelleEnabled != nil {
 		settings.GazelleEnabled = *patch.GazelleEnabled
 	}
@@ -390,6 +396,47 @@ func applyAutomationSettingsPatch(settings *models.CrossSeedAutomationSettings, 
 	if patch.SeasonPackTVDBPIN != nil {
 		settings.SeasonPackTVDBPIN = strings.TrimSpace(*patch.SeasonPackTVDBPIN)
 	}
+}
+
+var validSeasonPackRuleSources = map[string]struct{}{
+	"WEB":    {},
+	"BLURAY": {},
+	"REMUX":  {},
+	"HDTV":   {},
+}
+
+// normalizeSeasonPackCategoryRules cleans up incoming category routing rules:
+// it trims fields, lowercases the resolution, coerces the source to a known
+// uppercase value (unknown -> "" meaning any), drops rules missing a resolution
+// or category, and dedupes on (resolution, source) keeping the first match.
+func normalizeSeasonPackCategoryRules(rules []models.SeasonPackCategoryRule) []models.SeasonPackCategoryRule {
+	normalized := make([]models.SeasonPackCategoryRule, 0, len(rules))
+	seen := make(map[string]struct{}, len(rules))
+	for _, rule := range rules {
+		resolution := strings.ToLower(strings.TrimSpace(rule.Resolution))
+		category := strings.TrimSpace(rule.Category)
+		if resolution == "" || category == "" {
+			continue
+		}
+
+		source := strings.ToUpper(strings.TrimSpace(rule.Source))
+		if _, ok := validSeasonPackRuleSources[source]; !ok {
+			source = ""
+		}
+
+		key := resolution + "|" + source
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		normalized = append(normalized, models.SeasonPackCategoryRule{
+			Resolution: resolution,
+			Source:     source,
+			Category:   category,
+		})
+	}
+	return normalized
 }
 
 type automationRunRequest struct {
@@ -931,6 +978,7 @@ func (h *CrossSeedHandler) UpdateAutomationSettings(w http.ResponseWriter, r *ht
 		SeasonPackCoverageThreshold:  req.SeasonPackCoverageThreshold,
 		SeasonPackTags:               req.SeasonPackTags,
 		SeasonPackCategory:           strings.TrimSpace(req.SeasonPackCategory),
+		SeasonPackCategoryRules:      normalizeSeasonPackCategoryRules(req.SeasonPackCategoryRules),
 		GazelleEnabled:               req.GazelleEnabled,
 		RedactedAPIKey:               strings.TrimSpace(req.RedactedAPIKey),
 		OrpheusAPIKey:                strings.TrimSpace(req.OrpheusAPIKey),

--- a/internal/api/handlers/crossseed_seasonpack_test.go
+++ b/internal/api/handlers/crossseed_seasonpack_test.go
@@ -265,3 +265,49 @@ func TestPatchAutomationSettings_IsEmptyIncludesSeasonPackFields(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeSeasonPackCategoryRules(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []models.SeasonPackCategoryRule
+		want []models.SeasonPackCategoryRule
+	}{
+		{
+			name: "trims, lowercases resolution, uppercases source",
+			in:   []models.SeasonPackCategoryRule{{Resolution: " 2160P ", Source: " bluray ", Category: " tv-uhd "}},
+			want: []models.SeasonPackCategoryRule{{Resolution: "2160p", Source: "BLURAY", Category: "tv-uhd"}},
+		},
+		{
+			name: "empty source means any and is kept",
+			in:   []models.SeasonPackCategoryRule{{Resolution: "1080p", Source: "", Category: "tv-hd"}},
+			want: []models.SeasonPackCategoryRule{{Resolution: "1080p", Source: "", Category: "tv-hd"}},
+		},
+		{
+			name: "unrecognized source drops the rule instead of widening to any",
+			in:   []models.SeasonPackCategoryRule{{Resolution: "1080p", Source: "DVDRIP", Category: "tv-hd"}},
+			want: []models.SeasonPackCategoryRule{},
+		},
+		{
+			name: "drops rules missing resolution or category",
+			in: []models.SeasonPackCategoryRule{
+				{Resolution: "", Source: "WEB", Category: "tv-hd"},
+				{Resolution: "1080p", Source: "WEB", Category: ""},
+			},
+			want: []models.SeasonPackCategoryRule{},
+		},
+		{
+			name: "dedupes on resolution and source keeping the first",
+			in: []models.SeasonPackCategoryRule{
+				{Resolution: "1080p", Source: "WEB", Category: "first"},
+				{Resolution: "1080p", Source: "WEB", Category: "second"},
+			},
+			want: []models.SeasonPackCategoryRule{{Resolution: "1080p", Source: "WEB", Category: "first"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, normalizeSeasonPackCategoryRules(tt.in))
+		})
+	}
+}

--- a/internal/database/migrations/077_add_season_pack_category_rules.sql
+++ b/internal/database/migrations/077_add_season_pack_category_rules.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cross_seed_settings ADD COLUMN season_pack_category_rules TEXT NOT NULL DEFAULT '[]';

--- a/internal/database/postgres_migrations/078_add_season_pack_category_rules.sql
+++ b/internal/database/postgres_migrations/078_add_season_pack_category_rules.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cross_seed_settings ADD COLUMN season_pack_category_rules TEXT NOT NULL DEFAULT '[]';

--- a/internal/models/crossseed.go
+++ b/internal/models/crossseed.go
@@ -27,6 +27,15 @@ const (
 	CategoryAffixModeSuffix = "suffix"
 )
 
+// SeasonPackCategoryRule routes a season pack add to a category based on its
+// release quality. The first matching rule wins; otherwise the add falls back
+// to CrossSeedAutomationSettings.SeasonPackCategory ("Anything else").
+type SeasonPackCategoryRule struct {
+	Resolution string `json:"resolution"` // Canonical lowercase rls value, e.g. "1080p", "2160p"
+	Source     string `json:"source"`     // "" = any; else canonical uppercase: WEB, BLURAY, REMUX, HDTV
+	Category   string `json:"category"`   // qBittorrent category to file the add under
+}
+
 // CrossSeedAutomationSettings controls automatic cross-seed behaviour.
 // Contains both RSS Automation-specific settings and global cross-seed settings.
 type CrossSeedAutomationSettings struct {
@@ -85,16 +94,17 @@ type CrossSeedAutomationSettings struct {
 	SkipPieceBoundarySafetyCheck bool `json:"skipPieceBoundarySafetyCheck"` // Skip piece boundary safety check (risky: may corrupt existing seeded data)
 
 	// Season pack settings
-	SeasonPackSkipRepackCompare  bool     `json:"seasonPackSkipRepackCompare"`
-	SeasonPackSimplifyHDRCompare bool     `json:"seasonPackSimplifyHdrCompare"`
-	SeasonPackSimplifyWEBCompare bool     `json:"seasonPackSimplifyWebCompare"`
-	SeasonPackSkipYearCompare    bool     `json:"seasonPackSkipYearCompare"`
-	SeasonPackEnabled            bool     `json:"seasonPackEnabled"`           // Enable season pack webhook flow
-	SeasonPackCoverageThreshold  float64  `json:"seasonPackCoverageThreshold"` // Minimum episode coverage to trigger (0..1, default 0.75)
-	SeasonPackTags               []string `json:"seasonPackTags"`              // Tags for season pack results
-	SeasonPackCategory           string   `json:"seasonPackCategory"`          // Optional fixed category for season pack adds
-	SeasonPackTVDBAPIKey         string   `json:"seasonPackTvdbApiKey,omitempty"`
-	SeasonPackTVDBPIN            string   `json:"seasonPackTvdbPin,omitempty"`
+	SeasonPackSkipRepackCompare  bool                     `json:"seasonPackSkipRepackCompare"`
+	SeasonPackSimplifyHDRCompare bool                     `json:"seasonPackSimplifyHdrCompare"`
+	SeasonPackSimplifyWEBCompare bool                     `json:"seasonPackSimplifyWebCompare"`
+	SeasonPackSkipYearCompare    bool                     `json:"seasonPackSkipYearCompare"`
+	SeasonPackEnabled            bool                     `json:"seasonPackEnabled"`           // Enable season pack webhook flow
+	SeasonPackCoverageThreshold  float64                  `json:"seasonPackCoverageThreshold"` // Minimum episode coverage to trigger (0..1, default 0.75)
+	SeasonPackTags               []string                 `json:"seasonPackTags"`              // Tags for season pack results
+	SeasonPackCategory           string                   `json:"seasonPackCategory"`          // Fallback category for season pack adds ("Anything else")
+	SeasonPackCategoryRules      []SeasonPackCategoryRule `json:"seasonPackCategoryRules"`     // Per-quality routing rules; first match wins, else SeasonPackCategory
+	SeasonPackTVDBAPIKey         string                   `json:"seasonPackTvdbApiKey,omitempty"`
+	SeasonPackTVDBPIN            string                   `json:"seasonPackTvdbPin,omitempty"`
 
 	// Gazelle (OPS/RED) cross-seed settings.
 	// When enabled, qui uses the tracker JSON APIs to find matches for OPS/RED torrents
@@ -170,6 +180,7 @@ func DefaultCrossSeedAutomationSettings() *CrossSeedAutomationSettings {
 		SeasonPackCoverageThreshold:  0.75,
 		SeasonPackTags:               []string{"cross-seed"},
 		SeasonPackCategory:           "",
+		SeasonPackCategoryRules:      []SeasonPackCategoryRule{},
 		GazelleEnabled:               false,
 		RedactedAPIKey:               "",
 		OrpheusAPIKey:                "",
@@ -423,6 +434,7 @@ func (s *CrossSeedStore) GetSettings(ctx context.Context) (*CrossSeedAutomationS
 		       season_pack_skip_repack_compare, season_pack_simplify_hdr_compare,
 		       season_pack_simplify_web_compare, season_pack_skip_year_compare,
 		       season_pack_enabled, season_pack_coverage_threshold, season_pack_tags, season_pack_category,
+		       season_pack_category_rules,
 		       season_pack_tvdb_api_key_encrypted, season_pack_tvdb_pin_encrypted,
 		       gazelle_enabled, redacted_api_key_encrypted, orpheus_api_key_encrypted,
 		       created_at, updated_at
@@ -447,6 +459,7 @@ func (s *CrossSeedStore) GetSettings(ctx context.Context) (*CrossSeedAutomationS
 	var seasonPackSkipRepackCompare, seasonPackSimplifyHDRCompare, seasonPackSimplifyWEBCompare, seasonPackSkipYearCompare int
 	var seasonPackEnabled int
 	var seasonPackTags, seasonPackCategory sql.NullString
+	var seasonPackCategoryRules sql.NullString
 	var seasonPackTVDBAPIKeyEncrypted, seasonPackTVDBPINEncrypted sql.NullString
 	var gazelleEnabled int
 	var redactedAPIKeyEncrypted, orpheusAPIKeyEncrypted sql.NullString
@@ -496,6 +509,7 @@ func (s *CrossSeedStore) GetSettings(ctx context.Context) (*CrossSeedAutomationS
 		&settings.SeasonPackCoverageThreshold,
 		&seasonPackTags,
 		&seasonPackCategory,
+		&seasonPackCategoryRules,
 		&seasonPackTVDBAPIKeyEncrypted,
 		&seasonPackTVDBPINEncrypted,
 		&gazelleEnabled,
@@ -574,6 +588,9 @@ func (s *CrossSeedStore) GetSettings(ctx context.Context) (*CrossSeedAutomationS
 	}
 	if seasonPackCategory.Valid {
 		settings.SeasonPackCategory = seasonPackCategory.String
+	}
+	if err := decodeSeasonPackCategoryRules(seasonPackCategoryRules, &settings.SeasonPackCategoryRules); err != nil {
+		return nil, fmt.Errorf("decode season pack category rules: %w", err)
 	}
 
 	if createdAt.Valid {
@@ -774,6 +791,10 @@ func (s *CrossSeedStore) UpsertSettings(ctx context.Context, settings *CrossSeed
 	if err != nil {
 		return nil, fmt.Errorf("encode season pack tags: %w", err)
 	}
+	seasonPackCategoryRules, err := encodeSeasonPackCategoryRules(settings.SeasonPackCategoryRules)
+	if err != nil {
+		return nil, fmt.Errorf("encode season pack category rules: %w", err)
+	}
 
 	var existingRedactedEncrypted string
 	var existingOrpheusEncrypted string
@@ -894,10 +915,11 @@ func (s *CrossSeedStore) UpsertSettings(ctx context.Context, settings *CrossSeed
 			season_pack_skip_repack_compare, season_pack_simplify_hdr_compare,
 			season_pack_simplify_web_compare, season_pack_skip_year_compare,
 			season_pack_enabled, season_pack_coverage_threshold, season_pack_tags, season_pack_category,
+			season_pack_category_rules,
 			season_pack_tvdb_api_key_encrypted, season_pack_tvdb_pin_encrypted,
 			gazelle_enabled, redacted_api_key_encrypted, orpheus_api_key_encrypted
 		) VALUES (
-			?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+			?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 		)
 		ON CONFLICT(id) DO UPDATE SET
 			enabled = excluded.enabled,
@@ -943,6 +965,7 @@ func (s *CrossSeedStore) UpsertSettings(ctx context.Context, settings *CrossSeed
 			season_pack_coverage_threshold = excluded.season_pack_coverage_threshold,
 			season_pack_tags = excluded.season_pack_tags,
 			season_pack_category = excluded.season_pack_category,
+			season_pack_category_rules = excluded.season_pack_category_rules,
 			season_pack_tvdb_api_key_encrypted = excluded.season_pack_tvdb_api_key_encrypted,
 			season_pack_tvdb_pin_encrypted = excluded.season_pack_tvdb_pin_encrypted,
 			gazelle_enabled = excluded.gazelle_enabled,
@@ -1006,6 +1029,7 @@ func (s *CrossSeedStore) UpsertSettings(ctx context.Context, settings *CrossSeed
 		settings.SeasonPackCoverageThreshold,
 		seasonPackTags,
 		settings.SeasonPackCategory,
+		seasonPackCategoryRules,
 		seasonPackTVDBAPIKeyEncrypted,
 		seasonPackTVDBPINEncrypted,
 		BoolToSQLite(settings.GazelleEnabled),
@@ -1817,6 +1841,30 @@ func decodeStringSliceWithDefault(src sql.NullString, dest *[]string, defaultVal
 		return nil
 	}
 	var tmp []string
+	if err := json.Unmarshal([]byte(src.String), &tmp); err != nil {
+		return err
+	}
+	*dest = tmp
+	return nil
+}
+
+func encodeSeasonPackCategoryRules(rules []SeasonPackCategoryRule) (string, error) {
+	if rules == nil {
+		rules = []SeasonPackCategoryRule{}
+	}
+	data, err := json.Marshal(rules)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func decodeSeasonPackCategoryRules(src sql.NullString, dest *[]SeasonPackCategoryRule) error {
+	if !src.Valid || src.String == "" {
+		*dest = []SeasonPackCategoryRule{}
+		return nil
+	}
+	var tmp []SeasonPackCategoryRule
 	if err := json.Unmarshal([]byte(src.String), &tmp); err != nil {
 		return err
 	}

--- a/internal/models/postgres_bool_args_test.go
+++ b/internal/models/postgres_bool_args_test.go
@@ -409,6 +409,7 @@ func TestCrossSeedUpsertSettingsUsesIntegerBooleanArgs(t *testing.T) {
 			season_pack_coverage_threshold REAL NOT NULL DEFAULT 0.75,
 			season_pack_tags TEXT NOT NULL DEFAULT '["cross-seed"]',
 			season_pack_category TEXT NOT NULL DEFAULT '',
+			season_pack_category_rules TEXT NOT NULL DEFAULT '[]',
 			season_pack_tvdb_api_key_encrypted TEXT NOT NULL DEFAULT '',
 			season_pack_tvdb_pin_encrypted TEXT NOT NULL DEFAULT '',
 			gazelle_enabled INTEGER NOT NULL DEFAULT 0,
@@ -438,9 +439,9 @@ func TestCrossSeedUpsertSettingsUsesIntegerBooleanArgs(t *testing.T) {
 
 	_, err = store.UpsertSettings(context.Background(), settings)
 	require.NoError(t, err)
-	require.Len(t, insertArgs, 49)
+	require.Len(t, insertArgs, 50)
 
-	boolIndexes := []int{1, 3, 16, 18, 24, 25, 28, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 46}
+	boolIndexes := []int{1, 3, 16, 18, 24, 25, 28, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 47}
 	for _, idx := range boolIndexes {
 		_, ok := insertArgs[idx].(int)
 		require.Truef(t, ok, "expected int arg at index %d, got %T", idx, insertArgs[idx])

--- a/internal/services/crossseed/category_routing.go
+++ b/internal/services/crossseed/category_routing.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package crossseed
+
+import (
+	"context"
+	"strings"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/moistari/rls"
+
+	"github.com/autobrr/qui/internal/models"
+)
+
+// canonicalResolution normalizes a resolution string to its canonical lowercase
+// form (e.g. "1080P" -> "1080p") for comparison against routing rules.
+func canonicalResolution(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}
+
+// sourceClass classifies a release into one of the canonical source buckets used
+// by season pack category routing rules: REMUX, WEB, BLURAY, or HDTV. Returns ""
+// when the release is nil or its source does not map to a known bucket.
+func sourceClass(release *rls.Release) string {
+	if release == nil {
+		return ""
+	}
+
+	for _, other := range release.Other {
+		if strings.EqualFold(other, "REMUX") {
+			return "REMUX"
+		}
+	}
+
+	// normalizeSource yields values like "WEBDL", "BLURAY", "UHD.BLURAY", "HDTV".
+	// 2160p discs parse as "UHD.BluRay", so match BluRay as a substring.
+	source := normalizeSource(release.Source)
+	switch {
+	case isWebSource(source):
+		return "WEB"
+	case strings.Contains(source, "BLURAY"):
+		return "BLURAY"
+	case source == "HDTV":
+		return "HDTV"
+	default:
+		return ""
+	}
+}
+
+// matchSeasonPackCategoryRule finds the category for a season pack add given its
+// resolution and source class. Rules are first filtered to the matching
+// resolution. A rule with an explicit source matching srcClass wins over an
+// "Any" (empty source) rule; within each pass the first rule in slice order wins.
+// Returns ("", false) when no rule matches.
+func matchSeasonPackCategoryRule(rules []models.SeasonPackCategoryRule, resolution, srcClass string) (category string, matched bool) {
+	wantResolution := canonicalResolution(resolution)
+
+	if srcClass != "" {
+		for _, rule := range rules {
+			if canonicalResolution(rule.Resolution) != wantResolution {
+				continue
+			}
+			if strings.ToUpper(strings.TrimSpace(rule.Source)) == srcClass {
+				return rule.Category, true
+			}
+		}
+	}
+
+	for _, rule := range rules {
+		if canonicalResolution(rule.Resolution) != wantResolution {
+			continue
+		}
+		if strings.TrimSpace(rule.Source) == "" {
+			return rule.Category, true
+		}
+	}
+
+	return "", false
+}
+
+// resolveSeasonPackCategory determines the qBittorrent category for a season pack
+// add. Routing rules take priority, then the configured fallback category, then
+// the general cross-seed category derivation based on a matched episode.
+func (s *Service) resolveSeasonPackCategory(
+	ctx context.Context,
+	prep *seasonPackPrep,
+	indexer string,
+	episodes map[episodeIdentity]episodeMatch,
+) string {
+	if category, matched := matchSeasonPackCategoryRule(
+		prep.settings.SeasonPackCategoryRules,
+		prep.packRelease.Resolution,
+		sourceClass(prep.packRelease),
+	); matched {
+		return category
+	}
+
+	if fallback := strings.TrimSpace(prep.settings.SeasonPackCategory); fallback != "" {
+		return fallback
+	}
+
+	_, crossCategory := s.determineCrossSeedCategory(ctx, &CrossSeedRequest{
+		IndexerName: indexer,
+	}, &qbt.Torrent{
+		Category: firstMatchedEpisodeCategory(episodes),
+	}, prep.settings)
+	return crossCategory
+}

--- a/internal/services/crossseed/category_routing_test.go
+++ b/internal/services/crossseed/category_routing_test.go
@@ -1,0 +1,214 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package crossseed
+
+import (
+	"testing"
+
+	"github.com/moistari/rls"
+
+	"github.com/autobrr/qui/internal/models"
+)
+
+func TestSourceClass(t *testing.T) {
+	tests := []struct {
+		name    string
+		release *rls.Release
+		want    string
+	}{
+		{
+			name:    "nil release",
+			release: nil,
+			want:    "",
+		},
+		{
+			name:    "plain WEB",
+			release: &rls.Release{Source: "WEB", Resolution: "1080p"},
+			want:    "WEB",
+		},
+		{
+			name:    "WEB-DL",
+			release: &rls.Release{Source: "WEB-DL", Resolution: "1080p"},
+			want:    "WEB",
+		},
+		{
+			name:    "WEBRip",
+			release: &rls.Release{Source: "WEBRip", Resolution: "1080p"},
+			want:    "WEB",
+		},
+		{
+			name:    "BluRay without remux",
+			release: &rls.Release{Source: "BluRay", Resolution: "1080p"},
+			want:    "BLURAY",
+		},
+		{
+			name:    "BluRay with REMUX other",
+			release: &rls.Release{Source: "BluRay", Resolution: "1080p", Other: []string{"REMUX"}},
+			want:    "REMUX",
+		},
+		{
+			name:    "UHD BluRay 2160p with REMUX other",
+			release: &rls.Release{Source: "UHD.BluRay", Resolution: "2160p", Other: []string{"REMUX"}},
+			want:    "REMUX",
+		},
+		{
+			name:    "UHD BluRay 2160p encode without remux",
+			release: &rls.Release{Source: "UHD.BluRay", Resolution: "2160p"},
+			want:    "BLURAY",
+		},
+		{
+			name:    "remux other lowercase still matches",
+			release: &rls.Release{Source: "BluRay", Resolution: "1080p", Other: []string{"remux"}},
+			want:    "REMUX",
+		},
+		{
+			name:    "HDTV",
+			release: &rls.Release{Source: "HDTV", Resolution: "720p"},
+			want:    "HDTV",
+		},
+		{
+			name:    "unknown source",
+			release: &rls.Release{Source: "DVDRip", Resolution: ""},
+			want:    "",
+		},
+		{
+			name:    "empty source",
+			release: &rls.Release{Source: "", Resolution: "1080p"},
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sourceClass(tt.release); got != tt.want {
+				t.Errorf("sourceClass() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchSeasonPackCategoryRule(t *testing.T) {
+	tests := []struct {
+		name        string
+		rules       []models.SeasonPackCategoryRule
+		resolution  string
+		srcClass    string
+		wantCat     string
+		wantMatched bool
+	}{
+		{
+			name:        "empty rules",
+			rules:       nil,
+			resolution:  "1080p",
+			srcClass:    "WEB",
+			wantCat:     "",
+			wantMatched: false,
+		},
+		{
+			name: "specific source beats any at same resolution",
+			rules: []models.SeasonPackCategoryRule{
+				{Resolution: "1080p", Source: "", Category: "any-1080p"},
+				{Resolution: "1080p", Source: "WEB", Category: "web-1080p"},
+			},
+			resolution:  "1080p",
+			srcClass:    "WEB",
+			wantCat:     "web-1080p",
+			wantMatched: true,
+		},
+		{
+			name: "specific source wins even when any rule appears later",
+			rules: []models.SeasonPackCategoryRule{
+				{Resolution: "1080p", Source: "WEB", Category: "web-1080p"},
+				{Resolution: "1080p", Source: "", Category: "any-1080p"},
+			},
+			resolution:  "1080p",
+			srcClass:    "WEB",
+			wantCat:     "web-1080p",
+			wantMatched: true,
+		},
+		{
+			name: "any-source fallback when no specific match",
+			rules: []models.SeasonPackCategoryRule{
+				{Resolution: "1080p", Source: "BLURAY", Category: "bluray-1080p"},
+				{Resolution: "1080p", Source: "", Category: "any-1080p"},
+			},
+			resolution:  "1080p",
+			srcClass:    "WEB",
+			wantCat:     "any-1080p",
+			wantMatched: true,
+		},
+		{
+			name: "first-in-slice wins on specific tie",
+			rules: []models.SeasonPackCategoryRule{
+				{Resolution: "1080p", Source: "WEB", Category: "first"},
+				{Resolution: "1080p", Source: "WEB", Category: "second"},
+			},
+			resolution:  "1080p",
+			srcClass:    "WEB",
+			wantCat:     "first",
+			wantMatched: true,
+		},
+		{
+			name: "first-in-slice wins on any tie",
+			rules: []models.SeasonPackCategoryRule{
+				{Resolution: "1080p", Source: "", Category: "first-any"},
+				{Resolution: "1080p", Source: "", Category: "second-any"},
+			},
+			resolution:  "1080p",
+			srcClass:    "WEB",
+			wantCat:     "first-any",
+			wantMatched: true,
+		},
+		{
+			name: "resolution mismatch no match",
+			rules: []models.SeasonPackCategoryRule{
+				{Resolution: "2160p", Source: "WEB", Category: "web-2160p"},
+			},
+			resolution:  "1080p",
+			srcClass:    "WEB",
+			wantCat:     "",
+			wantMatched: false,
+		},
+		{
+			name: "resolution comparison is case-insensitive",
+			rules: []models.SeasonPackCategoryRule{
+				{Resolution: "1080P", Source: "WEB", Category: "web-1080p"},
+			},
+			resolution:  "1080p",
+			srcClass:    "WEB",
+			wantCat:     "web-1080p",
+			wantMatched: true,
+		},
+		{
+			name: "empty source class only matches any rules",
+			rules: []models.SeasonPackCategoryRule{
+				{Resolution: "1080p", Source: "WEB", Category: "web-1080p"},
+				{Resolution: "1080p", Source: "", Category: "any-1080p"},
+			},
+			resolution:  "1080p",
+			srcClass:    "",
+			wantCat:     "any-1080p",
+			wantMatched: true,
+		},
+		{
+			name: "empty source class no any rule no match",
+			rules: []models.SeasonPackCategoryRule{
+				{Resolution: "1080p", Source: "WEB", Category: "web-1080p"},
+			},
+			resolution:  "1080p",
+			srcClass:    "",
+			wantCat:     "",
+			wantMatched: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotCat, gotMatched := matchSeasonPackCategoryRule(tt.rules, tt.resolution, tt.srcClass)
+			if gotCat != tt.wantCat || gotMatched != tt.wantMatched {
+				t.Errorf("matchSeasonPackCategoryRule() = (%q, %v), want (%q, %v)", gotCat, gotMatched, tt.wantCat, tt.wantMatched)
+			}
+		})
+	}
+}

--- a/internal/services/crossseed/seasonpack.go
+++ b/internal/services/crossseed/seasonpack.go
@@ -383,13 +383,9 @@ func (s *Service) ApplySeasonPackWebhook(ctx context.Context, req *SeasonPackApp
 		return s.failApply(ctx, req.TorrentName, err, prep, winner)
 	}
 
-	crossCategory := strings.TrimSpace(prep.settings.SeasonPackCategory)
-	if crossCategory == "" {
-		_, crossCategory = s.determineCrossSeedCategory(ctx, &CrossSeedRequest{
-			IndexerName: req.Indexer,
-		}, &qbt.Torrent{
-			Category: firstMatchedEpisodeCategory(episodes),
-		}, prep.settings)
+	crossCategory := s.resolveSeasonPackCategory(ctx, prep, req.Indexer, episodes)
+	if err := s.ensureCrossCategory(ctx, inst.ID, crossCategory, "", false); err != nil {
+		log.Warn().Err(err).Str("torrentName", req.TorrentName).Str("category", crossCategory).Msg("season pack: failed to ensure cross-seed category exists")
 	}
 
 	opts := seasonPackAddOptions(planBuild.plan, crossCategory, planBuild.hasPendingFiles())

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -6423,12 +6423,21 @@ components:
 
     SeasonPackCategoryRule:
       type: object
+      required:
+        - resolution
+        - category
       properties:
         resolution:
           type: string
           description: Canonical lowercase release resolution to match (e.g. "1080p", "2160p").
         source:
           type: string
+          enum:
+            - ""
+            - WEB
+            - BLURAY
+            - REMUX
+            - HDTV
           description: Canonical uppercase release source to match (WEB, BLURAY, REMUX, HDTV). Empty matches any source.
         category:
           type: string

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -6421,6 +6421,19 @@ components:
           default: 0
           description: Seconds to wait after a torrent completes before starting the cross-seed search. 0 disables the delay.
 
+    SeasonPackCategoryRule:
+      type: object
+      properties:
+        resolution:
+          type: string
+          description: Canonical lowercase release resolution to match (e.g. "1080p", "2160p").
+        source:
+          type: string
+          description: Canonical uppercase release source to match (WEB, BLURAY, REMUX, HDTV). Empty matches any source.
+        category:
+          type: string
+          description: qBittorrent category to file matching season-pack injections under.
+
     CrossSeedAutomationSettingsPatch:
       type: object
       properties:
@@ -6542,6 +6555,11 @@ components:
         seasonPackCategory:
           type: string
           description: Fixed qBittorrent category for season-pack injections. Empty uses the global category mode.
+        seasonPackCategoryRules:
+          type: array
+          items:
+            $ref: '#/components/schemas/SeasonPackCategoryRule'
+          description: Per-quality routing rules that pick a category by release resolution and source. seasonPackCategory is the fallback when no rule matches.
         seasonPackTvdbApiKey:
           type: string
           description: TVDB API key for season pack metadata resolution. Redacted in API responses.
@@ -6670,6 +6688,11 @@ components:
         seasonPackCategory:
           type: string
           description: Fixed qBittorrent category for season-pack injections. Empty uses the global category mode.
+        seasonPackCategoryRules:
+          type: array
+          items:
+            $ref: '#/components/schemas/SeasonPackCategoryRule'
+          description: Per-quality routing rules that pick a category by release resolution and source. seasonPackCategory is the fallback when no rule matches.
         seasonPackTvdbApiKey:
           type: string
           description: TVDB API key for season pack metadata resolution. Redacted in API responses.

--- a/web/src/components/crossseed/SeasonPackCategoryRulesEditor.tsx
+++ b/web/src/components/crossseed/SeasonPackCategoryRulesEditor.tsx
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { Button } from "@/components/ui/button"
+import { MultiSelect, type Option } from "@/components/ui/multi-select"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { buildCategorySelectOptions } from "@/lib/category-utils"
+import type { SeasonPackCategoryRule } from "@/types"
+import { Plus, X } from "lucide-react"
+import { useMemo } from "react"
+import { useTranslation } from "react-i18next"
+
+// Resolution options for the routing rules (canonical lowercase rls values).
+const RESOLUTION_OPTIONS = ["2160p", "1080p", "720p", "576p", "480p"] as const
+
+// Source options. Stored value "" means any source; the rest are canonical uppercase.
+const SOURCE_OPTIONS: Array<{ value: string; labelKey: string }> = [
+  { value: "", labelKey: "rules.seasonPack.categoryRouting.anySource" },
+  { value: "WEB", labelKey: "rules.seasonPack.categoryRouting.source.web" },
+  { value: "BLURAY", labelKey: "rules.seasonPack.categoryRouting.source.bluray" },
+  { value: "REMUX", labelKey: "rules.seasonPack.categoryRouting.source.remux" },
+  { value: "HDTV", labelKey: "rules.seasonPack.categoryRouting.source.hdtv" },
+]
+
+// Select uses a non-empty sentinel for the "any source" entry because Radix
+// Select reserves "" for clearing the value.
+const ANY_SOURCE_VALUE = "__any__"
+
+interface SeasonPackCategoryRulesEditorProps {
+  value: SeasonPackCategoryRule[]
+  onChange: (rules: SeasonPackCategoryRule[]) => void
+  /** Aggregated qBittorrent category metadata used to suggest categories. */
+  categoryMetadata: Record<string, { name: string; savePath: string }>
+  disabled?: boolean
+}
+
+export function SeasonPackCategoryRulesEditor({
+  value,
+  onChange,
+  categoryMetadata,
+  disabled = false,
+}: SeasonPackCategoryRulesEditorProps) {
+  const { t } = useTranslation("crossseed")
+
+  const categoryOptions = useMemo<Option[]>(
+    () => buildCategorySelectOptions(categoryMetadata, value.map(rule => rule.category)),
+    [categoryMetadata, value]
+  )
+
+  const updateRule = (index: number, patch: Partial<SeasonPackCategoryRule>) => {
+    onChange(value.map((rule, i) => (i === index ? { ...rule, ...patch } : rule)))
+  }
+
+  const removeRule = (index: number) => {
+    onChange(value.filter((_, i) => i !== index))
+  }
+
+  const addRule = () => {
+    onChange([...value, { resolution: "1080p", source: "", category: "" }])
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1">
+        <p className="text-sm font-medium leading-none">{t("rules.seasonPack.categoryRouting.title")}</p>
+        <p className="text-xs text-muted-foreground">{t("rules.seasonPack.categoryRouting.description")}</p>
+      </div>
+
+      <div className="space-y-2">
+        {value.map((rule, index) => (
+          <div key={index} className="flex flex-wrap items-center gap-2">
+            <span className="text-xs text-muted-foreground">{t("rules.seasonPack.categoryRouting.whenResolution")}</span>
+            <Select
+              value={rule.resolution}
+              onValueChange={resolution => updateRule(index, { resolution })}
+              disabled={disabled}
+            >
+              <SelectTrigger className="h-9 w-[110px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {RESOLUTION_OPTIONS.map(resolution => (
+                  <SelectItem key={resolution} value={resolution}>{resolution}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <span className="text-xs text-muted-foreground">{t("rules.seasonPack.categoryRouting.fromSource")}</span>
+            <Select
+              value={rule.source === "" ? ANY_SOURCE_VALUE : rule.source}
+              onValueChange={source => updateRule(index, { source: source === ANY_SOURCE_VALUE ? "" : source })}
+              disabled={disabled}
+            >
+              <SelectTrigger className="h-9 w-[130px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {SOURCE_OPTIONS.map(option => (
+                  <SelectItem key={option.value || ANY_SOURCE_VALUE} value={option.value || ANY_SOURCE_VALUE}>
+                    {t(option.labelKey)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <span className="text-xs text-muted-foreground">{t("rules.seasonPack.categoryRouting.fileAs")}</span>
+            <MultiSelect
+              options={categoryOptions}
+              selected={rule.category ? [rule.category] : []}
+              onChange={values => updateRule(index, { category: values[0] ?? "" })}
+              onCreateOption={category => updateRule(index, { category })}
+              placeholder={t("rules.categories.selectOrTypeCategory")}
+              className="w-[180px]"
+              creatable
+              disabled={disabled}
+            />
+
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-9 w-9 shrink-0"
+              onClick={() => removeRule(index)}
+              disabled={disabled}
+              aria-label={t("rules.seasonPack.categoryRouting.removeRule")}
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+        ))}
+      </div>
+
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={addRule}
+        disabled={disabled}
+      >
+        <Plus className="h-4 w-4" />
+        {t("rules.seasonPack.categoryRouting.addRule")}
+      </Button>
+    </div>
+  )
+}

--- a/web/src/components/crossseed/__tests__/SeasonPackCategoryRulesEditor.test.tsx
+++ b/web/src/components/crossseed/__tests__/SeasonPackCategoryRulesEditor.test.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { cleanup, render, screen, fireEvent } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+// Return the key itself so assertions can target stable strings without loading
+// the full i18n runtime.
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+import { SeasonPackCategoryRulesEditor } from "@/components/crossseed/SeasonPackCategoryRulesEditor"
+import type { SeasonPackCategoryRule } from "@/types"
+
+describe("SeasonPackCategoryRulesEditor", () => {
+  // globals: false in vitest.config disables auto-cleanup, so do it explicitly.
+  afterEach(() => {
+    cleanup()
+  })
+
+  it("appends a default rule when Add rule is clicked", () => {
+    const onChange = vi.fn()
+    render(
+      <SeasonPackCategoryRulesEditor
+        value={[]}
+        onChange={onChange}
+        categoryMetadata={{}}
+      />
+    )
+
+    fireEvent.click(screen.getByText("rules.seasonPack.categoryRouting.addRule"))
+
+    expect(onChange).toHaveBeenCalledWith([
+      { resolution: "1080p", source: "", category: "" },
+    ])
+  })
+
+  it("removes the targeted rule", () => {
+    const onChange = vi.fn()
+    const value: SeasonPackCategoryRule[] = [
+      { resolution: "2160p", source: "WEB", category: "tv-uhd" },
+      { resolution: "1080p", source: "", category: "tv-hd" },
+    ]
+    render(
+      <SeasonPackCategoryRulesEditor
+        value={value}
+        onChange={onChange}
+        categoryMetadata={{}}
+      />
+    )
+
+    const removeButtons = screen.getAllByLabelText("rules.seasonPack.categoryRouting.removeRule")
+    fireEvent.click(removeButtons[0])
+
+    expect(onChange).toHaveBeenCalledWith([
+      { resolution: "1080p", source: "", category: "tv-hd" },
+    ])
+  })
+
+  it("disables the Add rule button when disabled", () => {
+    render(
+      <SeasonPackCategoryRulesEditor
+        value={[]}
+        onChange={vi.fn()}
+        categoryMetadata={{}}
+        disabled
+      />
+    )
+
+    const addButton = screen.getByText("rules.seasonPack.categoryRouting.addRule").closest("button")
+    expect(addButton).not.toBeNull()
+    expect((addButton as HTMLButtonElement).disabled).toBe(true)
+  })
+})

--- a/web/src/i18n/locales/de/crossseed.json
+++ b/web/src/i18n/locales/de/crossseed.json
@@ -212,7 +212,7 @@
       "tvdbDescription": "Optional. Verbessert die Genauigkeit des Schwellenwerts, wenn der Prüf-Endpunkt ohne Torrent-Daten aufgerufen wird. TVMaze wird automatisch als kostenloser Fallback verwendet.",
       "categoryRouting": {
         "title": "Kategorie-Routing",
-        "description": "Leite Season-Pack-Injektionen anhand von Auflösung und Quelle an eine qBittorrent-Kategorie weiter. Setze diese auf deine Sonarr-Download-Client-Kategorien, damit Sonarr das Pack importiert und Hardlinks erhält. Eine Regel mit einer bestimmten Quelle hat Vorrang vor einer Regel mit „Any“-Quelle bei derselben Auflösung.",
+        "description": "Leite Season-Pack-Injektionen anhand von Auflösung und Quelle an eine qBittorrent-Kategorie weiter. Setze diese auf deine Sonarr-Download-Client-Kategorien, damit Sonarr das Pack importiert und Hardlinks erhält. Eine Regel mit einer bestimmten Quelle hat Vorrang vor einer „Beliebige Quelle“-Regel bei derselben Auflösung.",
         "addRule": "Regel hinzufügen",
         "removeRule": "Regel entfernen",
         "whenResolution": "Wenn",

--- a/web/src/i18n/locales/de/crossseed.json
+++ b/web/src/i18n/locales/de/crossseed.json
@@ -210,10 +210,25 @@
       "tvdbPin": "TVDB Subscriber PIN",
       "pasteTvdbPin": "TVDB PIN einfügen",
       "tvdbDescription": "Optional. Verbessert die Genauigkeit des Schwellenwerts, wenn der Prüf-Endpunkt ohne Torrent-Daten aufgerufen wird. TVMaze wird automatisch als kostenloser Fallback verwendet.",
-      "categoryOverride": "Kategorie überschreiben",
-      "categoryPlaceholder": "z. B. tv-hd",
-      "categoryDescriptionBefore": "Optional. Feste qBittorrent-Kategorie für Season-Pack-Injektionen. Setze diese auf deine Sonarr-Download-Client-Kategorie (z. B. ",
-      "categoryDescriptionAfter": "), damit Sonarr das Pack importiert und Hardlinks zwischen der Bibliothek und deinen geseedeten Episoden erhält. Leer lassen, um dem Kategorie-Modus unten zu folgen."
+      "categoryRouting": {
+        "title": "Kategorie-Routing",
+        "description": "Leite Season-Pack-Injektionen anhand von Auflösung und Quelle an eine qBittorrent-Kategorie weiter. Setze diese auf deine Sonarr-Download-Client-Kategorien, damit Sonarr das Pack importiert und Hardlinks erhält. Eine Regel mit einer bestimmten Quelle hat Vorrang vor einer Regel mit „Any“-Quelle bei derselben Auflösung.",
+        "addRule": "Regel hinzufügen",
+        "removeRule": "Regel entfernen",
+        "whenResolution": "Wenn",
+        "fromSource": "von",
+        "anySource": "Beliebige Quelle",
+        "fileAs": "ablegen als",
+        "fallbackLabel": "Alles andere",
+        "fallbackDescriptionBefore": "Optional. Kategorie für Season-Pack-Injektionen, die keiner Regel oben entsprechen (z. B. ",
+        "fallbackDescriptionAfter": "). Leer lassen, um dem Kategorie-Modus unten zu folgen.",
+        "source": {
+          "web": "WEB",
+          "bluray": "BluRay",
+          "remux": "Remux",
+          "hdtv": "HDTV"
+        }
+      }
     },
     "gazelle": {
       "title": "Gazelle (OPS/RED)",

--- a/web/src/i18n/locales/en/crossseed.json
+++ b/web/src/i18n/locales/en/crossseed.json
@@ -210,10 +210,25 @@
       "tvdbPin": "TVDB Subscriber PIN",
       "pasteTvdbPin": "Paste TVDB PIN",
       "tvdbDescription": "Optional. Improves threshold accuracy when the check endpoint is called without torrent data. TVMaze is used automatically as a free fallback.",
-      "categoryOverride": "Category override",
-      "categoryPlaceholder": "e.g. tv-hd",
-      "categoryDescriptionBefore": "Optional. Fixed qBittorrent category for season pack injects. Set this to your Sonarr download-client category (e.g. ",
-      "categoryDescriptionAfter": ") so Sonarr imports the pack and preserves hardlinks between the library and your seeded episodes. Leave empty to follow the Category Mode below."
+      "categoryRouting": {
+        "title": "Category routing",
+        "description": "Route season pack injects to a qBittorrent category based on resolution and source. Set these to your Sonarr download-client categories so Sonarr imports the pack and preserves hardlinks. A rule with a specific source takes priority over an Any-source rule at the same resolution.",
+        "addRule": "Add rule",
+        "removeRule": "Remove rule",
+        "whenResolution": "When",
+        "fromSource": "from",
+        "anySource": "Any source",
+        "fileAs": "file as",
+        "fallbackLabel": "Anything else",
+        "fallbackDescriptionBefore": "Optional. Category for season pack injects that don't match any rule above (e.g. ",
+        "fallbackDescriptionAfter": "). Leave empty to follow the Category Mode below.",
+        "source": {
+          "web": "WEB",
+          "bluray": "BluRay",
+          "remux": "Remux",
+          "hdtv": "HDTV"
+        }
+      }
     },
     "gazelle": {
       "title": "Gazelle (OPS/RED)",

--- a/web/src/i18n/locales/fr/crossseed.json
+++ b/web/src/i18n/locales/fr/crossseed.json
@@ -210,10 +210,25 @@
       "tvdbPin": "Code PIN abonné TVDB",
       "pasteTvdbPin": "Coller le code PIN TVDB",
       "tvdbDescription": "Optionnel. Améliore la précision du seuil lorsque le point de vérification est appelé sans données torrent. TVMaze est utilisé automatiquement comme solution de repli gratuite.",
-      "categoryOverride": "Remplacement de catégorie",
-      "categoryPlaceholder": "ex. tv-hd",
-      "categoryDescriptionBefore": "Optionnel. Catégorie qBittorrent fixe pour les injections de packs de saison. Définissez ceci sur la catégorie du client de téléchargement Sonarr (ex. ",
-      "categoryDescriptionAfter": ") pour que Sonarr importe le pack et préserve les hardlinks entre la bibliothèque et vos épisodes en seed. Laisser vide pour suivre le Mode de catégorie ci-dessous."
+      "categoryRouting": {
+        "title": "Routage des catégories",
+        "description": "Acheminez les injections de packs de saison vers une catégorie qBittorrent selon la résolution et la source. Définissez-les sur vos catégories de client de téléchargement Sonarr pour que Sonarr importe le pack et préserve les hardlinks. Une règle avec une source spécifique est prioritaire sur une règle « Any » (toute source) à la même résolution.",
+        "addRule": "Ajouter une règle",
+        "removeRule": "Supprimer la règle",
+        "whenResolution": "Si",
+        "fromSource": "depuis",
+        "anySource": "Toute source",
+        "fileAs": "classer dans",
+        "fallbackLabel": "Tout le reste",
+        "fallbackDescriptionBefore": "Optionnel. Catégorie pour les injections de packs de saison qui ne correspondent à aucune règle ci-dessus (ex. ",
+        "fallbackDescriptionAfter": "). Laisser vide pour suivre le Mode de catégorie ci-dessous.",
+        "source": {
+          "web": "WEB",
+          "bluray": "BluRay",
+          "remux": "Remux",
+          "hdtv": "HDTV"
+        }
+      }
     },
     "gazelle": {
       "title": "Gazelle (OPS/RED)",

--- a/web/src/i18n/locales/fr/crossseed.json
+++ b/web/src/i18n/locales/fr/crossseed.json
@@ -212,7 +212,7 @@
       "tvdbDescription": "Optionnel. Améliore la précision du seuil lorsque le point de vérification est appelé sans données torrent. TVMaze est utilisé automatiquement comme solution de repli gratuite.",
       "categoryRouting": {
         "title": "Routage des catégories",
-        "description": "Acheminez les injections de packs de saison vers une catégorie qBittorrent selon la résolution et la source. Définissez-les sur vos catégories de client de téléchargement Sonarr pour que Sonarr importe le pack et préserve les hardlinks. Une règle avec une source spécifique est prioritaire sur une règle « Any » (toute source) à la même résolution.",
+        "description": "Acheminez les injections de packs de saison vers une catégorie qBittorrent selon la résolution et la source. Définissez-les sur vos catégories de client de téléchargement Sonarr pour que Sonarr importe le pack et préserve les hardlinks. Une règle avec une source spécifique est prioritaire sur une règle « Toute source » à la même résolution.",
         "addRule": "Ajouter une règle",
         "removeRule": "Supprimer la règle",
         "whenResolution": "Si",

--- a/web/src/i18n/locales/zh-CN/crossseed.json
+++ b/web/src/i18n/locales/zh-CN/crossseed.json
@@ -210,10 +210,25 @@
       "tvdbPin": "TVDB 订阅者 PIN",
       "pasteTvdbPin": "粘贴 TVDB PIN",
       "tvdbDescription": "可选。当调用检查端点而不带种子数据时，可提高阈值准确度。TVMaze 会作为免费回退自动使用。",
-      "categoryOverride": "分类覆盖",
-      "categoryPlaceholder": "例如 tv-hd",
-      "categoryDescriptionBefore": "可选。用于季度包注入的固定 qBittorrent 分类。将其设置为你的 Sonarr 下载客户端分类（例如 ",
-      "categoryDescriptionAfter": "），以便 Sonarr 导入该包并在媒体库与你做种的单集之间保留硬链接。留空则遵循下方的分类模式。"
+      "categoryRouting": {
+        "title": "分类路由",
+        "description": "根据分辨率和来源将季度包注入路由到 qBittorrent 分类。将这些设置为你的 Sonarr 下载客户端分类，以便 Sonarr 导入该包并保留硬链接。在相同分辨率下，指定来源的规则优先于 Any（任意来源）规则。",
+        "addRule": "添加规则",
+        "removeRule": "移除规则",
+        "whenResolution": "当",
+        "fromSource": "来自",
+        "anySource": "任意来源",
+        "fileAs": "归入",
+        "fallbackLabel": "其他所有",
+        "fallbackDescriptionBefore": "可选。用于不匹配上述任何规则的季度包注入的分类（例如 ",
+        "fallbackDescriptionAfter": "）。留空则遵循下方的分类模式。",
+        "source": {
+          "web": "WEB",
+          "bluray": "BluRay",
+          "remux": "Remux",
+          "hdtv": "HDTV"
+        }
+      }
     },
     "gazelle": {
       "title": "Gazelle（OPS/RED）",

--- a/web/src/i18n/locales/zh-CN/crossseed.json
+++ b/web/src/i18n/locales/zh-CN/crossseed.json
@@ -212,7 +212,7 @@
       "tvdbDescription": "可选。当调用检查端点而不带种子数据时，可提高阈值准确度。TVMaze 会作为免费回退自动使用。",
       "categoryRouting": {
         "title": "分类路由",
-        "description": "根据分辨率和来源将季度包注入路由到 qBittorrent 分类。将这些设置为你的 Sonarr 下载客户端分类，以便 Sonarr 导入该包并保留硬链接。在相同分辨率下，指定来源的规则优先于 Any（任意来源）规则。",
+        "description": "根据分辨率和来源将季度包注入路由到 qBittorrent 分类。将这些设置为你的 Sonarr 下载客户端分类，以便 Sonarr 导入该包并保留硬链接。在相同分辨率下，指定来源的规则优先于任意来源规则。",
         "addRule": "添加规则",
         "removeRule": "移除规则",
         "whenResolution": "当",

--- a/web/src/pages/CrossSeedPage.tsx
+++ b/web/src/pages/CrossSeedPage.tsx
@@ -6,6 +6,7 @@
 import { CompletionOverview } from "@/components/instances/preferences/CompletionOverview"
 import { BlocklistTab } from "@/components/cross-seed/BlocklistTab"
 import { DirScanTab } from "@/components/cross-seed/DirScanTab"
+import { SeasonPackCategoryRulesEditor } from "@/components/crossseed/SeasonPackCategoryRulesEditor"
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import {
@@ -50,6 +51,7 @@ import type {
   CrossSeedRun,
   CrossSeedSearchResult,
   Instance,
+  SeasonPackCategoryRule,
   SeasonPackRun
 } from "@/types"
 import { useTranslation } from "react-i18next"
@@ -128,6 +130,7 @@ interface GlobalCrossSeedSettings {
   seasonPackCoverageThreshold: number
   seasonPackTags: string[]
   seasonPackCategory: string
+  seasonPackCategoryRules: SeasonPackCategoryRule[]
   seasonPackTvdbApiKey: string
   seasonPackTvdbPin: string
   // Note: Hardlink mode settings have been moved to per-instance configuration
@@ -190,6 +193,7 @@ const DEFAULT_GLOBAL_SETTINGS: GlobalCrossSeedSettings = {
   seasonPackCoverageThreshold: 0.75,
   seasonPackTags: ["cross-seed"],
   seasonPackCategory: "",
+  seasonPackCategoryRules: [],
   seasonPackTvdbApiKey: "",
   seasonPackTvdbPin: "",
   // Webhook source filtering defaults - empty means no filtering (all torrents)
@@ -1128,6 +1132,7 @@ export function CrossSeedPage({ activeTab, onTabChange }: CrossSeedPageProps) {
         seasonPackCoverageThreshold: settings.seasonPackCoverageThreshold ?? 0.75,
         seasonPackTags: settings.seasonPackTags ?? ["cross-seed"],
         seasonPackCategory: settings.seasonPackCategory ?? "",
+        seasonPackCategoryRules: settings.seasonPackCategoryRules ?? [],
         seasonPackTvdbApiKey: settings.seasonPackTvdbApiKey ?? "",
         seasonPackTvdbPin: settings.seasonPackTvdbPin ?? "",
         // Note: Hardlink mode is now per-instance (configured in Instance Settings)
@@ -1226,6 +1231,7 @@ export function CrossSeedPage({ activeTab, onTabChange }: CrossSeedPageProps) {
       seasonPackCoverageThreshold: settings.seasonPackCoverageThreshold ?? 0.75,
       seasonPackTags: settings.seasonPackTags ?? ["cross-seed"],
       seasonPackCategory: settings.seasonPackCategory ?? "",
+      seasonPackCategoryRules: settings.seasonPackCategoryRules ?? [],
       seasonPackTvdbApiKey: settings.seasonPackTvdbApiKey ?? "",
       seasonPackTvdbPin: settings.seasonPackTvdbPin ?? "",
       // Note: Hardlink mode is now per-instance
@@ -1271,6 +1277,7 @@ export function CrossSeedPage({ activeTab, onTabChange }: CrossSeedPageProps) {
       seasonPackCoverageThreshold: globalSource.seasonPackCoverageThreshold,
       seasonPackTags: globalSource.seasonPackTags,
       seasonPackCategory: globalSource.seasonPackCategory,
+      seasonPackCategoryRules: globalSource.seasonPackCategoryRules,
       seasonPackTvdbApiKey: globalSource.seasonPackTvdbApiKey,
       seasonPackTvdbPin: globalSource.seasonPackTvdbPin,
       // Note: Hardlink mode is now per-instance (see Instance Settings)
@@ -1730,6 +1737,15 @@ export function CrossSeedPage({ activeTab, onTabChange }: CrossSeedPageProps) {
       globalSettings.customCategory ? [globalSettings.customCategory] : []
     ),
     [globalSettings.customCategory, webhookSourceMetadata?.categories]
+  )
+
+  // Season pack fallback category select options ("Anything else" routing target)
+  const seasonPackFallbackCategorySelectOptions = useMemo(
+    () => buildCategorySelectOptions(
+      webhookSourceMetadata?.categories ?? {},
+      globalSettings.seasonPackCategory ? [globalSettings.seasonPackCategory] : []
+    ),
+    [globalSettings.seasonPackCategory, webhookSourceMetadata?.categories]
   )
 
   // Helper to get current category mode from boolean flags
@@ -3002,20 +3018,29 @@ export function CrossSeedPage({ activeTab, onTabChange }: CrossSeedPageProps) {
                 <p className="text-xs text-muted-foreground">
                   {t("rules.seasonPack.tvdbDescription")}
                 </p>
-                <div className="space-y-2 pt-3 border-t border-border/50">
-                  <Label htmlFor="season-pack-category">{t("rules.seasonPack.categoryOverride")}</Label>
-                  <Input
-                    id="season-pack-category"
-                    value={globalSettings.seasonPackCategory}
-                    onChange={event => setGlobalSettings(prev => ({ ...prev, seasonPackCategory: event.target.value }))}
-                    placeholder={globalSettings.seasonPackEnabled ? t("rules.seasonPack.categoryPlaceholder") : t("rules.seasonPack.enableToConfigure")}
+                <div className="space-y-4 pt-3 border-t border-border/50">
+                  <SeasonPackCategoryRulesEditor
+                    value={globalSettings.seasonPackCategoryRules}
+                    onChange={rules => setGlobalSettings(prev => ({ ...prev, seasonPackCategoryRules: rules }))}
+                    categoryMetadata={webhookSourceMetadata?.categories ?? {}}
                     disabled={!globalSettings.seasonPackEnabled}
-                    className="max-w-sm"
-                    autoComplete="off"
                   />
-                  <p className="text-xs text-muted-foreground">
-                    {t("rules.seasonPack.categoryDescriptionBefore")}<code>tv-hd</code>{t("rules.seasonPack.categoryDescriptionAfter")}
-                  </p>
+                  <div className="space-y-2">
+                    <Label htmlFor="season-pack-category">{t("rules.seasonPack.categoryRouting.fallbackLabel")}</Label>
+                    <MultiSelect
+                      options={seasonPackFallbackCategorySelectOptions}
+                      selected={globalSettings.seasonPackCategory ? [globalSettings.seasonPackCategory] : []}
+                      onChange={values => setGlobalSettings(prev => ({ ...prev, seasonPackCategory: values[0] ?? "" }))}
+                      onCreateOption={value => setGlobalSettings(prev => ({ ...prev, seasonPackCategory: value }))}
+                      placeholder={globalSettings.seasonPackEnabled ? t("rules.categories.selectOrTypeCategory") : t("rules.seasonPack.enableToConfigure")}
+                      className="max-w-sm"
+                      creatable
+                      disabled={!globalSettings.seasonPackEnabled}
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      {t("rules.seasonPack.categoryRouting.fallbackDescriptionBefore")}<code>tv-hd</code>{t("rules.seasonPack.categoryRouting.fallbackDescriptionAfter")}
+                    </p>
+                  </div>
                 </div>
                 <SeasonPackRunsPanel
                   runs={seasonPackRuns}

--- a/web/src/types/crossseed.ts
+++ b/web/src/types/crossseed.ts
@@ -141,6 +141,12 @@ export interface CrossSeedRun {
   createdAt: string
 }
 
+export interface SeasonPackCategoryRule {
+  resolution: string
+  source: string
+  category: string
+}
+
 export interface CrossSeedAutomationSettings {
   enabled: boolean
   runIntervalMinutes: number
@@ -197,6 +203,7 @@ export interface CrossSeedAutomationSettings {
   seasonPackCoverageThreshold: number
   seasonPackTags: string[]
   seasonPackCategory: string
+  seasonPackCategoryRules: SeasonPackCategoryRule[]
   seasonPackTvdbApiKey?: string
   seasonPackTvdbPin?: string
   createdAt?: string
@@ -259,6 +266,7 @@ export interface CrossSeedAutomationSettingsPatch {
   seasonPackCoverageThreshold?: number
   seasonPackTags?: string[]
   seasonPackCategory?: string
+  seasonPackCategoryRules?: SeasonPackCategoryRule[]
   seasonPackTvdbApiKey?: string
   seasonPackTvdbPin?: string
 }


### PR DESCRIPTION
Replaces the single season pack category override with quality-based routing rules. Each rule maps a resolution and an optional source (WEB/BluRay/Remux/HDTV) to a qBittorrent category, with a specific-source rule winning over an Any-source rule at the same resolution. Unmatched packs fall back to the kept single category, then the global category mode, and the resolved category is created on the target instance if it does not exist (mirroring regular cross-seed adds). This lets people running multiple Sonarr instances route, for example, 1080p packs to `tv-hd` and 2160p packs to `tv-uhd`.

Resolution and source come from the already-parsed release, so there are no new lookups. Includes SQLite + Postgres migrations, OpenAPI updates, the rules editor UI, and en/de/fr/zh-CN translations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Season-pack category routing: define ordered rules to route injections by resolution and source (WEB, BluRay, Remux, HDTV), plus a fallback category when no rule matches.
  * UI editor to manage routing rules and a selectable fallback category.
  * Resolved categories are created automatically on target instances when missing.

* **Documentation**
  * Updated Season Packs guide to explain routing rules, precedence, remux detection tip, and fallback behavior.

* **Localization**
  * Translations updated for the new routing UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->