### PR TITLE
feat(crossseed): match cross-tracker relabels and alternate and/& title spellings

### DIFF
--- a/internal/services/crossseed/matching.go
+++ b/internal/services/crossseed/matching.go
@@ -765,6 +765,30 @@ func (s *Service) isWebSourceRelabel(source, candidate *rls.Release, sourceName,
 	return match
 }
 
+// shouldAcceptWebSourceRelabel reports whether a candidate that the release match
+// rejected solely on source mismatch should still be accepted as a cross-tracker
+// web-source relabel (WEBRip<->WEB-DL). ignoreSizeCheck mirrors the main size gate:
+// a single episode of a season-pack source is legitimately much smaller than its
+// pack, so the full-size tolerance is bypassed in that case and the apply-stage
+// file verification makes the final call.
+func (s *Service) shouldAcceptWebSourceRelabel(
+	source, candidate *rls.Release,
+	sourceName, candidateName string,
+	sourceTitles, candidateTitles []string,
+	findIndividualEpisodes, ignoreSizeCheck bool,
+	sourceSize, candidateSize int64,
+	tolerancePercent float64,
+	mismatchReason string,
+) bool {
+	if mismatchReason != sourceMismatchReason {
+		return false
+	}
+	if !ignoreSizeCheck && !s.isSizeWithinTolerance(sourceSize, candidateSize, tolerancePercent) {
+		return false
+	}
+	return s.isWebSourceRelabel(source, candidate, sourceName, candidateName, sourceTitles, candidateTitles, findIndividualEpisodes)
+}
+
 // joinNormalizedCodecSlice converts a codec slice to a normalized string for comparison.
 // Applies codec aliasing so that x264, H.264, H264, and AVC are treated as equivalent.
 func joinNormalizedCodecSlice(slice []string) string {

--- a/internal/services/crossseed/matching.go
+++ b/internal/services/crossseed/matching.go
@@ -402,6 +402,12 @@ func (s *Service) validateGroupSiteAndChecksum(source, candidate *rls.Release) (
 	return true, ""
 }
 
+// sourceMismatchReason is the rejection reason emitted when two releases differ
+// only by an incompatible source (e.g. WEBRip vs WEB-DL). Callers key off this
+// exact value to apply cross-tracker relabel tolerance, so it is a named constant
+// rather than an inline literal.
+const sourceMismatchReason = "source mismatch"
+
 func (s *Service) validateFormatAndCodec(source, candidate *rls.Release, isTV bool) (bool, string) {
 	normalizer := normalizerForService(s)
 
@@ -412,7 +418,7 @@ func (s *Service) validateFormatAndCodec(source, candidate *rls.Release, isTV bo
 	sourceSource := normalizeSource(source.Source)
 	candidateSource := normalizeSource(candidate.Source)
 	if !sourcesCompatible(sourceSource, candidateSource) {
-		return false, "source mismatch"
+		return false, sourceMismatchReason
 	}
 
 	// Resolution must match (1080p vs 2160p are different files).
@@ -735,6 +741,28 @@ func sourcesCompatible(source, candidate string) bool {
 	// At this point both are web sources, but they differ.
 	// WEBDL and WEBRIP are explicitly different and do not match each other.
 	return source == "WEB" || candidate == "WEB"
+}
+
+// isWebSourceRelabel reports whether candidate is the same release as source with
+// only its web-source label changed (e.g. WEBRip vs WEB-DL). The identical web
+// encode is frequently relabeled across trackers, so when nothing but the web
+// source differs we let the candidate reach the apply-stage file verification and
+// qBittorrent recheck instead of dropping it on the label alone. Callers must
+// still confirm the candidate size is within tolerance before trusting this.
+func (s *Service) isWebSourceRelabel(source, candidate *rls.Release, sourceName, candidateName string, sourceTitles, candidateTitles []string, findIndividualEpisodes bool) bool {
+	if source == nil || candidate == nil {
+		return false
+	}
+	if !isWebSource(normalizeSource(source.Source)) || !isWebSource(normalizeSource(candidate.Source)) {
+		return false
+	}
+
+	// Equalize the web-source label and re-run the full match. If it now matches,
+	// the source label was the only difference between the two releases.
+	probe := *candidate
+	probe.Source = source.Source
+	match, _ := s.releasesMatchWithReasonAndNamesAndTitles(source, &probe, sourceName, candidateName, sourceTitles, candidateTitles, findIndividualEpisodes)
+	return match
 }
 
 // joinNormalizedCodecSlice converts a codec slice to a normalized string for comparison.

--- a/internal/services/crossseed/matching_web_relabel_test.go
+++ b/internal/services/crossseed/matching_web_relabel_test.go
@@ -78,3 +78,107 @@ func TestIsWebSourceRelabel(t *testing.T) {
 		})
 	}
 }
