### PR TITLE
docs: document frontend testing conventions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@
 - For iterative local work: `cd web && pnpm test:watch`.
 - For a coverage report: `cd web && pnpm test:coverage`.
 - CI runs both `make test` and `make test-frontend` on every PR.
+- Frontend changes should ship with vitest specs. Behavior jsdom can't render — virtualization, drag-and-drop, scroll — needs a manual smoke (a passing suite isn't full coverage).
 
 See [`AGENTS.md`](AGENTS.md) and [`web/AGENTS.md`](web/AGENTS.md) for agent-specific conventions.
 

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -12,6 +12,15 @@ Frontend and i18n rules for work under `web/`.
 - Style: two-space indentation, double quotes, trailing commas on multiline literals, Unix line endings.
 - Frontend tests: Vitest + React Testing Library, colocated as `*.test.tsx` near the component.
 
+## Frontend Tests
+
+- Colocate `*.test.ts(x)` specs with the change. Prefer extracting logic into hooks (`web/src/hooks/`) and pure helpers (`web/src/lib/`) so it is unit-testable without mounting the whole tree (see `web/src/hooks/torrent-table/` for the pattern).
+- Vitest runs with `globals: false` + jsdom and **no setup file**:
+  - Import test globals explicitly: `import { describe, it, expect, vi } from "vitest"`; use `render` / `renderHook` / `act` from `@testing-library/react`.
+  - No jest-dom matchers (`toBeInTheDocument`, `toHaveTextContent`, …) — assert plain DOM: `el.textContent`, `el.getAttribute(...)`, `expect(node).toBeNull()`.
+  - When mounting components with effects, mock their boundaries (`@/lib/api`, router, context providers, `useVirtualizer`, query hooks) and return a **stable singleton** from each mock — fresh objects per render loop effects and OOM the worker. Use `vi.hoisted()` for values referenced inside `vi.mock` factories.
+- jsdom does no real layout, scroll, or pointer/drag work — it renders **zero virtual rows** and cannot exercise virtualization, dnd-kit, or scroll restoration. Unit-test the extractable logic (reorder math, row-height mapping, handler wiring) and **manually smoke** anything visual or interactive; a green suite is not full coverage. Run targeted with `cd web && npx vitest run <path>`; CI runs the full suite via `make test-frontend`.
+
 ## React Effects
 
 - Use `useEffect` only to sync with external systems: DOM, subscriptions, network.


### PR DESCRIPTION
## Summary

Documents the frontend-test conventions that aren't obvious from the config or existing docs — the ones that cost real time to (re)discover while building out coverage during the #1963 table decomposition.

### `AGENTS.md` — new **Frontend tests** subsection
- Ship colocated `*.test.ts(x)`; extract logic into hooks/lib so it's unit-testable without mounting the whole tree.
- Vitest is `globals: false` + jsdom + **no setup file** → import test globals from `"vitest"`, **no jest-dom matchers**, assert with plain DOM.
- Mounting components with effects: mock boundaries and return **stable singletons** (fresh objects per render loop effects → OOM the worker); `vi.hoisted()` for mock values in `vi.mock` factories.
- jsdom renders **zero virtual rows** and does no real layout/scroll/drag → unit-test the extractable logic and **manually smoke** anything visual/interactive; a green suite ≠ full coverage.

### `CONTRIBUTING.md` — one expectation bullet
- Frontend changes should ship with vitest specs; behavior jsdom can't render needs a manual smoke.

## Why here
`CONTRIBUTING.md` already covers the mechanics (run commands, colocation, CI) and explicitly defers "deeper conventions" to `AGENTS.md`/`CLAUDE.md` — so the *how* lives in `AGENTS.md` (note: `CLAUDE.md` is a symlink to `AGENTS.md`, so this updates both).

## Testing
Docs-only — no code paths affected.

Opened as **draft** for wording review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidelines to include frontend testing standards and manual testing requirements for complex UI interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->