### PR TITLE
feat(web): add file priority controls to torrent file views

### DIFF
--- a/web/src/components/torrents/FilePrioritySelect.tsx
+++ b/web/src/components/torrents/FilePrioritySelect.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
+import {
+  FILE_PRIORITY_LABEL_KEYS,
+  FILE_PRIORITY_OPTIONS,
+  type FilePriorityValue,
+  type FolderPriority
+} from "@/lib/file-priority"
+import { cn } from "@/lib/utils"
+import type { MouseEvent as ReactMouseEvent } from "react"
+import { useTranslation } from "react-i18next"
+
+interface FilePrioritySelectProps {
+  value: FolderPriority
+  disabled?: boolean
+  onChange: (priority: FilePriorityValue) => void
+  className?: string
+}
+
+// qBittorrent-style download-priority dropdown shared by the file table and tree views.
+// "Mixed" is a display-only state for folders whose files differ; it is never selectable.
+export function FilePrioritySelect({ value, disabled, onChange, className }: FilePrioritySelectProps) {
+  const { t } = useTranslation("torrents")
+  const isMixed = value === "mixed"
+
+  return (
+    <Select
+      value={String(value)}
+      disabled={disabled}
+      onValueChange={(next) => {
+        if (next === "mixed") return
+        onChange(Number(next) as FilePriorityValue)
+      }}
+    >
+      <SelectTrigger
+        size="sm"
+        className={cn("h-7 gap-1 px-2 text-xs", className)}
+        onClick={(e: ReactMouseEvent) => e.stopPropagation()}
+        aria-label={t("filePriority.header")}
+      >
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {isMixed && (
+          <SelectItem value="mixed" disabled>
+            {t("filePriority.mixed")}
+          </SelectItem>
+        )}
+        {FILE_PRIORITY_OPTIONS.map((option) => (
+          <SelectItem key={option} value={String(option)}>
+            {t(FILE_PRIORITY_LABEL_KEYS[option])}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}

--- a/web/src/components/torrents/FilePrioritySelect.tsx
+++ b/web/src/components/torrents/FilePrioritySelect.tsx
@@ -42,9 +42,13 @@ export function FilePrioritySelect({ value, disabled, onChange, className }: Fil
         onChange(Number(next) as FilePriorityValue)
       }}
     >
+      {/*
+        h-6! is intentional: the shared SelectTrigger sets its height via a data-[size]:h-*
+        variant whose attribute selector outspecifies a plain h-* utility, so a non-important
+        height would be ignored. Callers pass width only; height is owned here.
+      */}
       <SelectTrigger
-        size="sm"
-        className={cn("h-7 gap-1 px-2 text-xs", className)}
+        className={cn("h-6! gap-1 px-2 text-xs", className)}
         onClick={(e: ReactMouseEvent) => e.stopPropagation()}
         aria-label={t("filePriority.header")}
       >

--- a/web/src/components/torrents/TorrentDetailsPanel.tsx
+++ b/web/src/components/torrents/TorrentDetailsPanel.tsx
@@ -417,6 +417,33 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
     })
   }, [files, setFilePriorityMutation, supportsFilePriority, torrent])
 
+  const handleSetFilePriority = useCallback((file: TorrentFile, priority: number) => {
+    if (!torrent || !supportsFilePriority || file.priority === priority) {
+      return
+    }
+
+    setFilePriorityMutation.mutate({ indices: [file.index], priority, hash: torrent.hash })
+  }, [setFilePriorityMutation, supportsFilePriority, torrent])
+
+  const handleSetFolderPriority = useCallback((folderPath: string, priority: number) => {
+    if (!torrent || !supportsFilePriority || !files) {
+      return
+    }
+
+    // Apply to every descendant file that isn't already at the target priority.
+    const folderPrefix = folderPath + "/"
+    const indices = files
+      .filter(f => f.name.startsWith(folderPrefix))
+      .filter(f => f.priority !== priority)
+      .map(f => f.index)
+
+    if (indices.length === 0) {
+      return
+    }
+
+    setFilePriorityMutation.mutate({ indices, priority, hash: torrent.hash })
+  }, [files, setFilePriorityMutation, supportsFilePriority, torrent])
+
   // Fetch torrent peers with optimized refetch
   const isPeersTabActive = activeTab === "peers"
   const peersQueryKey = ["torrent-peers", instanceId, torrent?.hash] as const
