### PR TITLE
feat(api): add GET /api/version reporting the running version

### DIFF
--- a/internal/api/handlers/version.go
+++ b/internal/api/handlers/version.go
@@ -4,19 +4,29 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 
-	"github.com/autobrr/qui/internal/update"
+	"github.com/autobrr/qui/pkg/version"
 )
 
-type VersionHandler struct {
-	updateService *update.Service
+// latestReleaseProvider exposes the cached latest release discovered by the
+// update service. It is satisfied by *update.Service and kept intentionally
+// small so the version handler can be exercised without a live update check.
+type latestReleaseProvider interface {
+	GetLatestRelease(ctx context.Context) *version.Release
 }
 
-func NewVersionHandler(updateService *update.Service) *VersionHandler {
+type VersionHandler struct {
+	updateService  latestReleaseProvider
+	currentVersion string
+}
+
+func NewVersionHandler(updateService latestReleaseProvider, currentVersion string) *VersionHandler {
 	return &VersionHandler{
-		updateService: updateService,
+		updateService:  updateService,
+		currentVersion: currentVersion,
 	}
 }
 
@@ -25,6 +35,32 @@ type LatestVersionResponse struct {
 	Name        string `json:"name,omitempty"`
 	HTMLURL     string `json:"html_url"`
 	PublishedAt string `json:"published_at"`
+}
+
+// VersionResponse reports the version qui is currently running plus whether a
+// newer release has been detected. Intended for monitoring tools (e.g. Argus)
+// that track the deployed version of a service.
+type VersionResponse struct {
+	Version         string `json:"version"`
+	LatestVersion   string `json:"latestVersion,omitempty"`
+	UpdateAvailable bool   `json:"updateAvailable"`
+}
+
+// GetVersion returns the version qui is currently running. When the update
+// service has detected a newer release, LatestVersion and UpdateAvailable are
+// populated from the cached result; otherwise UpdateAvailable is false and
+// LatestVersion is omitted.
+func (h *VersionHandler) GetVersion(w http.ResponseWriter, r *http.Request) {
+	response := VersionResponse{
+		Version: h.currentVersion,
+	}
+
+	if release := h.updateService.GetLatestRelease(r.Context()); release != nil {
+		response.LatestVersion = release.TagName
+		response.UpdateAvailable = true
+	}
+
+	RespondJSON(w, http.StatusOK, response)
 }
 
 func (h *VersionHandler) GetLatestVersion(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/version_test.go
+++ b/internal/api/handlers/version_test.go
@@ -29,7 +29,7 @@ func (s stubReleaseProvider) GetLatestRelease(context.Context) *version.Release 
 func TestVersionHandler_GetVersion_NoUpdate(t *testing.T) {
 	handler := NewVersionHandler(stubReleaseProvider{release: nil}, "v1.2.3")
 
-	req := httptest.NewRequest(http.MethodGet, "/api/version", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/version", nil)
 	rec := httptest.NewRecorder()
 	handler.GetVersion(rec, req)
 
@@ -49,7 +49,7 @@ func TestVersionHandler_GetVersion_UpdateAvailable(t *testing.T) {
 		PublishedAt: time.Date(2026, 3, 2, 10, 0, 0, 0, time.UTC),
 	}}, "v1.2.3")
 
-	req := httptest.NewRequest(http.MethodGet, "/api/version", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/version", nil)
 	rec := httptest.NewRecorder()
 	handler.GetVersion(rec, req)
 

--- a/internal/api/handlers/version_test.go
+++ b/internal/api/handlers/version_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/pkg/version"
+)
+
+// stubReleaseProvider lets the version handler tests control the cached release
+// without performing a live update check.
+type stubReleaseProvider struct {
+	release *version.Release
+}
+
+func (s stubReleaseProvider) GetLatestRelease(context.Context) *version.Release {
+	return s.release
+}
+
+func TestVersionHandler_GetVersion_NoUpdate(t *testing.T) {
+	handler := NewVersionHandler(stubReleaseProvider{release: nil}, "v1.2.3")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/version", nil)
+	rec := httptest.NewRecorder()
+	handler.GetVersion(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+	var resp VersionResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, "v1.2.3", resp.Version)
+	require.False(t, resp.UpdateAvailable)
+	require.Empty(t, resp.LatestVersion)
+}
+
+func TestVersionHandler_GetVersion_UpdateAvailable(t *testing.T) {
+	handler := NewVersionHandler(stubReleaseProvider{release: &version.Release{
+		TagName:     "v1.3.0",
+		PublishedAt: time.Date(2026, 3, 2, 10, 0, 0, 0, time.UTC),
+	}}, "v1.2.3")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/version", nil)
+	rec := httptest.NewRecorder()
+	handler.GetVersion(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp VersionResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, "v1.2.3", resp.Version)
+	require.True(t, resp.UpdateAvailable)
+	require.Equal(t, "v1.3.0", resp.LatestVersion)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -341,7 +341,7 @@ func (s *Server) Handler() (*chi.Mux, error) {
 	clientAPIKeysHandler := handlers.NewClientAPIKeysHandler(s.clientAPIKeyStore, s.instanceStore, s.config.Config.BaseURL)
 	externalProgramsHandler := handlers.NewExternalProgramsHandler(s.externalProgramStore, s.externalProgramService, s.clientPool, s.automationStore)
 	arrHandler := handlers.NewArrHandler(s.arrInstanceStore, s.arrService)
-	versionHandler := handlers.NewVersionHandler(s.updateService)
+	versionHandler := handlers.NewVersionHandler(s.updateService, s.version)
 	applicationHandler := handlers.NewApplicationHandler(s.config, s.started)
 	qbittorrentInfoHandler := handlers.NewQBittorrentInfoHandler(s.clientPool)
 	backupsHandler := handlers.NewBackupsHandler(s.backupService)
@@ -493,7 +493,8 @@ func (s *Server) Handler() (*chi.Mux, error) {
 			// Log settings and streaming
 			logsHandler.Routes(r)
 
-			// Version endpoint for update checks
+			// Version endpoints (current running version + update checks)
+			r.Get("/version", versionHandler.GetVersion)
 			r.Get("/version/latest", versionHandler.GetLatestVersion)
 			r.Get("/application/info", applicationHandler.GetInfo)
 

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -4451,6 +4451,20 @@ paths:
         '204':
           description: No update available - current version is latest
 
+  /api/version:
+    get:
+      tags:
+        - System
+      summary: Get current running version
+      description: Returns the version qui is currently running, along with whether a newer release is available. Useful for monitoring tools (e.g. Argus) that track the deployed version of a service.
+      responses:
+        '200':
+          description: Current version information
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VersionResponse'
+
   /api/instances/{instanceID}/backups/import:
     post:
       tags:
@@ -6163,6 +6177,26 @@ components:
           format: date-time
           description: When the release was published
           example: "2025-09-23T10:30:00Z"
+
+    VersionResponse:
+      type: object
+      description: The version qui is currently running and whether a newer release is available
+      required:
+        - version
+        - updateAvailable
+      properties:
+        version:
+          type: string
+          description: The version qui is currently running
+          example: "v1.2.3"
+        latestVersion:
+          type: string
+          description: The latest available release tag. Present only when a newer release than the running version has been detected.
+          example: "v1.3.0"
+        updateAvailable:
+          type: boolean
+          description: Whether a newer release than the running version is available
+          example: true
 
     QBittorrentBuildInfo:
       type: object


### PR DESCRIPTION
## Summary

Adds a lightweight endpoint that reports the version qui is **currently running**, so monitoring tools (e.g. [Argus](https://github.com/release-argus/Argus)) can track the deployed version. Requested in discussion #1678.

Previously the API could only tell you:
- `GET /api/version/latest` — the *latest available* release (returns `204 No Content` when up to date), and
- `GET /api/application/info` — a heavy payload that includes the version alongside config/data dirs, DB target, host/port, etc.

Neither is a clean, stable contract for "what version is running." This adds one.

## New endpoint

`GET /api/version`

**Response — newer release detected:**
```json
{
  "version": "v1.2.3",
  "latestVersion": "v1.3.0",
  "updateAvailable": true
}
```

**Response — up to date / update checks disabled / not yet checked:**
```json
{
  "version": "v1.2.3",
  "updateAvailable": false
}
```

`version` is the running build (`buildinfo.Version`). `latestVersion` is omitted (`omitempty`) when no newer release is known; `updateAvailable` reflects the update service's cached check.

## Authentication

**Yes — authenticated.** The route is registered inside the same auth-protected group as the rest of `/api/*` (`middleware.IsAuthenticated`). Callers must provide one of:
- an API key via the `X-API-Key` header, or
- a valid session cookie.

(When qui is run with authentication globally disabled, the middleware passes through, exactly like every other API route.) For an Argus `deployed_version` lookup, set an `X-API-Key` header and extract `.version`.

## Changes

- `internal/api/handlers/version.go` — add `VersionResponse` + `GetVersion`, behind a small consumer-side `latestReleaseProvider` interface so the handler is testable without a live update check; `NewVersionHandler` now also takes the running version.
- `internal/api/server.go` — wire `buildinfo.Version` into the handler and register `GET /api/version` in the authenticated group.
- `internal/web/swagger/openapi.yaml` — document the `/api/version` path and `VersionResponse` schema.
- `internal/api/handlers/version_test.go` — cover the update-available and up-to-date paths.

## Testing

- [x] `go test -race -count=1 ./internal/api/handlers/... ./internal/web/swagger/...`
- [x] `make test-openapi` (spec now documents the new path + `VersionResponse` schema)
- [x] `go build ./...`; `gofmt` and `go vet` clean on changed files
- [ ] `make lint` — could not run locally due to a `golangci-lint`/Go toolchain mismatch (binary built with go1.25 vs the project's go1.26 target); deferring to CI

No UI changes, so no screenshots.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DTT3PFpVW9UjMxwduXz3aw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new version endpoint that returns the app’s current running version and whether an update is available.
  * When a cached newer release is detected, the response includes the latest available version.
* **Bug Fixes**
  * Version responses are now consistently returned as JSON (no more empty/no-content responses).
* **Documentation**
  * Updated the API specification with the new version endpoint and response schema.
* **Tests**
  * Added tests covering version responses both with no update and with an available update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->