### PR TITLE
fix(sse): send torrent page deltas instead of full snapshots

### DIFF
--- a/internal/api/sse/delta.go
+++ b/internal/api/sse/delta.go
@@ -1,0 +1,196 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package sse
+
+import (
+	"encoding/json"
+	"hash/fnv"
+	"slices"
+	"strconv"
+	"time"
+
+	"github.com/autobrr/qui/internal/qbittorrent"
+)
+
+// deltaKeyframeInterval bounds how long a group may go without a full snapshot.
+// Tick updates are normally incremental deltas, but at least this often the group
+// re-sends the whole page as a full "update" frame. This keyframe re-baselines any
+// client whose state drifted from the server baseline (a frame missed in the tiny
+// window between subscription registration and go-sse subscribe, or a late joiner
+// that inited against a slightly different page than the shared baseline). Drift is
+// therefore always self-healing within this bound without forcing a reconnect.
+const deltaKeyframeInterval = 30 * time.Second
+
+// buildUpdatePayload turns a freshly materialized page into the frame to broadcast
+// to the group, advancing the group's delta baseline as a side effect. It returns
+// either a full snapshot ("update") or an incremental delta ("delta"):
+//
+//   - A full snapshot is sent when the baseline is unseeded (first tick for a new
+//     group, including every reconnect that recreates a single-subscriber group) or
+//     when the keyframe interval has elapsed. Either re-baselines every subscriber.
+//   - Otherwise a delta is sent: the added or changed rows ride in the returned
+//     payload's Data.Torrents (or Data.CrossInstanceTorrents), and StreamDelta.Order
+//     carries the full page key order, present only when membership or ordering
+//     changed. Aggregate metadata (stats, counts, serverState, ...) always travels
+//     in full so dashboard speeds stay live even on a tick with no row changes.
+//
+// now is injected for deterministic keyframe testing. The caller holds no lock; the
+// group's single-processor invariant (the sending flag) already serializes ticks,
+// and baselineMu guards the baseline against the unrelated init path.
+func (g *subscriptionGroup) buildUpdatePayload(opts StreamOptions, resp *qbittorrent.TorrentResponse, meta *StreamMeta, now time.Time) *StreamPayload {
+	g.baselineMu.Lock()
+	defer g.baselineMu.Unlock()
+
+	isCross := opts.isMultiInstance()
+
+	var (
+		order      []string
+		changedIdx []int
+		newFP      map[string]uint64
+	)
+	if isCross {
+		order, changedIdx, newFP = computeRowDelta(resp.CrossInstanceTorrents, crossRowKey, g.baselineFP)
+	} else {
+		order, changedIdx, newFP = computeRowDelta(resp.Torrents, singleRowKey, g.baselineFP)
+	}
+
+	forceFull := !g.baselineSeeded || now.Sub(g.lastFullAt) >= deltaKeyframeInterval
+
+	// Advance the baseline before returning so the next tick diffs against this page,
+	// regardless of whether this frame is a delta or a keyframe.
+	prevOrder := g.baselineOrder
+	g.baselineFP = newFP
+	g.baselineOrder = order
+	g.baselineSeeded = true
+
+	if forceFull {
+		g.lastFullAt = now
+		return &StreamPayload{Type: streamEventUpdate, Data: resp, Meta: meta}
+	}
+
+	// Shallow-copy the response so the delta frame keeps every aggregate field but
+	// replaces the row slice with just the added/changed rows. Aggregate pointers are
+	// shared read-only.
+	deltaResp := *resp
+	if isCross {
+		deltaResp.CrossInstanceTorrents = subsetRows(resp.CrossInstanceTorrents, changedIdx)
+		deltaResp.Torrents = nil
+	} else {
+		deltaResp.Torrents = subsetRows(resp.Torrents, changedIdx)
+		deltaResp.CrossInstanceTorrents = nil
+	}
+
+	delta := &StreamDelta{}
+	if !slices.Equal(order, prevOrder) {
+		// Send the order even when empty (the page drained to zero rows): a pointer
+		// keeps a present-but-empty order distinct from an absent one on the wire, so
+		// the client clears instead of holding the deleted rows until the next keyframe.
+		delta.Order = &order
+	}
+
+	return &StreamPayload{Type: streamEventDelta, Data: &deltaResp, Delta: delta, Meta: meta}
+}
+
+// seedBaselineIfEmpty primes the delta baseline from a freshly built init snapshot,
+// but only if the group has no baseline yet. Seeding at init makes the client's init
+// snapshot and the server baseline identical, so the very next tick is a clean delta
+// the client applies without drift. A later joiner to an already-seeded group does
+// not re-seed (that would desync existing subscribers); its init may differ slightly
+// from the shared baseline until the next keyframe re-baselines everyone.
+func (g *subscriptionGroup) seedBaselineIfEmpty(opts StreamOptions, resp *qbittorrent.TorrentResponse, now time.Time) {
+	if resp == nil {
+		return
+	}
+
+	g.baselineMu.Lock()
+	defer g.baselineMu.Unlock()
+
+	if g.baselineSeeded {
+		return
+	}
+
+	var (
+		order []string
+		fp    map[string]uint64
+	)
+	if opts.isMultiInstance() {
+		order, _, fp = computeRowDelta(resp.CrossInstanceTorrents, crossRowKey, nil)
+	} else {
+		order, _, fp = computeRowDelta(resp.Torrents, singleRowKey, nil)
+	}
+
+	g.baselineFP = fp
+	g.baselineOrder = order
+	g.baselineSeeded = true
+	g.lastFullAt = now
+}
+
+// computeRowDelta walks the freshly materialized rows in display order, producing
+// the new ordered key list, the indices of rows that are new or whose content
+// changed since base, and the new key->fingerprint map to store as the next
+// baseline. A row is "changed" when its key is absent from base or its fingerprint
+// differs.
+func computeRowDelta[T any](rows []T, keyOf func(T) string, base map[string]uint64) (order []string, changedIdx []int, newFP map[string]uint64) {
+	order = make([]string, len(rows))
+	newFP = make(map[string]uint64, len(rows))
+	for i := range rows {
+		key := keyOf(rows[i])
+		order[i] = key
+		fp := fingerprintRow(rows[i])
+		newFP[key] = fp
+		if old, ok := base[key]; !ok || old != fp {
+			changedIdx = append(changedIdx, i)
+		}
+	}
+	return order, changedIdx, newFP
+}
+
+// fingerprintRow hashes a row's canonical JSON so two ticks can cheaply tell
+// whether a row's content changed. TorrentView/CrossInstanceTorrentView are plain
+// structs (no maps), so their marshaled form is deterministic across ticks. A
+// marshal error (not expected for these types) yields 0, which simply makes the row
+// compare equal to another unmarshalable row; the worst case is one tick of
+// staleness, self-healed by the next change or keyframe.
+func fingerprintRow[T any](row T) uint64 {
+	encoded, err := json.Marshal(row)
+	if err != nil {
+		return 0
+	}
+	h := fnv.New64a()
+	_, _ = h.Write(encoded)
+	return h.Sum64()
+}
+
+// subsetRows returns the rows at the given indices, preserving order.
+func subsetRows[T any](rows []T, idx []int) []T {
+	if len(idx) == 0 {
+		return nil
+	}
+	out := make([]T, 0, len(idx))
+	for _, i := range idx {
+		out = append(out, rows[i])
+	}
+	return out
+}
+
+// singleRowKey is a single-instance row's identity: its torrent hash.
+func singleRowKey(tv qbittorrent.TorrentView) string {
+	if tv.Torrent == nil {
+		return ""
+	}
+	return tv.Hash
+}
+
+// crossRowKey is a cross-instance row's identity: "<instanceID>:<hash>". The same
+// torrent cross-seeded onto two instances shares a hash but is two distinct rows,
+// so the instance id must be part of the key. Mirrors the frontend's crossInstanceRowKey.
+func crossRowKey(c qbittorrent.CrossInstanceTorrentView) string {
+	hash := ""
+	// Guard the embedded *TorrentView pointer before reading the promoted Hash, which
+	// resolves through it (a nil TorrentView would panic on c.Hash).
+	if c.TorrentView != nil && c.Torrent != nil {
+		hash = c.Hash
+	}
+	return strconv.Itoa(c.InstanceID) + ":" + hash
+}

--- a/internal/api/sse/delta.go
+++ b/internal/api/sse/delta.go
@@ -5,40 +5,41 @@ package sse
 
 import (
 	"encoding/json"
+	"hash"
 	"hash/fnv"
 	"slices"
 	"strconv"
-	"time"
+
+	qbt "github.com/autobrr/go-qbittorrent"
 
 	"github.com/autobrr/qui/internal/qbittorrent"
 )
-
-// deltaKeyframeInterval bounds how long a group may go without a full snapshot.
-// Tick updates are normally incremental deltas, but at least this often the group
-// re-sends the whole page as a full "update" frame. This keyframe re-baselines any
-// client whose state drifted from the server baseline (a frame missed in the tiny
-// window between subscription registration and go-sse subscribe, or a late joiner
-// that inited against a slightly different page than the shared baseline). Drift is
-// therefore always self-healing within this bound without forcing a reconnect.
-const deltaKeyframeInterval = 30 * time.Second
 
 // buildUpdatePayload turns a freshly materialized page into the frame to broadcast
 // to the group, advancing the group's delta baseline as a side effect. It returns
 // either a full snapshot ("update") or an incremental delta ("delta"):
 //
-//   - A full snapshot is sent when the baseline is unseeded (first tick for a new
-//     group, including every reconnect that recreates a single-subscriber group) or
-//     when the keyframe interval has elapsed. Either re-baselines every subscriber.
+//   - A full snapshot is sent only when the baseline is unseeded (the first tick for
+//     a new group, including every reconnect that recreates a single-subscriber
+//     group), which re-baselines every subscriber.
 //   - Otherwise a delta is sent: the added or changed rows ride in the returned
 //     payload's Data.Torrents (or Data.CrossInstanceTorrents), and StreamDelta.Order
 //     carries the full page key order, present only when membership or ordering
 //     changed. Aggregate metadata (stats, counts, serverState, ...) always travels
 //     in full so dashboard speeds stay live even on a tick with no row changes.
 //