+
+// TestShouldAcceptWebSourceRelabel covers the relabel-acceptance gate, including
+// the regression where a single-episode WEB relabel of a season-pack source was
+// dropped on the full-pack vs episode size mismatch before the episode-size
+// bypass could apply (P1). The pack is ~100GB, the episode ~5GB.
+func TestShouldAcceptWebSourceRelabel(t *testing.T) {
+	s := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
+
+	const (
+		packWebrip   = "Law.and.Order.Special.Victims.Unit.S05.1080p.AMZN.WEBRip.DD2.0.x264-NTb"
+		packWebdl    = "Law.and.Order.Special.Victims.Unit.S05.1080p.AMZN.WEB-DL.DD+2.0.x264-NTb"
+		episodeWebdl = "Law.and.Order.Special.Victims.Unit.S05E01.1080p.AMZN.WEB-DL.DD+2.0.x264-NTb"
+		otherShow    = "Law.and.Order.Organized.Crime.S05.1080p.AMZN.WEB-DL.DD+2.0.x264-NTb"
+	)
+
+	const (
+		packSize    int64 = 100_000_000_000
+		episodeSize int64 = 5_000_000_000
+	)
+
+	tests := []struct {
+		name            string
+		sourceName      string
+		candidateName   string
+		findEpisodes    bool
+		ignoreSizeCheck bool
+		sourceSize      int64
+		candidateSize   int64
+		mismatchReason  string
+		want            bool
+	}{
+		{
+			name:            "episode relabel accepted when episode-size bypass is active",
+			sourceName:      packWebrip,
+			candidateName:   episodeWebdl,
+			findEpisodes:    true,
+			ignoreSizeCheck: true,
+			sourceSize:      packSize,
+			candidateSize:   episodeSize,
+			mismatchReason:  sourceMismatchReason,
+			want:            true,
+		},
+		{
+			name:            "episode relabel dropped without the bypass on full-size mismatch",
+			sourceName:      packWebrip,
+			candidateName:   episodeWebdl,
+			findEpisodes:    true,
+			ignoreSizeCheck: false,
+			sourceSize:      packSize,
+			candidateSize:   episodeSize,
+			mismatchReason:  sourceMismatchReason,
+			want:            false,
+		},
+		{
+			name:            "full-pack relabel accepted within size tolerance",
+			sourceName:      packWebrip,
+			candidateName:   packWebdl,
+			findEpisodes:    false,
+			ignoreSizeCheck: false,
+			sourceSize:      packSize,
+			candidateSize:   packSize,
+			mismatchReason:  sourceMismatchReason,
+			want:            true,
+		},
+		{
+			name:            "non-source mismatch reason is never treated as a relabel",
+			sourceName:      packWebrip,
+			candidateName:   packWebdl,
+			findEpisodes:    false,
+			ignoreSizeCheck: false,
+			sourceSize:      packSize,
+			candidateSize:   packSize,
+			mismatchReason:  "resolution mismatch",
+			want:            false,
+		},
+		{
+			name:            "different show within size tolerance is not a relabel",
+			sourceName:      packWebrip,
+			candidateName:   otherShow,
+			findEpisodes:    false,
+			ignoreSizeCheck: false,
+			sourceSize:      packSize,
+			candidateSize:   packSize,
+			mismatchReason:  sourceMismatchReason,
+			want:            false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := rls.ParseString(tt.sourceName)
+			candidate := rls.ParseString(tt.candidateName)
+			got := s.shouldAcceptWebSourceRelabel(
+				&source, &candidate,
+				tt.sourceName, tt.candidateName,
+				nil, nil,
+				tt.findEpisodes, tt.ignoreSizeCheck,
+				tt.sourceSize, tt.candidateSize,
+				5.0, tt.mismatchReason,
+			)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/services/crossseed/matching_web_relabel_test.go
+++ b/internal/services/crossseed/matching_web_relabel_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package crossseed
+
+import (
+	"testing"
+
+	"github.com/moistari/rls"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/pkg/stringutils"
+)
+
+// TestIsWebSourceRelabel covers the cross-tracker relabel detector that lets the
+// same web encode through when only its WEBRip/WEB-DL label differs. The real
+// motivating case is "Law & Order: SVU" S05, which trackers list as both
+// WEBRip (the seeded copy) and WEB-DL (the relabel) at the same content size.
+func TestIsWebSourceRelabel(t *testing.T) {
+	s := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
+
+	const (
+		webripDotted = "Law.and.Order.Special.Victims.Unit.S05.1080p.AMZN.WEBRip.DD2.0.x264-NTb"
+		webdlDotted  = "Law.and.Order.Special.Victims.Unit.S05.1080p.AMZN.WEB-DL.DD+2.0.x264-NTb"
+		webdlSpaced  = "Law & Order: Special Victims Unit S05 1080p AMZN WEB-DL DD+ 2.0 H.264-NTb"
+	)
+
+	tests := []struct {
+		name          string
+		sourceName    string
+		candidateName string
+		want          bool
+	}{
+		{
+			name:          "WEBRip source vs WEB-DL relabel of same encode",
+			sourceName:    webripDotted,
+			candidateName: webdlDotted,
+			want:          true,
+		},
+		{
+			name:          "symmetric: WEB-DL source vs WEBRip relabel",
+			sourceName:    webdlDotted,
+			candidateName: webripDotted,
+			want:          true,
+		},
+		{
+			name:          "relabel detected through ampersand/colon title variant",
+			sourceName:    webripDotted,
+			candidateName: webdlSpaced,
+			want:          true,
+		},
+		{
+			name:          "different resolution is not a relabel",
+			sourceName:    webripDotted,
+			candidateName: "Law.and.Order.Special.Victims.Unit.S05.2160p.AMZN.WEB-DL.DD+2.0.x264-NTb",
+			want:          false,
+		},
+		{
+			name:          "different show is not a relabel",
+			sourceName:    webripDotted,
+			candidateName: "Law.and.Order.Organized.Crime.S05.1080p.AMZN.WEB-DL.DD+2.0.x264-NTb",
+			want:          false,
+		},
+		{
+			name:          "non-web source is not a relabel",
+			sourceName:    "Law.and.Order.Special.Victims.Unit.S05.1080p.BluRay.DD2.0.x264-NTb",
+			candidateName: webdlDotted,
+			want:          false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := rls.ParseString(tt.sourceName)
+			candidate := rls.ParseString(tt.candidateName)
+			got := s.isWebSourceRelabel(&source, &candidate, tt.sourceName, tt.candidateName, nil, nil, false)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/services/crossseed/search_connector_variant_test.go
+++ b/internal/services/crossseed/search_connector_variant_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package crossseed
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlternateConnectorQuery(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   string
+		wantAlt string
+		wantOK  bool
+	}{
+		{
+			name:    "spelled-out and becomes ampersand",
+			query:   "Law and Order Special Victims Unit 1080p",
+			wantAlt: "Law & Order Special Victims Unit 1080p",
+			wantOK:  true,
+		},
+		{
+			name:    "ampersand becomes spelled-out and",
+			query:   "Will & Grace 1080p",
+			wantAlt: "Will and Grace 1080p",
+			wantOK:  true,
+		},
+		{
+			name:    "no connector yields no variant",
+			query:   "Breaking Bad S01 1080p",
+			wantAlt: "",
+			wantOK:  false,
+		},
+		{
+			name:    "embedded and is not a standalone connector",
+			query:   "Andor S01 1080p",
+			wantAlt: "",
+			wantOK:  false,
+		},
+		{
+			name:    "collapses extra spacing left by ampersand removal",
+			query:   "Tom & Jerry",
+			wantAlt: "Tom and Jerry",
+			wantOK:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			alt, ok := alternateConnectorQuery(tt.query)
+			require.Equal(t, tt.wantOK, ok)
+			require.Equal(t, tt.wantAlt, alt)
+		})
+	}
+}

--- a/internal/services/crossseed/search_connector_variant_test.go
+++ b/internal/services/crossseed/search_connector_variant_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/services/jackett"
 )
 
 func TestAlternateConnectorQuery(t *testing.T) {
@@ -65,6 +67,77 @@ func TestAlternateConnectorQuery(t *testing.T) {
 			alt, ok := alternateConnectorQuery(tt.query)
 			require.Equal(t, tt.wantOK, ok)
 			require.Equal(t, tt.wantAlt, alt)
+		})
+	}
+}
+
+// TestEffectiveSearchYear locks in that the alternate connector pass reuses the
+// year actually searched: once the yearless retry has run, the alternate pass
+// must drop the year too rather than re-applying the proven-ineffective original.
+func TestEffectiveSearchYear(t *testing.T) {
+	tests := []struct {
+		name             string
+		requestedYear    int
+		yearlessRetryRan bool
+		want             int
+	}{
+		{
+			name:             "no retry keeps the requested year",
+			requestedYear:    2005,
+			yearlessRetryRan: false,
+			want:             2005,
+		},
+		{
+			name:             "after yearless retry the year is dropped",
+			requestedYear:    2005,
+			yearlessRetryRan: true,
+			want:             0,
+		},
+		{
+			name:             "no year requested stays zero",
+			requestedYear:    0,
+			yearlessRetryRan: false,
+			want:             0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, effectiveSearchYear(tt.requestedYear, tt.yearlessRetryRan))
+		})
+	}
+}
+
+// TestMergeAltConnectorResults verifies the alternate-pass merge appends results
+// and ORs the partial flag, so an incomplete alternate pass can never be reported
+// as a complete search.
+func TestMergeAltConnectorResults(t *testing.T) {
+	primary := []jackett.SearchResult{{Title: "primary-1"}}
+
+	tests := []struct {
+		name           string
+		primaryPartial bool
+		altPartial     bool
+		wantPartial    bool
+	}{
+		{name: "complete primary + complete alt stays complete", primaryPartial: false, altPartial: false, wantPartial: false},
+		{name: "partial alt makes the merged result partial", primaryPartial: false, altPartial: true, wantPartial: true},
+		{name: "partial primary stays partial", primaryPartial: true, altPartial: false, wantPartial: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			alt := &jackett.SearchResponse{
+				Results: []jackett.SearchResult{{Title: "alt-1"}, {Title: "alt-2"}},
+				Partial: tt.altPartial,
+			}
+
+			merged, partial := mergeAltConnectorResults(tt.primaryPartial, primary, alt)
+
+			require.Equal(t, tt.wantPartial, partial)
+			require.Len(t, merged, len(primary)+len(alt.Results))
+			require.Equal(t, "primary-1", merged[0].Title)
+			require.Equal(t, "alt-2", merged[len(merged)-1].Title)
 		})
 	}
 }

