### PR TITLE
fix(crossseed): retain candidates using exact size evidence

### DIFF
--- a/internal/services/crossseed/find_individual_episodes_test.go
+++ b/internal/services/crossseed/find_individual_episodes_test.go
@@ -136,6 +136,7 @@ func TestApplyTorrentSearchResultsPropagatesEpisodeFlag(t *testing.T) {
 		GUID:                "guid-2",
 		Size:                2048,
 		SearchDecisionClass: searchCandidateClassExactSizeFallback,
+		SearchSourceTitles:  []string{"ARR Alias"},
 	}
 	service.cacheSearchResults(instanceID, sourceTorrent.Hash, []TorrentSearchResult{cached}, 20)
 
@@ -176,6 +177,7 @@ func TestApplyTorrentSearchResultsPropagatesEpisodeFlag(t *testing.T) {
 	require.InDelta(t, 20, captured.SizeMismatchTolerancePercent, 0.001, "apply must reuse the search tolerance cached with the selected result")
 	require.True(t, captured.SizeMismatchTolerancePercentSet)
 	require.Equal(t, searchCandidateClassExactSizeFallback, captured.SearchDecisionClass)
+	require.Equal(t, cached.SearchSourceTitles, captured.SearchSourceTitles)
 	require.Equal(t, cached.Size, captured.AdvertisedCandidateSize)
 }
 

--- a/internal/services/crossseed/find_individual_episodes_test.go
+++ b/internal/services/crossseed/find_individual_episodes_test.go
@@ -129,12 +129,13 @@ func TestApplyTorrentSearchResultsPropagatesEpisodeFlag(t *testing.T) {
 	}
 
 	cached := TorrentSearchResult{
-		Indexer:     "Indexer",
-		IndexerID:   99,
-		Title:       "Show.S01E01.1080p.BluRay-GROUP",
-		DownloadURL: "https://example.invalid/episode.torrent",
-		GUID:        "guid-2",
-		Size:        2048,
+		Indexer:             "Indexer",
+		IndexerID:           99,
+		Title:               "Show.S01E01.1080p.BluRay-GROUP",
+		DownloadURL:         "https://example.invalid/episode.torrent",
+		GUID:                "guid-2",
+		Size:                2048,
+		SearchDecisionClass: searchCandidateClassExactSizeFallback,
 	}
 	service.cacheSearchResults(instanceID, sourceTorrent.Hash, []TorrentSearchResult{cached}, 20)
 
