### PR TITLE
fix(sse): pause torrent-list stream while the tab is hidden

### DIFF
--- a/web/src/hooks/useTorrentsList.test.tsx
+++ b/web/src/hooks/useTorrentsList.test.tsx
@@ -61,11 +61,15 @@ function setHidden(next: boolean) {
   })
 }
 
-function wrapper({ children }: { children: ReactNode }) {
+// One QueryClient per test, reused across rerenders (renderHook's rerender()
+// re-invokes the wrapper, so an inline client would reset the cache each time).
+function createWrapper() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, gcTime: 0 } },
   })
-  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
 }
 
 describe("useTorrentsList background stream gating", () => {
@@ -86,13 +90,13 @@ describe("useTorrentsList background stream gating", () => {
   })
 
   it("keeps the list stream enabled while the tab is visible", () => {
-    renderHook(() => useTorrentsList(1, { pollingEnabled: false }), { wrapper })
+    renderHook(() => useTorrentsList(1, { pollingEnabled: false }), { wrapper: createWrapper() })
 
     expect(lastStreamEnabled()).toBe(true)
   })
 
   it("pauses the list stream once the tab has been hidden past the delay", () => {
-    const { rerender } = renderHook(() => useTorrentsList(1, { pollingEnabled: false }), { wrapper })
+    const { rerender } = renderHook(() => useTorrentsList(1, { pollingEnabled: false }), { wrapper: createWrapper() })
 
     expect(lastStreamEnabled()).toBe(true)
 
@@ -106,7 +110,7 @@ describe("useTorrentsList background stream gating", () => {
   })
 
   it("resumes the list stream immediately when the tab becomes visible again", () => {
-    const { rerender } = renderHook(() => useTorrentsList(1, { pollingEnabled: false }), { wrapper })
+    const { rerender } = renderHook(() => useTorrentsList(1, { pollingEnabled: false }), { wrapper: createWrapper() })
 
     setHidden(true)
     act(() => {

--- a/web/src/hooks/useTorrentsList.test.tsx
+++ b/web/src/hooks/useTorrentsList.test.tsx
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { act, renderHook } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const { useSyncStreamMock } = vi.hoisted(() => ({ useSyncStreamMock: vi.fn() }))
+
+vi.mock("@/contexts/SyncStreamContext", () => ({
+  useSyncStream: useSyncStreamMock,
+}))
+
+vi.mock("@/hooks/useInstances", () => ({
+  useInstances: () => ({ instances: [{ id: 1, isActive: true }] }),
+}))
+
+vi.mock("@/hooks/useInstanceCapabilities", () => ({
+  useInstanceCapabilities: () => ({ data: undefined }),
+}))
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    getTorrents: vi.fn().mockResolvedValue({ torrents: [], total: 0, hasMore: false }),
+    getCrossInstanceTorrents: vi.fn().mockResolvedValue({ torrents: [], total: 0, hasMore: false }),
+  },
+}))
+
+import { useTorrentsList } from "@/hooks/useTorrentsList"
+
+const DEFAULT_STREAM_STATE = {
+  connected: false,
+  error: null,
+  lastMeta: undefined,
+  retrying: false,
+  retryAttempt: 0,
+  nextRetryAt: undefined,
+}
+
+// The single-instance torrent-list stream multiplexes a heavy limit:300 snapshot.
+// These helpers read back the `enabled` flag the hook hands to useSyncStream so we
+// can assert when the list subscription is paused.
+function lastStreamEnabled(): boolean | undefined {
+  const calls = useSyncStreamMock.mock.calls
+  if (calls.length === 0) {
+    return undefined
+  }
+  const options = calls[calls.length - 1][1] as { enabled?: boolean } | undefined
+  return options?.enabled
+}
+
+let hidden = false
+
+function setHidden(next: boolean) {
+  hidden = next
+  act(() => {
+    document.dispatchEvent(new Event("visibilitychange"))
+  })
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}
+
+describe("useTorrentsList background stream gating", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    hidden = false
+    useSyncStreamMock.mockReturnValue(DEFAULT_STREAM_STATE)
+    Object.defineProperty(document, "hidden", {
+      configurable: true,
+      get: () => hidden,
+    })
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it("keeps the list stream enabled while the tab is visible", () => {
+    renderHook(() => useTorrentsList(1, { pollingEnabled: false }), { wrapper })
+
+    expect(lastStreamEnabled()).toBe(true)
+  })
+
+  it("pauses the list stream once the tab has been hidden past the delay", () => {
+    const { rerender } = renderHook(() => useTorrentsList(1, { pollingEnabled: false }), { wrapper })
+
+    expect(lastStreamEnabled()).toBe(true)
+
+    setHidden(true)
+    act(() => {
+      vi.advanceTimersByTime(60_000)
+    })
+    rerender()
+
+    expect(lastStreamEnabled()).toBe(false)
+  })
+
+  it("resumes the list stream immediately when the tab becomes visible again", () => {
+    const { rerender } = renderHook(() => useTorrentsList(1, { pollingEnabled: false }), { wrapper })
+
+    setHidden(true)
+    act(() => {
+      vi.advanceTimersByTime(60_000)
+    })
+    rerender()
+    expect(lastStreamEnabled()).toBe(false)
+
+    setHidden(false)
+    rerender()
+
+    expect(lastStreamEnabled()).toBe(true)
+  })
+})

--- a/web/src/hooks/useTorrentsList.test.tsx
+++ b/web/src/hooks/useTorrentsList.test.tsx
@@ -29,7 +29,7 @@ vi.mock("@/lib/api", () => ({
   },
 }))
 
-import { useTorrentsList } from "@/hooks/useTorrentsList"
+import { STREAM_HIDDEN_PAUSE_DELAY_MS, useTorrentsList } from "@/hooks/useTorrentsList"
 
 const DEFAULT_STREAM_STATE = {
   connected: false,
@@ -102,7 +102,7 @@ describe("useTorrentsList background stream gating", () => {
 
     setHidden(true)
     act(() => {
-      vi.advanceTimersByTime(60_000)
+      vi.advanceTimersByTime(STREAM_HIDDEN_PAUSE_DELAY_MS)
     })
     rerender()
 
@@ -114,7 +114,7 @@ describe("useTorrentsList background stream gating", () => {
 
     setHidden(true)
     act(() => {
-      vi.advanceTimersByTime(60_000)
+      vi.advanceTimersByTime(STREAM_HIDDEN_PAUSE_DELAY_MS)
     })
     rerender()
     expect(lastStreamEnabled()).toBe(false)

--- a/web/src/hooks/useTorrentsList.ts
+++ b/web/src/hooks/useTorrentsList.ts
@@ -4,6 +4,7 @@
  */
 
 import { useSyncStream } from "@/contexts/SyncStreamContext"
+import { useDelayedVisibility } from "@/hooks/useDelayedVisibility"
 import { useInstanceCapabilities } from "@/hooks/useInstanceCapabilities"
 import { useInstances } from "@/hooks/useInstances"
 import type { InstanceMetadata } from "@/hooks/useInstanceMetadata"
@@ -27,6 +28,16 @@ export const TORRENT_STREAM_POLL_INTERVAL_SECONDS = Math.max(
   1,
   Math.round(TORRENT_STREAM_POLL_INTERVAL_MS / 1000)
 )
+
+// While the tab is hidden the table is invisible, so streaming a full page-0
+// snapshot (up to 300 torrents) every couple of seconds is pure waste: the work is
+// deferred and then burst-processed by a throttled background tab, and each frame is
+// retained by anyone running DevTools with "Persist Logs" on. Pause the heavy list
+// subscription once the tab has been hidden this long; the title-bar speed stream
+// (limit:1) stays live so background transfer rates keep updating. The grace delay
+// avoids tearing the stream down on quick tab switches; on refocus it resumes at once
+// and refetchOnWindowFocus pulls fresh data immediately.
+export const STREAM_HIDDEN_PAUSE_DELAY_MS = 30000
 
 interface UseTorrentsListOptions {
   enabled?: boolean
@@ -67,6 +78,11 @@ export function useTorrentsList(
   const [lastStreamSnapshot, setLastStreamSnapshot] = useState<TorrentResponse | null>(null)
   const pageSize = 300 // Load 300 at a time (backend default)
   const queryClient = useQueryClient()
+
+  // Pause the heavy list stream while the tab is backgrounded (see
+  // STREAM_HIDDEN_PAUSE_DELAY_MS). isHiddenDelayed only trips after a grace period,
+  // so quick tab switches don't churn the subscription.
+  const { isHiddenDelayed } = useDelayedVisibility(STREAM_HIDDEN_PAUSE_DELAY_MS)
 
   const metadataQueryKey = useMemo(
     () => ["instance-metadata", instanceId] as const,
@@ -280,7 +296,7 @@ export function useTorrentsList(
   )
 
   const streamState = useSyncStream(streamParams, {
-    enabled: Boolean(streamParams),
+    enabled: Boolean(streamParams) && !isHiddenDelayed,
     onMessage: handleStreamPayload,
   })
 


### PR DESCRIPTION
> ⚠️ **Merge order: this PR must be merged AFTER #1992 (the fix for #1991).** It is stacked on the `fix/sse-offline-flips` branch, so do not merge it into `develop` until #1992 has landed. Once #1992 merges, retarget this PR's base to `develop`.

Stacked on the offline-flips fixes (#1992). Those stop the background reconnect storm (#1991); this closes the remaining gap behind the "backgrounded tab eats GBs of RAM / pegs CPU and crashes" reports. While the tab is hidden the table is invisible, yet the limit:300 list stream keeps delivering a full page-0 snapshot every ~2s and the client re-runs normalize + setQueryData + setState + a full table re-render on each tick. A throttled background tab defers and burst-processes that, and DevTools "Persist Logs" retains every frame, which is what amplifies it into a multi-GB crash.

The list `useSyncStream` is now gated on `useDelayedVisibility`: it pauses once the tab has been hidden past a 30s grace delay and resumes immediately on refocus (`refetchOnWindowFocus` fetches fresh data). The limit:1 title-bar speed stream stays ungated so background transfer rates keep updating and the multiplexed socket stays open; `enabled:false` yields the clean default stream state, so there's no false offline badge. Covered by a new `useTorrentsList` spec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Torrent list streaming now automatically pauses after a short delay when the tab is inactive and resumes immediately when you return; lightweight speed updates remain uninterrupted.
* **Tests**
  * Added automated tests that simulate tab visibility to verify pause/resume timing and visibility gating behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->