### PR TITLE
fix: preserve empty torrent path components

### DIFF
--- a/internal/services/crossseed/parsing.go
+++ b/internal/services/crossseed/parsing.go
@@ -15,6 +15,7 @@ import (
 	qbt "github.com/autobrr/go-qbittorrent"
 	"github.com/moistari/rls"
 
+	"github.com/autobrr/qui/pkg/pathutil"
 	"github.com/autobrr/qui/pkg/stringutils"
 )
 
@@ -524,7 +525,7 @@ func BuildTorrentFilesFromInfo(rootName string, info metainfo.Info) qbt.TorrentF
 	files = make(qbt.TorrentFiles, len(info.Files))
 	var offset int64
 	for i, f := range info.Files {
-		displayPath := stringutils.SanitizeUTF8(f.DisplayPath(&info))
+		displayPath := stringutils.SanitizeUTF8(torrentDisplayPath(&info, &f))
 		name := rootName
 		if info.IsDir() && displayPath != "" {
 			name = rootName + "/" + displayPath
@@ -566,6 +567,22 @@ func BuildTorrentFilesFromInfo(rootName string, info metainfo.Info) qbt.TorrentF
 	}
 
 	return files
+}
+
+// torrentDisplayPath is metainfo.FileInfo.DisplayPath with libtorrent's empty-component
+// rule applied, so the path lines up with the one qBittorrent stores for the file.
+// The non-directory branch is kept so this stays a drop-in for DisplayPath.
+func torrentDisplayPath(info *metainfo.Info, f *metainfo.FileInfo) string {
+	if !info.IsDir() {
+		return info.BestName()
+	}
+
+	parts := f.BestPath()
+	components := make([]string, len(parts))
+	for i, part := range parts {
+		components[i] = pathutil.TorrentPathComponent(part)
+	}
+	return strings.Join(components, "/")
 }
 
 // ParseTorrentAnnounceDomain extracts the primary announce URL's domain from torrent bytes.

--- a/internal/services/crossseed/parsing_test.go
+++ b/internal/services/crossseed/parsing_test.go
@@ -6,8 +6,10 @@ package crossseed
 import (
 	"testing"
 
+	"github.com/anacrolix/torrent/metainfo"
 	"github.com/moistari/rls"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestDetermineContentType tests the unified content type detection including
@@ -339,4 +341,24 @@ func TestGameSceneGroupDetection(t *testing.T) {
 			assert.Equal(t, tt.wantCats, result.Categories, "categories mismatch for %s", tt.release)
 		})
 	}
+}
+
+func TestBuildTorrentFilesFromInfo_EmptyPathComponents(t *testing.T) {
+	// libtorrent maps an empty path component to "_" instead of dropping it, so the
+	// hardlink/reflink tree has to be built at that same path or qBittorrent reports
+	// the injected torrent as missing data.
+	info := metainfo.Info{
+		Name:        "Release",
+		PieceLength: 262144,
+		Files: []metainfo.FileInfo{
+			{Path: []string{"", "file.mkv"}, Length: 1},
+			{Path: []string{"sub", "", "other.mkv"}, Length: 1},
+		},
+	}
+
+	files := BuildTorrentFilesFromInfo("Release", info)
+
+	require.Len(t, files, 2)
+	assert.Equal(t, "Release/_/file.mkv", files[0].Name)
+	assert.Equal(t, "Release/sub/_/other.mkv", files[1].Name)
 }

--- a/internal/services/crossseed/piece_boundary.go
+++ b/internal/services/crossseed/piece_boundary.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/anacrolix/torrent/metainfo"
 	qbt "github.com/autobrr/go-qbittorrent"
+
+	"github.com/autobrr/qui/pkg/stringutils"
 )
 
 // PieceBoundarySafetyResult contains the outcome of a piece-boundary safety check.
