### PR TITLE
fix(torrents): route unified view exports to the owning instance

### DIFF
--- a/web/src/hooks/torrent-table/__tests__/useBulkActionWrappers.test.ts
+++ b/web/src/hooks/torrent-table/__tests__/useBulkActionWrappers.test.ts
@@ -86,6 +86,32 @@ describe("useBulkActionWrappers — argument forwarding", () => {
       sortOrder: "desc",
     }))
   })
+
+  it("forwards instanceIds and excluded targets to export on cross-instance select-all", () => {
+    const excludedTargets = [{ instanceId: 2, hash: "x" }]
+    const params = makeParams({
+      isAllSelected: true,
+      isCrossInstanceEndpoint: true,
+      instanceIds: [2, 3],
+      selectAllExcludedTargets: excludedTargets,
+    })
+    const { result } = render(params)
+    act(() => result.current.handleExportWrapper([], []))
+    expect(vi.mocked(params.exportTorrents)).toHaveBeenCalledWith(expect.objectContaining({
+      instanceIds: [2, 3],
+      excludeTargets: excludedTargets,
+    }))
+  })
+
+  it("omits instanceIds and excluded targets from export on a single-instance endpoint", () => {
+    const params = makeParams({ isAllSelected: true, isCrossInstanceEndpoint: false })
+    const { result } = render(params)
+    act(() => result.current.handleExportWrapper([], []))
+    expect(vi.mocked(params.exportTorrents)).toHaveBeenCalledWith(expect.objectContaining({
+      instanceIds: undefined,
+      excludeTargets: undefined,
+    }))
+  })
 })
 
 describe("useBulkActionWrappers — runAction", () => {

--- a/web/src/hooks/torrent-table/useBulkActionWrappers.ts
+++ b/web/src/hooks/torrent-table/useBulkActionWrappers.ts
@@ -158,6 +158,8 @@ export function useBulkActionWrappers({
       filters: selectAllFilters ?? filters,
       search: effectiveSearch,
       excludeHashes: selectAllExcludeHashes,
+      excludeTargets: isAllSelected && isCrossInstanceEndpoint ? selectAllExcludedTargets : undefined,
+      instanceIds: isCrossInstanceEndpoint ? instanceIds : undefined,
       sortField: activeSortField,
       sortOrder: activeSortOrder,
     })
@@ -169,6 +171,9 @@ export function useBulkActionWrappers({
     filters,
     effectiveSearch,
     selectAllExcludeHashes,
+    selectAllExcludedTargets,
+    isCrossInstanceEndpoint,
+    instanceIds,
     activeSortField,
     activeSortOrder,
   ])

--- a/web/src/hooks/useTorrentExporter.test.ts
+++ b/web/src/hooks/useTorrentExporter.test.ts
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { useTorrentExporter } from "@/hooks/useTorrentExporter"
+import { api } from "@/lib/api"
+import { makeTorrent } from "@/test/mockTorrent"
+import type { CrossInstanceTorrent, Torrent } from "@/types"
+import { act, renderHook } from "@testing-library/react"
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}))
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    exportTorrent: vi.fn(),
+    getTorrents: vi.fn(),
+    getCrossInstanceTorrents: vi.fn(),
+  },
+}))
+
+const mockedApi = vi.mocked(api)
+
+function makeCrossTorrent(overrides: Partial<CrossInstanceTorrent>): CrossInstanceTorrent {
+  return {
+    ...makeTorrent(overrides),
+    instanceId: overrides.instanceId ?? 1,
+    instanceName: overrides.instanceName ?? "instance",
+  }
+}
+
+function exportSelection(torrents: Torrent[], overrides: Record<string, unknown> = {}) {
+  return {
+    hashes: torrents.map(t => t.hash),
+    torrents,
+    isAllSelected: false,
+    totalSelected: torrents.length,
+    ...overrides,
+  }
+}
+
+let anchorClick: ReturnType<typeof vi.spyOn>
+
+beforeAll(() => {
+  URL.createObjectURL = vi.fn(() => "blob:mock")
+  URL.revokeObjectURL = vi.fn()
+  anchorClick = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {})
+})
+
+afterAll(() => {
+  anchorClick.mockRestore()
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockedApi.exportTorrent.mockResolvedValue({ blob: new Blob(["data"]), filename: null })
+  mockedApi.getTorrents.mockResolvedValue({ torrents: [], total: 0, hasMore: false })
+  mockedApi.getCrossInstanceTorrents.mockResolvedValue({ torrents: [], total: 0, hasMore: false })
+})
+
+describe("useTorrentExporter — per-torrent instance routing", () => {
+  it("routes each export to the torrent's own instance in unified scope", async () => {
+    const { result } = renderHook(() => useTorrentExporter({ instanceId: 0, incognitoMode: false }))
+    const torrents = [
+      makeCrossTorrent({ hash: "aaa", instanceId: 2 }),
+      makeCrossTorrent({ hash: "bbb", instanceId: 3 }),
+    ]
+
+    await act(async () => {
+      await result.current.exportTorrents(exportSelection(torrents))
+    })
+
+    expect(mockedApi.exportTorrent).toHaveBeenCalledTimes(2)
+    expect(mockedApi.exportTorrent).toHaveBeenCalledWith(2, "aaa")
+    expect(mockedApi.exportTorrent).toHaveBeenCalledWith(3, "bbb")
+    expect(mockedApi.exportTorrent).not.toHaveBeenCalledWith(0, expect.anything())
+  })
+
+  it("falls back to the view instance for plain torrents in a single-instance view", async () => {
+    const { result } = renderHook(() => useTorrentExporter({ instanceId: 2, incognitoMode: false }))
+    const torrents = [makeTorrent({ hash: "aaa" })]
+
+    await act(async () => {
+      await result.current.exportTorrents(exportSelection(torrents))
+    })
+
+    expect(mockedApi.exportTorrent).toHaveBeenCalledTimes(1)
+    expect(mockedApi.exportTorrent).toHaveBeenCalledWith(2, "aaa")
+  })
+
+  it("exports both copies when the same hash exists on two instances", async () => {
+    const { result } = renderHook(() => useTorrentExporter({ instanceId: 0, incognitoMode: false }))
+    const torrents = [
+      makeCrossTorrent({ hash: "same", instanceId: 2 }),
+      makeCrossTorrent({ hash: "same", instanceId: 3 }),
+    ]
+
+    await act(async () => {
+      await result.current.exportTorrents(exportSelection(torrents, { hashes: ["same"] }))
+    })
+
+    expect(mockedApi.exportTorrent).toHaveBeenCalledTimes(2)
+    expect(mockedApi.exportTorrent).toHaveBeenCalledWith(2, "same")
+    expect(mockedApi.exportTorrent).toHaveBeenCalledWith(3, "same")
+  })
+})
+
+describe("useTorrentExporter — select-all", () => {
+  it("pages the cross-instance endpoint in unified scope and routes per row", async () => {
+    mockedApi.getCrossInstanceTorrents.mockResolvedValue({
+      torrents: [],
+      crossInstanceTorrents: [
+        makeCrossTorrent({ hash: "aaa", instanceId: 2 }),
+        makeCrossTorrent({ hash: "bbb", instanceId: 3 }),
+      ],
+      total: 2,
+      hasMore: false,
+    })
+
+    const { result } = renderHook(() => useTorrentExporter({ instanceId: 0, incognitoMode: false }))
+
+    await act(async () => {
+      await result.current.exportTorrents(exportSelection([], {
+        isAllSelected: true,
+        totalSelected: 2,
+        instanceIds: [2, 3],
+      }))
+    })
+
+    expect(mockedApi.getCrossInstanceTorrents).toHaveBeenCalledWith(
+      expect.objectContaining({ instanceIds: [2, 3] })
+    )
+    expect(mockedApi.getTorrents).not.toHaveBeenCalled()
+    expect(mockedApi.exportTorrent).toHaveBeenCalledTimes(2)
+    expect(mockedApi.exportTorrent).toHaveBeenCalledWith(2, "aaa")
+    expect(mockedApi.exportTorrent).toHaveBeenCalledWith(3, "bbb")
+  })
+
+  it("keeps paging the per-instance endpoint in a single-instance view", async () => {
+    mockedApi.getTorrents.mockResolvedValue({
+      torrents: [makeTorrent({ hash: "aaa" })],
+      total: 1,
+      hasMore: false,
+    })
+
+    const { result } = renderHook(() => useTorrentExporter({ instanceId: 2, incognitoMode: false }))
+
+    await act(async () => {
+      await result.current.exportTorrents(exportSelection([], {
+        isAllSelected: true,
+        totalSelected: 1,
+      }))
+    })
+
+    expect(mockedApi.getTorrents).toHaveBeenCalledWith(2, expect.any(Object))
+    expect(mockedApi.getCrossInstanceTorrents).not.toHaveBeenCalled()
+    expect(mockedApi.exportTorrent).toHaveBeenCalledWith(2, "aaa")
+  })
+
+  it("skips excluded instance:hash targets in unified scope", async () => {
+    mockedApi.getCrossInstanceTorrents.mockResolvedValue({
+      torrents: [],
+      crossInstanceTorrents: [
+        makeCrossTorrent({ hash: "same", instanceId: 2 }),
+        makeCrossTorrent({ hash: "same", instanceId: 3 }),
+      ],
+      total: 2,
+      hasMore: false,
+    })
+
+    const { result } = renderHook(() => useTorrentExporter({ instanceId: 0, incognitoMode: false }))
+
+    await act(async () => {
+      await result.current.exportTorrents(exportSelection([], {
+        isAllSelected: true,
+        totalSelected: 1,
+        excludeTargets: [{ instanceId: 2, hash: "same" }],
+      }))
+    })
+
+    expect(mockedApi.exportTorrent).toHaveBeenCalledTimes(1)
+    expect(mockedApi.exportTorrent).toHaveBeenCalledWith(3, "same")
+  })
+})

