### PR TITLE
fix(sse): resolve sync-error staleness stamp off the sync-loop callback

### DIFF
--- a/internal/api/sse/manager.go
+++ b/internal/api/sse/manager.go
@@ -352,10 +352,14 @@ func NewStreamManager(clientPool *qbittorrent.ClientPool, syncManager syncProvid
 }
 
 // instanceLastSuccessfulSync returns the instance's last successful sync time, or
-// the zero time when no client is available. It uses the offline pool accessor so a
-// sync-error callback can stamp staleness metadata without triggering a connection
-// attempt that could block the sync loop. GetLastSyncUpdate reports the success-only
+// the zero time when no client is available. It uses the offline pool accessor to
+// avoid triggering a connection attempt. GetLastSyncUpdate reports the success-only
 // clock, so a failing instance keeps reporting its last good sync rather than now.
+//
+// GetLastSyncUpdate reads go-qbittorrent's LastSuccessfulSyncTime(), which locks the
+// SyncManager mutex. go-qbittorrent already holds that (non-reentrant) lock while it
+// invokes our OnError/OnUpdate callbacks, so this must never be called synchronously
+// from inside those callbacks (see HandleSyncError, which defers it to a goroutine).
 func (m *StreamManager) instanceLastSuccessfulSync(ctx context.Context, instanceID int) time.Time {
 	if m.clientPool == nil || instanceID <= 0 {
 		return time.Time{}
@@ -638,7 +642,6 @@ func (m *StreamManager) HandleSyncError(instanceID int, err error) {
 		Timestamp:      time.Now(),
 		RetryInSeconds: retrySeconds,
 	}
-	m.stampLastSuccessfulSync(m.ctx, meta, instanceID)
 
 	payload := &StreamPayload{
 		Type: streamEventError,
@@ -646,10 +649,21 @@ func (m *StreamManager) HandleSyncError(instanceID int, err error) {
 		Err:  message,
 	}
 
-	// Publish asynchronously so a slow or stalled subscriber can't block the
-	// qBittorrent sync loop's OnError callback during the synchronous fan-out.
-	// Mirrors HandleMainData.
-	go m.publishToInstance(instanceID, payload)
+	// Resolve the staleness stamp and publish asynchronously so the qBittorrent sync
+	// loop's OnError callback (this function) never blocks during the fan-out.
+	//
+	// The stamp MUST NOT be resolved synchronously here: go-qbittorrent invokes
+	// OnError while holding its SyncManager write lock, and stampLastSuccessfulSync
+	// reads LastSuccessfulSyncTime(), which takes a read lock on that same
+	// (non-reentrant) mutex. Calling it on this goroutine re-enters the held lock and
+	// self-deadlocks the sync loop, wedging the instance's client and starving every
+	// cached reader (e.g. GET /api/instances and cross-instance stream init). Doing it
+	// on a fresh goroutine lets the sync loop release its lock first. Mirrors
+	// HandleMainData.
+	go func() {
+		m.stampLastSuccessfulSync(m.ctx, meta, instanceID)
+		m.publishToInstance(instanceID, payload)
+	}()
 }
 
 // Serve implements the HTTP handler for GET /stream and multiplexes multiple subscriptions over one SSE session.

--- a/internal/api/sse/manager_test.go
+++ b/internal/api/sse/manager_test.go
@@ -96,6 +96,64 @@ func TestStreamManagerHandleSyncErrorStampsLastSuccessfulSync(t *testing.T) {
 		"last successful sync must not advance on a failed attempt")
 }
 
+func TestStreamManagerHandleSyncErrorResolvesStampOffCallbackGoroutine(t *testing.T) {
+	// Regression for a self-deadlock: HandleSyncError used to resolve the staleness
+	// stamp synchronously. go-qbittorrent invokes OnError while holding its SyncManager
+	// write lock, and the stamp reads LastSuccessfulSyncTime() which takes that same
+	// non-reentrant lock — wedging the sync loop and starving every cached reader
+	// (e.g. GET /api/instances). The stamp must be resolved on a fresh goroutine, so
+	// HandleSyncError must return without waiting on lastSuccessfulSyncFn.
+	manager := NewStreamManager(nil, nil, nil)
+	provider := newRecordingProvider()
+	manager.server.Provider = provider
+
+	stampStarted := make(chan struct{})
+	releaseStamp := make(chan struct{})
+	manager.lastSuccessfulSyncFn = func(_ context.Context, _ int) time.Time {
+		close(stampStarted)
+		<-releaseStamp
+		return time.Time{}
+	}
+
+	sub := &subscriptionState{
+		id:      "subscription-async-stamp",
+		options: StreamOptions{InstanceID: 42},
+		created: time.Now(),
+	}
+	manager.subscriptions[sub.id] = sub
+	manager.instanceIndex[sub.options.InstanceID] = map[string]*subscriptionState{
+		sub.id: sub,
+	}
+
+	returned := make(chan struct{})
+	go func() {
+		manager.HandleSyncError(sub.options.InstanceID, errors.New("sync failed"))
+		close(returned)
+	}()
+
+	// The stamp must run on a separate goroutine...
+	select {
+	case <-stampStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("lastSuccessfulSyncFn was never invoked")
+	}
+
+	// ...and HandleSyncError must have already returned to the (lock-holding) sync
+	// loop even though the stamp is still in flight. If the stamp were resolved
+	// synchronously, HandleSyncError would block here on releaseStamp.
+	select {
+	case <-returned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("HandleSyncError blocked on the staleness stamp; it must resolve it off the sync-loop callback goroutine")
+	}
+
+	close(releaseStamp)
+
+	require.Eventually(t, func() bool {
+		return len(provider.messagesFor(sub.id)) == 1
+	}, time.Second, 5*time.Millisecond, "error frame should still be published once the stamp resolves")
+}
+
 func TestStreamManagerHandleSyncErrorOmitsLastSuccessfulSyncWhenUnknown(t *testing.T) {
 	// A nil client pool means the default source cannot resolve a sync time, so the
 	// field must be omitted rather than serialized as the time.Time zero value.


### PR DESCRIPTION
When an instance failed to sync, `HandleSyncError` resolved the `LastSuccessfulSync` staleness stamp synchronously inside go-qbittorrent's `OnError` callback. That callback runs while go-qbittorrent holds its `SyncManager` write lock, and the stamp reads `LastSuccessfulSyncTime()` which takes a read lock on the same non-reentrant mutex — so the sync loop self-deadlocked while still holding the qui client's read lock. That starved every cached reader (`GET /api/instances`, cross-instance stream init), leaving the dashboard stuck on "No instances configured" and the unified torrent tab stuck on "Connecting to stream". Confirmed live from a goroutine dump: 89 readers + 67 writers parked on the client mutex for 11 minutes behind the wedged sync callback.

The fix moves the stamp onto the existing publish goroutine so the sync loop releases its lock first. Added a deterministic regression test asserting `HandleSyncError` returns without waiting on the stamp. Regression introduced in #2057.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for sync streams so status updates no longer risk blocking or deadlocking during error callbacks.
  * Error messages are still delivered as expected, while background sync timing updates now complete safely.

* **Tests**
  * Added a regression test to confirm sync errors return promptly and that the follow-up update is published after the blocking operation finishes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->