### PR TITLE
fix(pprof): bind to configurable loopback address instead of :6060

### DIFF
--- a/cmd/qui/main.go
+++ b/cmd/qui/main.go
@@ -98,7 +98,7 @@ func RunServeCommand() *cobra.Command {
 	command.Flags().StringVar(&configDir, "config-dir", "", "config directory path (default is OS-specific: ~/.config/qui/ or %APPDATA%\\qui\\). For backward compatibility, can also be a direct path to a .toml file")
 	command.Flags().StringVar(&dataDir, "data-dir", "", "data directory for database and other files (default is next to config file)")
 	command.Flags().StringVar(&logPath, "log-path", "", "log file path (default is stdout)")
-	command.Flags().BoolVar(&pprofFlag, "pprof", false, "enable pprof server on :6060")
+	command.Flags().BoolVar(&pprofFlag, "pprof", false, "enable pprof server (default 127.0.0.1:6060, override with QUI__PPROF_ADDR / pprofAddr)")
 
 	command.Run = func(cmd *cobra.Command, args []string) {
 		app := NewApplication(configDir, dataDir, logPath, pprofFlag, PolarOrgID)
@@ -841,11 +841,18 @@ func (app *Application) runServer() {
 
 	// Start profiling server if enabled
 	if cfg.Config.PprofEnabled {
+		// Bind to loopback by default so pprof never collides with another listener
+		// sharing the network namespace (e.g. a Tailscale sidecar already serving
+		// :6060) and is not exposed on a wildcard address. Override with QUI__PPROF_ADDR.
+		pprofAddr := cfg.Config.PprofAddr
+		if pprofAddr == "" {
+			pprofAddr = "127.0.0.1:6060"
+		}
 		go func() {
-			log.Info().Msg("Starting pprof server on :6060")
-			log.Info().Msg("Access profiling at: http://localhost:6060/debug/pprof/")
-			if err := http.ListenAndServe(":6060", nil); err != nil {
-				log.Error().Err(err).Msg("Profiling server failed")
+			log.Info().Str("addr", pprofAddr).Msg("Starting pprof server")
+			log.Info().Msgf("Access profiling at: http://%s/debug/pprof/", pprofAddr)
+			if err := http.ListenAndServe(pprofAddr, nil); err != nil {
+				log.Error().Err(err).Str("addr", pprofAddr).Msg("Profiling server failed")
 			}
 		}()
 	}

--- a/documentation/docs/configuration/environment.md
+++ b/documentation/docs/configuration/environment.md
@@ -89,7 +89,8 @@ QUI__CHECK_FOR_UPDATES=false  # Optional: disable update checks and UI indicator
 ## Profiling (pprof)
 
 ```bash
-QUI__PPROF_ENABLED=true  # Optional: enable pprof server on :6060 (default: false)
+QUI__PPROF_ENABLED=true        # Optional: enable pprof server (default: false)
+QUI__PPROF_ADDR=127.0.0.1:6060 # Optional: pprof bind address (default: 127.0.0.1:6060)
 ```
 
 ## Metrics

--- a/documentation/docs/configuration/reference.md
+++ b/documentation/docs/configuration/reference.md
@@ -66,7 +66,8 @@ qui watches `config.toml` for changes. Some settings are applied immediately (fo
 | `checkForUpdates` | `QUI__CHECK_FOR_UPDATES` | bool | `true` | Controls update checks and UI indicators. Restart recommended. |
 | `trackerIconsFetchEnabled` | `QUI__TRACKER_ICONS_FETCH_ENABLED` | bool | `true` | Disable to prevent remote tracker favicon fetches. Applied immediately. |
 | `crossSeedRecoverErroredTorrents` | `QUI__CROSS_SEED_RECOVER_ERRORED_TORRENTS` | bool | `false` | When enabled, cross-seed automation attempts recovery (pause, recheck, resume) for errored/missingFiles torrents. Can add 25+ minutes per torrent. Restart recommended. |
-| `pprofEnabled` | `QUI__PPROF_ENABLED` | bool | `false` | Enables pprof server on `:6060` (`/debug/pprof/`). Restart required. |
+| `pprofEnabled` | `QUI__PPROF_ENABLED` | bool | `false` | Enables pprof server (`/debug/pprof/`). Restart required. |
+| `pprofAddr` | `QUI__PPROF_ADDR` | string | `127.0.0.1:6060` | pprof server bind address. Loopback by default to avoid colliding with another listener in a shared network namespace (e.g. a Tailscale sidecar). Restart required. |
 | `metricsEnabled` | `QUI__METRICS_ENABLED` | bool | `false` | Enables a Prometheus metrics server (separate port). Restart required. |
 | `metricsHost` | `QUI__METRICS_HOST` | string | `127.0.0.1` | Metrics server bind address. Restart required. |
 | `metricsPort` | `QUI__METRICS_PORT` | int | `9074` | Metrics server port. Restart required. |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -124,6 +124,7 @@ func (c *AppConfig) defaults() {
 	c.viper.SetDefault("trackerIconsFetchEnabled", true)
 	c.viper.SetDefault("crossSeedRecoverErroredTorrents", false)
 	c.viper.SetDefault("pprofEnabled", false)
+	c.viper.SetDefault("pprofAddr", "127.0.0.1:6060")
 	c.viper.SetDefault("metricsEnabled", false)
 	c.viper.SetDefault("metricsHost", "127.0.0.1")
 	c.viper.SetDefault("metricsPort", 9074)
@@ -227,6 +228,7 @@ func (c *AppConfig) loadFromEnv() {
 	c.viper.BindEnv("trackerIconsFetchEnabled", envPrefix+"TRACKER_ICONS_FETCH_ENABLED")
 	c.viper.BindEnv("crossSeedRecoverErroredTorrents", envPrefix+"CROSS_SEED_RECOVER_ERRORED_TORRENTS")
 	c.viper.BindEnv("pprofEnabled", envPrefix+"PPROF_ENABLED")
+	c.viper.BindEnv("pprofAddr", envPrefix+"PPROF_ADDR")
 	c.viper.BindEnv("metricsEnabled", envPrefix+"METRICS_ENABLED")
 	c.viper.BindEnv("metricsHost", envPrefix+"METRICS_HOST")
 	c.viper.BindEnv("metricsPort", envPrefix+"METRICS_PORT")
@@ -342,6 +344,7 @@ func (c *AppConfig) hydrateConfigFromViper() {
 	c.Config.TrackerIconsFetchEnabled = c.viper.GetBool("trackerIconsFetchEnabled")
 	c.Config.CrossSeedRecoverErroredTorrents = c.viper.GetBool("crossSeedRecoverErroredTorrents")
 	c.Config.PprofEnabled = c.viper.GetBool("pprofEnabled")
+	c.Config.PprofAddr = c.viper.GetString("pprofAddr")
 
 	c.Config.MetricsEnabled = c.viper.GetBool("metricsEnabled")
 	c.Config.MetricsHost = c.viper.GetString("metricsHost")

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	DatabaseConnMaxLifetime  int    `toml:"databaseConnMaxLifetime" mapstructure:"databaseConnMaxLifetime"`
 	CheckForUpdates          bool   `toml:"checkForUpdates" mapstructure:"checkForUpdates"`
 	PprofEnabled             bool   `toml:"pprofEnabled" mapstructure:"pprofEnabled"`
+	PprofAddr                string `toml:"pprofAddr" mapstructure:"pprofAddr"`
 	MetricsEnabled           bool   `toml:"metricsEnabled" mapstructure:"metricsEnabled"`
 	MetricsHost              string `toml:"metricsHost" mapstructure:"metricsHost"`
 	MetricsPort              int    `toml:"metricsPort" mapstructure:"metricsPort"`


### PR DESCRIPTION
pprof hardcoded `:6060` (i.e. `0.0.0.0:6060`), which fails to bind when another listener in the same network namespace already owns the port — e.g. running qui behind a Tailscale sidecar that serves `:6060`. The profiler then silently never starts (`listen tcp :6060: bind: address already in use`), so `QUI__PPROF_ENABLED=true` looks enabled but yields nothing to profile.

This defaults the pprof bind address to `127.0.0.1:6060` (also safer than a wildcard) and adds `QUI__PPROF_ADDR` / `pprofAddr` to override it. With loopback binding, an existing `tailscale serve :6060 -> http://127.0.0.1:6060` mapping works as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The pprof profiling listener address is now configurable via the `QUI__PPROF_ADDR` environment variable or configuration file, with a default of `127.0.0.1:6060`.

* **Documentation**
  * Updated configuration documentation to reflect the new pprof address configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->