### PR TITLE
feat(rss): show feed titles in affected feeds selector

### DIFF
--- a/web/src/pages/RSSPage.tsx
+++ b/web/src/pages/RSSPage.tsx
@@ -1789,7 +1789,7 @@ const DEFAULT_RULE_FORM_STATE: RuleFormState = {
 interface RuleFormFieldsProps {
   state: RuleFormState
   onChange: <K extends keyof RuleFormState>(field: K, value: RuleFormState[K]) => void
-  feedUrls: string[]
+  feeds: FeedInfo[]
   categories: Record<string, Category>
   availableTags: string[]
   idPrefix: string
@@ -1798,7 +1798,7 @@ interface RuleFormFieldsProps {
 function RuleFormFields({
   state,
   onChange,
-  feedUrls,
+  feeds,
   categories,
   availableTags,
   idPrefix,
@@ -1865,27 +1865,30 @@ function RuleFormFields({
       <div className="space-y-2">
         <Label>{t("ruleForm.affectedFeeds")}</Label>
         <div className="grid grid-cols-1 gap-2 max-h-32 overflow-y-auto">
-          {feedUrls.map((feedUrl) => (
-            <label key={feedUrl} className="flex items-center gap-2 text-sm">
+          {feeds.map((feed) => (
+            <label key={feed.url} className="flex items-center gap-2 text-sm">
               <input
                 type="checkbox"
-                checked={state.affectedFeeds.includes(feedUrl)}
+                checked={state.affectedFeeds.includes(feed.url)}
                 onChange={(e) => {
                   if (e.target.checked) {
-                    onChange("affectedFeeds", [...state.affectedFeeds, feedUrl])
+                    onChange("affectedFeeds", [...state.affectedFeeds, feed.url])
                   } else {
                     onChange(
                       "affectedFeeds",
-                      state.affectedFeeds.filter((f) => f !== feedUrl)
+                      state.affectedFeeds.filter((f) => f !== feed.url)
                     )
                   }
                 }}
                 className="rounded"
               />
-              <span className="truncate">{feedUrl}</span>
+              <div className="flex flex-col min-w-0">
+                <span className="truncate font-medium">{feed.title || feed.url}</span>
+                <span className="truncate text-xs text-muted-foreground">{feed.url}</span>
+              </div>
             </label>
           ))}
-          {feedUrls.length === 0 && (
+          {feeds.length === 0 && (
             <p className="text-sm text-muted-foreground">{t("ruleForm.noFeedsAvailable")}</p>
           )}
         </div>
@@ -2017,7 +2020,7 @@ function AddRuleDialog({
   const [formState, setFormState] = useState<RuleFormState>(DEFAULT_RULE_FORM_STATE)
 
   const setRule = useSetRSSRule(instanceId)
-  const feedUrls = useMemo(() => getFeedUrls(feedsData), [feedsData])
+  const feeds = useMemo(() => getFeedInfos(feedsData), [feedsData])
 
   const handleFieldChange = <K extends keyof RuleFormState>(field: K, value: RuleFormState[K]) => {
     setFormState((prev) => ({ ...prev, [field]: value }))
@@ -2087,7 +2090,7 @@ function AddRuleDialog({
           <RuleFormFields
             state={formState}
             onChange={handleFieldChange}
-            feedUrls={feedUrls}
+            feeds={feeds}
             categories={categories}
             availableTags={availableTags}
             idPrefix="add"
@@ -2137,7 +2140,7 @@ function EditRuleDialog({
   const { formatDate } = useDateTimeFormatters()
 
   const setRuleMutation = useSetRSSRule(instanceId)
-  const feedUrls = useMemo(() => getFeedUrls(feedsData), [feedsData])
+  const feeds = useMemo(() => getFeedInfos(feedsData), [feedsData])
   const lastMatchDate = useMemo(() => {
     if (!rule?.lastMatch) return null
     const parsed = new Date(rule.lastMatch)
@@ -2212,7 +2215,7 @@ function EditRuleDialog({
           <RuleFormFields
             state={formState}
             onChange={handleFieldChange}
-            feedUrls={feedUrls}
+            feeds={feeds}
             categories={categories}
             availableTags={availableTags}
             idPrefix="edit"
@@ -2297,18 +2300,20 @@ function getFolderPaths(items: RSSItems | undefined, prefix = ""): string[] {
   return paths
 }
 
-function getFeedUrls(items: RSSItems | undefined): string[] {
+type FeedInfo = { url: string; title?: string }
+
+function getFeedInfos(items: RSSItems | undefined): FeedInfo[] {
   if (!items) return []
 
-  const urls: string[] = []
+  const infos: FeedInfo[] = []
   for (const item of Object.values(items)) {
     if (isRSSFeed(item)) {
-      urls.push(item.url)
+      infos.push({ url: item.url, title: item.title })
     } else {
-      urls.push(...getFeedUrls(item as RSSItems))
+      infos.push(...getFeedInfos(item as RSSItems))
     }
   }
-  return urls
+  return infos
 }
 
 // ============================================================================


### PR DESCRIPTION
In the RSS rule form, the "affected feeds" selector now displays each feed's title as the primary label with the URL shown underneath in smaller muted text. If a feed has no title, the URL is shown instead.

Previously only the raw URL was displayed, which was hard to read for long URLs.

# screenshot

| before | after |
| --- | --- |
| <img width="514" height="745" alt="截屏2026-07-04 23 11 28" src="https://github.com/user-attachments/assets/c89ca847-ba85-4fb6-a92e-e3a65c7a8632" /> | <img width="516" height="746" alt="截屏2026-07-04 23 11 39" src="https://github.com/user-attachments/assets/d60b03bd-2f85-44b1-968d-465e17af2ae0" />
 |

# note

- When the parent has truncate (which means overflow-hidden, text-ellipsis, and whitespace-nowrap), flex items default to min-width: auto, preventing the long text from truncating. min-w-0 overrides this behavior, allowing truncate to actually work.

| with min-w-0 | without min-w-0 |
| --- | --- |
| <img width="401" height="575" alt="截屏2026-07-04 23 18 15" src="https://github.com/user-attachments/assets/08fd2a60-61a0-42ed-9dea-e462108aa682" />  | <img width="401" height="580" alt="截屏2026-07-04 23 18 37" src="https://github.com/user-attachments/assets/2dc0b8ba-baf1-40c5-8b5b-03d74596ce2c" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved RSS rule feed selection to show feed titles when available, while also displaying the feed URL as supporting detail.
  * Feed selection now supports richer feed information (title + URL) instead of plain URL lists.
* **Bug Fixes**
  * Updated affected-feed matching to consistently store and match by feed URL, while preserving title-based display in the form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->