@@ -153,11 +155,12 @@ func BuildFilesForBoundaryCheck(
 
 	// Single-file torrent
 	if len(info.Files) == 0 {
+		name := stringutils.SanitizeUTF8(info.Name)
 		return []TorrentFileForBoundaryCheck{
 			{
-				Path:      info.Name,
+				Path:      name,
 				Size:      info.Length,
-				IsContent: isContentFile(info.Name),
+				IsContent: isContentFile(name),
 			},
 		}
 	}
@@ -167,16 +170,17 @@ func BuildFilesForBoundaryCheck(
 	// - When info.IsDir(): rootName + "/" + displayPath
 	// - Otherwise: displayPath
 	files := make([]TorrentFileForBoundaryCheck, 0, len(info.Files))
+	rootName := stringutils.SanitizeUTF8(info.Name)
 	for i := range info.Files {
-		displayPath := torrentDisplayPath(info, &info.Files[i])
+		displayPath := stringutils.SanitizeUTF8(torrentDisplayPath(info, &info.Files[i]))
 		var path string
 		switch {
 		case info.IsDir() && displayPath != "":
-			path = info.Name + "/" + displayPath
+			path = rootName + "/" + displayPath
 		case displayPath != "":
 			path = displayPath
 		default:
-			path = info.Name
+			path = rootName
 		}
 		files = append(files, TorrentFileForBoundaryCheck{
 			Path:      path,

--- a/internal/services/crossseed/piece_boundary.go
+++ b/internal/services/crossseed/piece_boundary.go
@@ -168,7 +168,7 @@ func BuildFilesForBoundaryCheck(
 	// - Otherwise: displayPath
 	files := make([]TorrentFileForBoundaryCheck, 0, len(info.Files))
 	for i := range info.Files {
-		displayPath := info.Files[i].DisplayPath(info)
+		displayPath := torrentDisplayPath(info, &info.Files[i])
 		var path string
 		switch {
 		case info.IsDir() && displayPath != "":

--- a/internal/services/crossseed/piece_boundary_test.go
+++ b/internal/services/crossseed/piece_boundary_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/anacrolix/torrent/bencode"
 	"github.com/anacrolix/torrent/metainfo"
 	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/pkg/stringutils"
 )
 
 func mustLoadTorrent(t *testing.T, torrentData []byte) (metainfo.MetaInfo, metainfo.Info) {
@@ -550,4 +552,28 @@ func TestPathFormatMatchesSourceFiles(t *testing.T) {
 	require.Len(t, files, 2)
 	require.Equal(t, "test-root/a-main.mkv", files[0].Path, "path should include root folder")
 	require.Equal(t, "test-root/b-extra.nfo", files[1].Path, "path should include root folder")
+}
+
+func TestBuildFilesForBoundaryCheck_MatchesQbtFileNames(t *testing.T) {
+	// The boundary-check paths are looked up in maps keyed by qbt.TorrentFiles.Name,
+	// so the two builders must format paths identically. Malformed UTF-8 in the
+	// metadata used to break that: only BuildTorrentFilesFromInfo sanitized it.
+	info := metainfo.Info{
+		Name:        "Movie.\xe1.2024",
+		PieceLength: 262144,
+		Files: []metainfo.FileInfo{
+			{Path: []string{"sub\xe1", "file.mkv"}, Length: 1},
+			{Path: []string{"", "extra.nfo"}, Length: 1},
+		},
+	}
+
+	qbtFiles := BuildTorrentFilesFromInfo(stringutils.SanitizeUTF8(info.Name), info)
+	boundaryFiles := BuildFilesForBoundaryCheck(&info, func(string) bool { return true })
+
+	require.Len(t, boundaryFiles, len(qbtFiles))
+	for i := range qbtFiles {
+		require.Equal(t, qbtFiles[i].Name, boundaryFiles[i].Path)
+	}
+	require.Equal(t, "Movie.�.2024/sub�/file.mkv", boundaryFiles[0].Path)
+	require.Equal(t, "Movie.�.2024/_/extra.nfo", boundaryFiles[1].Path)
 }

--- a/internal/services/crossseed/piece_boundary_test.go
+++ b/internal/services/crossseed/piece_boundary_test.go
@@ -73,10 +73,7 @@ func pieceHash(t *testing.T, pieces []byte, idx int) []byte {
 }
 
 func fileDisplayPath(info *metainfo.Info, file metainfo.FileInfo) string {
-	if len(info.Files) == 0 {
-		return info.Name
-	}
-	return file.DisplayPath(info)
+	return torrentDisplayPath(info, &file)
 }
 
 func TestPieceBoundaryOverlapCanCauseMainPieceHashMismatch(t *testing.T) {

--- a/internal/services/dirscan/matching.go
+++ b/internal/services/dirscan/matching.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/anacrolix/torrent/metainfo"
+	"github.com/autobrr/qui/pkg/pathutil"
 	"github.com/autobrr/qui/pkg/stringutils"
 )
 
@@ -392,31 +393,31 @@ func ParseTorrentBytes(data []byte) (*ParsedTorrent, error) {
 		// Multi-file torrent
 		parsed.Files = make([]TorrentFile, 0, len(info.Files))
 		root := name
-		effectivePaths := make(map[string]int, len(info.Files))
 		for i := range info.Files {
 			f := &info.Files[i]
 			rawPathParts := f.BestPath()
 			// Sanitize the parts before the root-dedup comparison below; root is already
 			// sanitized, so comparing it against a raw part would double-prefix.
-			for j, part := range rawPathParts {
-				rawPathParts[j] = stringutils.SanitizeUTF8(part)
+			pathParts := make([]string, 0, len(rawPathParts))
+			for _, part := range rawPathParts {
+				pathParts = append(pathParts, stringutils.SanitizeUTF8(part))
 			}
 			// For multi-file torrents, qBittorrent's "Original" layout places files under the
 			// top-level folder named by the torrent's info.name.
 			//
 			// The torrent file list itself typically does NOT include that folder in each file path,
 			// so we include it here to reflect the on-disk paths qBittorrent will expect.
-			if root == "" || len(rawPathParts) == 0 || rawPathParts[0] != root {
-				rawPathParts = append([]string{root}, rawPathParts...)
+			//
+			// The comparison runs before the empty-component mapping below, or a torrent named
+			// "_" whose paths start with an empty component would lose one level.
+			if root == "" || len(pathParts) == 0 || pathParts[0] != root {
+				pathParts = append([]string{root}, pathParts...)
 			}
-			pathParts := normalizeTorrentPathParts(rawPathParts)
-			effectivePath := path.Join(pathParts...)
-			if previous, exists := effectivePaths[effectivePath]; exists {
-				return nil, fmt.Errorf("torrent files %d and %d resolve to the same path %q", previous, i, effectivePath)
+			for j, part := range pathParts {
+				pathParts[j] = pathutil.TorrentPathComponent(part)
 			}
-			effectivePaths[effectivePath] = i
 			tf := TorrentFile{
-				Path:   effectivePath,
+				Path:   path.Join(pathParts...),
 				Size:   f.Length,
 				Offset: offset,
 			}
@@ -427,18 +428,4 @@ func ParseTorrentBytes(data []byte) (*ParsedTorrent, error) {
 	}
 
 	return parsed, nil
-}
-
-// normalizeTorrentPathParts replaces empty components as libtorrent and qBittorrent do.
-// It returns a copy so metadata-owned path slices are never modified.
-func normalizeTorrentPathParts(parts []string) []string {
-	normalized := make([]string, len(parts))
-	for i, part := range parts {
-		if part == "" {
-			normalized[i] = "_"
-			continue
-		}
-		normalized[i] = part
-	}
-	return normalized
 }

--- a/internal/services/dirscan/matching.go
+++ b/internal/services/dirscan/matching.go
@@ -392,24 +392,31 @@ func ParseTorrentBytes(data []byte) (*ParsedTorrent, error) {
 		// Multi-file torrent
 		parsed.Files = make([]TorrentFile, 0, len(info.Files))
 		root := name
+		effectivePaths := make(map[string]int, len(info.Files))
 		for i := range info.Files {
 			f := &info.Files[i]
-			pathParts := f.BestPath()
+			rawPathParts := f.BestPath()
 			// Sanitize the parts before the root-dedup comparison below; root is already
 			// sanitized, so comparing it against a raw part would double-prefix.
-			for j, part := range pathParts {
-				pathParts[j] = stringutils.SanitizeUTF8(part)
+			for j, part := range rawPathParts {
+				rawPathParts[j] = stringutils.SanitizeUTF8(part)
 			}
 			// For multi-file torrents, qBittorrent's "Original" layout places files under the
 			// top-level folder named by the torrent's info.name.
 			//
 			// The torrent file list itself typically does NOT include that folder in each file path,
 			// so we include it here to reflect the on-disk paths qBittorrent will expect.
-			if root != "" && (len(pathParts) == 0 || pathParts[0] != root) {
-				pathParts = append([]string{root}, pathParts...)
+			if root == "" || len(rawPathParts) == 0 || rawPathParts[0] != root {
+				rawPathParts = append([]string{root}, rawPathParts...)
 			}
+			pathParts := normalizeTorrentPathParts(rawPathParts)
+			effectivePath := path.Join(pathParts...)
+			if previous, exists := effectivePaths[effectivePath]; exists {
+				return nil, fmt.Errorf("torrent files %d and %d resolve to the same path %q", previous, i, effectivePath)
+			}
+			effectivePaths[effectivePath] = i
 			tf := TorrentFile{
-				Path:   path.Join(pathParts...),
+				Path:   effectivePath,
 				Size:   f.Length,
 				Offset: offset,
 			}
@@ -420,4 +427,18 @@ func ParseTorrentBytes(data []byte) (*ParsedTorrent, error) {
 	}
 
 	return parsed, nil
+}
+
+// normalizeTorrentPathParts replaces empty components as libtorrent and qBittorrent do.
+// It returns a copy so metadata-owned path slices are never modified.
+func normalizeTorrentPathParts(parts []string) []string {
+	normalized := make([]string, len(parts))
+	for i, part := range parts {
+		if part == "" {
+			normalized[i] = "_"
+			continue
+		}
+		normalized[i] = part
+	}
+	return normalized
 }

--- a/internal/services/dirscan/matching_test.go
+++ b/internal/services/dirscan/matching_test.go
@@ -96,6 +96,54 @@ func TestParseTorrentBytes_InvalidUTF8RootPrefixNotDoubled(t *testing.T) {
 	require.Equal(t, "Movie.\uFFFD.2024.1080p-GROUP/file.mkv", parsed.Files[0].Path)
 }
 
+func TestParseTorrentBytes_MultiFileNormalizesEmptyPathComponents(t *testing.T) {
+	tests := []struct {
+		name     string
+		root     string
+		filePath []string
+		wantPath string
+	}{
+		{name: "leading", root: "root", filePath: []string{"", "file"}, wantPath: "root/_/file"},
+		{name: "middle", root: "root", filePath: []string{"dir", "", "file"}, wantPath: "root/dir/_/file"},
+		{name: "trailing", root: "root", filePath: []string{"dir", ""}, wantPath: "root/dir/_"},
+		{name: "consecutive", root: "root", filePath: []string{"dir", "", "", "file"}, wantPath: "root/dir/_/_/file"},
+		{name: "underscore root", root: "_", filePath: []string{"", "file"}, wantPath: "_/_/file"},
+		{name: "empty root", root: "", filePath: []string{"file"}, wantPath: "_/file"},
+		{name: "empty root and component", root: "", filePath: []string{"", "file"}, wantPath: "_/_/file"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			torrentBytes := buildTorrentBytes(t, &metainfo.Info{
+				Name:        tt.root,
+				PieceLength: 262144,
+				Files: []metainfo.FileInfo{
+					{Path: tt.filePath, Length: 1},
+				},
+			})
+
+			parsed, err := ParseTorrentBytes(torrentBytes)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantPath, parsed.Files[0].Path)
+		})
+	}
+}
+
+func TestParseTorrentBytes_MultiFileRejectsNormalizedPathCollision(t *testing.T) {
+	torrentBytes := buildTorrentBytes(t, &metainfo.Info{
+		Name:        "root",
+		PieceLength: 262144,
+		Files: []metainfo.FileInfo{
+			{Path: []string{"", "file"}, Length: 1},
+			{Path: []string{"_", "file"}, Length: 1},
+		},
+	})
+
+	_, err := ParseTorrentBytes(torrentBytes)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "resolve to the same path \"root/_/file\"")
+}
+
 func TestMatcher_Strict_NormalizesFilenames(t *testing.T) {
 	matcher := NewMatcher(MatchModeStrict, 0)
 

--- a/internal/services/dirscan/matching_test.go
+++ b/internal/services/dirscan/matching_test.go
@@ -129,19 +129,27 @@ func TestParseTorrentBytes_MultiFileNormalizesEmptyPathComponents(t *testing.T) 
 	}
 }
 
-func TestParseTorrentBytes_MultiFileRejectsNormalizedPathCollision(t *testing.T) {
+func TestParseTorrentBytes_MultiFileKeepsDuplicatePadFiles(t *testing.T) {
+	// libtorrent 2.0 names canonical pad files after their size, so equally sized payload
+	// files produce two identical ".pad/<size>" entries. libtorrent allows that collision
+	// (torrent_info.cpp: "pad files are allowed to collide with each-other, as long as they
+	// have the same size"), so parsing must not reject the torrent either.
 	torrentBytes := buildTorrentBytes(t, &metainfo.Info{
-		Name:        "root",
+		Name:        "Pack",
 		PieceLength: 262144,
 		Files: []metainfo.FileInfo{
-			{Path: []string{"", "file"}, Length: 1},
-			{Path: []string{"_", "file"}, Length: 1},
+			{Path: []string{"part.r00"}, Length: 100000},
+			{Path: []string{".pad", "162144"}, Length: 162144},
+			{Path: []string{"part.r01"}, Length: 100000},
+			{Path: []string{".pad", "162144"}, Length: 162144},
 		},
 	})
 
-	_, err := ParseTorrentBytes(torrentBytes)
-	require.Error(t, err)
-	require.ErrorContains(t, err, "resolve to the same path \"root/_/file\"")
+	parsed, err := ParseTorrentBytes(torrentBytes)
+	require.NoError(t, err)
+	require.Len(t, parsed.Files, 4)
+	require.Equal(t, "Pack/.pad/162144", parsed.Files[1].Path)
+	require.Equal(t, "Pack/.pad/162144", parsed.Files[3].Path)
 }
 
 func TestMatcher_Strict_NormalizesFilenames(t *testing.T) {

--- a/pkg/pathutil/sanitize.go
+++ b/pkg/pathutil/sanitize.go
@@ -68,6 +68,22 @@ func SanitizePathSegment(name string) string {
 	return result
 }
 
+// TorrentPathComponent maps one component of a torrent's file path to the name
+// libtorrent, and therefore qBittorrent, puts on disk for it.
+//
+// libtorrent's sanitize_append_path_element replaces an empty component with "_"
+// instead of dropping it, on every release line qBittorrent ships (1.1, 1.2, 2.0).
+// Go's path.Join drops it, which would place a link tree one directory above where
+// qBittorrent looks for the data. Only this rule is mirrored: libtorrent's handling
+// of "." and ".." differs between 1.x and 2.0, so copying it would produce wrong
+// paths for whichever version we did not target.
+func TorrentPathComponent(component string) string {
+	if component == "" {
+		return "_"
+	}
+	return component
+}
+
 // IsolationFolderName generates a human-readable isolation folder name for
 // hardlink cross-seeding. Format: <sanitized-name>--<shortHash>
 //


### PR DESCRIPTION
Dir Scan and cross-seed both built torrent paths with Go's `path.Join` / metainfo's `DisplayPath`, which drop empty path components. libtorrent maps each empty component to `_` instead (`sanitize_append_path_element`), so in hardlink/reflink mode qui materialized the tree one directory above where qBittorrent expects the data, and the injected torrent reported missing files. The rule now lives in `pathutil.TorrentPathComponent` and is applied on both paths.

Only the empty-component rule is mirrored, because it is the one libtorrent has kept identical across 1.1, 1.2 and 2.0. Handling of `.` and `..` differs between them (2.0 maps both to `_`, 1.x drops them), so copying that would produce wrong paths for whichever version a user actually runs. The duplicate-path rejection from the first commit is dropped: libtorrent renames collisions to `base.N.ext` rather than refusing the torrent, and explicitly permits duplicate same-size pad files, which libtorrent 2.0 produces by construction since it names canonical pads after their size. Duplicate targets already fail closed in `hardlinktree` / `reflinktree` before anything is linked.

Reported in #2151.

## Testing

- `go test -race -count=1 ./internal/services/dirscan/... ./internal/services/crossseed/... ./pkg/pathutil/... ./pkg/hardlinktree/... ./pkg/reflinktree/...`
- `make precommit`
- `make build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved torrent file path handling for empty path components, preserving them as `_` to match qBittorrent behavior.
  * Corrected path handling for multi-file torrents, including empty roots and duplicate pad files.
  * Improved consistency between displayed torrent file names and boundary checks.
  * Added sanitization for malformed UTF-8 in torrent names and paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->