### PR TITLE
fix(docs): use relative file paths for markdown links

### DIFF
--- a/documentation/docs/configuration/environment.md
+++ b/documentation/docs/configuration/environment.md
@@ -7,7 +7,7 @@ title: Environment Variables
 
 Configuration is stored in `config.toml` (created automatically on first run, or manually with `qui generate-config`). You can also use environment variables:
 
-For the complete list (including `config.toml` keys, defaults, and notes), see [Configuration Reference](./reference).
+For the complete list (including `config.toml` keys, defaults, and notes), see [Configuration Reference](./reference.md).
 
 ## Server
 
@@ -123,7 +123,7 @@ Non-canonical CIDRs with host bits set (for example `10.0.0.5/8`) are rejected.
 
 `QUI__OIDC_ENABLED=true` cannot be combined with auth-disabled mode.
 
-Only use this when qui runs behind a reverse proxy that already handles authentication (e.g., Authelia, Authentik, Caddy with forward_auth). See the [Configuration Reference](./reference#authentication) for a full explanation of the risks.
+Only use this when qui runs behind a reverse proxy that already handles authentication (e.g., Authelia, Authentik, Caddy with forward_auth). See the [Configuration Reference](./reference.md#authentication) for a full explanation of the risks.
 
 Built-in health endpoints (`/health`, `/healthz/readiness`, `/healthz/liveness`) always allow loopback probes, so the official Docker image healthcheck continues to work even if your allowlist only includes the reverse proxy subnet(s).
 

--- a/documentation/docs/configuration/oidc.md
+++ b/documentation/docs/configuration/oidc.md
@@ -11,7 +11,7 @@ If your provider advertises PKCE (`S256`) support, qui uses it automatically for
 To confirm it is active, inspect `/api/auth/oidc/config` and verify `authorizationUrl` includes both `code_challenge=` and `code_challenge_method=S256`.
 qui does not currently emit a dedicated "PKCE enabled" log line, so the authorize URL is the easiest check.
 
-For the full mapping (TOML keys + environment variables + defaults), see [Configuration Reference](./reference).
+For the full mapping (TOML keys + environment variables + defaults), see [Configuration Reference](./reference.md).
 
 ## Configuration Options
 
@@ -36,7 +36,7 @@ When reverse proxying, include your base URL:
 https://host/qui/api/auth/oidc/callback
 ```
 
-If you run OIDC behind an SSO proxy (Cloudflare Access, Pangolin, etc.), review [SSO proxies and CORS](../advanced/sso-proxy-cors) for browser fetch behavior and proxy-side configuration.
+If you run OIDC behind an SSO proxy (Cloudflare Access, Pangolin, etc.), review [SSO proxies and CORS](../advanced/sso-proxy-cors.md) for browser fetch behavior and proxy-side configuration.
 
 ## Example Configuration
 

--- a/documentation/docs/configuration/reference.md
+++ b/documentation/docs/configuration/reference.md
@@ -136,7 +136,7 @@ Rules:
 - path/query/fragment/userinfo are rejected
 - invalid values refuse startup; invalid live reloads are rejected and keep the last valid allowlist
 
-For SSO proxy setups, prefer configuring CORS on the proxy auth endpoints first. See [SSO Proxies and CORS](../advanced/sso-proxy-cors).
+For SSO proxy setups, prefer configuring CORS on the proxy auth endpoints first. See [SSO Proxies and CORS](../advanced/sso-proxy-cors.md).
 
 ## Example `config.toml`
 

--- a/documentation/docs/features/cross-seed/autobrr.md
+++ b/documentation/docs/features/cross-seed/autobrr.md
@@ -144,7 +144,7 @@ Use this when autobrr shows the filter accepted the release (or your Discord not
 5. **Check paused torrents**
    - Cross-seeds are often added **paused**. Look in qBittorrent's paused list (and any cross-seed tag/category you configured).
 
-If you still can't see why, jump to [Cross-Seed Troubleshooting](troubleshooting).
+If you still can't see why, jump to [Cross-Seed Troubleshooting](./troubleshooting.md).
 
 ## Webhook Source Filters
 
@@ -173,4 +173,4 @@ qui also supports a dedicated season-pack flow through separate endpoints. When 
 
 This uses different endpoints (`/api/cross-seed/season-pack/check` and `/api/cross-seed/season-pack/apply`) and requires a separate autobrr filter.
 
-See [Season Packs](season-packs) for full setup instructions.
+See [Season Packs](./season-packs.md) for full setup instructions.

--- a/documentation/docs/features/cross-seed/dir-scan.md
+++ b/documentation/docs/features/cross-seed/dir-scan.md
@@ -355,8 +355,8 @@ Partial matches in link tree mode (hardlink or reflink) require **Download missi
 :::
 
 See:
-- [Hardlink Mode](hardlink-mode)
-- [Link Directories](link-directories)
+- [Hardlink Mode](./hardlink-mode.md)
+- [Link Directories](./link-directories.md)
 
 ### Fallback to regular mode
 
@@ -412,4 +412,4 @@ Click a run to see details including failure reasons for individual items.
 - Indexers may throttle requests. Check **Scheduler Activity** on the Indexers page.
 - Consider reducing scan frequency or limiting to fewer indexers.
 
-For cross-seed-wide issues (matching behavior, hardlink failures, recheck problems), see [Troubleshooting](troubleshooting).
+For cross-seed-wide issues (matching behavior, hardlink failures, recheck problems), see [Troubleshooting](./troubleshooting.md).

--- a/documentation/docs/features/cross-seed/hardlink-mode.md
+++ b/documentation/docs/features/cross-seed/hardlink-mode.md
@@ -34,7 +34,7 @@ Example: `/mnt/disk1/cross-seed, /mnt/disk2/cross-seed, /mnt/disk3/cross-seed`
 - Hardlink mode is a **per-instance setting** (not per request). Each qBittorrent instance can have its own hardlink configuration.
 - Torrents added via hardlink/reflink mode always use an explicit `savepath` (the link-tree root), which forces **AutoTMM off**. Enabling AutoTMM after adding can move files out of the link tree.
 - By default, if a hardlink cannot be created (no local access, filesystem mismatch, invalid base dir, etc.), the cross-seed **fails**.
-- Enable **"Fallback to regular mode"** to allow failed hardlink operations to use regular cross-seed mode instead of failing. Filesystem fallback uses a full recheck; see [troubleshooting](troubleshooting#when-rechecks-are-required-reuse-mode).
+- Enable **"Fallback to regular mode"** to allow failed hardlink operations to use regular cross-seed mode instead of failing. Filesystem fallback uses a full recheck; see [troubleshooting](./troubleshooting.md#when-rechecks-are-required-reuse-mode).
 - When fallback handles a partial or otherwise non-perfect match, qui runs a piece-boundary safety check before adding the torrent to qBittorrent. This fallback check is always enforced, even if **Skip piece boundary safety check** is enabled for regular reuse mode.
 - Hardlinked torrents are still categorized using your existing cross-seed category rules (category affix, indexer name, or custom category); the hardlink preset only affects on-disk folder layout.
 
@@ -74,7 +74,7 @@ For the `flat` preset, an isolation folder is always used to keep each torrent's
 
 By default, hardlink-added torrents start seeding immediately (since `skip_checking=true` means they're at 100% instantly). If you want hardlink-added torrents to remain paused, enable the "Skip auto-resume" option for your cross-seed source (Completion, RSS, Webhook, etc.).
 
-When hardlink/reflink mode creates a complete link tree with no extra files to download, qui adds the torrent with hash checking skipped and does not trigger an automatic recheck. If qBittorrent instead reports `missing files`, see [Hardlink/reflink cross-seed shows "missing files"](troubleshooting#hardlinkreflink-cross-seed-shows-missing-files).
+When hardlink/reflink mode creates a complete link tree with no extra files to download, qui adds the torrent with hash checking skipped and does not trigger an automatic recheck. If qBittorrent instead reports `missing files`, see [Hardlink/reflink cross-seed shows "missing files"](./troubleshooting.md#hardlinkreflink-cross-seed-shows-missing-files).
 
 When the incoming torrent has extra files that are not present in the matched torrent, qui adds the torrent paused, triggers a recheck, and resumes it only after qBittorrent reports progress at or above the configured threshold.
 
@@ -85,7 +85,7 @@ If hardlink/reflink mode falls back to regular mode for a partial or non-perfect
 - Hardlinks share disk blocks with the original file but increase the link count. Deleting one link does not necessarily free space until all links are removed.
 - Windows support: folder names are sanitized to remove characters Windows forbids. Torrent file paths themselves still need to be valid for your qBittorrent setup.
 - Hardlink mode supports extra files when piece-boundary safe. If the incoming torrent contains extra files not present in the matched torrent (e.g., `.nfo`/`.srt` sidecars), hardlink mode will link the content files and trigger a recheck so qBittorrent downloads the extras. If extras share pieces with content (unsafe), the cross-seed is skipped.
-- Partial matches (e.g., season packs where only some episodes are on disk) require the **Download missing files** setting to be enabled in [Dir Scan settings](dir-scan#settings-global). Without it, partial link tree injections are rejected.
+- Partial matches (e.g., season packs where only some episodes are on disk) require the **Download missing files** setting to be enabled in [Dir Scan settings](./dir-scan.md#settings-global). Without it, partial link tree injections are rejected.
 
 ## Reflink Mode (Alternative)
 

--- a/documentation/docs/features/cross-seed/overview.md
+++ b/documentation/docs/features/cross-seed/overview.md
@@ -22,13 +22,13 @@ qui supports three modes for handling files:
 - **Hardlink mode** (optional): Creates a hardlinked copy of the matched files laid out exactly as the incoming torrent expects, then adds the torrent pointing at that tree. Avoids rename-alignment entirely.
 - **Reflink mode** (optional): Creates copy-on-write clones (reflinks) of the matched files. Allows safe cross-seeding of torrents with extra/missing files because qBittorrent can write/repair the clones without affecting originals.
 
-Disc-based media (Blu-ray/DVD) requires manual verification. See [troubleshooting](troubleshooting#blu-ray-or-dvd-cross-seed-left-paused).
+Disc-based media (Blu-ray/DVD) requires manual verification. See [troubleshooting](./troubleshooting.md#blu-ray-or-dvd-cross-seed-left-paused).
 
 ## Prerequisites
 
 You need Prowlarr or Jackett to provide Torznab indexer feeds. Add your indexers in **Settings → Indexers** using the "1-click sync" feature to import from Prowlarr/Jackett automatically.
 
-Optional: qui can also query OPS/RED directly via the trackers' Gazelle JSON APIs. This complements Torznab, can handle OPS/RED searches even when no Torznab backend is available, and excludes OPS/RED Torznab indexers for per-torrent searches only when **both** Gazelle keys are configured. See [OPS/RED (Gazelle)](gazelle-ops-red).
+Optional: qui can also query OPS/RED directly via the trackers' Gazelle JSON APIs. This complements Torznab, can handle OPS/RED searches even when no Torznab backend is available, and excludes OPS/RED Torznab indexers for per-torrent searches only when **both** Gazelle keys are configured. See [OPS/RED (Gazelle)](./gazelle-ops-red.md).
 
 **Optional but recommended:** Configure Sonarr/Radarr instances in **Settings → Integrations** to enable external ID lookups (IMDb, TMDb, TVDb, TVMaze). When configured, qui queries your *arr instances to resolve IDs for cross-seed searches, improving match accuracy on indexers that support ID-based queries.
 - This is especially helpful for content that is "AKA" type, and can have differing names depending on locale.
@@ -81,7 +81,7 @@ Right-click any torrent in the list to access cross-seed actions:
 
 ### Season Pack Assembly
 
-Assemble season-pack torrents from individual episodes you already seed. When autobrr announces a season pack, qui checks your qBittorrent instances for matching episodes, links whatever is already local, and lets qBittorrent download the remainder after recheck when coverage passes the configured threshold (default 75%). Sonarr, TVDB, and TVMaze improve the threshold decision when available. Requires local filesystem access and hardlink/reflink mode. See [Season Packs](season-packs) for setup.
+Assemble season-pack torrents from individual episodes you already seed. When autobrr announces a season pack, qui checks your qBittorrent instances for matching episodes, links whatever is already local, and lets qBittorrent download the remainder after recheck when coverage passes the configured threshold (default 75%). Sonarr, TVDB, and TVMaze improve the threshold decision when available. Requires local filesystem access and hardlink/reflink mode. See [Season Packs](./season-packs.md) for setup.
 
 ## Blocklist
 

--- a/documentation/docs/features/cross-seed/rules.md
+++ b/documentation/docs/features/cross-seed/rules.md
@@ -20,7 +20,7 @@ Filesystem fallback and disc layouts (`BDMV`/`VIDEO_TS`) are treated more strict
 
 ## Season Pack Threshold
 
-The season-pack webhook uses a separate coverage threshold (default 75%) to decide whether enough local data exists to inject a pack. Season episode totals are sourced from Sonarr first, then TVDB or TVMaze when Sonarr cannot resolve the release. When torrent data is available, qui never uses a total lower than the playable file count in the pack torrent. Incomplete packs are added paused, rechecked, then resumed automatically when qBittorrent reports progress at or above the season-pack threshold. This is configured in **Rules > Season packs**. Instances must have local filesystem access and hardlink or reflink mode enabled to qualify. See [Season Packs](season-packs) for details.
+The season-pack webhook uses a separate coverage threshold (default 75%) to decide whether enough local data exists to inject a pack. Season episode totals are sourced from Sonarr first, then TVDB or TVMaze when Sonarr cannot resolve the release. When torrent data is available, qui never uses a total lower than the playable file count in the pack torrent. Incomplete packs are added paused, rechecked, then resumed automatically when qBittorrent reports progress at or above the season-pack threshold. This is configured in **Rules > Season packs**. Instances must have local filesystem access and hardlink or reflink mode enabled to qualify. See [Season Packs](./season-packs.md) for details.
 
 Season-pack matching rules live in **Rules > Season packs** and affect only the season-pack webhook flow.
 

--- a/documentation/docs/features/cross-seed/season-packs.md
+++ b/documentation/docs/features/cross-seed/season-packs.md
@@ -102,7 +102,7 @@ In hardlink mode, incomplete packs are also subject to piece-boundary protection
 
 Instances without local filesystem access or a link mode are skipped during eligibility checks.
 
-See [Hardlink Mode](hardlink-mode) for setup instructions.
+See [Hardlink Mode](./hardlink-mode.md) for setup instructions.
 
 ## Setup
 

--- a/documentation/docs/features/cross-seed/troubleshooting.md
+++ b/documentation/docs/features/cross-seed/troubleshooting.md
@@ -32,21 +32,21 @@ Library scan and completion search rows use **added**, **skipped**, or **failed*
 
 | Status or message | Outcome | What it usually means | What to check |
 | --- | --- | --- | --- |
-| `exists` | Skipped | The exact torrent infohash is already in the target qBittorrent instance. | This is normally harmless. If you expected a new tracker result, check the source and target indexers in [Cross-Seed Overview](overview#discovery-methods). |
-| `no_match` | Skipped | qui searched but did not find an existing local torrent with the required files. | Review [release matching](#release-didnt-match), source filters, and the discovery method in [Library Scan](overview#library-scan) or [Auto-Search on Completion](overview#auto-search-on-completion). |
-| `blocked` | Skipped | The candidate infohash is on the cross-seed blocklist. | Remove it from **Cross-Seed > Blocklist** if you want qui to try it again. See [Blocklist](overview#blocklist). |
-| `skipped_recheck` | Skipped | The match would require a recheck, but **Skip recheck** is enabled. | See [When Rechecks Are Required](#when-rechecks-are-required-reuse-mode) and [Rules](rules#matching). |
-| `skipped_unsafe_pieces` | Skipped | The incoming torrent has missing or extra files whose pieces overlap existing content, or a link-mode fallback would leave unsafe unmaterialized pieces. qui skips before adding to avoid modifying existing data. | See [Cross-seed skipped: "extra files share pieces with content"](#cross-seed-skipped-extra-files-share-pieces-with-content) and [Reflink Mode](hardlink-mode#reflink-mode-alternative). |
-| `below_threshold` | Skipped | The matched files do not meet the configured completion threshold after materialization or recheck. | Check **Size mismatch tolerance** in [Rules](rules#matching), then see [Cross-seed stuck at low percentage after recheck](#cross-seed-stuck-at-low-percentage-after-recheck). |
-| `requires_hardlink_reflink` | Skipped | The torrent layout would scatter rootless or extra files in regular reuse mode. | Enable [Hardlink Mode](hardlink-mode) or [Reflink Mode](hardlink-mode#reflink-mode-alternative), or download the torrent normally. |
+| `exists` | Skipped | The exact torrent infohash is already in the target qBittorrent instance. | This is normally harmless. If you expected a new tracker result, check the source and target indexers in [Cross-Seed Overview](./overview.md#discovery-methods). |
+| `no_match` | Skipped | qui searched but did not find an existing local torrent with the required files. | Review [release matching](#release-didnt-match), source filters, and the discovery method in [Library Scan](./overview.md#library-scan) or [Auto-Search on Completion](./overview.md#auto-search-on-completion). |
+| `blocked` | Skipped | The candidate infohash is on the cross-seed blocklist. | Remove it from **Cross-Seed > Blocklist** if you want qui to try it again. See [Blocklist](./overview.md#blocklist). |
+| `skipped_recheck` | Skipped | The match would require a recheck, but **Skip recheck** is enabled. | See [When Rechecks Are Required](#when-rechecks-are-required-reuse-mode) and [Rules](./rules.md#matching). |
+| `skipped_unsafe_pieces` | Skipped | The incoming torrent has missing or extra files whose pieces overlap existing content, or a link-mode fallback would leave unsafe unmaterialized pieces. qui skips before adding to avoid modifying existing data. | See [Cross-seed skipped: "extra files share pieces with content"](#cross-seed-skipped-extra-files-share-pieces-with-content) and [Reflink Mode](./hardlink-mode.md#reflink-mode-alternative). |
+| `below_threshold` | Skipped | The matched files do not meet the configured completion threshold after materialization or recheck. | Check **Size mismatch tolerance** in [Rules](./rules.md#matching), then see [Cross-seed stuck at low percentage after recheck](#cross-seed-stuck-at-low-percentage-after-recheck). |
+| `requires_hardlink_reflink` | Skipped | The torrent layout would scatter rootless or extra files in regular reuse mode. | Enable [Hardlink Mode](./hardlink-mode.md) or [Reflink Mode](./hardlink-mode.md#reflink-mode-alternative), or download the torrent normally. |
 | `size_mismatch` | Failed | A search result already exists by infohash, but the earlier content prefilter rejected it because the torrent file list did not match the source sizes. | Compare the torrent files on the trackers. This protects you from treating different content as a valid cross-seed. See [release matching](#release-didnt-match). |
 | `content_mismatch` | Failed | A search result already exists by infohash, but the earlier content prefilter rejected it for a non-size file-level reason. | Review the row message and enable trace logging if needed. See [How do I see why a release was filtered?](#how-do-i-see-why-a-release-was-filtered). |
-| `hardlink_error` | Failed | Hardlink mode was enabled but qui could not create or use the hardlink tree. | See [Hardlink mode failed](#hardlink-mode-failed) and [Hardlink Mode requirements](hardlink-mode#requirements). |
-| `reflink_error` | Failed | Reflink mode was enabled but qui could not create or use the reflink tree. | See [Reflink mode failed](#reflink-mode-failed) and [Reflink Requirements](hardlink-mode#reflink-requirements). |
-| `no_save_path` | Failed | qui could not find a valid target save path for the cross-seed. The matched torrent has no usable SavePath and the category does not provide an explicit SavePath. | Verify the matched torrent's save path and category save path in qBittorrent, then review [category behavior](rules#category-behavior-details). |
-| `error`, `alignment_failed`, or `pause_failed` | Failed | qBittorrent rejected the add, a required file or folder rename failed, or qui could not pause a misaligned torrent after an alignment failure. | Check the instance connection, qBittorrent logs, and save path/category behavior in [Rules](rules#category-behavior-details). |
+| `hardlink_error` | Failed | Hardlink mode was enabled but qui could not create or use the hardlink tree. | See [Hardlink mode failed](#hardlink-mode-failed) and [Hardlink Mode requirements](./hardlink-mode.md#requirements). |
+| `reflink_error` | Failed | Reflink mode was enabled but qui could not create or use the reflink tree. | See [Reflink mode failed](#reflink-mode-failed) and [Reflink Requirements](./hardlink-mode.md#reflink-requirements). |
+| `no_save_path` | Failed | qui could not find a valid target save path for the cross-seed. The matched torrent has no usable SavePath and the category does not provide an explicit SavePath. | Verify the matched torrent's save path and category save path in qBittorrent, then review [category behavior](./rules.md#category-behavior-details). |
+| `error`, `alignment_failed`, or `pause_failed` | Failed | qBittorrent rejected the add, a required file or folder rename failed, or qui could not pause a misaligned torrent after an alignment failure. | Check the instance connection, qBittorrent logs, and save path/category behavior in [Rules](./rules.md#category-behavior-details). |
 
-Failed search or completion runs can trigger notification events. See [Notifications](../notifications#event-types) for the event keys.
+Failed search or completion runs can trigger notification events. See [Notifications](../notifications.md#event-types) for the event keys.
 
 :::tip
 `size_mismatch` failures are generated from the size reported inside of torrent files, not the content on disk. These failures are strong indicators that the cross seeded content has mismatching piece hashes between trackers. One or more trackers had a bad hash copy.
@@ -56,7 +56,7 @@ If the source torrent is the bad hash, the hash in `debug` logging `[CROSSSEED-A
 :::
 
 :::tip
-Use [piece boundary protection](rules#matching) to protect content against bad hash torrents.
+Use [piece boundary protection](./rules.md#matching) to protect content against bad hash torrents.
 
 ## Why did my season-pack check return 404?
 
@@ -75,7 +75,7 @@ If the pack should match except for REPACK, HDR, WEB, or year differences, check
 
 Open **Cross-Seed > Rules > Season packs** for recent season-pack activity. It shows the check/apply phase, status, reason, message, coverage, matched episodes, total episodes, selected instance, and link mode. You can also query `/api/cross-seed/season-pack/runs?limit=20` directly.
 
-See [Season Packs](season-packs) for the full flow, setup requirements, and season-pack-specific debugging steps.
+See [Season Packs](./season-packs.md) for the full flow, setup requirements, and season-pack-specific debugging steps.
 
 ## How do I see why a release was filtered?
 

--- a/documentation/docs/features/instance-settings.md
+++ b/documentation/docs/features/instance-settings.md
@@ -53,7 +53,7 @@ When enabled, qui can access the same filesystem as qBittorrent. This unlocks se
 Only enable this if qui runs on the same machine (or has the same mounts) as qBittorrent. If paths don't match, features will fail silently or produce incorrect results.
 :::
 
-For Docker deployments, ensure the container has the necessary volume mounts. See [Docker configuration](/docs/getting-started/docker) for details.
+For Docker deployments, ensure the container has the necessary volume mounts. See [Docker configuration](../getting-started/docker.md) for details.
 
 ## Instance Actions
 

--- a/documentation/docs/features/reverse-proxy.md
+++ b/documentation/docs/features/reverse-proxy.md
@@ -52,7 +52,7 @@ http://localhost:7476/proxy/abc123def456ghi789jkl012mno345pqr678stu901vwx234yz
 4. Leave username/password blank and press **Test**
 5. Leave basic auth blank since qui handles that
 
-For cross-seed integration with autobrr, see the [Cross-Seed](/docs/features/cross-seed/autobrr) section.
+For cross-seed integration with autobrr, see the [Cross-Seed](./cross-seed/autobrr.md) section.
 
 ### cross-seed
 

--- a/documentation/docs/getting-started/windows.md
+++ b/documentation/docs/getting-started/windows.md
@@ -36,7 +36,7 @@ Avoid placing qui in `C:\Program Files` — it can cause permission issues with 
 
 ### Configuration
 
-qui stores its configuration and runtime data in `%APPDATA%\qui\` by default. With the default SQLite engine, `qui.db` is stored there too. For more details, see the [Configuration](/docs/configuration/environment) section.
+qui stores its configuration and runtime data in `%APPDATA%\qui\` by default. With the default SQLite engine, `qui.db` is stored there too. For more details, see the [Configuration](../configuration/environment.md) section.
 
 ## Create a Windows Task
 
@@ -85,7 +85,7 @@ qui has a built-in update command. You must stop the Task Scheduler job first, o
 
 For remote access, it's recommended to run qui behind a reverse proxy like [Caddy](https://caddyserver.com/) or nginx for TLS and additional security.
 
-See the [Base URL](/docs/configuration/base-url) section for reverse proxy configuration examples.
+See the [Base URL](../configuration/base-url.md) section for reverse proxy configuration examples.
 
 ## Finishing Up
 

--- a/documentation/docs/intro.md
+++ b/documentation/docs/intro.md
@@ -45,7 +45,7 @@ Translations are community-contributed and we welcome more. To add or improve a 
 
 Get started in minutes:
 
-1. [Install qui](/docs/getting-started/installation)
+1. [Install qui](./getting-started/installation.md)
 2. Open your browser to http://localhost:7476
 3. Create your admin account
 4. Add your qBittorrent instance(s)


### PR DESCRIPTION
Fix for #1935 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized internal documentation links across configuration, cross-seed, and getting-started guides to consistently use relative paths and `.md` targets, including corrected anchors for authentication and related sections.
  * Updated guidance content with an added note in the CORS configuration reference for SSO proxy setups, plus improved Cross-Seed troubleshooting tips and several supporting link corrections (including Season Pack Threshold references).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->