### PR TITLE
fix(qbittorrent): avoid sync cache reader convoys

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/andybalholm/brotli v1.2.2
 	github.com/autobrr/autobrr v1.80.0
 	github.com/autobrr/go-mediainfo v0.4.0
-	github.com/autobrr/go-qbittorrent v1.16.1-0.20260625085128-43497c5a0d9a
+	github.com/autobrr/go-qbittorrent v1.16.1-0.20260703161542-1ab32a2fa640
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/coreos/go-oidc/v3 v3.19.0

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/autobrr/autobrr v1.80.0 h1:tYoK23lHifpqqoFNlh2OYWIHH0H2zyoPQFPT4fHrzQ
 github.com/autobrr/autobrr v1.80.0/go.mod h1:dUMroJCUlEzeK0HMRvCBx6VsP+EhF+eZRIUiFDVCagA=
 github.com/autobrr/go-mediainfo v0.4.0 h1:S68enHlG067nE9UF61Yg7QoQBWfeXJTRYctyNxPf1UE=
 github.com/autobrr/go-mediainfo v0.4.0/go.mod h1:xVXgHDAYYpIeGQCQCdTBpoiY/O3tojJfflK+rrbzclQ=
-github.com/autobrr/go-qbittorrent v1.16.1-0.20260625085128-43497c5a0d9a h1:cd+oRy4o9QQMo5x+NJY5edSCL86i+HgOIIc5H3+nza8=
-github.com/autobrr/go-qbittorrent v1.16.1-0.20260625085128-43497c5a0d9a/go.mod h1:s36a75VlatWPpHI+pNg4Ta6eB3fRxQvTZPfgMtOsQfY=
+github.com/autobrr/go-qbittorrent v1.16.1-0.20260703161542-1ab32a2fa640 h1:P+fF7RJB6xjzbD2soC/SjnpYnIssei0pOknCZeZp6ws=
+github.com/autobrr/go-qbittorrent v1.16.1-0.20260703161542-1ab32a2fa640/go.mod h1:s36a75VlatWPpHI+pNg4Ta6eB3fRxQvTZPfgMtOsQfY=
 github.com/autobrr/rls v0.8.1 h1:OjoFFVGcTibGrwf6b4pfk7JHsSYrGOX7F5P/8WtS3aE=
 github.com/autobrr/rls v0.8.1/go.mod h1:11YJWgNe5H+UQrfFaNGjnkEy0OEsMFnmV4IL2tRKpPk=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=

--- a/internal/api/handlers/torrents.go
+++ b/internal/api/handlers/torrents.go
@@ -2898,7 +2898,6 @@ func (h *TorrentsHandler) ListCrossInstanceTorrents(w http.ResponseWriter, r *ht
 		return
 	}
 
-	w.Header().Set("X-Data-Source", "fresh")
 	RespondJSON(w, http.StatusOK, response)
 }
 

