### PR TITLE
feat(web): shift+click range select in torrent content tab

### DIFF
--- a/web/src/components/torrents/TorrentDetailsPanel.tsx
+++ b/web/src/components/torrents/TorrentDetailsPanel.tsx
@@ -380,6 +380,7 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
     const rangeSet = new Set(indices)
     const targetIndices = files
       .filter(file => rangeSet.has(file.index))
+      .filter(file => !pendingFileIndices.has(file.index))
       .filter(file => selected ? file.priority === 0 : file.priority !== 0)
       .map(file => file.index)
 
@@ -388,7 +389,7 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
     }
 
     setFilePriorityMutation.mutate({ indices: targetIndices, priority: selected ? 1 : 0, hash: torrent.hash })
-  }, [files, setFilePriorityMutation, supportsFilePriority, torrent])
+  }, [files, pendingFileIndices, setFilePriorityMutation, supportsFilePriority, torrent])
 
   const handleSelectAllFiles = useCallback(() => {
     if (!torrent || !supportsFilePriority || !files) {

--- a/web/src/components/torrents/TorrentDetailsPanel.tsx
+++ b/web/src/components/torrents/TorrentDetailsPanel.tsx
@@ -368,6 +368,28 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
     setFilePriorityMutation.mutate({ indices: [file.index], priority: desiredPriority, hash: torrent.hash })
   }, [setFilePriorityMutation, supportsFilePriority, torrent])
 
+  const handleToggleFileRange = useCallback((indices: number[], selected: boolean) => {
+    if (!torrent || !supportsFilePriority || !files || indices.length === 0) {
+      return
+    }
+
+    // Only touch files that actually need changing, mirroring handleSelectAllFiles
+    // and handleToggleFolderDownload. This preserves High/Maximum priority on
+    // already-selected files (a blanket priority:1 would downgrade them to Normal)
+    // and skips no-op churn for files already in the desired state.
+    const rangeSet = new Set(indices)
+    const targetIndices = files
+      .filter(file => rangeSet.has(file.index))
+      .filter(file => selected ? file.priority === 0 : file.priority !== 0)
+      .map(file => file.index)
+
+    if (targetIndices.length === 0) {
+      return
+    }
+
+    setFilePriorityMutation.mutate({ indices: targetIndices, priority: selected ? 1 : 0, hash: torrent.hash })
+  }, [files, setFilePriorityMutation, supportsFilePriority, torrent])
+
   const handleSelectAllFiles = useCallback(() => {
     if (!torrent || !supportsFilePriority || !files) {
       return
@@ -1590,6 +1612,7 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
                 incognitoMode={incognitoMode}
                 torrentHash={torrent.hash}
                 onToggleFile={handleToggleFileDownload}
+                onToggleFileRange={handleToggleFileRange}
                 onToggleFolder={handleToggleFolderDownload}
                 onSetFilePriority={handleSetFilePriority}
                 onSetFolderPriority={handleSetFolderPriority}
@@ -1646,6 +1669,7 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
                       incognitoMode={incognitoMode}
                       torrentHash={torrent.hash}
                       onToggleFile={handleToggleFileDownload}
+                      onToggleFileRange={handleToggleFileRange}
                       onToggleFolder={handleToggleFolderDownload}
                       onSetFilePriority={handleSetFilePriority}
                       onSetFolderPriority={handleSetFolderPriority}

--- a/web/src/components/torrents/TorrentFileTree.tsx
+++ b/web/src/components/torrents/TorrentFileTree.tsx
@@ -6,6 +6,7 @@
 import { FilePrioritySelect } from "@/components/torrents/FilePrioritySelect"
 import { Checkbox } from "@/components/ui/checkbox"
 import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from "@/components/ui/context-menu"
+import { useFileRangeSelection } from "@/hooks/useFileRangeSelection"
 import { FILE_PRIORITY, foldFolderPriority, normalizeFilePriority, type FolderPriority } from "@/lib/file-priority"
 import { getLinuxFileName } from "@/lib/incognito"
 import { cn, formatBytes } from "@/lib/utils"
@@ -22,6 +23,7 @@ interface TorrentFileTreeProps {
   incognitoMode: boolean
   torrentHash: string
   onToggleFile: (file: TorrentFile, selected: boolean) => void
+  onToggleFileRange: (indices: number[], selected: boolean) => void
   onToggleFolder: (folderPath: string, selected: boolean) => void
   onSetFilePriority: (file: TorrentFile, priority: number) => void
   onSetFolderPriority: (folderPath: string, priority: number) => void
@@ -188,6 +190,7 @@ export const TorrentFileTree = memo(function TorrentFileTree({
   incognitoMode,
   torrentHash,
   onToggleFile,
+  onToggleFileRange,
   onToggleFolder,
   onSetFilePriority,
   onSetFolderPriority,
@@ -275,6 +278,13 @@ export const TorrentFileTree = memo(function TorrentFileTree({
     })
   }, [])
 
+  const { handleCheckboxPointerDown, handleFileCheckbox } = useFileRangeSelection({
+    getRows: () => flatRows,
+    onToggleFile,
+    onToggleFileRange,
+    resetKey: torrentHash,
+  })
+
   return (
     <div
       ref={scrollContainerRef}
@@ -328,7 +338,8 @@ export const TorrentFileTree = memo(function TorrentFileTree({
                         <Checkbox
                           checked={!isSkipped}
                           disabled={isPending}
-                          onCheckedChange={(checked) => onToggleFile(file, checked === true)}
+                          onPointerDown={handleCheckboxPointerDown}
+                          onCheckedChange={(checked) => handleFileCheckbox(file, virtualRow.index, checked === true)}
                           aria-label={isSkipped ? t("fileTree.selectFileForDownload") : t("fileTree.skipFileDownload")}
                           className="shrink-0"
                         />

--- a/web/src/components/torrents/details/TorrentFileTable.tsx
+++ b/web/src/components/torrents/details/TorrentFileTable.tsx
@@ -9,6 +9,7 @@ import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } 
 import { Input } from "@/components/ui/input"
 import { Progress } from "@/components/ui/progress"
 import { TruncatedText } from "@/components/ui/truncated-text"
+import { useFileRangeSelection } from "@/hooks/useFileRangeSelection"
 import { FILE_PRIORITY, foldFolderPriority, normalizeFilePriority, type FilePriorityValue, type FolderPriority } from "@/lib/file-priority"
 import { getLinuxFileName, getLinuxFolderName } from "@/lib/incognito"
 import { cn, formatBytes } from "@/lib/utils"
@@ -26,6 +27,7 @@ interface TorrentFileTableProps {
   incognitoMode: boolean
   torrentHash: string
   onToggleFile: (file: TorrentFile, selected: boolean) => void
+  onToggleFileRange: (indices: number[], selected: boolean) => void
   onToggleFolder: (folderPath: string, selected: boolean) => void
   onSetFilePriority: (file: TorrentFile, priority: number) => void
   onSetFolderPriority: (folderPath: string, priority: number) => void
@@ -189,6 +191,7 @@ export const TorrentFileTable = memo(function TorrentFileTable({
   incognitoMode,
   torrentHash,
   onToggleFile,
+  onToggleFileRange,
   onToggleFolder,
   onSetFilePriority,
   onSetFolderPriority,
@@ -307,6 +310,13 @@ export const TorrentFileTable = memo(function TorrentFileTable({
     setExpandedFolders(new Set())
   }, [])
 
+  const { handleCheckboxPointerDown, clearShift, handleFileCheckbox } = useFileRangeSelection({
+    getRows: () => filteredRows,
+    onToggleFile,
+    onToggleFileRange,
+    resetKey: torrentHash,
+  })
+
   if (loading && !files) {
     return (
       <div className="flex items-center justify-center h-full">
@@ -415,10 +425,12 @@ export const TorrentFileTable = memo(function TorrentFileTable({
                     <div className="w-8 px-2 py-1.5 shrink-0 flex items-center">
                       <Checkbox
                         checked={isIndeterminate ? "indeterminate" : isSelected}
+                        onPointerDown={handleCheckboxPointerDown}
                         onCheckedChange={(checked) => {
                           if (isFile && file) {
-                            onToggleFile(file, checked === true)
+                            handleFileCheckbox(file, virtualRow.index, checked === true)
                           } else {
+                            clearShift()
                             onToggleFolder(node.id, checked === true)
                           }
                         }}

--- a/web/src/hooks/useFileRangeSelection.test.ts
+++ b/web/src/hooks/useFileRangeSelection.test.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { useFileRangeSelection } from "@/hooks/useFileRangeSelection"
+import type { RangeRow } from "@/lib/file-selection"
+import type { TorrentFile } from "@/types"
+import { act, renderHook } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+const fileRow = (index: number): RangeRow => ({ node: { file: { index } } })
+const folderRow = (): RangeRow => ({ node: {} })
+const asFile = (index: number) => ({ index } as TorrentFile)
+const pointer = (shiftKey: boolean) => ({ shiftKey } as React.PointerEvent<HTMLButtonElement>)
+
+function setup(rows: RangeRow[], resetKey = "hashA") {
+  const onToggleFile = vi.fn()
+  const onToggleFileRange = vi.fn()
+  const view = renderHook(
+    ({ rk }) => useFileRangeSelection({ getRows: () => rows, onToggleFile, onToggleFileRange, resetKey: rk }),
+    { initialProps: { rk: resetKey } }
+  )
+  return { ...view, onToggleFile, onToggleFileRange }
+}
+
+describe("useFileRangeSelection", () => {
+  it("plain click toggles a single file and sets the anchor", () => {
+    const { result, onToggleFile, onToggleFileRange } = setup([fileRow(10), fileRow(11), fileRow(12)])
+    act(() => {
+      result.current.handleCheckboxPointerDown(pointer(false))
+      result.current.handleFileCheckbox(asFile(10), 0, true)
+    })
+    expect(onToggleFile).toHaveBeenCalledWith(expect.objectContaining({ index: 10 }), true)
+    expect(onToggleFileRange).not.toHaveBeenCalled()
+  })
+
+  it("shift+click after an anchor toggles the inclusive range, not a single file", () => {
+    const { result, onToggleFile, onToggleFileRange } = setup([fileRow(10), fileRow(11), fileRow(12), fileRow(13)])
+    act(() => {
+      result.current.handleCheckboxPointerDown(pointer(false))
+      result.current.handleFileCheckbox(asFile(10), 0, true)
+    })
+    onToggleFile.mockClear()
+    act(() => {
+      result.current.handleCheckboxPointerDown(pointer(true))
+      result.current.handleFileCheckbox(asFile(13), 3, true)
+    })
+    expect(onToggleFileRange).toHaveBeenCalledWith([10, 11, 12, 13], true)
+    expect(onToggleFile).not.toHaveBeenCalled()
+  })
+
+  it("excludes folder rows from the range", () => {
+    const { result, onToggleFileRange } = setup([fileRow(10), folderRow(), fileRow(11), fileRow(12)])
+    act(() => {
+      result.current.handleCheckboxPointerDown(pointer(false))
+      result.current.handleFileCheckbox(asFile(10), 0, true)
+    })
+    act(() => {
+      result.current.handleCheckboxPointerDown(pointer(true))
+      result.current.handleFileCheckbox(asFile(12), 3, true)
+    })
+    expect(onToggleFileRange).toHaveBeenCalledWith([10, 11, 12], true)
+  })
+
+  it("shift+click with no prior anchor falls back to a single toggle", () => {
+    const { result, onToggleFile, onToggleFileRange } = setup([fileRow(10), fileRow(11)])
+    act(() => {
+      result.current.handleCheckboxPointerDown(pointer(true))
+      result.current.handleFileCheckbox(asFile(11), 1, true)
+    })
+    expect(onToggleFile).toHaveBeenCalledWith(expect.objectContaining({ index: 11 }), true)
+    expect(onToggleFileRange).not.toHaveBeenCalled()
+  })
+
+  it("falls back to a single toggle when the anchor is no longer in the rows", () => {
+    let rows: RangeRow[] = [fileRow(10), fileRow(11), fileRow(12)]
+    const onToggleFile = vi.fn()
+    const onToggleFileRange = vi.fn()
+    const { result, rerender } = renderHook(
+      ({ rk }) => useFileRangeSelection({ getRows: () => rows, onToggleFile, onToggleFileRange, resetKey: rk }),
+      { initialProps: { rk: "hashA" } }
+    )
+    act(() => {
+      result.current.handleCheckboxPointerDown(pointer(false))
+      result.current.handleFileCheckbox(asFile(10), 0, true)
+    })
+    // Anchor (index 10) gets filtered out of the visible rows (e.g. a search).
+    rows = [fileRow(11), fileRow(12)]
+    rerender({ rk: "hashA" })
+    act(() => {
+      result.current.handleCheckboxPointerDown(pointer(true))
+      result.current.handleFileCheckbox(asFile(12), 1, true)
+    })
+    expect(onToggleFileRange).not.toHaveBeenCalled()
+    expect(onToggleFile).toHaveBeenLastCalledWith(expect.objectContaining({ index: 12 }), true)
+  })
+
+  it("drops the anchor when resetKey changes (torrent switch)", () => {
+    const rows: RangeRow[] = [fileRow(10), fileRow(11), fileRow(12)]
+    const onToggleFile = vi.fn()
+    const onToggleFileRange = vi.fn()
+    const { result, rerender } = renderHook(
+      ({ rk }) => useFileRangeSelection({ getRows: () => rows, onToggleFile, onToggleFileRange, resetKey: rk }),
+      { initialProps: { rk: "hashA" } }
+    )
+    act(() => {
+      result.current.handleCheckboxPointerDown(pointer(false))
+      result.current.handleFileCheckbox(asFile(10), 0, true)
+    })
+    rerender({ rk: "hashB" }) // user switched to a different torrent
+    act(() => {
+      result.current.handleCheckboxPointerDown(pointer(true))
+      result.current.handleFileCheckbox(asFile(12), 2, true)
+    })
+    expect(onToggleFileRange).not.toHaveBeenCalled()
+    expect(onToggleFile).toHaveBeenLastCalledWith(expect.objectContaining({ index: 12 }), true)
+  })
+})

--- a/web/src/hooks/useFileRangeSelection.ts
+++ b/web/src/hooks/useFileRangeSelection.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { collectFileIndicesInRange, type RangeRow } from "@/lib/file-selection"
+import type { TorrentFile } from "@/types"
+import { useCallback, useRef } from "react"
+
+export interface UseFileRangeSelectionParams {
+  /**
+   * Lazily returns the current ordered, visible row list. A callback because the
+   * rows (filteredRows / flatRows) are derived after this hook runs, so the
+   * latest reference is read at click time rather than captured at call time.
+   */
+  getRows: () => ReadonlyArray<RangeRow>
+  onToggleFile: (file: TorrentFile, selected: boolean) => void
+  onToggleFileRange: (indices: number[], selected: boolean) => void
+  /**
+   * Identity of the current list (e.g. the torrent hash). When it changes the
+   * range anchor is dropped: TorrentFileTable is reused across torrent switches
+   * and file indices are per-torrent, so a stale anchor would mis-target the
+   * next torrent's rows. Harmless for the keyed TorrentFileTree, which remounts.
+   */
+  resetKey: string
+}
+
+export interface FileRangeSelection {
+  handleCheckboxPointerDown: (event: React.PointerEvent<HTMLButtonElement>) => void
+  clearShift: () => void
+  handleFileCheckbox: (file: TorrentFile, rowPos: number, checked: boolean) => void
+}
+
+/**
+ * Shift+click range selection for the Content tab's file checkboxes. The shift
+ * modifier must be captured on pointer down because Radix Checkbox's
+ * onCheckedChange carries no event. Mirrors the torrent table's range pattern.
+ */
+export function useFileRangeSelection({
+  getRows,
+  onToggleFile,
+  onToggleFileRange,
+  resetKey,
+}: UseFileRangeSelectionParams): FileRangeSelection {
+  const shiftPressedRef = useRef(false)
+  const lastClickedFileIndexRef = useRef<number | null>(null)
+
+  // Always read the latest row accessor (rows are derived after this hook runs).
+  const getRowsRef = useRef(getRows)
+  getRowsRef.current = getRows
+
+  // Drop the anchor when the list identity changes (render-time reset).
+  const resetKeyRef = useRef(resetKey)
+  if (resetKeyRef.current !== resetKey) {
+    resetKeyRef.current = resetKey
+    lastClickedFileIndexRef.current = null
+  }
+
+  const handleCheckboxPointerDown = useCallback((event: React.PointerEvent<HTMLButtonElement>) => {
+    shiftPressedRef.current = event.shiftKey
+  }, [])
+
+  const clearShift = useCallback(() => {
+    shiftPressedRef.current = false
+  }, [])
+
+  // Toggle a file checkbox, extending to a contiguous range when shift is held.
+  // rowPos is the clicked file's position within the ordered, visible row list.
+  const handleFileCheckbox = useCallback((file: TorrentFile, rowPos: number, checked: boolean) => {
+    const shift = shiftPressedRef.current
+    shiftPressedRef.current = false
+
+    if (shift && lastClickedFileIndexRef.current !== null) {
+      const rows = getRowsRef.current()
+      const anchorPos = rows.findIndex(row => row.node.file?.index === lastClickedFileIndexRef.current)
+      if (anchorPos !== -1) {
+        const indices = collectFileIndicesInRange(rows, anchorPos, rowPos)
+        onToggleFileRange(indices, checked)
+        lastClickedFileIndexRef.current = file.index
+        return
+      }
+    }
+
+    onToggleFile(file, checked)
+    lastClickedFileIndexRef.current = file.index
+  }, [onToggleFile, onToggleFileRange])
+
+  return { handleCheckboxPointerDown, clearShift, handleFileCheckbox }
+}

--- a/web/src/lib/__tests__/file-selection.test.ts
+++ b/web/src/lib/__tests__/file-selection.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { describe, expect, it } from "vitest"
+import { collectFileIndicesInRange } from "@/lib/file-selection"
+
+// Helpers mirroring the flat-row shape: file rows carry a node.file.index,
+// folder rows have no file.
+const fileRow = (index: number) => ({ node: { file: { index } } })
+const folderRow = () => ({ node: {} })
+
+describe("collectFileIndicesInRange", () => {
+  it("collects file indices across a forward range (inclusive)", () => {
+    const rows = [fileRow(10), fileRow(11), fileRow(12), fileRow(13)]
+    expect(collectFileIndicesInRange(rows, 1, 3)).toEqual([11, 12, 13])
+  })
+
+  it("handles a reversed range (current before anchor)", () => {
+    const rows = [fileRow(10), fileRow(11), fileRow(12), fileRow(13)]
+    expect(collectFileIndicesInRange(rows, 3, 1)).toEqual([11, 12, 13])
+  })
+
+  it("returns a single index when anchor == current", () => {
+    const rows = [fileRow(10), fileRow(11), fileRow(12)]
+    expect(collectFileIndicesInRange(rows, 1, 1)).toEqual([11])
+  })
+
+  it("excludes folder rows but includes file rows between them", () => {
+    const rows = [fileRow(0), folderRow(), fileRow(1), fileRow(2), folderRow()]
+    expect(collectFileIndicesInRange(rows, 0, 4)).toEqual([0, 1, 2])
+  })
+
+  it("ignores out-of-range positions", () => {
+    const rows = [fileRow(5), fileRow(6)]
+    expect(collectFileIndicesInRange(rows, 0, 99)).toEqual([5, 6])
+  })
+
+  it("returns empty when both positions are beyond the array", () => {
+    const rows = [fileRow(5), fileRow(6)]
+    expect(collectFileIndicesInRange(rows, 10, 99)).toEqual([])
+  })
+
+  it("returns empty for an empty rows input", () => {
+    expect(collectFileIndicesInRange([], 0, 0)).toEqual([])
+  })
+
+  it("returns an empty array when the range contains no files", () => {
+    const rows = [folderRow(), folderRow()]
+    expect(collectFileIndicesInRange(rows, 0, 1)).toEqual([])
+  })
+})

--- a/web/src/lib/file-selection.ts
+++ b/web/src/lib/file-selection.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+// Minimal shape shared by the Content tab's flat-row lists (both the desktop
+// TorrentFileTable and the vertical TorrentFileTree). Only the file index is
+// needed for range selection.
+export interface RangeRow {
+  node: { file?: { index: number } }
+}
+
+// Collects TorrentFile indices for every FILE row between two positions
+// (inclusive) in an ordered, visible flat-row list. Folder rows contribute
+// nothing directly; their visible child file rows are already part of the list.
+// Used by the Content tab's shift+click range selection.
+export function collectFileIndicesInRange(
+  rows: ReadonlyArray<RangeRow>,
+  anchorPos: number,
+  currentPos: number
+): number[] {
+  const start = Math.min(anchorPos, currentPos)
+  const end = Math.max(anchorPos, currentPos)
+  const indices: number[] = []
+  for (let i = start; i <= end; i++) {
+    const file = rows[i]?.node.file
+    if (file) {
+      indices.push(file.index)
+    }
+  }
+  return indices
+}


### PR DESCRIPTION
## Summary

Implements the quality-of-life request in discussion #2050: in the torrent **Content** tab you currently have to toggle files to download/skip one-by-one. This adds **shift+click range selection** — shift+clicking a file checkbox sets the download/skip state of every file between the last-clicked anchor and the shift-clicked row, in a single update (file-manager style).

## What changed

- **`web/src/lib/file-selection.ts`** (new) — pure `collectFileIndicesInRange(rows, anchorPos, currentPos)` returning the file indices for every file row in an inclusive range over the ordered, visible flat-row list (folder rows excluded; collapsed-folder children naturally excluded).
- **`web/src/hooks/useFileRangeSelection.ts`** (new) — shared hook owning the shift+click state machine (capture `shiftKey` on `onPointerDown` since Radix `Checkbox` `onCheckedChange` has no event; anchor by stable `file.index`). Drops the anchor when the torrent changes so the reused `TorrentFileTable` can't mis-target the next torrent. Mirrors the existing `useTorrentSelection` range pattern.
- **`TorrentFileTable.tsx` / `TorrentFileTree.tsx`** — consume the hook on the file checkbox.
- **`TorrentDetailsPanel.tsx`** — new `handleToggleFileRange` reusing the existing multi-index `setFilePriorityMutation`. It filters to only files that need changing (`selected ? priority===0 : priority!==0`), matching `handleSelectAllFiles` / `handleToggleFolderDownload` — so High/Maximum priorities are preserved (not downgraded to Normal) and no-ops don't churn the backend.

No backend/API/DB/i18n changes (the mutation already accepts `indices: number[]`; no new user-facing strings).

## Testing

- [x] `web` unit tests: `collectFileIndicesInRange` (8 cases) + `useFileRangeSelection` (6 cases — single toggle/anchor, shift range, folder exclusion, no-anchor fallback, anchor-filtered-out fallback, torrent-switch reset) — all pass
- [x] `tsc -b` clean, `eslint` clean on all touched files
- [x] `make build` green
- [x] Manual smoke (jsdom can't render virtualized rows): shift+click forward/backward ranges; across expanded vs collapsed folders (collapsed children excluded); with an active search filter; switch torrents then shift+click as the first action (single-toggles, no stale-anchor range); plain clicks still single-toggle; the per-file priority dropdown still works.

## Screenshots

No visual change — no new UI elements; this is a behavioral addition to the existing checkboxes, so there's nothing new to show in a still. Demo video of the current (one-by-one) workflow is in discussion #2050.

Closes discussion #2050.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of CodeRabbit

* **New Features**
  * Added shift-click range selection for torrent file checkboxes (applies to both file table and file tree views).
  * Enabled bulk download-priority updates for the selected range, with optimization to change priority only when needed.
* **Bug Fixes**
  * Improved shift-selection behavior when rows are filtered or when the anchor item is no longer visible.
  * Reset range-selection anchors when switching context to ensure actions apply to the correct torrent.
* **Tests**
  * Added unit tests covering range index calculation and shift-click selection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->