### PR TITLE
test(sse): warm up subscription before coalescing burst

### DIFF
--- a/internal/api/sse/manager_delivery_test.go
+++ b/internal/api/sse/manager_delivery_test.go
@@ -210,6 +210,18 @@ func (r *sseReader) waitForEvent(t *testing.T, eventType string, timeout time.Du
 	}
 }
 
+// drain discards any events already buffered on the reader without blocking, so a
+// subsequent waitForEvent observes only events produced after the drain.
+func (r *sseReader) drain() {
+	for {
+		select {
+		case <-r.events:
+		default:
+			return
+		}
+	}
+}
+
 // triggerRetryInterval paces re-invocation of an update/error trigger while a
 // freshly connected session finishes subscribing.
 const triggerRetryInterval = 100 * time.Millisecond
@@ -430,6 +442,32 @@ func TestServeCoalescesBurstOfUpdates(t *testing.T) {
 
 	// Drain the initial snapshot first so it does not count toward update builds.
 	reader.waitForEvent(t, streamEventInit, 5*time.Second)
+
+	// A fresh session is subscribed to its go-sse topics only *after* its init
+	// snapshot is written synchronously in onSession, so an update published in that
+	// window reaches no subscriber: it lands only in the replay buffer, which a fresh
+	// connection (empty Last-Event-ID) never replays. The sibling delivery tests ride
+	// out that window by re-firing their trigger; this test fires the coalescing burst
+	// exactly once, so it must establish the subscription up front. Re-fire one warm-up
+	// update until it lands; once it does the session stays subscribed for the life of
+	// the connection, so the single coalesced burst update below is delivered without
+	// coupling the coalescing measurement to go-sse's subscribe timing. The gate makes
+	// coalescing deterministic but cannot close this subscribe window.
+	reader.waitForEventTriggered(t, streamEventUpdate, 5*time.Second, func() {
+		manager.HandleMainData(instanceID, &qbt.MainData{Rid: 1000})
+	})
+
+	// Let the warm-up builds settle, then drop their buffered events, before
+	// snapshotting the build count. This keeps warm-up activity out of both the
+	// coalescing measurement and the delivery assertion below.
+	var prevCalls int
+	require.Eventually(t, func() bool {
+		cur := provider.torrentsCallCount()
+		settled := cur == prevCalls
+		prevCalls = cur
+		return settled
+	}, 2*time.Second, 50*time.Millisecond, "warm-up builds did not settle")
+	reader.drain()
 	callsAfterInit := provider.torrentsCallCount()
 
 	// Hold the first update build open so the entire burst provably arrives while a


### PR DESCRIPTION
`TestServeCoalescesBurstOfUpdates` is flaky. A fresh SSE session is subscribed to its go-sse topics only *after* its init snapshot is written synchronously in `onSession`, so an event published in that brief window reaches no subscriber (it lands only in the replay buffer, which a fresh connection with an empty `Last-Event-ID` never replays). The test publishes its single coalesced update once and waits with a plain `waitForEvent`, so whenever the subscribe lagged the gated build, that lone update was dropped and the test timed out at `manager_delivery_test.go:458`. Every sibling delivery test already rides out this window by re-firing its trigger (`waitForEventTriggered`/`waitForUpdateOnBoth`); this was the only update-delivery assertion that did not.

The fix establishes the subscription up front by re-firing one warm-up update until it lands (the same technique the sibling tests use), then settles and drops warm-up activity before snapshotting the build count. The coalesced burst update is now delivered to an already-subscribed session, while the existing gate keeps the coalescing measurement deterministic. Verified green across 30x + full-package `-race` runs locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability and timing for event streaming functionality with enhanced test helper utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->