### PR TITLE
fix(crossseed): pin explicit savepath when cross category save path diverges

### DIFF
--- a/internal/services/crossseed/category_cache_test.go
+++ b/internal/services/crossseed/category_cache_test.go
@@ -73,23 +73,27 @@ func TestEnsureCrossCategory_RevalidatesWhenRequestedSavePathChanges(t *testing.
 	}
 
 	ctx := context.Background()
+	ensure := func(path string) error {
+		_, err := service.ensureCrossCategory(ctx, instanceID, categoryName, path, true)
+		return err
+	}
 
-	require.NoError(t, service.ensureCrossCategory(ctx, instanceID, categoryName, linkModePath, true))
+	require.NoError(t, ensure(linkModePath))
 	getCategoriesCalls, createCategoryCalls := syncManager.callCounts()
 	require.Equal(t, 1, getCategoriesCalls)
 	require.Equal(t, 1, createCategoryCalls)
 
-	require.NoError(t, service.ensureCrossCategory(ctx, instanceID, categoryName, regularPath, true))
+	require.NoError(t, ensure(regularPath))
 	getCategoriesCalls, createCategoryCalls = syncManager.callCounts()
 	require.Equal(t, 3, getCategoriesCalls)
 	require.Equal(t, 1, createCategoryCalls)
 
-	require.NoError(t, service.ensureCrossCategory(ctx, instanceID, categoryName, regularPath, true))
+	require.NoError(t, ensure(regularPath))
 	getCategoriesCalls, createCategoryCalls = syncManager.callCounts()
 	require.Equal(t, 5, getCategoriesCalls)
 	require.Equal(t, 1, createCategoryCalls)
 
-	require.NoError(t, service.ensureCrossCategory(ctx, instanceID, categoryName, linkModePath, true))
+	require.NoError(t, ensure(linkModePath))
 	getCategoriesCalls, createCategoryCalls = syncManager.callCounts()
 	require.Equal(t, 5, getCategoriesCalls)
 	require.Equal(t, 1, createCategoryCalls)
@@ -113,13 +117,17 @@ func TestEnsureCrossCategory_CacheMatchesPathCaseInsensitively(t *testing.T) {
 	}
 
 	ctx := context.Background()
+	ensure := func(path string) error {
+		_, err := service.ensureCrossCategory(ctx, instanceID, categoryName, path, true)
+		return err
+	}
 
-	require.NoError(t, service.ensureCrossCategory(ctx, instanceID, categoryName, initialPath, true))
+	require.NoError(t, ensure(initialPath))
 	getCategoriesCalls, createCategoryCalls := syncManager.callCounts()
 	require.Equal(t, 1, getCategoriesCalls)
 	require.Equal(t, 1, createCategoryCalls)
 
-	require.NoError(t, service.ensureCrossCategory(ctx, instanceID, categoryName, requestPath, true))
+	require.NoError(t, ensure(requestPath))
 	getCategoriesCalls, createCategoryCalls = syncManager.callCounts()
 	require.Equal(t, 1, getCategoriesCalls)
 	require.Equal(t, 1, createCategoryCalls)