--- a/internal/services/crossseed/search_connector_variant_test.go
+++ b/internal/services/crossseed/search_connector_variant_test.go
@@ -25,6 +25,21 @@ func TestAlternateConnectorQuery(t *testing.T) {
 			wantOK:  true,
 		},
 		{
+			// rls preserves the source release's connector casing, so a release
+			// named "Law.And.Order..." yields the title "Law And Order ...". This
+			// title-case spelling is common in scene/p2p naming and must still swap.
+			name:    "title-case And connector is swapped",
+			query:   "Law And Order Special Victims Unit 1080p",
+			wantAlt: "Law & Order Special Victims Unit 1080p",
+			wantOK:  true,
+		},
+		{
+			name:    "uppercase AND connector is swapped",
+			query:   "Will AND Grace 1080p",
+			wantAlt: "Will & Grace 1080p",
+			wantOK:  true,
+		},
+		{
 			name:    "ampersand becomes spelled-out and",
 			query:   "Will & Grace 1080p",
 			wantAlt: "Will and Grace 1080p",
@@ -104,6 +119,65 @@ func TestEffectiveSearchYear(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.want, effectiveSearchYear(tt.requestedYear, tt.yearlessRetryRan))
+		})
+	}
+}
+
+// TestIndexersWithoutResults locks in the alternate-connector pass's indexer
+// scoping: it re-queries only the indexers that returned nothing in the primary
+// pass, in request order, so the extra round-trip stays minimal.
+func TestIndexersWithoutResults(t *testing.T) {
+	result := func(indexerID int) jackett.SearchResult {
+		return jackett.SearchResult{IndexerID: indexerID}
+	}
+
+	tests := []struct {
+		name        string
+		requestedID []int
+		results     []jackett.SearchResult
+		want        []int
+	}{
+		{
+			name:        "indexer that returned nothing is re-queried",
+			requestedID: []int{1, 2, 3},
+			results:     []jackett.SearchResult{result(1), result(3)},
+			want:        []int{2},
+		},
+		{
+			name:        "request order is preserved",
+			requestedID: []int{5, 4, 3, 2, 1},
+			results:     []jackett.SearchResult{result(3)},
+			want:        []int{5, 4, 2, 1},
+		},
+		{
+			name:        "an indexer with multiple results is still omitted",
+			requestedID: []int{1, 2},
+			results:     []jackett.SearchResult{result(1), result(1), result(1)},
+			want:        []int{2},
+		},
+		{
+			name:        "all indexers responded yields nothing to retry",
+			requestedID: []int{1, 2},
+			results:     []jackett.SearchResult{result(1), result(2)},
+			want:        nil,
+		},
+		{
+			name:        "zero primary results re-queries every requested indexer",
+			requestedID: []int{1, 2, 3},
+			results:     nil,
+			want:        []int{1, 2, 3},
+		},
+		{
+			name:        "empty requested set yields nil (all-indexers search is skipped)",
+			requestedID: nil,
+			results:     []jackett.SearchResult{result(1)},
+			want:        nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, indexersWithoutResults(tt.requestedID, tt.results))
 		})
 	}
 }