--- a/web/src/hooks/useTorrentExporter.ts
+++ b/web/src/hooks/useTorrentExporter.ts
@@ -6,6 +6,8 @@
 import { useCallback, useState } from "react"
 import { api } from "@/lib/api"
 import { getLinuxIsoName } from "@/lib/incognito"
+import { isAllInstancesScope } from "@/lib/instances"
+import { getTorrentTargetInstanceId, type TorrentActionTarget } from "@/lib/torrent-action-targets"
 import type { Torrent, TorrentFilters } from "@/types"
 import { useTranslation } from "react-i18next"
 import { toast } from "sonner"
@@ -23,6 +25,8 @@ interface ExportSelection {
   filters?: TorrentFilters
   search?: string
   excludeHashes?: string[]
+  excludeTargets?: TorrentActionTarget[]
+  instanceIds?: number[]
   sortField?: string
   sortOrder?: "asc" | "desc"
 }
@@ -40,12 +44,15 @@ export function useTorrentExporter({ instanceId, incognitoMode }: UseTorrentExpo
       filters,
       search,
       excludeHashes,
+      excludeTargets,
+      instanceIds,
       sortField,
       sortOrder,
     } = selection
 
     const sanitizedHashes = Array.from(new Set(hashes)).filter(Boolean)
     const excludeSet = new Set(excludeHashes ?? [])
