### PR TITLE
fix(web): preserve paginated rows on unified-view SSE updates

### DIFF
--- a/web/src/hooks/useTorrentsList.ts
+++ b/web/src/hooks/useTorrentsList.ts
@@ -8,7 +8,7 @@ import { useInstanceCapabilities } from "@/hooks/useInstanceCapabilities"
 import { useInstances } from "@/hooks/useInstances"
 import type { InstanceMetadata } from "@/hooks/useInstanceMetadata"
 import { api } from "@/lib/api"
-import { normalizeStreamedSnapshot, resolveStreamedCrossInstanceTorrents } from "@/lib/cross-instance-torrents"
+import { mergeStreamedCrossInstanceFirstPage, normalizeStreamedSnapshot } from "@/lib/cross-instance-torrents"
 import { isAllInstancesScope } from "@/lib/instances"
 import { mergeStreamedFirstPage } from "@/lib/stream-merge"
 import type {
@@ -234,10 +234,13 @@ export function useTorrentsList(
       queryClient.setQueryData(streamQueryKey, data)
 
       if (useCrossInstanceEndpoint) {
-        // Aggregated streams deliver the full first page of cross-instance torrents.
-        // Their identity is instanceId+hash, so the single-instance hash merge below
-        // does not apply; replace the list wholesale.
-        setAllTorrents(resolveStreamedCrossInstanceTorrents(data))
+        // Aggregated streams only ever deliver the first page of cross-instance
+        // torrents. Merge it into the displayed list keyed on instanceId+hash so
+        // pages the user paginated in via REST survive: a wholesale replace would
+        // reset the unified view to page 0 on every snapshot, so it could never
+        // scroll past the first page (issue #1983). Page 0 stays authoritative for
+        // its own window. See mergeStreamedCrossInstanceFirstPage.
+        setAllTorrents(prev => mergeStreamedCrossInstanceFirstPage(prev, data))
 
         if (typeof data.total === "number") {
           setLastKnownTotal(data.total)

--- a/web/src/lib/__tests__/cross-instance-torrents.test.ts
+++ b/web/src/lib/__tests__/cross-instance-torrents.test.ts
@@ -5,8 +5,8 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-import { normalizeCrossInstanceTorrents, normalizeStreamedSnapshot, resolveStreamedCrossInstanceTorrents } from "@/lib/cross-instance-torrents"
-import type { CrossInstanceTorrent, TorrentResponse } from "@/types"
+import { mergeStreamedCrossInstanceFirstPage, normalizeCrossInstanceTorrents, normalizeStreamedSnapshot, resolveStreamedCrossInstanceTorrents } from "@/lib/cross-instance-torrents"
+import type { CrossInstanceTorrent, Torrent, TorrentResponse } from "@/types"
 
 // A streamed cross-instance torrent as it arrives over SSE: the backend's
 // CrossInstanceTorrentView serializes instance metadata as snake_case
@@ -141,5 +141,81 @@ describe("normalizeStreamedSnapshot", () => {
   it("returns the snapshot unchanged when there is nothing to normalize", () => {
     const single = { total: 2, torrents: [] } as unknown as TorrentResponse
     expect(normalizeStreamedSnapshot(single)).toBe(single)
+  })
+})
+
+describe("mergeStreamedCrossInstanceFirstPage", () => {
+  type Snapshot = Pick<TorrentResponse, "total" | "crossInstanceTorrents" | "cross_instance_torrents">
+
+  function snapshot(total: number, ...page0: CrossInstanceTorrent[]): Snapshot {
+    return { total, cross_instance_torrents: page0 }
+  }
+
+  const hashes = (rows: CrossInstanceTorrent[]) => rows.map(row => row.hash)
+  const keys = (rows: CrossInstanceTorrent[]) => rows.map(row => `${row.instanceId}:${row.hash}`)
+
+  // The #1983 regression guard: the aggregated SSE stream only serves page 0, so it
+  // must MERGE into the displayed list rather than replace it. Before the fix every
+  // snapshot wiped the REST-appended later pages, pinning the unified view to page 0.
+  it("preserves pagination-loaded later pages on a steady stream update", () => {
+    // prev = page0[a@1, b@1] + page1[c@1, d@1]; the fresh snapshot is still page 0.
+    const prev: Torrent[] = [camel("a", 1, "alpha"), camel("b", 1, "alpha"), camel("c", 1, "alpha"), camel("d", 1, "alpha")]
+    const merged = mergeStreamedCrossInstanceFirstPage(
+      prev,
+      snapshot(4, streamed("a", 1, "alpha"), streamed("b", 1, "alpha"))
+    )
+    expect(hashes(merged)).toEqual(["a", "b", "c", "d"])
+  })
+
+  it("keeps cross-seeded same-hash rows on different instances distinct (instanceId+hash identity)", () => {
+    // prev = page0[x@1, y@1] + page1[x@2, z@1]; total 4, fresh page 0 = [x@1, y@1].
+    // 'x' exists on both instance 1 and instance 2. A hash-only merge would drop the
+    // trailing 'x@2' as a duplicate of page-0 'x@1'; the instanceId+hash key keeps it.
+    const prev: Torrent[] = [camel("x", 1, "alpha"), camel("y", 1, "alpha"), camel("x", 2, "beta"), camel("z", 1, "alpha")]
+    const merged = mergeStreamedCrossInstanceFirstPage(
+      prev,
+      snapshot(4, streamed("x", 1, "alpha"), streamed("y", 1, "alpha"))
+    )
+    expect(keys(merged)).toEqual(["1:x", "1:y", "2:x", "1:z"])
+  })
+
+  it("de-dupes a cross-instance row that reflowed from a later page up into page 0", () => {
+    // prev = page0[a@1, b@1] + page1[x@2, c@1]; total stays 4. b@1 reflows off the page-0
+    // window (e.g. after a re-sort) and x@2 reflows up into it, so the fresh page 0 is
+    // [a@1, x@2]. x@2 now appears in BOTH the fresh page and the stale trailing slice; the
+    // instanceId+hash key must collapse it to one row (and page 0 stays authoritative for
+    // its window, so the reflowed-out b@1 is dropped, not resurrected).
+    const prev: Torrent[] = [camel("a", 1, "alpha"), camel("b", 1, "alpha"), camel("x", 2, "beta"), camel("c", 1, "alpha")]
+    const merged = mergeStreamedCrossInstanceFirstPage(
+      prev,
+      snapshot(4, streamed("a", 1, "alpha"), streamed("x", 2, "beta"))
+    )
+    expect(keys(merged)).toEqual(["1:a", "2:x", "1:c"])
+  })
+
+  it("normalizes the streamed snake_case page so the Instance column is never blank", () => {
+    // Empty prev is also the filter-reset / initial-load path: useTorrentsList resets
+    // allTorrents to [] when scope/filters/search/sort change (useTorrentsList.ts), so this
+    // doubles as the "first stream payload after a reset" guard.
+    const merged = mergeStreamedCrossInstanceFirstPage(
+      [],
+      snapshot(2, streamed("a", 3, "seedbox"), streamed("b", 7, "home"))
+    )
+    expect(merged).toHaveLength(2)
+    expect(merged.every(t => typeof t.instanceId === "number" && typeof t.instanceName === "string" && t.instanceName.length > 0)).toBe(true)
+    expect(merged[0]).toEqual(expect.objectContaining({ hash: "a", instanceId: 3, instanceName: "seedbox" }))
+  })
+
+  it("clears the table on a total-0 snapshot no matter how many pages were appended", () => {
+    // #1983 is about deep pagination, so prove the clear path holds when prev spans several
+    // REST-appended pages: page0[a@1,b@1] + page1[c@1,d@1] + page2[e@1,f@1]. total===0 means
+    // the server now reports zero matches, so the whole client list is stale and must be
+    // invalidated — pagination depth must not leave orphaned rows behind.
+    const prev: Torrent[] = [
+      camel("a", 1, "alpha"), camel("b", 1, "alpha"),
+      camel("c", 1, "alpha"), camel("d", 1, "alpha"),
+      camel("e", 1, "alpha"), camel("f", 1, "alpha"),
+    ]
+    expect(mergeStreamedCrossInstanceFirstPage(prev, snapshot(0, streamed("a", 1, "alpha")))).toEqual([])
   })
 })

--- a/web/src/lib/__tests__/stream-merge.test.ts
+++ b/web/src/lib/__tests__/stream-merge.test.ts
@@ -114,4 +114,32 @@ describe("mergeStreamedFirstPage", () => {
     expect(hashes(merged)).toEqual(["a"])
     expect(hashes(merged)).not.toContain("b")
   })
+
+  describe("with a custom key extractor (cross-instance identity)", () => {
+    // Cross-instance rows are identified by instanceId+hash, because the same torrent
+    // cross-seeded onto two instances shares a hash but is two distinct rows.
+    type Row = { hash: string; instanceId: number }
+    const keyOf = (row: Row) => `${row.instanceId}:${row.hash}`
+    const row = (hash: string, instanceId: number): Row => ({ hash, instanceId })
+    const keys = (list: Row[]) => list.map(keyOf)
+
+    it("keeps cross-seeded same-hash rows on different instances as distinct trailing rows", () => {
+      // page size 2: prev = page0[x@1, y@1] + page1[x@2, z@1]; total 4. The fresh page 0
+      // is still [x@1, y@1]. A hash-only key would treat trailing 'x@2' as a duplicate of
+      // page-0 'x@1' and drop it; the instanceId+hash key must preserve it.
+      const prev = [row("x", 1), row("y", 1), row("x", 2), row("z", 1)]
+      const next = [row("x", 1), row("y", 1)]
+      const merged = mergeStreamedFirstPage(prev, next, 4, keyOf)
+      expect(keys(merged)).toEqual(["1:x", "1:y", "2:x", "1:z"])
+    })
+
+    it("still de-dupes a trailing row that genuinely reflowed up into page 0", () => {
+      // 'x@2' reflowed into the fresh page 0 and also lingers in the old trailing slice;
+      // it must appear once, identified by instanceId+hash.
+      const prev = [row("x", 1), row("y", 1), row("x", 2), row("z", 1)]
+      const next = [row("x", 1), row("x", 2)]
+      const merged = mergeStreamedFirstPage(prev, next, 4, keyOf)
+      expect(keys(merged)).toEqual(["1:x", "2:x", "1:z"])
+    })
+  })
 })

--- a/web/src/lib/cross-instance-torrents.ts
+++ b/web/src/lib/cross-instance-torrents.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import type { CrossInstanceTorrent, TorrentResponse } from "@/types"
+import { mergeStreamedFirstPage } from "@/lib/stream-merge"
+import type { CrossInstanceTorrent, Torrent, TorrentResponse } from "@/types"
 
 // RawCrossInstanceTorrent models a cross-instance torrent before normalization.
 // The backend's CrossInstanceTorrentView serializes instance metadata as
@@ -104,4 +105,30 @@ export function resolveStreamedCrossInstanceTorrents(
   }
 
   return normalized
+}
+
+// A cross-instance row's identity is instanceId+hash, not hash alone: the same
+// torrent cross-seeded onto two instances shares a hash but is two distinct rows.
+const crossInstanceRowKey = (torrent: CrossInstanceTorrent): string =>
+  `${torrent.instanceId}:${torrent.hash}`
+
+// mergeStreamedCrossInstanceFirstPage folds an aggregated SSE snapshot into the
+// list the unified table already displays. The stream only ever serves page 0, so
+// a wholesale replace would wipe any later pages the user paginated in via REST and
+// the unified view could never scroll past the first page (issue #1983). Instead we
+// merge: page 0 stays authoritative for its own window, while pagination-loaded
+// trailing pages are preserved and de-duplicated by instanceId+hash. `prev` is the
+// state list typed as the Torrent supertype; in aggregated scope every row is in
+// fact a CrossInstanceTorrent (it carries instanceId+instanceName), so we treat it
+// as such for the identity key.
+export function mergeStreamedCrossInstanceFirstPage(
+  prev: Torrent[],
+  data: Pick<TorrentResponse, "total" | "crossInstanceTorrents" | "cross_instance_torrents">
+): CrossInstanceTorrent[] {
+  return mergeStreamedFirstPage(
+    prev as CrossInstanceTorrent[],
+    resolveStreamedCrossInstanceTorrents(data),
+    typeof data.total === "number" ? data.total : undefined,
+    crossInstanceRowKey
+  )
 }

--- a/web/src/lib/stream-merge.ts
+++ b/web/src/lib/stream-merge.ts
@@ -29,12 +29,16 @@
  *     less harmful than hiding a row that still exists.
  *
  * Generic over any record carrying a stable `hash` so it can be unit tested without
- * constructing full torrent objects.
+ * constructing full torrent objects. `keyOf` selects the identity used for the page-0
+ * window dedup; it defaults to `hash` for single-instance rows, but aggregated
+ * (cross-instance) views pass `instanceId+hash` so cross-seeded copies of one torrent
+ * living on different instances stay distinct rows instead of collapsing into one.
  */
 export function mergeStreamedFirstPage<T extends { hash: string }>(
   prev: T[],
   nextTorrents: T[],
-  total?: number
+  total?: number,
+  keyOf: (torrent: T) => string = torrent => torrent.hash
 ): T[] {
   if (nextTorrents.length === 0) {
     return []
@@ -51,11 +55,11 @@ export function mergeStreamedFirstPage<T extends { hash: string }>(
     return nextTorrents
   }
 
-  const seen = new Set(nextTorrents.map(torrent => torrent.hash))
+  const seen = new Set(nextTorrents.map(keyOf))
 
   // Rows past the streamed page-0 window are pagination-loaded pages we want to keep.
   // De-duping against the fresh page drops any that reflowed up into page 0.
-  const trailing = prev.slice(nextTorrents.length).filter(torrent => !seen.has(torrent.hash))
+  const trailing = prev.slice(nextTorrents.length).filter(torrent => !seen.has(keyOf(torrent)))
 
   return [...nextTorrents, ...trailing]
 }


### PR DESCRIPTION
## Summary

In the unified / all-instances torrent view, scrolling never loaded past the first page — the list stayed pinned at the first REST page. Single-instance views were unaffected.

The aggregated SSE stream handler wholesale-replaced the displayed list with the streamed page 0 on every live update. Each tick reset the unified view back to page 0, wiping the later pages the user had scrolled in via REST, so the list could never grow.

This fix merges the streamed page 0 into the displayed list instead of replacing it:

- **`stream-merge.ts`** — `mergeStreamedFirstPage` gains an optional `keyOf` extractor (defaults to `hash`); single-instance behavior is unchanged.
- **`cross-instance-torrents.ts`** — new `mergeStreamedCrossInstanceFirstPage` normalizes the snapshot and merges it keyed on `instanceId+hash`, so cross-seeded copies of one torrent living on different instances stay distinct rows.
- **`useTorrentsList.ts`** — the cross-instance stream branch now merges instead of replacing wholesale. Page 0 stays authoritative for its own window; pagination-loaded later pages are preserved (mirroring the single-instance path).

## Testing

- [x] `web` unit tests pass (`pnpm vitest run src/lib`) — added regression tests covering: a stream snapshot must not wipe appended pages in cross-instance mode; `instanceId+hash` identity keeps cross-seeded same-hash rows distinct; reflowed-row dedup; and total-0 clearing across multiple appended pages.
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files
- [x] `make frontend` build succeeds

### Manual repro
1. Open the table in unified / all-instances scope with 1000+ aggregate torrents.
2. Scroll toward the bottom.
3. Before: the list stays at ~the first page. After: subsequent pages load, matching single-instance behavior.

Closes #1983

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-instance torrent pagination by preserving previously loaded pages when receiving real-time updates. Eliminates data loss that occurred during concurrent pagination operations, ensuring all loaded results remain visible when new updates arrive.

* **Tests**
  * Added comprehensive test coverage for cross-instance torrent pagination and stream merging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->