### PR TITLE
fix(ci): skip release binary build on main pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,7 +161,6 @@ jobs:
           fi
 
       - name: Run GoReleaser build and publish tags
-        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/develop'
         uses: goreleaser/goreleaser-action@v7.2.2
         with:
           distribution: goreleaser

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
 
   goreleaserbuild:
     name: Build distribution binaries
-    if: github.event_name != 'pull_request'
+    if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
     needs: [test, web]
     steps:


### PR DESCRIPTION
The `goreleaserbuild` job runs on any non-PR push, but its GoReleaser step is gated to tags and develop only. On `main` the build step is skipped, leaving `dist/` empty, and since #1969 added `if-no-files-found: error` the unconditional "Upload assets" step fails the Release workflow on every `main` push (develop, tags, and PRs are unaffected).

Gate the whole job to tags/develop so it only runs where it actually has binaries to upload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release build pipeline to execute only when triggered by version tags or the develop branch, providing more controlled release deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->