+    const excludeTargetSet = new Set((excludeTargets ?? []).map(target => targetKey(target.instanceId, target.hash)))
 
     if (!isAllSelected && sanitizedHashes.length === 0) {
       return
@@ -58,15 +65,17 @@ export function useTorrentExporter({ instanceId, incognitoMode }: UseTorrentExpo
       if (isAllSelected) {
         targets = await fetchAllMatchingTorrents({
           instanceId,
+          instanceIds,
           filters,
           search,
           sortField,
           sortOrder,
           totalSelected,
           excludeSet,
+          excludeTargetSet,
         })
       } else {
-        targets = dedupeTorrents(torrents, sanitizedHashes)
+        targets = dedupeTorrents(torrents, sanitizedHashes, instanceId)
       }
 
       if (targets.length === 0) {
@@ -78,11 +87,12 @@ export function useTorrentExporter({ instanceId, incognitoMode }: UseTorrentExpo
       let exportedCount = 0
 
       for (const torrent of targets) {
-        if (excludeSet.has(torrent.hash)) {
+        const targetInstanceId = getTorrentTargetInstanceId(torrent, instanceId)
+        if (excludeSet.has(torrent.hash) || excludeTargetSet.has(targetKey(targetInstanceId, torrent.hash))) {
           continue
         }
 
-        const { blob, filename } = await api.exportTorrent(instanceId, torrent.hash)
+        const { blob, filename } = await api.exportTorrent(targetInstanceId, torrent.hash)
         const fallbackName = filename || torrent.name || torrent.hash
         const downloadName = buildDownloadName(torrent.hash, fallbackName, incognitoMode)
         const uniqueName = ensureUniqueFilename(downloadName, filenameCounts)
@@ -94,9 +104,7 @@ export function useTorrentExporter({ instanceId, incognitoMode }: UseTorrentExpo
       if (exportedCount === 0) {
         toast.info(t("contextMenu.toast.noTorrentsExported"))
       } else {
-        toast.success(exportedCount === 1
-          ? t("contextMenu.toast.torrentExported")
-          : t("contextMenu.toast.torrentsExported", { count: exportedCount }))
+        toast.success(exportedCount === 1? t("contextMenu.toast.torrentExported"): t("contextMenu.toast.torrentsExported", { count: exportedCount }))
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : t("contextMenu.toast.exportFailed")
@@ -111,43 +119,50 @@ export function useTorrentExporter({ instanceId, incognitoMode }: UseTorrentExpo
 
 async function fetchAllMatchingTorrents({
   instanceId,
+  instanceIds,
   filters,
   search,
   sortField,
   sortOrder,
   totalSelected,
   excludeSet,
+  excludeTargetSet,
 }: {
   instanceId: number
+  instanceIds?: number[]
   filters?: TorrentFilters
   search?: string
   sortField?: string
   sortOrder?: "asc" | "desc"
   totalSelected: number
   excludeSet: Set<string>
+  excludeTargetSet: Set<string>
 }): Promise<Torrent[]> {
   const results: Torrent[] = []
   const seen = new Set<string>()
   let page = 0
   const limit = 300
+  const allInstances = isAllInstancesScope(instanceId)
 
   while (true) {
-    const response = await api.getTorrents(instanceId, {
+    const params = {
       page,
       limit,
       filters,
       search,
       sort: sortField,
       order: sortOrder,
-    })
+    }
+    const response = allInstances? await api.getCrossInstanceTorrents({ ...params, instanceIds }): await api.getTorrents(instanceId, params)
 
-    const pageTorrents = response.torrents ?? []
+    const pageTorrents = allInstances? response.crossInstanceTorrents ?? response.cross_instance_torrents ?? []: response.torrents ?? []
 
     for (const torrent of pageTorrents) {
-      if (seen.has(torrent.hash) || excludeSet.has(torrent.hash)) {
+      const key = targetKey(getTorrentTargetInstanceId(torrent, instanceId), torrent.hash)
+      if (seen.has(key) || excludeSet.has(torrent.hash) || excludeTargetSet.has(key)) {
         continue
       }
-      seen.add(torrent.hash)
+      seen.add(key)
       results.push(torrent)
 
       if (totalSelected > 0 && results.length >= totalSelected) {
@@ -173,18 +188,31 @@ async function fetchAllMatchingTorrents({
   return results
 }
 
-function dedupeTorrents(torrents: Torrent[], hashes: string[]): Torrent[] {
-  const map = new Map<string, Torrent>()
-  for (const torrent of torrents) {
-    map.set(torrent.hash, torrent)
-  }
+// Identity is instanceId:hash, not hash alone: in the unified view the same
+// infohash can live on several instances (cross-seeds) and each copy is a
+// distinct export target.
+function targetKey(instanceId: number, hash: string): string {
+  return `${instanceId}:${hash.toLowerCase()}`
+}
+
+function dedupeTorrents(torrents: Torrent[], hashes: string[], fallbackInstanceId: number): Torrent[] {
+  const wanted = new Set(hashes.map(hash => hash.toLowerCase()))
+  const seen = new Set<string>()
 
   const results: Torrent[] = []
-  for (const hash of hashes) {
-    const found = map.get(hash)
-    if (found) {
-      results.push(found)
+  for (const torrent of torrents) {
+    const hash = torrent.hash?.trim()
+    if (!hash || !wanted.has(hash.toLowerCase())) {
+      continue
     }
+
+    const key = targetKey(getTorrentTargetInstanceId(torrent, fallbackInstanceId), hash)
+    if (seen.has(key)) {
+      continue
+    }
+
+    seen.add(key)
+    results.push(torrent)
   }
   return results
 }


### PR DESCRIPTION
Exporting a torrent from the unified view failed with "Failed to export torrent" because every request went to `/api/instances/0/torrents/{hash}/export`, and instance 0 is the unified pseudo-instance the export endpoint doesn't know. Each export now resolves the torrent's own instance via `getTorrentTargetInstanceId`, matching how the other unified-view actions route. Select-all export pages the cross-instance endpoint in unified scope (honoring the instance subset and the per-target exclusions unified view tracks instead of `excludeHashes`), and dedupe is by `instanceId:hash` so cross-seeded copies of the same infohash export individually.

Frontend only; no backend or OpenAPI changes. Covered by new `useTorrentExporter` tests (per-row routing, single-instance fallback, composite dedupe, cross-instance select-all paging, target exclusion) plus extended `useBulkActionWrappers` forwarding tests. Reported in #2000.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced torrent export functionality to support exporting torrents across multiple instances simultaneously. Users can now perform bulk exports from unified views with proper instance routing and exclusion handling.

* **Tests**
  * Added comprehensive test coverage for cross-instance export scenarios, instance routing verification, and exclusion handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->