### PR TITLE
docs: update Telegram Shoutrrr URL format

### DIFF
--- a/documentation/docs/features/notifications.md
+++ b/documentation/docs/features/notifications.md
@@ -57,7 +57,7 @@ Use any Shoutrrr-supported URL scheme. A few examples:
 - `discord://token@channel`
 - `notifiarr://apikey`
 - `slack://token@channel`
-- `telegram://token@chat-id`
+- `telegram://token@telegram?chats=chat-id`
 - `gotify://host/token`
 
 Notifiarr can also include optional parameters such as `channel` or `name`, e.g. `notifiarr://apikey?name=qui&channel=123456789`.


### PR DESCRIPTION
Update the Telegram Shoutrrr URL example to use the current, officially supported format.

Replaces:
`telegram://token@chat-id`

with:
`telegram://token@telegram?chats=chat-id`

This matches the current Shoutrrr Telegram URL syntax and avoids confusion for users configuring Telegram notifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Telegram notification URL example to reflect the current format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->