### PR TITLE
chore(docs): fix missing tip close

### DIFF
--- a/documentation/docs/features/cross-seed/troubleshooting.md
+++ b/documentation/docs/features/cross-seed/troubleshooting.md
@@ -57,6 +57,7 @@ If the source torrent is the bad hash, the hash in `debug` logging `[CROSSSEED-A
 
 :::tip
 Use [piece boundary protection](./rules.md#matching) to protect content against bad hash torrents.
+:::
 
 ## Why did my season-pack check return 404?
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed the formatting of the troubleshooting tip for `size_mismatch` failures and piece boundary protection.
  * Improved rendering and readability without changing the documented guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->