### PR TITLE
fix(torrents): keep renamed folders expanded in file tree

### DIFF
--- a/web/src/components/torrents/TorrentFileTree.tsx
+++ b/web/src/components/torrents/TorrentFileTree.tsx
@@ -215,15 +215,16 @@ export const TorrentFileTree = memo(function TorrentFileTree({
   const [expandedFolders, setExpandedFolders] = useState<Set<string>>(
     () => new Set(allFolderIds)
   )
-  const knownFolderIds = useRef<Set<string>>(new Set(allFolderIds))
+  const [knownFolderIds, setKnownFolderIds] = useState(allFolderIds)
 
-  // Keep expandedFolders in sync when folder paths change (e.g., after rename)
-  useEffect(() => {
-    const previousIds = knownFolderIds.current
-    const currentIds = new Set(allFolderIds)
-    knownFolderIds.current = currentIds
-    setExpandedFolders((prev) => reconcileExpandedFolders(prev, previousIds, currentIds))
-  }, [allFolderIds])
+  // Keep expandedFolders in sync when folder paths change (e.g., after rename);
+  // render-time adjustment so the reconciled tree commits in one pass
+  if (knownFolderIds !== allFolderIds) {
+    setKnownFolderIds(allFolderIds)
+    setExpandedFolders(
+      reconcileExpandedFolders(expandedFolders, new Set(knownFolderIds), new Set(allFolderIds))
+    )
+  }
 
   const flatRows = useMemo(
     () => flattenTree(nodes, expandedFolders),

--- a/web/src/components/torrents/TorrentFileTree.tsx
+++ b/web/src/components/torrents/TorrentFileTree.tsx
@@ -8,6 +8,7 @@ import { Checkbox } from "@/components/ui/checkbox"
 import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from "@/components/ui/context-menu"
 import { useFileRangeSelection } from "@/hooks/useFileRangeSelection"
 import { FILE_PRIORITY, foldFolderPriority, normalizeFilePriority, type FolderPriority } from "@/lib/file-priority"
+import { reconcileExpandedFolders } from "@/lib/file-tree-expansion"
 import { getLinuxFileName, getLinuxSavePath } from "@/lib/incognito"
 import { cn, copyTextToClipboard, formatBytes, joinPath } from "@/lib/utils"
 import type { TorrentFile } from "@/types"
@@ -214,32 +215,14 @@ export const TorrentFileTree = memo(function TorrentFileTree({
   const [expandedFolders, setExpandedFolders] = useState<Set<string>>(
     () => new Set(allFolderIds)
   )
+  const knownFolderIds = useRef<Set<string>>(new Set(allFolderIds))
 
   // Keep expandedFolders in sync when folder paths change (e.g., after rename)
   useEffect(() => {
-    setExpandedFolders((prev) => {
-      const allFolderSet = new Set(allFolderIds)
-      const next = new Set(prev)
-      let changed = false
-
-      // Remove folders that no longer exist
-      for (const id of prev) {
-        if (!allFolderSet.has(id)) {
-          next.delete(id)
-          changed = true
-        }
-      }
-
-      // Add new folders as expanded by default
-      for (const id of allFolderIds) {
-        if (!prev.has(id)) {
-          next.add(id)
-          changed = true
-        }
-      }
-
-      return changed ? next : prev
-    })
+    const previousIds = knownFolderIds.current
+    const currentIds = new Set(allFolderIds)
+    knownFolderIds.current = currentIds
+    setExpandedFolders((prev) => reconcileExpandedFolders(prev, previousIds, currentIds))
   }, [allFolderIds])
 
   const flatRows = useMemo(

--- a/web/src/components/torrents/details/TorrentFileTable.tsx
+++ b/web/src/components/torrents/details/TorrentFileTable.tsx
@@ -11,6 +11,7 @@ import { Progress } from "@/components/ui/progress"
 import { TruncatedText } from "@/components/ui/truncated-text"
 import { useFileRangeSelection } from "@/hooks/useFileRangeSelection"
 import { FILE_PRIORITY, foldFolderPriority, normalizeFilePriority, type FilePriorityValue, type FolderPriority } from "@/lib/file-priority"
+import { reconcileExpandedFolders } from "@/lib/file-tree-expansion"
 import { getLinuxFileName, getLinuxFolderName, getLinuxSavePath } from "@/lib/incognito"
 import { cn, copyTextToClipboard, formatBytes, joinPath } from "@/lib/utils"
 import type { TorrentFile } from "@/types"
@@ -155,6 +156,20 @@ function buildFileTree(
   return roots
 }
 
+function collectFolderIds(nodes: FileTreeNode[]): Set<string> {
+  const ids = new Set<string>()
+  function walk(current: FileTreeNode[]) {
+    for (const node of current) {
+      if (node.kind === "folder") {
+        ids.add(node.id)
+        if (node.children) walk(node.children)
+      }
+    }
+  }
+  walk(nodes)
+  return ids
+}
+
 function flattenTree(
   nodes: FileTreeNode[],
   expandedFolders: Set<string>,
@@ -207,6 +222,7 @@ export const TorrentFileTable = memo(function TorrentFileTable({
   const [expandedFolders, setExpandedFolders] = useState<Set<string>>(() => new Set())
   const [searchQuery, setSearchQuery] = useState("")
   const initializedForHash = useRef<string | null>(null)
+  const knownFolderIds = useRef<Set<string>>(new Set())
   const scrollContainerRef = useRef<HTMLDivElement>(null)
 
   const tree = useMemo(
@@ -214,22 +230,20 @@ export const TorrentFileTable = memo(function TorrentFileTable({
     [files, incognitoMode, torrentHash]
   )
 
-  // Expand all folders by default when tree is first built for a new torrent
+  // Expand all folders by default when tree is first built for a new torrent,
+  // then keep the expanded set keyed to current paths (renames change node ids)
   useEffect(() => {
-    if (tree.length > 0 && initializedForHash.current !== torrentHash) {
+    if (tree.length === 0) return
+    const allFolderIds = collectFolderIds(tree)
+    if (initializedForHash.current !== torrentHash) {
       initializedForHash.current = torrentHash
-      const allFolderIds = new Set<string>()
-      function collectFolders(nodes: FileTreeNode[]) {
-        for (const node of nodes) {
-          if (node.kind === "folder") {
-            allFolderIds.add(node.id)
-            if (node.children) collectFolders(node.children)
-          }
-        }
-      }
-      collectFolders(tree)
+      knownFolderIds.current = allFolderIds
       setExpandedFolders(allFolderIds)
+      return
     }
+    const previousIds = knownFolderIds.current
+    knownFolderIds.current = allFolderIds
+    setExpandedFolders((prev) => reconcileExpandedFolders(prev, previousIds, allFolderIds))
   }, [tree, torrentHash])
 
   const flatRows = useMemo(
@@ -296,17 +310,7 @@ export const TorrentFileTable = memo(function TorrentFileTable({
   }, [])
 
   const expandAll = useCallback(() => {
-    const allFolderIds = new Set<string>()
-    function collectFolders(nodes: FileTreeNode[]) {
-      for (const node of nodes) {
-        if (node.kind === "folder") {
-          allFolderIds.add(node.id)
-          if (node.children) collectFolders(node.children)
-        }
-      }
-    }
-    collectFolders(tree)
-    setExpandedFolders(allFolderIds)
+    setExpandedFolders(collectFolderIds(tree))
   }, [tree])
 
   const collapseAll = useCallback(() => {

--- a/web/src/components/torrents/details/TorrentFileTable.tsx
+++ b/web/src/components/torrents/details/TorrentFileTable.tsx
@@ -221,30 +221,24 @@ export const TorrentFileTable = memo(function TorrentFileTable({
   const { t } = useTranslation("torrents")
   const [expandedFolders, setExpandedFolders] = useState<Set<string>>(() => new Set())
   const [searchQuery, setSearchQuery] = useState("")
-  const initializedForHash = useRef<string | null>(null)
-  const knownFolderIds = useRef<Set<string>>(new Set())
   const scrollContainerRef = useRef<HTMLDivElement>(null)
 
   const tree = useMemo(
     () => (files ? buildFileTree(files, incognitoMode, torrentHash) : []),
     [files, incognitoMode, torrentHash]
   )
+  const folderIds = useMemo(() => collectFolderIds(tree), [tree])
 
   // Expand all folders by default when tree is first built for a new torrent,
-  // then keep the expanded set keyed to current paths (renames change node ids)
-  useEffect(() => {
-    if (tree.length === 0) return
-    const allFolderIds = collectFolderIds(tree)
-    if (initializedForHash.current !== torrentHash) {
-      initializedForHash.current = torrentHash
-      knownFolderIds.current = allFolderIds
-      setExpandedFolders(allFolderIds)
-      return
-    }
-    const previousIds = knownFolderIds.current
-    knownFolderIds.current = allFolderIds
-    setExpandedFolders((prev) => reconcileExpandedFolders(prev, previousIds, allFolderIds))
-  }, [tree, torrentHash])
+  // then keep the expanded set keyed to current paths (renames change node ids);
+  // render-time adjustment so the reconciled tree commits in one pass
+  const [knownExpansion, setKnownExpansion] = useState<{ hash: string; ids: Set<string> } | null>(null)
+  if (tree.length > 0 && (knownExpansion?.hash !== torrentHash || knownExpansion.ids !== folderIds)) {
+    setKnownExpansion({ hash: torrentHash, ids: folderIds })
+    setExpandedFolders(
+      knownExpansion?.hash === torrentHash? reconcileExpandedFolders(expandedFolders, knownExpansion.ids, folderIds): new Set(folderIds)
+    )
+  }
 
   const flatRows = useMemo(
     () => flattenTree(tree, expandedFolders),
@@ -310,8 +304,8 @@ export const TorrentFileTable = memo(function TorrentFileTable({
   }, [])
 
   const expandAll = useCallback(() => {
-    setExpandedFolders(collectFolderIds(tree))
-  }, [tree])
+    setExpandedFolders(new Set(folderIds))
+  }, [folderIds])
 
   const collapseAll = useCallback(() => {
     setExpandedFolders(new Set())

--- a/web/src/lib/file-tree-expansion.test.ts
+++ b/web/src/lib/file-tree-expansion.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { describe, expect, it } from "vitest"
+import { reconcileExpandedFolders } from "./file-tree-expansion"
+
+describe("reconcileExpandedFolders", () => {
+  it("keeps a renamed folder expanded (old path dropped, new path auto-expanded)", () => {
+    const expanded = new Set(["Old", "Old/sub"])
+    const previousIds = new Set(["Old", "Old/sub"])
+    const currentIds = new Set(["New", "New/sub"])
+
+    const next = reconcileExpandedFolders(expanded, previousIds, currentIds)
+
+    expect(next).toEqual(new Set(["New", "New/sub"]))
+  })
+
+  it("does not re-expand a user-collapsed folder when ids are unchanged", () => {
+    const expanded = new Set(["a"])
+    const ids = new Set(["a", "b"])
+
+    const next = reconcileExpandedFolders(expanded, ids, ids)
+
+    expect(next).toBe(expanded)
+  })
+
+  it("preserves collapsed state for surviving folders while expanding new ones", () => {
+    const expanded = new Set(["a"])
+    const previousIds = new Set(["a", "b"])
+    const currentIds = new Set(["a", "b", "c"])
+
+    const next = reconcileExpandedFolders(expanded, previousIds, currentIds)
+
+    expect(next).toEqual(new Set(["a", "c"]))
+  })
+
+  it("expands everything when all ids are new (torrent switch)", () => {
+    const expanded = new Set(["old"])
+    const previousIds = new Set(["old"])
+    const currentIds = new Set(["x", "x/y"])
+
+    const next = reconcileExpandedFolders(expanded, previousIds, currentIds)
+
+    expect(next).toEqual(new Set(["x", "x/y"]))
+  })
+})

--- a/web/src/lib/file-tree-expansion.ts
+++ b/web/src/lib/file-tree-expansion.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+/**
+ * Reconcile the expanded-folder set after the file tree rebuilds.
+ *
+ * Folder expansion is keyed by path, so a rename changes the id of the folder
+ * and all its descendants. Dropping vanished ids and auto-expanding ids that
+ * were not previously known keeps a renamed folder expanded, while folders the
+ * user collapsed stay collapsed across refetches (their id persists).
+ *
+ * Returns the original set unchanged when nothing needs to change.
+ */
+export function reconcileExpandedFolders(
+  expanded: Set<string>,
+  previousIds: Set<string>,
+  currentIds: Set<string>
+): Set<string> {
+  let changed = false
+  const next = new Set<string>()
+
+  for (const id of expanded) {
+    if (currentIds.has(id)) {
+      next.add(id)
+    } else {
+      changed = true
+    }
+  }
+
+  for (const id of currentIds) {
+    if (!previousIds.has(id) && !next.has(id)) {
+      next.add(id)
+      changed = true
+    }
+  }
+
+  return changed ? next : expanded
+}


### PR DESCRIPTION
Renaming an expanded content folder collapsed it because folder expansion state is keyed by path: after the rename the files refetch rebuilt the tree with new paths and the stale entries in the expanded set no longer matched (renaming back to the old name made them match again, which is why the folder re-expanded on its own). Reported in #2108.

The expanded set is now reconciled against the known folder ids whenever the tree rebuilds: vanished paths are dropped and genuinely new paths default to expanded, so a renamed folder keeps its expansion while user-collapsed folders stay collapsed across refetches. The reconcile logic lives in a shared helper used by both TorrentFileTable and TorrentFileTree, which also fixes the latter force-re-expanding collapsed folders on every files refetch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved torrent file tree folder expansion persistence after refreshes, including folder renames.
  * Newly introduced folders expand automatically when appropriate, while user-collapsed folders remain collapsed.
  * Preserves the prior expanded state across torrent content changes and only falls back to expanding all folders when there’s no match.

* **Tests**
  * Added automated coverage for folder expansion reconciliation across renames, unchanged folders, newly added folders, and torrent switches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->