### PR TITLE
docs(agents): scope agent guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,8 @@ web/src/themes/premium/
 web/src/themes/premium/*
 docs/*
 !docs/CROSS_SEEDING.md
+!docs/architecture.md
+!docs/linting.md
 .mcp_unused.json
 config.toml
 .env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,228 +1,96 @@
 # AGENTS.md
 
-Repository guidelines for AI coding agents (Codex, Claude Code, etc.) working on qui.
+Repo rules for AI agents working on qui.
 
-## Owner Collaboration Notes
+## Collaboration
 
-- Do not implement review-suggested or extra changes outside requested scope without explicit user approval first.
+- Stay inside requested scope. Do not implement review-suggested/extra changes without explicit user approval.
 - Treat other agent/Codex/CodeRabbit feedback as input to discuss, not automatic action.
+- qui is single-user self-hosted software. Prefer readable, maintainable code over paranoid guards for impossible states.
 
-## Project Structure & Module Organization
+## Repo Map
 
-The Go backend lives in `cmd/qui` (entrypoint) and `internal/` modules for configuration, qBittorrent, metrics, and API routing; shared helpers sit in `pkg/`. The React/Vite client is in `web/src` with static assets in `web/public`, and its production bundle must stay synced to `internal/web/dist`. Reference docs live under `docs/`, while Docker and compose files in the repository root support container workflows.
+- Backend: `cmd/qui`, `internal/`, shared `pkg/`
+- Frontend: `web/src`, assets `web/public`, bundle output `internal/web/dist`
+- User docs: `documentation/docs/`; internal notes: `docs/`
+- Docker/compose/release files: repo root
 
-End-user docs live in the Docusaurus project under `documentation/docs/`. Prefer updating those for user-facing copy; `docs/` is mostly internal/engineering notes.
+Keep `README.md` concise; put feature deep-dives in `documentation/docs/`.
 
-Keep `README.md` concise. Feature deep-dives belong in `documentation/docs/`, not the root README.
+Before changing cross-module data flow, service boundaries, API routing, or long-lived architecture, read `docs/architecture.md`.
 
-## Build, Test, and Development Commands
+## Required Commands
 
-```bash
-# Build
-make build              # Frontend bundle + Go binary with version metadata
-make backend            # Go binary only
-make frontend           # Frontend bundle only
+- Build: `make build` (frontend bundle + Go binary)
+- Backend only: `make backend`
+- Frontend only: `make frontend`
+- Dev: `make dev`, `make dev-backend`, `make dev-frontend`
+- Required before final for code changes: `make precommit`, targeted tests for touched packages, `make build`
+- Go tests: always use `-race -count=1`
+- Full Go suite: `make test` (`go test -race -count=1 -v ./...`)
+- OpenAPI changes under `internal/web/swagger`: run `make test-openapi`
 
-# Development
-make dev                # Starts air (hot-reload) + pnpm dev
-make dev-backend        # Backend only with hot-reload
-make dev-frontend       # Frontend only
+For changes under `internal/services/crossseed` or `internal/qbittorrent`, run targeted package tests first. Skip local full `make test` by default; CI covers it unless requested.
 
-# Testing
-make test               # go test -race -count=1 -v ./...
-make test-openapi       # Validate OpenAPI spec after touching internal/web/swagger
+## Lint / Format
 
-# Linting
-make lint               # Changed files only (fast, use during iteration)
-make lint-json          # JSON output to lint-report.json
+- `make precommit` = fmt + gofix changed files + lint changed files.
+- `make lint` = changed files only.
+- `make lint-json` writes `lint-report.json`.
+- `make fmt` = gofmt + frontend eslint fix on changed files.
+- Avoid repo-wide `pnpm format` / `eslint --fix` sweeps unless explicitly requested.
+- If lint/check output reveals a real issue, fix the smallest relevant scope or report why blocked.
+- If lint output is unclear or requires policy judgment, read `docs/linting.md`; otherwise treat tool output and config as source of truth.
 
-# Pre-commit
-make precommit          # fmt + gofix + lint on changed files
+## Go / Backend
 
-# Formatting
-make fmt                # gofmt + frontend eslint --fix on changed files
-make gofix-changed      # Apply go fix on changed Go files only
-make gofix-check-changed # Check go fix drift on changed Go files only
-```
-
-## Linting Strategy
-
-The project uses golangci-lint v2 with strict configuration targeting AI-generated code patterns:
-
-| Linter | Purpose | Threshold |
-|--------|---------|-----------|
-| dupl | Catch code duplication | 100 tokens |
-| gocognit | Cognitive complexity | 15 |
-| funlen | Function length | 80 lines |
-| interfacebloat | Interface size | 5 methods |
-| errcheck | Unchecked errors | All, including type assertions |
-| gocritic | Non-idiomatic patterns | diagnostic + style + performance |
-
-**Workflow:**
-1. During implementation: `make precommit` (changed files only, fast feedback)
-2. To fix issues: `make lint-fix` then address remaining manually
-
-**Guardrail (web formatting):** avoid repo-wide `pnpm format` / `eslint --fix` sweeps unless explicitly requested. Prefer fixing only the files reported by lint for the current task/PR.
-
-## Coding Style & Naming Conventions
-
-Keep Go code `gofmt`-clean with PascalCase exports, camelCase locals, and package-level interfaces grouped by domain inside `internal/<area>`. The frontend follows ESLint @stylistic defaults: two-space indentation, double quotes, trailing commas on multiline literals, and Unix line endings. Organize React modules by feature within `web/src/{pages,routes,components}` and choose descriptive file names (e.g., `torrent-table.tsx`).
-
-**Critical conventions:**
-- Prefer explicit error handling over silent failures
-- Keep interfaces small (≤5 methods)
-- Avoid `map[string]interface{}` — use proper structs
-- No backward compatibility shims unless explicitly requested
-- **Loop variables (Go 1.22+):** Don't use `tt := tt` in parallel subtests — Go 1.22+ creates a new variable per iteration, so the old workaround is unnecessary and flagged by linters
-
-**Single-user self-hosted context:** qui runs on someone's home server, not as a multi-tenant SaaS with untrusted input and complex failure modes. Skip paranoid defensive programming for impossible or purely theoretical scenarios. Code that guards against states that can't happen adds complexity without value. Prioritize readable, maintainable code over excessive robustness.
+- Keep Go `gofmt` clean.
+- Exports: PascalCase. Locals: camelCase.
+- Group package interfaces by domain under `internal/<area>`.
+- Prefer explicit error handling.
+- Keep interfaces small (<=5 methods).
+- Avoid `map[string]interface{}`; use structs.
+- No backward compatibility shims unless requested.
+- Go 1.22+: do not add `tt := tt` in parallel subtests.
+- Tests live beside code as `*_test.go`; prefer table-driven tests and existing fixtures.
+- Test file writes should use `os.WriteFile(..., 0o600)` unless broader mode is required.
 
 ## Code Shape
 
-- Prefer behavior-bearing branches only. If multiple `switch` cases return the same value as `default`, collapse them.
-- In boolean classifiers, list only the exceptional cases (`true` cases or error cases). Let `default` handle the common path.
-- Do not add documentation-only branches unless they enforce something mechanically via compiler, linter, or tests.
-- When a branch only enumerates known states, ask whether it changes behavior, improves safety, or provides exhaustiveness checking. If not, delete it.
+- Prefer behavior-bearing branches only.
+- If multiple `switch` cases equal `default`, collapse them.
+- Boolean classifiers should list exceptional `true`/error cases; let `default` handle common path.
+- Do not add documentation-only branches unless compiler/linter/tests enforce value.
 
-## Cross-Platform Path Handling
+## Paths / Security
 
-qui must work on Windows and Unix-like hosts. Do not assume POSIX path behavior in Go code or tests unless the value is explicitly a torrent-internal path or remote qBittorrent path.
+qui must work on Windows and Unix-like hosts.
 
-- Use `filepath.Join`, `filepath.Clean`, `filepath.Rel`, and `filepath.Separator` for local filesystem paths.
-- Use `path` only for slash-delimited data formats such as torrent-internal file names, URLs, or API payloads that are defined to use `/`.
-- At boundaries between torrent/API paths and local filesystem paths, normalize deliberately: validate slash paths first, then convert with `filepath.FromSlash`.
-- Security/path traversal checks must reject both POSIX and Windows absolute/escaping forms on every OS: leading `/`, leading `\`, drive-letter paths, UNC paths, and `..` segments.
-- Tests should not assert raw `"/foo/"` substrings against local filesystem paths. Use `filepath.ToSlash(path)` for cross-platform assertions, or build expected paths with `filepath.Join`.
-- When adding path traversal tests, include both POSIX-style and Windows-style cases, even if the test is running on only one OS.
+- Local filesystem paths: `filepath.Join`, `filepath.Clean`, `filepath.Rel`, `filepath.Separator`.
+- Slash-delimited formats only: `path` for torrent-internal file names, URLs, API payloads.
+- At torrent/API -> local FS boundaries: validate slash paths, then convert with `filepath.FromSlash`.
+- Traversal checks must reject POSIX + Windows escaping on every OS: leading `/`, leading `\`, drive letters, UNC, `..`.
+- Cross-platform tests: avoid raw `"/foo/"` local path assertions; use `filepath.ToSlash` or `filepath.Join`.
+- Path traversal tests should include POSIX and Windows cases.
 
-## React Effects
+## Frontend
 
-- Use `useEffect` only to sync with external systems (DOM, subscriptions, network).
-- Avoid derived state in Effects; calculate during render, or `useMemo` for expensive compute.
-- Put user-driven logic in event handlers, not Effects.
-- To reset state, prefer a `key` or render-time adjustments instead of Effects.
-- Fetch Effects must guard against stale responses (cleanup/abort).
-- Source: https://react.dev/learn/you-might-not-need-an-effect
+Frontend-specific rules live in `web/AGENTS.md`. Read that file before editing `web/`, i18n, React components, or frontend tests.
 
-## Testing Guidelines
+## API / Database
 
-Place backend tests beside implementations as `*_test.go`, mirroring paths such as `internal/qbittorrent/pool_test.go`. Prefer table-driven cases and reuse the integration fixtures already in `internal/qbittorrent/`. Run targeted local tests for touched packages and add `make test-openapi` when contracts change. CI covers the full `make test` suite unless explicitly requested locally. Frontend work should include Vitest + React Testing Library specs named `*.test.tsx` near the component.
+- DB schema changes need SQLite + Postgres migrations, matching model/store updates, same PR.
+- Open PRs: consolidate schema work to at most one new SQLite migration and one new Postgres migration; edit draft migrations before merge.
+- API contract changes must update `internal/web/swagger` and pass `make test-openapi`.
+- Keep diffs minimal in high-churn areas: `internal/services/crossseed`, `internal/qbittorrent`, `internal/models`.
 
-When running tests, always use `-race` and `-count=1`.
+## Commits / PRs
 
-For changes under `internal/services/crossseed` or `internal/qbittorrent`, run targeted package tests first. Skip local full `make test` by default; CI covers it unless explicitly requested.
+- Conventional commits: `feat(scope):`, `fix(scope):`, etc.
+- Keep commits focused; split backend/frontend when practical.
+- Never add AI advertising/attribution/co-author lines.
+- PRs need clear summary, testing checklist, and screenshots for visual UI changes.
 
-When adding Go tests that create files with `os.WriteFile`, use `0o600` or tighter permissions unless the test explicitly needs broader mode bits. This avoids `gosec` `G306` lint failures.
+## Final Report
 
-## Commit & Pull Request Guidelines
-
-Follow the conventional commit style in history (`feat(scope):`, `fix(scope):`, etc.) and link issues or PR numbers in the body when relevant. Keep commits focused—split backend and frontend changes when practical.
-
-**Never add:**
-- "🤖 Generated with [Claude Code](https://claude.com/claude-code)"
-- "Co-Authored-By: Claude" or any AI co-author credits
-- Any advertising or attribution in commit messages
-
-PRs need a clear summary, testing checklist, and UI screenshots for visual tweaks. Confirm local targeted verification, `make lint`, and a fresh `make build` succeed before requesting review; rely on CI for the full `make test` suite unless explicitly requested.
-
-## Pre-Commit Checklist
-
-1. `make precommit` passes (`fmt` + `gofix-changed` + `lint`, changed files only)
-2. Targeted local tests for touched packages pass (full `make test` covered by CI unless explicitly requested)
-3. `make build` succeeds
-4. If touched `internal/web/swagger`, run `make test-openapi`
-
-## Security & Configuration Tips
-
-Load secrets such as `THEMES_REPO_TOKEN` via `.env` so the Makefile can fetch premium themes, and keep the file out of version control. Record configuration defaults in `config.toml` but evolve runtime schema through Go migrations rather than editing `qui.db` directly. Drop cached databases and logs (`qui.db*`, `logs/`) from commits to avoid leaking local data.
-
-## API & Database Change Rules
-
-- Database schema changes must ship as migrations under `internal/database/migrations`, include matching model/store updates in the same PR, and add both SQLite and Postgres migrations.
-- For an open PR, keep schema work consolidated to at most one new SQLite migration and one new Postgres migration. If the PR needs more schema changes before merge, edit the draft migration files for that PR instead of adding more migration files.
-- API contract changes must update OpenAPI content under `internal/web/swagger` and pass `make test-openapi`.
-- Prefer minimal, reviewable diffs in high-churn areas (`internal/services/crossseed`, `internal/qbittorrent`, `internal/models`).
-
-## Internationalization (i18n)
-
-The frontend uses `i18next` + `react-i18next` with 10 feature-based namespaces under `web/src/i18n/locales/<lang>/`:
-
-`common`, `auth`, `settings`, `torrents`, `dashboard`, `crossseed`, `rss`, `search`, `instances`, `automations`
-
-Locale JSON files are wired up via `import.meta.glob` in `web/src/i18n/index.ts`: English is bundled eagerly into the main chunk (it is the fallback), while every other language is split into its own lazily-loaded chunk and fetched on demand by `initI18n()` / `changeLanguage()`. This keeps the main bundle small as languages are added (important for the PWA precache size cap in `vite.config.ts`). Currently supported: `en`, `zh-CN`, `fr`, `de`. To expose a language in the UI, add its code to `supportedLanguages` and its display name to `languageNames` in that file.
-
-### i18n Validation Scripts
-
-```bash
-pnpm check:i18n              # Run all i18n checks; fails on errors, zh-CN warnings allowed
-pnpm check:i18n:hardcoded    # AST-based detector for UI strings not yet wrapped in t()
-pnpm check:i18n:zh-cn        # zh-CN translation coverage and quality checks
-```
-
-| Script | Purpose |
-|--------|---------|
-| `check-i18n-keys.mjs` | Validates literal `t("key")` / `i18n.t("key")` calls against English locale JSON when the file namespace can be resolved from `useTranslation(...)` or `ns:` |
-| `check-i18n-implementation.mjs` | Guards a small set of bootstrap invariants in `src/i18n/index.ts` and formatter-hook patterns in `src/hooks/useDateTimeFormatters.ts` |
-| `find-hardcoded-i18n-literals.mjs` | TypeScript AST scan for hardcoded UI strings that should use `t()` |
-| `check-zh-cn-coverage.mjs` | Validates zh-CN files against English for errors (missing/extra keys, interpolation, HTML tags, empty strings, encoding) and reports warnings for punctuation, untranslated strings, and plural-form cleanup |
-
-### Adding a New Language
-
-1. Create `web/src/i18n/locales/<lang>/` with all 10 namespace JSON files — they are picked up automatically via `import.meta.glob`
-2. In `web/src/i18n/index.ts`, add the language code to `supportedLanguages` and its native display name to `languageNames`
-3. Run `pnpm check:i18n` to validate English-key usage plus shared guards; if the new locale is not `zh-CN`, add or adapt a locale-coverage script because the current diff checker is zh-CN-specific
-
-### Translation Workflow
-
-Before translating or reviewing a new locale:
-
-1. Read the English namespace JSON and the relevant UI/components first so strings are translated in product context, not in isolation
-2. Research language-specific gotchas up front: plural rules, punctuation, formality/register, date/time wording, capitalization, technical-term handling, and any script/encoding concerns
-3. Keep a small glossary for product names, torrent/domain terms, and words that should stay in English vs be translated
-4. Preserve placeholders, HTML tags, and key structure exactly unless the locale checker explicitly allows a locale-specific exception
-5. Treat examples, paths, URLs, commands, and technical notation separately from user-facing copy; many should stay as-is
-6. Before calling the locale complete, add or adapt a `<lang>` coverage script against English and run it
-
-Locale coverage is not optional for new languages. The checker must compare every namespace file against English for:
-
-- missing keys
-- extra keys
-- interpolation placeholders
-- HTML tag parity
-- plural-form handling
-- empty strings
-- encoding / JSON validity
-
-Locale-specific quality rules such as punctuation, untranslated technical terms, or style consistency can be warnings, but key coverage and structural parity should fail the check.
-
-### i18n Conventions
-
-- **Plural forms:** English uses `_one`/`_other` (i18next v4 CLDR). Chinese has no plural -- zh-CN only needs `_other`. Legacy `_plural` keys are manually dispatched in code and must exist in all locales.
-- **Technical terms:** Product names and many torrent ecosystem terms are intentionally left in English where that reads better (`qBittorrent`, `Prowlarr`, `DHT`, `PEX`, etc.). Treat this as a translation guideline, not a blanket rule.
-- **Interpolation:** All `{{variable}}` placeholders must be preserved. `{{plural}}` is English-specific and can be omitted in non-English locales.
-- **Chinese punctuation:** Prefer full-width `，。：；！？` in Chinese text. Half-width is still correct inside URLs, IPs, file paths, and technical notation, and the current checker reports punctuation issues as warnings rather than hard failures.
-
-## Architecture Quick Reference
-
-```text
-cmd/qui/main.go              CLI entrypoint (serve, generate-config, create-user, etc.)
-internal/api/                HTTP handlers + middleware (chi router)
-internal/qbittorrent/        Client pool, sync manager
-internal/services/           Domain services (crossseed, jackett, reannounce, trackerrules)
-internal/proxy/              Reverse proxy for external apps
-internal/backups/            Scheduled snapshots
-internal/database/           SQLite + migrations
-internal/models/             Data models + store interfaces
-pkg/                         Shared utilities
-web/src/                     React 19 + Vite + TypeScript + Tailwind v4
-```
-
-**Key data flow:**
-1. `SyncManager` polls qBittorrent instances via `ClientPool`
-2. Torrent state cached in-memory with delta updates
-3. Frontend fetches via REST API, real-time updates via SSE
-4. Cross-seed service listens for torrent completion events
-
-## Notes
-
-- `web/src/components/torrents/TorrentDetailsPanel.tsx` live row state (speed/progress/ratio/state) is stream-backed via `useSyncStream`; polling only runs as a fallback while the stream is unavailable. The Content (files) and Peers tabs still poll on an interval, but that polling is tab-scoped and visibility-gated, so streaming them is optional future work rather than a pending migration.
+State required checks run, skipped/deferred checks with reason, and unresolved failures. Do not claim complete while a required repo check is known failing unless user accepts the risk.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@
 - For a coverage report: `cd web && pnpm test:coverage`.
 - CI runs both `make test` and `make test-frontend` on every PR.
 
-See [`AGENTS.md`](AGENTS.md) / [`CLAUDE.md`](CLAUDE.md) for deeper conventions (test placement, table-driven cases, etc.).
+See [`AGENTS.md`](AGENTS.md) and [`web/AGENTS.md`](web/AGENTS.md) for agent-specific conventions.
 
 ## Database Migrations
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,27 @@
+# Architecture Notes
+
+Internal reference for agents and maintainers. Read this before changing cross-module data flow, service boundaries, API routing, or long-lived architecture. For user-facing docs, use `documentation/docs/`.
+
+## Module Map
+
+- `cmd/qui/main.go`: CLI entrypoint for serve, config generation, user creation, and other commands.
+- `internal/api/`: HTTP handlers, middleware, and routing.
+- `internal/qbittorrent/`: qBittorrent client pool and sync manager.
+- `internal/services/`: domain services such as cross-seed, Jackett/Torznab, reannounce, and tracker rules.
+- `internal/proxy/`: reverse proxy support for external apps.
+- `internal/backups/`: scheduled snapshots.
+- `internal/database/`: SQLite/Postgres migrations and database setup.
+- `internal/models/`: data models and store interfaces.
+- `pkg/`: shared utilities.
+- `web/src/`: React 19, Vite, TypeScript, and Tailwind frontend.
+
+## Core Data Flow
+
+1. `SyncManager` polls qBittorrent instances through `ClientPool`.
+2. Torrent state is cached in memory with delta updates.
+3. Frontend reads state through REST APIs and receives live updates through SSE.
+4. Cross-seed services react to torrent completion and search/match events.
+
+## Frontend Live State Note
+
+`web/src/components/torrents/TorrentDetailsPanel.tsx` live row state such as speed, progress, ratio, and state is stream-backed via `useSyncStream`. Polling only runs as a fallback while the stream is unavailable. Content/files and Peers tabs still poll on an interval, but polling is tab-scoped and visibility-gated, so streaming them is optional future work rather than a pending migration.

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -1,0 +1,33 @@
+# Linting Notes
+
+Internal reference for lint policy and interpretation. Read this when lint output is unclear, when deciding whether to fix or report a lint issue, or when changing lint-related tooling. The actual lint configuration and tool output remain the source of truth.
+
+## Commands
+
+- `make precommit`: fmt + gofix changed files + lint changed files.
+- `make lint`: lint changed files only.
+- `make lint-json`: write lint output to `lint-report.json`.
+- `make fmt`: gofmt + frontend eslint fix on changed files.
+- `make gofix-changed`: apply `go fix` on changed Go files only.
+- `make gofix-check-changed`: check `go fix` drift on changed Go files only.
+
+## Linter Intent
+
+The project uses golangci-lint v2 with strict settings intended to catch common maintainability issues in generated or hand-written code.
+
+| Linter | Purpose | Threshold |
+| --- | --- | --- |
+| `dupl` | Catch code duplication | 100 tokens |
+| `gocognit` | Cognitive complexity | 15 |
+| `funlen` | Function length | 80 lines |
+| `interfacebloat` | Interface size | 5 methods |
+| `errcheck` | Unchecked errors | All, including type assertions |
+| `gocritic` | Non-idiomatic patterns | diagnostic + style + performance |
+
+## Policy
+
+- Prefer `make precommit` during implementation for fast changed-file feedback.
+- If lint/check output reveals a real issue, fix the smallest relevant scope.
+- If a lint finding is outside task scope or appears to be existing unrelated debt, report it instead of broadening the change.
+- Avoid repo-wide `pnpm format` or `eslint --fix` sweeps unless explicitly requested.
+- Do not weaken/delete/skip tests or lint rules to hide failures.

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -1,0 +1,60 @@
+# AGENTS.md
+
+Frontend and i18n rules for work under `web/`.
+
+## Frontend
+
+- React 19 + Vite + TypeScript + Tailwind v4.
+- Source: `web/src`; static assets: `web/public`.
+- Production bundle must stay synced to `internal/web/dist` via `make frontend` or `make build`.
+- Organize React modules by feature within `web/src/{pages,routes,components}`.
+- File names should be descriptive, e.g. `torrent-table.tsx`.
+- Style: two-space indentation, double quotes, trailing commas on multiline literals, Unix line endings.
+- Frontend tests: Vitest + React Testing Library, colocated as `*.test.tsx` near the component.
+
+## React Effects
+
+- Use `useEffect` only to sync with external systems: DOM, subscriptions, network.
+- Avoid derived state in Effects; calculate during render or use `useMemo` for expensive compute.
+- Put user-driven logic in event handlers.
+- To reset state, prefer a `key` or render-time adjustment.
+- Fetch Effects must guard stale responses with cleanup/abort.
+- Reference: https://react.dev/learn/you-might-not-need-an-effect
+
+## i18n
+
+Locales live under `web/src/i18n/locales/<lang>/` with 10 namespaces:
+
+`common`, `auth`, `settings`, `torrents`, `dashboard`, `crossseed`, `rss`, `search`, `instances`, `automations`
+
+English is fallback/eager-loaded. Other languages are lazy-loaded by `initI18n()` / `changeLanguage()` through `import.meta.glob` in `web/src/i18n/index.ts`. Supported today: `en`, `zh-CN`, `fr`, `de`.
+
+## i18n Commands
+
+- `pnpm check:i18n`
+- `pnpm check:i18n:hardcoded`
+- `pnpm check:i18n:zh-cn`
+
+Run relevant checks when touching UI strings, locale JSON, `web/src/i18n/index.ts`, or formatter hooks.
+
+## Adding Languages
+
+1. Add all 10 namespace JSON files under `web/src/i18n/locales/<lang>/`.
+2. Add code to `supportedLanguages` and display name to `languageNames` in `web/src/i18n/index.ts`.
+3. Add/adapt a locale coverage script if the locale is not `zh-CN`.
+4. Run `pnpm check:i18n`.
+
+Coverage must compare against English for missing/extra keys, interpolation placeholders, HTML tag parity, plural forms, empty strings, encoding, and JSON validity.
+
+## Translation Rules
+
+- Read English namespace JSON and relevant UI first; translate in product context.
+- Preserve placeholders, HTML tags, keys, examples, paths, URLs, commands, and technical notation unless the checker allows an exception.
+- Keep a glossary for product names and torrent/domain terms.
+- English plurals use `_one`/`_other`; Chinese needs `_other`. Legacy `_plural` keys are manually dispatched and must exist in all locales.
+- Product/ecosystem terms often stay English where clearer: `qBittorrent`, `Prowlarr`, `DHT`, `PEX`.
+- Chinese text should prefer full-width `，。：；！？`; half-width is fine inside URLs, IPs, paths, and technical notation.
+
+## Torrent Details Note
+
+`web/src/components/torrents/TorrentDetailsPanel.tsx` live row state is stream-backed via `useSyncStream`; polling is fallback while stream unavailable. Content/files and Peers tabs still poll on interval, but polling is tab-scoped and visibility-gated.

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## General guidance

This PR keeps the always-loaded agent guidance small, stable, and action-oriented while preserving deeper project guidance in scoped files that agents can load when relevant. The intent is not to remove pre-existing guidance; it is to make it more usable by Codex and Claude by separating baseline repo rules from frontend, lint-policy, and architecture references.

This follows the official token/context and memory guidance reviewed for this change:

- OpenAI's token docs explain that input text is tokenized and counted as request input, and that large prompts should be shortened, chunked, summarized, or pre-processed when needed: https://help.openai.com/en/articles/4936856-what-are-tokens-and-how-to-count-them
- OpenAI's prompt caching docs say cache hits require exact prefix matches and recommend placing static instructions/examples at the beginning while moving variable content later: https://platform.openai.com/docs/guides/prompt-caching
- Anthropic's Claude Code memory docs say Claude loads `CLAUDE.md`, supports importing `AGENTS.md`, loads directory-walked `CLAUDE.md` files into context, and follows concise/specific instructions more consistently: https://docs.anthropic.com/en/docs/claude-code/memory
- Anthropic's prompt caching docs similarly recommend keeping static instructions/context at the beginning and caching reusable prompt prefixes: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching

## What changed

- `AGENTS.md`
  - Condensed the root agent instructions from a broad all-in-one document into always-loaded repo rules: collaboration expectations, repo map, required commands, backend conventions, code shape, path/security rules, API/database rules, and PR/reporting expectations.
  - Added explicit conditional routing to `docs/architecture.md` before cross-module data-flow/service-boundary/API-routing work.
  - Added explicit conditional routing to `docs/linting.md` only when lint output requires policy judgment; otherwise the actual lint config/tool output remains source of truth.
  - Added explicit routing to `web/AGENTS.md` before frontend/i18n/React work.
  - Reason: OpenAI token docs count instructions as input tokens, and Anthropic memory docs emphasize concise/specific instructions. Keeping root memory shorter reduces default prompt load while retaining guidance through scoped references.

- `web/AGENTS.md`
  - Moved frontend, React Effects, i18n, language-addition, translation, and TorrentDetails live-state notes into a frontend-scoped agent file.
  - Reason: Anthropic documents directory-walked `CLAUDE.md` loading and imports, so frontend-specific guidance is better loaded when agents operate under `web/` instead of always consuming root context. This also matches OpenAI token guidance by limiting default input to relevant instructions.

- `web/CLAUDE.md`
  - Added `@AGENTS.md` so Claude Code can load the frontend-scoped rules from `web/AGENTS.md` when working in `web/`.
  - Reason: Anthropic's Claude Code memory docs state that Claude reads `CLAUDE.md`, not `AGENTS.md`, and recommend importing `AGENTS.md` with `@AGENTS.md` when both tools should share instructions.

- `docs/architecture.md`
  - Moved the architecture quick reference and core data-flow notes into an internal reference document.
  - Reason: architecture notes are important for cross-module changes, but not every agent task needs them in the root prompt. The root file now points to this document exactly when that context matters.

- `docs/linting.md`
  - Moved the linter threshold table and lint-policy notes into an internal reference document.
  - Reason: lint thresholds can drift from config/tool output, so the root file now keeps the durable behavior rule and directs agents to the detail document only for ambiguous lint judgment. This preserves the guidance without making it the main always-loaded source of truth.

- `.gitignore`
  - Unignored `docs/architecture.md` and `docs/linting.md` so these internal reference docs can be tracked despite the existing `docs/*` ignore.

- `CONTRIBUTING.md`
  - Updated the agent-guidance pointer to reference `AGENTS.md` and `web/AGENTS.md`.

## Validation

- Reviewed the changes against the official OpenAI token/counting and prompt-caching docs plus Anthropic Claude Code memory and prompt-caching docs listed above.
- Verified the staged diff is documentation/guidance only.
- No build/test run: no runtime code, generated assets, OpenAPI, database schema, or frontend source changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated and reorganized internal development guidelines, including architecture reference, linting standards, and contributor conventions for clearer project guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->