### PR TITLE
feat(logs): expose log file downloads in settings

### DIFF
--- a/internal/api/handlers/logs.go
+++ b/internal/api/handlers/logs.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"mime"
 	"net/http"
 	"os"
@@ -88,7 +89,9 @@ func (h *LogsHandler) listLogFiles() []LogFileEntry {
 
 	base := filepath.Base(logPath)
 	for _, entry := range entries {
-		if entry.IsDir() || !isQuiLogFile(entry.Name(), base) {
+		// Reject symlinks: a link named like a log file must not let the
+		// download endpoint serve a target outside the log directory.
+		if entry.IsDir() || entry.Type()&fs.ModeSymlink != 0 || !isQuiLogFile(entry.Name(), base) {
 			continue
 		}
 		info, err := entry.Info()

--- a/internal/api/handlers/logs.go
+++ b/internal/api/handlers/logs.go
@@ -12,7 +12,9 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -49,9 +51,28 @@ type LogFileEntry struct {
 	ModTime   time.Time `json:"modTime"`
 }
 
-// listLogFiles returns the .log files in the configured log directory.
-// Returns an empty slice when file logging is not configured or the
-// directory does not exist.
+// rotationTimestampRegex matches lumberjack's backup timestamp
+// (2006-01-02T15-04-05.000).
+var rotationTimestampRegex = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.\d{3}$`)
+
+// isQuiLogFile reports whether name is the configured log file or a lumberjack
+// rotation of it (base-{timestamp}{ext}). Anything else in the directory —
+// including .log files from other services — is not ours to serve.
+func isQuiLogFile(name, base string) bool {
+	if name == base {
+		return true
+	}
+	ext := filepath.Ext(base)
+	prefix := strings.TrimSuffix(base, ext) + "-"
+	if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, ext) {
+		return false
+	}
+	return rotationTimestampRegex.MatchString(strings.TrimSuffix(strings.TrimPrefix(name, prefix), ext))
+}
+
+// listLogFiles returns the active and rotated log files for the configured
+// log path. Returns an empty slice when file logging is not configured or
+// the directory does not exist.
 func (h *LogsHandler) listLogFiles() []LogFileEntry {
 	files := make([]LogFileEntry, 0)
 
@@ -65,8 +86,9 @@ func (h *LogsHandler) listLogFiles() []LogFileEntry {
 		return files
 	}
 
+	base := filepath.Base(logPath)
 	for _, entry := range entries {
-		if entry.IsDir() || filepath.Ext(entry.Name()) != ".log" {
+		if entry.IsDir() || !isQuiLogFile(entry.Name(), base) {
 			continue
 		}
 		info, err := entry.Info()
@@ -94,7 +116,7 @@ func (h *LogsHandler) DownloadLogFile(w http.ResponseWriter, r *http.Request) {
 
 	// Traversal guard by construction: the requested name must exactly match
 	// a directory entry from the listing, so client input is never joined
-	// into a path unless it is a real .log file base name.
+	// into a path unless it names one of qui's own log files.
 	found := false
 	for _, entry := range h.listLogFiles() {
 		if entry.Name == filename {

--- a/internal/api/handlers/logs.go
+++ b/internal/api/handlers/logs.go
@@ -8,7 +8,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"mime"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -35,6 +38,99 @@ func (h *LogsHandler) Routes(r chi.Router) {
 	r.Get("/log-settings", h.GetLogSettings)
 	r.Put("/log-settings", h.UpdateLogSettings)
 	r.Get("/logs/stream", h.StreamLogs)
+	r.Get("/logs/files", h.ListLogFiles)
+	r.Get("/logs/files/{filename}", h.DownloadLogFile)
+}
+
+// LogFileEntry describes a log file available for download.
+type LogFileEntry struct {
+	Name      string    `json:"name"`
+	SizeBytes int64     `json:"sizeBytes"`
+	ModTime   time.Time `json:"modTime"`
+}
+
+// listLogFiles returns the .log files in the configured log directory.
+// Returns an empty slice when file logging is not configured or the
+// directory does not exist.
+func (h *LogsHandler) listLogFiles() []LogFileEntry {
+	files := make([]LogFileEntry, 0)
+
+	logPath := h.appConfig.GetLogSettings().Path
+	if logPath == "" {
+		return files
+	}
+
+	entries, err := os.ReadDir(filepath.Dir(logPath))
+	if err != nil {
+		return files
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".log" {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		files = append(files, LogFileEntry{
+			Name:      entry.Name(),
+			SizeBytes: info.Size(),
+			ModTime:   info.ModTime(),
+		})
+	}
+
+	return files
+}
+
+// ListLogFiles returns the log files available for download.
+func (h *LogsHandler) ListLogFiles(w http.ResponseWriter, _ *http.Request) {
+	RespondJSON(w, http.StatusOK, h.listLogFiles())
+}
+
+// DownloadLogFile serves a single log file from the configured log directory.
+func (h *LogsHandler) DownloadLogFile(w http.ResponseWriter, r *http.Request) {
+	filename := chi.URLParam(r, "filename")
+
+	// Traversal guard by construction: the requested name must exactly match
+	// a directory entry from the listing, so client input is never joined
+	// into a path unless it is a real .log file base name.
+	found := false
+	for _, entry := range h.listLogFiles() {
+		if entry.Name == filename {
+			found = true
+			break
+		}
+	}
+	if !found {
+		RespondError(w, http.StatusNotFound, "Log file not found")
+		return
+	}
+
+	// #nosec G703,G304 -- filename is validated against the log directory listing above.
+	file, err := os.Open(filepath.Join(filepath.Dir(h.appConfig.GetLogSettings().Path), filename))
+	if err != nil {
+		RespondError(w, http.StatusNotFound, "Log file not found")
+		return
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil || info.IsDir() {
+		RespondError(w, http.StatusNotFound, "Log file not found")
+		return
+	}
+
+	disposition := mime.FormatMediaType("attachment", map[string]string{"filename": filename})
+	if disposition == "" {
+		disposition = fmt.Sprintf("attachment; filename=%q", filename)
+	}
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("Content-Disposition", disposition)
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Cache-Control", "no-store")
+	http.ServeContent(w, r, filename, info.ModTime(), file)
 }
 
 // GetLogSettings returns the current log settings.

--- a/internal/api/handlers/logs_test.go
+++ b/internal/api/handlers/logs_test.go
@@ -277,6 +277,35 @@ func TestLogsHandler_ListLogFiles_NonLogExtension(t *testing.T) {
 	}
 }
 
+func TestLogsHandler_ListLogFiles_RejectsSymlinks(t *testing.T) {
+	handler, logDir := createTestConfigWithLogDir(t)
+	writeLogsTestFile(t, logDir, "qui.log", "active")
+	// A symlink named like a rotation, pointing outside the log directory.
+	writeLogsTestFile(t, filepath.Dir(logDir), "target.log", "outside")
+	linkName := "qui-2026-01-01T00-00-00.000.log"
+	if err := os.Symlink(filepath.Join(filepath.Dir(logDir), "target.log"), filepath.Join(logDir, linkName)); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	router := logsTestRouter(handler)
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/logs/files", http.NoBody))
+	var files []LogFileEntry
+	if err := json.NewDecoder(rec.Body).Decode(&files); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(files) != 1 || files[0].Name != "qui.log" {
+		t.Fatalf("expected only qui.log in listing, got %+v", files)
+	}
+
+	rec = httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/logs/files/"+linkName, http.NoBody))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected status 404 for symlink, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestLogsHandler_DownloadLogFile(t *testing.T) {
 	handler, logDir := createTestConfigWithLogDir(t)
 	writeLogsTestFile(t, logDir, "qui.log", "log content here")

--- a/internal/api/handlers/logs_test.go
+++ b/internal/api/handlers/logs_test.go
@@ -218,6 +218,9 @@ func TestLogsHandler_ListLogFiles(t *testing.T) {
 	writeLogsTestFile(t, logDir, "qui.log", "active")
 	writeLogsTestFile(t, logDir, "qui-2026-01-01T00-00-00.000.log", "rotated")
 	writeLogsTestFile(t, logDir, "notes.txt", "not a log")
+	// .log files in the same directory that are not qui's must not be served.
+	writeLogsTestFile(t, logDir, "other-service.log", "someone else's log")
+	writeLogsTestFile(t, logDir, "qui-manual-backup.log", "prefix but not a rotation")
 	if err := os.Mkdir(filepath.Join(logDir, "nested.log"), 0o750); err != nil {
 		t.Fatal(err)
 	}
@@ -242,6 +245,34 @@ func TestLogsHandler_ListLogFiles(t *testing.T) {
 		}
 		if file.SizeBytes <= 0 {
 			t.Errorf("expected positive size for %q, got %d", file.Name, file.SizeBytes)
+		}
+	}
+}
+
+func TestLogsHandler_ListLogFiles_NonLogExtension(t *testing.T) {
+	handler, logDir := createTestConfigWithLogPath(t, "logs/qui.txt")
+
+	writeLogsTestFile(t, logDir, "qui.txt", "active")
+	writeLogsTestFile(t, logDir, "qui-2026-01-01T00-00-00.000.txt", "rotated")
+	writeLogsTestFile(t, logDir, "other.log", "not ours")
+
+	rec := httptest.NewRecorder()
+	logsTestRouter(handler).ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/logs/files", http.NoBody))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+
+	var files []LogFileEntry
+	if err := json.NewDecoder(rec.Body).Decode(&files); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("expected 2 log files, got %d: %+v", len(files), files)
+	}
+	for _, file := range files {
+		if file.Name != "qui.txt" && file.Name != "qui-2026-01-01T00-00-00.000.txt" {
+			t.Errorf("unexpected file in listing: %q", file.Name)
 		}
 	}
 }
@@ -271,6 +302,7 @@ func TestLogsHandler_DownloadLogFile_Rejected(t *testing.T) {
 	handler, logDir := createTestConfigWithLogDir(t)
 	writeLogsTestFile(t, logDir, "qui.log", "log content")
 	writeLogsTestFile(t, logDir, "notes.txt", "not a log")
+	writeLogsTestFile(t, logDir, "other-service.log", "someone else's log")
 	// A .log file outside the log directory that traversal must not reach.
 	writeLogsTestFile(t, filepath.Dir(logDir), "secret.log", "secret")
 
@@ -280,6 +312,7 @@ func TestLogsHandler_DownloadLogFile_Rejected(t *testing.T) {
 	}{
 		{"missing file", "/logs/files/missing.log"},
 		{"non-log extension", "/logs/files/notes.txt"},
+		{"unrelated log in same dir", "/logs/files/other-service.log"},
 		{"posix traversal", "/logs/files/..%2Fsecret.log"},
 		{"posix traversal double-encoded", "/logs/files/%2E%2E%2Fsecret.log"},
 		{"windows traversal", "/logs/files/..%5Csecret.log"},
@@ -357,6 +390,13 @@ func writeLogsTestFile(t *testing.T, dir, name, content string) {
 // configured under a temp directory and returns the log directory.
 func createTestConfigWithLogDir(t *testing.T) (*LogsHandler, string) {
 	t.Helper()
+	return createTestConfigWithLogPath(t, "logs/qui.log")
+}
+
+// createTestConfigWithLogPath is like createTestConfigWithLogDir but with a
+// caller-chosen logPath (slash-relative, under a "logs" subdirectory).
+func createTestConfigWithLogPath(t *testing.T, logPath string) (*LogsHandler, string) {
+	t.Helper()
 
 	tempDir := t.TempDir()
 	logDir := filepath.Join(tempDir, "logs")
@@ -367,7 +407,7 @@ func createTestConfigWithLogDir(t *testing.T) (*LogsHandler, string) {
 	configContent := `host = "127.0.0.1"
 port = 8080
 logLevel = "info"
-logPath = "logs/qui.log"
+logPath = "` + logPath + `"
 `
 	if err := os.WriteFile(filepath.Join(tempDir, "config.toml"), []byte(configContent), 0o600); err != nil {
 		t.Fatalf("failed to create config file: %v", err)

--- a/internal/api/handlers/logs_test.go
+++ b/internal/api/handlers/logs_test.go
@@ -9,9 +9,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/go-chi/chi/v5"
 
 	"github.com/autobrr/qui/internal/config"
 )
@@ -188,6 +191,194 @@ func TestLogsHandler_StreamLogs_WritesToHub(t *testing.T) {
 	if !strings.Contains(body, "test line 2") {
 		t.Error("expected body to contain 'test line 2'")
 	}
+}
+
+func TestLogsHandler_ListLogFiles_NoLogPath(t *testing.T) {
+	handler := NewLogsHandler(createTestConfig(t))
+
+	rec := httptest.NewRecorder()
+	logsTestRouter(handler).ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/logs/files", http.NoBody))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+
+	var files []LogFileEntry
+	if err := json.NewDecoder(rec.Body).Decode(&files); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(files) != 0 {
+		t.Errorf("expected empty list, got %d entries", len(files))
+	}
+}
+
+func TestLogsHandler_ListLogFiles(t *testing.T) {
+	handler, logDir := createTestConfigWithLogDir(t)
+
+	writeLogsTestFile(t, logDir, "qui.log", "active")
+	writeLogsTestFile(t, logDir, "qui-2026-01-01T00-00-00.000.log", "rotated")
+	writeLogsTestFile(t, logDir, "notes.txt", "not a log")
+	if err := os.Mkdir(filepath.Join(logDir, "nested.log"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := httptest.NewRecorder()
+	logsTestRouter(handler).ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/logs/files", http.NoBody))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+
+	var files []LogFileEntry
+	if err := json.NewDecoder(rec.Body).Decode(&files); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("expected 2 log files, got %d: %+v", len(files), files)
+	}
+	for _, file := range files {
+		if file.Name != "qui.log" && file.Name != "qui-2026-01-01T00-00-00.000.log" {
+			t.Errorf("unexpected file in listing: %q", file.Name)
+		}
+		if file.SizeBytes <= 0 {
+			t.Errorf("expected positive size for %q, got %d", file.Name, file.SizeBytes)
+		}
+	}
+}
+
+func TestLogsHandler_DownloadLogFile(t *testing.T) {
+	handler, logDir := createTestConfigWithLogDir(t)
+	writeLogsTestFile(t, logDir, "qui.log", "log content here")
+
+	rec := httptest.NewRecorder()
+	logsTestRouter(handler).ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/logs/files/qui.log", http.NoBody))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if body := rec.Body.String(); body != "log content here" {
+		t.Errorf("unexpected body: %q", body)
+	}
+	if cd := rec.Header().Get("Content-Disposition"); cd != `attachment; filename=qui.log` {
+		t.Errorf("unexpected Content-Disposition: %q", cd)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "text/plain; charset=utf-8" {
+		t.Errorf("unexpected Content-Type: %q", ct)
+	}
+}
+
+func TestLogsHandler_DownloadLogFile_Rejected(t *testing.T) {
+	handler, logDir := createTestConfigWithLogDir(t)
+	writeLogsTestFile(t, logDir, "qui.log", "log content")
+	writeLogsTestFile(t, logDir, "notes.txt", "not a log")
+	// A .log file outside the log directory that traversal must not reach.
+	writeLogsTestFile(t, filepath.Dir(logDir), "secret.log", "secret")
+
+	tests := []struct {
+		name   string
+		target string
+	}{
+		{"missing file", "/logs/files/missing.log"},
+		{"non-log extension", "/logs/files/notes.txt"},
+		{"posix traversal", "/logs/files/..%2Fsecret.log"},
+		{"posix traversal double-encoded", "/logs/files/%2E%2E%2Fsecret.log"},
+		{"windows traversal", "/logs/files/..%5Csecret.log"},
+		{"absolute posix path", "/logs/files/%2Fetc%2Fpasswd"},
+		{"windows drive letter", "/logs/files/C:%5Csecret.log"},
+		{"windows unc path", "/logs/files/%5C%5Cserver%5Cshare%5Csecret.log"},
+	}
+
+	router := logsTestRouter(handler)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, tt.target, http.NoBody))
+
+			if rec.Code != http.StatusNotFound {
+				t.Errorf("expected status 404, got %d: %s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestLogsHandler_DownloadLogFile_RejectedDirectParam invokes the handler with
+// pre-decoded URL params, independent of how the router escapes path segments,
+// to prove the handler's own validation rejects traversal on every OS.
+func TestLogsHandler_DownloadLogFile_RejectedDirectParam(t *testing.T) {
+	handler, logDir := createTestConfigWithLogDir(t)
+	writeLogsTestFile(t, logDir, "qui.log", "log content")
+	// A .log file outside the log directory that traversal must not reach.
+	writeLogsTestFile(t, filepath.Dir(logDir), "secret.log", "secret")
+
+	tests := []struct {
+		name     string
+		filename string
+	}{
+		{"posix traversal", "../secret.log"},
+		{"windows traversal", `..\secret.log`},
+		{"absolute posix path", "/etc/passwd"},
+		{"leading backslash", `\secret.log`},
+		{"windows drive letter", `C:\secret.log`},
+		{"windows unc path", `\\server\share\secret.log`},
+		{"nested path", "logs/qui.log"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			routeCtx := chi.NewRouteContext()
+			routeCtx.URLParams.Add("filename", tt.filename)
+			ctx := context.WithValue(t.Context(), chi.RouteCtxKey, routeCtx)
+			req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/logs/files/ignored", http.NoBody)
+			rec := httptest.NewRecorder()
+
+			handler.DownloadLogFile(rec, req)
+
+			if rec.Code != http.StatusNotFound {
+				t.Errorf("expected status 404 for %q, got %d: %s", tt.filename, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func logsTestRouter(handler *LogsHandler) *chi.Mux {
+	router := chi.NewRouter()
+	handler.Routes(router)
+	return router
+}
+
+func writeLogsTestFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// createTestConfigWithLogDir creates a LogsHandler with file logging
+// configured under a temp directory and returns the log directory.
+func createTestConfigWithLogDir(t *testing.T) (*LogsHandler, string) {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	logDir := filepath.Join(tempDir, "logs")
+	if err := os.MkdirAll(logDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	configContent := `host = "127.0.0.1"
+port = 8080
+logLevel = "info"
+logPath = "logs/qui.log"
+`
+	if err := os.WriteFile(filepath.Join(tempDir, "config.toml"), []byte(configContent), 0o600); err != nil {
+		t.Fatalf("failed to create config file: %v", err)
+	}
+
+	cfg, err := config.New(tempDir, "test")
+	if err != nil {
+		t.Fatalf("failed to create config: %v", err)
+	}
+
+	return NewLogsHandler(cfg), logDir
 }
 
 // createTestConfig creates a minimal AppConfig for testing.

--- a/internal/api/handlers/notifications.go
+++ b/internal/api/handlers/notifications.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/autobrr/qui/internal/models"
 	"github.com/autobrr/qui/internal/services/notifications"
+	"github.com/autobrr/qui/pkg/redact"
 )
 
 type NotificationsHandler struct {
@@ -302,7 +303,8 @@ func (h *NotificationsHandler) TestTarget(w http.ResponseWriter, r *http.Request
 	}
 
 	if err := h.service.SendTest(r.Context(), target, title, message); err != nil {
-		log.Error().Err(err).Str("target", target.Name).Msg("notifications: test send failed")
+		// Redact: shoutrrr errors embed the post URL, which carries the webhook token
+		log.Error().Str("error", redact.String(err.Error())).Str("target", target.Name).Msg("notifications: test send failed")
 		RespondError(w, http.StatusBadGateway, "failed to send test notification")
 		return
 	}

--- a/internal/qbittorrent/client.go
+++ b/internal/qbittorrent/client.go
@@ -136,7 +136,7 @@ func NewClientWithTimeout(instanceID int, instanceHost, username, password, apiK
 		if basicPassword != nil {
 			cfg.BasicPass = *basicPassword
 		}
-	} else if hostUser != "" {
+	} else if hostUser != "" || hostPass != "" {
 		cfg.BasicUser = hostUser
 		cfg.BasicPass = hostPass
 	}

--- a/internal/qbittorrent/client.go
+++ b/internal/qbittorrent/client.go
@@ -6,6 +6,7 @@ package qbittorrent
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -36,6 +37,20 @@ var (
 	shareLimitsActionMinVersion          = semver.MustParse("2.15.1")
 	shareLimitsModeMinVersion            = semver.MustParse("2.16.0") // unused still, Web API 2.16.0+
 )
+
+// splitHostUserinfo strips userinfo credentials from a host URL, returning the
+// clean host plus the extracted username and password. Hosts without userinfo
+// (the normal case) are returned unchanged.
+func splitHostUserinfo(host string) (cleanHost, user, pass string) {
+	u, err := url.Parse(host)
+	if err != nil || u.User == nil {
+		return host, "", ""
+	}
+	user = u.User.Username()
+	pass, _ = u.User.Password()
+	u.User = nil
+	return u.String(), user, pass
+}
 
 // errInvalidWebAPIVersion marks a session whose webapiVersion endpoint answered
 // with something other than a qBittorrent version (e.g. a reverse-proxy login
@@ -102,6 +117,11 @@ type Client struct {
 }
 
 func NewClientWithTimeout(instanceID int, instanceHost, username, password, apiKey string, basicUsername, basicPassword *string, tlsSkipVerify bool, timeout time.Duration) (*Client, error) {
+	// Strip credentials embedded in the host URL (user:pass@host) so they never
+	// reach go-qbt request URLs, whose error strings get logged verbatim all
+	// over qui. They move to basic auth, which is what URL userinfo means.
+	instanceHost, hostUser, hostPass := splitHostUserinfo(instanceHost)
+
 	cfg := qbt.Config{
 		Host:          instanceHost,
 		Username:      username,
@@ -116,6 +136,9 @@ func NewClientWithTimeout(instanceID int, instanceHost, username, password, apiK
 		if basicPassword != nil {
 			cfg.BasicPass = *basicPassword
 		}
+	} else if hostUser != "" {
+		cfg.BasicUser = hostUser
+		cfg.BasicPass = hostPass
 	}
 
 	qbtClient := qbt.NewClient(cfg)

--- a/internal/qbittorrent/client_test.go
+++ b/internal/qbittorrent/client_test.go
@@ -613,3 +613,47 @@ func TestClientSetSyncEventSinkUpdatesDispatch(t *testing.T) {
 		t.Errorf("expected 1 error call after setting sink, got %d", len(errorCalls))
 	}
 }
+
+func TestSplitHostUserinfo(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		wantHost string
+		wantUser string
+		wantPass string
+	}{
+		{
+			name:     "plain host unchanged",
+			host:     "http://qbit.example.com:8080",
+			wantHost: "http://qbit.example.com:8080",
+		},
+		{
+			// #nosec G101 -- fake credentials exercising userinfo stripping.
+			name:     "userinfo stripped and returned",
+			host:     "https://proxyuser:proxypass@qbit.example.com",
+			wantHost: "https://qbit.example.com",
+			wantUser: "proxyuser",
+			wantPass: "proxypass",
+		},
+		{
+			name:     "userinfo without password",
+			host:     "http://onlyuser@qbit.example.com:8080/base",
+			wantHost: "http://qbit.example.com:8080/base",
+			wantUser: "onlyuser",
+		},
+		{
+			name:     "empty host",
+			host:     "",
+			wantHost: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotHost, gotUser, gotPass := splitHostUserinfo(tt.host)
+			require.Equal(t, tt.wantHost, gotHost)
+			require.Equal(t, tt.wantUser, gotUser)
+			require.Equal(t, tt.wantPass, gotPass)
+		})
+	}
+}

--- a/internal/qbittorrent/client_test.go
+++ b/internal/qbittorrent/client_test.go
@@ -642,6 +642,12 @@ func TestSplitHostUserinfo(t *testing.T) {
 			wantUser: "onlyuser",
 		},
 		{
+			name:     "password-only userinfo",
+			host:     "https://:proxypass@qbit.example.com",
+			wantHost: "https://qbit.example.com",
+			wantPass: "proxypass",
+		},
+		{
 			name:     "empty host",
 			host:     "",
 			wantHost: "",

--- a/internal/services/jackett/client.go
+++ b/internal/services/jackett/client.go
@@ -49,7 +49,9 @@ type MagnetDownloadError struct {
 }
 
 func (e *MagnetDownloadError) Error() string {
-	return fmt.Sprintf("torrent download redirected to magnet link: %s", e.MagnetURL)
+	// Redact: magnet tr= announce URLs embed private-tracker passkeys, and
+	// this error gets logged verbatim by automation runs.
+	return "torrent download redirected to magnet link: " + redact.URLString(e.MagnetURL)
 }
 
 // IsRateLimited returns true if this error indicates rate limiting (HTTP 429).

--- a/internal/services/jackett/client_test.go
+++ b/internal/services/jackett/client_test.go
@@ -173,3 +173,16 @@ func TestDiscoverJackettIndexers_RedactsAPIKey(t *testing.T) {
 			"Error message with apikey param should have value redacted. Got: %s", errStr)
 	}
 }
+
+func TestMagnetDownloadError_RedactsTrackerPasskeys(t *testing.T) {
+	rawMagnet := "magnet:?xt=urn:btih:c12fe1c06bba254a9dc9f519b335aa7c1367a88a&tr=https%3A%2F%2Ftracker.example.com%2Fannounce%3Fpasskey%3DDEADBEEF01"
+	err := &MagnetDownloadError{MagnetURL: rawMagnet}
+
+	msg := err.Error()
+	assert.NotContains(t, msg, "DEADBEEF01")
+	assert.Contains(t, msg, "tracker.example.com")
+	assert.Contains(t, msg, "c12fe1c06bba254a9dc9f519b335aa7c1367a88a")
+
+	// The field itself must stay raw: the manual-add handler consumes it.
+	assert.Equal(t, rawMagnet, err.MagnetURL)
+}

--- a/internal/services/notifications/service.go
+++ b/internal/services/notifications/service.go
@@ -22,6 +22,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/pkg/redact"
 )
 
 const (
@@ -181,7 +182,9 @@ func (s *Service) dispatch(ctx context.Context, event Event) {
 		}
 
 		if err := s.send(ctx, target, event, title, message); err != nil {
-			s.logger.Error().Err(err).Str("target", target.Name).Str("event", string(event.Type)).Msg("notifications: send failed")
+			// Redact: shoutrrr errors embed the post URL, which carries the
+			// webhook token / bot token for most services.
+			s.logger.Error().Str("error", redact.String(err.Error())).Str("target", target.Name).Str("event", string(event.Type)).Msg("notifications: send failed")
 		}
 	}
 }

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -4471,6 +4471,46 @@ paths:
                 type: string
                 description: Each message is a log line in SSE format
 
+  /api/logs/files:
+    get:
+      tags:
+        - System
+      summary: List log files
+      description: List the log files (active and rotated) in the configured log directory. Returns an empty list when file logging is not configured.
+      responses:
+        '200':
+          description: Log files available for download
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LogFile'
+
+  /api/logs/files/{filename}:
+    get:
+      tags:
+        - System
+      summary: Download a log file
+      description: Download a single log file from the configured log directory. The filename must exactly match an entry returned by the log file listing.
+      parameters:
+        - name: filename
+          in: path
+          required: true
+          description: Log file name as returned by the listing endpoint
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Log file content
+          content:
+            text/plain:
+              schema:
+                type: string
+                format: binary
+        '404':
+          description: Log file not found
+
   /api/version/latest:
     get:
       tags:
@@ -6186,6 +6226,28 @@ components:
           type: integer
           description: Number of backup files to keep
           example: 5
+
+    LogFile:
+      type: object
+      description: A log file available for download
+      required:
+        - name
+        - sizeBytes
+        - modTime
+      properties:
+        name:
+          type: string
+          description: Log file name
+          example: "qui.log"
+        sizeBytes:
+          type: integer
+          format: int64
+          description: File size in bytes
+          example: 1048576
+        modTime:
+          type: string
+          format: date-time
+          description: Last modification time
 
     LogExclusions:
       type: object

--- a/pkg/redact/redact.go
+++ b/pkg/redact/redact.go
@@ -12,18 +12,29 @@ import (
 )
 
 // sensitiveParams lists query parameter names that should be redacted (case-insensitive).
-var sensitiveParams = []string{"apikey", "api_key", "passkey", "token", "password"}
+var sensitiveParams = []string{"apikey", "api_key", "passkey", "token", "password", "authkey", "torrent_pass"}
 
 // sensitiveParamRegex matches sensitive query parameters in a string.
 // Used as a fallback when URL parsing fails or for error message redaction.
-var sensitiveParamRegex = regexp.MustCompile(`(?i)(apikey|api_key|passkey|token|password)=([^&\s]*)`)
+var sensitiveParamRegex = regexp.MustCompile(`(?i)(apikey|api_key|passkey|token|password|authkey|torrent_pass)=([^&\s]*)`)
 
 // proxyPathRegex matches /proxy/{api-key}/ segments in paths
 var proxyPathRegex = regexp.MustCompile(`(/proxy/)([^/]+)(/|$)`)
 
+// pathTokenRegex matches path segments that look like credentials: long,
+// unbroken alphanumeric tokens (tracker passkeys, Discord webhook tokens).
+// Real path segments (file names, endpoints) virtually always contain dots,
+// spaces, or are shorter than this.
+var pathTokenRegex = regexp.MustCompile(`^[A-Za-z0-9_-]{24,}$`)
+
+// urlInTextRegex finds http(s) and magnet URLs embedded in free text
+// (typically error messages) so each can be redacted individually.
+var urlInTextRegex = regexp.MustCompile(`https?://[^\s"'<>]+|magnet:\?[^\s"'<>]+`)
+
 // URLString redacts sensitive query parameter values in a URL string.
-// Also redacts passwords in userinfo (user:pass@host) and proxy path segments.
-// If the URL can be parsed, it replaces values of known sensitive parameters with REDACTED.
+// Also redacts userinfo passwords (user:pass@host), proxy path segments,
+// credential-shaped path segments, and URLs nested in query values (magnet
+// tr= announce URLs, redirect targets).
 // If parsing fails, it uses a regex fallback to perform the same redaction.
 func URLString(raw string) string {
 	if raw == "" {
@@ -33,7 +44,7 @@ func URLString(raw string) string {
 	parsed, err := url.Parse(raw)
 	if err != nil {
 		// Fallback to regex for unparseable URLs
-		return String(raw)
+		return regexRedact(raw)
 	}
 
 	modified := false
@@ -56,15 +67,46 @@ func URLString(raw string) string {
 		}
 	}
 
-	// Redact sensitive query parameters
+	// Redact credential-shaped path segments (/download/{passkey}/x.torrent,
+	// Discord webhook tokens)
+	if segments := strings.Split(parsed.Path, "/"); len(segments) > 0 {
+		segmentModified := false
+		for i, segment := range segments {
+			if pathTokenRegex.MatchString(segment) {
+				segments[i] = "REDACTED"
+				segmentModified = true
+			}
+		}
+		if segmentModified {
+			parsed.Path = strings.Join(segments, "/")
+			parsed.RawPath = ""
+			modified = true
+		}
+	}
+
+	// Redact sensitive query parameters, and recurse into query values that
+	// are themselves URLs (magnet tr= announce URLs carry passkeys)
 	query := parsed.Query()
-	for _, param := range sensitiveParams {
-		// Check all case variations - url.Values keys are case-sensitive
-		for key := range query {
+	for key, values := range query {
+		redactedWholeParam := false
+		for _, param := range sensitiveParams {
 			if strings.EqualFold(key, param) {
 				// Always redact to exactly one REDACTED value
 				query[key] = []string{"REDACTED"}
 				modified = true
+				redactedWholeParam = true
+				break
+			}
+		}
+		if redactedWholeParam {
+			continue
+		}
+		for i, value := range values {
+			if strings.HasPrefix(value, "http://") || strings.HasPrefix(value, "https://") {
+				if redacted := URLString(value); redacted != value {
+					values[i] = redacted
+					modified = true
+				}
 			}
 		}
 	}
@@ -101,18 +143,24 @@ func URLError(err error) error {
 // userinfoPasswordRegex matches user:password@ patterns in URLs
 var userinfoPasswordRegex = regexp.MustCompile(`(://[^/:@\s]+):([^@\s]+)@`)
 
-// String redacts sensitive query parameter values in any string using regex.
-// Also redacts userinfo passwords and proxy path segments.
+// String redacts sensitive information in any string. URLs found in the text
+// get full URL redaction (query params, userinfo, path tokens); the remainder
+// gets a regex pass for URL fragments.
 // This is useful for sanitizing error messages that may contain URLs or URL fragments.
 func String(s string) string {
 	if s == "" {
 		return s
 	}
-	// Redact sensitive query params
+	result := urlInTextRegex.ReplaceAllStringFunc(s, URLString)
+	return regexRedact(result)
+}
+
+// regexRedact redacts sensitive query params, userinfo passwords, and proxy
+// path segments using regexes only. Fallback for unparseable URLs and bare
+// URL fragments in text.
+func regexRedact(s string) string {
 	result := sensitiveParamRegex.ReplaceAllString(s, "${1}=REDACTED")
-	// Redact userinfo passwords (user:pass@ -> user:REDACTED@)
 	result = userinfoPasswordRegex.ReplaceAllString(result, "${1}:REDACTED@")
-	// Redact proxy path segments
 	result = proxyPathRegex.ReplaceAllString(result, "${1}REDACTED${3}")
 	return result
 }

--- a/pkg/redact/redact.go
+++ b/pkg/redact/redact.go
@@ -102,7 +102,9 @@ func URLString(raw string) string {
 			continue
 		}
 		for i, value := range values {
-			if strings.HasPrefix(value, "http://") || strings.HasPrefix(value, "https://") {
+			// Any scheme, not just http(s): magnet tr= values are often
+			// udp:// announce URLs carrying a passkey in the path.
+			if strings.Contains(value, "://") {
 				if redacted := URLString(value); redacted != value {
 					values[i] = redacted
 					modified = true

--- a/pkg/redact/redact_test.go
+++ b/pkg/redact/redact_test.go
@@ -149,6 +149,12 @@ func TestURLString(t *testing.T) {
 			wantNotHave: []string{"DEADBEEF01", "abcdef0123456789abcdef0123456789"},
 		},
 		{
+			name:        "magnet with passkey in udp announce url",
+			input:       "magnet:?xt=urn:btih:c12fe1c06bba254a9dc9f519b335aa7c1367a88a&tr=udp%3A%2F%2Ftracker.example.com%2Fabcdef0123456789abcdef0123456789%2Fannounce&tr=udp%3A%2F%2Fopen.example.org%3A1337%2Fannounce",
+			wantContain: []string{"c12fe1c06bba254a9dc9f519b335aa7c1367a88a", "tracker.example.com", "open.example.org"},
+			wantNotHave: []string{"abcdef0123456789abcdef0123456789"},
+		},
+		{
 			name:        "short path segments untouched",
 			input:       "http://localhost:8080/api/v2/torrents/info",
 			wantContain: []string{"http://localhost:8080/api/v2/torrents/info"},

--- a/pkg/redact/redact_test.go
+++ b/pkg/redact/redact_test.go
@@ -124,6 +124,36 @@ func TestURLString(t *testing.T) {
 			wantContain: []string{"apikey=REDACTED", "t=caps"},
 			wantNotHave: nil,
 		},
+		{
+			name:        "gazelle authkey and torrent_pass",
+			input:       "https://tracker.example.com/torrents.php?action=download&id=12345&authkey=0123456789abcdef&torrent_pass=fedcba9876543210",
+			wantContain: []string{"authkey=REDACTED", "torrent_pass=REDACTED", "id=12345"},
+			wantNotHave: []string{"0123456789abcdef", "fedcba9876543210"},
+		},
+		{
+			name:        "passkey as path segment",
+			input:       "https://tracker.example.com/abcdef0123456789abcdef0123456789/announce",
+			wantContain: []string{"/REDACTED/announce"},
+			wantNotHave: []string{"abcdef0123456789abcdef0123456789"},
+		},
+		{
+			name:        "discord webhook token in path",
+			input:       "https://discord.com/api/webhooks/1234567890/aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789_aBcDeFgHiJkLmNoPqRsTuVwXyZ01",
+			wantContain: []string{"/api/webhooks/1234567890/REDACTED"},
+			wantNotHave: []string{"aBcDeFgHiJkLmNoPqRsTuVwXyZ"},
+		},
+		{
+			name:        "magnet with passkey announce urls in tr params",
+			input:       "magnet:?xt=urn:btih:c12fe1c06bba254a9dc9f519b335aa7c1367a88a&dn=Some.Release&tr=https%3A%2F%2Ftracker.example.com%2Fannounce%3Fpasskey%3DDEADBEEF01&tr=https%3A%2F%2Fother.example.com%2Fabcdef0123456789abcdef0123456789%2Fannounce",
+			wantContain: []string{"c12fe1c06bba254a9dc9f519b335aa7c1367a88a", "tracker.example.com", "other.example.com"},
+			wantNotHave: []string{"DEADBEEF01", "abcdef0123456789abcdef0123456789"},
+		},
+		{
+			name:        "short path segments untouched",
+			input:       "http://localhost:8080/api/v2/torrents/info",
+			wantContain: []string{"http://localhost:8080/api/v2/torrents/info"},
+			wantNotHave: nil,
+		},
 	}
 
 	for _, tt := range tests {
@@ -217,6 +247,24 @@ func TestString(t *testing.T) {
 			input:       "request to /proxy/mysecretkey/api/v2/torrents failed",
 			wantContain: []string{"/proxy/REDACTED/api/v2/torrents"},
 			wantNotHave: []string{"mysecretkey"},
+		},
+		{
+			name:        "shoutrrr error with discord webhook url",
+			input:       `making HTTP POST request: Post "https://discord.com/api/webhooks/1234567890/aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789_aBcDeFgHiJkLmNoPqRsTuVwXyZ01": dial tcp: i/o timeout`,
+			wantContain: []string{"/api/webhooks/1234567890/REDACTED", "dial tcp: i/o timeout"},
+			wantNotHave: []string{"aBcDeFgHiJkLmNoPqRsTuVwXyZ"},
+		},
+		{
+			name:        "error with magnet link tr passkeys",
+			input:       "torrent download redirected to magnet link: magnet:?xt=urn:btih:c12fe1c06bba254a9dc9f519b335aa7c1367a88a&tr=https%3A%2F%2Ftracker.example.com%2Fannounce%3Fpasskey%3DDEADBEEF01",
+			wantContain: []string{"c12fe1c06bba254a9dc9f519b335aa7c1367a88a", "tracker.example.com"},
+			wantNotHave: []string{"DEADBEEF01"},
+		},
+		{
+			name:        "error with gazelle download url",
+			input:       "download failed: https://tracker.example.com/torrents.php?action=download&id=1&authkey=SECRETAUTH&torrent_pass=SECRETPASS",
+			wantContain: []string{"authkey=REDACTED", "torrent_pass=REDACTED"},
+			wantNotHave: []string{"SECRETAUTH", "SECRETPASS"},
 		},
 	}
 

--- a/web/src/components/settings/LogSettingsPanel.tsx
+++ b/web/src/components/settings/LogSettingsPanel.tsx
@@ -724,7 +724,7 @@ function LiveLogViewer({ configPath }: { configPath?: string }) {
               <Button variant="outline" size="sm" className="h-8 gap-1">
                 <Filter className="h-3.5 w-3.5" />
                 <span className="text-xs">
-                  {selectedLevels.size === ALL_LOG_LEVELS.length? t("logs.viewer.allLevels"): selectedLevels.size === 0? t("logs.viewer.none"): t("logs.viewer.levelCount", { count: selectedLevels.size })}
+                  {selectedLevels.size === ALL_LOG_LEVELS.length ? t("logs.viewer.allLevels") : selectedLevels.size === 0 ? t("logs.viewer.none") : t("logs.viewer.levelCount", { count: selectedLevels.size })}
                 </span>
                 <ChevronDown className="h-3.5 w-3.5 opacity-50" />
               </Button>

--- a/web/src/components/settings/LogSettingsPanel.tsx
+++ b/web/src/components/settings/LogSettingsPanel.tsx
@@ -30,13 +30,14 @@ import {
   SelectValue
 } from "@/components/ui/select"
 import { Switch } from "@/components/ui/switch"
+import { useDateTimeFormatters } from "@/hooks/useDateTimeFormatters"
 import { usePersistedLogExclusions } from "@/hooks/usePersistedLogExclusions"
 import { api } from "@/lib/api"
-import { copyTextToClipboard } from "@/lib/utils"
+import { copyTextToClipboard, formatBytes } from "@/lib/utils"
 import type { LogSettingsUpdate } from "@/types"
 import { useForm } from "@tanstack/react-form"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import { AlertCircle, ChevronDown, Copy, FileText, Filter, Loader2, Lock, Search, Settings, X } from "lucide-react"
+import { AlertCircle, ChevronDown, Copy, Download, FileText, Filter, Loader2, Lock, Search, Settings, X } from "lucide-react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { toast } from "sonner"
@@ -723,11 +724,7 @@ function LiveLogViewer({ configPath }: { configPath?: string }) {
               <Button variant="outline" size="sm" className="h-8 gap-1">
                 <Filter className="h-3.5 w-3.5" />
                 <span className="text-xs">
-                  {selectedLevels.size === ALL_LOG_LEVELS.length
-                    ? t("logs.viewer.allLevels")
-                    : selectedLevels.size === 0
-                      ? t("logs.viewer.none")
-                      : t("logs.viewer.levelCount", { count: selectedLevels.size })}
+                  {selectedLevels.size === ALL_LOG_LEVELS.length? t("logs.viewer.allLevels"): selectedLevels.size === 0? t("logs.viewer.none"): t("logs.viewer.levelCount", { count: selectedLevels.size })}
                 </span>
                 <ChevronDown className="h-3.5 w-3.5 opacity-50" />
               </Button>
@@ -883,6 +880,64 @@ function LiveLogViewer({ configPath }: { configPath?: string }) {
   )
 }
 
+function LogFilesList() {
+  const { t } = useTranslation("settings")
+  const { formatDate } = useDateTimeFormatters()
+  const [downloadingFile, setDownloadingFile] = useState<string | null>(null)
+  const { data: files } = useQuery({
+    queryKey: ["log-files"],
+    queryFn: () => api.getLogFiles(),
+    staleTime: 30 * 1000,
+  })
+
+  const handleDownload = async (filename: string) => {
+    setDownloadingFile(filename)
+    try {
+      await api.downloadLogFile(filename)
+    } catch {
+      toast.error(t("logs.files.toasts.downloadFailed", { filename }))
+    } finally {
+      setDownloadingFile(null)
+    }
+  }
+
+  if (!files || files.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="space-y-2">
+      <h4 className="text-sm font-medium">{t("logs.files.title")}</h4>
+      <div className="divide-y rounded-md border">
+        {files.map((file) => (
+          <div key={file.name} className="flex items-center justify-between gap-4 px-3 py-2">
+            <div className="min-w-0">
+              <p className="truncate font-mono text-sm" title={file.name}>{file.name}</p>
+              <p className="text-xs text-muted-foreground">
+                {formatBytes(file.sizeBytes)} • {formatDate(new Date(file.modTime))}
+              </p>
+            </div>
+            <Button
+              size="icon"
+              variant="ghost"
+              className="shrink-0"
+              disabled={downloadingFile === file.name}
+              onClick={() => handleDownload(file.name)}
+            >
+              {downloadingFile === file.name ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Download className="h-4 w-4" />
+              )}
+              <span className="sr-only">{t("logs.files.downloadSrOnly", { filename: file.name })}</span>
+            </Button>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
 export function LogSettingsPanel() {
   const { t } = useTranslation("settings")
   const { data: settings } = useQuery({
@@ -921,8 +976,9 @@ export function LogSettingsPanel() {
           </Popover>
         </div>
       </CardHeader>
-      <CardContent>
+      <CardContent className="space-y-4">
         <LiveLogViewer configPath={settings?.configPath} />
+        <LogFilesList />
       </CardContent>
     </Card>
   )

--- a/web/src/components/settings/LogSettingsPanel.tsx
+++ b/web/src/components/settings/LogSettingsPanel.tsx
@@ -883,7 +883,7 @@ function LiveLogViewer({ configPath }: { configPath?: string }) {
 function LogFilesList() {
   const { t } = useTranslation("settings")
   const { formatDate } = useDateTimeFormatters()
-  const [downloadingFile, setDownloadingFile] = useState<string | null>(null)
+  const [downloadingFiles, setDownloadingFiles] = useState<Set<string>>(new Set())
   const { data: files } = useQuery({
     queryKey: ["log-files"],
     queryFn: () => api.getLogFiles(),
@@ -891,13 +891,17 @@ function LogFilesList() {
   })
 
   const handleDownload = async (filename: string) => {
-    setDownloadingFile(filename)
+    setDownloadingFiles((prev) => new Set(prev).add(filename))
     try {
       await api.downloadLogFile(filename)
     } catch {
       toast.error(t("logs.files.toasts.downloadFailed", { filename }))
     } finally {
-      setDownloadingFile(null)
+      setDownloadingFiles((prev) => {
+        const next = new Set(prev)
+        next.delete(filename)
+        return next
+      })
     }
   }
 
@@ -921,10 +925,10 @@ function LogFilesList() {
               size="icon"
               variant="ghost"
               className="shrink-0"
-              disabled={downloadingFile === file.name}
+              disabled={downloadingFiles.has(file.name)}
               onClick={() => handleDownload(file.name)}
             >
-              {downloadingFile === file.name ? (
+              {downloadingFiles.has(file.name) ? (
                 <Loader2 className="h-4 w-4 animate-spin" />
               ) : (
                 <Download className="h-4 w-4" />

--- a/web/src/i18n/locales/cs/settings.json
+++ b/web/src/i18n/locales/cs/settings.json
@@ -407,6 +407,13 @@
       "jsonCopied": "JSON logový záznam zkopírován",
       "rawCopied": "Nezpracovaný logový záznam zkopírován",
       "copyFailed": "Nepodařilo se zkopírovat logový záznam"
+    },
+    "files": {
+      "title": "Soubory protokolu",
+      "downloadSrOnly": "Stáhnout {{filename}}",
+      "toasts": {
+        "downloadFailed": "Stažení souboru {{filename}} se nezdařilo"
+      }
     }
   },
   "themes": {

--- a/web/src/i18n/locales/de/settings.json
+++ b/web/src/i18n/locales/de/settings.json
@@ -407,6 +407,13 @@
       "jsonCopied": "JSON-Protokolleintrag kopiert",
       "rawCopied": "Roher Protokolleintrag kopiert",
       "copyFailed": "Protokolleintrag konnte nicht kopiert werden"
+    },
+    "files": {
+      "title": "Protokolldateien",
+      "downloadSrOnly": "{{filename}} herunterladen",
+      "toasts": {
+        "downloadFailed": "Download von {{filename}} fehlgeschlagen"
+      }
     }
   },
   "themes": {

--- a/web/src/i18n/locales/en/settings.json
+++ b/web/src/i18n/locales/en/settings.json
@@ -407,6 +407,13 @@
       "jsonCopied": "JSON log entry copied",
       "rawCopied": "Raw log entry copied",
       "copyFailed": "Failed to copy log entry"
+    },
+    "files": {
+      "title": "Log files",
+      "downloadSrOnly": "Download {{filename}}",
+      "toasts": {
+        "downloadFailed": "Failed to download {{filename}}"
+      }
     }
   },
   "themes": {

--- a/web/src/i18n/locales/fr/settings.json
+++ b/web/src/i18n/locales/fr/settings.json
@@ -407,6 +407,13 @@
       "jsonCopied": "Entrée JSON copiée",
       "rawCopied": "Entrée brute copiée",
       "copyFailed": "Échec de la copie de l'entrée"
+    },
+    "files": {
+      "title": "Fichiers journaux",
+      "downloadSrOnly": "Télécharger {{filename}}",
+      "toasts": {
+        "downloadFailed": "Échec du téléchargement de {{filename}}"
+      }
     }
   },
   "themes": {

--- a/web/src/i18n/locales/it/settings.json
+++ b/web/src/i18n/locales/it/settings.json
@@ -407,6 +407,13 @@
       "jsonCopied": "Voce di log JSON copiata",
       "rawCopied": "Voce di log grezza copiata",
       "copyFailed": "Impossibile copiare la voce di log"
+    },
+    "files": {
+      "title": "File di log",
+      "downloadSrOnly": "Scarica {{filename}}",
+      "toasts": {
+        "downloadFailed": "Download di {{filename}} non riuscito"
+      }
     }
   },
   "themes": {

--- a/web/src/i18n/locales/ko/settings.json
+++ b/web/src/i18n/locales/ko/settings.json
@@ -405,6 +405,13 @@
       "jsonCopied": "JSON 로그 항목이 복사되었습니다",
       "rawCopied": "원시 로그 항목이 복사되었습니다",
       "copyFailed": "로그 항목을 복사하지 못했습니다"
+    },
+    "files": {
+      "title": "로그 파일",
+      "downloadSrOnly": "{{filename}} 다운로드",
+      "toasts": {
+        "downloadFailed": "{{filename}} 다운로드에 실패했습니다"
+      }
     }
   },
   "themes": {

--- a/web/src/i18n/locales/uk/settings.json
+++ b/web/src/i18n/locales/uk/settings.json
@@ -411,6 +411,13 @@
       "jsonCopied": "JSON запис журналу скопійовано",
       "rawCopied": "Необроблений запис журналу скопійовано",
       "copyFailed": "Не вдалося скопіювати запис журналу"
+    },
+    "files": {
+      "title": "Файли журналу",
+      "downloadSrOnly": "Завантажити {{filename}}",
+      "toasts": {
+        "downloadFailed": "Не вдалося завантажити {{filename}}"
+      }
     }
   },
   "themes": {

--- a/web/src/i18n/locales/zh-CN/settings.json
+++ b/web/src/i18n/locales/zh-CN/settings.json
@@ -405,6 +405,13 @@
       "jsonCopied": "JSON 日志条目已复制",
       "rawCopied": "原始日志条目已复制",
       "copyFailed": "复制日志条目失败"
+    },
+    "files": {
+      "title": "日志文件",
+      "downloadSrOnly": "下载 {{filename}}",
+      "toasts": {
+        "downloadFailed": "下载 {{filename}} 失败"
+      }
     }
   },
   "themes": {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -67,6 +67,7 @@ import type {
   LocalCrossSeedMatch,
   LogExclusions,
   LogExclusionsInput,
+  LogFile,
   LogSettings,
   LogSettingsUpdate,
   MarkRSSAsReadRequest,
@@ -2479,6 +2480,28 @@ class ApiClient {
   // Get the SSE log stream URL for EventSource
   getLogStreamUrl(limit = 1000): string {
     return `${API_BASE}/logs/stream?limit=${limit}`
+  }
+
+  async getLogFiles(): Promise<LogFile[]> {
+    return this.request<LogFile[]>("/logs/files")
+  }
+
+  async downloadLogFile(filename: string): Promise<void> {
+    const response = await ssoSafeFetch(`${API_BASE}/logs/files/${encodeURIComponent(filename)}`, { method: "GET" })
+
+    if (!response.ok) {
+      throw new Error(`Failed to download log file: ${response.statusText}`)
+    }
+
+    const blob = await response.blob()
+    const url = window.URL.createObjectURL(blob)
+    const a = document.createElement("a")
+    a.href = url
+    a.download = filename
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    window.URL.revokeObjectURL(url)
   }
 
   // Directory Scanner endpoints

--- a/web/src/types/logs.ts
+++ b/web/src/types/logs.ts
@@ -19,3 +19,9 @@ export interface LogSettingsUpdate {
   maxSize?: number
   maxBackups?: number
 }
+
+export interface LogFile {
+  name: string
+  sizeBytes: number
+  modTime: string
+}


### PR DESCRIPTION
Adds log file downloads to Settings > Logs: the tab now lists the active and rotated `.log` files (name, size, modified time) with per-file download, served via `http.ServeContent` behind auth. Filenames are validated by exact match against the log directory listing, so client input is never joined into a path unless it names a real log file; the endpoint returns an empty list when file logging is not configured. New routes are documented in the OpenAPI spec and the UI strings are translated for all 8 locales.

Since logs are served verbatim, an audit of every log statement (adversarially verified per finding) preceded this, and the confirmed leaks are fixed at the source rather than by download-time sanitization: `pkg/redact` now covers Gazelle `authkey`/`torrent_pass`, credential-shaped path segments (tracker passkeys, Discord webhook tokens), magnet `tr=` announce URLs, and URLs inside error text; `MagnetDownloadError` redacts its own message; notification send failures log through `redact.String`; and instance host userinfo (`user:pass@`) is stripped into basic auth before it can reach go-qbt request URLs, whose error strings get logged throughout qui.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added log-file management in Settings (list available logs and download individual files).
  * Added system API endpoints for listing/downloading logs with updated Swagger documentation.
  * Exposed log file metadata (name, size, modification time) to the UI.
* **Bug Fixes**
  * Prevented sensitive data leakage by expanding URL/error redaction across logs and notification/error handling.
  * Hardened log downloads with strict filename validation and safer 404 behavior.
  * Improved qBittorrent connections by stripping embedded user credentials from instance hosts.
* **Tests**
  * Added coverage for log listing/downloading, host userinfo parsing, and magnet/error redaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->