--- a/internal/services/crossseed/search_connector_variant_test.go
+++ b/internal/services/crossseed/search_connector_variant_test.go
@@ -41,10 +41,22 @@ func TestAlternateConnectorQuery(t *testing.T) {
 			wantOK:  false,
 		},
 		{
-			name:    "collapses extra spacing left by ampersand removal",
+			name:    "standalone ampersand connector becomes and",
 			query:   "Tom & Jerry",
 			wantAlt: "Tom and Jerry",
 			wantOK:  true,
+		},
+		{
+			name:    "intra-token ampersand is not a connector",
+			query:   "AT&T S01 1080p",
+			wantAlt: "",
+			wantOK:  false,
+		},
+		{
+			name:    "intra-token ampersand R&B is left intact",
+			query:   "Best of R&B 2024",
+			wantAlt: "",
+			wantOK:  false,
 		},
 	}
 

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -7646,6 +7646,23 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 		candidateRelease := s.releaseCache.Parse(res.Title)
 		match, mismatchReason := s.releasesMatchWithReasonAndNamesAndTitles(searchRelease, candidateRelease, sourceTorrent.Name, res.Title, arrTitles, nil, opts.FindIndividualEpisodes)
 		if !match {
+			// Detect cross-tracker web-source relabels (e.g. WEBRip vs WEB-DL) of the
+			// same encode that are within size tolerance. These are currently rejected
+			// here; the log surfaces how often it happens so the relabel tolerance can
+			// be validated before it is acted on.
+			if mismatchReason == sourceMismatchReason &&
+				s.isSizeWithinTolerance(sourceTorrent.Size, res.Size, tolerancePercent) &&
+				s.isWebSourceRelabel(searchRelease, candidateRelease, sourceTorrent.Name, res.Title, arrTitles, nil, opts.FindIndividualEpisodes) {
+				log.Info().
+					Str("sourceTitle", sourceTorrent.Name).
+					Str("candidateTitle", res.Title).
+					Str("sourceSource", searchRelease.Source).
+					Str("candidateSource", candidateRelease.Source).
+					Int64("sourceSize", sourceTorrent.Size).
+					Int64("candidateSize", res.Size).
+					Float64("tolerancePercent", tolerancePercent).
+					Msg("[CROSSSEED-SEARCH] Web-source relabel within size tolerance detected (currently rejected; apply-stage verification would confirm)")
+			}
 			releaseFilteredCount++
 			recordReleaseRejection(
 				releaseFilterReasons,

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -6999,6 +6999,25 @@ func alternateConnectorQuery(query string) (string, bool) {
 	return "", false
 }
 
+// effectiveSearchYear returns the year actually used by the latest search pass: 0
+// once the yearless retry has run, otherwise the originally requested year. The
+// alternate connector pass uses this so it does not re-apply a year the primary
+// search already proved ineffective.
+func effectiveSearchYear(requestedYear int, yearlessRetryRan bool) int {
+	if yearlessRetryRan {
+		return 0
+	}
+	return requestedYear
+}
+
+// mergeAltConnectorResults appends the alternate connector pass's results to the
+// primary results and returns the combined partial flag, so an incomplete
+// alternate pass is never reported as a complete search. Callers invoke it only
+// when alt carries results.
+func mergeAltConnectorResults(primaryPartial bool, primaryResults []jackett.SearchResult, alt *jackett.SearchResponse) ([]jackett.SearchResult, bool) {
+	return append(primaryResults, alt.Results...), primaryPartial || alt.Partial
+}
+
 // searchOnce runs a single Torznab search to completion and returns its response.
 // It is used for follow-up passes (e.g. the alternate connector-spelling query)
 // that need their own result set rather than the primary search's.
@@ -7624,7 +7643,7 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 	var lateFilterSnapshot *AsyncIndexerFilteringState
 	var lateExcludedCount int
 
-	effectiveYear := searchReq.Year
+	yearlessRetryRan := false
 
 	// Retry without year for single-indexer searches when the first pass returned zero.
 	if len(searchResults) == 0 && searchReq.Year > 0 && len(filteredIndexerIDs) <= 1 {
@@ -7668,7 +7687,7 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 			}
 			return nil, wrapCrossSeedSearchError(waitCtx.Err())
 		}
-		effectiveYear = 0 // yearless retry was executed
+		yearlessRetryRan = true
 	}
 
 	// Cross-tracker title-variant coverage: some trackers index a show with "&"