-// now is injected for deterministic keyframe testing. The caller holds no lock; the
-// group's single-processor invariant (the sending flag) already serializes ticks,
-// and baselineMu guards the baseline against the unrelated init path.
-func (g *subscriptionGroup) buildUpdatePayload(opts StreamOptions, resp *qbittorrent.TorrentResponse, meta *StreamMeta, now time.Time) *StreamPayload {
+// There is intentionally no periodic full keyframe: a recurring full page re-send is
+// hundreds of KB and, over an HTTP/2 proxy, head-of-line-blocks every other request
+// on the shared connection each time it fires. Correctness instead rests on
+// init-seeds-baseline (the client's init equals the server baseline) plus a fresh
+// init on every reconnect; the only drift window is the sub-millisecond gap between
+// subscription registration and go-sse subscribe, which self-heals on the next
+// reconnect.
+//
+// The caller holds no lock; the group's single-processor invariant (the sending
+// flag) already serializes ticks, and baselineMu guards the baseline against the
+// unrelated init path.
+func (g *subscriptionGroup) buildUpdatePayload(opts StreamOptions, resp *qbittorrent.TorrentResponse, meta *StreamMeta) *StreamPayload {
 	g.baselineMu.Lock()
 	defer g.baselineMu.Unlock()
 
@@ -50,22 +51,20 @@ func (g *subscriptionGroup) buildUpdatePayload(opts StreamOptions, resp *qbittor
 		newFP      map[string]uint64
 	)
 	if isCross {
-		order, changedIdx, newFP = computeRowDelta(resp.CrossInstanceTorrents, crossRowKey, g.baselineFP)
+		order, changedIdx, newFP = computeRowDelta(resp.CrossInstanceTorrents, crossRowKey, crossRowFingerprint, g.baselineFP)
 	} else {
-		order, changedIdx, newFP = computeRowDelta(resp.Torrents, singleRowKey, g.baselineFP)
+		order, changedIdx, newFP = computeRowDelta(resp.Torrents, singleRowKey, singleRowFingerprint, g.baselineFP)
 	}
 
-	forceFull := !g.baselineSeeded || now.Sub(g.lastFullAt) >= deltaKeyframeInterval
+	forceFull := !g.baselineSeeded
 
-	// Advance the baseline before returning so the next tick diffs against this page,
-	// regardless of whether this frame is a delta or a keyframe.
+	// Advance the baseline before returning so the next tick diffs against this page.
 	prevOrder := g.baselineOrder
 	g.baselineFP = newFP
 	g.baselineOrder = order
 	g.baselineSeeded = true
 
 	if forceFull {
-		g.lastFullAt = now
 		return &StreamPayload{Type: streamEventUpdate, Data: resp, Meta: meta}
 	}
 
@@ -85,7 +84,7 @@ func (g *subscriptionGroup) buildUpdatePayload(opts StreamOptions, resp *qbittor
 	if !slices.Equal(order, prevOrder) {
 		// Send the order even when empty (the page drained to zero rows): a pointer
 		// keeps a present-but-empty order distinct from an absent one on the wire, so
-		// the client clears instead of holding the deleted rows until the next keyframe.
+		// the client clears instead of holding the deleted rows.
 		delta.Order = &order
 	}
 
@@ -97,8 +96,8 @@ func (g *subscriptionGroup) buildUpdatePayload(opts StreamOptions, resp *qbittor
 // snapshot and the server baseline identical, so the very next tick is a clean delta
 // the client applies without drift. A later joiner to an already-seeded group does
 // not re-seed (that would desync existing subscribers); its init may differ slightly
-// from the shared baseline until the next keyframe re-baselines everyone.
-func (g *subscriptionGroup) seedBaselineIfEmpty(opts StreamOptions, resp *qbittorrent.TorrentResponse, now time.Time) {
+// from the shared baseline until it reconnects.
+func (g *subscriptionGroup) seedBaselineIfEmpty(opts StreamOptions, resp *qbittorrent.TorrentResponse) {
 	if resp == nil {
 		return
 	}
@@ -115,29 +114,27 @@ func (g *subscriptionGroup) seedBaselineIfEmpty(opts StreamOptions, resp *qbitto
 		fp    map[string]uint64
 	)
 	if opts.isMultiInstance() {
-		order, _, fp = computeRowDelta(resp.CrossInstanceTorrents, crossRowKey, nil)
+		order, _, fp = computeRowDelta(resp.CrossInstanceTorrents, crossRowKey, crossRowFingerprint, nil)
 	} else {
-		order, _, fp = computeRowDelta(resp.Torrents, singleRowKey, nil)
+		order, _, fp = computeRowDelta(resp.Torrents, singleRowKey, singleRowFingerprint, nil)
 	}
 
 	g.baselineFP = fp
 	g.baselineOrder = order
 	g.baselineSeeded = true
-	g.lastFullAt = now
 }
 
 // computeRowDelta walks the freshly materialized rows in display order, producing
-// the new ordered key list, the indices of rows that are new or whose content
-// changed since base, and the new key->fingerprint map to store as the next
-// baseline. A row is "changed" when its key is absent from base or its fingerprint
-// differs.
-func computeRowDelta[T any](rows []T, keyOf func(T) string, base map[string]uint64) (order []string, changedIdx []int, newFP map[string]uint64) {
+// the new ordered key list, the indices of rows that are new or whose change
+// fingerprint differs from base, and the new key->fingerprint map to store as the
+// next baseline.
+func computeRowDelta[T any](rows []T, keyOf func(T) string, fpOf func(T) uint64, base map[string]uint64) (order []string, changedIdx []int, newFP map[string]uint64) {
 	order = make([]string, len(rows))
 	newFP = make(map[string]uint64, len(rows))
 	for i := range rows {
 		key := keyOf(rows[i])
 		order[i] = key
-		fp := fingerprintRow(rows[i])
+		fp := fpOf(rows[i])
 		newFP[key] = fp
 		if old, ok := base[key]; !ok || old != fp {
 			changedIdx = append(changedIdx, i)
@@ -146,19 +143,59 @@ func computeRowDelta[T any](rows []T, keyOf func(T) string, base map[string]uint
 	return order, changedIdx, newFP
 }
 
-// fingerprintRow hashes a row's canonical JSON so two ticks can cheaply tell
-// whether a row's content changed. TorrentView/CrossInstanceTorrentView are plain
-// structs (no maps), so their marshaled form is deterministic across ticks. A
-// marshal error (not expected for these types) yields 0, which simply makes the row
-// compare equal to another unmarshalable row; the worst case is one tick of
-// staleness, self-healed by the next change or keyframe.
-func fingerprintRow[T any](row T) uint64 {
-	encoded, err := json.Marshal(row)
-	if err != nil {
-		return 0
+// maskVolatile zeroes the per-second counters and swarm/peer-count jitter that change
+// on an otherwise-idle torrent every tick. They are excluded from change detection
+// only: on a mostly-idle instance these are the sole fields that move each tick, so
+// hashing them would flag nearly every row as changed and make each "delta" almost
+// as large as a full snapshot (the root cause of the stream saturating an HTTP/2
+// connection). The excluded fields still ride along with their current value whenever
+// a row is sent for a real change (speed, progress, state, ratio, ...); they are just
+// not on their own a reason to resend a row.
+func maskVolatile(t *qbt.Torrent) qbt.Torrent {
+	masked := *t
+	masked.Reannounce = 0
+	masked.TimeActive = 0
+	masked.SeedingTime = 0
+	masked.ETA = 0
+	masked.LastActivity = 0
+	masked.SeenComplete = 0
+	masked.Popularity = 0
+	masked.Availability = 0
+	masked.NumComplete = 0
+	masked.NumIncomplete = 0
+	masked.NumLeechs = 0
+	masked.NumSeeds = 0
+	return masked
+}
+
+func writeTorrentFingerprint(h hash.Hash64, t *qbt.Torrent) {
+	if t == nil {
+		return
 	}
+	masked := maskVolatile(t)
+	if encoded, err := json.Marshal(&masked); err == nil {
+		_, _ = h.Write(encoded)
+	}
+}
+
+// singleRowFingerprint hashes a single-instance row's change-relevant content.
+func singleRowFingerprint(tv qbittorrent.TorrentView) uint64 {
 	h := fnv.New64a()
-	_, _ = h.Write(encoded)
+	writeTorrentFingerprint(h, tv.Torrent)
+	_, _ = h.Write([]byte(tv.TrackerHealth))
+	return h.Sum64()
+}
+
+// crossRowFingerprint hashes a cross-instance row's change-relevant content,
+// including its instance identity (the same torrent on two instances is two rows).
+func crossRowFingerprint(c qbittorrent.CrossInstanceTorrentView) uint64 {
+	h := fnv.New64a()
+	if c.TorrentView != nil {
+		writeTorrentFingerprint(h, c.Torrent)
+		_, _ = h.Write([]byte(c.TrackerHealth))
+	}
+	_, _ = h.Write([]byte(strconv.Itoa(c.InstanceID)))
+	_, _ = h.Write([]byte(c.InstanceName))
 	return h.Sum64()
 }
 

--- a/internal/api/sse/delta_test.go
+++ b/internal/api/sse/delta_test.go
@@ -6,7 +6,6 @@ package sse
 import (
 	"encoding/json"
 	"testing"
-	"time"
 
 	qbt "github.com/autobrr/go-qbittorrent"
 	"github.com/stretchr/testify/require"
@@ -15,7 +14,7 @@ import (
 )
 
 // tv builds a single-instance row with a hash and a name; the name drives the
-// content fingerprint so tests can flip a row "changed" by changing its name.
+// change fingerprint so tests can flip a row "changed" by changing its name.
 func tv(hash, name string) qbittorrent.TorrentView {
 	return qbittorrent.TorrentView{Torrent: &qbt.Torrent{Hash: hash, Name: name}}
 }
@@ -46,24 +45,23 @@ func changedHashes(payload *StreamPayload) []string {
 func TestBuildUpdatePayloadSeedsFullThenStreamsDeltas(t *testing.T) {
 	g := &subscriptionGroup{}
 	opts := StreamOptions{InstanceID: 1}
-	now := time.Now()
 
 	// First tick on an unseeded group is a full snapshot that seeds the baseline.
-	full := g.buildUpdatePayload(opts, singleResp(tv("a", "A"), tv("b", "B"), tv("c", "C")), &StreamMeta{}, now)
+	full := g.buildUpdatePayload(opts, singleResp(tv("a", "A"), tv("b", "B"), tv("c", "C")), &StreamMeta{})
 	require.Equal(t, streamEventUpdate, full.Type)
 	require.Nil(t, full.Delta)
 	require.Len(t, full.Data.Torrents, 3)
 	require.True(t, g.baselineSeeded)
 
 	// No change: an aggregate-only delta with no changed rows and no order.
-	steady := g.buildUpdatePayload(opts, singleResp(tv("a", "A"), tv("b", "B"), tv("c", "C")), &StreamMeta{}, now.Add(2*time.Second))
+	steady := g.buildUpdatePayload(opts, singleResp(tv("a", "A"), tv("b", "B"), tv("c", "C")), &StreamMeta{})
 	require.Equal(t, streamEventDelta, steady.Type)
 	require.Empty(t, steady.Data.Torrents)
 	require.Nil(t, steady.Delta.Order)
 	require.Equal(t, 3, steady.Data.Total, "aggregate total still reflects the full page")
 
 	// One row's content changes: it rides in the delta, order stays implicit.
-	changed := g.buildUpdatePayload(opts, singleResp(tv("a", "A"), tv("b", "B2"), tv("c", "C")), &StreamMeta{}, now.Add(4*time.Second))
+	changed := g.buildUpdatePayload(opts, singleResp(tv("a", "A"), tv("b", "B2"), tv("c", "C")), &StreamMeta{})
 	require.Equal(t, streamEventDelta, changed.Type)
 	require.Equal(t, []string{"b"}, changedHashes(changed))
 	require.Nil(t, changed.Delta.Order, "order is omitted when only values change")
@@ -72,11 +70,10 @@ func TestBuildUpdatePayloadSeedsFullThenStreamsDeltas(t *testing.T) {
 func TestBuildUpdatePayloadAddSendsOrderAndRow(t *testing.T) {
 	g := &subscriptionGroup{}
 	opts := StreamOptions{InstanceID: 1}
-	now := time.Now()
 
-	g.buildUpdatePayload(opts, singleResp(tv("a", "A"), tv("b", "B")), &StreamMeta{}, now)
+	g.buildUpdatePayload(opts, singleResp(tv("a", "A"), tv("b", "B")), &StreamMeta{})
 
-	added := g.buildUpdatePayload(opts, singleResp(tv("a", "A"), tv("b", "B"), tv("d", "D")), &StreamMeta{}, now.Add(2*time.Second))
+	added := g.buildUpdatePayload(opts, singleResp(tv("a", "A"), tv("b", "B"), tv("d", "D")), &StreamMeta{})
 	require.Equal(t, streamEventDelta, added.Type)
 	require.NotNil(t, added.Delta.Order)
 	require.Equal(t, []string{"a", "b", "d"}, *added.Delta.Order, "membership change sends full order")
@@ -86,11 +83,10 @@ func TestBuildUpdatePayloadAddSendsOrderAndRow(t *testing.T) {
 func TestBuildUpdatePayloadRemoveSendsShorterOrder(t *testing.T) {
 	g := &subscriptionGroup{}
 	opts := StreamOptions{InstanceID: 1}
-	now := time.Now()
 
-	g.buildUpdatePayload(opts, singleResp(tv("a", "A"), tv("b", "B"), tv("c", "C")), &StreamMeta{}, now)
+	g.buildUpdatePayload(opts, singleResp(tv("a", "A"), tv("b", "B"), tv("c", "C")), &StreamMeta{})
 
-	removed := g.buildUpdatePayload(opts, singleResp(tv("a", "A"), tv("c", "C")), &StreamMeta{}, now.Add(2*time.Second))
+	removed := g.buildUpdatePayload(opts, singleResp(tv("a", "A"), tv("c", "C")), &StreamMeta{})
 	require.Equal(t, streamEventDelta, removed.Type)
 	require.NotNil(t, removed.Delta.Order)
 	require.Equal(t, []string{"a", "c"}, *removed.Delta.Order)
@@ -100,11 +96,10 @@ func TestBuildUpdatePayloadRemoveSendsShorterOrder(t *testing.T) {
 func TestBuildUpdatePayloadReorderSendsOrderOnly(t *testing.T) {
 	g := &subscriptionGroup{}
 	opts := StreamOptions{InstanceID: 1}
-	now := time.Now()
 
-	g.buildUpdatePayload(opts, singleResp(tv("a", "A"), tv("b", "B"), tv("c", "C")), &StreamMeta{}, now)
+	g.buildUpdatePayload(opts, singleResp(tv("a", "A"), tv("b", "B"), tv("c", "C")), &StreamMeta{})
 
-	reordered := g.buildUpdatePayload(opts, singleResp(tv("c", "C"), tv("b", "B"), tv("a", "A")), &StreamMeta{}, now.Add(2*time.Second))
+	reordered := g.buildUpdatePayload(opts, singleResp(tv("c", "C"), tv("b", "B"), tv("a", "A")), &StreamMeta{})
 	require.Equal(t, streamEventDelta, reordered.Type)
 	require.NotNil(t, reordered.Delta.Order)
 	require.Equal(t, []string{"c", "b", "a"}, *reordered.Delta.Order)
@@ -118,11 +113,10 @@ func TestBuildUpdatePayloadReorderSendsOrderOnly(t *testing.T) {
 func TestBuildUpdatePayloadEmptiedPageSendsPresentEmptyOrder(t *testing.T) {
 	g := &subscriptionGroup{}
 	opts := StreamOptions{InstanceID: 1}
-	now := time.Now()
 
-	g.buildUpdatePayload(opts, singleResp(tv("a", "A"), tv("b", "B")), &StreamMeta{}, now)
+	g.buildUpdatePayload(opts, singleResp(tv("a", "A"), tv("b", "B")), &StreamMeta{})
 
-	cleared := g.buildUpdatePayload(opts, singleResp(), &StreamMeta{}, now.Add(2*time.Second))
+	cleared := g.buildUpdatePayload(opts, singleResp(), &StreamMeta{})
 	require.Equal(t, streamEventDelta, cleared.Type)
 	require.NotNil(t, cleared.Delta.Order, "an emptied page must send a present order, not omit it")
 	require.Empty(t, *cleared.Delta.Order)
@@ -135,36 +129,63 @@ func TestBuildUpdatePayloadEmptiedPageSendsPresentEmptyOrder(t *testing.T) {
 	require.Contains(t, string(encoded), `"order":[]`)
 }
 
-func TestBuildUpdatePayloadKeyframeReissuesFullSnapshot(t *testing.T) {
+// TestBuildUpdatePayloadHasNoPeriodicKeyframe verifies that after the seed there is
+// no periodic full re-send. A recurring full page would head-of-line-block every
+// other request on a shared HTTP/2 connection each time it fired.
+func TestBuildUpdatePayloadHasNoPeriodicKeyframe(t *testing.T) {
 	g := &subscriptionGroup{}
 	opts := StreamOptions{InstanceID: 1}
-	now := time.Now()
 
-	g.buildUpdatePayload(opts, singleResp(tv("a", "A")), &StreamMeta{}, now)
+	first := g.buildUpdatePayload(opts, singleResp(tv("a", "A")), &StreamMeta{})
+	require.Equal(t, streamEventUpdate, first.Type, "first tick seeds with a full snapshot")
 
-	// A tick within the keyframe window stays a delta.
-	within := g.buildUpdatePayload(opts, singleResp(tv("a", "A")), &StreamMeta{}, now.Add(deltaKeyframeInterval-time.Second))
-	require.Equal(t, streamEventDelta, within.Type)
+	for range 200 {
+		p := g.buildUpdatePayload(opts, singleResp(tv("a", "A")), &StreamMeta{})
+		require.Equal(t, streamEventDelta, p.Type, "every later tick stays a delta")
+	}
+}
 
-	// A tick at/after the keyframe interval re-sends the whole page to re-baseline.
-	keyframe := g.buildUpdatePayload(opts, singleResp(tv("a", "A")), &StreamMeta{}, now.Add(deltaKeyframeInterval))
-	require.Equal(t, streamEventUpdate, keyframe.Type)
-	require.Nil(t, keyframe.Delta)
-	require.Len(t, keyframe.Data.Torrents, 1)
+// TestVolatileFieldsDoNotTriggerResend is the core of the streaming fix: a torrent
+// whose only change is a per-second counter (reannounce/time_active/...) or peer
+// jitter must NOT be re-sent, otherwise a mostly-idle page re-sends nearly every row
+// every tick and the "delta" is almost a full snapshot.
+func TestVolatileFieldsDoNotTriggerResend(t *testing.T) {
+	g := &subscriptionGroup{}
+	opts := StreamOptions{InstanceID: 1}
+
+	base := &qbt.Torrent{Hash: "a", Name: "A", Reannounce: 1800, TimeActive: 100, SeedingTime: 100, NumSeeds: 3}
+	g.buildUpdatePayload(opts, singleResp(qbittorrent.TorrentView{Torrent: base}), &StreamMeta{})
+
+	// Only volatile fields move (counters tick, peer count jitters): no resend.
+	ticked := *base
+	ticked.Reannounce = 1798
+	ticked.TimeActive = 102
+	ticked.SeedingTime = 102
+	ticked.LastActivity = 999
+	ticked.NumSeeds = 7
+	ticked.Popularity = 1.5
+	idle := g.buildUpdatePayload(opts, singleResp(qbittorrent.TorrentView{Torrent: &ticked}), &StreamMeta{})
+	require.Equal(t, streamEventDelta, idle.Type)
+	require.Empty(t, changedHashes(idle), "a torrent that only ticked its counters must not be re-sent")
+
+	// A real change (download speed) does trigger a resend.
+	active := ticked
+	active.DlSpeed = 1024
+	sent := g.buildUpdatePayload(opts, singleResp(qbittorrent.TorrentView{Torrent: &active}), &StreamMeta{})
+	require.Equal(t, []string{"a"}, changedHashes(sent), "a real change (speed) must re-send the row")
 }
 
 func TestBuildUpdatePayloadCrossInstance(t *testing.T) {
 	g := &subscriptionGroup{}
 	opts := StreamOptions{InstanceIDs: []int{1, 2}}
-	now := time.Now()
 
 	// Seed: same hash on two instances are distinct rows keyed by instanceId:hash.
-	full := g.buildUpdatePayload(opts, crossResp(ci(1, "a", "A"), ci(2, "a", "A")), &StreamMeta{}, now)
+	full := g.buildUpdatePayload(opts, crossResp(ci(1, "a", "A"), ci(2, "a", "A")), &StreamMeta{})
 	require.Equal(t, streamEventUpdate, full.Type)
 	require.Len(t, full.Data.CrossInstanceTorrents, 2)
 
 	// Change only instance 2's copy: just that row rides in the delta.
-	changed := g.buildUpdatePayload(opts, crossResp(ci(1, "a", "A"), ci(2, "a", "A2")), &StreamMeta{}, now.Add(2*time.Second))
+	changed := g.buildUpdatePayload(opts, crossResp(ci(1, "a", "A"), ci(2, "a", "A2")), &StreamMeta{})
 	require.Equal(t, streamEventDelta, changed.Type)
 	require.Nil(t, changed.Data.Torrents, "single-instance slice stays empty on a cross-instance delta")
 	require.Len(t, changed.Data.CrossInstanceTorrents, 1)
@@ -172,11 +193,9 @@ func TestBuildUpdatePayloadCrossInstance(t *testing.T) {
 	require.Nil(t, changed.Delta.Order, "value-only change keeps order implicit")
 }
 
-// TestCrossInstanceMetadataChangeIsFlaggedAsChanged refutes the concern that a
-// table-visible cross-instance field (instance name) could change while hiding
-// behind an "aggregate-only" delta the client skips. The fingerprint marshals the
-// whole row including instance_name, so any such change forces the row into the
-// changed set and the frame is never aggregate-only.
+// TestCrossInstanceMetadataChangeIsFlaggedAsChanged confirms a table-visible
+// cross-instance field (instance name) is part of the change fingerprint, so a
+// metadata change re-sends the row rather than hiding behind an aggregate-only tick.
 func TestCrossInstanceMetadataChangeIsFlaggedAsChanged(t *testing.T) {
 	rowA := qbittorrent.CrossInstanceTorrentView{
 		TorrentView:  &qbittorrent.TorrentView{Torrent: &qbt.Torrent{Hash: "a", Name: "A"}},
@@ -186,17 +205,14 @@ func TestCrossInstanceMetadataChangeIsFlaggedAsChanged(t *testing.T) {
 	rowRenamed := rowA
 	rowRenamed.InstanceName = "alpha-renamed"
 
-	_, _, fp := computeRowDelta([]qbittorrent.CrossInstanceTorrentView{rowA}, crossRowKey, nil)
-	_, changedIdx, _ := computeRowDelta([]qbittorrent.CrossInstanceTorrentView{rowRenamed}, crossRowKey, fp)
+	_, _, fp := computeRowDelta([]qbittorrent.CrossInstanceTorrentView{rowA}, crossRowKey, crossRowFingerprint, nil)
+	_, changedIdx, _ := computeRowDelta([]qbittorrent.CrossInstanceTorrentView{rowRenamed}, crossRowKey, crossRowFingerprint, fp)
 	require.Equal(t, []int{0}, changedIdx, "an instance_name change must be detected as a changed row")
 
-	// And through the full tick path: only metadata changed, so the row rides in the
-	// delta (rowsChanged on the client) rather than being an aggregate-only skip.
 	g := &subscriptionGroup{}
 	opts := StreamOptions{InstanceIDs: []int{1}}
-	now := time.Now()
-	g.buildUpdatePayload(opts, crossResp(rowA), &StreamMeta{}, now)
-	delta := g.buildUpdatePayload(opts, crossResp(rowRenamed), &StreamMeta{}, now.Add(2*time.Second))
+	g.buildUpdatePayload(opts, crossResp(rowA), &StreamMeta{})
+	delta := g.buildUpdatePayload(opts, crossResp(rowRenamed), &StreamMeta{})
 	require.Equal(t, streamEventDelta, delta.Type)
 	require.Len(t, delta.Data.CrossInstanceTorrents, 1, "metadata-only change still carries the row")
 	require.Equal(t, "alpha-renamed", delta.Data.CrossInstanceTorrents[0].InstanceName)
@@ -206,19 +222,19 @@ func TestComputeRowDeltaFlagsNewAndChangedRows(t *testing.T) {
 	base := map[string]uint64{}
 	rows := []qbittorrent.TorrentView{tv("a", "A"), tv("b", "B")}
 
-	order, changedIdx, fp := computeRowDelta(rows, singleRowKey, base)
+	order, changedIdx, fp := computeRowDelta(rows, singleRowKey, singleRowFingerprint, base)
 	require.Equal(t, []string{"a", "b"}, order)
 	require.Equal(t, []int{0, 1}, changedIdx, "every row is new against an empty baseline")
 	require.Len(t, fp, 2)
 
 	// Re-diff identical rows against the produced fingerprints: nothing changed.
-	order2, changedIdx2, fp2 := computeRowDelta(rows, singleRowKey, fp)
+	order2, changedIdx2, fp2 := computeRowDelta(rows, singleRowKey, singleRowFingerprint, fp)
 	require.Equal(t, []string{"a", "b"}, order2)
 	require.Empty(t, changedIdx2)
 	require.Equal(t, fp, fp2, "fingerprints are stable for unchanged content")
 
 	// Flip one row's content: only that index is flagged.
 	mutated := []qbittorrent.TorrentView{tv("a", "A"), tv("b", "B-new")}
-	_, changedIdx3, _ := computeRowDelta(mutated, singleRowKey, fp)
+	_, changedIdx3, _ := computeRowDelta(mutated, singleRowKey, singleRowFingerprint, fp)
 	require.Equal(t, []int{1}, changedIdx3)
 }

--- a/internal/api/sse/delta_test.go
+++ b/internal/api/sse/delta_test.go
@@ -172,6 +172,36 @@ func TestBuildUpdatePayloadCrossInstance(t *testing.T) {
 	require.Nil(t, changed.Delta.Order, "value-only change keeps order implicit")
 }
 
+// TestCrossInstanceMetadataChangeIsFlaggedAsChanged refutes the concern that a
+// table-visible cross-instance field (instance name) could change while hiding
+// behind an "aggregate-only" delta the client skips. The fingerprint marshals the
+// whole row including instance_name, so any such change forces the row into the
+// changed set and the frame is never aggregate-only.
+func TestCrossInstanceMetadataChangeIsFlaggedAsChanged(t *testing.T) {
+	rowA := qbittorrent.CrossInstanceTorrentView{
+		TorrentView:  &qbittorrent.TorrentView{Torrent: &qbt.Torrent{Hash: "a", Name: "A"}},
+		InstanceID:   1,
+		InstanceName: "alpha",
+	}
+	rowRenamed := rowA
+	rowRenamed.InstanceName = "alpha-renamed"
+
+	_, _, fp := computeRowDelta([]qbittorrent.CrossInstanceTorrentView{rowA}, crossRowKey, nil)
+	_, changedIdx, _ := computeRowDelta([]qbittorrent.CrossInstanceTorrentView{rowRenamed}, crossRowKey, fp)
+	require.Equal(t, []int{0}, changedIdx, "an instance_name change must be detected as a changed row")
+
+	// And through the full tick path: only metadata changed, so the row rides in the
+	// delta (rowsChanged on the client) rather than being an aggregate-only skip.
+	g := &subscriptionGroup{}
+	opts := StreamOptions{InstanceIDs: []int{1}}
+	now := time.Now()
+	g.buildUpdatePayload(opts, crossResp(rowA), &StreamMeta{}, now)
+	delta := g.buildUpdatePayload(opts, crossResp(rowRenamed), &StreamMeta{}, now.Add(2*time.Second))
+	require.Equal(t, streamEventDelta, delta.Type)
+	require.Len(t, delta.Data.CrossInstanceTorrents, 1, "metadata-only change still carries the row")
+	require.Equal(t, "alpha-renamed", delta.Data.CrossInstanceTorrents[0].InstanceName)
+}
+
 func TestComputeRowDeltaFlagsNewAndChangedRows(t *testing.T) {
 	base := map[string]uint64{}
 	rows := []qbittorrent.TorrentView{tv("a", "A"), tv("b", "B")}

--- a/internal/api/sse/delta_test.go
+++ b/internal/api/sse/delta_test.go
@@ -1,0 +1,194 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package sse
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/qbittorrent"
+)
+
+// tv builds a single-instance row with a hash and a name; the name drives the
+// content fingerprint so tests can flip a row "changed" by changing its name.
+func tv(hash, name string) qbittorrent.TorrentView {
+	return qbittorrent.TorrentView{Torrent: &qbt.Torrent{Hash: hash, Name: name}}
+}
+
+func singleResp(rows ...qbittorrent.TorrentView) *qbittorrent.TorrentResponse {
+	return &qbittorrent.TorrentResponse{Torrents: rows, Total: len(rows)}
+}
+
+func ci(instanceID int, hash, name string) qbittorrent.CrossInstanceTorrentView {
+	return qbittorrent.CrossInstanceTorrentView{
+		TorrentView: &qbittorrent.TorrentView{Torrent: &qbt.Torrent{Hash: hash, Name: name}},
+		InstanceID:  instanceID,
+	}
+}
+
+func crossResp(rows ...qbittorrent.CrossInstanceTorrentView) *qbittorrent.TorrentResponse {
+	return &qbittorrent.TorrentResponse{CrossInstanceTorrents: rows, Total: len(rows)}
+}
+
+func changedHashes(payload *StreamPayload) []string {
+	out := make([]string, 0, len(payload.Data.Torrents))
+	for _, row := range payload.Data.Torrents {
+		out = append(out, row.Hash)
+	}
+	return out
+}
+
+func TestBuildUpdatePayloadSeedsFullThenStreamsDeltas(t *testing.T) {
+	g := &subscriptionGroup{}
+	opts := StreamOptions{InstanceID: 1}
+	now := time.Now()
+
+	// First tick on an unseeded group is a full snapshot that seeds the baseline.
+	full := g.buildUpdatePayload(opts, singleResp(tv("a", "A"), tv("b", "B"), tv("c", "C")), &StreamMeta{}, now)
+	require.Equal(t, streamEventUpdate, full.Type)
+	require.Nil(t, full.Delta)
+	require.Len(t, full.Data.Torrents, 3)
+	require.True(t, g.baselineSeeded)
+
+	// No change: an aggregate-only delta with no changed rows and no order.
+	steady := g.buildUpdatePayload(opts, singleResp(tv("a", "A"), tv("b", "B"), tv("c", "C")), &StreamMeta{}, now.Add(2*time.Second))
+	require.Equal(t, streamEventDelta, steady.Type)
+	require.Empty(t, steady.Data.Torrents)
+	require.Nil(t, steady.Delta.Order)
+	require.Equal(t, 3, steady.Data.Total, "aggregate total still reflects the full page")
+
+	// One row's content changes: it rides in the delta, order stays implicit.
+	changed := g.buildUpdatePayload(opts, singleResp(tv("a", "A"), tv("b", "B2"), tv("c", "C")), &StreamMeta{}, now.Add(4*time.Second))
+	require.Equal(t, streamEventDelta, changed.Type)
+	require.Equal(t, []string{"b"}, changedHashes(changed))
+	require.Nil(t, changed.Delta.Order, "order is omitted when only values change")
+}
+
+func TestBuildUpdatePayloadAddSendsOrderAndRow(t *testing.T) {
+	g := &subscriptionGroup{}
+	opts := StreamOptions{InstanceID: 1}
+	now := time.Now()
+
+	g.buildUpdatePayload(opts, singleResp(tv("a", "A"), tv("b", "B")), &StreamMeta{}, now)
+
+	added := g.buildUpdatePayload(opts, singleResp(tv("a", "A"), tv("b", "B"), tv("d", "D")), &StreamMeta{}, now.Add(2*time.Second))
+	require.Equal(t, streamEventDelta, added.Type)
+	require.NotNil(t, added.Delta.Order)
+	require.Equal(t, []string{"a", "b", "d"}, *added.Delta.Order, "membership change sends full order")
+	require.Equal(t, []string{"d"}, changedHashes(added), "only the new row is carried")
+}
+
+func TestBuildUpdatePayloadRemoveSendsShorterOrder(t *testing.T) {
+	g := &subscriptionGroup{}
+	opts := StreamOptions{InstanceID: 1}
+	now := time.Now()
+
+	g.buildUpdatePayload(opts, singleResp(tv("a", "A"), tv("b", "B"), tv("c", "C")), &StreamMeta{}, now)
+
+	removed := g.buildUpdatePayload(opts, singleResp(tv("a", "A"), tv("c", "C")), &StreamMeta{}, now.Add(2*time.Second))
+	require.Equal(t, streamEventDelta, removed.Type)
+	require.NotNil(t, removed.Delta.Order)
+	require.Equal(t, []string{"a", "c"}, *removed.Delta.Order)
+	require.Empty(t, changedHashes(removed), "surviving unchanged rows are not re-sent")
+}
+
+func TestBuildUpdatePayloadReorderSendsOrderOnly(t *testing.T) {
+	g := &subscriptionGroup{}
+	opts := StreamOptions{InstanceID: 1}
+	now := time.Now()
+
+	g.buildUpdatePayload(opts, singleResp(tv("a", "A"), tv("b", "B"), tv("c", "C")), &StreamMeta{}, now)
+
+	reordered := g.buildUpdatePayload(opts, singleResp(tv("c", "C"), tv("b", "B"), tv("a", "A")), &StreamMeta{}, now.Add(2*time.Second))
+	require.Equal(t, streamEventDelta, reordered.Type)
+	require.NotNil(t, reordered.Delta.Order)
+	require.Equal(t, []string{"c", "b", "a"}, *reordered.Delta.Order)
+	require.Empty(t, changedHashes(reordered), "a pure reorder carries no row payloads")
+}
+
+// TestBuildUpdatePayloadEmptiedPageSendsPresentEmptyOrder guards the N->0 clear:
+// when the page drains to zero rows, the delta must carry a present-but-empty order
+// that survives JSON marshaling, otherwise the client cannot distinguish a full
+// clear from an aggregate-only tick and leaves the deleted rows on screen.
+func TestBuildUpdatePayloadEmptiedPageSendsPresentEmptyOrder(t *testing.T) {
+	g := &subscriptionGroup{}
+	opts := StreamOptions{InstanceID: 1}
+	now := time.Now()
+
+	g.buildUpdatePayload(opts, singleResp(tv("a", "A"), tv("b", "B")), &StreamMeta{}, now)
+
+	cleared := g.buildUpdatePayload(opts, singleResp(), &StreamMeta{}, now.Add(2*time.Second))
+	require.Equal(t, streamEventDelta, cleared.Type)
+	require.NotNil(t, cleared.Delta.Order, "an emptied page must send a present order, not omit it")
+	require.Empty(t, *cleared.Delta.Order)
+	require.Empty(t, changedHashes(cleared))
+
+	// The present-but-empty order must serialize on the wire (not be dropped by
+	// omitempty), so the client sees `"order":[]` and clears.
+	encoded, err := json.Marshal(cleared)
+	require.NoError(t, err)
+	require.Contains(t, string(encoded), `"order":[]`)
+}
+
+func TestBuildUpdatePayloadKeyframeReissuesFullSnapshot(t *testing.T) {
+	g := &subscriptionGroup{}
+	opts := StreamOptions{InstanceID: 1}
+	now := time.Now()
+
+	g.buildUpdatePayload(opts, singleResp(tv("a", "A")), &StreamMeta{}, now)
+
+	// A tick within the keyframe window stays a delta.
+	within := g.buildUpdatePayload(opts, singleResp(tv("a", "A")), &StreamMeta{}, now.Add(deltaKeyframeInterval-time.Second))
+	require.Equal(t, streamEventDelta, within.Type)
+
+	// A tick at/after the keyframe interval re-sends the whole page to re-baseline.
+	keyframe := g.buildUpdatePayload(opts, singleResp(tv("a", "A")), &StreamMeta{}, now.Add(deltaKeyframeInterval))
+	require.Equal(t, streamEventUpdate, keyframe.Type)
+	require.Nil(t, keyframe.Delta)
+	require.Len(t, keyframe.Data.Torrents, 1)
+}
+
+func TestBuildUpdatePayloadCrossInstance(t *testing.T) {
+	g := &subscriptionGroup{}
+	opts := StreamOptions{InstanceIDs: []int{1, 2}}
+	now := time.Now()
+
+	// Seed: same hash on two instances are distinct rows keyed by instanceId:hash.
+	full := g.buildUpdatePayload(opts, crossResp(ci(1, "a", "A"), ci(2, "a", "A")), &StreamMeta{}, now)
+	require.Equal(t, streamEventUpdate, full.Type)
+	require.Len(t, full.Data.CrossInstanceTorrents, 2)
+
+	// Change only instance 2's copy: just that row rides in the delta.
+	changed := g.buildUpdatePayload(opts, crossResp(ci(1, "a", "A"), ci(2, "a", "A2")), &StreamMeta{}, now.Add(2*time.Second))
+	require.Equal(t, streamEventDelta, changed.Type)
+	require.Nil(t, changed.Data.Torrents, "single-instance slice stays empty on a cross-instance delta")
+	require.Len(t, changed.Data.CrossInstanceTorrents, 1)
+	require.Equal(t, 2, changed.Data.CrossInstanceTorrents[0].InstanceID)
+	require.Nil(t, changed.Delta.Order, "value-only change keeps order implicit")
+}
+
+func TestComputeRowDeltaFlagsNewAndChangedRows(t *testing.T) {
+	base := map[string]uint64{}
+	rows := []qbittorrent.TorrentView{tv("a", "A"), tv("b", "B")}
+
+	order, changedIdx, fp := computeRowDelta(rows, singleRowKey, base)
+	require.Equal(t, []string{"a", "b"}, order)
+	require.Equal(t, []int{0, 1}, changedIdx, "every row is new against an empty baseline")
+	require.Len(t, fp, 2)
+
+	// Re-diff identical rows against the produced fingerprints: nothing changed.
+	order2, changedIdx2, fp2 := computeRowDelta(rows, singleRowKey, fp)
+	require.Equal(t, []string{"a", "b"}, order2)
+	require.Empty(t, changedIdx2)
+	require.Equal(t, fp, fp2, "fingerprints are stable for unchanged content")
+
+	// Flip one row's content: only that index is flagged.
+	mutated := []qbittorrent.TorrentView{tv("a", "A"), tv("b", "B-new")}
+	_, changedIdx3, _ := computeRowDelta(mutated, singleRowKey, fp)
+	require.Equal(t, []int{1}, changedIdx3)
+}

--- a/internal/api/sse/manager.go
+++ b/internal/api/sse/manager.go
@@ -32,6 +32,7 @@ const (
 	maxLimit             = 2000
 	streamEventInit      = "init"
 	streamEventUpdate    = "update"
+	streamEventDelta     = "delta"
 	streamEventError     = "stream-error"
 	streamEventHeartbeat = "heartbeat"
 	streamEventActivity  = "activity"
@@ -218,10 +219,20 @@ type subscriptionGroup struct {
 	sending     bool
 	hasPending  bool
 	pendingMeta *StreamMeta
-	pendingType string
 
 	subsMu sync.RWMutex
 	subs   map[string]*subscriptionState
+
+	// Delta baseline for this group's page-0 window, owned by the single tick
+	// processor (processGroup) and guarded by baselineMu against the unrelated init
+	// path. baselineFP maps each row key to its last-broadcast content fingerprint;
+	// baselineOrder is the last-broadcast key order; lastFullAt timestamps the last
+	// full keyframe. See buildUpdatePayload.
+	baselineMu     sync.Mutex
+	baselineFP     map[string]uint64
+	baselineOrder  []string
+	baselineSeeded bool
+	lastFullAt     time.Time
 }
 
 type syncLoopState struct {
@@ -246,10 +257,28 @@ type backoffState struct {
 
 // StreamPayload is the message envelope sent to the frontend.
 type StreamPayload struct {
-	Type string                       `json:"type"`
-	Data *qbittorrent.TorrentResponse `json:"data,omitempty"`
-	Meta *StreamMeta                  `json:"meta,omitempty"`
-	Err  string                       `json:"error,omitempty"`
+	Type  string                       `json:"type"`
+	Data  *qbittorrent.TorrentResponse `json:"data,omitempty"`
+	Delta *StreamDelta                 `json:"delta,omitempty"`
+	Meta  *StreamMeta                  `json:"meta,omitempty"`
+	Err   string                       `json:"error,omitempty"`
+}
+
+// StreamDelta describes how to reconcile a group's page-0 window against the
+// previous frame on a "delta" event. The added or changed rows themselves ride in
+// StreamPayload.Data.Torrents (single-instance) or Data.CrossInstanceTorrents
+// (cross-instance); Order lists the full page key sequence and is present only when
+// membership or ordering changed. When Order is omitted the client applies the
+// changed rows in place at their existing positions. Keys are the torrent hash for
+// single-instance streams and "<instanceID>:<hash>" for cross-instance streams.
+//
+// Order is a pointer so a present-but-empty order (the page drained to zero rows,
+// e.g. every match deleted) serializes as `[]` and stays distinct from an absent
+// order. A plain `[]string` with omitempty would drop the empty slice on the wire,
+// making a full clear indistinguishable from an aggregate-only tick and leaving the
+// deleted rows on screen until the next keyframe.
+type StreamDelta struct {
+	Order *[]string `json:"order,omitempty"`
 }
 
 // StreamMeta carries lightweight metadata about the sync update.
@@ -537,7 +566,7 @@ func (m *StreamManager) HandleMainData(instanceID int, data *qbt.MainData) {
 		Timestamp:  time.Now(),
 	}
 
-	go m.publishInstance(instanceID, streamEventUpdate, meta)
+	go m.publishInstance(instanceID, meta)
 }
 
 // HandleSyncError implements qbittorrent.SyncEventSink.
@@ -961,6 +990,13 @@ func (m *StreamManager) writeInitToSession(w http.ResponseWriter, sub *subscript
 		return
 	}
 
+	// Seed the delta baseline from this init snapshot so the client's first frame and
+	// the server baseline match exactly; the next tick is then a clean delta. No-op if
+	// the group is already seeded (a tick or an earlier joiner got there first).
+	if payload.Data != nil {
+		group.seedBaselineIfEmpty(group.options, payload.Data, time.Now())
+	}
+
 	m.writePayloadToSession(w, clonePayloadForSubscriber(payload, sub))
 }
 
@@ -1030,7 +1066,7 @@ func flushSession(w http.ResponseWriter) {
 	}
 }
 
-func (m *StreamManager) publishInstance(instanceID int, eventType string, meta *StreamMeta) {
+func (m *StreamManager) publishInstance(instanceID int, meta *StreamMeta) {
 	if m.closing.Load() {
 		return
 	}
@@ -1041,7 +1077,7 @@ func (m *StreamManager) publishInstance(instanceID int, eventType string, meta *
 	}
 
 	for _, group := range groups {
-		m.enqueueGroup(group, eventType, meta)
+		m.enqueueGroup(group, meta)
 	}
 }
 
@@ -1065,7 +1101,7 @@ func (m *StreamManager) groupsForInstance(instanceID int) []*subscriptionGroup {
 	return result
 }
 
-func (m *StreamManager) enqueueGroup(group *subscriptionGroup, eventType string, meta *StreamMeta) {
+func (m *StreamManager) enqueueGroup(group *subscriptionGroup, meta *StreamMeta) {
 	if group == nil || m.closing.Load() {
 		return
 	}
@@ -1074,7 +1110,6 @@ func (m *StreamManager) enqueueGroup(group *subscriptionGroup, eventType string,
 
 	group.mu.Lock()
 	group.pendingMeta = metaCopy
-	group.pendingType = eventType
 	group.hasPending = true
 	if group.sending {
 		group.mu.Unlock()
@@ -1107,7 +1142,6 @@ func (m *StreamManager) processGroup(group *subscriptionGroup) {
 			group.mu.Unlock()
 			return
 		}
-		eventType := group.pendingType
 		meta := group.pendingMeta
 		opts := group.options
 		group.hasPending = false
@@ -1118,7 +1152,10 @@ func (m *StreamManager) processGroup(group *subscriptionGroup) {
 			continue
 		}
 
-		payload := m.buildGroupPayload(group, opts, eventType, meta)
+		// Every enqueued group event is a tick update (init is written synchronously
+		// in onSession, never routed here), so build an incremental update: a delta
+		// against the group baseline, or a full keyframe. See buildUpdatePayload.
+		payload := m.buildGroupUpdatePayload(group, opts, meta)
 		if payload == nil {
 			continue
 		}
@@ -1136,17 +1173,49 @@ func (m *StreamManager) processGroup(group *subscriptionGroup) {
 	}
 }
 
+// buildGroupPayload materializes the current page and wraps it as a full snapshot
+// of the given event type. Used for the synchronous init write; tick updates go
+// through buildGroupUpdatePayload instead.
 func (m *StreamManager) buildGroupPayload(group *subscriptionGroup, opts StreamOptions, eventType string, meta *StreamMeta) *StreamPayload {
-	if group == nil || m.syncManager == nil {
-		return nil
-	}
-
-	if m.closing.Load() {
+	if group == nil || m.syncManager == nil || m.closing.Load() {
 		return nil
 	}
 
 	metaCopy := cloneMeta(meta)
+	response, errPayload := m.materializeGroupResponse(opts, metaCopy, group.key)
+	if errPayload != nil {
+		return errPayload
+	}
 
+	return &StreamPayload{
+		Type: eventType,
+		Data: response,
+		Meta: metaCopy,
+	}
+}
+
+// buildGroupUpdatePayload materializes the current page and turns it into a tick
+// frame: an incremental delta against the group baseline, or a full keyframe. See
+// buildUpdatePayload for the delta-vs-full decision and baseline advancement.
+func (m *StreamManager) buildGroupUpdatePayload(group *subscriptionGroup, opts StreamOptions, meta *StreamMeta) *StreamPayload {
+	if group == nil || m.syncManager == nil || m.closing.Load() {
+		return nil
+	}
+
+	metaCopy := cloneMeta(meta)
+	response, errPayload := m.materializeGroupResponse(opts, metaCopy, group.key)
+	if errPayload != nil {
+		return errPayload
+	}
+
+	return group.buildUpdatePayload(opts, response, metaCopy, time.Now())
+}
+
+// materializeGroupResponse fetches the current filtered/sorted/paginated page for
+// the group's view from the warm sync cache. On success it returns the response and
+// a nil payload; on failure it returns a nil response and a ready-to-send
+// stream-error payload (carrying a retry hint).
+func (m *StreamManager) materializeGroupResponse(opts StreamOptions, metaCopy *StreamMeta, groupKey string) (*qbittorrent.TorrentResponse, *StreamPayload) {
 	ctx, cancel := context.WithTimeout(m.ctx, 10*time.Second)
 	defer cancel()
 	ctx = qbittorrent.WithSkipFreshData(ctx)
@@ -1196,7 +1265,7 @@ func (m *StreamManager) buildGroupPayload(group *subscriptionGroup, opts StreamO
 		log.Error().Err(err).
 			Int("instanceID", opts.InstanceID).
 			Ints("instanceIDs", opts.InstanceIDs).
-			Str("groupKey", group.key).
+			Str("groupKey", groupKey).
 			Msg("Failed to build torrent response for SSE subscribers")
 
 		// Carry a retry hint so the frontend can show a recovery countdown and keep
@@ -1206,7 +1275,7 @@ func (m *StreamManager) buildGroupPayload(group *subscriptionGroup, opts StreamO
 		}
 		metaCopy.RetryInSeconds = m.currentRetrySeconds(retryInstanceID)
 
-		return &StreamPayload{
+		return nil, &StreamPayload{
 			Type: streamEventError,
 			Meta: metaCopy,
 			Err:  errMsg,
@@ -1219,11 +1288,7 @@ func (m *StreamManager) buildGroupPayload(group *subscriptionGroup, opts StreamO
 		response.InstanceMeta = m.buildInstanceMeta(ctx, opts.InstanceID)
 	}
 
-	return &StreamPayload{
-		Type: eventType,
-		Data: response,
-		Meta: metaCopy,
-	}
+	return response, nil
 }
 
 // currentRetrySeconds reports the instance's current sync interval (in seconds)

--- a/internal/api/sse/manager.go
+++ b/internal/api/sse/manager.go
@@ -225,14 +225,12 @@ type subscriptionGroup struct {
 
 	// Delta baseline for this group's page-0 window, owned by the single tick
 	// processor (processGroup) and guarded by baselineMu against the unrelated init
-	// path. baselineFP maps each row key to its last-broadcast content fingerprint;
-	// baselineOrder is the last-broadcast key order; lastFullAt timestamps the last
-	// full keyframe. See buildUpdatePayload.
+	// path. baselineFP maps each row key to its last-broadcast change fingerprint;
+	// baselineOrder is the last-broadcast key order. See buildUpdatePayload.
 	baselineMu     sync.Mutex
 	baselineFP     map[string]uint64
 	baselineOrder  []string
 	baselineSeeded bool
-	lastFullAt     time.Time
 }
 
 type syncLoopState struct {
@@ -994,7 +992,7 @@ func (m *StreamManager) writeInitToSession(w http.ResponseWriter, sub *subscript
 	// the server baseline match exactly; the next tick is then a clean delta. No-op if
 	// the group is already seeded (a tick or an earlier joiner got there first).
 	if payload.Data != nil {
-		group.seedBaselineIfEmpty(group.options, payload.Data, time.Now())
+		group.seedBaselineIfEmpty(group.options, payload.Data)
 	}
 
 	m.writePayloadToSession(w, clonePayloadForSubscriber(payload, sub))
@@ -1208,7 +1206,7 @@ func (m *StreamManager) buildGroupUpdatePayload(group *subscriptionGroup, opts S
 		return errPayload
 	}
 
-	return group.buildUpdatePayload(opts, response, metaCopy, time.Now())
+	return group.buildUpdatePayload(opts, response, metaCopy)
 }
 
 // materializeGroupResponse fetches the current filtered/sorted/paginated page for

--- a/internal/api/sse/manager_delivery_test.go
+++ b/internal/api/sse/manager_delivery_test.go
@@ -222,9 +222,60 @@ func (r *sseReader) drain() {
 	}
 }
 
+// isTickEvent reports whether an event is a per-tick torrent frame. Steady-state
+// ticks are incremental "delta" frames; a full "update" frame is only sent for the
+// seed tick and the periodic keyframe. Delivery/coalescing/isolation tests assert a
+// tick frame was delivered regardless of which encoding it took.
+func isTickEvent(event string) bool {
+	return event == streamEventUpdate || event == streamEventDelta
+}
+
+// waitForTick blocks until any per-tick frame (update or delta) arrives.
+func (r *sseReader) waitForTick(t *testing.T, timeout time.Duration) sseEvent {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		select {
+		case ev := <-r.events:
+			if isTickEvent(ev.event) {
+				return ev
+			}
+		case err := <-r.errc:
+			t.Fatalf("stream closed before receiving a tick frame: %v", err)
+		case <-deadline:
+			t.Fatalf("timed out waiting for a tick (update/delta) frame")
+		}
+	}
+}
+
 // triggerRetryInterval paces re-invocation of an update/error trigger while a
 // freshly connected session finishes subscribing.
 const triggerRetryInterval = 100 * time.Millisecond
+
+// waitForTickTriggered is waitForEventTriggered for per-tick frames: it re-invokes
+// trigger until any update/delta frame arrives, tolerating the post-init subscribe
+// window.
+func (r *sseReader) waitForTickTriggered(t *testing.T, timeout time.Duration, trigger func()) sseEvent {
+	t.Helper()
+	deadline := time.After(timeout)
+	tick := time.NewTicker(triggerRetryInterval)
+	defer tick.Stop()
+	trigger()
+	for {
+		select {
+		case ev := <-r.events:
+			if isTickEvent(ev.event) {
+				return ev
+			}
+		case err := <-r.errc:
+			t.Fatalf("stream closed before receiving a tick frame: %v", err)
+		case <-tick.C:
+			trigger()
+		case <-deadline:
+			t.Fatalf("timed out waiting for a tick (update/delta) frame")
+		}
+	}
+}
 
 // waitForEventTriggered invokes trigger, then re-invokes it on a fixed interval
 // until an event of eventType arrives. A new session receives its init snapshot
@@ -281,8 +332,9 @@ func (r *sseReader) waitForErrorTriggered(t *testing.T, wantMsg string, timeout 
 	}
 }
 
-// waitForUpdateOnBoth re-invokes trigger until both readers receive an update
-// event, tolerating the post-init subscribe window for either session.
+// waitForUpdateOnBoth re-invokes trigger until both readers receive a per-tick
+// frame (update or delta), tolerating the post-init subscribe window for either
+// session.
 func waitForUpdateOnBoth(t *testing.T, a, b *sseReader, timeout time.Duration, trigger func()) {
 	t.Helper()
 	deadline := time.After(timeout)
@@ -293,11 +345,11 @@ func waitForUpdateOnBoth(t *testing.T, a, b *sseReader, timeout time.Duration, t
 	for !gotA || !gotB {
 		select {
 		case ev := <-a.events:
-			if ev.event == streamEventUpdate {
+			if isTickEvent(ev.event) {
 				gotA = true
 			}
 		case ev := <-b.events:
-			if ev.event == streamEventUpdate {
+			if isTickEvent(ev.event) {
 				gotB = true
 			}
 		case err := <-a.errc:
@@ -410,15 +462,17 @@ func TestServeEndToEndDeliversInitAndUpdate(t *testing.T) {
 	require.Equal(t, canned.SessionID, initPayload.Data.SessionID)
 	require.Equal(t, canned.HasMore, initPayload.Data.HasMore)
 
-	// 2. An external main-data update is fanned out as an update event. The trigger
-	// is retried because the session subscribes shortly after its init is flushed, so
-	// the first publish can land before the subscription exists.
-	updateEvent := reader.waitForEventTriggered(t, streamEventUpdate, 5*time.Second, func() {
+	// 2. An external main-data update is fanned out as a tick frame. Since init seeded
+	// the baseline with the same canned page, this tick is a delta carrying no row
+	// changes but the full aggregate metadata (total, sessionID). The trigger is
+	// retried because the session subscribes shortly after its init is flushed, so the
+	// first publish can land before the subscription exists.
+	updateEvent := reader.waitForTickTriggered(t, 5*time.Second, func() {
 		manager.HandleMainData(instanceID, &qbt.MainData{Rid: 99, FullUpdate: true})
 	})
 	updatePayload := decodeStreamPayloadData(t, updateEvent.data)
-	require.Equal(t, streamEventUpdate, updatePayload.Type)
-	require.NotNil(t, updatePayload.Data, "update event should carry data")
+	require.True(t, isTickEvent(updatePayload.Type), "expected a tick frame, got %q", updatePayload.Type)
+	require.NotNil(t, updatePayload.Data, "tick frame should carry aggregate data")
 	require.Equal(t, canned.Total, updatePayload.Data.Total)
 	require.Equal(t, canned.SessionID, updatePayload.Data.SessionID)
 	require.Equal(t, instanceID, updatePayload.Meta.InstanceID)
@@ -453,7 +507,7 @@ func TestServeCoalescesBurstOfUpdates(t *testing.T) {
 	// the connection, so the single coalesced burst update below is delivered without
 	// coupling the coalescing measurement to go-sse's subscribe timing. The gate makes
 	// coalescing deterministic but cannot close this subscribe window.
-	reader.waitForEventTriggered(t, streamEventUpdate, 5*time.Second, func() {
+	reader.waitForTickTriggered(t, 5*time.Second, func() {
 		manager.HandleMainData(instanceID, &qbt.MainData{Rid: 1000})
 	})
 
@@ -492,8 +546,8 @@ func TestServeCoalescesBurstOfUpdates(t *testing.T) {
 	// runs for the coalesced pending update.
 	release()
 
-	// At least one coalesced update must reach the subscriber.
-	reader.waitForEvent(t, streamEventUpdate, 5*time.Second)
+	// At least one coalesced tick frame must reach the subscriber.
+	reader.waitForTick(t, 5*time.Second)
 
 	updateBuilds := provider.torrentsCallCount() - callsAfterInit
 	require.Positive(t, updateBuilds, "burst should trigger at least one build")

--- a/internal/api/sse/manager_isolation_test.go
+++ b/internal/api/sse/manager_isolation_test.go
@@ -205,11 +205,11 @@ func TestSlowClientDoesNotBlockOthers(t *testing.T) {
 	readerB, _ := connectStream(t, srv, streamPayload(instanceID, "fast-B"))
 	readerB.waitForEvent(t, streamEventInit, 5*time.Second)
 
-	// Fire updates; B must receive one promptly while A's reader sits idle.
-	updateB := readerB.waitForEventTriggered(t, streamEventUpdate, 5*time.Second, func() {
+	// Fire updates; B must receive a tick frame promptly while A's reader sits idle.
+	updateB := readerB.waitForTickTriggered(t, 5*time.Second, func() {
 		manager.HandleMainData(instanceID, &qbt.MainData{Rid: 1, FullUpdate: true})
 	})
-	require.Equal(t, streamEventUpdate, updateB.event)
+	require.True(t, isTickEvent(updateB.event), "expected a tick frame, got %q", updateB.event)
 }
 
 // TestFlushAfterCloseDoesNotPanic guards the lifecycle race that makes closing

--- a/internal/api/sse/manager_test.go
+++ b/internal/api/sse/manager_test.go
@@ -592,7 +592,6 @@ func TestStreamManager_ProcessGroupCoalescing(t *testing.T) {
 	// First enqueue sets hasPending and sends
 	group.mu.Lock()
 	group.pendingMeta = &StreamMeta{InstanceID: 1, Timestamp: time.Now()}
-	group.pendingType = streamEventUpdate
 	group.hasPending = true
 	group.sending = true // Simulate that processGroup is already running
 	group.mu.Unlock()
@@ -601,7 +600,6 @@ func TestStreamManager_ProcessGroupCoalescing(t *testing.T) {
 	newMeta := &StreamMeta{InstanceID: 1, Timestamp: time.Now().Add(time.Second)}
 	group.mu.Lock()
 	group.pendingMeta = newMeta
-	group.pendingType = streamEventUpdate
 	group.hasPending = true
 	// sending stays true - no new goroutine needed
 	group.mu.Unlock()
@@ -610,7 +608,6 @@ func TestStreamManager_ProcessGroupCoalescing(t *testing.T) {
 	finalMeta := &StreamMeta{InstanceID: 1, Timestamp: time.Now().Add(2 * time.Second)}
 	group.mu.Lock()
 	group.pendingMeta = finalMeta
-	group.pendingType = streamEventUpdate
 	group.hasPending = true
 	group.mu.Unlock()
 

--- a/web/src/contexts/SyncStreamContext.test.tsx
+++ b/web/src/contexts/SyncStreamContext.test.tsx
@@ -432,7 +432,10 @@ describe("SyncStreamContext", () => {
 
       const source = MockEventSource.instances[0]
       act(() => {
-        source.emitOpen() // arms the 15s stale watchdog
+        source.emitOpen()
+        // The first event switches the watchdog from the init grace to the 15s
+        // steady-state budget this test exercises.
+        source.emit("heartbeat")
       })
       expect(MockEventSource.instances).toHaveLength(1)
 
@@ -449,6 +452,39 @@ describe("SyncStreamContext", () => {
       expect(source.closed).toBe(true)
       expect(controls.getState().retrying).toBe(true)
       expect(controls.getState().retryAttempt).toBe(1)
+    })
+
+    it("does NOT kill a slow init whose first event lands after 15s but within the grace", () => {
+      // The init is a single large SSE event that can take longer than the 15s
+      // steady-state budget to drain on a big instance; the pre-first-event grace
+      // must keep the connection alive so it is not torn down into a reconnect storm.
+      renderSubscriber(BASE_PARAMS)
+      flushConnectionQueue()
+
+      const source = MockEventSource.instances[0]
+      act(() => {
+        source.emitOpen()
+      })
+
+      // 30s with no event yet: past the old 15s watchdog, still within the grace.
+      act(() => {
+        vi.advanceTimersByTime(30_000)
+      })
+      expect(source.closed).toBe(false)
+      expect(MockEventSource.instances).toHaveLength(1)
+
+      // The init finally lands; from here the normal 15s budget applies.
+      act(() => {
+        source.emit("init", { type: "init", meta: { instanceId: 1, timestamp: "now", streamKey: createStreamKey(BASE_PARAMS) }, data: { torrents: [], total: 0 } })
+      })
+      act(() => {
+        vi.advanceTimersByTime(STALE - 1)
+      })
+      expect(source.closed).toBe(false)
+      act(() => {
+        vi.advanceTimersByTime(1)
+      })
+      expect(source.closed).toBe(true)
     })
 
     it("does NOT reconnect while heartbeats keep resetting the watchdog", () => {
@@ -483,7 +519,9 @@ describe("SyncStreamContext", () => {
 
       const source = MockEventSource.instances[0]
       act(() => {
-        source.emitOpen() // arms the 15s stale watchdog, readyState = OPEN
+        source.emitOpen() // readyState = OPEN
+        // First event -> steady-state 15s watchdog (this test asserts that budget).
+        source.emit("heartbeat")
       })
 
       // Tab goes hidden: the stale timer is cleared (timing is meaningless while throttled).
@@ -630,21 +668,27 @@ describe("SyncStreamContext", () => {
       expect(controls.getState().retryAttempt).toBe(1)
     })
 
-    it("still escalates a connection stuck in CONNECTING via the 15s stale watchdog", () => {
+    it("still escalates a connection stuck in CONNECTING via the initial stale grace", () => {
       const { controls } = renderSubscriber(BASE_PARAMS)
       flushConnectionQueue()
       const source = MockEventSource.instances[0]
 
       act(() => {
-        source.emitOpen() // arms the 15s stale watchdog
+        source.emitOpen() // arms the watchdog (init grace, no event yet)
       })
       act(() => {
         source.emitTransientError() // CONNECTING: does not escalate
       })
       expect(source.closed).toBe(false)
 
+      // No event ever arrives, so the longer pre-first-event grace applies; just
+      // under it the connection is still alive, and crossing it escalates.
       act(() => {
-        vi.advanceTimersByTime(STALE) // 15000
+        vi.advanceTimersByTime(INITIAL_GRACE - 1)
+      })
+      expect(source.closed).toBe(false)
+      act(() => {
+        vi.advanceTimersByTime(1)
       })
 
       expect(source.closed).toBe(true)
@@ -667,9 +711,10 @@ describe("SyncStreamContext", () => {
 
       // ...but a connection that never opens must still escalate via the stale
       // watchdog armed at connection creation (not only in onopen), so qui's own
-      // backoff and offline state engage instead of waiting silently forever.
+      // backoff and offline state engage instead of waiting silently forever. No
+      // event ever arrives, so the longer pre-first-event grace governs the timing.
       act(() => {
-        vi.advanceTimersByTime(STALE)
+        vi.advanceTimersByTime(INITIAL_GRACE)
       })
       expect(source.closed).toBe(true)
       expect(controls.getState().retrying).toBe(true)
@@ -876,7 +921,8 @@ describe("SyncStreamContext", () => {
   })
 })
 
-const STALE = 15000 // STREAM_STALE_TIMEOUT_MS
+const STALE = 15000 // STREAM_STALE_TIMEOUT_MS (applies once the first event has arrived)
+const INITIAL_GRACE = 60000 // STREAM_INITIAL_TIMEOUT_MS (applies until the first event)
 const GRACE = 1200 // HANDOFF_GRACE_PERIOD_MS
 
 // jsdom defaults document.visibilityState to "visible" and makes it read-only,

--- a/web/src/contexts/SyncStreamContext.tsx
+++ b/web/src/contexts/SyncStreamContext.tsx
@@ -39,10 +39,21 @@ export function isClientConnectionErrorCode(error: string | null | undefined): b
   return error != null && CLIENT_CONNECTION_ERROR_CODES.has(error)
 }
 
-// The backend emits a heartbeat every 5s. If no event (heartbeat, init or update)
-// arrives within this window the connection is considered dead even when the
+// The backend emits a heartbeat every 5s. Once any event has arrived, if none
+// follows within this window the connection is considered dead even when the
 // browser still reports it open, so we force a reconnect.
 const STREAM_STALE_TIMEOUT_MS = 15000
+
+// Grace window applied until the FIRST event of a fresh connection arrives. The
+// init snapshot is a single large SSE event (hundreds of KB on big instances), and
+// SSE is ordered, so the 5s heartbeats are queued behind it and cannot arrive until
+// it fully drains. A flat 15s watchdog therefore fires mid-init on a slow link,
+// tears down the in-flight download, and reconnects into a fresh full init - a
+// self-sustaining reconnect storm that saturates the (shared, h2) connection and
+// starves every other request. This longer pre-first-event budget lets the init
+// land; REST polling still serves data meanwhile (the stream isn't "connected"
+// until its first event), and the normal 15s budget resumes once events flow.
+const STREAM_INITIAL_TIMEOUT_MS = 60000
 
 export interface StreamParams {
   // Single-instance subscription is keyed by instanceId. For an aggregated
@@ -123,6 +134,11 @@ interface StreamConnection {
   retryTimer?: number
   nextRetryAt?: number
   staleTimer?: number
+  // False until the first event of the current source arrives. While false the
+  // watchdog uses the longer STREAM_INITIAL_TIMEOUT_MS so a large init has time to
+  // drain; the first event flips it true and the normal STREAM_STALE_TIMEOUT_MS
+  // applies thereafter. Reset to false whenever a new EventSource is created.
+  firstEventSeen?: boolean
 }
 
 interface PendingConnectionUpdate {
@@ -478,6 +494,8 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
       // Watchdog: any inbound event (init/update/delta/stream-error/heartbeat) proves
       // the connection is alive and resets the timer. If it elapses, the connection is
       // treated as dead and reconnected even when the browser still reports it open.
+      // Before the first event the longer STREAM_INITIAL_TIMEOUT_MS applies so a large
+      // init has time to drain without being killed mid-download (see that constant).
       const resetStaleTimer = () => {
         const conn = connectionRef.current
         if (conn.staleTimer !== undefined) {
@@ -497,15 +515,17 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
         if (typeof document !== "undefined" && document.visibilityState !== "visible") {
           return
         }
+        const timeout = conn.firstEventSeen ? STREAM_STALE_TIMEOUT_MS : STREAM_INITIAL_TIMEOUT_MS
         const schedule = typeof window !== "undefined"? window.setTimeout: (setTimeout as unknown as (handler: () => void, timeout: number) => number)
         conn.staleTimer = schedule(() => {
           conn.staleTimer = undefined
           handleNetworkError()
-        }, STREAM_STALE_TIMEOUT_MS)
+        }, timeout)
       }
       resetStaleTimerRef.current = resetStaleTimer
 
       const payloadHandler = (event: MessageEvent | Event) => {
+        connectionRef.current.firstEventSeen = true
         resetStaleTimer()
         if (!("data" in event)) {
           return
@@ -562,6 +582,7 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
 
       // Heartbeats carry no torrent data; they exist solely to keep the watchdog alive.
       const heartbeatHandler = () => {
+        connectionRef.current.firstEventSeen = true
         resetStaleTimer()
       }
 
@@ -569,6 +590,7 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
       // the watchdog alive and invalidate the matching cached query so it refetches
       // on demand instead of polling.
       const activityHandler = (event: MessageEvent | Event) => {
+        connectionRef.current.firstEventSeen = true
         resetStaleTimer()
         if (!("data" in event)) {
           return
@@ -648,6 +670,9 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
       source.onerror = handleSourceError
 
       connection.source = source
+      // Fresh source: no event has arrived yet, so the watchdog grants the longer
+      // init grace until the first one lands (see STREAM_INITIAL_TIMEOUT_MS).
+      connection.firstEventSeen = false
       connection.handlers = {
         payload: payloadHandler,
         networkError: handleNetworkError,

--- a/web/src/contexts/SyncStreamContext.tsx
+++ b/web/src/contexts/SyncStreamContext.tsx
@@ -305,6 +305,7 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
       if (handlers) {
         source.removeEventListener("init", handlers.payload)
         source.removeEventListener("update", handlers.payload)
+        source.removeEventListener("delta", handlers.payload)
         source.removeEventListener("stream-error", handlers.payload)
         source.removeEventListener("heartbeat", handlers.heartbeat)
         source.removeEventListener("activity", handlers.activity)
@@ -474,8 +475,8 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
         handleNetworkError(event)
       }
 
-      // Watchdog: any inbound event (init/update/stream-error/heartbeat) proves the
-      // connection is alive and resets the timer. If it elapses, the connection is
+      // Watchdog: any inbound event (init/update/delta/stream-error/heartbeat) proves
+      // the connection is alive and resets the timer. If it elapses, the connection is
       // treated as dead and reconnected even when the browser still reports it open.
       const resetStaleTimer = () => {
         const conn = connectionRef.current
@@ -496,9 +497,7 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
         if (typeof document !== "undefined" && document.visibilityState !== "visible") {
           return
         }
-        const schedule = typeof window !== "undefined"
-          ? window.setTimeout
-          : (setTimeout as unknown as (handler: () => void, timeout: number) => number)
+        const schedule = typeof window !== "undefined"? window.setTimeout: (setTimeout as unknown as (handler: () => void, timeout: number) => number)
         conn.staleTimer = schedule(() => {
           conn.staleTimer = undefined
           handleNetworkError()
@@ -597,6 +596,7 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
       const source = new EventSource(url, { withCredentials: true })
       source.addEventListener("init", payloadHandler)
       source.addEventListener("update", payloadHandler)
+      source.addEventListener("delta", payloadHandler)
       source.addEventListener("stream-error", payloadHandler)
       source.addEventListener("heartbeat", heartbeatHandler)
       source.addEventListener("activity", activityHandler)

--- a/web/src/hooks/useTorrentsList.ts
+++ b/web/src/hooks/useTorrentsList.ts
@@ -252,7 +252,12 @@ export function useTorrentsList(
       let data: TorrentResponse
       // Aggregate-only delta ticks (speeds/counts changed but no row added, removed,
       // reordered, or changed) leave the page untouched, so the table list is left
-      // referentially stable and only the stats/server-state sinks run.
+      // referentially stable and only the stats/server-state sinks run. This skip is
+      // safe because the server change-detects rows by fingerprinting the WHOLE row
+      // JSON: any table-visible field (including cross-instance instance_name) that
+      // changes forces the row into the delta, so changed:false guarantees no
+      // row-visible change. Per-row styling derived from aggregate maps (category/tag)
+      // still refreshes every tick via the unconditional metadata sinks below.
       let rowsChanged = true
       if (payload.type === "delta") {
         const base = lastFullSnapshotRef.current

--- a/web/src/hooks/useTorrentsList.ts
+++ b/web/src/hooks/useTorrentsList.ts
@@ -9,7 +9,7 @@ import { useInstanceCapabilities } from "@/hooks/useInstanceCapabilities"
 import { useInstances } from "@/hooks/useInstances"
 import type { InstanceMetadata } from "@/hooks/useInstanceMetadata"
 import { api } from "@/lib/api"
-import { mergeStreamedCrossInstanceFirstPage, normalizeStreamedSnapshot } from "@/lib/cross-instance-torrents"
+import { applyStreamDelta, mergeStreamedCrossInstanceFirstPage, normalizeStreamedSnapshot } from "@/lib/cross-instance-torrents"
 import { isAllInstancesScope } from "@/lib/instances"
 import { mergeStreamedFirstPage } from "@/lib/stream-merge"
 import type {
@@ -21,7 +21,7 @@ import type {
   TorrentStreamPayload
 } from "@/types"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 export const TORRENT_STREAM_POLL_INTERVAL_MS = 3000
 export const TORRENT_STREAM_POLL_INTERVAL_SECONDS = Math.max(
@@ -76,6 +76,11 @@ export function useTorrentsList(
   const [lastKnownTotal, setLastKnownTotal] = useState(0)
   const [lastProcessedPage, setLastProcessedPage] = useState(-1)
   const [lastStreamSnapshot, setLastStreamSnapshot] = useState<TorrentResponse | null>(null)
+  // The last full page-0 snapshot, retained as the base that incoming SSE deltas are
+  // applied against. Held in a ref (not state) so a delta can read the just-applied
+  // snapshot synchronously without re-running this callback. Seeded by every full
+  // frame (init/update/keyframe) and reset when the view identity changes.
+  const lastFullSnapshotRef = useRef<TorrentResponse | null>(null)
   const pageSize = 300 // Load 300 at a time (backend default)
   const queryClient = useQueryClient()
 
@@ -237,13 +242,36 @@ export function useTorrentsList(
       if (!payload?.data) {
         return
       }
-      // Normalize the streamed snapshot once at the boundary so every sink — the
-      // query cache (read by the REST-processing effect below), the retained
-      // snapshot, and the table rows — sees identical camelCase cross-instance
-      // metadata. Feeding the raw snake_case payload to the cache would let the
-      // effect overwrite the table with un-normalized rows on the next tick,
-      // flickering the Instance column.
-      const data = normalizeStreamedSnapshot(payload.data)
+
+      // Resolve the frame to a full page-0 snapshot. Full frames (init/update and the
+      // periodic delta keyframe) carry the whole page; a delta frame carries only the
+      // changed rows and is reconstructed against the retained baseline. Either way the
+      // result is normalized to camelCase once here so every sink — the query cache
+      // (read by the REST-processing effect below), the retained snapshot, and the
+      // table rows — sees identical metadata and the Instance column never flickers.
+      let data: TorrentResponse
+      // Aggregate-only delta ticks (speeds/counts changed but no row added, removed,
+      // reordered, or changed) leave the page untouched, so the table list is left
+      // referentially stable and only the stats/server-state sinks run.
+      let rowsChanged = true
+      if (payload.type === "delta") {
+        const base = lastFullSnapshotRef.current
+        if (!base) {
+          // No full baseline yet (a delta raced ahead of the init snapshot, or arrived
+          // after a view reset). The next full frame reseeds; drop this one rather than
+          // apply it against nothing.
+          return
+        }
+        const applied = applyStreamDelta(base, payload, Boolean(useCrossInstanceEndpoint))
+        data = applied.data
+        rowsChanged = applied.changed
+      } else {
+        data = normalizeStreamedSnapshot(payload.data)
+      }
+
+      // Retain the reconstructed full snapshot as the base for the next delta.
+      lastFullSnapshotRef.current = data
+
       setLastStreamSnapshot(data)
       updateAppInfoCache(data)
       updateMetadataCache(data)
@@ -256,7 +284,9 @@ export function useTorrentsList(
         // reset the unified view to page 0 on every snapshot, so it could never
         // scroll past the first page (issue #1983). Page 0 stays authoritative for
         // its own window. See mergeStreamedCrossInstanceFirstPage.
-        setAllTorrents(prev => mergeStreamedCrossInstanceFirstPage(prev, data))
+        if (rowsChanged) {
+          setAllTorrents(prev => mergeStreamedCrossInstanceFirstPage(prev, data))
+        }
 
         if (typeof data.total === "number") {
           setLastKnownTotal(data.total)
@@ -267,22 +297,24 @@ export function useTorrentsList(
         return
       }
 
-      setAllTorrents(prev => {
-        const nextTorrents = data.torrents ?? []
+      if (rowsChanged) {
+        setAllTorrents(prev => {
+          const nextTorrents = data.torrents ?? []
 
-        if (data.total === 0 || nextTorrents.length === 0) {
-          return []
-        }
+          if (data.total === 0 || nextTorrents.length === 0) {
+            return []
+          }
 
-        // Page 0 is authoritative for its window (a row it omits was deleted or moved
-        // off page 0, so it must not be re-added); pagination-loaded later pages are
-        // preserved. See mergeStreamedFirstPage.
-        return mergeStreamedFirstPage(
-          prev,
-          nextTorrents,
-          typeof data.total === "number" ? data.total : undefined
-        )
-      })
+          // Page 0 is authoritative for its window (a row it omits was deleted or moved
+          // off page 0, so it must not be re-added); pagination-loaded later pages are
+          // preserved. See mergeStreamedFirstPage.
+          return mergeStreamedFirstPage(
+            prev,
+            nextTorrents,
+            typeof data.total === "number" ? data.total : undefined
+          )
+        })
+      }
 
       if (typeof data.total === "number") {
         setLastKnownTotal(data.total)
@@ -323,6 +355,9 @@ export function useTorrentsList(
     setLastKnownTotal(0)
     setLastProcessedPage(-1)
     setLastStreamSnapshot(null)
+    // Drop the delta baseline so a delta from the previous view can never be applied
+    // against the new one; the new subscription's init reseeds it.
+    lastFullSnapshotRef.current = null
   }, [instanceId, filterKey, searchKey, sort, order, instanceIdsKey])
 
   useEffect(() => {

--- a/web/src/lib/__tests__/cross-instance-torrents.test.ts
+++ b/web/src/lib/__tests__/cross-instance-torrents.test.ts
@@ -5,7 +5,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-import { mergeStreamedCrossInstanceFirstPage, normalizeCrossInstanceTorrents, normalizeStreamedSnapshot, resolveStreamedCrossInstanceTorrents } from "@/lib/cross-instance-torrents"
+import { applyStreamDelta, mergeStreamedCrossInstanceFirstPage, normalizeCrossInstanceTorrents, normalizeStreamedSnapshot, resolveStreamedCrossInstanceTorrents } from "@/lib/cross-instance-torrents"
 import type { CrossInstanceTorrent, Torrent, TorrentResponse } from "@/types"
 
 // A streamed cross-instance torrent as it arrives over SSE: the backend's
@@ -217,5 +217,81 @@ describe("mergeStreamedCrossInstanceFirstPage", () => {
       camel("e", 1, "alpha"), camel("f", 1, "alpha"),
     ]
     expect(mergeStreamedCrossInstanceFirstPage(prev, snapshot(0, streamed("a", 1, "alpha")))).toEqual([])
+  })
+})
+
+describe("applyStreamDelta", () => {
+  function singleBase(...hashes: string[]): TorrentResponse {
+    return {
+      torrents: hashes.map(hash => ({ hash, name: `${hash}.iso` })) as unknown as Torrent[],
+      total: hashes.length,
+    }
+  }
+
+  it("reconstructs a single-instance page from an in-place value change", () => {
+    const base = singleBase("a", "b", "c")
+    const a = base.torrents![0]
+    const payload = {
+      type: "delta" as const,
+      data: { torrents: [{ hash: "b", name: "b-new.iso" }] as unknown as Torrent[], total: 3 },
+    }
+    const { data, changed } = applyStreamDelta(base, payload, false)
+    expect(changed).toBe(true)
+    expect(data.torrents!.map(t => t.hash)).toEqual(["a", "b", "c"])
+    expect(data.torrents![0]).toBe(a) // unchanged row keeps reference
+    expect(data.torrents![1].name).toBe("b-new.iso")
+  })
+
+  it("applies a single-instance reorder + add from the order list", () => {
+    const base = singleBase("a", "b")
+    const payload = {
+      type: "delta" as const,
+      delta: { order: ["b", "d", "a"] },
+      data: { torrents: [{ hash: "d", name: "d.iso" }] as unknown as Torrent[], total: 3 },
+    }
+    const { data } = applyStreamDelta(base, payload, false)
+    expect(data.torrents!.map(t => t.hash)).toEqual(["b", "d", "a"])
+  })
+
+  it("clears the page when a delta drains it to zero rows (present empty order)", () => {
+    const base = singleBase("a", "b")
+    const payload = {
+      type: "delta" as const,
+      delta: { order: [] as string[] },
+      data: { torrents: [] as unknown as Torrent[], total: 0 },
+    }
+    const { data, changed } = applyStreamDelta(base, payload, false)
+    expect(changed).toBe(true)
+    expect(data.torrents).toEqual([])
+  })
+
+  it("passes the page through unchanged on an aggregate-only delta", () => {
+    const base = singleBase("a", "b")
+    const prevRows = base.torrents
+    const payload = { type: "delta" as const, data: { torrents: [], total: 2, stats: { downloading: 1 } } as unknown as TorrentResponse }
+    const { data, changed } = applyStreamDelta(base, payload, false)
+    expect(changed).toBe(false)
+    expect(data.torrents).toBe(prevRows) // page list referentially stable
+  })
+
+  it("reconstructs a cross-instance page and normalizes snake_case changed rows", () => {
+    const base: TorrentResponse = {
+      crossInstanceTorrents: [camel("a", 1, "alpha"), camel("a", 2, "beta")],
+      total: 2,
+    } as TorrentResponse
+    const payload = {
+      type: "delta" as const,
+      data: {
+        cross_instance_torrents: [streamed("a", 2, "beta")],
+        total: 2,
+      } as unknown as TorrentResponse,
+    }
+    const { data, changed } = applyStreamDelta(base, payload, true)
+    expect(changed).toBe(true)
+    const rows = data.crossInstanceTorrents!
+    expect(rows.map(r => `${r.instanceId}:${r.hash}`)).toEqual(["1:a", "2:a"])
+    // The changed instance-2 row is normalized to camelCase instance metadata.
+    expect(rows[1].instanceId).toBe(2)
+    expect(rows[1].instanceName).toBe("beta")
   })
 })

--- a/web/src/lib/__tests__/stream-merge.test.ts
+++ b/web/src/lib/__tests__/stream-merge.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, expect, it } from "vitest"
-import { mergeStreamedFirstPage } from "@/lib/stream-merge"
+import { applyOrderedDelta, mergeStreamedFirstPage } from "@/lib/stream-merge"
 
 type Row = { hash: string }
 const rows = (...hashes: string[]): Row[] => hashes.map(hash => ({ hash }))
@@ -141,5 +141,74 @@ describe("mergeStreamedFirstPage", () => {
       const merged = mergeStreamedFirstPage(prev, next, 4, keyOf)
       expect(keys(merged)).toEqual(["1:x", "2:x", "1:z"])
     })
+  })
+})
+
+describe("applyOrderedDelta", () => {
+  type Named = { hash: string; name: string }
+  const named = (hash: string, name = hash): Named => ({ hash, name })
+  const keyOf = (row: Named) => row.hash
+  const order = (list: Named[]) => list.map(row => row.hash)
+
+  it("returns the previous rows by reference on an aggregate-only tick", () => {
+    const prev = [named("a"), named("b")]
+    const result = applyOrderedDelta(prev, [], undefined, keyOf)
+    expect(result.changed).toBe(false)
+    expect(result.rows).toBe(prev)
+  })
+
+  it("applies an in-place value change while keeping unchanged rows referentially stable", () => {
+    const a = named("a")
+    const b = named("b")
+    const bUpdated = named("b", "b-new")
+    const { rows, changed } = applyOrderedDelta([a, b], [bUpdated], undefined, keyOf)
+    expect(changed).toBe(true)
+    expect(order(rows)).toEqual(["a", "b"])
+    expect(rows[0]).toBe(a) // unchanged row keeps its reference
+    expect(rows[1]).toBe(bUpdated) // changed row swapped in
+  })
+
+  it("inserts an added row at the position given by order", () => {
+    const { rows } = applyOrderedDelta(
+      [named("a"), named("b")],
+      [named("d")],
+      ["a", "d", "b"],
+      keyOf
+    )
+    expect(order(rows)).toEqual(["a", "d", "b"])
+  })
+
+  it("drops a removed row via the new order", () => {
+    const { rows } = applyOrderedDelta(
+      [named("a"), named("b"), named("c")],
+      [],
+      ["a", "c"],
+      keyOf
+    )
+    expect(order(rows)).toEqual(["a", "c"])
+  })
+
+  it("clears the page on a present-but-empty order (N->0 delete), not treating it as aggregate-only", () => {
+    // The page drained to zero rows. A present empty order must produce an empty
+    // page with changed:true, distinct from an absent order (aggregate-only tick)
+    // which would keep the previous rows.
+    const result = applyOrderedDelta([named("a"), named("b")], [], [], keyOf)
+    expect(result.changed).toBe(true)
+    expect(result.rows).toEqual([])
+  })
+
+  it("reorders existing rows without new payloads, preserving references", () => {
+    const a = named("a")
+    const b = named("b")
+    const c = named("c")
+    const { rows } = applyOrderedDelta([a, b, c], [], ["c", "b", "a"], keyOf)
+    expect(order(rows)).toEqual(["c", "b", "a"])
+    expect(rows[0]).toBe(c)
+    expect(rows[2]).toBe(a)
+  })
+
+  it("ignores an order key with no known row (defensive against a missed add)", () => {
+    const { rows } = applyOrderedDelta([named("a")], [], ["a", "ghost"], keyOf)
+    expect(order(rows)).toEqual(["a"])
   })
 })

--- a/web/src/lib/cross-instance-torrents.ts
+++ b/web/src/lib/cross-instance-torrents.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { mergeStreamedFirstPage } from "@/lib/stream-merge"
-import type { CrossInstanceTorrent, Torrent, TorrentResponse } from "@/types"
+import { applyOrderedDelta, mergeStreamedFirstPage } from "@/lib/stream-merge"
+import type { CrossInstanceTorrent, Torrent, TorrentResponse, TorrentStreamPayload } from "@/types"
 
 // RawCrossInstanceTorrent models a cross-instance torrent before normalization.
 // The backend's CrossInstanceTorrentView serializes instance metadata as
@@ -111,6 +111,57 @@ export function resolveStreamedCrossInstanceTorrents(
 // torrent cross-seeded onto two instances shares a hash but is two distinct rows.
 const crossInstanceRowKey = (torrent: CrossInstanceTorrent): string =>
   `${torrent.instanceId}:${torrent.hash}`
+
+// A single-instance row's identity is its torrent hash.
+const singleInstanceRowKey = (torrent: Torrent): string => torrent.hash
+
+// applyStreamDelta reconstructs a full page-0 snapshot from the previous snapshot
+// and an incremental delta frame, routing single-instance vs cross-instance shapes
+// and normalizing the changed cross-instance rows to camelCase. The delta frame's
+// `data` carries every aggregate field plus only the added/changed rows (in
+// `torrents` or `cross_instance_torrents`); this swaps those changed rows back for
+// the reconstructed full page so the result is shaped exactly like a full snapshot
+// and can flow through the same sinks. `changed` is false on an aggregate-only tick
+// (no row adds/removes/reorders/changes), letting the caller leave table state
+// untouched while still refreshing stats and server state.
+export function applyStreamDelta(
+  prev: TorrentResponse,
+  payload: TorrentStreamPayload,
+  isCrossInstance: boolean
+): { data: TorrentResponse; changed: boolean } {
+  const order = payload.delta?.order
+  const frame = payload.data ?? ({} as TorrentResponse)
+
+  if (isCrossInstance) {
+    const prevRows = prev.crossInstanceTorrents ?? []
+    const changedRows = normalizeCrossInstanceTorrents(
+      (frame.crossInstanceTorrents ?? frame.cross_instance_torrents) as RawCrossInstanceTorrent[] | undefined
+    ) ?? []
+
+    const { rows, changed } = applyOrderedDelta(prevRows, changedRows, order, crossInstanceRowKey)
+
+    return {
+      data: {
+        ...frame,
+        crossInstanceTorrents: rows,
+        cross_instance_torrents: rows,
+      },
+      changed,
+    }
+  }
+
+  const prevRows = prev.torrents ?? []
+  const changedRows = frame.torrents ?? []
+  const { rows, changed } = applyOrderedDelta(prevRows, changedRows, order, singleInstanceRowKey)
+
+  return {
+    data: {
+      ...frame,
+      torrents: rows,
+    },
+    changed,
+  }
+}
 
 // mergeStreamedCrossInstanceFirstPage folds an aggregated SSE snapshot into the
 // list the unified table already displays. The stream only ever serves page 0, so

--- a/web/src/lib/stream-merge.ts
+++ b/web/src/lib/stream-merge.ts
@@ -63,3 +63,55 @@ export function mergeStreamedFirstPage<T extends { hash: string }>(
 
   return [...nextTorrents, ...trailing]
 }
+
+/**
+ * Apply an incremental SSE delta to the previous page-0 window, reconstructing the
+ * full page from the changed rows plus the rows already held.
+ *
+ * The backend sends only added or changed rows (`changedRows`) and, when membership
+ * or ordering changed, the full page key sequence (`order`). Reconstruction:
+ *
+ *   1. Index the previous rows by key, then upsert the changed rows. Unchanged rows
+ *      keep their exact previous object reference, so a row that only moved (or did
+ *      not change at all) stays referentially stable and the table re-renders only
+ *      the rows whose data actually changed.
+ *   2. Materialize the page in `order` when present; otherwise reuse the previous
+ *      order (the backend omits `order` only when no row was added or removed and
+ *      nothing reordered, so the previous key sequence is still authoritative).
+ *
+ * Returns `changed: false` only when there is nothing to apply (no `order`, no
+ * changed rows), in which case the previous rows are returned by reference so the
+ * caller can skip touching table state entirely on an aggregate-only tick.
+ */
+export function applyOrderedDelta<T>(
+  prevRows: T[],
+  changedRows: T[],
+  order: string[] | undefined,
+  keyOf: (row: T) => string
+): { rows: T[]; changed: boolean } {
+  if (!order && changedRows.length === 0) {
+    return { rows: prevRows, changed: false }
+  }
+
+  const byKey = new Map<string, T>()
+  for (const row of prevRows) {
+    byKey.set(keyOf(row), row)
+  }
+  for (const row of changedRows) {
+    byKey.set(keyOf(row), row)
+  }
+
+  // Without an explicit order the membership is unchanged, so the previous key
+  // sequence still describes the page; the changed rows were applied in place above.
+  const keys = order ?? prevRows.map(keyOf)
+
+  const rows: T[] = []
+  for (const key of keys) {
+    const row = byKey.get(key)
+    if (row !== undefined) {
+      rows.push(row)
+    }
+  }
+
+  return { rows, changed: true }
+}

--- a/web/src/types/torrents.ts
+++ b/web/src/types/torrents.ts
@@ -267,9 +267,20 @@ export interface TorrentStreamMeta {
   streamKey?: string
 }
 
+// TorrentStreamDelta reconciles a delta frame's page-0 window against the previous
+// frame. The added/changed rows ride in the frame's `data.torrents` (or
+// `cross_instance_torrents`); `order` is the full page key sequence, present only
+// when membership or ordering changed (otherwise changed rows apply in place). Keys
+// are the torrent hash for single-instance streams and "<instanceId>:<hash>" for
+// cross-instance streams.
+export interface TorrentStreamDelta {
+  order?: string[]
+}
+
 export interface TorrentStreamPayload {
-  type: "init" | "update" | "stream-error" | "heartbeat"
+  type: "init" | "update" | "delta" | "stream-error" | "heartbeat"
   data?: TorrentResponse
+  delta?: TorrentStreamDelta
   meta?: TorrentStreamMeta
   error?: string
 }


### PR DESCRIPTION
Fixes #2046. Since v1.20 the torrent-list SSE re-sent the full page on every tick: measured ~577 KB every ~2s (~290 KB/s sustained per open tab) on a 4.8k-torrent instance. That is wasted CPU and bandwidth for every user, and on a slow-drained connection (a constrained link, or a backgrounded tab that stops draining) it fills the HTTP/2 connection-level flow-control window and head-of-line-blocks other requests like `auth/me`. This keeps a per-group baseline and sends `delta` frames of only the rows whose meaningful fields changed, with per-second counters (`reannounce`, `time_active`, peer counts) excluded from change-detection so an otherwise-idle row no longer flags every tick. Measured steady delta is ~22 KB vs ~577 KB, roughly 26x less; aggregate metadata still travels whole so existing stream consumers stay correct unchanged.

`init` seeds the baseline so the first delta applies cleanly, with no periodic keyframe (a recurring full re-send would re-jam the connection on a bad link); correctness rests on init-seeds-baseline plus a fresh init on reconnect. The frontend rebuilds the page from deltas with stable row references, and the stream watchdog gets a grace window before the first event so a large init is not killed mid-download into a reconnect storm. Hard cutover, no capability flag, since qui ships frontend and backend as one binary.