@@ -1564,6 +1591,8 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
                 torrentHash={torrent.hash}
                 onToggleFile={handleToggleFileDownload}
                 onToggleFolder={handleToggleFolderDownload}
+                onSetFilePriority={handleSetFilePriority}
+                onSetFolderPriority={handleSetFolderPriority}
                 onRenameFile={handleRenameFileClick}
                 onRenameFolder={(folderPath) => { void handleRenameFolderDialogOpen(folderPath) }}
                 onDownloadFile={hasLocalFilesystemAccess ? handleDownloadFile : undefined}
@@ -1618,6 +1647,8 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
                       torrentHash={torrent.hash}
                       onToggleFile={handleToggleFileDownload}
                       onToggleFolder={handleToggleFolderDownload}
+                      onSetFilePriority={handleSetFilePriority}
+                      onSetFolderPriority={handleSetFolderPriority}
                       onRenameFile={handleRenameFileClick}
                       onRenameFolder={(folderPath) => { void handleRenameFolderDialogOpen(folderPath) }}
                       onDownloadFile={hasLocalFilesystemAccess ? handleDownloadFile : undefined}

--- a/web/src/components/torrents/TorrentFileTree.tsx
+++ b/web/src/components/torrents/TorrentFileTree.tsx
@@ -3,8 +3,10 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
+import { FilePrioritySelect } from "@/components/torrents/FilePrioritySelect"
 import { Checkbox } from "@/components/ui/checkbox"
 import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from "@/components/ui/context-menu"
+import { FILE_PRIORITY, foldFolderPriority, normalizeFilePriority, type FolderPriority } from "@/lib/file-priority"
 import { getLinuxFileName } from "@/lib/incognito"
 import { cn, formatBytes } from "@/lib/utils"
 import type { TorrentFile } from "@/types"