@@ -7693,7 +7712,7 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 				altReq := *searchReq
 				altReq.Query = altQuery
 				altReq.IndexerIDs = altIndexerIDs
-				altReq.Year = effectiveYear // use the year actually searched (0 if yearless retry ran)
+				altReq.Year = effectiveSearchYear(searchReq.Year, yearlessRetryRan) // year actually searched (0 if yearless retry ran)
 				// Treat the alternate-spelling pass as an internal continuation of the
 				// primary search rather than a separate tracked job: skip its search-history
 				// recording so it does not create parallel history entries. Outcome reporting
@@ -7713,8 +7732,7 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 						Int("altResults", len(altResp.Results)).
 						Ints("altIndexerIDs", altIndexerIDs).
 						Msg("[CROSSSEED-SEARCH] Alternate connector-spelling pass returned additional candidates")
-					searchResults = append(searchResults, altResp.Results...)
-					searchResp.Partial = searchResp.Partial || altResp.Partial
+					searchResults, searchResp.Partial = mergeAltConnectorResults(searchResp.Partial, searchResults, altResp)
 				}
 			}
 		}
@@ -7756,9 +7774,14 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 			// only difference and the candidate is within size tolerance, accept it and
 			// let the apply-stage file-size verification + qBittorrent recheck make the
 			// final call, rather than dropping a byte-identical release on its label.
