### PR TITLE
fix(db): index string_pool FK columns so GC stops timing out

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,7 @@ Frontend-specific rules live in `web/AGENTS.md`. Read that file before editing `
 - DB schema changes need SQLite + Postgres migrations, matching model/store updates, same PR.
 - Open PRs: consolidate schema work to at most one new SQLite migration and one new Postgres migration; edit draft migrations before merge.
 - API contract changes must update `internal/web/swagger` and pass `make test-openapi`.
+- New `string_pool` FK columns need a leading index in BOTH the SQLite and Postgres migrations, plus an entry in `referencedStringsInsertQuery`. Neither engine auto-indexes FK child columns and the daily string_pool GC full-scans unindexed ones (discussion #2048). `TestStringPoolFKColumnsAreIndexed` enforces this on SQLite; the Postgres index is on you.
 - Keep diffs minimal in high-churn areas: `internal/services/crossseed`, `internal/qbittorrent`, `internal/models`.
 
 ## Commits / PRs

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -568,6 +568,88 @@ func TestCleanupUnusedStrings_BasicAuthStringRefs(t *testing.T) {
 	require.False(t, exists, "orphan string should be cleaned up")
 }
 
+// TestStringPoolFKColumnsAreIndexed guards the string_pool GC stall fixed in migration 078
+// (discussion #2048). Every column that references string_pool via ON DELETE RESTRICT must:
+//  1. have a leading index, or FK enforcement full-scans it once per deleted string during
+//     CleanupUnusedStrings and eventually exceeds its deadline; and
+//  2. be collected by referencedStringsInsertQuery, or the GC would try to delete strings the
+//     column still references and fail the RESTRICT check.
+//
+// The check is schema-driven (PRAGMA foreign_key_list), so any future table that adds a
+// string_pool FK is covered automatically without touching this test.
+func TestStringPoolFKColumnsAreIndexed(t *testing.T) {
+	log.Logger = log.Output(io.Discard)
+	ctx := t.Context()
+	db := openTestDatabase(t)
+	conn := db.Conn()
+
+	var tables []string
+	rows, err := conn.QueryContext(ctx, "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'")
+	require.NoError(t, err)
+	for rows.Next() {
+		var name string
+		require.NoError(t, rows.Scan(&name))
+		tables = append(tables, name)
+	}
+	require.NoError(t, rows.Err())
+	require.NoError(t, rows.Close())
+
+	type fkCol struct{ table, column string }
+	var fkCols []fkCol
+	for _, table := range tables {
+		// Table names come from sqlite_master (trusted schema), so interpolation is safe;
+		// PRAGMA foreign_key_list does not accept bound parameters.
+		fkRows, err := conn.QueryContext(ctx, fmt.Sprintf("PRAGMA foreign_key_list(%q)", table))
+		require.NoError(t, err)
+		for fkRows.Next() {
+			var (
+				id, seq                   int
+				refTable, from, to        sql.NullString
+				onUpdate, onDelete, match sql.NullString
+			)
+			require.NoError(t, fkRows.Scan(&id, &seq, &refTable, &from, &to, &onUpdate, &onDelete, &match))
+			if refTable.String == "string_pool" {
+				fkCols = append(fkCols, fkCol{table: table, column: from.String})
+			}
+		}
+		require.NoError(t, fkRows.Err())
+		require.NoError(t, fkRows.Close())
+	}
+
+	require.NotEmpty(t, fkCols, "expected to discover string_pool foreign-key columns")
+
+	for _, fc := range fkCols {
+		// (1) FK enforcement during DELETE probes `WHERE col = ?`; this must resolve via an
+		// index (SEARCH), not a full table scan (SCAN). Verified against the freshly migrated
+		// (empty) schema: the planner picks SEARCH purely on index availability here.
+		planRows, err := conn.QueryContext(ctx, fmt.Sprintf("EXPLAIN QUERY PLAN SELECT 1 FROM %q WHERE %q = 1", fc.table, fc.column))
+		require.NoError(t, err)
+		var plan strings.Builder
+		for planRows.Next() {
+			var id, parent, notused int
+			var detail string
+			require.NoError(t, planRows.Scan(&id, &parent, &notused, &detail))
+			plan.WriteString(detail)
+			plan.WriteByte('\n')
+		}
+		require.NoError(t, planRows.Err())
+		require.NoError(t, planRows.Close())
+
+		require.NotContainsf(t, plan.String(), "SCAN",
+			"%s.%s references string_pool but lacks a leading index; FK enforcement will "+
+				"full-scan it during string_pool GC. Add an index (see migration 078). Plan:\n%s",
+			fc.table, fc.column, plan.String())
+
+		// (2) The GC must actually collect this reference, or it will try to delete strings the
+		// column still points at and fail the RESTRICT check.
+		require.Containsf(t, referencedStringsInsertQuery,
+			fmt.Sprintf("SELECT %s AS string_id FROM %s", fc.column, fc.table),
+			"%s.%s references string_pool but is not collected by referencedStringsInsertQuery; "+
+				"the string_pool GC would fail trying to delete strings it still references.",
+			fc.table, fc.column)
+	}
+}
+
 func TestTxTempTableQueriesBypassStatementCache(t *testing.T) {
 	t.Parallel()
 

--- a/internal/database/migrations/078_index_string_pool_fk_columns.sql
+++ b/internal/database/migrations/078_index_string_pool_fk_columns.sql
@@ -1,0 +1,54 @@
+-- Migration 078: Index string_pool foreign-key child columns
+--
+-- Every table below references string_pool(id) via ON DELETE RESTRICT. SQLite does
+-- not auto-index foreign-key child columns, so the daily string_pool garbage
+-- collector (CleanupUnusedStrings) had to full-scan each unindexed column once per
+-- deleted string to satisfy RESTRICT. On large pools that pushed the GC past its
+-- deadline ("context deadline exceeded") and held the writer lock long enough to
+-- surface as flapping "no instances" in the UI. See discussion #2048.
+--
+-- A composite index does NOT help here: FK enforcement probes `WHERE col = ?`, so the
+-- column must be the LEADING column of an index. That is why torrent_hash_id needs a
+-- dedicated index even though it already appears as the second column of
+-- idx_torrent_files_cache_lookup / the torrent_files_sync primary key.
+--
+-- Migrations 014 and 043 already did this for the torznab/arr tables; these are the
+-- columns the original migration 010 (and a few later ones) missed.
+
+-- torrent_files_cache (large): name_id unindexed; torrent_hash_id only second in idx_torrent_files_cache_lookup
+CREATE INDEX IF NOT EXISTS idx_torrent_files_cache_name_id ON torrent_files_cache(name_id);
+CREATE INDEX IF NOT EXISTS idx_torrent_files_cache_hash_id ON torrent_files_cache(torrent_hash_id);
+
+-- torrent_files_sync (large): torrent_hash_id only second in the primary key
+CREATE INDEX IF NOT EXISTS idx_torrent_files_sync_hash_id ON torrent_files_sync(torrent_hash_id);
+
+-- instance_backup_items (large): torrent_hash_id already covered by idx_backup_items_hash
+CREATE INDEX IF NOT EXISTS idx_backup_items_name_id ON instance_backup_items(name_id);
+CREATE INDEX IF NOT EXISTS idx_backup_items_category_id ON instance_backup_items(category_id);
+CREATE INDEX IF NOT EXISTS idx_backup_items_tags_id ON instance_backup_items(tags_id);
+CREATE INDEX IF NOT EXISTS idx_backup_items_archive_rel_path_id ON instance_backup_items(archive_rel_path_id);
+CREATE INDEX IF NOT EXISTS idx_backup_items_infohash_v1_id ON instance_backup_items(infohash_v1_id);
+CREATE INDEX IF NOT EXISTS idx_backup_items_infohash_v2_id ON instance_backup_items(infohash_v2_id);
+CREATE INDEX IF NOT EXISTS idx_backup_items_torrent_blob_path_id ON instance_backup_items(torrent_blob_path_id);
+
+-- instance_backup_runs (grows with backup history)
+CREATE INDEX IF NOT EXISTS idx_backup_runs_kind_id ON instance_backup_runs(kind_id);
+CREATE INDEX IF NOT EXISTS idx_backup_runs_status_id ON instance_backup_runs(status_id);
+CREATE INDEX IF NOT EXISTS idx_backup_runs_requested_by_id ON instance_backup_runs(requested_by_id);
+CREATE INDEX IF NOT EXISTS idx_backup_runs_error_message_id ON instance_backup_runs(error_message_id);
+CREATE INDEX IF NOT EXISTS idx_backup_runs_archive_path_id ON instance_backup_runs(archive_path_id);
+CREATE INDEX IF NOT EXISTS idx_backup_runs_manifest_path_id ON instance_backup_runs(manifest_path_id);
+
+-- bounded tables: cheap indexes that keep the invariant "every string_pool FK column has a leading index"
+CREATE INDEX IF NOT EXISTS idx_instances_name_id ON instances(name_id);
+CREATE INDEX IF NOT EXISTS idx_instances_host_id ON instances(host_id);
+CREATE INDEX IF NOT EXISTS idx_instances_username_id ON instances(username_id);
+CREATE INDEX IF NOT EXISTS idx_instances_basic_username_id ON instances(basic_username_id);
+CREATE INDEX IF NOT EXISTS idx_api_keys_name_id ON api_keys(name_id);
+CREATE INDEX IF NOT EXISTS idx_client_api_keys_client_name_id ON client_api_keys(client_name_id);
+CREATE INDEX IF NOT EXISTS idx_instance_errors_error_type_id ON instance_errors(error_type_id);
+CREATE INDEX IF NOT EXISTS idx_instance_errors_error_message_id ON instance_errors(error_message_id);
+CREATE INDEX IF NOT EXISTS idx_torznab_indexers_basic_username_id ON torznab_indexers(basic_username_id);
+CREATE INDEX IF NOT EXISTS idx_torznab_categories_category_name_id ON torznab_indexer_categories(category_name_id);
+CREATE INDEX IF NOT EXISTS idx_torznab_errors_error_message_id ON torznab_indexer_errors(error_message_id);
+CREATE INDEX IF NOT EXISTS idx_arr_instances_basic_username_id ON arr_instances(basic_username_id);

--- a/internal/database/postgres_migrations/080_index_string_pool_fk_columns.sql
+++ b/internal/database/postgres_migrations/080_index_string_pool_fk_columns.sql
@@ -1,0 +1,50 @@
+-- Index string_pool foreign-key child columns (Postgres mirror of SQLite migration 078).
+--
+-- Every table below references string_pool(id) via ON DELETE RESTRICT. Postgres does not
+-- auto-create indexes on foreign-key child columns, so the daily string_pool garbage
+-- collector (CleanupUnusedStrings) had to sequential-scan each unindexed column once per
+-- deleted string to satisfy RESTRICT, eventually exceeding its deadline on large pools.
+-- See discussion #2048.
+--
+-- FK enforcement probes `WHERE col = ?`, so the column must be the LEADING column of an
+-- index; a composite index that merely contains it as a later column does not help. That
+-- is why torrent_hash_id gets a dedicated index despite already being the second column of
+-- idx_torrent_files_cache_lookup / the torrent_files_sync primary key.
+
+-- torrent_files_cache (large)
+CREATE INDEX IF NOT EXISTS idx_torrent_files_cache_name_id ON torrent_files_cache(name_id);
+CREATE INDEX IF NOT EXISTS idx_torrent_files_cache_hash_id ON torrent_files_cache(torrent_hash_id);
+
+-- torrent_files_sync (large)
+CREATE INDEX IF NOT EXISTS idx_torrent_files_sync_hash_id ON torrent_files_sync(torrent_hash_id);
+
+-- instance_backup_items (large): torrent_hash_id already covered by idx_backup_items_hash
+CREATE INDEX IF NOT EXISTS idx_backup_items_name_id ON instance_backup_items(name_id);
+CREATE INDEX IF NOT EXISTS idx_backup_items_category_id ON instance_backup_items(category_id);
+CREATE INDEX IF NOT EXISTS idx_backup_items_tags_id ON instance_backup_items(tags_id);
+CREATE INDEX IF NOT EXISTS idx_backup_items_archive_rel_path_id ON instance_backup_items(archive_rel_path_id);
+CREATE INDEX IF NOT EXISTS idx_backup_items_infohash_v1_id ON instance_backup_items(infohash_v1_id);
+CREATE INDEX IF NOT EXISTS idx_backup_items_infohash_v2_id ON instance_backup_items(infohash_v2_id);
+CREATE INDEX IF NOT EXISTS idx_backup_items_torrent_blob_path_id ON instance_backup_items(torrent_blob_path_id);
+
+-- instance_backup_runs (grows with backup history)
+CREATE INDEX IF NOT EXISTS idx_backup_runs_kind_id ON instance_backup_runs(kind_id);
+CREATE INDEX IF NOT EXISTS idx_backup_runs_status_id ON instance_backup_runs(status_id);
+CREATE INDEX IF NOT EXISTS idx_backup_runs_requested_by_id ON instance_backup_runs(requested_by_id);
+CREATE INDEX IF NOT EXISTS idx_backup_runs_error_message_id ON instance_backup_runs(error_message_id);
+CREATE INDEX IF NOT EXISTS idx_backup_runs_archive_path_id ON instance_backup_runs(archive_path_id);
+CREATE INDEX IF NOT EXISTS idx_backup_runs_manifest_path_id ON instance_backup_runs(manifest_path_id);
+
+-- bounded tables: cheap indexes that keep the invariant "every string_pool FK column has a leading index"
+CREATE INDEX IF NOT EXISTS idx_instances_name_id ON instances(name_id);
+CREATE INDEX IF NOT EXISTS idx_instances_host_id ON instances(host_id);
+CREATE INDEX IF NOT EXISTS idx_instances_username_id ON instances(username_id);
+CREATE INDEX IF NOT EXISTS idx_instances_basic_username_id ON instances(basic_username_id);
+CREATE INDEX IF NOT EXISTS idx_api_keys_name_id ON api_keys(name_id);
+CREATE INDEX IF NOT EXISTS idx_client_api_keys_client_name_id ON client_api_keys(client_name_id);
+CREATE INDEX IF NOT EXISTS idx_instance_errors_error_type_id ON instance_errors(error_type_id);
+CREATE INDEX IF NOT EXISTS idx_instance_errors_error_message_id ON instance_errors(error_message_id);
+CREATE INDEX IF NOT EXISTS idx_torznab_indexers_basic_username_id ON torznab_indexers(basic_username_id);
+CREATE INDEX IF NOT EXISTS idx_torznab_categories_category_name_id ON torznab_indexer_categories(category_name_id);
+CREATE INDEX IF NOT EXISTS idx_torznab_errors_error_message_id ON torznab_indexer_errors(error_message_id);
+CREATE INDEX IF NOT EXISTS idx_arr_instances_basic_username_id ON arr_instances(basic_username_id);


### PR DESCRIPTION
The daily `string_pool` garbage collector timed out with "context deadline exceeded" on larger databases, surfacing in the UI as intermittent "no instances". `string_pool` is referenced by ~10 tables via `ON DELETE RESTRICT`, but neither SQLite nor Postgres auto-indexes FK child columns, so each GC delete full-scanned every unindexed referencing column once per row. In a repro a single unindexed leg took ~42s vs ~0.03s once indexed.

This adds the missing leading indexes on all `string_pool` FK child columns (SQLite migration 078, Postgres 080) and a schema-driven regression test that fails if any current or future `string_pool` FK column lacks an index or is missing from `referencedStringsInsertQuery`. A composite index where the column is not the leading column does not help FK enforcement, so a few `*_hash_id` columns get dedicated indexes too.

Reported in https://github.com/autobrr/qui/discussions/2048

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized database index structures to improve foreign key constraint performance and prevent potential full-table scans during cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->