@@ -146,15 +154,19 @@ func TestEnsureCrossCategory_ConcurrentDifferentRequestedPathsCreateOnce(t *test
 
 	ctx := context.Background()
 	errs := make(chan error, 2)
+	ensure := func(path string) error {
+		_, err := service.ensureCrossCategory(ctx, instanceID, categoryName, path, true)
+		return err
+	}
 
 	go func() {
-		errs <- service.ensureCrossCategory(ctx, instanceID, categoryName, linkModePath, true)
+		errs <- ensure(linkModePath)
 	}()
 
 	<-syncManager.getStarted
 
 	go func() {
-		errs <- service.ensureCrossCategory(ctx, instanceID, categoryName, regularPath, true)
+		errs <- ensure(regularPath)
 	}()
 
 	close(syncManager.releaseGet)

--- a/internal/services/crossseed/category_divergence_test.go
+++ b/internal/services/crossseed/category_divergence_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package crossseed
+
+import (
+	"context"
+	"testing"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/pkg/stringutils"
+)
+
+// divergentCategorySyncManager embeds the rootless mock and overrides category
+// lookups so a cross-seed category can be made to already exist with a save path
+// that diverges from the matched torrent's location.
+type divergentCategorySyncManager struct {
+	*rootlessSavePathSyncManager
+	categories map[string]qbt.Category
+	created    map[string]string
+}
+
+func (m *divergentCategorySyncManager) GetCategories(context.Context, int) (map[string]qbt.Category, error) {
+	return m.categories, nil
+}
+
+func (m *divergentCategorySyncManager) CreateCategory(_ context.Context, _ int, name, path string) error {
+	if m.created == nil {
+		m.created = make(map[string]string)
+	}
+	m.created[name] = path
+	if m.categories == nil {
+		m.categories = make(map[string]qbt.Category)
+	}
+	m.categories[name] = qbt.Category{Name: name, SavePath: path}
+	return nil
+}
+
+// TestProcessCrossSeedCandidate_DivergentCrossCategoryPinsSavePath verifies that when
+// the affixed cross-seed category already exists with a save path that differs from the
+// matched torrent's location, qui does NOT delegate the path to qBittorrent via autoTMM
+// (which would relocate/re-download into the category's path). Instead it pins an explicit
+// savepath at the matched torrent's location so existing files are reused. This mirrors
+// hardlink/reflink mode and prevents the "<base>/<category>.cross re-download" bug.
+func TestProcessCrossSeedCandidate_DivergentCrossCategoryPinsSavePath(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	instanceID := 1
+	matchedHash := "matchedhash"
+	newHash := "newhash"
+	matchedName := "Show.S01E01.1080p.WEB-DL-GROUP"
+
+	candidateFiles := qbt.TorrentFiles{
+		{Name: "Show.S01E01.mkv", Size: 1024},
+	}
+	sourceFiles := qbt.TorrentFiles{
+		{Name: "Show.S01E01.mkv", Size: 1024},
+	}
+
+	// Matched torrent is auto-managed and lives at /downloads/tv/Show.S01E01.
+	// ContentPath dir matches SavePath, so the rootless-content-dir override does NOT
+	// fire; the only thing that can disable autoTMM here is the divergence guard.
+	matchedTorrent := qbt.Torrent{
+		Hash:        matchedHash,
+		Name:        matchedName,
+		Progress:    1.0,
+		Category:    "tv",
+		AutoManaged: true,
+		ContentPath: "/downloads/tv/Show.S01E01/Show.S01E01.mkv",
+	}
+
+	base := &rootlessSavePathSyncManager{
+		files: map[string]qbt.TorrentFiles{
+			matchedHash: candidateFiles,
+			newHash:     sourceFiles,
+		},
+		props: map[string]*qbt.TorrentProperties{
+			matchedHash: {SavePath: "/downloads/tv/Show.S01E01"},
+		},
+	}
+
+	// The affixed category already exists pointing at the wrong (divergent) folder,
+	// exactly like qBittorrent's implicit "<default>/tv.cross" path or stale config.
+	sync := &divergentCategorySyncManager{
+		rootlessSavePathSyncManager: base,
+		categories: map[string]qbt.Category{
+			"tv.cross": {Name: "tv.cross", SavePath: "/downloads/tv.cross"},
+		},
+	}
+
+	instanceStore := &rootlessSavePathInstanceStore{
+		instances: map[int]*models.Instance{
+			instanceID: {ID: instanceID, UseHardlinks: false},
+		},
+	}
+
+	service := &Service{
+		syncManager:      sync,
+		instanceStore:    instanceStore,
+		releaseCache:     NewReleaseCache(),
+		stringNormalizer: stringutils.NewDefaultNormalizer(),
+		automationSettingsLoader: func(context.Context) (*models.CrossSeedAutomationSettings, error) {
+			return models.DefaultCrossSeedAutomationSettings(), nil
+		},
+	}
+
+	startPaused := true
+	req := &CrossSeedRequest{StartPaused: &startPaused}
+
+	candidate := CrossSeedCandidate{
+		InstanceID:   instanceID,
+		InstanceName: "Test",
+		Torrents:     []qbt.Torrent{matchedTorrent},
+	}
+
+	result := service.processCrossSeedCandidate(ctx, candidate, []byte("torrent"), newHash, "", matchedName, req, service.releaseCache.Parse(matchedName), sourceFiles, nil)
+	require.True(t, result.Success)
+	require.Equal(t, "added", result.Status)
+
+	require.NotNil(t, base.addedOptions)
+	// The category is still applied for isolation...
+	require.Equal(t, "tv.cross", base.addedOptions["category"])
+	// ...but autoTMM is disabled and the save path is pinned to the matched torrent's
+	// location so qBittorrent reuses the existing files instead of re-downloading.
+	require.Equal(t, "false", base.addedOptions["autoTMM"], "autoTMM must be disabled when the cross category save path diverges")
+	require.Equal(t, "/downloads/tv/Show.S01E01", base.addedOptions["savepath"])
+}

--- a/internal/services/crossseed/seasonpack.go
+++ b/internal/services/crossseed/seasonpack.go
@@ -384,7 +384,7 @@ func (s *Service) ApplySeasonPackWebhook(ctx context.Context, req *SeasonPackApp
 	}
 
 	crossCategory := s.resolveSeasonPackCategory(ctx, prep, req.Indexer, episodes)
-	if err := s.ensureCrossCategory(ctx, inst.ID, crossCategory, "", false); err != nil {
+	if _, err := s.ensureCrossCategory(ctx, inst.ID, crossCategory, "", false); err != nil {
 		log.Warn().Err(err).Str("torrentName", req.TorrentName).Str("category", crossCategory).Msg("season pack: failed to ensure cross-seed category exists")
 	}
 

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -4665,6 +4665,10 @@ func (s *Service) processCrossSeedCandidate(
 	// categorySavePath includes the fallback to matched torrent's path for category creation
 	var categorySavePath string
 	var actualCategorySavePath string
+	// crossCategoryActualSavePath is the cross-seed category's real save path as it
+	// exists in qBittorrent (after ensureCrossCategory). Regular mode compares it
+	// against the matched torrent's location to decide whether autoTMM is safe.
+	var crossCategoryActualSavePath string
 	var categoryCreationFailed bool
 	if crossCategory != "" {
 		// Try to get SavePath from the base category definition in qBittorrent
@@ -4691,13 +4695,16 @@ func (s *Service) processCrossSeedCandidate(
 		// the fallback to props.SavePath would produce the wrong path.
 		if !useReflinkMode && !useHardlinkMode {
 			// Ensure the cross-seed category exists with the correct SavePath
-			if err := s.ensureCrossCategory(ctx, candidate.InstanceID, crossCategory, categorySavePath, true); err != nil {
+			actualPath, err := s.ensureCrossCategory(ctx, candidate.InstanceID, crossCategory, categorySavePath, true)
+			if err != nil {
 				log.Warn().Err(err).
 					Str("category", crossCategory).
 					Str("savePath", categorySavePath).
 					Msg("[CROSSSEED] Failed to ensure category exists, continuing without category")
 				crossCategory = ""            // Clear category to proceed without it
 				categoryCreationFailed = true // Track for result message
+			} else {
+				crossCategoryActualSavePath = actualPath
 			}
 		}
 	}
@@ -4948,6 +4955,26 @@ func (s *Service) processCrossSeedCandidate(
 		tmmDecision := shouldEnableAutoTMM(crossCategory, matchedTorrent.AutoManaged, useCategoryFromIndexer, useCustomCategory, actualCategorySavePath, props.SavePath)
 		if forceManualSavePath {
 			tmmDecision.Enabled = false
+		}
+
+		// Under autoTMM, qBittorrent resolves the save path from the assigned (affixed)
+		// category — its configured save_path, or the implicit <default_save_path>/<category>
+		// when none is set. That only reuses the matched torrent's files when it equals the
+		// matched torrent's location. ensureCrossCategory never rewrites a pre-existing
+		// category whose path diverges (it only warns), so trusting autoTMM there would
+		// relocate the cross-seed into e.g. <base>/<category>.cross and re-download instead
+		// of reusing files. When the category's actual path diverges (or is unset), pin an
+		// explicit savepath like hardlink/reflink mode does.
+		if tmmDecision.Enabled && crossCategory != "" {
+			if crossCategoryActualSavePath == "" || normalizePathForComparison(crossCategoryActualSavePath) != normalizePathForComparison(savePath) {
+				tmmDecision.Enabled = false
+				log.Debug().
+					Int("instanceID", candidate.InstanceID).
+					Str("crossCategory", crossCategory).
+					Str("crossCategorySavePath", crossCategoryActualSavePath).
+					Str("matchedSavePath", savePath).
+					Msg("[CROSSSEED] Cross category save path diverges from matched torrent; pinning explicit savepath instead of autoTMM")
+			}
 		}
 
 		log.Debug().
@@ -11186,6 +11213,11 @@ func applyCategoryAffix(category, affixMode, affix string) string {
 // explicit savepath and autoTMM disabled, so category save_path drift is not actionable there.
 // If it doesn't exist, it creates it with the provided save_path.
 //
+// It returns the category's actual save_path (normalized for comparison): the existing path when
+// the category already exists, otherwise the path it was created with. Regular mode uses this to
+// detect divergence from the matched torrent's location and pin an explicit savepath instead of
+// trusting autoTMM. The returned path is empty only when crossCategory is empty.
+//
 // This function uses singleflight to deduplicate concurrent creation attempts for the same
 // category, and maintains local state to avoid relying on potentially stale GetCategories responses.
 func (s *Service) ensureCrossCategory(
@@ -11194,9 +11226,9 @@ func (s *Service) ensureCrossCategory(
 	crossCategory,
 	savePath string,
 	compareExistingSavePath bool,
-) error {
+) (string, error) {
 	if crossCategory == "" {
-		return nil
+		return "", nil
 	}
 
 	key := fmt.Sprintf("%d:%s", instanceID, crossCategory)
@@ -11219,7 +11251,8 @@ func (s *Service) ensureCrossCategory(
 	// Fast path: we already created or verified this category in this session
 	// for the same requested save path.
 	if cached, ok := s.createdCategories.Load(key); ok && cacheMatches(cached) {
-		return nil
+		cachedSavePath, _ := cached.(string)
+		return cachedSavePath, nil
 	}
 
 	// Use singleflight to deduplicate concurrent calls for the same category.
@@ -11271,17 +11304,17 @@ func (s *Service) ensureCrossCategory(
 	})
 
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	actualSavePath, _ := actualSavePathValue.(string)
 	if !compareExistingSavePath || requestedSavePath == "" || actualSavePath == requestedSavePath {
-		return nil
+		return actualSavePath, nil
 	}
 
 	categories, err := s.syncManager.GetCategories(ctx, instanceID)
 	if err != nil {
-		return fmt.Errorf("get categories after singleflight: %w", err)
+		return "", fmt.Errorf("get categories after singleflight: %w", err)
 	}
 
 	if existing, exists := categories[crossCategory]; exists {
@@ -11295,11 +11328,11 @@ func (s *Service) ensureCrossCategory(
 				Msg("[CROSSSEED] Cross-seed category exists with different save path")
 		}
 		s.createdCategories.Store(key, actualSavePath)
-		return nil
+		return actualSavePath, nil
 	}
 
 	if err := s.syncManager.CreateCategory(ctx, instanceID, crossCategory, savePath); err != nil {
-		return fmt.Errorf("create category after singleflight: %w", err)
+		return "", fmt.Errorf("create category after singleflight: %w", err)
 	}
 
 	s.createdCategories.Store(key, requestedSavePath)
@@ -11309,7 +11342,7 @@ func (s *Service) ensureCrossCategory(
 		Str("savePath", savePath).
 		Msg("[CROSSSEED] Created category for cross-seed after singleflight revalidation")
 
-	return nil
+	return requestedSavePath, nil
 }
 
 func shouldWarnOnCategorySavePathMismatch(compareExistingSavePath bool, requestedSavePath, existingSavePath string) bool {
@@ -12511,7 +12544,7 @@ func (s *Service) processHardlinkMode(
 	categoryCreationFailed := false
 	if crossCategory != "" {
 		categorySavePath := s.buildCategorySavePath(ctx, instance, selectedBaseDir, incomingTrackerDomain, candidate, req)
-		if err := s.ensureCrossCategory(ctx, candidate.InstanceID, crossCategory, categorySavePath, false); err != nil {
+		if _, err := s.ensureCrossCategory(ctx, candidate.InstanceID, crossCategory, categorySavePath, false); err != nil {
 			log.Warn().Err(err).
 				Str("category", crossCategory).
 				Str("savePath", categorySavePath).
@@ -13186,7 +13219,7 @@ func (s *Service) processReflinkMode(
 	categoryCreationFailed := false
 	if crossCategory != "" {
 		categorySavePath := s.buildCategorySavePath(ctx, instance, selectedBaseDir, incomingTrackerDomain, candidate, req)
-		if err := s.ensureCrossCategory(ctx, candidate.InstanceID, crossCategory, categorySavePath, false); err != nil {
+		if _, err := s.ensureCrossCategory(ctx, candidate.InstanceID, crossCategory, categorySavePath, false); err != nil {
 			log.Warn().Err(err).
 				Str("category", crossCategory).
 				Str("savePath", categorySavePath).


### PR DESCRIPTION
Regular (non-hardlink/reflink) cross-seed mode enabled autoTMM for affixed categories whenever the matched torrent was auto-managed, handing save-path resolution to qBittorrent. With a `.cross` affix, qBittorrent resolves the path from the affixed category (its configured `save_path`, or the implicit `<default>/<category>` when none is set), which need not equal the matched torrent's location — and `ensureCrossCategory` only *warns* on a divergent pre-existing category, never rewrites it. The result: the cross-seed was relocated into e.g. `<base>/<category>.cross` and re-downloaded 100% instead of reusing existing files. Hardlink/reflink modes were immune because they always pin an explicit `savepath` with autoTMM off.

`ensureCrossCategory` now returns the category's actual save path, and regular mode disables autoTMM + pins an explicit `savepath` to the matched torrent's location when that path diverges (or is unset), mirroring link modes. The matching-path case is unchanged (autoTMM stays on). Includes a regression test covering a pre-existing divergent `.cross` category. Reported on Discord: a "seedbox" instance using a category suffix re-downloaded cross-seeds while the hardlink "media" instance worked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced cross-seed functionality to intelligently handle category save-path configurations, ensuring correct behavior when actual category paths diverge from matched torrent locations and maintaining expected file placement outcomes.

* **Tests**
  * Added comprehensive test cases validating cross-seed behavior with divergent category save paths.
  * Improved cross-seed testing infrastructure with refactored utilities for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->