--- a/internal/api/handlers/torrents.go
+++ b/internal/api/handlers/torrents.go
@@ -350,7 +350,7 @@ func (h *TorrentsHandler) GetTorrentField(w http.ResponseWriter, r *http.Request
 			if instanceID == allInstancesID && len(req.Targets) == 0 {
 				requestedHashes := buildExcludeHashSet(req.Hashes)
 				response, crossErr := h.syncManager.GetCrossInstanceTorrentsWithFilters(
-					r.Context(),
+					qbittorrent.WithSkipFreshData(r.Context()),
 					0,
 					0,
 					"",
@@ -445,7 +445,7 @@ func (h *TorrentsHandler) GetTorrentField(w http.ResponseWriter, r *http.Request
 
 	if instanceID == allInstancesID {
 		response, err := h.syncManager.GetCrossInstanceTorrentsWithFilters(
-			r.Context(),
+			qbittorrent.WithSkipFreshData(r.Context()),
 			0,
 			0,
 			req.Sort,
@@ -2878,7 +2878,16 @@ func (h *TorrentsHandler) ListCrossInstanceTorrents(w http.ResponseWriter, r *ht
 	offset := page * limit
 
 	// Get torrents from all instances with the filter expression
-	response, err := h.syncManager.GetCrossInstanceTorrentsWithFilters(r.Context(), limit, offset, sort, order, search, filters, instanceIDs)
+	response, err := h.syncManager.GetCrossInstanceTorrentsWithFilters(
+		qbittorrent.WithSkipFreshData(r.Context()),
+		limit,
+		offset,
+		sort,
+		order,
+		search,
+		filters,
+		instanceIDs,
+	)
 	if err != nil {
 		// Note: Cross-instance queries don't have a single instanceID, so we pass 0 for logging purposes
 		if respondIfInstanceDisabled(w, err, 0, "torrents:listCrossInstance") {

--- a/internal/api/handlers/torrents_field_test.go
+++ b/internal/api/handlers/torrents_field_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 	"unsafe"
@@ -114,6 +115,52 @@ func TestGetTorrentField_MagnetURIReturnsSelectedLinks(t *testing.T) {
 	}, response.Values)
 }
 
+func TestListCrossInstanceTorrentsSkipsFreshData(t *testing.T) {
+	handler, release := createStaleCrossInstanceReadHarness(t)
+	defer release()
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/torrents/cross-instance?limit=10", nil)
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handler.ListCrossInstanceTorrents(rec, req)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("cross-instance list joined a stale in-flight sync")
+	}
+
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+}
+
+func TestGetTorrentFieldCrossInstanceReadSkipsFreshData(t *testing.T) {
+	handler, release := createStaleCrossInstanceReadHarness(t)
+	defer release()
+
+	req := newTorrentFieldRequest(t, allInstancesID, map[string]any{
+		"field": "magnet_uri",
+	})
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handler.GetTorrentField(rec, req)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("cross-instance torrent field read joined a stale in-flight sync")
+	}
+
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+}
+
 func createTorrentFieldTestHarness(t *testing.T, torrentsByInstanceName map[string][]qbt.Torrent) (*models.InstanceStore, *quiqbt.SyncManager, map[string]int) {
 	t.Helper()
 
@@ -146,6 +193,49 @@ func createTorrentFieldTestHarness(t *testing.T, torrentsByInstanceName map[stri
 	return instanceStore, syncManager, instanceIDs
 }
 
+func createStaleCrossInstanceReadHarness(t *testing.T) (*TorrentsHandler, func()) {
+	t.Helper()
+
+	releaseSync := make(chan struct{})
+	var releaseSyncOnce sync.Once
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/sync/maindata":
+			<-releaseSync
+			_, _ = w.Write([]byte(`{"rid":2,"full_update":true,"torrents":{}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	db := testdb.NewMigratedSQLite(t, "torrents-stale-cross-instance")
+	instanceStore, err := models.NewInstanceStore(db, []byte("01234567890123456789012345678901"))
+	require.NoError(t, err)
+	errorStore := models.NewInstanceErrorStore(db)
+	clientPool, err := quiqbt.NewClientPool(instanceStore, errorStore)
+	require.NoError(t, err)
+
+	instance, err := instanceStore.Create(context.Background(), "alpha", srv.URL, "user", "pass", nil, nil, false, nil)
+	require.NoError(t, err)
+
+	client := newStaleCachedClient(t, srv.URL, []qbt.Torrent{
+		{Name: "Alpha", Hash: "aaa", MagnetURI: "magnet:?xt=urn:btih:aaa", AddedOn: 1},
+	})
+	setUnexportedField(t, clientPool, "clients", map[int]*quiqbt.Client{instance.ID: client})
+
+	release := func() {
+		releaseSyncOnce.Do(func() {
+			close(releaseSync)
+			srv.Close()
+			_ = clientPool.Close()
+		})
+	}
+	t.Cleanup(release)
+
+	return NewTorrentsHandler(quiqbt.NewSyncManager(clientPool, nil), nil, instanceStore), release
+}
+
 func newCachedClient(t *testing.T, torrents []qbt.Torrent) *quiqbt.Client {
 	t.Helper()
 
@@ -160,6 +250,32 @@ func newCachedClient(t *testing.T, torrents []qbt.Torrent) *quiqbt.Client {
 	setUnexportedField(t, syncManager, "lastSync", time.Now())
 
 	client := &quiqbt.Client{}
+	setUnexportedField(t, client, "isHealthy", true)
+	setUnexportedField(t, client, "lastHealthCheck", time.Now())
+	setUnexportedField(t, client, "syncManager", syncManager)
+
+	return client
+}
+
+func newStaleCachedClient(t *testing.T, host string, torrents []qbt.Torrent) *quiqbt.Client {
+	t.Helper()
+
+	qbtClient := qbt.NewClient(qbt.Config{Host: host, Timeout: 60})
+	syncOpts := qbt.DefaultSyncOptions()
+	syncOpts.DynamicSync = true
+	syncManager := qbtClient.NewSyncManager(syncOpts)
+
+	torrentMap := make(map[string]qbt.Torrent, len(torrents))
+	for _, torrent := range torrents {
+		torrentMap[torrent.Hash] = torrent
+	}
+
+	setUnexportedField(t, syncManager, "data", &qbt.MainData{Torrents: torrentMap})
+	setUnexportedField(t, syncManager, "allTorrents", append([]qbt.Torrent(nil), torrents...))
+	setUnexportedField(t, syncManager, "lastSync", time.Now().Add(-time.Hour))
+	setUnexportedField(t, syncManager, "lastSuccessfulSync", time.Now().Add(-time.Hour))
+
+	client := &quiqbt.Client{Client: qbtClient}
 	setUnexportedField(t, client, "isHealthy", true)
 	setUnexportedField(t, client, "lastHealthCheck", time.Now())
 	setUnexportedField(t, client, "syncManager", syncManager)

--- a/internal/api/handlers/torrents_field_test.go
+++ b/internal/api/handlers/torrents_field_test.go
@@ -152,7 +152,7 @@ func TestGetTorrentFieldCrossInstanceReadSkipsFreshData(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	req := newTorrentFieldRequestWithContext(t, ctx, allInstancesID, map[string]any{
+	req := newTorrentFieldRequestWithContext(ctx, t, allInstancesID, map[string]any{
 		"field": "magnet_uri",
 	})
 	rec := httptest.NewRecorder()
@@ -302,10 +302,10 @@ func newStaleCachedClient(t *testing.T, host string, torrents []qbt.Torrent) *qu
 
 func newTorrentFieldRequest(t *testing.T, instanceID int, payload map[string]any) *http.Request {
 	t.Helper()
-	return newTorrentFieldRequestWithContext(t, context.Background(), instanceID, payload)
+	return newTorrentFieldRequestWithContext(context.Background(), t, instanceID, payload)
 }
 
-func newTorrentFieldRequestWithContext(t *testing.T, ctx context.Context, instanceID int, payload map[string]any) *http.Request {
+func newTorrentFieldRequestWithContext(ctx context.Context, t *testing.T, instanceID int, payload map[string]any) *http.Request {
 	t.Helper()
 
 	body, err := json.Marshal(payload)

--- a/internal/api/handlers/torrents_field_test.go
+++ b/internal/api/handlers/torrents_field_test.go
@@ -119,7 +119,9 @@ func TestListCrossInstanceTorrentsSkipsFreshData(t *testing.T) {
 	handler, release := createStaleCrossInstanceReadHarness(t)
 	defer release()
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/torrents/cross-instance?limit=10", nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/api/torrents/cross-instance?limit=10", nil)
 	rec := httptest.NewRecorder()
 
 	done := make(chan struct{})
@@ -131,17 +133,26 @@ func TestListCrossInstanceTorrentsSkipsFreshData(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(time.Second):
+		cancel()
+		release()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+		}
 		t.Fatal("cross-instance list joined a stale in-flight sync")
 	}
 
 	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	require.Empty(t, rec.Header().Get("X-Data-Source"))
 }
 
 func TestGetTorrentFieldCrossInstanceReadSkipsFreshData(t *testing.T) {
 	handler, release := createStaleCrossInstanceReadHarness(t)
 	defer release()
 
-	req := newTorrentFieldRequest(t, allInstancesID, map[string]any{
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req := newTorrentFieldRequestWithContext(t, ctx, allInstancesID, map[string]any{
 		"field": "magnet_uri",
 	})
 	rec := httptest.NewRecorder()
@@ -155,6 +166,12 @@ func TestGetTorrentFieldCrossInstanceReadSkipsFreshData(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(time.Second):
+		cancel()
+		release()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+		}
 		t.Fatal("cross-instance torrent field read joined a stale in-flight sync")
 	}
 
@@ -285,11 +302,16 @@ func newStaleCachedClient(t *testing.T, host string, torrents []qbt.Torrent) *qu
 
 func newTorrentFieldRequest(t *testing.T, instanceID int, payload map[string]any) *http.Request {
 	t.Helper()
+	return newTorrentFieldRequestWithContext(t, context.Background(), instanceID, payload)
+}
+
+func newTorrentFieldRequestWithContext(t *testing.T, ctx context.Context, instanceID int, payload map[string]any) *http.Request {
+	t.Helper()
 
 	body, err := json.Marshal(payload)
 	require.NoError(t, err)
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/instances/"+strconv.Itoa(instanceID)+"/torrents/field", bytes.NewReader(body))
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/api/instances/"+strconv.Itoa(instanceID)+"/torrents/field", bytes.NewReader(body))
 	routeCtx := chi.NewRouteContext()
 	routeCtx.URLParams.Add("instanceID", strconv.Itoa(instanceID))
 

--- a/internal/api/sse/manager.go
+++ b/internal/api/sse/manager.go
@@ -362,10 +362,8 @@ func NewStreamManager(clientPool *qbittorrent.ClientPool, syncManager syncProvid
 // avoid triggering a connection attempt. GetLastSyncUpdate reports the success-only
 // clock, so a failing instance keeps reporting its last good sync rather than now.
 //
-// GetLastSyncUpdate reads go-qbittorrent's LastSuccessfulSyncTime(), which locks the
-// SyncManager mutex. go-qbittorrent already holds that (non-reentrant) lock while it
-// invokes our OnError/OnUpdate callbacks, so this must never be called synchronously
-// from inside those callbacks (see HandleSyncError, which defers it to a goroutine).
+// Resolve this from callback fan-out goroutines rather than directly inside
+// OnError/OnUpdate so the qBittorrent sync loop is not blocked by stream publishing.
 func (m *StreamManager) instanceLastSuccessfulSync(ctx context.Context, instanceID int) time.Time {
 	if m.clientPool == nil || instanceID <= 0 {
 		return time.Time{}
@@ -673,17 +671,8 @@ func (m *StreamManager) HandleSyncError(instanceID int, err error) {
 		Err:  message,
 	}
 
-	// Resolve the staleness stamp and publish asynchronously so the qBittorrent sync
-	// loop's OnError callback (this function) never blocks during the fan-out.
-	//
-	// The stamp MUST NOT be resolved synchronously here: go-qbittorrent invokes
-	// OnError while holding its SyncManager write lock, and stampLastSuccessfulSync
-	// reads LastSuccessfulSyncTime(), which takes a read lock on that same
-	// (non-reentrant) mutex. Calling it on this goroutine re-enters the held lock and
-	// self-deadlocks the sync loop, wedging the instance's client and starving every
-	// cached reader (e.g. GET /api/instances and cross-instance stream init). Doing it
-	// on a fresh goroutine lets the sync loop release its lock first. Mirrors
-	// HandleMainData.
+	// Resolve the staleness stamp and publish asynchronously so this callback's
+	// fan-out does not hold up the qBittorrent sync loop. Mirrors HandleMainData.
 	go func() {
 		m.stampLastSuccessfulSync(m.ctx, meta, instanceID)
 		m.publishToInstance(instanceID, payload)

--- a/internal/api/sse/manager_test.go
+++ b/internal/api/sse/manager_test.go
@@ -231,12 +231,8 @@ func TestStreamManagerHandleSyncErrorStampsLastSuccessfulSync(t *testing.T) {
 }
 
 func TestStreamManagerHandleSyncErrorResolvesStampOffCallbackGoroutine(t *testing.T) {
-	// Regression for a self-deadlock: HandleSyncError used to resolve the staleness
-	// stamp synchronously. go-qbittorrent invokes OnError while holding its SyncManager
-	// write lock, and the stamp reads LastSuccessfulSyncTime() which takes that same
-	// non-reentrant lock — wedging the sync loop and starving every cached reader
-	// (e.g. GET /api/instances). The stamp must be resolved on a fresh goroutine, so
-	// HandleSyncError must return without waiting on lastSuccessfulSyncFn.
+	// The staleness stamp is resolved on a fresh goroutine so this callback's fan-out
+	// does not hold up the qBittorrent sync loop.
 	manager := NewStreamManager(nil, nil, nil)
 	provider := newRecordingProvider()
 	manager.server.Provider = provider

--- a/internal/qbittorrent/client.go
+++ b/internal/qbittorrent/client.go
@@ -209,12 +209,11 @@ func (c *Client) GetLastHealthCheck() time.Time {
 // advances on failed sync attempts too and would mask a stalled instance from
 // readiness/staleness checks.
 func (c *Client) GetLastSyncUpdate() time.Time {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	if c.syncManager == nil {
+	syncManager := c.GetSyncManager()
+	if syncManager == nil {
 		return time.Time{}
 	}
-	return c.syncManager.LastSuccessfulSyncTime()
+	return syncManager.LastSuccessfulSyncTime()
 }
 
 func (c *Client) updateHealthStatus(healthy bool) {
@@ -488,14 +487,12 @@ func (c *Client) SupportsPathAutocomplete() bool {
 
 // getTorrentsByHashes returns multiple torrents by their hashes (O(n) where n is number of requested hashes)
 func (c *Client) getTorrentsByHashes(hashes []string) []qbt.Torrent {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	if c.syncManager == nil {
+	syncManager := c.GetSyncManager()
+	if syncManager == nil {
 		return nil
 	}
 
-	return c.syncManager.GetTorrents(qbt.TorrentFilterOptions{Hashes: hashes})
+	return syncManager.GetTorrents(qbt.TorrentFilterOptions{Hashes: hashes})
 }
 
 func (c *Client) HealthCheck(ctx context.Context) error {
@@ -563,12 +560,11 @@ func (c *Client) GetSyncManager() *qbt.SyncManager {
 }
 
 func (c *Client) trackerManager() *qbt.TrackerManager {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	if c.syncManager == nil {
+	syncManager := c.GetSyncManager()
+	if syncManager == nil {
 		return nil
 	}
-	return c.syncManager.Trackers()
+	return syncManager.Trackers()
 }
 
 func (c *Client) supportsTrackerInclude() bool {
@@ -804,21 +800,19 @@ func (c *Client) applyOptimisticCacheUpdate(hashes []string, action string, _ ma
 	log.Debug().Int("instanceID", c.instanceID).Str("action", action).Int("hashCount", len(hashes)).Msg("Starting optimistic cache update")
 
 	now := time.Now()
+	syncManager := c.GetSyncManager()
 
 	// Apply optimistic updates based on action using sync manager data
 	for _, hash := range hashes {
 		var originalState qbt.TorrentState
 		var progress float64
 
-		// Need mutex only for syncManager access
-		c.mu.RLock()
-		if c.syncManager != nil {
-			if torrent, exists := c.syncManager.GetTorrent(hash); exists {
+		if syncManager != nil {
+			if torrent, exists := syncManager.GetTorrent(hash); exists {
 				originalState = torrent.State
 				progress = torrent.Progress
 			}
 		}
-		c.mu.RUnlock()
 
 		state := getTargetState(action, progress)
 		if state != "" && state != originalState {

--- a/internal/qbittorrent/client_test.go
+++ b/internal/qbittorrent/client_test.go
@@ -196,6 +196,7 @@ func TestClientCheckedGetterDoesNotConvoyCapabilityReaders(t *testing.T) {
 			probeDone := make(chan struct{})
 			go func() {
 				client.mu.RLock()
+				_ = client.supportsSetTags
 				client.mu.RUnlock()
 				close(probeDone)
 			}()

--- a/internal/qbittorrent/client_test.go
+++ b/internal/qbittorrent/client_test.go
@@ -177,7 +177,50 @@ func TestClientCheckedGetterDoesNotConvoyCapabilityReaders(t *testing.T) {
 	go func() {
 		refreshDone <- client.RefreshCapabilities(context.Background())
 	}()
-	time.Sleep(100 * time.Millisecond)
+
+	writerQueued := make(chan struct{})
+	stopWriterProbe := make(chan struct{})
+	var stopWriterProbeOnce sync.Once
+	stopProbe := func() {
+		stopWriterProbeOnce.Do(func() { close(stopWriterProbe) })
+	}
+	defer stopProbe()
+	go func() {
+		for {
+			select {
+			case <-stopWriterProbe:
+				return
+			default:
+			}
+
+			probeDone := make(chan struct{})
+			go func() {
+				client.mu.RLock()
+				client.mu.RUnlock()
+				close(probeDone)
+			}()
+
+			select {
+			case <-probeDone:
+			case <-stopWriterProbe:
+				return
+			case <-time.After(10 * time.Millisecond):
+				close(writerQueued)
+				return
+			}
+		}
+	}()
+
+	refreshComplete := false
+	select {
+	case err := <-refreshDone:
+		require.NoError(t, err)
+		refreshComplete = true
+	case <-writerQueued:
+	case <-time.After(time.Second):
+		t.Fatal("capability refresh neither completed nor queued for the client lock")
+	}
+	stopProbe()
 
 	readDone := make(chan bool, 1)
 	go func() {
@@ -193,11 +236,13 @@ func TestClientCheckedGetterDoesNotConvoyCapabilityReaders(t *testing.T) {
 
 	release()
 
-	select {
-	case err := <-refreshDone:
-		require.NoError(t, err)
-	case <-time.After(time.Second):
-		t.Fatal("capability refresh did not finish")
+	if !refreshComplete {
+		select {
+		case err := <-refreshDone:
+			require.NoError(t, err)
+		case <-time.After(time.Second):
+			t.Fatal("capability refresh did not finish")
+		}
 	}
 
 	select {

--- a/internal/qbittorrent/client_test.go
+++ b/internal/qbittorrent/client_test.go
@@ -128,6 +128,85 @@ func TestClientSubcategoriesAlwaysEnabledCapability(t *testing.T) {
 	}
 }
 
+func TestClientCheckedGetterDoesNotConvoyCapabilityReaders(t *testing.T) {
+	syncStarted := make(chan struct{})
+	releaseSync := make(chan struct{})
+	var closeSyncStarted sync.Once
+	var releaseSyncOnce sync.Once
+	release := func() {
+		releaseSyncOnce.Do(func() { close(releaseSync) })
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/sync/maindata":
+			closeSyncStarted.Do(func() { close(syncStarted) })
+			<-releaseSync
+			_, _ = w.Write([]byte(`{"rid":1,"full_update":true,"torrents":{}}`))
+		case "/api/v2/app/webapiVersion":
+			_, _ = w.Write([]byte("2.16.0"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	defer release()
+
+	qbtClient := qbt.NewClient(qbt.Config{Host: srv.URL, Timeout: 60})
+	syncOpts := qbt.DefaultSyncOptions()
+	syncOpts.DynamicSync = true
+	client := &Client{
+		Client:          qbtClient,
+		syncManager:     qbtClient.NewSyncManager(syncOpts),
+		supportsSetTags: true,
+	}
+
+	getterDone := make(chan struct{})
+	go func() {
+		defer close(getterDone)
+		_ = client.getTorrentsByHashes([]string{"abc"})
+	}()
+
+	select {
+	case <-syncStarted:
+	case <-time.After(time.Second):
+		t.Fatal("checked getter did not start a sync")
+	}
+
+	refreshDone := make(chan error, 1)
+	go func() {
+		refreshDone <- client.RefreshCapabilities(context.Background())
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	readDone := make(chan bool, 1)
+	go func() {
+		readDone <- client.SupportsSetTags()
+	}()
+
+	select {
+	case supported := <-readDone:
+		require.True(t, supported)
+	case <-time.After(time.Second):
+		t.Fatal("capability reader convoyed behind checked getter and pending writer")
+	}
+
+	release()
+
+	select {
+	case err := <-refreshDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("capability refresh did not finish")
+	}
+
+	select {
+	case <-getterDone:
+	case <-time.After(time.Second):
+		t.Fatal("checked getter did not finish")
+	}
+}
+
 func TestNewClientWithTimeoutRejectsLoginCookiesWithoutVerifiedSessionMarker(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Bumps go-qbittorrent to the fetch-outside-lock SyncManager commit and keeps qui from holding client locks across checked sync-cache getters.

Cross-instance list and field reads now use cached data, so slow-but-connectable instances degrade to stale metadata instead of parking the page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-instance torrent field and list lookups to skip fresh-data fetching, preventing delays when in-flight sync is stale/blocked; also removed the “fresh” data-source response header on these paths.
  * Refined qBittorrent client sync access to reduce lock and concurrency contention during sync and cached reads.
  * Updated the bundled qBittorrent integration to a newer version.
* **Tests**
  * Added concurrency-focused regression coverage to ensure cross-instance reads complete even when sync endpoints are intentionally blocked, including header expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->