### PR TITLE
fix(torrents): keep rename dialog scrolled to start of file name

### DIFF
--- a/web/src/components/torrents/TorrentDialogs.test.tsx
+++ b/web/src/components/torrents/TorrentDialogs.test.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { RenameTorrentFileDialog } from "@/components/torrents/TorrentDialogs"
+import { cleanup, render, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+vi.mock("@/lib/api", () => ({ api: {} }))
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: () => ({ getTotalSize: () => 0, getVirtualItems: () => [] }),
+}))
+vi.mock("@/hooks/usePathAutocomplete", () => ({
+  usePathAutocomplete: () => ({ suggestions: [], isLoading: false }),
+}))
+
+afterEach(cleanup)
+
+function renderDialog(path: string) {
+  render(
+    <RenameTorrentFileDialog
+      open
+      onOpenChange={() => {}}
+      files={[{ name: path }]}
+      onConfirm={() => {}}
+      initialPath={path}
+    />
+  )
+  return document.getElementById("fileName") as HTMLInputElement
+}
+
+describe("RenameTorrentFileDialog", () => {
+  it("selects only the base name, never the extension (#2107)", async () => {
+    const name = "Movie.Name.2023.UHD.BluRay.2160p.DTS-HD.MA.5.1.HEVC.REMUX-GROUP.mkv"
+    const input = renderDialog(`folder/${name}`)
+    await waitFor(() => expect(input.selectionEnd).toBe(name.lastIndexOf(".")))
+    expect(input.selectionStart).toBe(0)
+    expect(input.value.slice(input.selectionEnd!)).toBe(".mkv")
+    // backward direction keeps the caret at the start, so engines that scroll
+    // the caret into view show the start of the name, not the dot boundary
+    expect(input.selectionDirection).toBe("backward")
+  })
+
+  it("scrolls the input back to the start so the unselected extension is not hidden off-screen (#2107)", async () => {
+    const name = "Movie.Name.2023.UHD.BluRay.2160p.DTS-HD.MA.5.1.HEVC.REMUX-GROUP.mkv"
+    const input = renderDialog(`folder/${name}`)
+    // jsdom does no layout, so emulate the scroll a real browser performs when
+    // it brings the selection end of an overflowing value into view.
+    let scrollLeft = 500
+    Object.defineProperty(input, "scrollLeft", {
+      configurable: true,
+      get: () => scrollLeft,
+      set: (v: number) => { scrollLeft = v },
+    })
+    await waitFor(() => expect(input.selectionEnd).toBe(name.lastIndexOf(".")))
+    expect(scrollLeft).toBe(0)
+  })
+
+  it("selects the whole name when there is no extension", async () => {
+    const input = renderDialog("folder/NoExtensionFile")
+    await waitFor(() => expect(input.selectionEnd).toBe("NoExtensionFile".length))
+    expect(input.selectionStart).toBe(0)
+  })
+})

--- a/web/src/components/torrents/TorrentDialogs.tsx
+++ b/web/src/components/torrents/TorrentDialogs.tsx
@@ -895,10 +895,14 @@ export const RenameTorrentFileDialog = memo(function RenameTorrentFileDialog({
           inputRef.current.focus()
           const dotIndex = fileName.lastIndexOf(".")
           if (dotIndex > 0) {
-            inputRef.current.setSelectionRange(0, dotIndex)
+            // "backward" puts the caret at the start: engines that scroll the
+            // caret into view show the start of the name instead of stopping
+            // just before the extension, which read as select-all (#2107)
+            inputRef.current.setSelectionRange(0, dotIndex, "backward")
           } else {
             inputRef.current.select()
           }
+          inputRef.current.scrollLeft = 0
         }
       }, 50)
     }


### PR DESCRIPTION
The rename-file dialog already selects only the base name, but on long names some engines scroll the caret into view and stop just before the extension, so every visible character is highlighted and the dialog reads as if the extension were selected too. Selecting backward keeps the caret at the start of the name and `scrollLeft = 0` covers engines that don't caret-scroll, so the dialog now opens showing the start of the selection and the extension is visibly preserved while typing.

Addresses #2107.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the rename dialog so filenames with extensions now preselect only the name part, making it easier to edit without affecting the extension.
  * Ensured the selected text stays visible when the rename field opens, preventing the extension from being hidden off-screen.
  * Filenames without extensions still select the full name as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->