### PR TITLE
fix(sse): size full-sync timeout to prevent permanent disconnect on large instances

### DIFF
--- a/internal/api/sse/manager.go
+++ b/internal/api/sse/manager.go
@@ -37,7 +37,18 @@ const (
 	streamEventActivity  = "activity"
 	defaultSyncInterval  = 2 * time.Second
 	maxSyncInterval      = 30 * time.Second
-	heartbeatInterval    = 5 * time.Second
+	// syncTimeoutIncremental bounds a steady-state incremental /sync/maindata tick.
+	// Healthy delta updates finish well under this even on large instances, so the
+	// short budget keeps the ~2s loop snappy and frees the goroutine when qbit is
+	// briefly slow.
+	syncTimeoutIncremental = 10 * time.Second
+	// syncTimeoutFull bounds a full /sync/maindata update (first sync for an instance,
+	// or any sync after a failure when qBittorrent has reset the rid and resends the
+	// whole torrent set). A 20k-torrent full fetch+parse can exceed 10s; this is
+	// aligned with the qbit HTTP client timeout (60s, see ClientPool.GetClient) so the
+	// per-sync budget is bounded by the transport, not a tighter inner deadline.
+	syncTimeoutFull   = 60 * time.Second
+	heartbeatInterval = 5 * time.Second
 	// maxStreamRequests caps the number of stream subscriptions a single SSE
 	// connection may request, bounding per-connection fan-out and resource use.
 	maxStreamRequests = 64
@@ -225,6 +236,12 @@ type heartbeatLoopState struct {
 type backoffState struct {
 	attempt  int
 	interval time.Duration
+	// primed is set true once the instance has completed at least one successful
+	// sync. Before priming the next sync is a full /sync/maindata and must use the
+	// full-sync timeout. primed is never cleared by a failure (failure streaks are
+	// tracked by attempt > 0); it is only dropped when the whole entry is deleted on
+	// unregister, so a re-registered instance correctly resyncs full first.
+	primed bool
 }
 
 // StreamPayload is the message envelope sent to the frontend.
@@ -1632,11 +1649,8 @@ func (m *StreamManager) markSyncSuccess(instanceID int) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	state, ok := m.syncBackoff[instanceID]
-	if !ok {
-		return
-	}
-
+	state := m.ensureBackoffStateLocked(instanceID)
+	state.primed = true
 	state.attempt = 0
 
 	if state.interval != defaultSyncInterval {
@@ -1728,12 +1742,29 @@ func jitteredInterval(interval time.Duration) time.Duration {
 	return interval + jitter
 }
 
+// syncTimeout returns the context budget for the next forceSync of instanceID.
+// A full /sync/maindata is likely when the instance has never completed a sync
+// (no entry / not primed) or is in a failure streak (attempt > 0): qBittorrent
+// resets the rid on these and resends the whole torrent set, which can exceed the
+// incremental budget on large instances. A primed instance with no active failure
+// streak is in a healthy delta streak and gets the short budget.
+func (m *StreamManager) syncTimeout(instanceID int) time.Duration {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	state, ok := m.syncBackoff[instanceID]
+	if !ok || !state.primed || state.attempt > 0 {
+		return syncTimeoutFull
+	}
+	return syncTimeoutIncremental
+}
+
 func (m *StreamManager) forceSync(parent context.Context, instanceID int) {
 	if m.closing.Load() {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(parent, 10*time.Second)
+	ctx, cancel := context.WithTimeout(parent, m.syncTimeout(instanceID))
 	defer cancel()
 
 	syncMgr, err := m.syncManager.GetQBittorrentSyncManager(ctx, instanceID)

--- a/internal/api/sse/manager_test.go
+++ b/internal/api/sse/manager_test.go
@@ -398,6 +398,9 @@ func TestStreamManager_syncTimeout_concurrent(t *testing.T) {
 	}
 
 	wg.Wait()
+
+	// State stays readable and yields a valid budget after concurrent access.
+	require.Contains(t, []time.Duration{syncTimeoutIncremental, syncTimeoutFull}, manager.syncTimeout(1))
 }
 
 func TestStreamManager_markSyncSuccess_primes(t *testing.T) {

--- a/internal/api/sse/manager_test.go
+++ b/internal/api/sse/manager_test.go
@@ -327,15 +327,114 @@ func TestMarkSyncSuccess_ResetsBackoff(t *testing.T) {
 	require.Equal(t, defaultSyncInterval, state.interval, "interval should be reset to default")
 }
 
-func TestMarkSyncSuccess_NoOpWithoutPriorState(t *testing.T) {
+func TestMarkSyncSuccess_PrimesWithoutPriorState(t *testing.T) {
 	manager := NewStreamManager(nil, nil, nil)
 
-	// Calling success without prior failure should be a no-op
+	// First success without a prior failure should create a primed entry so the
+	// next sync uses the incremental budget.
 	manager.markSyncSuccess(99)
 
-	// Backoff state should not exist for this instance
-	_, exists := manager.syncBackoff[99]
-	require.False(t, exists, "backoff state should not be created by markSyncSuccess")
+	state, exists := manager.syncBackoff[99]
+	require.True(t, exists, "first success should create a primed backoff entry")
+	require.True(t, state.primed, "first success should prime the instance")
+	require.Equal(t, 0, state.attempt)
+}
+
+func TestStreamManager_syncTimeout(t *testing.T) {
+	tests := []struct {
+		name  string
+		state *backoffState
+		want  time.Duration
+	}{
+		{name: "no_state_uses_full", state: nil, want: syncTimeoutFull},
+		{name: "unprimed_attempt0_uses_full", state: &backoffState{primed: false, attempt: 0}, want: syncTimeoutFull},
+		{name: "unprimed_with_attempts_uses_full", state: &backoffState{primed: false, attempt: 2}, want: syncTimeoutFull},
+		{name: "failure_streak_uses_full", state: &backoffState{primed: true, attempt: 1}, want: syncTimeoutFull},
+		{name: "deep_failure_streak_uses_full", state: &backoffState{primed: true, attempt: 4}, want: syncTimeoutFull},
+		{name: "primed_healthy_uses_incremental", state: &backoffState{primed: true, attempt: 0}, want: syncTimeoutIncremental},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := NewStreamManager(nil, nil, nil)
+			if tt.state != nil {
+				manager.syncBackoff[1] = tt.state
+			}
+			require.Equal(t, tt.want, manager.syncTimeout(1))
+		})
+	}
+}
+
+func TestStreamManager_syncTimeout_concurrent(t *testing.T) {
+	// syncTimeout reads backoffState fields that markSyncSuccess/markSyncFailure
+	// mutate under m.mu. This must stay race-free; run under `go test -race`.
+	manager := NewStreamManager(nil, nil, nil)
+
+	const goroutines = 8
+	const iterations = 500
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 3)
+
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				_ = manager.syncTimeout(1)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				manager.markSyncFailure(1)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				manager.markSyncSuccess(1)
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+func TestStreamManager_markSyncSuccess_primes(t *testing.T) {
+	manager := NewStreamManager(nil, nil, nil)
+
+	manager.markSyncSuccess(1)
+
+	require.True(t, manager.syncBackoff[1].primed, "first success should prime the instance")
+	require.Equal(t, syncTimeoutIncremental, manager.syncTimeout(1), "primed healthy instance uses incremental budget")
+}
+
+func TestStreamManager_failureAfterPrimeKeepsFull_thenRecovers(t *testing.T) {
+	manager := NewStreamManager(nil, nil, nil)
+
+	manager.markSyncSuccess(1)
+	require.Equal(t, syncTimeoutIncremental, manager.syncTimeout(1))
+
+	manager.markSyncFailure(1)
+	require.Positive(t, manager.syncBackoff[1].attempt, "failure should advance attempt")
+	require.True(t, manager.syncBackoff[1].primed, "failure must not clear primed")
+	require.Equal(t, syncTimeoutFull, manager.syncTimeout(1), "failure streak uses full budget")
+
+	manager.markSyncSuccess(1)
+	require.Equal(t, 0, manager.syncBackoff[1].attempt, "recovery resets attempt")
+	require.True(t, manager.syncBackoff[1].primed)
+	require.Equal(t, syncTimeoutIncremental, manager.syncTimeout(1), "recovered instance returns to incremental budget")
+}
+
+func TestStreamManager_unprimedFirstSyncUsesFull(t *testing.T) {
+	manager := NewStreamManager(nil, nil, nil)
+
+	// Failure before the first success creates an unprimed entry (the wedge condition).
+	manager.markSyncFailure(1)
+	require.Equal(t, syncTimeoutFull, manager.syncTimeout(1), "unprimed instance uses full budget")
+
+	manager.markSyncSuccess(1)
+	require.Equal(t, syncTimeoutIncremental, manager.syncTimeout(1), "first success drops to incremental budget")
 }
 
 func TestBackoffState_IndependentPerInstance(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes a regression in v1.20.0 where qui permanently loses its connection to qBittorrent on large instances (~18k–20k+ torrents) and stays disconnected until the container is restarted. The UI shows a permanent loading skeleton and reverse-proxied *arr apps get no response.

## Root cause

PR #551 moved qBittorrent polling server-side. A per-instance loop (`startSyncLoop` → `forceSync`) drives `/sync/maindata`, and `forceSync` wrapped **every** sync in a fixed **10-second** timeout:

```go
ctx, cancel := context.WithTimeout(parent, 10*time.Second)
```

qBittorrent's `/sync/maindata` is incremental via a `rid`. The wedge:

1. A **full update** for 20k torrents takes longer than 10s → `forceSync`'s context cancels mid-response.
2. The library's `MainData.Update` returns the error **without advancing its local `rid`** (`dest.Rid = source.Rid` is never reached) — so qui keeps the stale rid.
3. But qBittorrent **has** advanced its internal rid, so the next request (stale rid) forces **another full update** → >10s again → cancelled → stale rid → repeats forever. Exponential backoff only slows retries to a 30s cap; it never escapes.

Small instances self-heal instantly because their full update finishes well under 10s — which is why this only bites large instances.

This is a **regression**: in v1.19 the `internal/api/sse/` path didn't exist; sync ran via `Sync(context.Background())`, bounded only by the **60s** qbit HTTP client timeout. #551 silently dropped the effective per-sync budget from ~60s to 10s.

## Fix

A **two-tier timeout** in `forceSync`:

- `syncTimeoutIncremental = 10s` — steady-state delta ticks (unchanged behavior for the common path; keeps the ~2s loop snappy).
- `syncTimeoutFull = 60s` — full/initial sync, aligned with the qbit HTTP client timeout so the budget is bounded by the transport.

A full update is expected when the instance has **never completed a sync** *or* is in a **failure streak** (`attempt > 0`):

```go
func (m *StreamManager) syncTimeout(instanceID int) time.Duration {
    m.mu.RLock()
    defer m.mu.RUnlock()
    state, ok := m.syncBackoff[instanceID]
    if !ok || !state.primed || state.attempt > 0 {
        return syncTimeoutFull
    }
    return syncTimeoutIncremental
}
```

A new `backoffState.primed` flag is set on first success and **never cleared by failure** (failure streaks are tracked by `attempt`). After a transient incremental timeout strands the rid, the next tick — which faces qBittorrent's forced full update — gets the full 60s, completes, advances the rid, and the instance returns to the 10s budget. That's the wedge escape.

`forceSync`'s context still derives from the loop `parent`, so shutdown/loop-restart still cancels an in-flight full sync promptly. The `syncMgr.Sync` error branch is unchanged (still relies on the library `OnError` → `HandleSyncError` path, no double-reporting).

## Testing

- `go build ./...` — clean
- `go test -race -count=1 ./internal/api/sse/... ./internal/qbittorrent/...` — pass
- `gofmt -l` clean; `golangci-lint --new-from-merge-base=develop` — 0 issues
- New tests: table-driven `TestStreamManager_syncTimeout` (all state combinations), `TestStreamManager_failureAfterPrimeKeepsFull_thenRecovers` (wedge-escape proof), `TestStreamManager_unprimedFirstSyncUsesFull` (exact wedge condition), and `TestStreamManager_syncTimeout_concurrent` (`-race` guard on the shared backoff state)

## Reports this addresses

Multiple users on Discord reported v1.20.0 disconnecting from qBittorrent "after a while" and staying disconnected until container restart, all correlated with large instances (18k–20k+ torrents). Reverting to v1.19.0 resolved it for some. No prior GitHub issue was filed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated SSE sync-loop timeout selection to better reflect instance health, using shorter budgets for incremental updates after initial success and longer budgets for full synchronization during failure streaks.
  * Updated forced sync to use the same adaptive timeout logic.

* **Tests**
  * Revised and expanded coverage for priming behavior, timeout transitions across failure streak depth, and race-safe concurrent state access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->