### PR TITLE
fix(arr): make arr_id_cache expiry timezone-independent

### DIFF
--- a/internal/models/arr_id_cache.go
+++ b/internal/models/arr_id_cache.go
@@ -58,12 +58,20 @@ func ComputeTitleHash(title string) string {
 	return hex.EncodeToString(hash[:])
 }
 
-// Get retrieves a cached ID entry if it exists and hasn't expired
+// Get retrieves a cached ID entry if it exists and hasn't expired.
+//
+// Expiry is compared against a bound UTC time parameter rather than SQL's
+// CURRENT_TIMESTAMP. expires_at is stored by binding a Go time.Time, which the
+// SQLite driver serializes as a string; CURRENT_TIMESTAMP returns its own UTC
+// string in a different format, so a lexical comparison of the two only behaves
+// chronologically when the process runs in UTC. Binding the comparison value
+// through the same driver path (and storing expires_at in UTC, see SetWithTitles)
+// makes the comparison timezone-independent on both SQLite and Postgres (#1961).
 func (s *ArrIDCacheStore) Get(ctx context.Context, titleHash, contentType string) (*ArrIDCacheEntry, error) {
 	query := `
 		SELECT id, title_hash, content_type, arr_instance_id, imdb_id, tmdb_id, tvdb_id, tvmaze_id, titles_json, is_negative, cached_at, expires_at
 		FROM arr_id_cache
-		WHERE title_hash = ? AND content_type = ? AND expires_at > CURRENT_TIMESTAMP
+		WHERE title_hash = ? AND content_type = ? AND expires_at > ?
 	`
 
 	var entry ArrIDCacheEntry
@@ -71,7 +79,7 @@ func (s *ArrIDCacheStore) Get(ctx context.Context, titleHash, contentType string
 	var tmdbID, tvdbID, tvmazeID *int
 	var isNegative int
 
-	err := s.db.QueryRowContext(ctx, query, titleHash, contentType).Scan(
+	err := s.db.QueryRowContext(ctx, query, titleHash, contentType, time.Now().UTC()).Scan(
 		&entry.ID,
 		&entry.TitleHash,
 		&entry.ContentType,
@@ -120,7 +128,10 @@ func (s *ArrIDCacheStore) Set(ctx context.Context, titleHash, contentType string
 
 // SetWithTitles creates or updates a cache entry with known ARR title aliases.
 func (s *ArrIDCacheStore) SetWithTitles(ctx context.Context, titleHash, contentType string, arrInstanceID *int, ids *ExternalIDs, titles []string, isNegative bool, ttl time.Duration) error {
-	expiresAt := time.Now().Add(ttl)
+	// Store expires_at in UTC so the bound-UTC comparisons in Get/CleanupExpired/
+	// CountValid are timezone-independent. Without .UTC() the value carries the
+	// process-local offset and the cache silently misses in non-UTC zones (#1961).
+	expiresAt := time.Now().Add(ttl).UTC()
 
 	// Prepare nullable values
 	var imdbID, titlesJSON *string
@@ -198,9 +209,10 @@ func (s *ArrIDCacheStore) DeleteByArrInstance(ctx context.Context, arrInstanceID
 
 // CleanupExpired removes all expired cache entries
 func (s *ArrIDCacheStore) CleanupExpired(ctx context.Context) (int64, error) {
-	query := `DELETE FROM arr_id_cache WHERE expires_at <= CURRENT_TIMESTAMP`
+	// Compare against a bound UTC time rather than CURRENT_TIMESTAMP; see Get (#1961).
+	query := `DELETE FROM arr_id_cache WHERE expires_at <= ?`
 
-	result, err := s.db.ExecContext(ctx, query)
+	result, err := s.db.ExecContext(ctx, query, time.Now().UTC())
 	if err != nil {
 		return 0, fmt.Errorf("failed to cleanup expired arr id cache entries: %w", err)
 	}
@@ -225,8 +237,9 @@ func (s *ArrIDCacheStore) Count(ctx context.Context) (int64, error) {
 
 // CountValid returns the number of non-expired cache entries
 func (s *ArrIDCacheStore) CountValid(ctx context.Context) (int64, error) {
+	// Compare against a bound UTC time rather than CURRENT_TIMESTAMP; see Get (#1961).
 	var count int64
-	err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM arr_id_cache WHERE expires_at > CURRENT_TIMESTAMP").Scan(&count)
+	err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM arr_id_cache WHERE expires_at > ?", time.Now().UTC()).Scan(&count)
 	if err != nil {
 		return 0, fmt.Errorf("failed to count valid arr id cache entries: %w", err)
 	}

--- a/internal/models/arr_id_cache_test.go
+++ b/internal/models/arr_id_cache_test.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package models_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/testutil/testdb"
+)
+
+// forceNonUTCLocal points time.Local at a fixed non-UTC zone for the duration of
+// the test, reproducing a home server whose system clock is not UTC. CI runners
+// default to UTC, which is the exact configuration that hid #1961, so without this
+// the regression would stay invisible. These tests must not call t.Parallel():
+// time.Local is process-global, but Go runs non-parallel tests sequentially before
+// any parallel ones resume, so a non-parallel test owns time.Local while it runs.
+func forceNonUTCLocal(t *testing.T) {
+	t.Helper()
+	original := time.Local
+	// -06:00, no DST; any non-UTC offset triggers the original lexical-comparison flip.
+	time.Local = time.FixedZone("test-non-utc", -6*60*60)
+	t.Cleanup(func() { time.Local = original })
+}
+
+// TestArrIDCacheStore_GetReturnsLiveEntryInNonUTCTimezone is the #1961 guard: Set
+// stored expires_at in local time while Get compared it against CURRENT_TIMESTAMP
+// (UTC). In any non-UTC zone the lexical comparison of the two string formats
+// flipped, so Get returned sql.ErrNoRows for a freshly written, unexpired entry —
+// silently disabling the cache. After the fix both sides use a UTC time.Time.
+func TestArrIDCacheStore_GetReturnsLiveEntryInNonUTCTimezone(t *testing.T) {
+	forceNonUTCLocal(t)
+
+	ctx := context.Background()
+	db := testdb.NewMigratedSQLite(t, "arr-id-cache-nonutc")
+	store := models.NewArrIDCacheStore(db)
+
+	ids := &models.ExternalIDs{IMDbID: "tt1234567", TMDbID: 42}
+	require.NoError(t, store.Set(ctx, "title-hash", "tv", nil, ids, false, time.Hour))
+
+	entry, err := store.Get(ctx, "title-hash", "tv")
+	require.NoError(t, err) // pre-fix in non-UTC: "sql: no rows in result set"
+	require.NotNil(t, entry)
+	require.Equal(t, *ids, entry.ExternalIDs)
+	require.False(t, entry.IsNegative)
+}
+
+// TestArrIDCacheStore_ExpiryHelpersRespectNonUTCTimezone confirms the same UTC
+// normalization holds for the expiry-counting and cleanup helpers: a live entry
+// counts as valid and survives cleanup, while an already-expired entry is excluded
+// and removed — regardless of the process timezone.
+func TestArrIDCacheStore_ExpiryHelpersRespectNonUTCTimezone(t *testing.T) {
+	forceNonUTCLocal(t)
+
+	ctx := context.Background()
+	db := testdb.NewMigratedSQLite(t, "arr-id-cache-nonutc-expiry")
+	store := models.NewArrIDCacheStore(db)
+
+	require.NoError(t, store.Set(ctx, "live", "tv", nil, nil, false, time.Hour))
+	require.NoError(t, store.Set(ctx, "stale", "movie", nil, nil, false, -time.Hour))
+
+	// The already-expired entry must be unretrievable via Get even before cleanup runs.
+	_, err := store.Get(ctx, "stale", "movie")
+	require.ErrorIs(t, err, sql.ErrNoRows)
+
+	valid, err := store.CountValid(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), valid)
+
+	removed, err := store.CleanupExpired(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), removed)
+
+	total, err := store.Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), total)
+
+	// The live entry is the survivor and is still retrievable.
+	entry, err := store.Get(ctx, "live", "tv")
+	require.NoError(t, err)
+	require.NotNil(t, entry)
+}
+
+// TestArrIDCacheStore_GetReturnsNegativeEntryInNonUTCTimezone confirms negative
+// cache entries (a remembered "not found", with no external IDs) round-trip in a
+// non-UTC zone too — they take the same UTC-normalized expiry path as positive
+// entries, and a negative hit is what spares the upstream ARR a repeat lookup.
+func TestArrIDCacheStore_GetReturnsNegativeEntryInNonUTCTimezone(t *testing.T) {
+	forceNonUTCLocal(t)
+
+	ctx := context.Background()
+	db := testdb.NewMigratedSQLite(t, "arr-id-cache-nonutc-negative")
+	store := models.NewArrIDCacheStore(db)
+
+	require.NoError(t, store.Set(ctx, "missing-title", "movie", nil, nil, true, time.Hour))
+
+	entry, err := store.Get(ctx, "missing-title", "movie")
+	require.NoError(t, err)
+	require.NotNil(t, entry)
+	require.True(t, entry.IsNegative)
+	require.True(t, entry.ExternalIDs.IsEmpty())
+}


### PR DESCRIPTION
## Summary

`ArrIDCacheStore`'s cache was silently disabled for anyone running qui in a non-UTC timezone. `Set` stored `expires_at` as a **local-time** `time.Time`, while `Get` / `CleanupExpired` / `CountValid` compared it against SQLite's `CURRENT_TIMESTAMP` (UTC). The modernc.org/sqlite driver serializes the bound `time.Time` as a string whose lexical ordering against the `CURRENT_TIMESTAMP` UTC string only matches chronological order when the process runs in UTC. In any other timezone, `Get` returned `sql.ErrNoRows` for a freshly written, unexpired entry — so every ARR title lookup hit the upstream HTTP endpoint instead of the cache. CI never caught it because GitHub runners default to `TZ=UTC`.

## Fix

Make both sides of every expiry comparison flow through the same driver path as UTC `time.Time` values:

- `SetWithTitles` stores `time.Now().Add(ttl).UTC()`.
- `Get` / `CleanupExpired` / `CountValid` compare `expires_at > ?` (and `<= ?`) binding `time.Now().UTC()` instead of `CURRENT_TIMESTAMP`.

This is dialect-agnostic — the `?` placeholder is rebound to `$N` for Postgres — and needs **no migration**. It also removes a latent `timestamp` vs `timestamptz` coercion that `CURRENT_TIMESTAMP` caused on Postgres. `cached_at` is unchanged (it is never used in a comparison).

The sibling `torznab_search_cache` store uses the same `expires_at > CURRENT_TIMESTAMP` SQL but is already safe because it stores `expires_at` in UTC, so it is intentionally left untouched.

## Upgrade note

Pre-fix rows written with a local-time `expires_at` are treated as expired after upgrading. This is a benign one-time cache miss (the entry is re-fetched), not stale or wrong data — no migration required.

## Testing

- [x] `go test -race -count=1 ./internal/models/ ./internal/services/arr/` passes under both the default TZ and `TZ=UTC`.
- [x] The two pre-existing arr service tests that failed outside UTC (`TestService_LookupExternalIDsUsesNegativeCache`, `...KeepsLegacyPositiveCacheWhenAliasHydrationMisses`) now pass under `TZ=America/Chicago`.
- [x] New regression test `internal/models/arr_id_cache_test.go` pins `time.Local` to a fixed non-UTC zone so it reproduces on UTC CI runners — **verified to fail before this change** (`sql: no rows in result set`) and pass after. Covers positive + negative entries, the expired-entry-unretrievable path, and `CountValid`/`CleanupExpired`.
- [x] `gofmt`, `golangci-lint`, `go vet` clean on the changed files; `make build` succeeds.

## Follow-up (not in this PR)

The issue suggested running the suite under a non-UTC `TZ` in CI to catch this class of bug. This PR's regression test already reproduces it under UTC, but a dedicated non-UTC CI job remains a reasonable separate addition.

Closes #1961

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cache expiry handling to work correctly regardless of system timezone settings, ensuring consistent behavior across different server environments.

* **Tests**
  * Added timezone-specific tests to verify cache operations function properly when the system timezone is non-UTC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->