### PR TITLE
docs: promote multi-language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ docker run -d \
 - **Automations**: Rule-based torrent management with conditions and actions
 - **Backups & Restore**: Scheduled snapshots with multiple restore modes
 - **Reverse Proxy**: Transparent qBittorrent proxy for external apps
+- **Multi-Language**: Available in English, German, French, and Simplified Chinese, with automatic browser-language detection
 
 ## Community
 

--- a/documentation/docs/intro.md
+++ b/documentation/docs/intro.md
@@ -24,6 +24,7 @@ A web interface for qBittorrent. Manage multiple qBittorrent instances from a si
 - **Cross-Seed**: Automatically find and add matching torrents across trackers with autobrr webhook integration
 - **Reverse Proxy**: Transparent qBittorrent proxy for external apps like autobrr, Sonarr, and Radarr—no credential sharing needed
 - **Incognito Mode**: Disguise torrents as Linux ISOs for screen sharing and screenshots
+- **Multi-Language**: Interface available in English, German, French, and Simplified Chinese with automatic browser-language detection
 
 ## Browser Extensions
 
@@ -31,6 +32,14 @@ Right-click any magnet or torrent link to add it directly to your qBittorrent in
 
 - [Chrome Extension](https://chromewebstore.google.com/detail/kbjnjgihepmcoilegnghgpmijbecoili)
 - [Firefox Add-on](https://addons.mozilla.org/en-US/firefox/addon/qui/)
+
+## Languages
+
+qui is available in English, German, French, and Simplified Chinese. The interface detects your browser language on first load and remembers your choice after that.
+
+To change it manually, open the user menu in the top-right corner and pick a language from the globe submenu.
+
+Translations are community-contributed and we welcome more. To add or improve a language, start a [Discussion](https://github.com/autobrr/qui/discussions/new/choose) or reach out on [Discord](https://discord.autobrr.com/qui). The translation workflow is documented in [`web/AGENTS.md`](https://github.com/autobrr/qui/blob/develop/web/AGENTS.md).
 
 ## Quick Start
 

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -43,6 +43,7 @@ Run relevant checks when touching UI strings, locale JSON, `web/src/i18n/index.t
 2. Add code to `supportedLanguages` and display name to `languageNames` in `web/src/i18n/index.ts`.
 3. Add/adapt a locale coverage script if the locale is not `zh-CN`.
 4. Run `pnpm check:i18n`.
+5. Update the supported-language list in `README.md` (Features) and `documentation/docs/intro.md` (Features + Languages section) so the promoted list stays accurate.
 
 Coverage must compare against English for missing/extra keys, interpolation placeholders, HTML tag parity, plural forms, empty strings, encoding, and JSON validity.
 


### PR DESCRIPTION
qui has shipped multi-language support (English, German, French, and Simplified Chinese) since v1.20.0 with automatic browser-locale detection, but it was not mentioned anywhere in the README or docs. This adds a Features bullet to both and a short Languages section in the docs covering how to switch languages and contribute translations.

Also adds a checklist line to `web/AGENTS.md` so the promoted language list stays in sync whenever a new language is added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated feature documentation to highlight multi-language support availability in English, German, French, and Simplified Chinese with automatic browser-language detection.
  * Added a Languages section with instructions for switching languages via the user menu and resources for translation contributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->