### PR TITLE
ci(discussions): unblock triage/dedup runs and harden the write path

### DIFF
--- a/.github/scripts/discussion-write.sh
+++ b/.github/scripts/discussion-write.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# Hardened write helper for the discussion triage / deduplication workflows.
+#
+# Claude is given ONLY this script for GitHub mutations (no raw `gh api graphql`),
+# so a prompt-injection in untrusted discussion content cannot run arbitrary
+# GraphQL within the token's `discussions: write` scope. Two invariants hold even
+# if Claude is fully compromised:
+#
+#   1. The target discussion is read from the workflow event payload, never from
+#      Claude, so writes can only ever land on the discussion under triage.
+#   2. Label names are validated against the repository's real label set before
+#      any mutation runs; unknown names are dropped.
+#
+# Usage (the discussion number is bound to the triggering event, not passed in):
+#   ./.github/scripts/discussion-write.sh add-label    <name> [<name>...]
+#   ./.github/scripts/discussion-write.sh remove-label <name> [<name>...]
+#   ./.github/scripts/discussion-write.sh comment       <body>
+#
+set -euo pipefail
+
+die() { echo "Error: $*" >&2; exit 1; }
+
+# --- Resolve the target discussion from the event payload (not from Claude) ---
+[[ -n "${GITHUB_EVENT_PATH:-}" && -f "$GITHUB_EVENT_PATH" ]] || die "GITHUB_EVENT_PATH not available"
+NUMBER=$(jq -r '.inputs.discussion_number // .discussion.number // empty' "$GITHUB_EVENT_PATH")
+[[ "$NUMBER" =~ ^[0-9]+$ ]] || die "no valid discussion number in event payload"
+
+REPO="${GH_REPO:-${GITHUB_REPOSITORY:-}}"
+[[ "$REPO" == */* && "$REPO" != */*/* ]] || die "GITHUB_REPOSITORY must be owner/repo"
+OWNER="${REPO%%/*}"
+NAME="${REPO##*/}"
+export GH_REPO="$REPO"
+
+# Resolve the discussion's GraphQL node id. All inputs are passed as typed
+# variables, never interpolated into the query string.
+discussion_id() {
+  # SC2016: the $-prefixed names are GraphQL variables, not shell vars; they must
+  # reach gh literally, so single quotes (no shell expansion) are intentional.
+  # shellcheck disable=SC2016
+  gh api graphql \
+    -f query='query($owner:String!,$name:String!,$num:Int!){repository(owner:$owner,name:$name){discussion(number:$num){id}}}' \
+    -f owner="$OWNER" -f name="$NAME" -F num="$NUMBER" \
+    --jq '.data.repository.discussion.id'
+}
+
+# Map requested label NAMES to their ids, dropping any name not present in the
+# repository. Prints one id per valid label to stdout.
+resolve_label_ids() {
+  local labels_json name id
+  labels_json=$(gh label list --json name,id --limit 500)
+  for name in "$@"; do
+    id=$(jq -r --arg n "$name" '.[] | select(.name == $n) | .id' <<<"$labels_json")
+    if [[ -n "$id" ]]; then
+      printf '%s\n' "$id"
+    else
+      echo "Skipping unknown label: $name" >&2
+    fi
+  done
+}
+
+apply_labels() {
+  local mutation="$1"; shift # addLabelsToLabelable | removeLabelsFromLabelable
+  [[ $# -gt 0 ]] || die "no label names given"
+
+  local ids_raw ids=()
+  ids_raw=$(resolve_label_ids "$@")
+  [[ -n "$ids_raw" ]] && mapfile -t ids <<<"$ids_raw"
+  if [[ ${#ids[@]} -eq 0 ]]; then
+    echo "No valid labels to apply." >&2
+    return 0
+  fi
+
+  local node_id var_args=() id query
+  node_id=$(discussion_id)
+  [[ -n "$node_id" ]] || die "could not resolve discussion #$NUMBER"
+  for id in "${ids[@]}"; do var_args+=(-f "labels[]=$id"); done
+
+  # shellcheck disable=SC2016 # $id/$labels are GraphQL variables, not shell vars
+  query=$(printf 'mutation($id:ID!,$labels:[ID!]!){%s(input:{labelableId:$id,labelIds:$labels}){clientMutationId}}' "$mutation")
+  gh api graphql -f query="$query" -f id="$node_id" "${var_args[@]}" >/dev/null
+  echo "${mutation}: ${ids[*]}"
+}
+
+cmd="${1:-}"; shift || true
+case "$cmd" in
+  add-label)
+    apply_labels addLabelsToLabelable "$@"
+    ;;
+  remove-label)
+    apply_labels removeLabelsFromLabelable "$@"
+    ;;
+  comment)
+    [[ $# -eq 1 ]] || die "comment requires exactly one body argument"
+    [[ -n "$1" ]] || die "comment body is empty"
+    node_id=$(discussion_id)
+    [[ -n "$node_id" ]] || die "could not resolve discussion #$NUMBER"
+    # shellcheck disable=SC2016 # $id/$body are GraphQL variables, not shell vars
+    gh api graphql \
+      -f query='mutation($id:ID!,$body:String!){addDiscussionComment(input:{discussionId:$id,body:$body}){comment{url}}}' \
+      -f id="$node_id" -f body="$1" --jq '.data.addDiscussionComment.comment.url'
+    ;;
+  *)
+    die "unknown command '$cmd' (use: add-label | remove-label | comment)"
+    ;;
+esac

--- a/.github/scripts/discussion-write.sh
+++ b/.github/scripts/discussion-write.sh
@@ -17,9 +17,22 @@
 #   ./.github/scripts/discussion-write.sh remove-label <name> [<name>...]
 #   ./.github/scripts/discussion-write.sh comment       <body>
 #
+# The calling workflow restricts which of those operations are permitted via
+# DISCUSSION_WRITE_ALLOWED_OPS (comma-separated). Triage is label-only; only the
+# dedup workflow opts into `comment`. It defaults to label operations so a
+# workflow that forgets to set it still cannot post comments.
+#
 set -euo pipefail
 
 die() { echo "Error: $*" >&2; exit 1; }
+
+ALLOWED_OPS="${DISCUSSION_WRITE_ALLOWED_OPS:-add-label,remove-label}"
+op_allowed() {
+  case ",${ALLOWED_OPS}," in
+    *",$1,"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
 
 # --- Resolve the target discussion from the event payload (not from Claude) ---
 [[ -n "${GITHUB_EVENT_PATH:-}" && -f "$GITHUB_EVENT_PATH" ]] || die "GITHUB_EVENT_PATH not available"
@@ -85,12 +98,15 @@ apply_labels() {
 cmd="${1:-}"; shift || true
 case "$cmd" in
   add-label)
+    op_allowed add-label || die "add-label is not permitted here (allowed: $ALLOWED_OPS)"
     apply_labels addLabelsToLabelable "$@"
     ;;
   remove-label)
+    op_allowed remove-label || die "remove-label is not permitted here (allowed: $ALLOWED_OPS)"
     apply_labels removeLabelsFromLabelable "$@"
     ;;
   comment)
+    op_allowed comment || die "comment is not permitted here (allowed: $ALLOWED_OPS)"
     [[ $# -eq 1 ]] || die "comment requires exactly one body argument"
     [[ -n "$1" ]] || die "comment body is empty"
     node_id=$(discussion_id)

--- a/.github/workflows/discussion-deduplication.yml
+++ b/.github/workflows/discussion-deduplication.yml
@@ -68,6 +68,10 @@ jobs:
           EOF
 
       - name: Run Claude Code for Deduplication
+        env:
+          # Bound how many times Claude can invoke the write helper per run, so a
+          # prompt-injection in discussion content cannot spam comments/labels.
+          CLAUDE_CODE_SCRIPT_CAPS: '{"discussion-write.sh": 5}'
         uses: anthropics/claude-code-action@v1.0.153
         with:
           # The dispatch job re-triggers this run via workflow_dispatch using
@@ -102,14 +106,13 @@ jobs:
                - Only mark as duplicate if you're confident (>80% similar intent)
                - Exclude the current discussion (number ${{ inputs.discussion_number || github.event.discussion.number }}) from matches
 
-            5A. IF DUPLICATE FOUND:
+            5A. IF DUPLICATE FOUND (the helper acts on the current discussion,
+                which is fixed by the workflow, so you only supply the text/name):
                 First, post a helpful comment linking to the original:
-                gh discussion comment ${{ inputs.discussion_number || github.event.discussion.number }} --repo ${{ github.repository }} --body "This appears to be a duplicate of #[ORIGINAL_NUMBER]. Please see the existing discussion for updates and add any additional context there."
+                ./.github/scripts/discussion-write.sh comment "This appears to be a duplicate of #ORIGINAL_NUMBER. Please see the existing discussion for updates and add any additional context there."
 
-                Then, add the "duplicate" label using GraphQL:
-                - Get label IDs: gh label list --json name,id --limit 100
-                - Get discussion node ID: gh api graphql -f query='query { repository(owner:"${{ github.repository_owner }}", name:"${{ github.event.repository.name }}") { discussion(number: ${{ inputs.discussion_number || github.event.discussion.number }}) { id } } }'
-                - Add label: gh api graphql -f query='mutation { addLabelsToLabelable(input: {labelIds: ["LABEL_ID"], labelableId: "DISCUSSION_NODE_ID"}) { clientMutationId } }'
+                Then, add the "duplicate" label:
+                ./.github/scripts/discussion-write.sh add-label "duplicate"
 
             5B. IF NOT A DUPLICATE:
                 Do nothing. Do not add labels or comments for unique discussions.
@@ -122,7 +125,7 @@ jobs:
             - If unsure, err on the side of NOT marking as duplicate
             - Do not comment on unique discussions
           claude_args: |
-            --allowedTools "Bash(gh search:*),Bash(gh label list:*),Bash(gh api graphql:*),Bash(gh discussion comment:*),mcp__github__get_discussion,mcp__github__get_discussion_comments,mcp__github__list_discussions"
+            --allowedTools "Bash(gh search:*),Bash(./.github/scripts/discussion-write.sh:*),mcp__github__get_discussion,mcp__github__get_discussion_comments,mcp__github__list_discussions"
             --max-turns 25
             --mcp-config /tmp/mcp-config/mcp-servers.json
           settings: |

--- a/.github/workflows/discussion-deduplication.yml
+++ b/.github/workflows/discussion-deduplication.yml
@@ -129,5 +129,5 @@ jobs:
             --max-turns 25
             --mcp-config /tmp/mcp-config/mcp-servers.json
           settings: |
-            {"env": {"GH_TOKEN": "${{ secrets.GITHUB_TOKEN }}"}}
+            {"env": {"GH_TOKEN": "${{ secrets.GITHUB_TOKEN }}", "DISCUSSION_WRITE_ALLOWED_OPS": "add-label,comment"}}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/discussion-deduplication.yml
+++ b/.github/workflows/discussion-deduplication.yml
@@ -70,6 +70,10 @@ jobs:
       - name: Run Claude Code for Deduplication
         uses: anthropics/claude-code-action@v1.0.153
         with:
+          # The dispatch job re-triggers this run via workflow_dispatch using
+          # GITHUB_TOKEN, so the actor is github-actions[bot]. Allow it past the
+          # agent-mode human-actor guard. Scoped to github-actions only (not '*').
+          allowed_bots: "github-actions"
           prompt: |
             You're a deduplication assistant for GitHub discussions. Your task is to find potential duplicates and handle them appropriately.
 

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -119,7 +119,7 @@ jobs:
 
             TASK OVERVIEW:
 
-            1. First, fetch the list of labels available in this repository by running: `gh label list --json name,id --limit 100`. Run exactly this command with nothing else.
+            1. First, fetch the list of labels available in this repository by running: `gh label list --json name,id --limit 500`. Run exactly this command with nothing else.
 
             2. Next, use the GitHub tools to get context about the discussion:
                - You have access to these tools:
@@ -168,5 +168,5 @@ jobs:
             --max-turns 25
             --mcp-config /tmp/mcp-config/mcp-servers.json
           settings: |
-            {"env": {"GH_TOKEN": "${{ secrets.GITHUB_TOKEN }}"}}
+            {"env": {"GH_TOKEN": "${{ secrets.GITHUB_TOKEN }}", "DISCUSSION_WRITE_ALLOWED_OPS": "add-label,remove-label"}}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -100,6 +100,10 @@ jobs:
         if: steps.check-duplicate.outputs.skip != 'true'
         uses: anthropics/claude-code-action@v1.0.153
         with:
+          # The dispatch job re-triggers this run via workflow_dispatch using
+          # GITHUB_TOKEN, so the actor is github-actions[bot]. Allow it past the
+          # agent-mode human-actor guard. Scoped to github-actions only (not '*').
+          allowed_bots: "github-actions"
           prompt: |
             You're a triage assistant for GitHub discussions. Your task is to analyze the discussion and select appropriate labels from the provided list.
 

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -98,6 +98,10 @@ jobs:
 
       - name: Run Claude Code for Discussion Triage
         if: steps.check-duplicate.outputs.skip != 'true'
+        env:
+          # Bound how many times Claude can invoke the write helper per run, so a
+          # prompt-injection in discussion content cannot spam label mutations.
+          CLAUDE_CODE_SCRIPT_CAPS: '{"discussion-write.sh": 5}'
         uses: anthropics/claude-code-action@v1.0.153
         with:
           # The dispatch job re-triggers this run via workflow_dispatch using
@@ -139,30 +143,28 @@ jobs:
                - Consider platform labels if applicable
                - Do NOT apply the "duplicate" label - that is handled by a separate workflow
 
-            5. Apply the selected labels using GraphQL:
-               - First, get the discussion's GraphQL node ID by running:
-                 gh api graphql -f query='query { repository(owner:"${{ github.repository_owner }}", name:"${{ github.event.repository.name }}") { discussion(number: ${{ inputs.discussion_number || github.event.discussion.number }}) { id } } }'
-               - Then add labels using the addLabelsToLabelable mutation. Example:
-                 gh api graphql -f query='mutation { addLabelsToLabelable(input: {labelIds: ["LABEL_ID_1", "LABEL_ID_2"], labelableId: "DISCUSSION_NODE_ID"}) { clientMutationId } }'
-               - Replace LABEL_ID_1, LABEL_ID_2 with actual label IDs from step 1, and DISCUSSION_NODE_ID with the ID from the query above
+            5. Apply the selected labels with the write helper. The discussion is
+               fixed by the workflow, so you only pass label NAMES (not IDs):
+               - Run: `./.github/scripts/discussion-write.sh add-label "LABEL_NAME_1" "LABEL_NAME_2"`
+               - Use the exact label names from step 1. The helper validates each
+                 name against the repository's labels and silently ignores any
+                 name that does not exist, so only pass names you saw in step 1.
                - DO NOT post any comments explaining your decision
                - DO NOT communicate directly with users
-               - If no labels are clearly applicable, do not apply any labels
+               - If no labels are clearly applicable, do not run the helper at all
 
             6. After applying labels, remove the "needs-triage" label if present:
-               - Use the removeLabelsFromLabelable mutation:
-                 gh api graphql -f query='mutation { removeLabelsFromLabelable(input: {labelIds: ["NEEDS_TRIAGE_LABEL_ID"], labelableId: "DISCUSSION_NODE_ID"}) { clientMutationId } }'
-               - Get the "needs-triage" label ID from the label list in step 1
-               - Only remove it if you successfully applied at least one label
+               - Run: `./.github/scripts/discussion-write.sh remove-label "needs-triage"`
+               - Only do this if you successfully applied at least one label in step 5
 
             IMPORTANT GUIDELINES:
             - Be thorough in your analysis
             - Only select labels from the repository's label list
             - DO NOT post any comments to the discussion
-            - Your ONLY action should be to apply labels using the GraphQL mutation
+            - Your ONLY action should be to apply labels via ./.github/scripts/discussion-write.sh
             - It's okay to not add any labels if none are clearly applicable
           claude_args: |
-            --allowedTools "Bash(gh label list:*),Bash(gh api graphql:*),mcp__github__get_discussion,mcp__github__get_discussion_comments,mcp__github__list_discussions"
+            --allowedTools "Bash(gh label list:*),Bash(./.github/scripts/discussion-write.sh:*),mcp__github__get_discussion,mcp__github__get_discussion_comments,mcp__github__list_discussions"
             --max-turns 25
             --mcp-config /tmp/mcp-config/mcp-servers.json
           settings: |


### PR DESCRIPTION
The discussion triage and deduplication workflows re-dispatch themselves via `workflow_dispatch` using `GITHUB_TOKEN`, so the re-dispatched run's actor is `github-actions[bot]`. In agent mode, `claude-code-action` runs `checkHumanActor`, which rejects any non-`User` actor not in `allowed_bots` (default empty), so every re-dispatched run was failing with `Workflow initiated by non-human actor: github-actions (type: Bot)`. The `discussion`-event half looked green because it only re-dispatches; the actual Claude step never ran. This scopes `allowed_bots` to `github-actions` (not `*`) on both steps, the minimal allowlist for the self-dispatch.

While here, hardens the write surface. Claude reads untrusted discussion content via MCP, so the old broad grants (`Bash(gh api graphql:*)`, plus `Bash(gh discussion comment:*)` in dedup) let a prompt-injection drive arbitrary mutations within the token's `discussions: write` scope. All writes now go through `.github/scripts/discussion-write.sh`, which pins the target discussion from the event payload (never from Claude) and validates label names against the repo's real labels. A `DISCUSSION_WRITE_ALLOWED_OPS` gate restricts the helper per workflow: triage is label-only, only dedup opts into posting a comment. `CLAUDE_CODE_SCRIPT_CAPS` bounds helper calls per run. Mirrors the upstream `scripts/edit-issue-labels.sh` pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated discussion triage and deduplication by reliably posting duplicate links/comments and applying or removing labels.
  * Reduced redundant write attempts within a single automated run by limiting how many times the helper can execute.
  * Fixed re-run behavior for workflow-dispatch automation by explicitly allowing the expected bot actor.
* **Chores**
  * Introduced a hardened helper script to standardize and safely control comment and label write operations during these workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->