@@ -174,6 +175,8 @@ func TestApplyTorrentSearchResultsPropagatesEpisodeFlag(t *testing.T) {
 	require.True(t, captured.FindIndividualEpisodes, "apply requests must propagate episode flag")
 	require.InDelta(t, 20, captured.SizeMismatchTolerancePercent, 0.001, "apply must reuse the search tolerance cached with the selected result")
 	require.True(t, captured.SizeMismatchTolerancePercentSet)
+	require.Equal(t, searchCandidateClassExactSizeFallback, captured.SearchDecisionClass)
+	require.Equal(t, cached.Size, captured.AdvertisedCandidateSize)
 }
 
 func TestCacheSearchResultsEmptyResultsOverwritePrevious(t *testing.T) {

--- a/internal/services/crossseed/find_individual_episodes_test.go
+++ b/internal/services/crossseed/find_individual_episodes_test.go
@@ -178,7 +178,6 @@ func TestApplyTorrentSearchResultsPropagatesEpisodeFlag(t *testing.T) {
 	require.True(t, captured.SizeMismatchTolerancePercentSet)
 	require.Equal(t, searchCandidateClassExactSizeFallback, captured.SearchDecisionClass)
 	require.Equal(t, cached.SearchSourceTitles, captured.SearchSourceTitles)
-	require.Equal(t, cached.Size, captured.AdvertisedCandidateSize)
 }
 
 func TestCacheSearchResultsEmptyResultsOverwritePrevious(t *testing.T) {

--- a/internal/services/crossseed/find_individual_episodes_test.go
+++ b/internal/services/crossseed/find_individual_episodes_test.go
@@ -129,14 +129,16 @@ func TestApplyTorrentSearchResultsPropagatesEpisodeFlag(t *testing.T) {
 	}
 
 	cached := TorrentSearchResult{
-		Indexer:             "Indexer",
-		IndexerID:           99,
-		Title:               "Show.S01E01.1080p.BluRay-GROUP",
-		DownloadURL:         "https://example.invalid/episode.torrent",
-		GUID:                "guid-2",
-		Size:                2048,
-		SearchDecisionClass: searchCandidateClassExactSizeFallback,
-		SearchSourceTitles:  []string{"ARR Alias"},
+		Indexer:                    "Indexer",
+		IndexerID:                  99,
+		Title:                      "Show.S01E01.1080p.BluRay-GROUP",
+		DownloadURL:                "https://example.invalid/episode.torrent",
+		GUID:                       "guid-2",
+		Size:                       2048,
+		SearchDecisionClass:        searchCandidateClassExactSizeFallback,
+		SearchStrictMismatchReason: "collection mismatch",
+		SearchRelaxedDifferences:   []string{"collection"},
+		SearchSourceTitles:         []string{"ARR Alias"},
 	}
 	service.cacheSearchResults(instanceID, sourceTorrent.Hash, []TorrentSearchResult{cached}, 20)
 
@@ -177,6 +179,10 @@ func TestApplyTorrentSearchResultsPropagatesEpisodeFlag(t *testing.T) {
 	require.InDelta(t, 20, captured.SizeMismatchTolerancePercent, 0.001, "apply must reuse the search tolerance cached with the selected result")
 	require.True(t, captured.SizeMismatchTolerancePercentSet)
 	require.Equal(t, searchCandidateClassExactSizeFallback, captured.SearchDecisionClass)
+	require.Equal(t, instanceID, captured.SearchSourceInstanceID)
+	require.Equal(t, sourceTorrent.Hash, captured.SearchSourceHash)
+	require.Equal(t, cached.SearchStrictMismatchReason, captured.SearchStrictMismatchReason)
+	require.Equal(t, cached.SearchRelaxedDifferences, captured.SearchRelaxedDifferences)
 	require.Equal(t, cached.SearchSourceTitles, captured.SearchSourceTitles)
 }
 

--- a/internal/services/crossseed/models.go
+++ b/internal/services/crossseed/models.go
@@ -77,6 +77,14 @@ type CrossSeedRequest struct {
 	// this torrent. Only cached search results may set it; exact-size provenance
 	// bypasses only the duplicate apply-stage release prefilter.
 	SearchDecisionClass searchCandidateClass `json:"-"`
+	// SearchSourceInstanceID and SearchSourceHash identify the torrent whose size
+	// was compared with the selected search result.
+	SearchSourceInstanceID int    `json:"-"`
+	SearchSourceHash       string `json:"-"`
+	// SearchStrictMismatchReason and SearchRelaxedDifferences preserve the exact
+	// metadata relaxation admitted during search.
+	SearchStrictMismatchReason string   `json:"-"`
+	SearchRelaxedDifferences   []string `json:"-"`
 	// SearchSourceTitles preserves ARR aliases used to admit the cached search result.
 	SearchSourceTitles []string `json:"-"`
 }
@@ -190,10 +198,15 @@ type FindCandidatesRequest struct {
 	SourceFilterExcludeCategories []string `json:"-"`
 	// SourceFilterExcludeTags excludes candidate torrents with any of these tags.
 	SourceFilterExcludeTags []string `json:"-"`
-	// ExactSizeFallback permits a search-origin exact-size result to bypass the
-	// duplicate release prefilter. Candidate file matching and apply safety checks
-	// still run normally. The field is internal so direct requests remain strict.
-	ExactSizeFallback bool `json:"-"`
+	// SearchDecisionClass and source identity bind an exact-size search decision
+	// to the one existing torrent that supplied the size evidence.
+	SearchDecisionClass    searchCandidateClass `json:"-"`
+	SearchSourceInstanceID int                  `json:"-"`
+	SearchSourceHash       string               `json:"-"`
+	// SearchStrictMismatchReason and SearchRelaxedDifferences limit the apply-stage
+	// bypass to metadata differences explicitly admitted during search.
+	SearchStrictMismatchReason string   `json:"-"`
+	SearchRelaxedDifferences   []string `json:"-"`
 	// SearchSourceTitles are ARR aliases for the existing torrent that originated the search.
 	SearchSourceTitles []string `json:"-"`
 }
@@ -310,6 +323,10 @@ type TorrentSearchResult struct {
 	MatchScore           float64 `json:"match_score"`
 	// SearchDecisionClass is retained only in the in-memory search result cache.
 	SearchDecisionClass searchCandidateClass `json:"-"`
+	// SearchStrictMismatchReason and SearchRelaxedDifferences retain the exact
+	// release-metadata relaxation admitted for this cached result.
+	SearchStrictMismatchReason string   `json:"-"`
+	SearchRelaxedDifferences   []string `json:"-"`
 	// SearchSourceTitles retains ARR aliases used to admit this cached result.
 	SearchSourceTitles []string `json:"-"`
 }

--- a/internal/services/crossseed/models.go
+++ b/internal/services/crossseed/models.go
@@ -78,8 +78,6 @@ type CrossSeedRequest struct {
 	SearchDecisionClass searchCandidateClass `json:"-"`
 	// SearchSourceTitles preserves ARR aliases used to admit the cached search result.
 	SearchSourceTitles []string `json:"-"`
-	// AdvertisedCandidateSize is the Torznab size used by the search classifier.
-	AdvertisedCandidateSize int64 `json:"-"`
 }
 
 func (r *CrossSeedRequest) UnmarshalJSON(data []byte) error {
@@ -193,8 +191,6 @@ type FindCandidatesRequest struct {
 	SourceFilterExcludeTags []string `json:"-"`
 	// ExactSizeFallback permits the scoped search-origin release prefilter fallback.
 	ExactSizeFallback bool `json:"-"`
-	// TorrentSize is the downloaded torrent's actual metainfo total.
-	TorrentSize int64 `json:"-"`
 	// SearchSourceTitles are ARR aliases for the existing torrent that originated the search.
 	SearchSourceTitles []string `json:"-"`
 }

--- a/internal/services/crossseed/models.go
+++ b/internal/services/crossseed/models.go
@@ -73,6 +73,11 @@ type CrossSeedRequest struct {
 	// SourceFilterExcludeTags excludes candidate torrents with any of these tags.
 	// Internal-only, not exposed via JSON API.
 	SourceFilterExcludeTags []string `json:"-"`
+	// SearchDecisionClass records the private search classification that admitted
+	// this torrent. Only cached search results may set it.
+	SearchDecisionClass searchCandidateClass `json:"-"`
+	// AdvertisedCandidateSize is the Torznab size used by the search classifier.
+	AdvertisedCandidateSize int64 `json:"-"`
 }
 
 func (r *CrossSeedRequest) UnmarshalJSON(data []byte) error {
@@ -184,6 +189,10 @@ type FindCandidatesRequest struct {
 	SourceFilterExcludeCategories []string `json:"-"`
 	// SourceFilterExcludeTags excludes candidate torrents with any of these tags.
 	SourceFilterExcludeTags []string `json:"-"`
+	// ExactSizeFallback permits the scoped search-origin release prefilter fallback.
+	ExactSizeFallback bool `json:"-"`
+	// TorrentSize is the downloaded torrent's actual metainfo total.
+	TorrentSize int64 `json:"-"`
 }
 
 // FindCandidatesResponse represents potential cross-seed candidates
@@ -296,6 +305,8 @@ type TorrentSearchResult struct {
 	TVDbID               string  `json:"tvdb_id,omitempty"`
 	MatchReason          string  `json:"match_reason,omitempty"`
 	MatchScore           float64 `json:"match_score"`
+	// SearchDecisionClass is retained only in the in-memory search result cache.
+	SearchDecisionClass searchCandidateClass `json:"-"`
 }
 
 // TorrentSearchResponse bundles the seeded torrent information with potential cross-seed matches.

--- a/internal/services/crossseed/models.go
+++ b/internal/services/crossseed/models.go
@@ -74,7 +74,8 @@ type CrossSeedRequest struct {
 	// Internal-only, not exposed via JSON API.
 	SourceFilterExcludeTags []string `json:"-"`
 	// SearchDecisionClass records the private search classification that admitted
-	// this torrent. Only cached search results may set it.
+	// this torrent. Only cached search results may set it; exact-size provenance
+	// bypasses only the duplicate apply-stage release prefilter.
 	SearchDecisionClass searchCandidateClass `json:"-"`
 	// SearchSourceTitles preserves ARR aliases used to admit the cached search result.
 	SearchSourceTitles []string `json:"-"`
@@ -189,7 +190,9 @@ type FindCandidatesRequest struct {
 	SourceFilterExcludeCategories []string `json:"-"`
 	// SourceFilterExcludeTags excludes candidate torrents with any of these tags.
 	SourceFilterExcludeTags []string `json:"-"`
-	// ExactSizeFallback permits the scoped search-origin release prefilter fallback.
+	// ExactSizeFallback permits a search-origin exact-size result to bypass the
+	// duplicate release prefilter. Candidate file matching and apply safety checks
+	// still run normally. The field is internal so direct requests remain strict.
 	ExactSizeFallback bool `json:"-"`
 	// SearchSourceTitles are ARR aliases for the existing torrent that originated the search.
 	SearchSourceTitles []string `json:"-"`

--- a/internal/services/crossseed/models.go
+++ b/internal/services/crossseed/models.go
@@ -76,6 +76,8 @@ type CrossSeedRequest struct {
 	// SearchDecisionClass records the private search classification that admitted
 	// this torrent. Only cached search results may set it.
 	SearchDecisionClass searchCandidateClass `json:"-"`
+	// SearchSourceTitles preserves ARR aliases used to admit the cached search result.
+	SearchSourceTitles []string `json:"-"`
 	// AdvertisedCandidateSize is the Torznab size used by the search classifier.
 	AdvertisedCandidateSize int64 `json:"-"`
 }
@@ -193,6 +195,8 @@ type FindCandidatesRequest struct {
 	ExactSizeFallback bool `json:"-"`
 	// TorrentSize is the downloaded torrent's actual metainfo total.
 	TorrentSize int64 `json:"-"`
+	// SearchSourceTitles are ARR aliases for the existing torrent that originated the search.
+	SearchSourceTitles []string `json:"-"`
 }
 
 // FindCandidatesResponse represents potential cross-seed candidates
@@ -307,6 +311,8 @@ type TorrentSearchResult struct {
 	MatchScore           float64 `json:"match_score"`
 	// SearchDecisionClass is retained only in the in-memory search result cache.
 	SearchDecisionClass searchCandidateClass `json:"-"`
+	// SearchSourceTitles retains ARR aliases used to admit this cached result.
+	SearchSourceTitles []string `json:"-"`
 }
 
 // TorrentSearchResponse bundles the seeded torrent information with potential cross-seed matches.

--- a/internal/services/crossseed/search_candidate_match.go
+++ b/internal/services/crossseed/search_candidate_match.go
@@ -23,9 +23,8 @@ const (
 type searchSizeEvidence string
 
 const (
-	searchSizeEvidenceNone           searchSizeEvidence = "none"
-	searchSizeEvidenceExact          searchSizeEvidence = "exact"
-	searchSizeEvidenceTorznabFloat32 searchSizeEvidence = "torznab-float32"
+	searchSizeEvidenceNone  searchSizeEvidence = "none"
+	searchSizeEvidenceExact searchSizeEvidence = "exact"
 )
 
 type searchCandidateInput struct {
@@ -123,8 +122,7 @@ func (s *Service) classifySearchCandidate(input searchCandidateInput) searchCand
 		return decision
 	}
 
-	if class != searchCandidateClassExactSizeFallback &&
-		!ignoreSizeCheck && !s.isSizeWithinTolerance(input.SourceSize, input.CandidateSize, input.TolerancePercent) {
+	if !ignoreSizeCheck && !s.isSizeWithinTolerance(input.SourceSize, input.CandidateSize, input.TolerancePercent) {
 		decision.RejectReason = "size mismatch"
 		decision.SizeRejected = true
 		return decision
@@ -168,30 +166,19 @@ func positiveExactSize(sourceSize, candidateSize int64) bool {
 }
 
 func classifySearchSizeEvidence(sourceSize, candidateSize int64) searchSizeEvidence {
-	if sourceSize <= 0 || candidateSize <= 0 {
-		return searchSizeEvidenceNone
-	}
-	if sourceSize == candidateSize {
+	if positiveExactSize(sourceSize, candidateSize) {
 		return searchSizeEvidenceExact
-	}
-	// Cardigann-based Torznab indexers parse raw byte counts through a 32-bit
-	// float. Reproduce that exact conversion only as secondary evidence after
-	// literal equality.
-	if int64(float32(sourceSize)) == candidateSize {
-		return searchSizeEvidenceTorznabFloat32
 	}
 	return searchSizeEvidenceNone
 }
 
 func (evidence searchSizeEvidence) matches() bool {
-	return evidence == searchSizeEvidenceExact || evidence == searchSizeEvidenceTorznabFloat32
+	return evidence == searchSizeEvidenceExact
 }
 
 func (evidence searchSizeEvidence) priority() int {
 	switch evidence {
 	case searchSizeEvidenceExact:
-		return 2
-	case searchSizeEvidenceTorznabFloat32:
 		return 1
 	case searchSizeEvidenceNone:
 		return 0
@@ -203,8 +190,6 @@ func (evidence searchSizeEvidence) matchReason() string {
 	switch evidence {
 	case searchSizeEvidenceExact:
 		return "exact byte size"
-	case searchSizeEvidenceTorznabFloat32:
-		return "Torznab float32-compatible size"
 	case searchSizeEvidenceNone:
 		return ""
 	}

--- a/internal/services/crossseed/search_candidate_match.go
+++ b/internal/services/crossseed/search_candidate_match.go
@@ -119,9 +119,10 @@ func (s *Service) classifySearchCandidate(input searchCandidateInput) searchCand
 	):
 		class = searchCandidateClassWebSourceRelabel
 	case decision.SizeEvidence.matches():
-		if ok, reason := s.validateExactSizeSearchIdentity(input); ok {
+		relaxedDifferences := softMetadataDifferences(input.SourceRelease, input.CandidateRelease)
+		if ok, reason := s.validateExactSizeFallback(input, mismatchReason, relaxedDifferences); ok {
 			class = searchCandidateClassExactSizeFallback
-			decision.RelaxedDifferences = softMetadataDifferences(input.SourceRelease, input.CandidateRelease)
+			decision.RelaxedDifferences = relaxedDifferences
 		} else {
 			decision.RejectReason = reason
 			return decision
@@ -276,6 +277,38 @@ func (s *Service) validateExactSizeSearchIdentity(input searchCandidateInput) (b
 	}
 
 	return true, ""
+}
+
+// validateExactSizeFallback keeps hard release identity strict and permits only
+// mismatch categories explicitly recorded as relaxed for this search result.
+func (s *Service) validateExactSizeFallback(input searchCandidateInput, mismatchReason string, relaxedDifferences []string) (bool, string) {
+	if ok, reason := s.validateExactSizeSearchIdentity(input); !ok {
+		return false, reason
+	}
+
+	difference, ok := exactSizeRelaxedDifferenceForReason(input, mismatchReason)
+	if !ok || !slices.Contains(relaxedDifferences, difference) {
+		return false, mismatchReason
+	}
+
+	return true, ""
+}
+
+func exactSizeRelaxedDifferenceForReason(input searchCandidateInput, mismatchReason string) (string, bool) {
+	reason := strings.ToLower(strings.TrimSpace(mismatchReason))
+	reason = strings.TrimSuffix(reason, " mismatch")
+	difference := strings.ReplaceAll(reason, " ", "-")
+	switch difference {
+	case "source", "collection", "codec", "hdr", "bit-depth", "cut", "edition", "language", "version", "disc", "platform", "architecture":
+		return difference, true
+	}
+
+	compatible, variantReason := checkVariantsCompatible(input.SourceRelease, input.CandidateRelease)
+	if !compatible && strings.EqualFold(strings.TrimSpace(mismatchReason), variantReason) {
+		return "variant", true
+	}
+
+	return "", false
 }
 
 func normalizedGroupSiteIdentity(s *Service, release *rls.Release) string {

--- a/internal/services/crossseed/search_candidate_match.go
+++ b/internal/services/crossseed/search_candidate_match.go
@@ -123,7 +123,8 @@ func (s *Service) classifySearchCandidate(input searchCandidateInput) searchCand
 		return decision
 	}
 
-	if !ignoreSizeCheck && !s.isSizeWithinTolerance(input.SourceSize, input.CandidateSize, input.TolerancePercent) {
+	if class != searchCandidateClassExactSizeFallback &&
+		!ignoreSizeCheck && !s.isSizeWithinTolerance(input.SourceSize, input.CandidateSize, input.TolerancePercent) {
 		decision.RejectReason = "size mismatch"
 		decision.SizeRejected = true
 		return decision

--- a/internal/services/crossseed/search_candidate_match.go
+++ b/internal/services/crossseed/search_candidate_match.go
@@ -20,6 +20,14 @@ const (
 	searchCandidateClassExactSizeFallback searchCandidateClass = "exact-size-fallback"
 )
 
+type searchSizeEvidence string
+
+const (
+	searchSizeEvidenceNone           searchSizeEvidence = "none"
+	searchSizeEvidenceExact          searchSizeEvidence = "exact"
+	searchSizeEvidenceTorznabFloat32 searchSizeEvidence = "torznab-float32"
+)
+
 type searchCandidateInput struct {
 	SourceRelease          *rls.Release
 	CandidateRelease       *rls.Release
@@ -36,7 +44,7 @@ type searchCandidateInput struct {
 type searchCandidateDecision struct {
 	Accepted             bool
 	Class                searchCandidateClass
-	ExactSize            bool
+	SizeEvidence         searchSizeEvidence
 	SourceTitles         []string
 	RejectReason         string
 	StrictMismatchReason string
@@ -46,19 +54,19 @@ type searchCandidateDecision struct {
 	SizeRejected         bool
 }
 
-// Score bands mirror the explicit sorter: any exact-size decision outranks the
-// release scorer's tolerance-only range, and stricter exact classes display a
-// higher score than relaxed classes.
+// Score bands mirror the explicit sorter: positive size evidence outranks the
+// release scorer's tolerance-only range, and stricter classes display a higher
+// score than relaxed classes within the same evidence tier.
 const (
-	exactSizeFallbackScoreBonus = 2.0
-	exactSizeRelabelScoreBonus  = 3.0
-	exactSizeStrictScoreBonus   = 4.0
+	sizeEvidenceFallbackScoreBonus = 2.0
+	sizeEvidenceRelabelScoreBonus  = 3.0
+	sizeEvidenceStrictScoreBonus   = 4.0
 )
 
 func (s *Service) classifySearchCandidate(input searchCandidateInput) searchCandidateDecision {
 	decision := searchCandidateDecision{
-		Class:     searchCandidateClassRejected,
-		ExactSize: positiveExactSize(input.SourceSize, input.CandidateSize),
+		Class:        searchCandidateClassRejected,
+		SizeEvidence: classifySearchSizeEvidence(input.SourceSize, input.CandidateSize),
 	}
 	ignoreSizeCheck := input.FindIndividualEpisodes &&
 		isTVSeasonPack(input.SourceRelease) && isTVEpisode(input.CandidateRelease)
@@ -92,7 +100,7 @@ func (s *Service) classifySearchCandidate(input searchCandidateInput) searchCand
 		mismatchReason,
 	):
 		class = searchCandidateClassWebSourceRelabel
-	case decision.ExactSize:
+	case decision.SizeEvidence.matches():
 		if ok, reason := s.validateExactSizeSearchIdentity(input); ok {
 			class = searchCandidateClassExactSizeFallback
 			decision.RelaxedDifferences = softMetadataDifferences(input.SourceRelease, input.CandidateRelease)
@@ -131,22 +139,22 @@ func (s *Service) classifySearchCandidate(input searchCandidateInput) searchCand
 
 	switch class {
 	case searchCandidateClassExactSizeFallback:
-		decision.Score += exactSizeFallbackScoreBonus
-		decision.MatchReason = "exact byte size; strict title/season/resolution/group"
+		decision.Score += sizeEvidenceFallbackScoreBonus
+		decision.MatchReason = decision.SizeEvidence.matchReason() + "; strict title/season/resolution/group"
 		if len(decision.RelaxedDifferences) > 0 {
 			decision.MatchReason += "; relaxed " + strings.Join(decision.RelaxedDifferences, ",")
 		}
 	case searchCandidateClassWebSourceRelabel:
-		if decision.ExactSize {
-			decision.Score += exactSizeRelabelScoreBonus
-			decision.MatchReason = "exact byte size; web-source relabel; " + decision.MatchReason
+		if decision.SizeEvidence.matches() {
+			decision.Score += sizeEvidenceRelabelScoreBonus
+			decision.MatchReason = decision.SizeEvidence.matchReason() + "; web-source relabel; " + decision.MatchReason
 		} else {
 			decision.MatchReason = "web-source relabel; " + decision.MatchReason
 		}
 	case searchCandidateClassStrict:
-		if decision.ExactSize {
-			decision.Score += exactSizeStrictScoreBonus
-			decision.MatchReason = "exact byte size; strict metadata; " + decision.MatchReason
+		if decision.SizeEvidence.matches() {
+			decision.Score += sizeEvidenceStrictScoreBonus
+			decision.MatchReason = decision.SizeEvidence.matchReason() + "; strict metadata; " + decision.MatchReason
 		}
 	case searchCandidateClassRejected:
 	}
@@ -156,6 +164,50 @@ func (s *Service) classifySearchCandidate(input searchCandidateInput) searchCand
 
 func positiveExactSize(sourceSize, candidateSize int64) bool {
 	return sourceSize > 0 && candidateSize > 0 && sourceSize == candidateSize
+}
+
+func classifySearchSizeEvidence(sourceSize, candidateSize int64) searchSizeEvidence {
+	if sourceSize <= 0 || candidateSize <= 0 {
+		return searchSizeEvidenceNone
+	}
+	if sourceSize == candidateSize {
+		return searchSizeEvidenceExact
+	}
+	// Cardigann-based Torznab indexers parse raw byte counts through a 32-bit
+	// float. Reproduce that exact conversion only as secondary evidence after
+	// literal equality.
+	if int64(float32(sourceSize)) == candidateSize {
+		return searchSizeEvidenceTorznabFloat32
+	}
+	return searchSizeEvidenceNone
+}
+
+func (evidence searchSizeEvidence) matches() bool {
+	return evidence == searchSizeEvidenceExact || evidence == searchSizeEvidenceTorznabFloat32
+}
+
+func (evidence searchSizeEvidence) priority() int {
+	switch evidence {
+	case searchSizeEvidenceExact:
+		return 2
+	case searchSizeEvidenceTorznabFloat32:
+		return 1
+	case searchSizeEvidenceNone:
+		return 0
+	}
+	return 0
+}
+
+func (evidence searchSizeEvidence) matchReason() string {
+	switch evidence {
+	case searchSizeEvidenceExact:
+		return "exact byte size"
+	case searchSizeEvidenceTorznabFloat32:
+		return "Torznab float32-compatible size"
+	case searchSizeEvidenceNone:
+		return ""
+	}
+	return ""
 }
 
 func (s *Service) validateExactSizeSearchIdentity(input searchCandidateInput) (bool, string) {

--- a/internal/services/crossseed/search_candidate_match.go
+++ b/internal/services/crossseed/search_candidate_match.go
@@ -4,7 +4,6 @@
 package crossseed
 
 import (
-	"fmt"
 	"slices"
 	"strings"
 
@@ -298,8 +297,4 @@ func softMetadataDifferences(source, candidate *rls.Release) []string {
 	}
 
 	return differences
-}
-
-func exactSizeFallbackValidationError(advertisedSize, actualSize int64) error {
-	return fmt.Errorf("exact-size search evidence invalid: advertised size %d does not match downloaded torrent size %d", advertisedSize, actualSize)
 }

--- a/internal/services/crossseed/search_candidate_match.go
+++ b/internal/services/crossseed/search_candidate_match.go
@@ -1,0 +1,264 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package crossseed
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/moistari/rls"
+)
+
+type searchCandidateClass string
+
+const (
+	searchCandidateClassRejected          searchCandidateClass = "rejected"
+	searchCandidateClassStrict            searchCandidateClass = "strict"
+	searchCandidateClassWebSourceRelabel  searchCandidateClass = "web-source-relabel"
+	searchCandidateClassExactSizeFallback searchCandidateClass = "exact-size-fallback"
+)
+
+type searchCandidateInput struct {
+	SourceRelease          *rls.Release
+	CandidateRelease       *rls.Release
+	SourceName             string
+	CandidateName          string
+	SourceTitles           []string
+	CandidateTitles        []string
+	SourceSize             int64
+	CandidateSize          int64
+	TolerancePercent       float64
+	FindIndividualEpisodes bool
+}
+
+type searchCandidateDecision struct {
+	Accepted             bool
+	Class                searchCandidateClass
+	ExactSize            bool
+	RejectReason         string
+	StrictMismatchReason string
+	RelaxedDifferences   []string
+	Score                float64
+	MatchReason          string
+	SizeRejected         bool
+}
+
+// Score bands mirror the explicit sorter: any exact-size decision outranks the
+// release scorer's tolerance-only range, and stricter exact classes display a
+// higher score than relaxed classes.
+const (
+	exactSizeFallbackScoreBonus = 2.0
+	exactSizeRelabelScoreBonus  = 3.0
+	exactSizeStrictScoreBonus   = 4.0
+)
+
+func (s *Service) classifySearchCandidate(input searchCandidateInput) searchCandidateDecision {
+	decision := searchCandidateDecision{
+		Class:     searchCandidateClassRejected,
+		ExactSize: positiveExactSize(input.SourceSize, input.CandidateSize),
+	}
+	ignoreSizeCheck := input.FindIndividualEpisodes &&
+		isTVSeasonPack(input.SourceRelease) && isTVEpisode(input.CandidateRelease)
+
+	strictMatch, mismatchReason := s.releasesMatchWithReasonAndNamesAndTitles(
+		input.SourceRelease,
+		input.CandidateRelease,
+		input.SourceName,
+		input.CandidateName,
+		input.SourceTitles,
+		input.CandidateTitles,
+		input.FindIndividualEpisodes,
+	)
+	decision.StrictMismatchReason = mismatchReason
+
+	class := searchCandidateClassStrict
+	switch {
+	case strictMatch:
+	case s.shouldAcceptWebSourceRelabel(
+		input.SourceRelease,
+		input.CandidateRelease,
+		input.SourceName,
+		input.CandidateName,
+		input.SourceTitles,
+		input.CandidateTitles,
+		input.FindIndividualEpisodes,
+		ignoreSizeCheck,
+		input.SourceSize,
+		input.CandidateSize,
+		input.TolerancePercent,
+		mismatchReason,
+	):
+		class = searchCandidateClassWebSourceRelabel
+	case decision.ExactSize:
+		if ok, reason := s.validateExactSizeSearchIdentity(input); ok {
+			class = searchCandidateClassExactSizeFallback
+			decision.RelaxedDifferences = softMetadataDifferences(input.SourceRelease, input.CandidateRelease)
+		} else {
+			decision.RejectReason = reason
+			return decision
+		}
+	default:
+		decision.RejectReason = mismatchReason
+		return decision
+	}
+
+	// Search context: candidate is the new torrent, source is the existing torrent.
+	if reject, reason := rejectSeasonPackFromEpisode(
+		input.CandidateRelease,
+		input.SourceRelease,
+		input.FindIndividualEpisodes,
+	); reject {
+		decision.RejectReason = reason
+		return decision
+	}
+
+	if !ignoreSizeCheck && !s.isSizeWithinTolerance(input.SourceSize, input.CandidateSize, input.TolerancePercent) {
+		decision.RejectReason = "size mismatch"
+		decision.SizeRejected = true
+		return decision
+	}
+
+	decision.Accepted = true
+	decision.Class = class
+	decision.Score, decision.MatchReason = evaluateReleaseMatch(input.SourceRelease, input.CandidateRelease)
+	if decision.Score <= 0 {
+		decision.Score = 1
+	}
+
+	switch class {
+	case searchCandidateClassExactSizeFallback:
+		decision.Score += exactSizeFallbackScoreBonus
+		decision.MatchReason = "exact byte size; strict title/season/resolution/group"
+		if len(decision.RelaxedDifferences) > 0 {
+			decision.MatchReason += "; relaxed " + strings.Join(decision.RelaxedDifferences, ",")
+		}
+	case searchCandidateClassWebSourceRelabel:
+		if decision.ExactSize {
+			decision.Score += exactSizeRelabelScoreBonus
+			decision.MatchReason = "exact byte size; web-source relabel; " + decision.MatchReason
+		} else {
+			decision.MatchReason = "web-source relabel; " + decision.MatchReason
+		}
+	case searchCandidateClassStrict:
+		if decision.ExactSize {
+			decision.Score += exactSizeStrictScoreBonus
+			decision.MatchReason = "exact byte size; strict metadata; " + decision.MatchReason
+		}
+	case searchCandidateClassRejected:
+	}
+
+	return decision
+}
+
+func positiveExactSize(sourceSize, candidateSize int64) bool {
+	return sourceSize > 0 && candidateSize > 0 && sourceSize == candidateSize
+}
+
+func (s *Service) validateExactSizeSearchIdentity(input searchCandidateInput) (bool, string) {
+	source := input.SourceRelease
+	candidate := input.CandidateRelease
+	if source == nil || candidate == nil {
+		return false, "missing parsed release"
+	}
+
+	isTV := isTVRelease(source) || isTVRelease(candidate)
+	if ok, reason := s.validateTitleArtistAndDates(
+		source,
+		candidate,
+		input.SourceName,
+		input.CandidateName,
+		input.SourceTitles,
+		input.CandidateTitles,
+		isTV,
+	); !ok {
+		return false, reason
+	}
+	if ok, reason := validateTVStructure(source, candidate, input.FindIndividualEpisodes, isTV); !ok {
+		return false, reason
+	}
+
+	normalizer := normalizerForService(s)
+	sourceResolution := normalizer.Normalize(source.Resolution)
+	candidateResolution := normalizer.Normalize(candidate.Resolution)
+	if sourceResolution == "" || candidateResolution == "" || sourceResolution != candidateResolution {
+		return false, "resolution mismatch"
+	}
+
+	sourceIdentity := normalizedGroupSiteIdentity(s, source)
+	candidateIdentity := normalizedGroupSiteIdentity(s, candidate)
+	if sourceIdentity == "" || candidateIdentity == "" || sourceIdentity != candidateIdentity {
+		return false, "group/site mismatch"
+	}
+
+	sourceSum := normalizer.Normalize(source.Sum)
+	candidateSum := normalizer.Normalize(candidate.Sum)
+	if (sourceSum != "" || candidateSum != "") && sourceSum != candidateSum {
+		return false, "checksum mismatch"
+	}
+
+	// Missing artist/date metadata cannot establish the high-confidence identity
+	// required by this fallback when the other release explicitly carries it.
+	sourceArtist := normalizer.Normalize(source.Artist)
+	candidateArtist := normalizer.Normalize(candidate.Artist)
+	if (sourceArtist != "" || candidateArtist != "") && sourceArtist != candidateArtist {
+		return false, "artist mismatch"
+	}
+	sourceHasDate := source.Year > 0 && source.Month > 0 && source.Day > 0
+	candidateHasDate := candidate.Year > 0 && candidate.Month > 0 && candidate.Day > 0
+	if sourceHasDate != candidateHasDate {
+		return false, "date mismatch"
+	}
+
+	return true, ""
+}
+
+func normalizedGroupSiteIdentity(s *Service, release *rls.Release) string {
+	if release == nil {
+		return ""
+	}
+	normalizer := normalizerForService(s)
+	if group := normalizer.Normalize(release.Group); group != "" {
+		return group
+	}
+	return normalizer.Normalize(release.Site)
+}
+
+func softMetadataDifferences(source, candidate *rls.Release) []string {
+	if source == nil || candidate == nil {
+		return nil
+	}
+
+	normalizer := normalizerForService(nil)
+	differences := make([]string, 0, 12)
+	add := func(name, sourceValue, candidateValue string) {
+		if sourceValue != candidateValue && !slices.Contains(differences, name) {
+			differences = append(differences, name)
+		}
+	}
+
+	add("source", normalizeSource(source.Source), normalizeSource(candidate.Source))
+	sourceCollection := normalizer.Normalize(strings.TrimSpace(source.Collection + " " + source.Subtitle))
+	candidateCollection := normalizer.Normalize(strings.TrimSpace(candidate.Collection + " " + candidate.Subtitle))
+	add("collection", sourceCollection, candidateCollection)
+	add("codec", joinNormalizedCodecSlice(source.Codec), joinNormalizedCodecSlice(candidate.Codec))
+	add("hdr", joinNormalizedHDRSlice(source.HDR), joinNormalizedHDRSlice(candidate.HDR))
+	add("bit-depth", normalizer.Normalize(source.BitDepth), normalizer.Normalize(candidate.BitDepth))
+	add("cut", joinNormalizedSlice(source.Cut), joinNormalizedSlice(candidate.Cut))
+	add("edition", joinNormalizedSlice(source.Edition), joinNormalizedSlice(candidate.Edition))
+	add("language", joinNormalizedSlice(source.Language), joinNormalizedSlice(candidate.Language))
+	add("version", normalizer.Normalize(source.Version), normalizer.Normalize(candidate.Version))
+	add("disc", normalizer.Normalize(source.Disc), normalizer.Normalize(candidate.Disc))
+	add("platform", normalizer.Normalize(source.Platform), normalizer.Normalize(candidate.Platform))
+	add("architecture", normalizer.Normalize(source.Arch), normalizer.Normalize(candidate.Arch))
+	if compatible, _ := checkVariantsCompatible(source, candidate); !compatible {
+		differences = append(differences, "variant")
+	}
+
+	return differences
+}
+
+func exactSizeFallbackValidationError(advertisedSize, actualSize int64) error {
+	return fmt.Errorf("exact-size search evidence invalid: advertised size %d does not match downloaded torrent size %d", advertisedSize, actualSize)
+}

--- a/internal/services/crossseed/search_candidate_match.go
+++ b/internal/services/crossseed/search_candidate_match.go
@@ -10,15 +10,23 @@ import (
 	"github.com/moistari/rls"
 )
 
+// searchCandidateClass identifies the search-only rule that admitted a result.
+// The class is carried privately through cached search results so apply can
+// preserve that decision without exposing a client-settable bypass.
 type searchCandidateClass string
 
 const (
-	searchCandidateClassRejected          searchCandidateClass = "rejected"
-	searchCandidateClassStrict            searchCandidateClass = "strict"
-	searchCandidateClassWebSourceRelabel  searchCandidateClass = "web-source-relabel"
+	searchCandidateClassRejected         searchCandidateClass = "rejected"
+	searchCandidateClassStrict           searchCandidateClass = "strict"
+	searchCandidateClassWebSourceRelabel searchCandidateClass = "web-source-relabel"
+	// searchCandidateClassExactSizeFallback means positive exact byte equality
+	// replaced only the soft release-attribute checks rejected by strict matching.
 	searchCandidateClassExactSizeFallback searchCandidateClass = "exact-size-fallback"
 )
 
+// searchSizeEvidence describes size evidence available before a candidate
+// torrent is downloaded. SourceSize is qBittorrent's wanted size and
+// CandidateSize is the Torznab-advertised size.
 type searchSizeEvidence string
 
 const (
@@ -26,6 +34,8 @@ const (
 	searchSizeEvidenceExact searchSizeEvidence = "exact"
 )
 
+// searchCandidateInput contains the source and Torznab candidate data available
+// to both main result filtering and alternate-query usability checks.
 type searchCandidateInput struct {
 	SourceRelease          *rls.Release
 	CandidateRelease       *rls.Release
@@ -39,6 +49,9 @@ type searchCandidateInput struct {
 	FindIndividualEpisodes bool
 }
 
+// searchCandidateDecision records admission provenance, including which strict
+// mismatch exact-size evidence relaxed. Rejected decisions never grant apply
+// access to the release-prefilter bypass.
 type searchCandidateDecision struct {
 	Accepted             bool
 	Class                searchCandidateClass
@@ -61,6 +74,13 @@ const (
 	sizeEvidenceStrictScoreBonus   = 4.0
 )
 
+// classifySearchCandidate applies the shared search-only admission rules.
+// Exact-size fallback requires positive byte-for-byte size equality plus strict
+// title, TV structure, resolution, group/site, checksum, artist, and date
+// identity. It may relax descriptive attributes such as source, collection,
+// HDR, codec, or bit depth. Apply later uses the private decision class only to
+// skip its duplicate release prefilter; normal torrent-file validation remains
+// authoritative.
 func (s *Service) classifySearchCandidate(input searchCandidateInput) searchCandidateDecision {
 	decision := searchCandidateDecision{
 		Class:        searchCandidateClassRejected,
@@ -160,6 +180,8 @@ func (s *Service) classifySearchCandidate(input searchCandidateInput) searchCand
 	return decision
 }
 
+// positiveExactSize requires both search APIs to report the same non-zero byte
+// count. Missing sizes and tolerance-only matches cannot activate the fallback.
 func positiveExactSize(sourceSize, candidateSize int64) bool {
 	return sourceSize > 0 && candidateSize > 0 && sourceSize == candidateSize
 }
@@ -195,6 +217,8 @@ func (evidence searchSizeEvidence) matchReason() string {
 	return ""
 }
 
+// validateExactSizeSearchIdentity enforces identity attributes that exact size
+// must never replace. It returns the first hard mismatch for search diagnostics.
 func (s *Service) validateExactSizeSearchIdentity(input searchCandidateInput) (bool, string) {
 	source := input.SourceRelease
 	candidate := input.CandidateRelease

--- a/internal/services/crossseed/search_candidate_match.go
+++ b/internal/services/crossseed/search_candidate_match.go
@@ -37,6 +37,7 @@ type searchCandidateDecision struct {
 	Accepted             bool
 	Class                searchCandidateClass
 	ExactSize            bool
+	SourceTitles         []string
 	RejectReason         string
 	StrictMismatchReason string
 	RelaxedDifferences   []string
@@ -122,6 +123,7 @@ func (s *Service) classifySearchCandidate(input searchCandidateInput) searchCand
 
 	decision.Accepted = true
 	decision.Class = class
+	decision.SourceTitles = slices.Clone(input.SourceTitles)
 	decision.Score, decision.MatchReason = evaluateReleaseMatch(input.SourceRelease, input.CandidateRelease)
 	if decision.Score <= 0 {
 		decision.Score = 1

--- a/internal/services/crossseed/search_candidate_match.go
+++ b/internal/services/crossseed/search_candidate_match.go
@@ -207,9 +207,10 @@ func (s *Service) validateExactSizeSearchIdentity(input searchCandidateInput) (b
 	if (sourceArtist != "" || candidateArtist != "") && sourceArtist != candidateArtist {
 		return false, "artist mismatch"
 	}
-	sourceHasDate := source.Year > 0 && source.Month > 0 && source.Day > 0
-	candidateHasDate := candidate.Year > 0 && candidate.Month > 0 && candidate.Day > 0
-	if sourceHasDate != candidateHasDate {
+	if source.Year != candidate.Year {
+		return false, "year mismatch"
+	}
+	if source.Month != candidate.Month || source.Day != candidate.Day {
 		return false, "date mismatch"
 	}
 

--- a/internal/services/crossseed/search_candidate_match_test.go
+++ b/internal/services/crossseed/search_candidate_match_test.go
@@ -1,0 +1,373 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package crossseed
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+	"time"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/moistari/rls"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/services/jackett"
+	"github.com/autobrr/qui/pkg/stringutils"
+)
+
+func TestClassifySearchCandidateExactSizeFallback(t *testing.T) {
+	service := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
+	const (
+		sourceName    = "Example.Show.2024.S01.2160p.ATV.WEB-DL.DDP5.1.DV.HDR.H.265-NTb"
+		candidateName = "Example Show 2024 S01 2160p ATVP WEB-DL DD+ 5.1 DV HDR10+ H.265-NTb"
+		size          = int64(94_329_473_840)
+	)
+	source := rls.ParseString(sourceName)
+	candidate := rls.ParseString(candidateName)
+
+	strict, strictReason := service.releasesMatchWithReasonAndNamesAndTitles(
+		&source, &candidate, sourceName, candidateName, nil, nil, false,
+	)
+	require.False(t, strict)
+	require.NotEmpty(t, strictReason)
+
+	decision := service.classifySearchCandidate(searchCandidateInput{
+		SourceRelease:    &source,
+		CandidateRelease: &candidate,
+		SourceName:       sourceName,
+		CandidateName:    candidateName,
+		SourceSize:       size,
+		CandidateSize:    size,
+		TolerancePercent: 5,
+	})
+
+	require.True(t, decision.Accepted)
+	require.Equal(t, searchCandidateClassExactSizeFallback, decision.Class)
+	require.True(t, decision.ExactSize)
+	require.Contains(t, decision.RelaxedDifferences, "collection")
+	require.Contains(t, decision.RelaxedDifferences, "hdr")
+	require.Contains(t, decision.MatchReason, "exact byte size")
+	require.Contains(t, decision.MatchReason, "relaxed collection")
+}
+
+func TestClassifySearchCandidateExactSizePreconditions(t *testing.T) {
+	service := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
+	sourceName := "Example.Show.S01.2160p.ATV.WEB-DL.HDR.H.265-NTb"
+	candidateName := "Example.Show.S01.2160p.ATVP.WEB-DL.HDR10+.H.265-NTb"
+	source := rls.ParseString(sourceName)
+	candidate := rls.ParseString(candidateName)
+	const size = int64(9_432_947_384)
+
+	tests := []struct {
+		name          string
+		sourceSize    int64
+		candidateSize int64
+	}{
+		{name: "one byte difference", sourceSize: size, candidateSize: size + 1},
+		{name: "within tolerance is not exact", sourceSize: size, candidateSize: size + size/100},
+		{name: "zero equals zero", sourceSize: 0, candidateSize: 0},
+		{name: "missing source size", sourceSize: 0, candidateSize: size},
+		{name: "missing candidate size", sourceSize: size, candidateSize: 0},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			decision := service.classifySearchCandidate(searchCandidateInput{
+				SourceRelease:    &source,
+				CandidateRelease: &candidate,
+				SourceName:       sourceName,
+				CandidateName:    candidateName,
+				SourceSize:       test.sourceSize,
+				CandidateSize:    test.candidateSize,
+				TolerancePercent: 5,
+			})
+			require.False(t, decision.Accepted)
+			require.NotEqual(t, searchCandidateClassExactSizeFallback, decision.Class)
+		})
+	}
+}
+
+func TestClassifySearchCandidateExactSizeHardIdentity(t *testing.T) {
+	service := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
+	const size = int64(94_329_473_840)
+	base := rls.ParseString("Example.Show.2024.S01.2160p.ATV.WEB-DL.HDR.H.265-NTb")
+
+	tests := []struct {
+		name   string
+		mutate func(*rls.Release)
+		reason string
+	}{
+		{name: "different title", mutate: func(r *rls.Release) { r.Title = "Different Show" }, reason: "title mismatch"},
+		{name: "different season", mutate: func(r *rls.Release) { r.Series++ }, reason: "season mismatch"},
+		{name: "missing resolution", mutate: func(r *rls.Release) { r.Resolution = "" }, reason: "resolution mismatch"},
+		{name: "different resolution", mutate: func(r *rls.Release) { r.Resolution = "1080p" }, reason: "resolution mismatch"},
+		{name: "missing group", mutate: func(r *rls.Release) { r.Group = ""; r.Site = "" }, reason: "group/site mismatch"},
+		{name: "different group", mutate: func(r *rls.Release) { r.Group = "FLUX" }, reason: "group/site mismatch"},
+		{name: "different checksum", mutate: func(r *rls.Release) { r.Sum = "DEADBEEF" }, reason: "checksum mismatch"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source := base
+			candidate := base
+			source.Collection = "ATV"
+			candidate.Collection = "ATVP"
+			if test.name == "different checksum" {
+				source.Sum = "AAAAAAAA"
+			}
+			test.mutate(&candidate)
+			decision := service.classifySearchCandidate(searchCandidateInput{
+				SourceRelease:    &source,
+				CandidateRelease: &candidate,
+				SourceName:       source.Title,
+				CandidateName:    candidate.Title,
+				SourceSize:       size,
+				CandidateSize:    size,
+				TolerancePercent: 5,
+			})
+			require.False(t, decision.Accepted)
+			require.Equal(t, test.reason, decision.RejectReason)
+		})
+	}
+}
+
+func TestClassifySearchCandidateExactSizeTVAndContentIdentity(t *testing.T) {
+	service := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
+	const size = int64(94_329_473_840)
+
+	t.Run("different episode", func(t *testing.T) {
+		source := rls.ParseString("Example.Show.S01E01.2160p.ATV.WEB-DL.H.265-NTb")
+		candidate := rls.ParseString("Example.Show.S01E02.2160p.ATVP.WEB-DL.H.265-NTb")
+		decision := service.classifySearchCandidate(searchCandidateInput{
+			SourceRelease:    &source,
+			CandidateRelease: &candidate,
+			SourceName:       source.Title,
+			CandidateName:    candidate.Title,
+			SourceSize:       size,
+			CandidateSize:    size,
+			TolerancePercent: 5,
+		})
+		require.False(t, decision.Accepted)
+		require.Equal(t, "episode mismatch", decision.RejectReason)
+	})
+
+	t.Run("forbidden season pack from episode", func(t *testing.T) {
+		source := rls.ParseString("Example.Show.S01E01.2160p.ATV.WEB-DL.H.265-NTb")
+		candidate := rls.ParseString("Example.Show.S01.2160p.ATVP.WEB-DL.H.265-NTb")
+		decision := service.classifySearchCandidate(searchCandidateInput{
+			SourceRelease:          &source,
+			CandidateRelease:       &candidate,
+			SourceName:             source.Title,
+			CandidateName:          candidate.Title,
+			SourceSize:             size,
+			CandidateSize:          size,
+			TolerancePercent:       5,
+			FindIndividualEpisodes: true,
+		})
+		require.False(t, decision.Accepted)
+		require.Equal(t, rejectReasonSeasonPackFromEpisode, decision.RejectReason)
+	})
+
+	t.Run("different non TV type", func(t *testing.T) {
+		source := rls.Release{Type: rls.Movie, Title: "Shared Title", Resolution: "2160p", Group: "NTb", Collection: "ATV"}
+		candidate := source
+		candidate.Type = rls.Music
+		candidate.Collection = "ATVP"
+		decision := service.classifySearchCandidate(searchCandidateInput{
+			SourceRelease:    &source,
+			CandidateRelease: &candidate,
+			SourceName:       source.Title,
+			CandidateName:    candidate.Title,
+			SourceSize:       size,
+			CandidateSize:    size,
+			TolerancePercent: 5,
+		})
+		require.False(t, decision.Accepted)
+		require.Equal(t, "content type mismatch", decision.RejectReason)
+	})
+}
+
+func TestSearchCandidateInternalMetadataIsNotJSON(t *testing.T) {
+	resultBytes, err := json.Marshal(TorrentSearchResult{
+		Title:               "candidate",
+		SearchDecisionClass: searchCandidateClassExactSizeFallback,
+	})
+	require.NoError(t, err)
+	require.NotContains(t, string(resultBytes), "exact-size-fallback")
+
+	requestBytes, err := json.Marshal(CrossSeedRequest{
+		SearchDecisionClass:     searchCandidateClassExactSizeFallback,
+		AdvertisedCandidateSize: 123,
+	})
+	require.NoError(t, err)
+	require.NotContains(t, string(requestBytes), "exact-size-fallback")
+	require.NotContains(t, string(requestBytes), "123")
+}
+
+func TestSortScoredTorrentSearchResultsExactSizePriority(t *testing.T) {
+	now := time.Now()
+	items := []scoredTorrentSearchResult{
+		{result: jackett.SearchResult{Title: "tolerance", Seeders: 100, PublishDate: now}, score: 10, class: searchCandidateClassStrict},
+		{result: jackett.SearchResult{Title: "fallback", Seeders: 1, PublishDate: now.Add(-time.Hour)}, score: 2, exactSize: true, class: searchCandidateClassExactSizeFallback},
+		{result: jackett.SearchResult{Title: "strict", Seeders: 0, PublishDate: now.Add(-2 * time.Hour)}, score: 1, exactSize: true, class: searchCandidateClassStrict},
+	}
+
+	sortScoredTorrentSearchResults(items)
+
+	require.Equal(t, []string{"strict", "fallback", "tolerance"}, []string{
+		items[0].result.Title,
+		items[1].result.Title,
+		items[2].result.Title,
+	})
+}
+
+func TestExecuteCrossSeedSearchAttemptPropagatesExactSizeDecision(t *testing.T) {
+	const size = int64(94_329_473_840)
+	var captured *CrossSeedRequest
+	service := &Service{
+		torrentDownloadFunc: func(context.Context, jackett.TorrentDownloadRequest) ([]byte, error) {
+			return []byte("torrent"), nil
+		},
+		crossSeedInvoker: func(_ context.Context, request *CrossSeedRequest) (*CrossSeedResponse, error) {
+			captured = request
+			return &CrossSeedResponse{Success: true}, nil
+		},
+	}
+	state := &searchRunState{opts: SearchRunOptions{InstanceID: 1}}
+	match := TorrentSearchResult{
+		Indexer:             "Indexer",
+		IndexerID:           7,
+		Title:               "candidate",
+		DownloadURL:         "https://example.invalid/candidate.torrent",
+		Size:                size,
+		SearchDecisionClass: searchCandidateClassExactSizeFallback,
+	}
+
+	result, err := service.executeCrossSeedSearchAttempt(
+		context.Background(),
+		state,
+		&qbt.Torrent{Hash: "source", Name: "source"},
+		match,
+		time.Now(),
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, models.CrossSeedSearchResultStatusAdded, result.Status)
+	require.NotNil(t, captured)
+	require.Equal(t, searchCandidateClassExactSizeFallback, captured.SearchDecisionClass)
+	require.Equal(t, size, captured.AdvertisedCandidateSize)
+}
+
+func TestCrossSeedRejectsInvalidAdvertisedExactSize(t *testing.T) {
+	torrentData := createTestTorrent(
+		t,
+		"Example.Show.S01.2160p.ATVP.WEB-DL.HDR10+.H.265-NTb",
+		[]string{"Example.Show.S01E01.mkv"},
+		256*1024,
+	)
+	meta, err := ParseTorrentMetadataWithInfo(torrentData)
+	require.NoError(t, err)
+	var actualSize int64
+	for _, file := range meta.Files {
+		actualSize += file.Size
+	}
+	service := &Service{releaseCache: NewReleaseCache()}
+
+	_, err = service.CrossSeed(context.Background(), &CrossSeedRequest{
+		TorrentData:             base64.StdEncoding.EncodeToString(torrentData),
+		SearchDecisionClass:     searchCandidateClassExactSizeFallback,
+		AdvertisedCandidateSize: actualSize + 1,
+		TargetInstanceIDs:       []int{1},
+		FindIndividualEpisodes:  false,
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "advertised size")
+	require.Contains(t, err.Error(), "downloaded torrent size")
+}
+
+func TestFindCandidatesExactSizeFallbackIsScopedAndContinuesToFileValidation(t *testing.T) {
+	const (
+		instanceID   = 1
+		torrentSize  = int64(94_329_473_840)
+		targetName   = "Example.Show.2024.S01.2160p.ATVP.WEB-DL.DV.HDR10+.H.265-NTb"
+		existingName = "Example.Show.2024.S01.2160p.ATV.WEB-DL.DV.HDR.H.265-NTb"
+		existingHash = "existing"
+	)
+	instance := &models.Instance{ID: instanceID, Name: "main"}
+	existing := qbt.Torrent{
+		Hash:     existingHash,
+		Name:     existingName,
+		Size:     torrentSize,
+		Progress: 1,
+	}
+	files := map[string]qbt.TorrentFiles{
+		existingHash: {
+			{
+				Name: "Example.Show.2024.S01E01.2160p.ATV.WEB-DL.DV.HDR.H.265-NTb.mkv",
+				Size: torrentSize,
+			},
+		},
+	}
+	service := &Service{
+		instanceStore:    &fakeInstanceStore{instances: map[int]*models.Instance{instanceID: instance}},
+		syncManager:      newFakeSyncManager(instance, []qbt.Torrent{existing}, files),
+		releaseCache:     NewReleaseCache(),
+		stringNormalizer: stringutils.NewDefaultNormalizer(),
+	}
+
+	directResponse, err := service.FindCandidates(context.Background(), &FindCandidatesRequest{
+		TorrentName:       targetName,
+		TargetInstanceIDs: []int{instanceID},
+	})
+	require.NoError(t, err)
+	require.Empty(t, directResponse.Candidates, "direct requests must retain strict release matching")
+
+	fallbackResponse, err := service.FindCandidates(context.Background(), &FindCandidatesRequest{
+		TorrentName:       targetName,
+		TargetInstanceIDs: []int{instanceID},
+		ExactSizeFallback: true,
+		TorrentSize:       torrentSize,
+	})
+	require.NoError(t, err)
+	require.Len(t, fallbackResponse.Candidates, 1)
+	require.Len(t, fallbackResponse.Candidates[0].Torrents, 1)
+	require.Equal(t, existingHash, fallbackResponse.Candidates[0].Torrents[0].Hash)
+	require.NotEmpty(t, fallbackResponse.Candidates[0].MatchType)
+
+	wrongSizeResponse, err := service.FindCandidates(context.Background(), &FindCandidatesRequest{
+		TorrentName:       targetName,
+		TargetInstanceIDs: []int{instanceID},
+		ExactSizeFallback: true,
+		TorrentSize:       torrentSize + 1,
+	})
+	require.NoError(t, err)
+	require.Empty(t, wrongSizeResponse.Candidates)
+
+	incompatibleFiles := map[string]qbt.TorrentFiles{
+		existingHash: {
+			{
+				Name: "Example.Show.2024.S02E01.2160p.ATV.WEB-DL.DV.HDR.H.265-NTb.mkv",
+				Size: torrentSize,
+			},
+		},
+	}
+	incompatibleService := &Service{
+		instanceStore:    &fakeInstanceStore{instances: map[int]*models.Instance{instanceID: instance}},
+		syncManager:      newFakeSyncManager(instance, []qbt.Torrent{existing}, incompatibleFiles),
+		releaseCache:     NewReleaseCache(),
+		stringNormalizer: stringutils.NewDefaultNormalizer(),
+	}
+	incompatibleResponse, err := incompatibleService.FindCandidates(context.Background(), &FindCandidatesRequest{
+		TorrentName:       targetName,
+		TargetInstanceIDs: []int{instanceID},
+		ExactSizeFallback: true,
+		TorrentSize:       torrentSize,
+	})
+	require.NoError(t, err)
+	require.Empty(t, incompatibleResponse.Candidates, "fallback must not bypass file-level release validation")
+}

--- a/internal/services/crossseed/search_candidate_match_test.go
+++ b/internal/services/crossseed/search_candidate_match_test.go
@@ -87,6 +87,19 @@ func TestClassifySearchCandidateTorznabFloat32Fallback(t *testing.T) {
 	require.Contains(t, decision.MatchReason, "Torznab float32-compatible size")
 	require.Equal(t, sourceSize, canonicalSearchResultSize(decision, sourceSize, torznabSize))
 
+	zeroToleranceDecision := service.classifySearchCandidate(searchCandidateInput{
+		SourceRelease:    &source,
+		CandidateRelease: &candidate,
+		SourceName:       sourceName,
+		CandidateName:    candidateName,
+		SourceSize:       sourceSize,
+		CandidateSize:    torznabSize,
+		TolerancePercent: 0,
+	})
+	require.True(t, zeroToleranceDecision.Accepted)
+	require.Equal(t, searchCandidateClassExactSizeFallback, zeroToleranceDecision.Class)
+	require.Equal(t, searchSizeEvidenceTorznabFloat32, zeroToleranceDecision.SizeEvidence)
+
 	exactDecision := decision
 	exactDecision.SizeEvidence = searchSizeEvidenceExact
 	require.Equal(t, sourceSize, canonicalSearchResultSize(exactDecision, sourceSize, sourceSize))

--- a/internal/services/crossseed/search_candidate_match_test.go
+++ b/internal/services/crossseed/search_candidate_match_test.go
@@ -59,14 +59,13 @@ func TestClassifySearchCandidateExactSizeFallback(t *testing.T) {
 	require.Contains(t, decision.MatchReason, "relaxed collection")
 }
 
-func TestClassifySearchCandidateTorznabFloat32Fallback(t *testing.T) {
+func TestClassifySearchCandidateRejectsNonExactSizeFallback(t *testing.T) {
 	service := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
 	const (
-		sourceName        = "Example.Show.2024.S01.2160p.ATV.WEB-DL.DDP5.1.DV.HDR.H.265-NTb"
-		candidateName     = "Example Show 2024 S01 2160p ATVP WEB-DL DD+ 5.1 DV HDR10+ H.265-NTb"
-		sourceSize        = int64(94_329_473_840)
-		torznabSize       = int64(94_329_470_976)
-		unrelatedNearSize = sourceSize - 1
+		sourceName    = "Example.Show.2024.S01.2160p.ATV.WEB-DL.DDP5.1.DV.HDR.H.265-NTb"
+		candidateName = "Example Show 2024 S01 2160p ATVP WEB-DL DD+ 5.1 DV HDR10+ H.265-NTb"
+		sourceSize    = int64(94_329_473_840)
+		candidateSize = int64(94_329_470_976)
 	)
 	source := rls.ParseString(sourceName)
 	candidate := rls.ParseString(candidateName)
@@ -77,63 +76,16 @@ func TestClassifySearchCandidateTorznabFloat32Fallback(t *testing.T) {
 		SourceName:       sourceName,
 		CandidateName:    candidateName,
 		SourceSize:       sourceSize,
-		CandidateSize:    torznabSize,
+		CandidateSize:    candidateSize,
 		TolerancePercent: 5,
 	})
 
-	require.True(t, decision.Accepted)
-	require.Equal(t, searchCandidateClassExactSizeFallback, decision.Class)
-	require.Equal(t, searchSizeEvidenceTorznabFloat32, decision.SizeEvidence)
-	require.Contains(t, decision.MatchReason, "Torznab float32-compatible size")
-	require.Equal(t, sourceSize, canonicalSearchResultSize(decision, sourceSize, torznabSize))
-
-	zeroToleranceDecision := service.classifySearchCandidate(searchCandidateInput{
-		SourceRelease:    &source,
-		CandidateRelease: &candidate,
-		SourceName:       sourceName,
-		CandidateName:    candidateName,
-		SourceSize:       sourceSize,
-		CandidateSize:    torznabSize,
-		TolerancePercent: 0,
-	})
-	require.True(t, zeroToleranceDecision.Accepted)
-	require.Equal(t, searchCandidateClassExactSizeFallback, zeroToleranceDecision.Class)
-	require.Equal(t, searchSizeEvidenceTorznabFloat32, zeroToleranceDecision.SizeEvidence)
-
-	exactDecision := decision
-	exactDecision.SizeEvidence = searchSizeEvidenceExact
-	require.Equal(t, sourceSize, canonicalSearchResultSize(exactDecision, sourceSize, sourceSize))
-
-	unrelatedDecision := service.classifySearchCandidate(searchCandidateInput{
-		SourceRelease:    &source,
-		CandidateRelease: &candidate,
-		SourceName:       sourceName,
-		CandidateName:    candidateName,
-		SourceSize:       sourceSize,
-		CandidateSize:    unrelatedNearSize,
-		TolerancePercent: 5,
-	})
-	require.False(t, unrelatedDecision.Accepted)
-	require.Equal(t, searchSizeEvidenceNone, unrelatedDecision.SizeEvidence)
-	require.Equal(t, unrelatedNearSize, canonicalSearchResultSize(unrelatedDecision, sourceSize, unrelatedNearSize))
-
-	differentGroup := candidate
-	differentGroup.Group = "FLUX"
-	hardRejected := service.classifySearchCandidate(searchCandidateInput{
-		SourceRelease:    &source,
-		CandidateRelease: &differentGroup,
-		SourceName:       sourceName,
-		CandidateName:    candidateName,
-		SourceSize:       sourceSize,
-		CandidateSize:    torznabSize,
-		TolerancePercent: 5,
-	})
-	require.False(t, hardRejected.Accepted)
-	require.Equal(t, searchSizeEvidenceTorznabFloat32, hardRejected.SizeEvidence)
-	require.Equal(t, "group/site mismatch", hardRejected.RejectReason)
+	require.False(t, decision.Accepted)
+	require.Equal(t, searchCandidateClassRejected, decision.Class)
+	require.Equal(t, searchSizeEvidenceNone, decision.SizeEvidence)
 }
 
-func TestClassifySearchSizeEvidenceExactFirst(t *testing.T) {
+func TestClassifySearchSizeEvidenceExactOnly(t *testing.T) {
 	const (
 		sourceSize  = int64(94_329_473_840)
 		torznabSize = int64(94_329_470_976)
@@ -145,8 +97,8 @@ func TestClassifySearchSizeEvidenceExactFirst(t *testing.T) {
 		candidateSize int64
 		want          searchSizeEvidence
 	}{
-		{name: "exact before compatibility", sourceSize: sourceSize, candidateSize: sourceSize, want: searchSizeEvidenceExact},
-		{name: "Torznab float32 compatibility", sourceSize: sourceSize, candidateSize: torznabSize, want: searchSizeEvidenceTorznabFloat32},
+		{name: "exact positive size", sourceSize: sourceSize, candidateSize: sourceSize, want: searchSizeEvidenceExact},
+		{name: "formerly compatible rounded size", sourceSize: sourceSize, candidateSize: torznabSize, want: searchSizeEvidenceNone},
 		{name: "arbitrary near size", sourceSize: sourceSize, candidateSize: sourceSize - 1, want: searchSizeEvidenceNone},
 		{name: "missing source size", sourceSize: 0, candidateSize: torznabSize, want: searchSizeEvidenceNone},
 		{name: "missing candidate size", sourceSize: sourceSize, candidateSize: 0, want: searchSizeEvidenceNone},
@@ -459,18 +411,16 @@ func TestSortScoredTorrentSearchResultsSizeEvidencePriority(t *testing.T) {
 	now := time.Now()
 	items := []scoredTorrentSearchResult{
 		{result: jackett.SearchResult{Title: "tolerance", Seeders: 100, PublishDate: now}, score: 10, class: searchCandidateClassStrict},
-		{result: jackett.SearchResult{Title: "compatible", Seeders: 100, PublishDate: now}, score: 10, sizeEvidence: searchSizeEvidenceTorznabFloat32, class: searchCandidateClassStrict},
 		{result: jackett.SearchResult{Title: "fallback", Seeders: 1, PublishDate: now.Add(-time.Hour)}, score: 2, sizeEvidence: searchSizeEvidenceExact, class: searchCandidateClassExactSizeFallback},
 		{result: jackett.SearchResult{Title: "strict", Seeders: 0, PublishDate: now.Add(-2 * time.Hour)}, score: 1, sizeEvidence: searchSizeEvidenceExact, class: searchCandidateClassStrict},
 	}
 
 	sortScoredTorrentSearchResults(items)
 
-	require.Equal(t, []string{"strict", "fallback", "compatible", "tolerance"}, []string{
+	require.Equal(t, []string{"strict", "fallback", "tolerance"}, []string{
 		items[0].result.Title,
 		items[1].result.Title,
 		items[2].result.Title,
-		items[3].result.Title,
 	})
 }
 

--- a/internal/services/crossseed/search_candidate_match_test.go
+++ b/internal/services/crossseed/search_candidate_match_test.go
@@ -7,6 +7,9 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -16,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/services/arr"
 	"github.com/autobrr/qui/internal/services/jackett"
 	"github.com/autobrr/qui/pkg/stringutils"
 )
@@ -198,6 +202,77 @@ func TestClassifySearchCandidateExactSizeHardIdentity(t *testing.T) {
 				TolerancePercent: 5,
 			})
 			require.False(t, decision.Accepted)
+			require.Equal(t, test.reason, decision.RejectReason)
+		})
+	}
+}
+
+func TestClassifySearchCandidateExactSizeDateIdentity(t *testing.T) {
+	service := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
+	const size = int64(94_329_473_840)
+	base := rls.ParseString("Example.Show.S01.2160p.ATV.WEB-DL.HDR.H.265-NTb")
+
+	tests := []struct {
+		name                                        string
+		sourceYear, sourceMonth, sourceDay          int
+		candidateYear, candidateMonth, candidateDay int
+		accepted                                    bool
+		reason                                      string
+	}{
+		{
+			name:          "source year with missing candidate year",
+			sourceYear:    2024,
+			candidateYear: 0,
+			reason:        "year mismatch",
+		},
+		{
+			name:           "unequal incomplete dates",
+			sourceYear:     2024,
+			sourceMonth:    1,
+			candidateYear:  2024,
+			candidateMonth: 2,
+			reason:         "date mismatch",
+		},
+		{
+			name:           "equal complete dates",
+			sourceYear:     2024,
+			sourceMonth:    1,
+			sourceDay:      2,
+			candidateYear:  2024,
+			candidateMonth: 1,
+			candidateDay:   2,
+			accepted:       true,
+		},
+		{
+			name:     "both dates absent",
+			accepted: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source := base
+			candidate := base
+			source.Collection = "ATV"
+			candidate.Collection = "ATVP"
+			source.Year, source.Month, source.Day = test.sourceYear, test.sourceMonth, test.sourceDay
+			candidate.Year, candidate.Month, candidate.Day = test.candidateYear, test.candidateMonth, test.candidateDay
+
+			decision := service.classifySearchCandidate(searchCandidateInput{
+				SourceRelease:    &source,
+				CandidateRelease: &candidate,
+				SourceName:       source.Title,
+				CandidateName:    candidate.Title,
+				SourceSize:       size,
+				CandidateSize:    size,
+				TolerancePercent: 5,
+			})
+
+			require.Equal(t, test.accepted, decision.Accepted)
+			if test.accepted {
+				require.Equal(t, searchCandidateClassExactSizeFallback, decision.Class)
+				return
+			}
 			require.Equal(t, test.reason, decision.RejectReason)
 		})
 	}
@@ -494,4 +569,141 @@ func TestCrossSeedRevalidatesARRSourceTitles(t *testing.T) {
 	aliased := apply([]string{"Money Heist"})
 	require.NotEqual(t, "no_match", aliased.Results[0].Status)
 	require.Contains(t, aliased.Results[0].Message, "torrent properties")
+}
+
+func TestARRAliasSurvivesSearchToManualAndAutomatedApply(t *testing.T) {
+	const (
+		instanceID    = 1
+		sourceHash    = "0123456789abcdef0123456789abcdef01234567"
+		sourceName    = "La.Casa.De.Papel.S01E01.1080p.NF.WEB-DL.DDP5.1.H.264-NTb"
+		candidateName = "Money.Heist.S01E01.1080p.NF.WEB-DL.DDP5.1.H.264-NTb"
+	)
+	aliases := []string{"Money Heist"}
+	candidateData := createTestTorrent(t, candidateName, []string{"payload.mkv"}, 256*1024)
+	meta, err := ParseTorrentMetadataWithInfo(candidateData)
+	require.NoError(t, err)
+	var candidateSize int64
+	for _, file := range meta.Files {
+		candidateSize += file.Size
+	}
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/candidate.torrent" {
+			w.Header().Set("Content-Type", "application/x-bittorrent")
+			if _, writeErr := w.Write(candidateData); writeErr != nil {
+				t.Errorf("write candidate torrent: %v", writeErr)
+			}
+			return
+		}
+		w.Header().Set("Content-Type", "application/rss+xml")
+		if _, writeErr := fmt.Fprintf(w, `<rss version="2.0"><channel><title>Alias Indexer</title><item>
+			<title>%s</title><guid>alias-only-candidate</guid><size>%d</size>
+			<enclosure url="%s/candidate.torrent" length="%d" type="application/x-bittorrent" />
+		</item></channel></rss>`, candidateName, candidateSize, server.URL, candidateSize); writeErr != nil {
+			t.Errorf("write Torznab response: %v", writeErr)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	instance := &models.Instance{ID: instanceID, Name: "main"}
+	source := qbt.Torrent{
+		Hash:     sourceHash,
+		Name:     sourceName,
+		Size:     candidateSize,
+		Progress: 1,
+	}
+	filterCache := ttlcache.New(ttlcache.Options[string, *AsyncIndexerFilteringState]{})
+	filterCache.Set(asyncFilteringCacheKey(instanceID, sourceHash), &AsyncIndexerFilteringState{
+		CapabilitiesCompleted: true,
+		ContentCompleted:      false,
+		CapabilityIndexers:    []int{1},
+		FilteredIndexers:      []int{1},
+	}, ttlcache.DefaultTTL)
+	arrLookup := &spyARRLookupService{
+		result: &arr.ExternalIDsResult{
+			IDs:         &models.ExternalIDs{},
+			ContentType: arr.ContentTypeTV,
+			Source:      "test",
+		},
+	}
+	service := &Service{
+		instanceStore: &fakeInstanceStore{instances: map[int]*models.Instance{instanceID: instance}},
+		jackettService: newJackettServiceWithIndexers([]*models.TorznabIndexer{
+			{
+				ID:             1,
+				Name:           "Alias Indexer",
+				BaseURL:        server.URL,
+				Backend:        models.TorznabBackendNative,
+				TimeoutSeconds: 5,
+				Enabled:        true,
+			},
+		}),
+		syncManager: newFakeSyncManager(instance, []qbt.Torrent{source}, map[string]qbt.TorrentFiles{
+			sourceHash: meta.Files,
+		}),
+		arrService:          arrLookup,
+		asyncFilteringCache: filterCache,
+		releaseCache:        NewReleaseCache(),
+		searchResultCache:   ttlcache.New(ttlcache.Options[string, cachedTorrentSearchResults]{}),
+		stringNormalizer:    stringutils.NewDefaultNormalizer(),
+	}
+
+	search := func(titles []string) *TorrentSearchResponse {
+		arrLookup.result.Titles = append([]string(nil), titles...)
+		response, _, _, searchErr := service.searchTorrentMatches(
+			context.Background(),
+			instanceID,
+			sourceHash,
+			TorrentSearchOptions{
+				IndexerIDs:                      []int{1},
+				SkipGazelle:                     true,
+				SizeMismatchTolerancePercent:    5,
+				SizeMismatchTolerancePercentSet: true,
+			},
+			nil,
+		)
+		require.NoError(t, searchErr)
+		return response
+	}
+
+	require.Empty(t, search([]string{"Unrelated Show"}).Results)
+	response := search(aliases)
+	require.Len(t, response.Results, 1)
+	match := response.Results[0]
+	require.Equal(t, searchCandidateClassStrict, match.SearchDecisionClass)
+	require.Equal(t, aliases, match.SearchSourceTitles)
+
+	t.Run("manual apply", func(t *testing.T) {
+		applyResponse, applyErr := service.ApplyTorrentSearchResults(context.Background(), instanceID, sourceHash, &ApplyTorrentSearchRequest{
+			Selections: []TorrentSearchSelection{
+				{
+					IndexerID:   match.IndexerID,
+					Indexer:     match.Indexer,
+					DownloadURL: match.DownloadURL,
+					Title:       match.Title,
+					GUID:        match.GUID,
+				},
+			},
+		})
+		require.NoError(t, applyErr)
+		require.Len(t, applyResponse.Results, 1)
+		require.Len(t, applyResponse.Results[0].InstanceResults, 1)
+		instanceResult := applyResponse.Results[0].InstanceResults[0]
+		require.NotEqual(t, "no_match", instanceResult.Status)
+		require.Contains(t, instanceResult.Message, "torrent properties")
+	})
+
+	t.Run("automated apply", func(t *testing.T) {
+		result, applyErr := service.executeCrossSeedSearchAttempt(
+			context.Background(),
+			&searchRunState{opts: SearchRunOptions{InstanceID: instanceID}},
+			&source,
+			match,
+			time.Now(),
+		)
+		require.NoError(t, applyErr)
+		require.Equal(t, models.CrossSeedSearchResultStatusFailed, result.Status)
+		require.Contains(t, result.Message, "torrent properties")
+	})
 }

--- a/internal/services/crossseed/search_candidate_match_test.go
+++ b/internal/services/crossseed/search_candidate_match_test.go
@@ -397,14 +397,12 @@ func TestSearchCandidateInternalMetadataIsNotJSON(t *testing.T) {
 	require.NotContains(t, string(resultBytes), "ARR secret result alias")
 
 	requestBytes, err := json.Marshal(CrossSeedRequest{
-		SearchDecisionClass:     searchCandidateClassExactSizeFallback,
-		SearchSourceTitles:      []string{"ARR secret request alias"},
-		AdvertisedCandidateSize: 123,
+		SearchDecisionClass: searchCandidateClassExactSizeFallback,
+		SearchSourceTitles:  []string{"ARR secret request alias"},
 	})
 	require.NoError(t, err)
 	require.NotContains(t, string(requestBytes), "exact-size-fallback")
 	require.NotContains(t, string(requestBytes), "ARR secret request alias")
-	require.NotContains(t, string(requestBytes), "123")
 }
 
 func TestSortScoredTorrentSearchResultsSizeEvidencePriority(t *testing.T) {
@@ -461,35 +459,6 @@ func TestExecuteCrossSeedSearchAttemptPropagatesExactSizeDecision(t *testing.T) 
 	require.NotNil(t, captured)
 	require.Equal(t, searchCandidateClassExactSizeFallback, captured.SearchDecisionClass)
 	require.Equal(t, sourceTitles, captured.SearchSourceTitles)
-	require.Equal(t, size, captured.AdvertisedCandidateSize)
-}
-
-func TestCrossSeedRejectsInvalidAdvertisedExactSize(t *testing.T) {
-	torrentData := createTestTorrent(
-		t,
-		"Example.Show.S01.2160p.ATVP.WEB-DL.HDR10+.H.265-NTb",
-		[]string{"Example.Show.S01E01.mkv"},
-		256*1024,
-	)
-	meta, err := ParseTorrentMetadataWithInfo(torrentData)
-	require.NoError(t, err)
-	var actualSize int64
-	for _, file := range meta.Files {
-		actualSize += file.Size
-	}
-	service := &Service{releaseCache: NewReleaseCache()}
-
-	_, err = service.CrossSeed(context.Background(), &CrossSeedRequest{
-		TorrentData:             base64.StdEncoding.EncodeToString(torrentData),
-		SearchDecisionClass:     searchCandidateClassExactSizeFallback,
-		AdvertisedCandidateSize: actualSize + 1,
-		TargetInstanceIDs:       []int{1},
-		FindIndividualEpisodes:  false,
-	})
-
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "advertised size")
-	require.Contains(t, err.Error(), "downloaded torrent size")
 }
 
 func TestFindCandidatesExactSizeFallbackIsScopedAndContinuesToFileValidation(t *testing.T) {
@@ -502,9 +471,11 @@ func TestFindCandidatesExactSizeFallbackIsScopedAndContinuesToFileValidation(t *
 	)
 	instance := &models.Instance{ID: instanceID, Name: "main"}
 	existing := qbt.Torrent{
-		Hash:     existingHash,
-		Name:     existingName,
-		Size:     torrentSize,
+		Hash: existingHash,
+		Name: existingName,
+		// Search already established exact size. Apply must not replace that
+		// evidence with a new comparison against downloaded metainfo.
+		Size:     torrentSize + 1,
 		Progress: 1,
 	}
 	files := map[string]qbt.TorrentFiles{
@@ -533,22 +504,12 @@ func TestFindCandidatesExactSizeFallbackIsScopedAndContinuesToFileValidation(t *
 		TorrentName:       targetName,
 		TargetInstanceIDs: []int{instanceID},
 		ExactSizeFallback: true,
-		TorrentSize:       torrentSize,
 	})
 	require.NoError(t, err)
 	require.Len(t, fallbackResponse.Candidates, 1)
 	require.Len(t, fallbackResponse.Candidates[0].Torrents, 1)
 	require.Equal(t, existingHash, fallbackResponse.Candidates[0].Torrents[0].Hash)
 	require.NotEmpty(t, fallbackResponse.Candidates[0].MatchType)
-
-	wrongSizeResponse, err := service.FindCandidates(context.Background(), &FindCandidatesRequest{
-		TorrentName:       targetName,
-		TargetInstanceIDs: []int{instanceID},
-		ExactSizeFallback: true,
-		TorrentSize:       torrentSize + 1,
-	})
-	require.NoError(t, err)
-	require.Empty(t, wrongSizeResponse.Candidates)
 
 	incompatibleFiles := map[string]qbt.TorrentFiles{
 		existingHash: {
@@ -568,7 +529,6 @@ func TestFindCandidatesExactSizeFallbackIsScopedAndContinuesToFileValidation(t *
 		TorrentName:       targetName,
 		TargetInstanceIDs: []int{instanceID},
 		ExactSizeFallback: true,
-		TorrentSize:       torrentSize,
 	})
 	require.NoError(t, err)
 	require.Empty(t, incompatibleResponse.Candidates, "fallback must not bypass file-level release validation")

--- a/internal/services/crossseed/search_candidate_match_test.go
+++ b/internal/services/crossseed/search_candidate_match_test.go
@@ -52,11 +52,98 @@ func TestClassifySearchCandidateExactSizeFallback(t *testing.T) {
 
 	require.True(t, decision.Accepted)
 	require.Equal(t, searchCandidateClassExactSizeFallback, decision.Class)
-	require.True(t, decision.ExactSize)
+	require.Equal(t, searchSizeEvidenceExact, decision.SizeEvidence)
 	require.Contains(t, decision.RelaxedDifferences, "collection")
 	require.Contains(t, decision.RelaxedDifferences, "hdr")
 	require.Contains(t, decision.MatchReason, "exact byte size")
 	require.Contains(t, decision.MatchReason, "relaxed collection")
+}
+
+func TestClassifySearchCandidateTorznabFloat32Fallback(t *testing.T) {
+	service := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
+	const (
+		sourceName        = "Example.Show.2024.S01.2160p.ATV.WEB-DL.DDP5.1.DV.HDR.H.265-NTb"
+		candidateName     = "Example Show 2024 S01 2160p ATVP WEB-DL DD+ 5.1 DV HDR10+ H.265-NTb"
+		sourceSize        = int64(94_329_473_840)
+		torznabSize       = int64(94_329_470_976)
+		unrelatedNearSize = sourceSize - 1
+	)
+	source := rls.ParseString(sourceName)
+	candidate := rls.ParseString(candidateName)
+
+	decision := service.classifySearchCandidate(searchCandidateInput{
+		SourceRelease:    &source,
+		CandidateRelease: &candidate,
+		SourceName:       sourceName,
+		CandidateName:    candidateName,
+		SourceSize:       sourceSize,
+		CandidateSize:    torznabSize,
+		TolerancePercent: 5,
+	})
+
+	require.True(t, decision.Accepted)
+	require.Equal(t, searchCandidateClassExactSizeFallback, decision.Class)
+	require.Equal(t, searchSizeEvidenceTorznabFloat32, decision.SizeEvidence)
+	require.Contains(t, decision.MatchReason, "Torznab float32-compatible size")
+	require.Equal(t, sourceSize, canonicalSearchResultSize(decision, sourceSize, torznabSize))
+
+	exactDecision := decision
+	exactDecision.SizeEvidence = searchSizeEvidenceExact
+	require.Equal(t, sourceSize, canonicalSearchResultSize(exactDecision, sourceSize, sourceSize))
+
+	unrelatedDecision := service.classifySearchCandidate(searchCandidateInput{
+		SourceRelease:    &source,
+		CandidateRelease: &candidate,
+		SourceName:       sourceName,
+		CandidateName:    candidateName,
+		SourceSize:       sourceSize,
+		CandidateSize:    unrelatedNearSize,
+		TolerancePercent: 5,
+	})
+	require.False(t, unrelatedDecision.Accepted)
+	require.Equal(t, searchSizeEvidenceNone, unrelatedDecision.SizeEvidence)
+	require.Equal(t, unrelatedNearSize, canonicalSearchResultSize(unrelatedDecision, sourceSize, unrelatedNearSize))
+
+	differentGroup := candidate
+	differentGroup.Group = "FLUX"
+	hardRejected := service.classifySearchCandidate(searchCandidateInput{
+		SourceRelease:    &source,
+		CandidateRelease: &differentGroup,
+		SourceName:       sourceName,
+		CandidateName:    candidateName,
+		SourceSize:       sourceSize,
+		CandidateSize:    torznabSize,
+		TolerancePercent: 5,
+	})
+	require.False(t, hardRejected.Accepted)
+	require.Equal(t, searchSizeEvidenceTorznabFloat32, hardRejected.SizeEvidence)
+	require.Equal(t, "group/site mismatch", hardRejected.RejectReason)
+}
+
+func TestClassifySearchSizeEvidenceExactFirst(t *testing.T) {
+	const (
+		sourceSize  = int64(94_329_473_840)
+		torznabSize = int64(94_329_470_976)
+	)
+
+	tests := []struct {
+		name          string
+		sourceSize    int64
+		candidateSize int64
+		want          searchSizeEvidence
+	}{
+		{name: "exact before compatibility", sourceSize: sourceSize, candidateSize: sourceSize, want: searchSizeEvidenceExact},
+		{name: "Torznab float32 compatibility", sourceSize: sourceSize, candidateSize: torznabSize, want: searchSizeEvidenceTorznabFloat32},
+		{name: "arbitrary near size", sourceSize: sourceSize, candidateSize: sourceSize - 1, want: searchSizeEvidenceNone},
+		{name: "missing source size", sourceSize: 0, candidateSize: torznabSize, want: searchSizeEvidenceNone},
+		{name: "missing candidate size", sourceSize: sourceSize, candidateSize: 0, want: searchSizeEvidenceNone},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, classifySearchSizeEvidence(test.sourceSize, test.candidateSize))
+		})
+	}
 }
 
 func TestSearchCandidateARRSourceTitlesSurviveResultCache(t *testing.T) {
@@ -355,20 +442,22 @@ func TestSearchCandidateInternalMetadataIsNotJSON(t *testing.T) {
 	require.NotContains(t, string(requestBytes), "123")
 }
 
-func TestSortScoredTorrentSearchResultsExactSizePriority(t *testing.T) {
+func TestSortScoredTorrentSearchResultsSizeEvidencePriority(t *testing.T) {
 	now := time.Now()
 	items := []scoredTorrentSearchResult{
 		{result: jackett.SearchResult{Title: "tolerance", Seeders: 100, PublishDate: now}, score: 10, class: searchCandidateClassStrict},
-		{result: jackett.SearchResult{Title: "fallback", Seeders: 1, PublishDate: now.Add(-time.Hour)}, score: 2, exactSize: true, class: searchCandidateClassExactSizeFallback},
-		{result: jackett.SearchResult{Title: "strict", Seeders: 0, PublishDate: now.Add(-2 * time.Hour)}, score: 1, exactSize: true, class: searchCandidateClassStrict},
+		{result: jackett.SearchResult{Title: "compatible", Seeders: 100, PublishDate: now}, score: 10, sizeEvidence: searchSizeEvidenceTorznabFloat32, class: searchCandidateClassStrict},
+		{result: jackett.SearchResult{Title: "fallback", Seeders: 1, PublishDate: now.Add(-time.Hour)}, score: 2, sizeEvidence: searchSizeEvidenceExact, class: searchCandidateClassExactSizeFallback},
+		{result: jackett.SearchResult{Title: "strict", Seeders: 0, PublishDate: now.Add(-2 * time.Hour)}, score: 1, sizeEvidence: searchSizeEvidenceExact, class: searchCandidateClassStrict},
 	}
 
 	sortScoredTorrentSearchResults(items)
 
-	require.Equal(t, []string{"strict", "fallback", "tolerance"}, []string{
+	require.Equal(t, []string{"strict", "fallback", "compatible", "tolerance"}, []string{
 		items[0].result.Title,
 		items[1].result.Title,
 		items[2].result.Title,
+		items[3].result.Title,
 	})
 }
 

--- a/internal/services/crossseed/search_candidate_match_test.go
+++ b/internal/services/crossseed/search_candidate_match_test.go
@@ -439,6 +439,65 @@ func TestSortScoredTorrentSearchResultsSizeEvidencePriority(t *testing.T) {
 	})
 }
 
+func TestDeduplicateScoredTorrentSearchResultsKeepsBestClassificationAndKeylessResults(t *testing.T) {
+	items := []scoredTorrentSearchResult{
+		{
+			result: jackett.SearchResult{
+				Title: "guid-tolerance",
+				GUID:  "shared-guid",
+			},
+			score: 10,
+			class: searchCandidateClassStrict,
+		},
+		{
+			result: jackett.SearchResult{
+				Title:       "url-tolerance",
+				DownloadURL: "https://example.invalid/shared.torrent",
+			},
+			score: 10,
+			class: searchCandidateClassStrict,
+		},
+		{
+			result: jackett.SearchResult{Title: "keyless-one"},
+			score:  1,
+			class:  searchCandidateClassStrict,
+		},
+		{
+			result: jackett.SearchResult{
+				Title: "guid-exact",
+				GUID:  "shared-guid",
+			},
+			score:        2,
+			sizeEvidence: searchSizeEvidenceExact,
+			class:        searchCandidateClassExactSizeFallback,
+		},
+		{
+			result: jackett.SearchResult{
+				Title:       "url-exact",
+				DownloadURL: "https://example.invalid/shared.torrent",
+			},
+			score:        2,
+			sizeEvidence: searchSizeEvidenceExact,
+			class:        searchCandidateClassExactSizeFallback,
+		},
+		{
+			result: jackett.SearchResult{Title: "keyless-two"},
+			score:  1,
+			class:  searchCandidateClassStrict,
+		},
+	}
+
+	sortScoredTorrentSearchResults(items)
+	items = deduplicateScoredTorrentSearchResults(items)
+
+	require.Len(t, items, 4)
+	titles := make([]string, 0, len(items))
+	for _, item := range items {
+		titles = append(titles, item.result.Title)
+	}
+	require.ElementsMatch(t, []string{"guid-exact", "url-exact", "keyless-one", "keyless-two"}, titles)
+}
+
 func TestExecuteCrossSeedSearchAttemptPropagatesExactSizeDecision(t *testing.T) {
 	const size = int64(94_329_473_840)
 	sourceTitles := []string{"ARR Alias"}

--- a/internal/services/crossseed/search_candidate_match_test.go
+++ b/internal/services/crossseed/search_candidate_match_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/autobrr/autobrr/pkg/ttlcache"
 	qbt "github.com/autobrr/go-qbittorrent"
 	"github.com/moistari/rls"
 	"github.com/stretchr/testify/require"
@@ -52,6 +53,73 @@ func TestClassifySearchCandidateExactSizeFallback(t *testing.T) {
 	require.Contains(t, decision.RelaxedDifferences, "hdr")
 	require.Contains(t, decision.MatchReason, "exact byte size")
 	require.Contains(t, decision.MatchReason, "relaxed collection")
+}
+
+func TestSearchCandidateARRSourceTitlesSurviveResultCache(t *testing.T) {
+	service := &Service{
+		stringNormalizer:  stringutils.NewDefaultNormalizer(),
+		searchResultCache: ttlcache.New(ttlcache.Options[string, cachedTorrentSearchResults]{}),
+	}
+	const (
+		sourceName    = "La.Casa.De.Papel.S01E01.1080p.NF.WEB-DL.DDP5.1.H.264-NTb"
+		candidateName = "Money.Heist.S01E01.1080p.NF.WEB-DL.DDP5.1.H.264-NTb"
+	)
+	source := rls.ParseString(sourceName)
+	candidate := rls.ParseString(candidateName)
+	sourceTitles := []string{"Money Heist"}
+
+	decision := service.classifySearchCandidate(searchCandidateInput{
+		SourceRelease:    &source,
+		CandidateRelease: &candidate,
+		SourceName:       sourceName,
+		CandidateName:    candidateName,
+		SourceTitles:     sourceTitles,
+		SourceSize:       100,
+		CandidateSize:    101,
+		TolerancePercent: 5,
+	})
+	require.True(t, decision.Accepted)
+	require.Equal(t, searchCandidateClassStrict, decision.Class)
+	require.Equal(t, []string{"Money Heist"}, decision.SourceTitles)
+
+	// The decision owns the title lineage it accepted; later mutations of the ARR
+	// response must not alter an in-flight or cached search result.
+	sourceTitles[0] = "mutated"
+	require.Equal(t, []string{"Money Heist"}, decision.SourceTitles)
+
+	results, duplicateFiltered, err := service.buildTorrentSearchResults(context.Background(), 1, "source", []scoredTorrentSearchResult{
+		{
+			result:       jackett.SearchResult{Title: candidateName},
+			class:        decision.Class,
+			sourceTitles: decision.SourceTitles,
+		},
+	}, 1)
+	require.NoError(t, err)
+	require.Zero(t, duplicateFiltered)
+	require.Len(t, results, 1)
+	require.Equal(t, []string{"Money Heist"}, results[0].SearchSourceTitles)
+
+	service.cacheSearchResults(1, "source", results, 5)
+	results[0].SearchSourceTitles[0] = "mutated after cache write"
+	cached := service.getCachedSearchResults(1, "source")
+	require.NotNil(t, cached)
+	require.Equal(t, []string{"Money Heist"}, cached.results[0].SearchSourceTitles)
+	cached.results[0].SearchSourceTitles[0] = "mutated after cache read"
+	require.Equal(t, []string{"Money Heist"}, service.getCachedSearchResults(1, "source").results[0].SearchSourceTitles)
+
+	rejected := service.classifySearchCandidate(searchCandidateInput{
+		SourceRelease:    &source,
+		CandidateRelease: &candidate,
+		SourceName:       sourceName,
+		CandidateName:    candidateName,
+		SourceTitles:     []string{"Unrelated Show"},
+		SourceSize:       100,
+		CandidateSize:    101,
+		TolerancePercent: 5,
+	})
+	require.False(t, rejected.Accepted)
+	require.Equal(t, "title mismatch", rejected.RejectReason)
+	require.Empty(t, rejected.SourceTitles)
 }
 
 func TestClassifySearchCandidateExactSizePreconditions(t *testing.T) {
@@ -195,16 +263,20 @@ func TestSearchCandidateInternalMetadataIsNotJSON(t *testing.T) {
 	resultBytes, err := json.Marshal(TorrentSearchResult{
 		Title:               "candidate",
 		SearchDecisionClass: searchCandidateClassExactSizeFallback,
+		SearchSourceTitles:  []string{"ARR secret result alias"},
 	})
 	require.NoError(t, err)
 	require.NotContains(t, string(resultBytes), "exact-size-fallback")
+	require.NotContains(t, string(resultBytes), "ARR secret result alias")
 
 	requestBytes, err := json.Marshal(CrossSeedRequest{
 		SearchDecisionClass:     searchCandidateClassExactSizeFallback,
+		SearchSourceTitles:      []string{"ARR secret request alias"},
 		AdvertisedCandidateSize: 123,
 	})
 	require.NoError(t, err)
 	require.NotContains(t, string(requestBytes), "exact-size-fallback")
+	require.NotContains(t, string(requestBytes), "ARR secret request alias")
 	require.NotContains(t, string(requestBytes), "123")
 }
 
@@ -227,6 +299,7 @@ func TestSortScoredTorrentSearchResultsExactSizePriority(t *testing.T) {
 
 func TestExecuteCrossSeedSearchAttemptPropagatesExactSizeDecision(t *testing.T) {
 	const size = int64(94_329_473_840)
+	sourceTitles := []string{"ARR Alias"}
 	var captured *CrossSeedRequest
 	service := &Service{
 		torrentDownloadFunc: func(context.Context, jackett.TorrentDownloadRequest) ([]byte, error) {
@@ -245,6 +318,7 @@ func TestExecuteCrossSeedSearchAttemptPropagatesExactSizeDecision(t *testing.T) 
 		DownloadURL:         "https://example.invalid/candidate.torrent",
 		Size:                size,
 		SearchDecisionClass: searchCandidateClassExactSizeFallback,
+		SearchSourceTitles:  sourceTitles,
 	}
 
 	result, err := service.executeCrossSeedSearchAttempt(
@@ -259,6 +333,7 @@ func TestExecuteCrossSeedSearchAttemptPropagatesExactSizeDecision(t *testing.T) 
 	require.Equal(t, models.CrossSeedSearchResultStatusAdded, result.Status)
 	require.NotNil(t, captured)
 	require.Equal(t, searchCandidateClassExactSizeFallback, captured.SearchDecisionClass)
+	require.Equal(t, sourceTitles, captured.SearchSourceTitles)
 	require.Equal(t, size, captured.AdvertisedCandidateSize)
 }
 
@@ -370,4 +445,53 @@ func TestFindCandidatesExactSizeFallbackIsScopedAndContinuesToFileValidation(t *
 	})
 	require.NoError(t, err)
 	require.Empty(t, incompatibleResponse.Candidates, "fallback must not bypass file-level release validation")
+}
+
+func TestCrossSeedRevalidatesARRSourceTitles(t *testing.T) {
+	const (
+		instanceID   = 1
+		targetName   = "Money.Heist.S01E01.1080p.NF.WEB-DL.DDP5.1.H.264-NTb"
+		existingName = "La.Casa.De.Papel.S01E01.1080p.NF.WEB-DL.DDP5.1.H.264-NTb"
+		existingHash = "existing"
+	)
+	torrentData := createTestTorrent(t, targetName, []string{"payload.mkv"}, 256*1024)
+	meta, err := ParseTorrentMetadataWithInfo(torrentData)
+	require.NoError(t, err)
+	var torrentSize int64
+	for _, file := range meta.Files {
+		torrentSize += file.Size
+	}
+
+	instance := &models.Instance{ID: instanceID, Name: "main"}
+	existing := qbt.Torrent{
+		Hash:     existingHash,
+		Name:     existingName,
+		Size:     torrentSize,
+		Progress: 1,
+	}
+	service := &Service{
+		instanceStore:    &fakeInstanceStore{instances: map[int]*models.Instance{instanceID: instance}},
+		syncManager:      newFakeSyncManager(instance, []qbt.Torrent{existing}, map[string]qbt.TorrentFiles{existingHash: meta.Files}),
+		releaseCache:     NewReleaseCache(),
+		stringNormalizer: stringutils.NewDefaultNormalizer(),
+	}
+
+	apply := func(sourceTitles []string) *CrossSeedResponse {
+		response, applyErr := service.CrossSeed(context.Background(), &CrossSeedRequest{
+			TorrentData:         base64.StdEncoding.EncodeToString(torrentData),
+			TargetInstanceIDs:   []int{instanceID},
+			SearchDecisionClass: searchCandidateClassStrict,
+			SearchSourceTitles:  sourceTitles,
+		})
+		require.NoError(t, applyErr)
+		require.Len(t, response.Results, 1)
+		return response
+	}
+
+	require.Equal(t, "no_match", apply(nil).Results[0].Status)
+	require.Equal(t, "no_match", apply([]string{"Unrelated Show"}).Results[0].Status)
+
+	aliased := apply([]string{"Money Heist"})
+	require.NotEqual(t, "no_match", aliased.Results[0].Status)
+	require.Contains(t, aliased.Results[0].Message, "torrent properties")
 }

--- a/internal/services/crossseed/search_candidate_match_test.go
+++ b/internal/services/crossseed/search_candidate_match_test.go
@@ -154,14 +154,19 @@ func TestSearchCandidateARRSourceTitlesSurviveResultCache(t *testing.T) {
 	require.Zero(t, duplicateFiltered)
 	require.Len(t, results, 1)
 	require.Equal(t, []string{"Money Heist"}, results[0].SearchSourceTitles)
+	results[0].SearchRelaxedDifferences = []string{"collection"}
 
 	service.cacheSearchResults(1, "source", results, 5)
 	results[0].SearchSourceTitles[0] = "mutated after cache write"
+	results[0].SearchRelaxedDifferences[0] = "mutated after cache write"
 	cached := service.getCachedSearchResults(1, "source")
 	require.NotNil(t, cached)
 	require.Equal(t, []string{"Money Heist"}, cached.results[0].SearchSourceTitles)
+	require.Equal(t, []string{"collection"}, cached.results[0].SearchRelaxedDifferences)
 	cached.results[0].SearchSourceTitles[0] = "mutated after cache read"
+	cached.results[0].SearchRelaxedDifferences[0] = "mutated after cache read"
 	require.Equal(t, []string{"Money Heist"}, service.getCachedSearchResults(1, "source").results[0].SearchSourceTitles)
+	require.Equal(t, []string{"collection"}, service.getCachedSearchResults(1, "source").results[0].SearchRelaxedDifferences)
 
 	rejected := service.classifySearchCandidate(searchCandidateInput{
 		SourceRelease:    &source,
@@ -388,20 +393,32 @@ func TestClassifySearchCandidateExactSizeTVAndContentIdentity(t *testing.T) {
 
 func TestSearchCandidateInternalMetadataIsNotJSON(t *testing.T) {
 	resultBytes, err := json.Marshal(TorrentSearchResult{
-		Title:               "candidate",
-		SearchDecisionClass: searchCandidateClassExactSizeFallback,
-		SearchSourceTitles:  []string{"ARR secret result alias"},
+		Title:                      "candidate",
+		SearchDecisionClass:        searchCandidateClassExactSizeFallback,
+		SearchStrictMismatchReason: "secret mismatch",
+		SearchRelaxedDifferences:   []string{"secret difference"},
+		SearchSourceTitles:         []string{"ARR secret result alias"},
 	})
 	require.NoError(t, err)
 	require.NotContains(t, string(resultBytes), "exact-size-fallback")
+	require.NotContains(t, string(resultBytes), "secret mismatch")
+	require.NotContains(t, string(resultBytes), "secret difference")
 	require.NotContains(t, string(resultBytes), "ARR secret result alias")
 
 	requestBytes, err := json.Marshal(CrossSeedRequest{
-		SearchDecisionClass: searchCandidateClassExactSizeFallback,
-		SearchSourceTitles:  []string{"ARR secret request alias"},
+		SearchDecisionClass:        searchCandidateClassExactSizeFallback,
+		SearchSourceInstanceID:     12345,
+		SearchSourceHash:           "secret source hash",
+		SearchStrictMismatchReason: "secret request mismatch",
+		SearchRelaxedDifferences:   []string{"secret request difference"},
+		SearchSourceTitles:         []string{"ARR secret request alias"},
 	})
 	require.NoError(t, err)
 	require.NotContains(t, string(requestBytes), "exact-size-fallback")
+	require.NotContains(t, string(requestBytes), "12345")
+	require.NotContains(t, string(requestBytes), "secret source hash")
+	require.NotContains(t, string(requestBytes), "secret request mismatch")
+	require.NotContains(t, string(requestBytes), "secret request difference")
 	require.NotContains(t, string(requestBytes), "ARR secret request alias")
 }
 
@@ -437,13 +454,15 @@ func TestExecuteCrossSeedSearchAttemptPropagatesExactSizeDecision(t *testing.T) 
 	}
 	state := &searchRunState{opts: SearchRunOptions{InstanceID: 1}}
 	match := TorrentSearchResult{
-		Indexer:             "Indexer",
-		IndexerID:           7,
-		Title:               "candidate",
-		DownloadURL:         "https://example.invalid/candidate.torrent",
-		Size:                size,
-		SearchDecisionClass: searchCandidateClassExactSizeFallback,
-		SearchSourceTitles:  sourceTitles,
+		Indexer:                    "Indexer",
+		IndexerID:                  7,
+		Title:                      "candidate",
+		DownloadURL:                "https://example.invalid/candidate.torrent",
+		Size:                       size,
+		SearchDecisionClass:        searchCandidateClassExactSizeFallback,
+		SearchStrictMismatchReason: "collection mismatch",
+		SearchRelaxedDifferences:   []string{"collection"},
+		SearchSourceTitles:         sourceTitles,
 	}
 
 	result, err := service.executeCrossSeedSearchAttempt(
@@ -458,16 +477,21 @@ func TestExecuteCrossSeedSearchAttemptPropagatesExactSizeDecision(t *testing.T) 
 	require.Equal(t, models.CrossSeedSearchResultStatusAdded, result.Status)
 	require.NotNil(t, captured)
 	require.Equal(t, searchCandidateClassExactSizeFallback, captured.SearchDecisionClass)
+	require.Equal(t, 1, captured.SearchSourceInstanceID)
+	require.Equal(t, "source", captured.SearchSourceHash)
+	require.Equal(t, "collection mismatch", captured.SearchStrictMismatchReason)
+	require.Equal(t, []string{"collection"}, captured.SearchRelaxedDifferences)
 	require.Equal(t, sourceTitles, captured.SearchSourceTitles)
 }
 
 func TestFindCandidatesExactSizeFallbackIsScopedAndContinuesToFileValidation(t *testing.T) {
 	const (
-		instanceID   = 1
-		torrentSize  = int64(94_329_473_840)
-		targetName   = "Example.Show.2024.S01.2160p.ATVP.WEB-DL.DV.HDR10+.H.265-NTb"
-		existingName = "Example.Show.2024.S01.2160p.ATV.WEB-DL.DV.HDR.H.265-NTb"
-		existingHash = "existing"
+		instanceID    = 1
+		torrentSize   = int64(94_329_473_840)
+		targetName    = "Example.Show.2024.S01.2160p.ATVP.WEB-DL.DV.HDR10+.H.265-NTb"
+		existingName  = "Example.Show.2024.S01.2160p.ATV.WEB-DL.DV.HDR.H.265-NTb"
+		existingHash  = "existing"
+		unrelatedHash = "unrelated"
 	)
 	instance := &models.Instance{ID: instanceID, Name: "main"}
 	existing := qbt.Torrent{
@@ -478,8 +502,16 @@ func TestFindCandidatesExactSizeFallbackIsScopedAndContinuesToFileValidation(t *
 		Size:     torrentSize + 1,
 		Progress: 1,
 	}
+	unrelated := existing
+	unrelated.Hash = unrelatedHash
 	files := map[string]qbt.TorrentFiles{
 		existingHash: {
+			{
+				Name: "Example.Show.2024.S01E01.2160p.ATV.WEB-DL.DV.HDR.H.265-NTb.mkv",
+				Size: torrentSize,
+			},
+		},
+		unrelatedHash: {
 			{
 				Name: "Example.Show.2024.S01E01.2160p.ATV.WEB-DL.DV.HDR.H.265-NTb.mkv",
 				Size: torrentSize,
@@ -488,9 +520,34 @@ func TestFindCandidatesExactSizeFallbackIsScopedAndContinuesToFileValidation(t *
 	}
 	service := &Service{
 		instanceStore:    &fakeInstanceStore{instances: map[int]*models.Instance{instanceID: instance}},
-		syncManager:      newFakeSyncManager(instance, []qbt.Torrent{existing}, files),
+		syncManager:      newFakeSyncManager(instance, []qbt.Torrent{existing, unrelated}, files),
 		releaseCache:     NewReleaseCache(),
 		stringNormalizer: stringutils.NewDefaultNormalizer(),
+	}
+	sourceRelease := rls.ParseString(existingName)
+	targetRelease := rls.ParseString(targetName)
+	decision := service.classifySearchCandidate(searchCandidateInput{
+		SourceRelease:    &sourceRelease,
+		CandidateRelease: &targetRelease,
+		SourceName:       existingName,
+		CandidateName:    targetName,
+		SourceSize:       torrentSize,
+		CandidateSize:    torrentSize,
+		TolerancePercent: 5,
+	})
+	require.True(t, decision.Accepted)
+	require.Equal(t, searchCandidateClassExactSizeFallback, decision.Class)
+
+	fallbackRequest := func() *FindCandidatesRequest {
+		return &FindCandidatesRequest{
+			TorrentName:                targetName,
+			TargetInstanceIDs:          []int{instanceID},
+			SearchDecisionClass:        decision.Class,
+			SearchSourceInstanceID:     instanceID,
+			SearchSourceHash:           existingHash,
+			SearchStrictMismatchReason: decision.StrictMismatchReason,
+			SearchRelaxedDifferences:   append([]string(nil), decision.RelaxedDifferences...),
+		}
 	}
 
 	directResponse, err := service.FindCandidates(context.Background(), &FindCandidatesRequest{
@@ -500,16 +557,34 @@ func TestFindCandidatesExactSizeFallbackIsScopedAndContinuesToFileValidation(t *
 	require.NoError(t, err)
 	require.Empty(t, directResponse.Candidates, "direct requests must retain strict release matching")
 
-	fallbackResponse, err := service.FindCandidates(context.Background(), &FindCandidatesRequest{
-		TorrentName:       targetName,
-		TargetInstanceIDs: []int{instanceID},
-		ExactSizeFallback: true,
-	})
+	fallbackResponse, err := service.FindCandidates(context.Background(), fallbackRequest())
 	require.NoError(t, err)
 	require.Len(t, fallbackResponse.Candidates, 1)
 	require.Len(t, fallbackResponse.Candidates[0].Torrents, 1)
 	require.Equal(t, existingHash, fallbackResponse.Candidates[0].Torrents[0].Hash)
 	require.NotEmpty(t, fallbackResponse.Candidates[0].MatchType)
+
+	unrecordedDifferenceRequest := fallbackRequest()
+	unrecordedDifferenceRequest.SearchRelaxedDifferences = []string{"hdr"}
+	unrecordedDifferenceResponse, err := service.FindCandidates(context.Background(), unrecordedDifferenceRequest)
+	require.NoError(t, err)
+	require.Empty(t, unrecordedDifferenceResponse.Candidates, "fallback must retain the search-recorded relaxation")
+
+	for name, hardMismatchTitle := range map[string]string{
+		"title":      "Different.Show.2024.S01.2160p.ATVP.WEB-DL.DV.HDR10+.H.265-NTb",
+		"season":     "Example.Show.2024.S02.2160p.ATVP.WEB-DL.DV.HDR10+.H.265-NTb",
+		"episode":    "Example.Show.2024.S01E02.2160p.ATVP.WEB-DL.DV.HDR10+.H.265-NTb",
+		"resolution": "Example.Show.2024.S01.1080p.ATVP.WEB-DL.DV.HDR10+.H.265-NTb",
+		"group":      "Example.Show.2024.S01.2160p.ATVP.WEB-DL.DV.HDR10+.H.265-FLUX",
+	} {
+		t.Run("retains strict "+name, func(t *testing.T) {
+			request := fallbackRequest()
+			request.TorrentName = hardMismatchTitle
+			response, findErr := service.FindCandidates(context.Background(), request)
+			require.NoError(t, findErr)
+			require.Empty(t, response.Candidates)
+		})
+	}
 
 	incompatibleFiles := map[string]qbt.TorrentFiles{
 		existingHash: {
@@ -525,11 +600,7 @@ func TestFindCandidatesExactSizeFallbackIsScopedAndContinuesToFileValidation(t *
 		releaseCache:     NewReleaseCache(),
 		stringNormalizer: stringutils.NewDefaultNormalizer(),
 	}
-	incompatibleResponse, err := incompatibleService.FindCandidates(context.Background(), &FindCandidatesRequest{
-		TorrentName:       targetName,
-		TargetInstanceIDs: []int{instanceID},
-		ExactSizeFallback: true,
-	})
+	incompatibleResponse, err := incompatibleService.FindCandidates(context.Background(), fallbackRequest())
 	require.NoError(t, err)
 	require.Empty(t, incompatibleResponse.Candidates, "fallback must not bypass file-level release validation")
 }

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -4001,33 +4001,13 @@ func (s *Service) findCandidates(ctx context.Context, req *FindCandidatesRequest
 				req.FindIndividualEpisodes,
 			)
 			if !releasesMatch {
-				exactSizeIdentity := req.ExactSizeFallback &&
-					positiveExactSize(req.TorrentSize, torrent.Size)
-				if exactSizeIdentity {
-					var reason string
-					exactSizeIdentity, reason = s.validateExactSizeSearchIdentity(searchCandidateInput{
-						SourceRelease:          targetRelease,
-						CandidateRelease:       candidateRelease,
-						SourceName:             req.TorrentName,
-						CandidateName:          torrent.Name,
-						CandidateTitles:        req.SearchSourceTitles,
-						SourceSize:             req.TorrentSize,
-						CandidateSize:          torrent.Size,
-						FindIndividualEpisodes: req.FindIndividualEpisodes,
-					})
-					if !exactSizeIdentity {
-						log.Debug().
-							Str("targetTitle", req.TorrentName).
-							Str("existingTorrent", torrent.Name).
-							Int64("targetSize", req.TorrentSize).
-							Int64("existingSize", torrent.Size).
-							Str("rejectReason", reason).
-							Msg("[CROSSSEED] Exact-size search fallback failed candidate identity prefilter")
-					}
-				}
-				if !exactSizeIdentity {
+				if !req.ExactSizeFallback {
 					continue
 				}
+				log.Debug().
+					Str("targetTitle", req.TorrentName).
+					Str("existingTorrent", torrent.Name).
+					Msg("[CROSSSEED] Search-origin exact-size fallback bypassed strict release prefilter")
 			}
 
 			hashKey := normalizeHash(torrent.Hash)
@@ -4147,15 +4127,6 @@ func (s *Service) CrossSeed(ctx context.Context, req *CrossSeedRequest) (*CrossS
 		torrentHash = meta.HashV2
 	}
 	sourceRelease := s.releaseCache.Parse(meta.Name)
-	var actualTorrentSize int64
-	for _, file := range meta.Files {
-		actualTorrentSize += file.Size
-	}
-	if req.SearchDecisionClass == searchCandidateClassExactSizeFallback {
-		if req.AdvertisedCandidateSize <= 0 || actualTorrentSize != req.AdvertisedCandidateSize {
-			return nil, exactSizeFallbackValidationError(req.AdvertisedCandidateSize, actualTorrentSize)
-		}
-	}
 
 	// Use FindCandidates to locate matching torrents
 	findReq := &FindCandidatesRequest{
@@ -4163,7 +4134,6 @@ func (s *Service) CrossSeed(ctx context.Context, req *CrossSeedRequest) (*CrossS
 		TargetInstanceIDs:      req.TargetInstanceIDs,
 		FindIndividualEpisodes: req.FindIndividualEpisodes,
 		ExactSizeFallback:      req.SearchDecisionClass == searchCandidateClassExactSizeFallback,
-		TorrentSize:            actualTorrentSize,
 		SearchSourceTitles:     slices.Clone(req.SearchSourceTitles),
 	}
 	// Pass through source filters for RSS automation
@@ -4201,8 +4171,12 @@ func (s *Service) CrossSeed(ctx context.Context, req *CrossSeedRequest) (*CrossS
 
 	if response.TorrentInfo != nil {
 		response.TorrentInfo.TotalFiles = len(meta.Files)
-		if actualTorrentSize > 0 {
-			response.TorrentInfo.Size = actualTorrentSize
+		var totalSize int64
+		for _, f := range meta.Files {
+			totalSize += f.Size
+		}
+		if totalSize > 0 {
+			response.TorrentInfo.Size = totalSize
 		}
 	}
 
@@ -8466,7 +8440,6 @@ func (s *Service) ApplyTorrentSearchResults(ctx context.Context, instanceID int,
 				SkipPieceBoundarySafetyCheck: skipPieceBoundarySafetyCheck,
 				SearchDecisionClass:          cachedResult.SearchDecisionClass,
 				SearchSourceTitles:           slices.Clone(cachedResult.SearchSourceTitles),
-				AdvertisedCandidateSize:      cachedResult.Size,
 			}
 			payload.SizeMismatchTolerancePercent = cachedSearchResults.sizeMismatchTolerancePercent
 			payload.SizeMismatchTolerancePercentSet = true
@@ -9878,7 +9851,6 @@ func (s *Service) executeCrossSeedSearchAttempt(ctx context.Context, state *sear
 		SourceFilterExcludeTags:       append([]string(nil), state.opts.ExcludeTags...),
 		SearchDecisionClass:           match.SearchDecisionClass,
 		SearchSourceTitles:            slices.Clone(match.SearchSourceTitles),
-		AdvertisedCandidateSize:       match.Size,
 	}
 	if state.opts.CategoryOverride != nil && strings.TrimSpace(*state.opts.CategoryOverride) != "" {
 		cat := *state.opts.CategoryOverride

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -7822,7 +7822,6 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 	}
 
 	scored := make([]scoredTorrentSearchResult, 0, len(searchResults))
-	seen := make(map[string]struct{})
 	sizeFilteredCount := 0
 	releaseFilteredCount := 0
 	releaseFilterReasons := make(map[string]int)
@@ -7831,17 +7830,6 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 	exactSizeHardRejected := 0
 
 	for _, res := range searchResults {
-		key := res.GUID
-		if key == "" {
-			key = res.DownloadURL
-		}
-		if key != "" {
-			if _, exists := seen[key]; exists {
-				continue
-			}
-			seen[key] = struct{}{}
-		}
-
 		candidateRelease := s.releaseCache.Parse(res.Title)
 		// Search has only qBittorrent's wanted source size and Torznab's advertised
 		// candidate size. Positive exact equality may replace soft release metadata;
@@ -7928,6 +7916,12 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 		})
 	}
 
+	// Classify every result before deduplication, then use the existing evidence
+	// ordering so a rejected or tolerance-only occurrence cannot hide an exact-size
+	// occurrence with the same GUID/download URL. Keyless results remain distinct.
+	sortScoredTorrentSearchResults(scored)
+	scored = deduplicateScoredTorrentSearchResults(scored)
+
 	// Log filtering statistics
 	totalResults := len(searchResults)
 	matchedResults := len(scored)
@@ -7969,8 +7963,6 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 		sourceInfo.FileCount = len(sourceFiles)
 	}
 
-	sortScoredTorrentSearchResults(scored)
-
 	results, duplicateFilteredCount, err := s.buildTorrentSearchResults(ctx, instanceID, sourceTorrent.Hash, scored, limit)
 	if err != nil {
 		return nil, gazelleLookupAttempted, remoteRequestsMade, err
@@ -8010,6 +8002,27 @@ func sortScoredTorrentSearchResults(scored []scoredTorrentSearchResult) {
 		}
 		return scored[i].score > scored[j].score
 	})
+}
+
+func deduplicateScoredTorrentSearchResults(scored []scoredTorrentSearchResult) []scoredTorrentSearchResult {
+	seen := make(map[string]struct{}, len(scored))
+	deduplicated := scored[:0]
+	for _, item := range scored {
+		key := item.result.GUID
+		if key == "" {
+			key = item.result.DownloadURL
+		}
+		if key == "" {
+			deduplicated = append(deduplicated, item)
+			continue
+		}
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		deduplicated = append(deduplicated, item)
+	}
+	return deduplicated
 }
 
 type scoredTorrentSearchResult struct {

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -3989,11 +3989,10 @@ func (s *Service) findCandidates(ctx context.Context, req *FindCandidatesRequest
 
 			// Check if releases are related (quick filter). Search-origin ARR aliases
 			// belong to the existing torrent, which is the candidate in this reversed
-			// apply-stage comparison. An exact-size fallback already established byte
-			// equality from qBittorrent and Torznab during search, so its private marker
-			// may bypass this duplicate release check. File matching below and the later
-			// apply safety checks remain unchanged and authoritative.
-			releasesMatch, _ := s.releasesMatchWithReasonAndNamesAndTitles(
+			// apply-stage comparison. Exact-size provenance may relax only the recorded
+			// soft differences for the specific torrent whose qBittorrent size supplied
+			// the search evidence. File matching and later safety checks still run.
+			releasesMatch, mismatchReason := s.releasesMatchWithReasonAndNamesAndTitles(
 				targetRelease,
 				candidateRelease,
 				req.TorrentName,
@@ -4003,13 +4002,34 @@ func (s *Service) findCandidates(ctx context.Context, req *FindCandidatesRequest
 				req.FindIndividualEpisodes,
 			)
 			if !releasesMatch {
-				if !req.ExactSizeFallback {
+				hashKey := normalizeHash(torrent.Hash)
+				searchSourceHash := normalizeHash(req.SearchSourceHash)
+				isExactSizeSource := req.SearchDecisionClass == searchCandidateClassExactSizeFallback &&
+					req.SearchSourceInstanceID == instanceID &&
+					searchSourceHash != "" && hashKey == searchSourceHash
+				if !isExactSizeSource {
+					continue
+				}
+
+				fallbackInput := searchCandidateInput{
+					SourceRelease:          candidateRelease,
+					CandidateRelease:       targetRelease,
+					SourceName:             torrent.Name,
+					CandidateName:          req.TorrentName,
+					SourceTitles:           req.SearchSourceTitles,
+					FindIndividualEpisodes: req.FindIndividualEpisodes,
+				}
+				if ok, _ := s.validateExactSizeFallback(fallbackInput, mismatchReason, req.SearchRelaxedDifferences); !ok {
 					continue
 				}
 				log.Debug().
 					Str("targetTitle", req.TorrentName).
 					Str("existingTorrent", torrent.Name).
-					Msg("[CROSSSEED] Search-origin exact-size fallback bypassed strict release prefilter")
+					Str("sourceHash", hashKey).
+					Str("searchMismatchReason", req.SearchStrictMismatchReason).
+					Str("applyMismatchReason", mismatchReason).
+					Strs("relaxedDifferences", req.SearchRelaxedDifferences).
+					Msg("[CROSSSEED] Search-origin exact-size fallback relaxed release prefilter")
 			}
 
 			hashKey := normalizeHash(torrent.Hash)
@@ -4130,16 +4150,19 @@ func (s *Service) CrossSeed(ctx context.Context, req *CrossSeedRequest) (*CrossS
 	}
 	sourceRelease := s.releaseCache.Parse(meta.Name)
 
-	// Carry only the private search decision into candidate discovery. Exact byte
-	// equality is not recalculated from downloaded metainfo: the marker merely
-	// prevents the quick release prefilter from undoing search admission, after
-	// which the existing file and apply safety checks run normally.
+	// Carry private search provenance into candidate discovery. Source identity
+	// and recorded soft differences constrain the release-prefilter relaxation;
+	// existing file and apply safety checks still run normally.
 	findReq := &FindCandidatesRequest{
-		TorrentName:            meta.Name,
-		TargetInstanceIDs:      req.TargetInstanceIDs,
-		FindIndividualEpisodes: req.FindIndividualEpisodes,
-		ExactSizeFallback:      req.SearchDecisionClass == searchCandidateClassExactSizeFallback,
-		SearchSourceTitles:     slices.Clone(req.SearchSourceTitles),
+		TorrentName:                meta.Name,
+		TargetInstanceIDs:          req.TargetInstanceIDs,
+		FindIndividualEpisodes:     req.FindIndividualEpisodes,
+		SearchDecisionClass:        req.SearchDecisionClass,
+		SearchSourceInstanceID:     req.SearchSourceInstanceID,
+		SearchSourceHash:           req.SearchSourceHash,
+		SearchStrictMismatchReason: req.SearchStrictMismatchReason,
+		SearchRelaxedDifferences:   slices.Clone(req.SearchRelaxedDifferences),
+		SearchSourceTitles:         slices.Clone(req.SearchSourceTitles),
 	}
 	// Pass through source filters for RSS automation
 	if len(req.SourceFilterCategories) > 0 {
@@ -7894,12 +7917,14 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 			Msg("[CROSSSEED-SEARCH] Candidate accepted")
 
 		scored = append(scored, scoredTorrentSearchResult{
-			result:       res,
-			score:        decision.Score,
-			reason:       decision.MatchReason,
-			sizeEvidence: decision.SizeEvidence,
-			class:        decision.Class,
-			sourceTitles: decision.SourceTitles,
+			result:               res,
+			score:                decision.Score,
+			reason:               decision.MatchReason,
+			sizeEvidence:         decision.SizeEvidence,
+			class:                decision.Class,
+			strictMismatchReason: decision.StrictMismatchReason,
+			relaxedDifferences:   decision.RelaxedDifferences,
+			sourceTitles:         decision.SourceTitles,
 		})
 	}
 
@@ -7988,12 +8013,14 @@ func sortScoredTorrentSearchResults(scored []scoredTorrentSearchResult) {
 }
 
 type scoredTorrentSearchResult struct {
-	result       jackett.SearchResult
-	score        float64
-	reason       string
-	sizeEvidence searchSizeEvidence
-	class        searchCandidateClass
-	sourceTitles []string
+	result               jackett.SearchResult
+	score                float64
+	reason               string
+	sizeEvidence         searchSizeEvidence
+	class                searchCandidateClass
+	strictMismatchReason string
+	relaxedDifferences   []string
+	sourceTitles         []string
 }
 
 func searchCandidateClassPriority(class searchCandidateClass) int {
@@ -8190,7 +8217,15 @@ func (s *Service) buildTorrentSearchResults(ctx context.Context, instanceID int,
 							Str("existingName", existing.Name)
 					}
 					event.Msg("[CROSSSEED-SEARCH] Keeping duplicate search result because existing torrent was rejected by content prefilter")
-					results = append(results, torrentSearchResultFromJackett(res, item.reason, item.score, item.class, item.sourceTitles))
+					results = append(results, torrentSearchResultFromJackett(
+						res,
+						item.reason,
+						item.score,
+						item.class,
+						item.strictMismatchReason,
+						item.relaxedDifferences,
+						item.sourceTitles,
+					))
 					if len(results) >= limit {
 						break
 					}
@@ -8214,7 +8249,15 @@ func (s *Service) buildTorrentSearchResults(ctx context.Context, instanceID int,
 			}
 		}
 
-		results = append(results, torrentSearchResultFromJackett(res, item.reason, item.score, item.class, item.sourceTitles))
+		results = append(results, torrentSearchResultFromJackett(
+			res,
+			item.reason,
+			item.score,
+			item.class,
+			item.strictMismatchReason,
+			item.relaxedDifferences,
+			item.sourceTitles,
+		))
 		if len(results) >= limit {
 			break
 		}
@@ -8223,30 +8266,40 @@ func (s *Service) buildTorrentSearchResults(ctx context.Context, instanceID int,
 	return results, duplicateFilteredCount, nil
 }
 
-func torrentSearchResultFromJackett(res jackett.SearchResult, reason string, score float64, class searchCandidateClass, sourceTitles []string) TorrentSearchResult {
+func torrentSearchResultFromJackett(
+	res jackett.SearchResult,
+	reason string,
+	score float64,
+	class searchCandidateClass,
+	strictMismatchReason string,
+	relaxedDifferences []string,
+	sourceTitles []string,
+) TorrentSearchResult {
 	return TorrentSearchResult{
-		Indexer:              res.Indexer,
-		IndexerID:            res.IndexerID,
-		Title:                res.Title,
-		DownloadURL:          res.DownloadURL,
-		InfoURL:              res.InfoURL,
-		Size:                 res.Size,
-		Seeders:              res.Seeders,
-		Leechers:             res.Leechers,
-		CategoryID:           res.CategoryID,
-		CategoryName:         res.CategoryName,
-		PublishDate:          res.PublishDate.Format(time.RFC3339),
-		DownloadVolumeFactor: res.DownloadVolumeFactor,
-		UploadVolumeFactor:   res.UploadVolumeFactor,
-		GUID:                 res.GUID,
-		InfoHashV1:           strings.TrimSpace(res.InfoHashV1),
-		InfoHashV2:           strings.TrimSpace(res.InfoHashV2),
-		IMDbID:               res.IMDbID,
-		TVDbID:               res.TVDbID,
-		MatchReason:          reason,
-		MatchScore:           score,
-		SearchDecisionClass:  class,
-		SearchSourceTitles:   slices.Clone(sourceTitles),
+		Indexer:                    res.Indexer,
+		IndexerID:                  res.IndexerID,
+		Title:                      res.Title,
+		DownloadURL:                res.DownloadURL,
+		InfoURL:                    res.InfoURL,
+		Size:                       res.Size,
+		Seeders:                    res.Seeders,
+		Leechers:                   res.Leechers,
+		CategoryID:                 res.CategoryID,
+		CategoryName:               res.CategoryName,
+		PublishDate:                res.PublishDate.Format(time.RFC3339),
+		DownloadVolumeFactor:       res.DownloadVolumeFactor,
+		UploadVolumeFactor:         res.UploadVolumeFactor,
+		GUID:                       res.GUID,
+		InfoHashV1:                 strings.TrimSpace(res.InfoHashV1),
+		InfoHashV2:                 strings.TrimSpace(res.InfoHashV2),
+		IMDbID:                     res.IMDbID,
+		TVDbID:                     res.TVDbID,
+		MatchReason:                reason,
+		MatchScore:                 score,
+		SearchDecisionClass:        class,
+		SearchStrictMismatchReason: strictMismatchReason,
+		SearchRelaxedDifferences:   slices.Clone(relaxedDifferences),
+		SearchSourceTitles:         slices.Clone(sourceTitles),
 	}
 }
 
@@ -8447,6 +8500,10 @@ func (s *Service) ApplyTorrentSearchResults(ctx context.Context, instanceID int,
 				SkipRecheck:                  skipRecheck,
 				SkipPieceBoundarySafetyCheck: skipPieceBoundarySafetyCheck,
 				SearchDecisionClass:          cachedResult.SearchDecisionClass,
+				SearchSourceInstanceID:       instanceID,
+				SearchSourceHash:             hash,
+				SearchStrictMismatchReason:   cachedResult.SearchStrictMismatchReason,
+				SearchRelaxedDifferences:     slices.Clone(cachedResult.SearchRelaxedDifferences),
 				SearchSourceTitles:           slices.Clone(cachedResult.SearchSourceTitles),
 			}
 			payload.SizeMismatchTolerancePercent = cachedSearchResults.sizeMismatchTolerancePercent
@@ -8676,6 +8733,7 @@ func cloneTorrentSearchResults(results []TorrentSearchResult) []TorrentSearchRes
 	cloned := make([]TorrentSearchResult, len(results))
 	copy(cloned, results)
 	for i := range cloned {
+		cloned[i].SearchRelaxedDifferences = slices.Clone(results[i].SearchRelaxedDifferences)
 		cloned[i].SearchSourceTitles = slices.Clone(results[i].SearchSourceTitles)
 	}
 	return cloned
@@ -9858,6 +9916,10 @@ func (s *Service) executeCrossSeedSearchAttempt(ctx context.Context, state *sear
 		SourceFilterExcludeCategories: append([]string(nil), state.opts.ExcludeCategories...),
 		SourceFilterExcludeTags:       append([]string(nil), state.opts.ExcludeTags...),
 		SearchDecisionClass:           match.SearchDecisionClass,
+		SearchSourceInstanceID:        state.opts.InstanceID,
+		SearchSourceHash:              torrent.Hash,
+		SearchStrictMismatchReason:    match.SearchStrictMismatchReason,
+		SearchRelaxedDifferences:      slices.Clone(match.SearchRelaxedDifferences),
 		SearchSourceTitles:            slices.Clone(match.SearchSourceTitles),
 	}
 	if state.opts.CategoryOverride != nil && strings.TrimSpace(*state.opts.CategoryOverride) != "" {

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -7825,8 +7825,11 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 	releaseFilteredCount := 0
 	releaseFilterReasons := make(map[string]int)
 	exactSizeCandidates := 0
+	torznabFloat32Candidates := 0
 	exactSizeFallbackAccepted := 0
+	torznabFloat32FallbackAccepted := 0
 	exactSizeHardRejected := 0
+	torznabFloat32HardRejected := 0
 
 	for _, res := range searchResults {
 		key := res.GUID
@@ -7852,8 +7855,12 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 			TolerancePercent:       tolerancePercent,
 			FindIndividualEpisodes: opts.FindIndividualEpisodes,
 		})
-		if decision.ExactSize {
+		switch decision.SizeEvidence {
+		case searchSizeEvidenceExact:
 			exactSizeCandidates++
+		case searchSizeEvidenceTorznabFloat32:
+			torznabFloat32Candidates++
+		case searchSizeEvidenceNone:
 		}
 		if !decision.Accepted {
 			if decision.SizeRejected {
@@ -7875,8 +7882,14 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 					"[CROSSSEED-SEARCH] Candidate rejected by search classifier",
 				)
 			}
-			if decision.ExactSize && decision.StrictMismatchReason != "" {
-				exactSizeHardRejected++
+			if decision.StrictMismatchReason != "" {
+				switch decision.SizeEvidence {
+				case searchSizeEvidenceExact:
+					exactSizeHardRejected++
+				case searchSizeEvidenceTorznabFloat32:
+					torznabFloat32HardRejected++
+				case searchSizeEvidenceNone:
+				}
 			}
 			log.Debug().
 				Int("indexerID", res.IndexerID).
@@ -7886,6 +7899,7 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 				Int64("sourceSize", sourceTorrent.Size).
 				Int64("candidateSize", res.Size).
 				Int64("sizeDeltaBytes", res.Size-sourceTorrent.Size).
+				Str("sizeEvidence", string(decision.SizeEvidence)).
 				Str("decisionClass", string(decision.Class)).
 				Str("strictMismatchReason", decision.StrictMismatchReason).
 				Str("rejectReason", decision.RejectReason).
@@ -7895,6 +7909,9 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 
 		if decision.Class == searchCandidateClassExactSizeFallback {
 			exactSizeFallbackAccepted++
+			if decision.SizeEvidence == searchSizeEvidenceTorznabFloat32 {
+				torznabFloat32FallbackAccepted++
+			}
 		}
 		log.Debug().
 			Int("indexerID", res.IndexerID).
@@ -7904,16 +7921,18 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 			Int64("sourceSize", sourceTorrent.Size).
 			Int64("candidateSize", res.Size).
 			Int64("sizeDeltaBytes", res.Size-sourceTorrent.Size).
+			Str("sizeEvidence", string(decision.SizeEvidence)).
 			Str("decisionClass", string(decision.Class)).
 			Str("strictMismatchReason", decision.StrictMismatchReason).
 			Strs("relaxedDifferences", decision.RelaxedDifferences).
 			Msg("[CROSSSEED-SEARCH] Candidate accepted")
 
+		res.Size = canonicalSearchResultSize(decision, sourceTorrent.Size, res.Size)
 		scored = append(scored, scoredTorrentSearchResult{
 			result:       res,
 			score:        decision.Score,
 			reason:       decision.MatchReason,
-			exactSize:    decision.ExactSize,
+			sizeEvidence: decision.SizeEvidence,
 			class:        decision.Class,
 			sourceTitles: decision.SourceTitles,
 		})
@@ -7930,8 +7949,11 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 		Int("lateContentFiltered", lateExcludedCount).
 		Int("finalMatches", matchedResults).
 		Int("exactSizeCandidates", exactSizeCandidates).
+		Int("torznabFloat32Candidates", torznabFloat32Candidates).
 		Int("exactSizeFallbackAccepted", exactSizeFallbackAccepted).
+		Int("torznabFloat32FallbackAccepted", torznabFloat32FallbackAccepted).
 		Int("exactSizeHardRejected", exactSizeHardRejected).
+		Int("torznabFloat32HardRejected", torznabFloat32HardRejected).
 		Float64("tolerancePercent", tolerancePercent).
 		Msg("[CROSSSEED-SEARCH] Search filtering completed")
 
@@ -7987,8 +8009,8 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 
 func sortScoredTorrentSearchResults(scored []scoredTorrentSearchResult) {
 	sort.SliceStable(scored, func(i, j int) bool {
-		if scored[i].exactSize != scored[j].exactSize {
-			return scored[i].exactSize
+		if scored[i].sizeEvidence != scored[j].sizeEvidence {
+			return scored[i].sizeEvidence.priority() > scored[j].sizeEvidence.priority()
 		}
 		if scored[i].class != scored[j].class {
 			return searchCandidateClassPriority(scored[i].class) > searchCandidateClassPriority(scored[j].class)
@@ -8007,9 +8029,21 @@ type scoredTorrentSearchResult struct {
 	result       jackett.SearchResult
 	score        float64
 	reason       string
-	exactSize    bool
+	sizeEvidence searchSizeEvidence
 	class        searchCandidateClass
 	sourceTitles []string
+}
+
+func canonicalSearchResultSize(decision searchCandidateDecision, sourceSize, candidateSize int64) int64 {
+	// Downstream exact-size validation remains literal. For an admitted legacy
+	// Torznab result, carry the exact source size that the reported float32 value
+	// represents; a different downloaded metainfo size will still be rejected.
+	if decision.Accepted &&
+		decision.Class == searchCandidateClassExactSizeFallback &&
+		decision.SizeEvidence == searchSizeEvidenceTorznabFloat32 {
+		return sourceSize
+	}
+	return candidateSize
 }
 
 func searchCandidateClassPriority(class searchCandidateClass) int {

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -3987,10 +3987,20 @@ func (s *Service) findCandidates(ctx context.Context, req *FindCandidatesRequest
 				continue
 			}
 
-			// Check if releases are related (quick filter). Only search-origin
-			// exact-size fallbacks may defer soft metadata differences to the normal
-			// file-level validation below.
-			if !s.releasesMatch(targetRelease, candidateRelease, req.FindIndividualEpisodes) {
+			// Check if releases are related (quick filter). Search-origin ARR aliases
+			// belong to the existing torrent, which is the candidate in this reversed
+			// apply-stage comparison. Only exact-size fallbacks may defer remaining
+			// soft metadata differences to the normal file-level validation below.
+			releasesMatch, _ := s.releasesMatchWithReasonAndNamesAndTitles(
+				targetRelease,
+				candidateRelease,
+				req.TorrentName,
+				torrent.Name,
+				nil,
+				req.SearchSourceTitles,
+				req.FindIndividualEpisodes,
+			)
+			if !releasesMatch {
 				exactSizeIdentity := req.ExactSizeFallback &&
 					positiveExactSize(req.TorrentSize, torrent.Size)
 				if exactSizeIdentity {
@@ -4000,6 +4010,7 @@ func (s *Service) findCandidates(ctx context.Context, req *FindCandidatesRequest
 						CandidateRelease:       candidateRelease,
 						SourceName:             req.TorrentName,
 						CandidateName:          torrent.Name,
+						CandidateTitles:        req.SearchSourceTitles,
 						SourceSize:             req.TorrentSize,
 						CandidateSize:          torrent.Size,
 						FindIndividualEpisodes: req.FindIndividualEpisodes,
@@ -4153,6 +4164,7 @@ func (s *Service) CrossSeed(ctx context.Context, req *CrossSeedRequest) (*CrossS
 		FindIndividualEpisodes: req.FindIndividualEpisodes,
 		ExactSizeFallback:      req.SearchDecisionClass == searchCandidateClassExactSizeFallback,
 		TorrentSize:            actualTorrentSize,
+		SearchSourceTitles:     slices.Clone(req.SearchSourceTitles),
 	}
 	// Pass through source filters for RSS automation
 	if len(req.SourceFilterCategories) > 0 {
@@ -7898,11 +7910,12 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 			Msg("[CROSSSEED-SEARCH] Candidate accepted")
 
 		scored = append(scored, scoredTorrentSearchResult{
-			result:    res,
-			score:     decision.Score,
-			reason:    decision.MatchReason,
-			exactSize: decision.ExactSize,
-			class:     decision.Class,
+			result:       res,
+			score:        decision.Score,
+			reason:       decision.MatchReason,
+			exactSize:    decision.ExactSize,
+			class:        decision.Class,
+			sourceTitles: decision.SourceTitles,
 		})
 	}
 
@@ -7991,11 +8004,12 @@ func sortScoredTorrentSearchResults(scored []scoredTorrentSearchResult) {
 }
 
 type scoredTorrentSearchResult struct {
-	result    jackett.SearchResult
-	score     float64
-	reason    string
-	exactSize bool
-	class     searchCandidateClass
+	result       jackett.SearchResult
+	score        float64
+	reason       string
+	exactSize    bool
+	class        searchCandidateClass
+	sourceTitles []string
 }
 
 func searchCandidateClassPriority(class searchCandidateClass) int {
@@ -8192,7 +8206,7 @@ func (s *Service) buildTorrentSearchResults(ctx context.Context, instanceID int,
 							Str("existingName", existing.Name)
 					}
 					event.Msg("[CROSSSEED-SEARCH] Keeping duplicate search result because existing torrent was rejected by content prefilter")
-					results = append(results, torrentSearchResultFromJackett(res, item.reason, item.score, item.class))
+					results = append(results, torrentSearchResultFromJackett(res, item.reason, item.score, item.class, item.sourceTitles))
 					if len(results) >= limit {
 						break
 					}
@@ -8216,7 +8230,7 @@ func (s *Service) buildTorrentSearchResults(ctx context.Context, instanceID int,
 			}
 		}
 
-		results = append(results, torrentSearchResultFromJackett(res, item.reason, item.score, item.class))
+		results = append(results, torrentSearchResultFromJackett(res, item.reason, item.score, item.class, item.sourceTitles))
 		if len(results) >= limit {
 			break
 		}
@@ -8225,7 +8239,7 @@ func (s *Service) buildTorrentSearchResults(ctx context.Context, instanceID int,
 	return results, duplicateFilteredCount, nil
 }
 
-func torrentSearchResultFromJackett(res jackett.SearchResult, reason string, score float64, class searchCandidateClass) TorrentSearchResult {
+func torrentSearchResultFromJackett(res jackett.SearchResult, reason string, score float64, class searchCandidateClass, sourceTitles []string) TorrentSearchResult {
 	return TorrentSearchResult{
 		Indexer:              res.Indexer,
 		IndexerID:            res.IndexerID,
@@ -8248,6 +8262,7 @@ func torrentSearchResultFromJackett(res jackett.SearchResult, reason string, sco
 		MatchReason:          reason,
 		MatchScore:           score,
 		SearchDecisionClass:  class,
+		SearchSourceTitles:   slices.Clone(sourceTitles),
 	}
 }
 
@@ -8448,6 +8463,7 @@ func (s *Service) ApplyTorrentSearchResults(ctx context.Context, instanceID int,
 				SkipRecheck:                  skipRecheck,
 				SkipPieceBoundarySafetyCheck: skipPieceBoundarySafetyCheck,
 				SearchDecisionClass:          cachedResult.SearchDecisionClass,
+				SearchSourceTitles:           slices.Clone(cachedResult.SearchSourceTitles),
 				AdvertisedCandidateSize:      cachedResult.Size,
 			}
 			payload.SizeMismatchTolerancePercent = cachedSearchResults.sizeMismatchTolerancePercent
@@ -8648,8 +8664,7 @@ func (s *Service) cacheSearchResults(instanceID int, hash string, results []Torr
 
 	key := searchResultCacheKey(instanceID, hash)
 
-	cloned := make([]TorrentSearchResult, len(results))
-	copy(cloned, results)
+	cloned := cloneTorrentSearchResults(results)
 
 	s.searchResultCache.Set(key, cachedTorrentSearchResults{
 		results:                      cloned,
@@ -8664,8 +8679,7 @@ func (s *Service) getCachedSearchResults(instanceID int, hash string) *cachedTor
 
 	key := searchResultCacheKey(instanceID, hash)
 	if cached, found := s.searchResultCache.Get(key); found {
-		cloned := make([]TorrentSearchResult, len(cached.results))
-		copy(cloned, cached.results)
+		cloned := cloneTorrentSearchResults(cached.results)
 		return &cachedTorrentSearchResults{
 			results:                      cloned,
 			sizeMismatchTolerancePercent: cached.sizeMismatchTolerancePercent,
@@ -8673,6 +8687,15 @@ func (s *Service) getCachedSearchResults(instanceID int, hash string) *cachedTor
 	}
 
 	return nil
+}
+
+func cloneTorrentSearchResults(results []TorrentSearchResult) []TorrentSearchResult {
+	cloned := make([]TorrentSearchResult, len(results))
+	copy(cloned, results)
+	for i := range cloned {
+		cloned[i].SearchSourceTitles = slices.Clone(results[i].SearchSourceTitles)
+	}
+	return cloned
 }
 
 func (s *Service) resolveSelectionFromCache(cached []TorrentSearchResult, selection TorrentSearchSelection) (*TorrentSearchResult, error) {
@@ -9852,6 +9875,7 @@ func (s *Service) executeCrossSeedSearchAttempt(ctx context.Context, state *sear
 		SourceFilterExcludeCategories: append([]string(nil), state.opts.ExcludeCategories...),
 		SourceFilterExcludeTags:       append([]string(nil), state.opts.ExcludeTags...),
 		SearchDecisionClass:           match.SearchDecisionClass,
+		SearchSourceTitles:            slices.Clone(match.SearchSourceTitles),
 		AdvertisedCandidateSize:       match.Size,
 	}
 	if state.opts.CategoryOverride != nil && strings.TrimSpace(*state.opts.CategoryOverride) != "" {

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -3989,8 +3989,10 @@ func (s *Service) findCandidates(ctx context.Context, req *FindCandidatesRequest
 
 			// Check if releases are related (quick filter). Search-origin ARR aliases
 			// belong to the existing torrent, which is the candidate in this reversed
-			// apply-stage comparison. Only exact-size fallbacks may defer remaining
-			// soft metadata differences to the normal file-level validation below.
+			// apply-stage comparison. An exact-size fallback already established byte
+			// equality from qBittorrent and Torznab during search, so its private marker
+			// may bypass this duplicate release check. File matching below and the later
+			// apply safety checks remain unchanged and authoritative.
 			releasesMatch, _ := s.releasesMatchWithReasonAndNamesAndTitles(
 				targetRelease,
 				candidateRelease,
@@ -4128,7 +4130,10 @@ func (s *Service) CrossSeed(ctx context.Context, req *CrossSeedRequest) (*CrossS
 	}
 	sourceRelease := s.releaseCache.Parse(meta.Name)
 
-	// Use FindCandidates to locate matching torrents
+	// Carry only the private search decision into candidate discovery. Exact byte
+	// equality is not recalculated from downloaded metainfo: the marker merely
+	// prevents the quick release prefilter from undoing search admission, after
+	// which the existing file and apply safety checks run normally.
 	findReq := &FindCandidatesRequest{
 		TorrentName:            meta.Name,
 		TargetInstanceIDs:      req.TargetInstanceIDs,
@@ -7815,6 +7820,9 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 		}
 
 		candidateRelease := s.releaseCache.Parse(res.Title)
+		// Search has only qBittorrent's wanted source size and Torznab's advertised
+		// candidate size. Positive exact equality may replace soft release metadata;
+		// the downloaded torrent is inspected later by the normal apply pipeline.
 		decision := s.classifySearchCandidate(searchCandidateInput{
 			SourceRelease:          searchRelease,
 			CandidateRelease:       candidateRelease,

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -3987,9 +3987,36 @@ func (s *Service) findCandidates(ctx context.Context, req *FindCandidatesRequest
 				continue
 			}
 
-			// Check if releases are related (quick filter)
+			// Check if releases are related (quick filter). Only search-origin
+			// exact-size fallbacks may defer soft metadata differences to the normal
+			// file-level validation below.
 			if !s.releasesMatch(targetRelease, candidateRelease, req.FindIndividualEpisodes) {
-				continue
+				exactSizeIdentity := req.ExactSizeFallback &&
+					positiveExactSize(req.TorrentSize, torrent.Size)
+				if exactSizeIdentity {
+					var reason string
+					exactSizeIdentity, reason = s.validateExactSizeSearchIdentity(searchCandidateInput{
+						SourceRelease:          targetRelease,
+						CandidateRelease:       candidateRelease,
+						SourceName:             req.TorrentName,
+						CandidateName:          torrent.Name,
+						SourceSize:             req.TorrentSize,
+						CandidateSize:          torrent.Size,
+						FindIndividualEpisodes: req.FindIndividualEpisodes,
+					})
+					if !exactSizeIdentity {
+						log.Debug().
+							Str("targetTitle", req.TorrentName).
+							Str("existingTorrent", torrent.Name).
+							Int64("targetSize", req.TorrentSize).
+							Int64("existingSize", torrent.Size).
+							Str("rejectReason", reason).
+							Msg("[CROSSSEED] Exact-size search fallback failed candidate identity prefilter")
+					}
+				}
+				if !exactSizeIdentity {
+					continue
+				}
 			}
 
 			hashKey := normalizeHash(torrent.Hash)
@@ -4109,12 +4136,23 @@ func (s *Service) CrossSeed(ctx context.Context, req *CrossSeedRequest) (*CrossS
 		torrentHash = meta.HashV2
 	}
 	sourceRelease := s.releaseCache.Parse(meta.Name)
+	var actualTorrentSize int64
+	for _, file := range meta.Files {
+		actualTorrentSize += file.Size
+	}
+	if req.SearchDecisionClass == searchCandidateClassExactSizeFallback {
+		if req.AdvertisedCandidateSize <= 0 || actualTorrentSize != req.AdvertisedCandidateSize {
+			return nil, exactSizeFallbackValidationError(req.AdvertisedCandidateSize, actualTorrentSize)
+		}
+	}
 
 	// Use FindCandidates to locate matching torrents
 	findReq := &FindCandidatesRequest{
 		TorrentName:            meta.Name,
 		TargetInstanceIDs:      req.TargetInstanceIDs,
 		FindIndividualEpisodes: req.FindIndividualEpisodes,
+		ExactSizeFallback:      req.SearchDecisionClass == searchCandidateClassExactSizeFallback,
+		TorrentSize:            actualTorrentSize,
 	}
 	// Pass through source filters for RSS automation
 	if len(req.SourceFilterCategories) > 0 {
@@ -4151,12 +4189,8 @@ func (s *Service) CrossSeed(ctx context.Context, req *CrossSeedRequest) (*CrossS
 
 	if response.TorrentInfo != nil {
 		response.TorrentInfo.TotalFiles = len(meta.Files)
-		var totalSize int64
-		for _, f := range meta.Files {
-			totalSize += f.Size
-		}
-		if totalSize > 0 {
-			response.TorrentInfo.Size = totalSize
+		if actualTorrentSize > 0 {
+			response.TorrentInfo.Size = actualTorrentSize
 		}
 	}
 
@@ -7014,21 +7048,21 @@ func indexersWithoutResults(requestedIDs []int, results []jackett.SearchResult) 
 	return missing
 }
 
-// searchResultUsable reports whether a primary-pass result would survive the
-// match loop's release/size filtering and become a real cross-seed candidate: a
-// direct release match (or an accepted web-source relabel) that is not a
-// forbidden season-pack pairing and is within size tolerance. It mirrors the
-// match loop's acceptance so both judge a hit's usability by the same rule.
+// searchResultUsable reports whether the shared search classifier accepts a
+// primary-pass result. Keeping this a boolean projection prevents alternate-query
+// scheduling from drifting from the main result loop.
 func (s *Service) searchResultUsable(searchRelease, candidateRelease *rls.Release, sourceName string, sourceSize int64, candidateTitle string, candidateSize int64, arrTitles []string, tolerancePercent float64, findIndividualEpisodes bool) bool {
-	ignoreSizeCheck := findIndividualEpisodes && isTVSeasonPack(searchRelease) && isTVEpisode(candidateRelease)
-	match, mismatchReason := s.releasesMatchWithReasonAndNamesAndTitles(searchRelease, candidateRelease, sourceName, candidateTitle, arrTitles, nil, findIndividualEpisodes)
-	if !match && !s.shouldAcceptWebSourceRelabel(searchRelease, candidateRelease, sourceName, candidateTitle, arrTitles, nil, findIndividualEpisodes, ignoreSizeCheck, sourceSize, candidateSize, tolerancePercent, mismatchReason) {
-		return false
-	}
-	if reject, _ := rejectSeasonPackFromEpisode(candidateRelease, searchRelease, findIndividualEpisodes); reject {
-		return false
-	}
-	return ignoreSizeCheck || s.isSizeWithinTolerance(sourceSize, candidateSize, tolerancePercent)
+	return s.classifySearchCandidate(searchCandidateInput{
+		SourceRelease:          searchRelease,
+		CandidateRelease:       candidateRelease,
+		SourceName:             sourceName,
+		CandidateName:          candidateTitle,
+		SourceTitles:           arrTitles,
+		SourceSize:             sourceSize,
+		CandidateSize:          candidateSize,
+		TolerancePercent:       tolerancePercent,
+		FindIndividualEpisodes: findIndividualEpisodes,
+	}).Accepted
 }
 
 // indexersWithoutUsableResults returns the requested indexer IDs whose primary
@@ -7778,6 +7812,9 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 	sizeFilteredCount := 0
 	releaseFilteredCount := 0
 	releaseFilterReasons := make(map[string]int)
+	exactSizeCandidates := 0
+	exactSizeFallbackAccepted := 0
+	exactSizeHardRejected := 0
 
 	for _, res := range searchResults {
 		key := res.GUID
@@ -7792,88 +7829,80 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 		}
 
 		candidateRelease := s.releaseCache.Parse(res.Title)
-		match, mismatchReason := s.releasesMatchWithReasonAndNamesAndTitles(searchRelease, candidateRelease, sourceTorrent.Name, res.Title, arrTitles, nil, opts.FindIndividualEpisodes)
-		ignoreSizeCheck := opts.FindIndividualEpisodes && isTVSeasonPack(searchRelease) && isTVEpisode(candidateRelease)
-		if !match {
-			// Cross-tracker relabel tolerance: the same web encode is frequently
-			// relabeled WEBRip<->WEB-DL across trackers. When the source label is the
-			// only difference and the candidate is within size tolerance, accept it and
-			// let the apply-stage file-size verification + qBittorrent recheck make the
-			// final call, rather than dropping a byte-identical release on its label.
-			relabelMatch := s.shouldAcceptWebSourceRelabel(
-				searchRelease, candidateRelease,
-				sourceTorrent.Name, res.Title,
-				arrTitles, nil,
-				opts.FindIndividualEpisodes, ignoreSizeCheck,
-				sourceTorrent.Size, res.Size,
-				tolerancePercent, mismatchReason,
-			)
-			if !relabelMatch {
+		decision := s.classifySearchCandidate(searchCandidateInput{
+			SourceRelease:          searchRelease,
+			CandidateRelease:       candidateRelease,
+			SourceName:             sourceTorrent.Name,
+			CandidateName:          res.Title,
+			SourceTitles:           arrTitles,
+			SourceSize:             sourceTorrent.Size,
+			CandidateSize:          res.Size,
+			TolerancePercent:       tolerancePercent,
+			FindIndividualEpisodes: opts.FindIndividualEpisodes,
+		})
+		if decision.ExactSize {
+			exactSizeCandidates++
+		}
+		if !decision.Accepted {
+			if decision.SizeRejected {
+				sizeFilteredCount++
+			} else {
 				releaseFilteredCount++
+				reason := decision.RejectReason
+				if reason == "" {
+					reason = decision.StrictMismatchReason
+				}
 				recordReleaseRejection(
 					releaseFilterReasons,
-					mismatchReason,
+					reason,
 					sourceTorrent.Name,
 					res.Title,
 					opts.FindIndividualEpisodes,
 					releaseFilterDebugInfoFrom(searchRelease),
 					releaseFilterDebugInfoFrom(candidateRelease),
-					"[CROSSSEED-SEARCH] Candidate filtered out by release match",
+					"[CROSSSEED-SEARCH] Candidate rejected by search classifier",
 				)
-				continue
 			}
-
-			log.Info().
-				Str("sourceTitle", sourceTorrent.Name).
-				Str("candidateTitle", res.Title).
-				Str("sourceSource", searchRelease.Source).
-				Str("candidateSource", candidateRelease.Source).
-				Int64("sourceSize", sourceTorrent.Size).
-				Int64("candidateSize", res.Size).
-				Float64("tolerancePercent", tolerancePercent).
-				Msg("[CROSSSEED-SEARCH] Accepting cross-tracker web-source relabel; apply-stage file verification will confirm")
-		}
-
-		// Reject forbidden pairing: season pack candidate (new) vs single episode source (existing).
-		// In search context: candidateRelease is the new torrent, sourceRelease is the existing local torrent.
-		if reject, reason := rejectSeasonPackFromEpisode(candidateRelease, searchRelease, opts.FindIndividualEpisodes); reject {
-			releaseFilteredCount++
-			recordReleaseRejection(
-				releaseFilterReasons,
-				reason,
-				sourceTorrent.Name,
-				res.Title,
-				opts.FindIndividualEpisodes,
-				releaseFilterDebugInfoFrom(searchRelease),
-				releaseFilterDebugInfoFrom(candidateRelease),
-				"[CROSSSEED-SEARCH] Candidate filtered out by release pairing rule",
-			)
-			continue
-		}
-
-		// Size validation: check if candidate size is within tolerance of source size
-		if !ignoreSizeCheck && !s.isSizeWithinTolerance(sourceTorrent.Size, res.Size, tolerancePercent) {
-			sizeFilteredCount++
+			if decision.ExactSize && decision.StrictMismatchReason != "" {
+				exactSizeHardRejected++
+			}
 			log.Debug().
+				Int("indexerID", res.IndexerID).
+				Str("indexer", res.Indexer).
 				Str("sourceTitle", sourceTorrent.Name).
 				Str("candidateTitle", res.Title).
 				Int64("sourceSize", sourceTorrent.Size).
 				Int64("candidateSize", res.Size).
-				Float64("tolerancePercent", tolerancePercent).
-				Bool("ignoredSizeCheck", ignoreSizeCheck).
-				Msg("[CROSSSEED-SEARCH] Candidate filtered out due to size mismatch")
+				Int64("sizeDeltaBytes", res.Size-sourceTorrent.Size).
+				Str("decisionClass", string(decision.Class)).
+				Str("strictMismatchReason", decision.StrictMismatchReason).
+				Str("rejectReason", decision.RejectReason).
+				Msg("[CROSSSEED-SEARCH] Candidate rejected")
 			continue
 		}
 
-		score, reason := evaluateReleaseMatch(searchRelease, candidateRelease)
-		if score <= 0 {
-			score = 1.0
+		if decision.Class == searchCandidateClassExactSizeFallback {
+			exactSizeFallbackAccepted++
 		}
+		log.Debug().
+			Int("indexerID", res.IndexerID).
+			Str("indexer", res.Indexer).
+			Str("sourceTitle", sourceTorrent.Name).
+			Str("candidateTitle", res.Title).
+			Int64("sourceSize", sourceTorrent.Size).
+			Int64("candidateSize", res.Size).
+			Int64("sizeDeltaBytes", res.Size-sourceTorrent.Size).
+			Str("decisionClass", string(decision.Class)).
+			Str("strictMismatchReason", decision.StrictMismatchReason).
+			Strs("relaxedDifferences", decision.RelaxedDifferences).
+			Msg("[CROSSSEED-SEARCH] Candidate accepted")
 
 		scored = append(scored, scoredTorrentSearchResult{
-			result: res,
-			score:  score,
-			reason: reason,
+			result:    res,
+			score:     decision.Score,
+			reason:    decision.MatchReason,
+			exactSize: decision.ExactSize,
+			class:     decision.Class,
 		})
 	}
 
@@ -7887,6 +7916,9 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 		Int("sizeFiltered", sizeFilteredCount).
 		Int("lateContentFiltered", lateExcludedCount).
 		Int("finalMatches", matchedResults).
+		Int("exactSizeCandidates", exactSizeCandidates).
+		Int("exactSizeFallbackAccepted", exactSizeFallbackAccepted).
+		Int("exactSizeHardRejected", exactSizeHardRejected).
 		Float64("tolerancePercent", tolerancePercent).
 		Msg("[CROSSSEED-SEARCH] Search filtering completed")
 
@@ -7915,15 +7947,7 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 		sourceInfo.FileCount = len(sourceFiles)
 	}
 
-	sort.SliceStable(scored, func(i, j int) bool {
-		if scored[i].score == scored[j].score {
-			if scored[i].result.Seeders == scored[j].result.Seeders {
-				return scored[i].result.PublishDate.After(scored[j].result.PublishDate)
-			}
-			return scored[i].result.Seeders > scored[j].result.Seeders
-		}
-		return scored[i].score > scored[j].score
-	})
+	sortScoredTorrentSearchResults(scored)
 
 	results, duplicateFilteredCount, err := s.buildTorrentSearchResults(ctx, instanceID, sourceTorrent.Hash, scored, limit)
 	if err != nil {
@@ -7948,10 +7972,44 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 	}, gazelleLookupAttempted, remoteRequestsMade, nil
 }
 
+func sortScoredTorrentSearchResults(scored []scoredTorrentSearchResult) {
+	sort.SliceStable(scored, func(i, j int) bool {
+		if scored[i].exactSize != scored[j].exactSize {
+			return scored[i].exactSize
+		}
+		if scored[i].class != scored[j].class {
+			return searchCandidateClassPriority(scored[i].class) > searchCandidateClassPriority(scored[j].class)
+		}
+		if scored[i].score == scored[j].score {
+			if scored[i].result.Seeders == scored[j].result.Seeders {
+				return scored[i].result.PublishDate.After(scored[j].result.PublishDate)
+			}
+			return scored[i].result.Seeders > scored[j].result.Seeders
+		}
+		return scored[i].score > scored[j].score
+	})
+}
+
 type scoredTorrentSearchResult struct {
-	result jackett.SearchResult
-	score  float64
-	reason string
+	result    jackett.SearchResult
+	score     float64
+	reason    string
+	exactSize bool
+	class     searchCandidateClass
+}
+
+func searchCandidateClassPriority(class searchCandidateClass) int {
+	switch class {
+	case searchCandidateClassStrict:
+		return 3
+	case searchCandidateClassWebSourceRelabel:
+		return 2
+	case searchCandidateClassExactSizeFallback:
+		return 1
+	case searchCandidateClassRejected:
+		return 0
+	}
+	return 0
 }
 
 func (s *Service) completedAsyncContentFilterSnapshot(instanceID int, hash string) (*AsyncIndexerFilteringState, string, bool) {
@@ -8134,7 +8192,7 @@ func (s *Service) buildTorrentSearchResults(ctx context.Context, instanceID int,
 							Str("existingName", existing.Name)
 					}
 					event.Msg("[CROSSSEED-SEARCH] Keeping duplicate search result because existing torrent was rejected by content prefilter")
-					results = append(results, torrentSearchResultFromJackett(res, item.reason, item.score))
+					results = append(results, torrentSearchResultFromJackett(res, item.reason, item.score, item.class))
 					if len(results) >= limit {
 						break
 					}
@@ -8158,7 +8216,7 @@ func (s *Service) buildTorrentSearchResults(ctx context.Context, instanceID int,
 			}
 		}
 
-		results = append(results, torrentSearchResultFromJackett(res, item.reason, item.score))
+		results = append(results, torrentSearchResultFromJackett(res, item.reason, item.score, item.class))
 		if len(results) >= limit {
 			break
 		}
@@ -8167,7 +8225,7 @@ func (s *Service) buildTorrentSearchResults(ctx context.Context, instanceID int,
 	return results, duplicateFilteredCount, nil
 }
 
-func torrentSearchResultFromJackett(res jackett.SearchResult, reason string, score float64) TorrentSearchResult {
+func torrentSearchResultFromJackett(res jackett.SearchResult, reason string, score float64, class searchCandidateClass) TorrentSearchResult {
 	return TorrentSearchResult{
 		Indexer:              res.Indexer,
 		IndexerID:            res.IndexerID,
@@ -8189,6 +8247,7 @@ func torrentSearchResultFromJackett(res jackett.SearchResult, reason string, sco
 		TVDbID:               res.TVDbID,
 		MatchReason:          reason,
 		MatchScore:           score,
+		SearchDecisionClass:  class,
 	}
 }
 
@@ -8388,6 +8447,8 @@ func (s *Service) ApplyTorrentSearchResults(ctx context.Context, instanceID int,
 				SkipAutoResume:               skipAutoResume,
 				SkipRecheck:                  skipRecheck,
 				SkipPieceBoundarySafetyCheck: skipPieceBoundarySafetyCheck,
+				SearchDecisionClass:          cachedResult.SearchDecisionClass,
+				AdvertisedCandidateSize:      cachedResult.Size,
 			}
 			payload.SizeMismatchTolerancePercent = cachedSearchResults.sizeMismatchTolerancePercent
 			payload.SizeMismatchTolerancePercentSet = true
@@ -9790,6 +9851,8 @@ func (s *Service) executeCrossSeedSearchAttempt(ctx context.Context, state *sear
 		SourceFilterTags:              append([]string(nil), state.opts.Tags...),
 		SourceFilterExcludeCategories: append([]string(nil), state.opts.ExcludeCategories...),
 		SourceFilterExcludeTags:       append([]string(nil), state.opts.ExcludeTags...),
+		SearchDecisionClass:           match.SearchDecisionClass,
+		AdvertisedCandidateSize:       match.Size,
 	}
 	if state.opts.CategoryOverride != nil && strings.TrimSpace(*state.opts.CategoryOverride) != "" {
 		cat := *state.opts.CategoryOverride

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -7825,11 +7825,8 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 	releaseFilteredCount := 0
 	releaseFilterReasons := make(map[string]int)
 	exactSizeCandidates := 0
-	torznabFloat32Candidates := 0
 	exactSizeFallbackAccepted := 0
-	torznabFloat32FallbackAccepted := 0
 	exactSizeHardRejected := 0
-	torznabFloat32HardRejected := 0
 
 	for _, res := range searchResults {
 		key := res.GUID
@@ -7855,12 +7852,8 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 			TolerancePercent:       tolerancePercent,
 			FindIndividualEpisodes: opts.FindIndividualEpisodes,
 		})
-		switch decision.SizeEvidence {
-		case searchSizeEvidenceExact:
+		if decision.SizeEvidence == searchSizeEvidenceExact {
 			exactSizeCandidates++
-		case searchSizeEvidenceTorznabFloat32:
-			torznabFloat32Candidates++
-		case searchSizeEvidenceNone:
 		}
 		if !decision.Accepted {
 			if decision.SizeRejected {
@@ -7882,14 +7875,8 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 					"[CROSSSEED-SEARCH] Candidate rejected by search classifier",
 				)
 			}
-			if decision.StrictMismatchReason != "" {
-				switch decision.SizeEvidence {
-				case searchSizeEvidenceExact:
-					exactSizeHardRejected++
-				case searchSizeEvidenceTorznabFloat32:
-					torznabFloat32HardRejected++
-				case searchSizeEvidenceNone:
-				}
+			if decision.StrictMismatchReason != "" && decision.SizeEvidence == searchSizeEvidenceExact {
+				exactSizeHardRejected++
 			}
 			log.Debug().
 				Int("indexerID", res.IndexerID).
@@ -7909,9 +7896,6 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 
 		if decision.Class == searchCandidateClassExactSizeFallback {
 			exactSizeFallbackAccepted++
-			if decision.SizeEvidence == searchSizeEvidenceTorznabFloat32 {
-				torznabFloat32FallbackAccepted++
-			}
 		}
 		log.Debug().
 			Int("indexerID", res.IndexerID).
@@ -7927,7 +7911,6 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 			Strs("relaxedDifferences", decision.RelaxedDifferences).
 			Msg("[CROSSSEED-SEARCH] Candidate accepted")
 
-		res.Size = canonicalSearchResultSize(decision, sourceTorrent.Size, res.Size)
 		scored = append(scored, scoredTorrentSearchResult{
 			result:       res,
 			score:        decision.Score,
@@ -7949,11 +7932,8 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 		Int("lateContentFiltered", lateExcludedCount).
 		Int("finalMatches", matchedResults).
 		Int("exactSizeCandidates", exactSizeCandidates).
-		Int("torznabFloat32Candidates", torznabFloat32Candidates).
 		Int("exactSizeFallbackAccepted", exactSizeFallbackAccepted).
-		Int("torznabFloat32FallbackAccepted", torznabFloat32FallbackAccepted).
 		Int("exactSizeHardRejected", exactSizeHardRejected).
-		Int("torznabFloat32HardRejected", torznabFloat32HardRejected).
 		Float64("tolerancePercent", tolerancePercent).
 		Msg("[CROSSSEED-SEARCH] Search filtering completed")
 
@@ -8032,18 +8012,6 @@ type scoredTorrentSearchResult struct {
 	sizeEvidence searchSizeEvidence
 	class        searchCandidateClass
 	sourceTitles []string
-}
-
-func canonicalSearchResultSize(decision searchCandidateDecision, sourceSize, candidateSize int64) int64 {
-	// Downstream exact-size validation remains literal. For an admitted legacy
-	// Torznab result, carry the exact source size that the reported float32 value
-	// represents; a different downloaded metainfo size will still be rejected.
-	if decision.Accepted &&
-		decision.Class == searchCandidateClassExactSizeFallback &&
-		decision.SizeEvidence == searchSizeEvidenceTorznabFloat32 {
-		return sourceSize
-	}
-	return candidateSize
 }
 
 func searchCandidateClassPriority(class searchCandidateClass) int {

--- a/internal/services/crossseed/service_duplicate_filtering_test.go
+++ b/internal/services/crossseed/service_duplicate_filtering_test.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"sync/atomic"
@@ -505,6 +507,109 @@ func TestFilterSearchResultsByLateContentFilterCompletedStateWithNoResultsReturn
 	require.Equal(t, map[int]string{1: "already seeded from Tracker One"}, snapshot.ExcludedIndexers)
 	require.Equal(t, []string{"Existing.Movie.2015.1080p.BluRay-GROUP"}, snapshot.ContentMatches)
 	require.Zero(t, dropped)
+}
+
+func TestSearchTorrentMatchesRefreshesLateFilterStatus(t *testing.T) {
+	const (
+		instanceID = 1
+		sourceHash = "0123456789abcdef0123456789abcdef01234567"
+		sourceName = "Example.Show.S01E01.1080p.WEB-DL.DDP5.1.H.264-GROUP"
+	)
+
+	tests := []struct {
+		name        string
+		resultItems string
+		wantResults int
+	}{
+		{name: "zero results"},
+		{
+			name: "populated results",
+			resultItems: `<item>
+				<title>` + sourceName + `</title>
+				<guid>candidate-guid</guid>
+				<size>123</size>
+				<enclosure url="https://example.invalid/candidate.torrent" length="123" type="application/x-bittorrent" />
+			</item>`,
+			wantResults: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			filterCache := ttlcache.New(ttlcache.Options[string, *AsyncIndexerFilteringState]{})
+			cacheKey := asyncFilteringCacheKey(instanceID, sourceHash)
+			filterCache.Set(cacheKey, &AsyncIndexerFilteringState{
+				CapabilitiesCompleted: true,
+				ContentCompleted:      false,
+				CapabilityIndexers:    []int{1, 2},
+				FilteredIndexers:      []int{1, 2},
+			}, ttlcache.DefaultTTL)
+
+			lateState := &AsyncIndexerFilteringState{
+				CapabilitiesCompleted: true,
+				ContentCompleted:      true,
+				CapabilityIndexers:    []int{1, 2},
+				FilteredIndexers:      []int{1},
+				ExcludedIndexers:      map[int]string{2: "already seeded from Tracker Two"},
+				ContentMatches:        []string{"Existing.Show.S01E01.1080p.WEB-DL-GROUP"},
+			}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				filterCache.Set(cacheKey, lateState, ttlcache.DefaultTTL)
+				w.Header().Set("Content-Type", "application/rss+xml")
+				if _, writeErr := fmt.Fprintf(w, `<rss version="2.0"><channel><title>Tracker One</title>%s</channel></rss>`, test.resultItems); writeErr != nil {
+					t.Errorf("write Torznab response: %v", writeErr)
+				}
+			}))
+			t.Cleanup(server.Close)
+
+			instance := &models.Instance{ID: instanceID, Name: "main"}
+			source := qbt.Torrent{
+				Hash:     sourceHash,
+				Name:     sourceName,
+				Size:     123,
+				Progress: 1,
+			}
+			service := &Service{
+				instanceStore: &fakeInstanceStore{instances: map[int]*models.Instance{instanceID: instance}},
+				jackettService: newJackettServiceWithIndexers([]*models.TorznabIndexer{
+					{
+						ID:             1,
+						Name:           "Tracker One",
+						BaseURL:        server.URL,
+						Backend:        models.TorznabBackendNative,
+						TimeoutSeconds: 5,
+						Enabled:        true,
+					},
+				}),
+				syncManager: newFakeSyncManager(instance, []qbt.Torrent{source}, map[string]qbt.TorrentFiles{
+					sourceHash: {{Name: sourceName + ".mkv", Size: source.Size}},
+				}),
+				asyncFilteringCache: filterCache,
+				releaseCache:        NewReleaseCache(),
+				stringNormalizer:    stringutils.NewDefaultNormalizer(),
+			}
+
+			response, _, _, err := service.searchTorrentMatches(
+				context.Background(),
+				instanceID,
+				sourceHash,
+				TorrentSearchOptions{
+					IndexerIDs:                      []int{1},
+					SkipGazelle:                     true,
+					SizeMismatchTolerancePercent:    5,
+					SizeMismatchTolerancePercentSet: true,
+				},
+				nil,
+			)
+			require.NoError(t, err)
+			require.Len(t, response.Results, test.wantResults)
+			require.Equal(t, lateState.CapabilityIndexers, response.SourceTorrent.AvailableIndexers)
+			require.Equal(t, lateState.FilteredIndexers, response.SourceTorrent.FilteredIndexers)
+			require.Equal(t, lateState.ExcludedIndexers, response.SourceTorrent.ExcludedIndexers)
+			require.Equal(t, lateState.ContentMatches, response.SourceTorrent.ContentMatches)
+			require.True(t, response.SourceTorrent.ContentFilteringCompleted)
+		})
+	}
 }
 
 func TestFilterSearchResultsByLateContentFilterDropsExcludedIndexers(t *testing.T) {

--- a/internal/services/crossseed/service_search_test.go
+++ b/internal/services/crossseed/service_search_test.go
@@ -51,7 +51,12 @@ type failingEnabledIndexerStore struct {
 	indexers []*models.TorznabIndexer
 }
 
-func (s *failingEnabledIndexerStore) Get(context.Context, int) (*models.TorznabIndexer, error) {
+func (s *failingEnabledIndexerStore) Get(_ context.Context, id int) (*models.TorznabIndexer, error) {
+	for _, indexer := range s.indexers {
+		if indexer != nil && indexer.ID == id {
+			return indexer, nil
+		}
+	}
 	return nil, nil
 }
 


### PR DESCRIPTION
## Summary

- add exact-first, search-only size evidence so minor provider/HDR/codec naming differences can reach torrent-file validation
- retain strict name/title, season/episode, resolution, release group/site, and checksum identity checks

Resolves #2159.

## Additional fixes found during review

Code review identified two pre-existing issues that are not part of the size-matching change itself:

- **ARR title aliases were lost between search and apply.** Search classification could accept a candidate using an ARR-derived source-title alias, but that title lineage was not retained in the cached result or propagated through manual and automated apply. Final downloaded-torrent validation could therefore reject the same candidate under stricter title comparison. The fix preserves the aliases through the search decision, cache, and both apply paths.
- **Late asynchronous content-filter results were not reliably reflected in the search response.** Content filtering can complete while the Torznab search is in progress, leaving the returned `SourceTorrent` metadata based on the earlier incomplete snapshot. The response now refreshes the available, filtered, and excluded indexers, content matches, and completion state from the completed snapshot, including zero-result searches.

These fixes are included here because their underlying corrections require changes to the same search-result metadata propagation, apply handling, and post-search response assembly modified by this PR. Splitting them out would require overlapping changes to the new handling.

## Testing

- `go test -race -count=1 ./internal/services/crossseed`
- `make precommit`
- `make build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Improvements**
  - Strengthened cross-seed candidate matching with stricter identity gates for the exact-size fallback, requiring true byte-identical sizes.
  - Reworked Torznab result handling to consistently classify matches, with improved prioritization and deduplication.
  - Preserved source title/ARR alias lineage end-to-end through caching and manual/automated apply.

- **Bug Fixes**
  - Prevented accepting matches when advertised sizes don’t match the torrent.
  - Fixed refreshing of async content-filtering status when completion finishes late.
  - Fixed in-memory indexer lookup so Torznab searches use the correct indexer by ID.

- **Tests**
  - Added extensive automated coverage for matching, caching, and metadata propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->