### PR TITLE
chore(deps): bump go-qbittorrent to v1.17.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/andybalholm/brotli v1.2.2
 	github.com/autobrr/autobrr v1.80.0
 	github.com/autobrr/go-mediainfo v0.4.0
-	github.com/autobrr/go-qbittorrent v1.16.1-0.20260703161542-1ab32a2fa640
+	github.com/autobrr/go-qbittorrent v1.17.0
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/coreos/go-oidc/v3 v3.19.0

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/autobrr/go-mediainfo v0.4.0 h1:S68enHlG067nE9UF61Yg7QoQBWfeXJTRYctyNx
 github.com/autobrr/go-mediainfo v0.4.0/go.mod h1:xVXgHDAYYpIeGQCQCdTBpoiY/O3tojJfflK+rrbzclQ=
 github.com/autobrr/go-qbittorrent v1.16.1-0.20260703161542-1ab32a2fa640 h1:P+fF7RJB6xjzbD2soC/SjnpYnIssei0pOknCZeZp6ws=
 github.com/autobrr/go-qbittorrent v1.16.1-0.20260703161542-1ab32a2fa640/go.mod h1:s36a75VlatWPpHI+pNg4Ta6eB3fRxQvTZPfgMtOsQfY=
+github.com/autobrr/go-qbittorrent v1.17.0 h1:GEIfzkdLKkRFkkxGhEnY+LS9dTlMKXE1ZBMOSDCjG3A=
+github.com/autobrr/go-qbittorrent v1.17.0/go.mod h1:9ujARiuSKZf8+NtApflTB69Wsptsp0Qk1mSVVC0tGzM=
 github.com/autobrr/rls v0.8.1 h1:OjoFFVGcTibGrwf6b4pfk7JHsSYrGOX7F5P/8WtS3aE=
 github.com/autobrr/rls v0.8.1/go.mod h1:11YJWgNe5H+UQrfFaNGjnkEy0OEsMFnmV4IL2tRKpPk=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=


### PR DESCRIPTION
## Summary

Fixes tracker edits failing against qBittorrent 5.2.x with `new url is not a valid URL` (discussion #2101).

The cause is upstream, not in qui. WebAPI 2.13.0 renamed the `torrents/editTracker` parameter `origUrl` to `url`, so the pinned client sent no recognized "old URL" field and qBittorrent returned 400 — which `go-qbittorrent` maps to `ErrInvalidURL`, hence the misleading message pointing at the *new* URL.

`go-qbittorrent` v1.17.0 sends both keys, so the call works across WebAPI versions:

```go
opts := map[string]string{
    "hash": hash,
    // WebAPI 2.13.0 renamed origUrl to url; send both.
    "origUrl": old,
    "url":     old,
    "newUrl":  new,
}
```

qui's own code needed no changes — `internal/qbittorrent/sync_manager.go:6894` and `:7025` call `EditTrackerCtx` directly and there was no local workaround to unwind.

## Changes

`go.mod` / `go.sum` only: `github.com/autobrr/go-qbittorrent` `v1.16.1-0.20260703161542-1ab32a2fa640` → `v1.17.0`.

## Testing

- [x] `make build`
- [x] `go test -race -count=1 ./internal/qbittorrent/... ./internal/api/handlers/... ./internal/services/crossseed/...`
- [x] `make precommit` — fmt/gofix clean
- [ ] `make lint` — could not run locally: the sandbox's `golangci-lint` is built with go1.25 while `go.mod` targets `go 1.26`, so it aborts on config load (`the Go language version (go1.25) used to build golangci-lint is lower than the targeted Go version (1.26)`). Verified this fails identically on a clean tree, so it predates this change. Deferred to CI.

No UI changes, so no screenshots.

Closes #2101

---
_Generated by [Claude Code](https://claude.ai/code/session_01XtAAXGrBksrkyvEvpfZphP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Completed a routine maintenance update to keep the application’s underlying components current.
  * No user-facing features, workflows, or behavior were changed in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->