### PR TITLE
feat(qbittorrent): detect "torrent has been rejected" as unregistered

### DIFF
--- a/internal/qbittorrent/tracker_statuses.go
+++ b/internal/qbittorrent/tracker_statuses.go
@@ -35,6 +35,7 @@ var defaultUnregisteredStatuses = []string{
 	"torrent existiert nicht",
 	"torrent has been deleted",
 	"torrent has been nuked",
+	"torrent has been rejected",
 	"torrent introuvable",
 	"torrent is not authorized for use on this tracker",
 	"torrent is not found",

--- a/internal/qbittorrent/tracker_statuses_test.go
+++ b/internal/qbittorrent/tracker_statuses_test.go
@@ -141,6 +141,11 @@ func TestTrackerMessageMatchesUnregistered(t *testing.T) {
 			message: "Other: Repack available, or grab internal:",
 			want:    true,
 		},
+		{
+			name:    "torrent has been rejected",
+			message: "Torrent has been rejected.",
+			want:    true,
+		},
 
 		// Non-matching messages
 		{


### PR DESCRIPTION
## Summary

Adds `"torrent has been rejected"` to the unregistered tracker status patterns, as requested in discussion #1154. Multiple trackers (seedpool was confirmed in the discussion) use the message `Torrent has been rejected.` for torrents removed from the site, so these torrents are now flagged with the Unregistered health state.

Matching is case-insensitive substring matching (same as the existing patterns), so the full phrase keeps the risk of false positives low.

## Changes

- `internal/qbittorrent/tracker_statuses.go`: add `"torrent has been rejected"` to `defaultUnregisteredStatuses`
- `internal/qbittorrent/tracker_statuses_test.go`: add a test case for `Torrent has been rejected.`

## Testing

- [x] `go test -race -count=1 -run 'TestTrackerMessage' ./internal/qbittorrent/`
- [x] `make precommit`
- [x] `make build`

Closes #1154

---
_Generated by [Claude Code](https://claude.ai/code/session_011az3HMdc9Bcuc77ArJg6wh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracker health detection by recognizing “torrent has been rejected” messages as an unregistered tracker status.
  * Provides more accurate status reporting for rejected torrents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->