@@ -21,6 +23,8 @@ interface TorrentFileTreeProps {
   torrentHash: string
   onToggleFile: (file: TorrentFile, selected: boolean) => void
   onToggleFolder: (folderPath: string, selected: boolean) => void
+  onSetFilePriority: (file: TorrentFile, priority: number) => void
+  onSetFolderPriority: (folderPath: string, priority: number) => void
   onRenameFile: (filePath: string) => void
   onRenameFolder: (folderPath: string) => void
   onDownloadFile?: (file: TorrentFile) => void
@@ -37,6 +41,7 @@ interface FileTreeNode {
   totalProgress: number
   selectedCount: number
   totalCount: number
+  priority: FolderPriority
 }
 
 interface FlatRow {
@@ -82,6 +87,7 @@ function buildFileTree(
           totalProgress: isLeaf ? file.progress * file.size : 0,
           selectedCount: isLeaf && file.priority !== 0 ? 1 : 0,
           totalCount: isLeaf ? 1 : 0,
+          priority: isLeaf ? normalizeFilePriority(file.priority) : FILE_PRIORITY.normal,
         }
         nodeMap.set(currentPath, node)
 
@@ -110,6 +116,7 @@ function buildFileTree(
       let totalProgress = 0
       let selectedCount = 0
       let totalCount = 0
+      let priority: FolderPriority | undefined
 
       for (const child of node.children) {
         calculateAggregates(child)
@@ -117,12 +124,16 @@ function buildFileTree(
         totalProgress += child.totalProgress
         selectedCount += child.selectedCount
         totalCount += child.totalCount
+        priority = priority === undefined ? child.priority : foldFolderPriority(priority, child.priority)
       }
 
       node.totalSize = totalSize
       node.totalProgress = totalProgress
       node.selectedCount = selectedCount
       node.totalCount = totalCount
+      if (priority !== undefined) {
+        node.priority = priority
+      }
 
       // Sort children: folders first, then files, both alphabetically
       node.children.sort((a, b) => {
@@ -178,6 +189,8 @@ export const TorrentFileTree = memo(function TorrentFileTree({
   torrentHash,
   onToggleFile,
   onToggleFolder,
+  onSetFilePriority,
+  onSetFolderPriority,
   onRenameFile,
   onRenameFolder,
   onDownloadFile,
@@ -228,8 +241,9 @@ export const TorrentFileTree = memo(function TorrentFileTree({
     [nodes, expandedFolders]
   )
 
-  // Row height: ~44px for tree rows (two lines with padding)
-  const ROW_HEIGHT = 44
+  // Row height: ~48px for tree rows (two lines with padding; the name line carries the
+  // compact priority dropdown when file priority is supported)
+  const ROW_HEIGHT = 48
 
   const virtualizer = useVirtualizer({
     count: flatRows.length,
@@ -320,11 +334,19 @@ export const TorrentFileTree = memo(function TorrentFileTree({
                         />
                       )}
                       <span className={cn(
-                        "text-xs font-mono truncate",
+                        "flex-1 min-w-0 text-xs font-mono truncate",
                         isSkipped && supportsFilePriority && "text-muted-foreground/70"
                       )}>
                         {node.name}
                       </span>
+                      {supportsFilePriority && (
+                        <FilePrioritySelect
+                          value={node.priority}
+                          disabled={isPending}
+                          onChange={(priority) => onSetFilePriority(file, priority)}
+                          className="h-6 w-32 shrink-0"
+                        />
+                      )}
                     </div>
                     <div className="flex items-center gap-2" style={{ paddingLeft: supportsFilePriority ? "24px" : "0" }}>
                       {isPending && (
@@ -431,9 +453,16 @@ export const TorrentFileTree = memo(function TorrentFileTree({
                         className="shrink-0"
                       />
                     )}
-                    <span className="text-xs font-medium truncate">
+                    <span className="flex-1 min-w-0 text-xs font-medium truncate">
                       {node.name}/
                     </span>
+                    {supportsFilePriority && (
+                      <FilePrioritySelect
+                        value={node.priority}
+                        onChange={(priority) => onSetFolderPriority(node.id, priority)}
+                        className="h-6 w-32 shrink-0"
+                      />
+                    )}
                   </div>
                   <div className="flex items-center gap-2" style={{ paddingLeft: supportsFilePriority ? "40px" : "24px" }}>
                     <span className="text-[10px] text-muted-foreground tabular-nums whitespace-nowrap">

--- a/web/src/components/torrents/TorrentFileTree.tsx
+++ b/web/src/components/torrents/TorrentFileTree.tsx
@@ -344,7 +344,7 @@ export const TorrentFileTree = memo(function TorrentFileTree({
                           value={node.priority}
                           disabled={isPending}
                           onChange={(priority) => onSetFilePriority(file, priority)}
-                          className="h-6 w-32 shrink-0"
+                          className="w-32 shrink-0"
                         />
                       )}
                     </div>
@@ -460,7 +460,7 @@ export const TorrentFileTree = memo(function TorrentFileTree({
                       <FilePrioritySelect
                         value={node.priority}
                         onChange={(priority) => onSetFolderPriority(node.id, priority)}
-                        className="h-6 w-32 shrink-0"
+                        className="w-32 shrink-0"
                       />
                     )}
                   </div>

--- a/web/src/components/torrents/details/TorrentFileTable.tsx
+++ b/web/src/components/torrents/details/TorrentFileTable.tsx
@@ -367,7 +367,7 @@ export const TorrentFileTable = memo(function TorrentFileTable({
         ref={scrollContainerRef}
         className="flex-1 min-h-0 overflow-auto scrollbar-thin"
       >
-        <div className="min-w-[640px]">
+        <div className={cn("min-w-[500px]", supportsFilePriority && "min-w-[640px]")}>
           {/* Header - sticky */}
           <div className="sticky top-0 z-10 bg-background border-b flex text-xs">
             {supportsFilePriority && (
@@ -480,7 +480,7 @@ export const TorrentFileTable = memo(function TorrentFileTable({
                       <FilePrioritySelect
                         value={node.priority}
                         disabled={isPending}
-                        className="w-full h-6"
+                        className="w-full"
                         onChange={(priority: FilePriorityValue) => {
                           if (isFile && file) {
                             onSetFilePriority(file, priority)

--- a/web/src/components/torrents/details/TorrentFileTable.tsx
+++ b/web/src/components/torrents/details/TorrentFileTable.tsx
@@ -3,11 +3,13 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
+import { FilePrioritySelect } from "@/components/torrents/FilePrioritySelect"
 import { Checkbox } from "@/components/ui/checkbox"
 import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from "@/components/ui/context-menu"
 import { Input } from "@/components/ui/input"
 import { Progress } from "@/components/ui/progress"
 import { TruncatedText } from "@/components/ui/truncated-text"
+import { FILE_PRIORITY, foldFolderPriority, normalizeFilePriority, type FilePriorityValue, type FolderPriority } from "@/lib/file-priority"
 import { getLinuxFileName, getLinuxFolderName } from "@/lib/incognito"
 import { cn, formatBytes } from "@/lib/utils"
 import type { TorrentFile } from "@/types"
@@ -25,6 +27,8 @@ interface TorrentFileTableProps {
   torrentHash: string
   onToggleFile: (file: TorrentFile, selected: boolean) => void
   onToggleFolder: (folderPath: string, selected: boolean) => void
+  onSetFilePriority: (file: TorrentFile, priority: number) => void
+  onSetFolderPriority: (folderPath: string, priority: number) => void
   onRenameFile?: (filePath: string) => void
   onRenameFolder?: (folderPath: string) => void
   onDownloadFile?: (file: TorrentFile) => void
@@ -41,6 +45,7 @@ interface FileTreeNode {
   totalProgress: number
   selectedCount: number
   totalCount: number
+  priority: FolderPriority
 }
 
 interface FlatRow {
@@ -94,6 +99,7 @@ function buildFileTree(
           totalProgress: isLeaf ? file.progress * file.size : 0,
           selectedCount: isLeaf && file.priority !== 0 ? 1 : 0,
           totalCount: isLeaf ? 1 : 0,
+          priority: isLeaf ? normalizeFilePriority(file.priority) : FILE_PRIORITY.normal,
         }
         nodeMap.set(currentPath, node)
 
@@ -119,6 +125,9 @@ function buildFileTree(
       node.totalProgress = node.children.reduce((sum, child) => sum + child.totalProgress, 0)
       node.selectedCount = node.children.reduce((sum, child) => sum + child.selectedCount, 0)
       node.totalCount = node.children.reduce((sum, child) => sum + child.totalCount, 0)
+      if (node.children.length > 0) {
+        node.priority = node.children.map(child => child.priority).reduce(foldFolderPriority)
+      }
     }
   }
 
@@ -181,6 +190,8 @@ export const TorrentFileTable = memo(function TorrentFileTable({
   torrentHash,
   onToggleFile,
   onToggleFolder,
+  onSetFilePriority,
+  onSetFolderPriority,
   onRenameFile,
   onRenameFolder,
   onDownloadFile,
@@ -356,7 +367,7 @@ export const TorrentFileTable = memo(function TorrentFileTable({
         ref={scrollContainerRef}
         className="flex-1 min-h-0 overflow-auto scrollbar-thin"
       >
-        <div className="min-w-[500px]">
+        <div className="min-w-[640px]">
           {/* Header - sticky */}
           <div className="sticky top-0 z-10 bg-background border-b flex text-xs">
             {supportsFilePriority && (
@@ -365,6 +376,9 @@ export const TorrentFileTable = memo(function TorrentFileTable({
             <div className="flex-1 px-2 py-1.5 text-left font-medium text-muted-foreground">{t("fileTable.headers.name")}</div>
             <div className="w-28 px-2 py-1.5 text-left font-medium text-muted-foreground shrink-0">{t("fileTable.headers.progress")}</div>
             <div className="w-24 px-2 py-1.5 text-right font-medium text-muted-foreground shrink-0">{t("fileTable.headers.size")}</div>
+            {supportsFilePriority && (
+              <div className="w-36 px-2 py-1.5 text-left font-medium text-muted-foreground shrink-0">{t("filePriority.header")}</div>
+            )}
           </div>
           {/* Virtualized body */}
           <div
@@ -461,6 +475,22 @@ export const TorrentFileTable = memo(function TorrentFileTable({
                   <div className="w-24 px-2 py-1.5 text-right tabular-nums shrink-0">
                     {formatBytes(node.totalSize)}
                   </div>
+                  {supportsFilePriority && (
+                    <div className="w-36 px-2 shrink-0 flex items-center">
+                      <FilePrioritySelect
+                        value={node.priority}
+                        disabled={isPending}
+                        className="w-full h-6"
+                        onChange={(priority: FilePriorityValue) => {
+                          if (isFile && file) {
+                            onSetFilePriority(file, priority)
+                          } else {
+                            onSetFolderPriority(node.id, priority)
+                          }
+                        }}
+                      />
+                    </div>
+                  )}
                 </div>
               )
 

--- a/web/src/i18n/locales/de/torrents.json
+++ b/web/src/i18n/locales/de/torrents.json
@@ -1182,6 +1182,14 @@
       "urlCopied": "URL in die Zwischenablage kopiert"
     }
   },
+  "filePriority": {
+    "header": "Priorität",
+    "doNotDownload": "Nicht herunterladen",
+    "normal": "Normal",
+    "high": "Hoch",
+    "maximum": "Maximal",
+    "mixed": "Gemischt"
+  },
   "fileTable": {
     "expandAll": "Alle ausklappen",
     "collapseAll": "Alle einklappen",

--- a/web/src/i18n/locales/en/torrents.json
+++ b/web/src/i18n/locales/en/torrents.json
@@ -1182,6 +1182,14 @@
       "urlCopied": "URL copied to clipboard"
     }
   },
+  "filePriority": {
+    "header": "Priority",
+    "doNotDownload": "Do not download",
+    "normal": "Normal",
+    "high": "High",
+    "maximum": "Maximum",
+    "mixed": "Mixed"
+  },
   "fileTable": {
     "expandAll": "Expand All",
     "collapseAll": "Collapse All",

--- a/web/src/i18n/locales/fr/torrents.json
+++ b/web/src/i18n/locales/fr/torrents.json
@@ -1182,6 +1182,14 @@
       "urlCopied": "URL copiée dans le presse-papiers"
     }
   },
+  "filePriority": {
+    "header": "Priorité",
+    "doNotDownload": "Ne pas télécharger",
+    "normal": "Normale",
+    "high": "Haute",
+    "maximum": "Maximale",
+    "mixed": "Mixte"
+  },
   "fileTable": {
     "expandAll": "Tout développer",
     "collapseAll": "Tout réduire",

--- a/web/src/i18n/locales/it/torrents.json
+++ b/web/src/i18n/locales/it/torrents.json
@@ -1182,6 +1182,14 @@
       "urlCopied": "URL copiato negli appunti"
     }
   },
+  "filePriority": {
+    "header": "Priorità",
+    "doNotDownload": "Non scaricare",
+    "normal": "Normale",
+    "high": "Alta",
+    "maximum": "Massima",
+    "mixed": "Mista"
+  },
   "fileTable": {
     "expandAll": "Espandi tutto",
     "collapseAll": "Comprimi tutto",

--- a/web/src/i18n/locales/ko/torrents.json
+++ b/web/src/i18n/locales/ko/torrents.json
@@ -1123,6 +1123,14 @@
       "urlCopied": "URL이 클립보드에 복사되었습니다"
     }
   },
+  "filePriority": {
+    "header": "우선순위",
+    "doNotDownload": "다운로드 안 함",
+    "normal": "보통",
+    "high": "높음",
+    "maximum": "최대",
+    "mixed": "혼합"
+  },
   "fileTable": {
     "expandAll": "모두 펼치기",
     "collapseAll": "모두 접기",

--- a/web/src/i18n/locales/zh-CN/torrents.json
+++ b/web/src/i18n/locales/zh-CN/torrents.json
@@ -1132,7 +1132,7 @@
   "filePriority": {
     "header": "优先级",
     "doNotDownload": "不下载",
-    "normal": "普通",
+    "normal": "正常",
     "high": "高",
     "maximum": "最高",
     "mixed": "混合"

--- a/web/src/i18n/locales/zh-CN/torrents.json
+++ b/web/src/i18n/locales/zh-CN/torrents.json
@@ -1123,6 +1123,14 @@
       "urlCopied": "URL 已复制到剪贴板"
     }
   },
+  "filePriority": {
+    "header": "优先级",
+    "doNotDownload": "不下载",
+    "normal": "普通",
+    "high": "高",
+    "maximum": "最高",
+    "mixed": "混合"
+  },
   "fileTable": {
     "expandAll": "全部展开",
     "collapseAll": "全部折叠",

--- a/web/src/lib/__tests__/file-priority.test.ts
+++ b/web/src/lib/__tests__/file-priority.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { describe, expect, it } from "vitest"
+import {
+  FILE_PRIORITY,
+  FILE_PRIORITY_LABEL_KEYS,
+  FILE_PRIORITY_OPTIONS,
+  foldFolderPriority,
+  normalizeFilePriority,
+  type FolderPriority
+} from "@/lib/file-priority"
+
+describe("normalizeFilePriority", () => {
+  it("maps 0 to doNotDownload", () => {
+    expect(normalizeFilePriority(0)).toBe(FILE_PRIORITY.doNotDownload)
+  })
+
+  it("maps 1 to normal", () => {
+    expect(normalizeFilePriority(1)).toBe(FILE_PRIORITY.normal)
+  })
+
+  it("collapses legacy values 2-5 to normal", () => {
+    for (const value of [2, 3, 4, 5]) {
+      expect(normalizeFilePriority(value)).toBe(FILE_PRIORITY.normal)
+    }
+  })
+
+  it("maps 6 to high and 7 to maximum", () => {
+    expect(normalizeFilePriority(6)).toBe(FILE_PRIORITY.high)
+    expect(normalizeFilePriority(7)).toBe(FILE_PRIORITY.maximum)
+  })
+
+  it("clamps out-of-range values to the nearest bucket", () => {
+    expect(normalizeFilePriority(-5)).toBe(FILE_PRIORITY.doNotDownload)
+    expect(normalizeFilePriority(99)).toBe(FILE_PRIORITY.maximum)
+  })
+})
+
+describe("foldFolderPriority", () => {
+  it("returns the shared value when both sides match", () => {
+    expect(foldFolderPriority(FILE_PRIORITY.high, FILE_PRIORITY.high)).toBe(FILE_PRIORITY.high)
+  })
+
+  it("returns 'mixed' when the values differ", () => {
+    expect(foldFolderPriority(FILE_PRIORITY.normal, FILE_PRIORITY.maximum)).toBe("mixed")
+  })
+
+  it("propagates 'mixed' from either side", () => {
+    expect(foldFolderPriority("mixed", FILE_PRIORITY.normal)).toBe("mixed")
+    expect(foldFolderPriority(FILE_PRIORITY.normal, "mixed")).toBe("mixed")
+  })
+
+  it("reduces a list of file priorities correctly", () => {
+    const fold = (values: FolderPriority[]) => values.reduce(foldFolderPriority)
+    expect(fold([FILE_PRIORITY.high, FILE_PRIORITY.high, FILE_PRIORITY.high])).toBe(FILE_PRIORITY.high)
+    expect(fold([FILE_PRIORITY.high, FILE_PRIORITY.normal])).toBe("mixed")
+  })
+})
+
+describe("priority metadata", () => {
+  it("exposes the four selectable options in display order", () => {
+    expect(FILE_PRIORITY_OPTIONS).toEqual([0, 1, 6, 7])
+  })
+
+  it("has a label key for every option", () => {
+    for (const option of FILE_PRIORITY_OPTIONS) {
+      expect(FILE_PRIORITY_LABEL_KEYS[option]).toMatch(/^filePriority\./)
+    }
+  })
+})

--- a/web/src/lib/file-priority.ts
+++ b/web/src/lib/file-priority.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+// qBittorrent download-priority values exposed in its WebUI. libtorrent technically
+// uses 0-7, but qBittorrent only surfaces these four; legacy values (2-5) collapse to
+// Normal. See discussion #1007.
+export const FILE_PRIORITY = {
+  doNotDownload: 0,
+  normal: 1,
+  high: 6,
+  maximum: 7,
+} as const
+
+export type FilePriorityValue = (typeof FILE_PRIORITY)[keyof typeof FILE_PRIORITY]
+
+export const FILE_PRIORITY_OPTIONS: FilePriorityValue[] = [
+  FILE_PRIORITY.doNotDownload,
+  FILE_PRIORITY.normal,
+  FILE_PRIORITY.high,
+  FILE_PRIORITY.maximum,
+]
+
+// Collapse any qBittorrent priority (0-7) into one of the four canonical buckets so the
+// dropdown always has a concrete value to display.
+export function normalizeFilePriority(priority: number): FilePriorityValue {
+  if (priority <= 0) return FILE_PRIORITY.doNotDownload
+  if (priority >= 7) return FILE_PRIORITY.maximum
+  if (priority >= 6) return FILE_PRIORITY.high
+  return FILE_PRIORITY.normal
+}
+
+// A folder's effective priority: a single value when all descendant files share it,
+// otherwise "mixed" (a display-only state, like qBittorrent's WebUI).
+export type FolderPriority = FilePriorityValue | "mixed"
+
+export function foldFolderPriority(a: FolderPriority, b: FolderPriority): FolderPriority {
+  if (a === "mixed" || b === "mixed") return "mixed"
+  return a === b ? a : "mixed"
+}
+
+// i18n keys (in the "torrents" namespace) for each priority level.
+export const FILE_PRIORITY_LABEL_KEYS: Record<FilePriorityValue, string> = {
+  [FILE_PRIORITY.doNotDownload]: "filePriority.doNotDownload",
+  [FILE_PRIORITY.normal]: "filePriority.normal",
+  [FILE_PRIORITY.high]: "filePriority.high",
+  [FILE_PRIORITY.maximum]: "filePriority.maximum",
+}


### PR DESCRIPTION
## Summary

Adds per-file/folder download **priority** controls to the torrent Content tab,
matching qBittorrent's WebUI. qui previously only exposed include/exclude (a checkbox
toggling priority `0` ↔ `1`), so **High** and **Maximum** were unreachable even though
the backend already supported the full range.

Addresses discussion #1007.

## Changes

- New **Priority** column (to the right of Size) in the horizontal/table file view
  (`TorrentFileTable`), with a per-row dropdown: **Do not download / Normal / High /
  Maximum**.
- Folders show **Mixed** (display-only, not selectable) when their files differ;
  picking a level applies it to every descendant file.
- The same dropdown is added inline to the vertical tree view (`TorrentFileTree`) for
  parity.
- Existing download checkbox retained (qBittorrent keeps both).
- New shared helper `web/src/lib/file-priority.ts` (+ unit tests) for the
  level/normalization/fold logic.
- i18n added across all 6 locales (en, de, fr, it, ko, zh-CN).

Backend is unchanged — `SetTorrentFilePriority` already accepts priority `0–7`.

## Testing

- [x] `vitest` for the `file-priority` helper (11/11)
- [x] `pnpm check:i18n` (0 errors)
- [x] `tsc -b` typecheck + `eslint` on changed files
- [x] `make frontend` build + `internal/web/dist` sync
- [x] Manual smoke against a live qBittorrent instance (set each level on a file and a
      folder; verified it syncs and folders show "Mixed")

## Screenshots

**Priority dropdown — Do not download / Normal / High / Maximum**
<img width="1920" height="1080" alt="priority-dropdown" src="https://github.com/user-attachments/assets/9bb8f351-c4dd-4f2f-8146-ed607f4aeb6b" />

**Mixed folder state — files set to High and Maximum, so the folder shows "Mixed"**
<img width="1920" height="1080" alt="priority-column-mixed" src="https://github.com/user-attachments/assets/c29580fb-7f63-4051-8bf9-0c2333e6bbf0" />

**Close-up of the new Priority column**
<img width="1344" height="198" alt="priority-column-closeup" src="https://github.com/user-attachments/assets/c6a1d727-c98d-4156-8c58-d91ba3c27c5b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added per-file priority controls and folder priority assignment in torrent file views (file table and file tree), including a qBittorrent-style priority dropdown and updated layout.
  * Folder priority now reflects the combined priorities of contained items, with “Mixed” shown as a display-only state.

* **Bug Fixes**
  * Improved folder priority propagation/aggregation so folder rows stay in sync with their contents.

* **Documentation**
  * Added localized file-priority UI labels (“Do not download,” “Normal,” “High,” “Maximum,” “Mixed”) across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->