-			relabelMatch := mismatchReason == sourceMismatchReason &&
-				(ignoreSizeCheck || s.isSizeWithinTolerance(sourceTorrent.Size, res.Size, tolerancePercent)) &&
-				s.isWebSourceRelabel(searchRelease, candidateRelease, sourceTorrent.Name, res.Title, arrTitles, nil, opts.FindIndividualEpisodes)
+			relabelMatch := s.shouldAcceptWebSourceRelabel(
+				searchRelease, candidateRelease,
+				sourceTorrent.Name, res.Title,
+				arrTitles, nil,
+				opts.FindIndividualEpisodes, ignoreSizeCheck,
+				sourceTorrent.Size, res.Size,
+				tolerancePercent, mismatchReason,
+			)
 			if !relabelMatch {
 				releaseFilteredCount++
 				recordReleaseRejection(

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -6986,16 +6986,38 @@ func (s *Service) resolveTorznabIndexerIDs(ctx context.Context, requested []int,
 // swapped between "and" and "&", so trackers that index a show with the opposite
 // spelling are still reachable (e.g. "Law and Order" vs "Law & Order"). Returns
 // ("", false) when no swap applies.
+//
+// Only standalone, whitespace-delimited connector tokens are swapped, so
+// intra-token ampersands like "AT&T" or "R&B" and embedded words like "Andor"
+// are left intact. The spelled-out connector is matched case-insensitively
+// because the query is built from the rls-parsed title, which preserves the
+// source release's original casing ("and", "And", "AND" are all common).
 func alternateConnectorQuery(query string) (string, bool) {
-	if strings.Contains(query, " and ") {
-		return strings.ReplaceAll(query, " and ", " & "), true
+	tokens := strings.Split(query, " ")
+
+	// Prefer swapping a spelled-out connector to "&": match any casing.
+	swapped := false
+	for i, tok := range tokens {
+		if strings.EqualFold(tok, "and") {
+			tokens[i] = "&"
+			swapped = true
+		}
 	}
-	// Only swap a standalone, whitespace-delimited "&" connector. Queries are
-	// space-joined, so " & " captures the real connector form while leaving
-	// intra-token ampersands like "AT&T" or "R&B" untouched.
-	if strings.Contains(query, " & ") {
-		return strings.ReplaceAll(query, " & ", " and "), true
+	if swapped {
+		return strings.Join(tokens, " "), true
 	}
+
+	// Otherwise swap a standalone "&" connector to "and".
+	for i, tok := range tokens {
+		if tok == "&" {
+			tokens[i] = "and"
+			swapped = true
+		}
+	}
+	if swapped {
+		return strings.Join(tokens, " "), true
+	}
+
 	return "", false
 }
 
@@ -7016,6 +7038,27 @@ func effectiveSearchYear(requestedYear int, yearlessRetryRan bool) int {
 // when alt carries results.
 func mergeAltConnectorResults(primaryPartial bool, primaryResults []jackett.SearchResult, alt *jackett.SearchResponse) ([]jackett.SearchResult, bool) {
 	return append(primaryResults, alt.Results...), primaryPartial || alt.Partial
+}
+
+// indexersWithoutResults returns the requested indexer IDs that produced no
+// results in the primary pass, preserving request order. The alternate connector
+// pass re-queries only these so the extra round-trip stays minimal; an indexer
+// that returned at least one candidate is omitted.
+func indexersWithoutResults(requestedIDs []int, results []jackett.SearchResult) []int {
+	if len(requestedIDs) == 0 {
+		return nil
+	}
+	responded := make(map[int]struct{}, len(results))
+	for _, r := range results {
+		responded[r.IndexerID] = struct{}{}
+	}
+	var missing []int
+	for _, id := range requestedIDs {
+		if _, seen := responded[id]; !seen {
+			missing = append(missing, id)
+		}
+	}
+	return missing
 }
 
 // searchOnce runs a single Torznab search to completion and returns its response.
@@ -7698,16 +7741,7 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 	// ID-based searches, which do not rely on title text.
 	if !opts.DisableTorznab && !searchReq.OmitQueryForIDs {
 		if altQuery, ok := alternateConnectorQuery(searchReq.Query); ok {
-			responded := make(map[int]struct{}, len(searchResults))
-			for _, r := range searchResults {
-				responded[r.IndexerID] = struct{}{}
-			}
-			var altIndexerIDs []int
-			for _, id := range searchReq.IndexerIDs {
-				if _, seen := responded[id]; !seen {
-					altIndexerIDs = append(altIndexerIDs, id)
-				}
-			}
+			altIndexerIDs := indexersWithoutResults(searchReq.IndexerIDs, searchResults)
 			if len(altIndexerIDs) > 0 {
 				altReq := *searchReq
 				altReq.Query = altQuery

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -7624,6 +7624,8 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 	var lateFilterSnapshot *AsyncIndexerFilteringState
 	var lateExcludedCount int
 
+	effectiveYear := searchReq.Year
+
 	// Retry without year for single-indexer searches when the first pass returned zero.
 	if len(searchResults) == 0 && searchReq.Year > 0 && len(filteredIndexerIDs) <= 1 {
 		log.Debug().
@@ -7666,6 +7668,7 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 			}
 			return nil, wrapCrossSeedSearchError(waitCtx.Err())
 		}
+		effectiveYear = 0 // yearless retry was executed
 	}
 
 	// Cross-tracker title-variant coverage: some trackers index a show with "&"
@@ -7690,6 +7693,7 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 				altReq := *searchReq
 				altReq.Query = altQuery
 				altReq.IndexerIDs = altIndexerIDs
+				altReq.Year = effectiveYear // use the year actually searched (0 if yearless retry ran)
 				// Treat the alternate-spelling pass as an internal continuation of the
 				// primary search rather than a separate tracked job: skip its search-history
 				// recording so it does not create parallel history entries. Outcome reporting
@@ -7710,6 +7714,7 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 						Ints("altIndexerIDs", altIndexerIDs).
 						Msg("[CROSSSEED-SEARCH] Alternate connector-spelling pass returned additional candidates")
 					searchResults = append(searchResults, altResp.Results...)
+					searchResp.Partial = searchResp.Partial || altResp.Partial
 				}
 			}
 		}
@@ -7744,6 +7749,7 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 
 		candidateRelease := s.releaseCache.Parse(res.Title)
 		match, mismatchReason := s.releasesMatchWithReasonAndNamesAndTitles(searchRelease, candidateRelease, sourceTorrent.Name, res.Title, arrTitles, nil, opts.FindIndividualEpisodes)
+		ignoreSizeCheck := opts.FindIndividualEpisodes && isTVSeasonPack(searchRelease) && isTVEpisode(candidateRelease)
 		if !match {
 			// Cross-tracker relabel tolerance: the same web encode is frequently
 			// relabeled WEBRip<->WEB-DL across trackers. When the source label is the
@@ -7751,7 +7757,7 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 			// let the apply-stage file-size verification + qBittorrent recheck make the
 			// final call, rather than dropping a byte-identical release on its label.
 			relabelMatch := mismatchReason == sourceMismatchReason &&
-				s.isSizeWithinTolerance(sourceTorrent.Size, res.Size, tolerancePercent) &&
+				(ignoreSizeCheck || s.isSizeWithinTolerance(sourceTorrent.Size, res.Size, tolerancePercent)) &&
 				s.isWebSourceRelabel(searchRelease, candidateRelease, sourceTorrent.Name, res.Title, arrTitles, nil, opts.FindIndividualEpisodes)
 			if !relabelMatch {
 				releaseFilteredCount++
@@ -7795,8 +7801,6 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 			)
 			continue
 		}
-
-		ignoreSizeCheck := opts.FindIndividualEpisodes && isTVSeasonPack(searchRelease) && isTVEpisode(candidateRelease)
 
 		// Size validation: check if candidate size is within tolerance of source size
 		if !ignoreSizeCheck && !s.isSizeWithinTolerance(sourceTorrent.Size, res.Size, tolerancePercent) {

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -6982,6 +6982,58 @@ func (s *Service) resolveTorznabIndexerIDs(ctx context.Context, requested []int,
 	return ids, nil
 }
 
+// alternateConnectorQuery returns a variant of query with the title connector
+// swapped between "and" and "&", so trackers that index a show with the opposite
+// spelling are still reachable (e.g. "Law and Order" vs "Law & Order"). Returns
+// ("", false) when no swap applies.
+func alternateConnectorQuery(query string) (string, bool) {
+	if strings.Contains(query, " and ") {
+		return strings.ReplaceAll(query, " and ", " & "), true
+	}
+	if strings.Contains(query, "&") {
+		alt := strings.Join(strings.Fields(strings.ReplaceAll(query, "&", "and")), " ")
+		if alt != query {
+			return alt, true
+		}
+	}
+	return "", false
+}
+
+// searchOnce runs a single Torznab search to completion and returns its response.
+// It is used for follow-up passes (e.g. the alternate connector-spelling query)
+// that need their own result set rather than the primary search's.
+func (s *Service) searchOnce(ctx context.Context, req *jackett.TorznabSearchRequest) (*jackett.SearchResponse, error) {
+	respCh := make(chan *jackett.SearchResponse, 1)
+	errCh := make(chan error, 1)
+	var once sync.Once
+	req.OnAllComplete = func(resp *jackett.SearchResponse, err error) {
+		once.Do(func() {
+			if err != nil {
+				select {
+				case errCh <- err:
+				case <-ctx.Done():
+				}
+				return
+			}
+			select {
+			case respCh <- resp:
+			case <-ctx.Done():
+			}
+		})
+	}
+	if err := s.jackettService.Search(ctx, req); err != nil {
+		return nil, err
+	}
+	select {
+	case resp := <-respCh:
+		return resp, nil
+	case err := <-errCh:
+		return nil, err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
 // SearchTorrentMatches queries Torznab indexers for candidate torrents that match an existing torrent.
 func (s *Service) SearchTorrentMatches(ctx context.Context, instanceID int, hash string, opts TorrentSearchOptions) (*TorrentSearchResponse, error) {
 	gazelleClients, gazelleErr := s.buildGazelleClientSet(ctx, nil)
@@ -7613,6 +7665,47 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 				return nil, wrapCrossSeedSearchError(errors.New("search timed out"))
 			}
 			return nil, wrapCrossSeedSearchError(waitCtx.Err())
+		}
+	}
+
+	// Cross-tracker title-variant coverage: some trackers index a show with "&"
+	// (e.g. "Law & Order: SVU") while the release name spells out "and". A literal
+	// q only matches one spelling, so re-query the indexers that returned nothing
+	// for the primary spelling using the alternate connector and merge the extra
+	// candidates (the match loop dedupes by GUID/download URL). Skipped for
+	// ID-based searches, which do not rely on title text.
+	if !opts.DisableTorznab && !searchReq.OmitQueryForIDs {
+		if altQuery, ok := alternateConnectorQuery(searchReq.Query); ok {
+			responded := make(map[int]struct{}, len(searchResults))
+			for _, r := range searchResults {
+				responded[r.IndexerID] = struct{}{}
+			}
+			var altIndexerIDs []int
+			for _, id := range searchReq.IndexerIDs {
+				if _, seen := responded[id]; !seen {
+					altIndexerIDs = append(altIndexerIDs, id)
+				}
+			}
+			if len(altIndexerIDs) > 0 {
+				altReq := *searchReq
+				altReq.Query = altQuery
+				altReq.IndexerIDs = altIndexerIDs
+				if altResp, altErr := s.searchOnce(waitCtx, &altReq); altErr != nil {
+					log.Debug().
+						Err(altErr).
+						Str("altQuery", altQuery).
+						Ints("altIndexerIDs", altIndexerIDs).
+						Msg("[CROSSSEED-SEARCH] Alternate connector-spelling pass failed; continuing with primary results")
+				} else if altResp != nil && len(altResp.Results) > 0 {
+					log.Debug().
+						Str("query", searchReq.Query).
+						Str("altQuery", altQuery).
+						Int("altResults", len(altResp.Results)).
+						Ints("altIndexerIDs", altIndexerIDs).
+						Msg("[CROSSSEED-SEARCH] Alternate connector-spelling pass returned additional candidates")
+					searchResults = append(searchResults, altResp.Results...)
+				}
+			}
 		}
 	}
 

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -6990,11 +6990,11 @@ func alternateConnectorQuery(query string) (string, bool) {
 	if strings.Contains(query, " and ") {
 		return strings.ReplaceAll(query, " and ", " & "), true
 	}
-	if strings.Contains(query, "&") {
-		alt := strings.Join(strings.Fields(strings.ReplaceAll(query, "&", "and")), " ")
-		if alt != query {
-			return alt, true
-		}
+	// Only swap a standalone, whitespace-delimited "&" connector. Queries are
+	// space-joined, so " & " captures the real connector form while leaving
+	// intra-token ampersands like "AT&T" or "R&B" untouched.
+	if strings.Contains(query, " & ") {
+		return strings.ReplaceAll(query, " & ", " and "), true
 	}
 	return "", false
 }
@@ -7690,6 +7690,12 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 				altReq := *searchReq
 				altReq.Query = altQuery
 				altReq.IndexerIDs = altIndexerIDs
+				// Treat the alternate-spelling pass as an internal continuation of the
+				// primary search rather than a separate tracked job: skip its search-history
+				// recording so it does not create parallel history entries. Outcome reporting
+				// keys on indexer ID under the primary job (which already searched these
+				// indexers), so the merged candidates attribute correctly.
+				altReq.SkipHistory = true
 				if altResp, altErr := s.searchOnce(waitCtx, &altReq); altErr != nil {
 					log.Debug().
 						Err(altErr).

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -7646,35 +7646,38 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 		candidateRelease := s.releaseCache.Parse(res.Title)
 		match, mismatchReason := s.releasesMatchWithReasonAndNamesAndTitles(searchRelease, candidateRelease, sourceTorrent.Name, res.Title, arrTitles, nil, opts.FindIndividualEpisodes)
 		if !match {
-			// Detect cross-tracker web-source relabels (e.g. WEBRip vs WEB-DL) of the
-			// same encode that are within size tolerance. These are currently rejected
-			// here; the log surfaces how often it happens so the relabel tolerance can
-			// be validated before it is acted on.
-			if mismatchReason == sourceMismatchReason &&
+			// Cross-tracker relabel tolerance: the same web encode is frequently
+			// relabeled WEBRip<->WEB-DL across trackers. When the source label is the
+			// only difference and the candidate is within size tolerance, accept it and
+			// let the apply-stage file-size verification + qBittorrent recheck make the
+			// final call, rather than dropping a byte-identical release on its label.
+			relabelMatch := mismatchReason == sourceMismatchReason &&
 				s.isSizeWithinTolerance(sourceTorrent.Size, res.Size, tolerancePercent) &&
-				s.isWebSourceRelabel(searchRelease, candidateRelease, sourceTorrent.Name, res.Title, arrTitles, nil, opts.FindIndividualEpisodes) {
-				log.Info().
-					Str("sourceTitle", sourceTorrent.Name).
-					Str("candidateTitle", res.Title).
-					Str("sourceSource", searchRelease.Source).
-					Str("candidateSource", candidateRelease.Source).
-					Int64("sourceSize", sourceTorrent.Size).
-					Int64("candidateSize", res.Size).
-					Float64("tolerancePercent", tolerancePercent).
-					Msg("[CROSSSEED-SEARCH] Web-source relabel within size tolerance detected (currently rejected; apply-stage verification would confirm)")
+				s.isWebSourceRelabel(searchRelease, candidateRelease, sourceTorrent.Name, res.Title, arrTitles, nil, opts.FindIndividualEpisodes)
+			if !relabelMatch {
+				releaseFilteredCount++
+				recordReleaseRejection(
+					releaseFilterReasons,
+					mismatchReason,
+					sourceTorrent.Name,
+					res.Title,
+					opts.FindIndividualEpisodes,
+					releaseFilterDebugInfoFrom(searchRelease),
+					releaseFilterDebugInfoFrom(candidateRelease),
+					"[CROSSSEED-SEARCH] Candidate filtered out by release match",
+				)
+				continue
 			}
-			releaseFilteredCount++
-			recordReleaseRejection(
-				releaseFilterReasons,
-				mismatchReason,
-				sourceTorrent.Name,
-				res.Title,
-				opts.FindIndividualEpisodes,
-				releaseFilterDebugInfoFrom(searchRelease),
-				releaseFilterDebugInfoFrom(candidateRelease),
-				"[CROSSSEED-SEARCH] Candidate filtered out by release match",
-			)
-			continue
+
+			log.Info().
+				Str("sourceTitle", sourceTorrent.Name).
+				Str("candidateTitle", res.Title).
+				Str("sourceSource", searchRelease.Source).
+				Str("candidateSource", candidateRelease.Source).
+				Int64("sourceSize", sourceTorrent.Size).
+				Int64("candidateSize", res.Size).
+				Float64("tolerancePercent", tolerancePercent).
+				Msg("[CROSSSEED-SEARCH] Accepting cross-tracker web-source relabel; apply-stage file verification will confirm")
 		}
 
 		// Reject forbidden pairing: season pack candidate (new) vs single episode source (existing).


### PR DESCRIPTION
## Problem

The same web encode is frequently listed under different release names on different trackers. Concrete case: *Law & Order: SVU* S05, seeded as `Law.and.Order.Special.Victims.Unit.S05.1080p.AMZN.WEBRip.DD2.0.x264-NTb`, is listed on other trackers as `Law & Order: Special Victims Unit S05 1080p AMZN WEB-DL DD+ 2.0 H.264-NTb` — same content size, different label. Two independent gaps caused these to be silently skipped by the Torznab cross-seed search:

1. **Discovery** — the search query is built verbatim from the release name (`...and...`), so trackers that index the show with `&` (`Law & Order:`) return zero results for the literal query. Trackers that spell it `and` matched and cross-seeded fine, which is why only some trackers were ever hit.
2. **Matching** — even when the candidate is surfaced (e.g. a tracker that uses the `and` spelling but the `WEB-DL` label), the matcher rejects it on `WEBRip` vs `WEB-DL` *before* the size check, dropping byte-identical content on the label alone.

## Changes

Three focused commits:

1. **Detect** cross-tracker web-source relabels (log only). Adds `isWebSourceRelabel`, which re-runs the release match with the candidate's web-source label equalized to the source's; if it then matches, the source label was the only difference.
2. **Accept** those relabels. When a candidate is rejected solely on source mismatch, is within the existing size tolerance, and is such a relabel, it is treated as a match. The title/source check was only a cheap precheck — the authoritative gate runs at apply time (`getMatchTypeWithReason` compares real file names/sizes, `hasContentFileSizeMismatch` refuses byte-level mismatches, and torrents are added paused with a forced recheck so a non-matching encode can never resume and leech). The relaxation defers a label decision the apply stage already makes on real files.
3. **Discover** the alternate spelling. After the primary search, when the query contains an `and`/`&` connector, re-query *only the indexers that returned nothing* with the swapped spelling and merge the extra candidates (the match loop dedupes by GUID/download URL). Skipped for ID-based searches.

The default size tolerance (5%) is unchanged. The fix lives in `searchTorrentMatches`, which covers manual search, the seeded search run, and completion-triggered cross-seed.

## Testing

- [x] `go build ./...` and `make backend`
- [x] `go test -race -count=1 ./internal/services/crossseed/...`
- [x] New unit tests: `TestIsWebSourceRelabel` (covers the real `&`/colon SVU titles and negative cases), `TestAlternateConnectorQuery`
- [x] `gofmt` clean; `golangci-lint --new-from-merge-base=develop` reports 0 issues
- Behavior diagnosed against a live instance (confirmed the missing trackers list the same release under a different label/spelling); full end-to-end verification of injection is pending a deploy of this build.

Commits are split so each can be tested independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cross-tracker matching improved to accept certain WEB source relabels (e.g., WEBRip ⇄ WEB-DL) with configurable size tolerance and episode/pack handling.
  * Torznab multi-pass search enhanced to retry only indexers that returned nothing using alternate connector spellings (and ↔ &), merging additional results and partial-status.

* **Tests**
  * Added unit tests for web-source relabel detection/acceptance and alternate-connector query, year-handling, and merge behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->