### PR TITLE
fix(hardlink): use 128-bit Windows file IDs

### DIFF
--- a/internal/models/dirscan.go
+++ b/internal/models/dirscan.go
@@ -143,7 +143,7 @@ type DirScanFile struct {
 	FilePath           string            `json:"filePath"`
 	FileSize           int64             `json:"fileSize"`
 	FileModTime        time.Time         `json:"fileModTime"`
-	FileID             []byte            `json:"-"` // Platform-neutral FileID (dev+ino on Unix, vol+idx on Windows)
+	FileID             []byte            `json:"-"` // Platform-neutral FileID (dev+ino on Unix, volume serial+128-bit ID on Windows)
 	Status             DirScanFileStatus `json:"status"`
 	MatchedTorrentHash string            `json:"matchedTorrentHash,omitempty"`
 	MatchedIndexerID   *int              `json:"matchedIndexerId,omitempty"`

--- a/internal/models/dirscan_file_test.go
+++ b/internal/models/dirscan_file_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package models_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/models"
+)
+
+func TestDirScanStore_UpsertFile_ReplacesChangedFileIDForSamePath(t *testing.T) {
+	ctx := context.Background()
+	db := setupDirScanTestDB(t)
+
+	instanceStore, err := models.NewInstanceStore(db, []byte("01234567890123456789012345678901"))
+	require.NoError(t, err)
+	instance, err := instanceStore.Create(ctx, "Test", "http://localhost:8080", "user", "pass", nil, nil, false, nil)
+	require.NoError(t, err)
+
+	store := models.NewDirScanStore(db)
+	dir, err := store.CreateDirectory(ctx, &models.DirScanDirectory{
+		Path:                "/data/media",
+		Enabled:             true,
+		TargetInstanceID:    instance.ID,
+		ScanIntervalMinutes: 60,
+	})
+	require.NoError(t, err)
+
+	file := &models.DirScanFile{
+		DirectoryID: dir.ID,
+		FilePath:    "/data/media/file.mkv",
+		FileSize:    1,
+		FileModTime: time.Now(),
+		FileID:      bytesOfLength(12, 1),
+		Status:      models.DirScanFileStatusPending,
+	}
+	require.NoError(t, store.UpsertFile(ctx, file))
+
+	file.FileID = bytesOfLength(24, 2)
+	require.NoError(t, store.UpsertFile(ctx, file))
+
+	files, err := store.ListFiles(ctx, dir.ID, nil, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	require.Equal(t, file.FileID, files[0].FileID)
+}
+
+func bytesOfLength(length int, value byte) []byte {
+	result := make([]byte, length)
+	for i := range result {
+		result[i] = value
+	}
+	return result
+}

--- a/pkg/hardlink/fileid_windows.go
+++ b/pkg/hardlink/fileid_windows.go
@@ -6,6 +6,7 @@
 package hardlink
 
 import (
+	"encoding/binary"
 	"hash"
 	"os"
 	"unsafe"
@@ -14,7 +15,7 @@ import (
 )
 
 // FILE_READ_ATTRIBUTES is the Windows access right for reading file attributes.
-// Required for GetFileInformationByHandleEx to reliably work on all filesystem types.
+// This is the minimum access needed to query file identity and link counts.
 const fileReadAttributes = 0x0080
 
 type fileIDInfo struct {
@@ -56,8 +57,6 @@ func GetFileID(fi os.FileInfo, path string) (FileID, uint64, error) {
 		attrs |= windows.FILE_FLAG_OPEN_REPARSE_POINT
 	}
 	// Use full sharing mode to avoid failures when file is open by another process.
-	// FILE_READ_ATTRIBUTES is required for GetFileInformationByHandleEx to work
-	// reliably across different Windows filesystem types.
 	shareMode := uint32(windows.FILE_SHARE_READ | windows.FILE_SHARE_WRITE | windows.FILE_SHARE_DELETE)
 	h, err := windows.CreateFile(pathp, fileReadAttributes, shareMode, nil, windows.OPEN_EXISTING, attrs, 0)
 	if err != nil {
@@ -74,7 +73,7 @@ func GetFileID(fi os.FileInfo, path string) (FileID, uint64, error) {
 		(*byte)(unsafe.Pointer(&idInfo)),
 		uint32(unsafe.Sizeof(idInfo)),
 	); err != nil {
-		return FileID{}, 0, err
+		return legacyFileID(h, err)
 	}
 
 	var standardInfo fileStandardInfo
@@ -91,6 +90,26 @@ func GetFileID(fi os.FileInfo, path string) (FileID, uint64, error) {
 		VolumeSerialNumber: idInfo.VolumeSerialNumber,
 		Identifier:         idInfo.Identifier,
 	}, uint64(standardInfo.NumberOfLinks), nil
+}
+
+// legacyFileID synthesizes a FileID from the pre-Win8 GetFileInformationByHandle
+// call. FileIdInfo is an optional per-driver query: FAT/exFAT reject it with
+// ERROR_INVALID_PARAMETER and some SMB redirectors (notably Azure Files) with
+// ERROR_INVALID_LEVEL, where the legacy 64-bit file index still works. Falling
+// back keeps file identity working there instead of silently disabling
+// already-seeding detection, rename tracking and hardlink scopes.
+// Mirrors microsoft/STL's _Get_file_id_by_handle. idErr is returned when the
+// legacy call fails too, since FileIdInfo is the path that matters on NTFS/ReFS.
+func legacyFileID(h windows.Handle, idErr error) (FileID, uint64, error) {
+	var info windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(h, &info); err != nil {
+		return FileID{}, 0, idErr
+	}
+
+	id := FileID{VolumeSerialNumber: uint64(info.VolumeSerialNumber)}
+	binary.LittleEndian.PutUint32(id.Identifier[0:4], info.FileIndexHigh)
+	binary.LittleEndian.PutUint32(id.Identifier[4:8], info.FileIndexLow)
+	return id, uint64(info.NumberOfLinks), nil
 }
 
 // Bytes returns a byte slice representation of the FileID for hashing.

--- a/pkg/hardlink/fileid_windows.go
+++ b/pkg/hardlink/fileid_windows.go
@@ -8,64 +8,95 @@ package hardlink
 import (
 	"hash"
 	"os"
-	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 // FILE_READ_ATTRIBUTES is the Windows access right for reading file attributes.
-// Required for GetFileInformationByHandle to reliably work on all filesystem types.
+// Required for GetFileInformationByHandleEx to reliably work on all filesystem types.
 const fileReadAttributes = 0x0080
 
+type fileIDInfo struct {
+	VolumeSerialNumber uint64
+	Identifier         [16]byte
+}
+
+type fileStandardInfo struct {
+	AllocationSize int64
+	EndOfFile      int64
+	NumberOfLinks  uint32
+	DeletePending  byte
+	Directory      byte
+	_              [2]byte
+}
+
 // FileID uniquely identifies a physical file on disk.
-// On Windows, this is the (VolumeSerialNumber, FileIndexHigh, FileIndexLow) tuple.
+// On Windows, this is the (VolumeSerialNumber, 128-bit file identifier) tuple.
 // This type is comparable and can be used as a map key without allocations.
 type FileID struct {
-	VolumeSerialNumber uint32
-	FileIndexHigh      uint32
-	FileIndexLow       uint32
+	VolumeSerialNumber uint64
+	Identifier         [16]byte
 }
 
 // IsZero returns true if the FileID is the zero value (uninitialized).
 func (f FileID) IsZero() bool {
-	return f.VolumeSerialNumber == 0 && f.FileIndexHigh == 0 && f.FileIndexLow == 0
+	return f.VolumeSerialNumber == 0 && f.Identifier == [16]byte{}
 }
 
 // GetFileID returns the FileID and link count for a file with low-allocation overhead.
 // This is more efficient than LinkInfo when you don't need the string representation.
 func GetFileID(fi os.FileInfo, path string) (FileID, uint64, error) {
-	pathp, err := syscall.UTF16PtrFromString(path)
+	pathp, err := windows.UTF16PtrFromString(path)
 	if err != nil {
 		return FileID{}, 0, err
 	}
-	attrs := uint32(syscall.FILE_FLAG_BACKUP_SEMANTICS)
+	attrs := uint32(windows.FILE_FLAG_BACKUP_SEMANTICS)
 	if isSymlink(fi) {
-		attrs |= syscall.FILE_FLAG_OPEN_REPARSE_POINT
+		attrs |= windows.FILE_FLAG_OPEN_REPARSE_POINT
 	}
 	// Use full sharing mode to avoid failures when file is open by another process.
-	// FILE_READ_ATTRIBUTES is required for GetFileInformationByHandle to work
+	// FILE_READ_ATTRIBUTES is required for GetFileInformationByHandleEx to work
 	// reliably across different Windows filesystem types.
-	shareMode := uint32(syscall.FILE_SHARE_READ | syscall.FILE_SHARE_WRITE | syscall.FILE_SHARE_DELETE)
-	h, err := syscall.CreateFile(pathp, fileReadAttributes, shareMode, nil, syscall.OPEN_EXISTING, attrs, 0)
+	shareMode := uint32(windows.FILE_SHARE_READ | windows.FILE_SHARE_WRITE | windows.FILE_SHARE_DELETE)
+	h, err := windows.CreateFile(pathp, fileReadAttributes, shareMode, nil, windows.OPEN_EXISTING, attrs, 0)
 	if err != nil {
 		return FileID{}, 0, err
 	}
-	defer syscall.CloseHandle(h)
+	defer func() {
+		_ = windows.CloseHandle(h)
+	}()
 
-	var info syscall.ByHandleFileInformation
-	if err := syscall.GetFileInformationByHandle(h, &info); err != nil {
+	var idInfo fileIDInfo
+	if err := windows.GetFileInformationByHandleEx(
+		h,
+		windows.FileIdInfo,
+		(*byte)(unsafe.Pointer(&idInfo)),
+		uint32(unsafe.Sizeof(idInfo)),
+	); err != nil {
+		return FileID{}, 0, err
+	}
+
+	var standardInfo fileStandardInfo
+	if err := windows.GetFileInformationByHandleEx(
+		h,
+		windows.FileStandardInfo,
+		(*byte)(unsafe.Pointer(&standardInfo)),
+		uint32(unsafe.Sizeof(standardInfo)),
+	); err != nil {
 		return FileID{}, 0, err
 	}
 
 	return FileID{
-		VolumeSerialNumber: info.VolumeSerialNumber,
-		FileIndexHigh:      info.FileIndexHigh,
-		FileIndexLow:       info.FileIndexLow,
-	}, uint64(info.NumberOfLinks), nil
+		VolumeSerialNumber: idInfo.VolumeSerialNumber,
+		Identifier:         idInfo.Identifier,
+	}, uint64(standardInfo.NumberOfLinks), nil
 }
 
 // Bytes returns a byte slice representation of the FileID for hashing.
 // This is used for computing file signatures across platforms.
 func (f FileID) Bytes() []byte {
-	var buf [12]byte
+	var buf [24]byte
 	f.fillBytes(&buf)
 	return buf[:]
 }
@@ -73,24 +104,21 @@ func (f FileID) Bytes() []byte {
 // WriteToHash writes the FileID bytes directly to a hash.Hash.
 // Uses a stack-allocated buffer to avoid heap escapes (unlike Bytes which returns a slice).
 func (f FileID) WriteToHash(h hash.Hash) {
-	var buf [12]byte
+	var buf [24]byte
 	f.fillBytes(&buf)
 	h.Write(buf[:])
 }
 
-func (f FileID) fillBytes(buf *[12]byte) {
-	buf[0] = byte(f.VolumeSerialNumber >> 24)
-	buf[1] = byte(f.VolumeSerialNumber >> 16)
-	buf[2] = byte(f.VolumeSerialNumber >> 8)
-	buf[3] = byte(f.VolumeSerialNumber)
-	buf[4] = byte(f.FileIndexHigh >> 24)
-	buf[5] = byte(f.FileIndexHigh >> 16)
-	buf[6] = byte(f.FileIndexHigh >> 8)
-	buf[7] = byte(f.FileIndexHigh)
-	buf[8] = byte(f.FileIndexLow >> 24)
-	buf[9] = byte(f.FileIndexLow >> 16)
-	buf[10] = byte(f.FileIndexLow >> 8)
-	buf[11] = byte(f.FileIndexLow)
+func (f FileID) fillBytes(buf *[24]byte) {
+	buf[0] = byte(f.VolumeSerialNumber >> 56)
+	buf[1] = byte(f.VolumeSerialNumber >> 48)
+	buf[2] = byte(f.VolumeSerialNumber >> 40)
+	buf[3] = byte(f.VolumeSerialNumber >> 32)
+	buf[4] = byte(f.VolumeSerialNumber >> 24)
+	buf[5] = byte(f.VolumeSerialNumber >> 16)
+	buf[6] = byte(f.VolumeSerialNumber >> 8)
+	buf[7] = byte(f.VolumeSerialNumber)
+	copy(buf[8:], f.Identifier[:])
 }
 
 // Less returns true if this FileID is less than other.
@@ -99,8 +127,10 @@ func (f FileID) Less(other FileID) bool {
 	if f.VolumeSerialNumber != other.VolumeSerialNumber {
 		return f.VolumeSerialNumber < other.VolumeSerialNumber
 	}
-	if f.FileIndexHigh != other.FileIndexHigh {
-		return f.FileIndexHigh < other.FileIndexHigh
+	for i := range f.Identifier {
+		if f.Identifier[i] != other.Identifier[i] {
+			return f.Identifier[i] < other.Identifier[i]
+		}
 	}
-	return f.FileIndexLow < other.FileIndexLow
+	return false
 }

--- a/pkg/hardlink/fileid_windows_test.go
+++ b/pkg/hardlink/fileid_windows_test.go
@@ -1,0 +1,136 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+//go:build windows
+
+package hardlink
+
+import (
+	"bytes"
+	"hash"
+	"os"
+	"path/filepath"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/require"
+)
+
+type recordingHash struct {
+	bytes.Buffer
+}
+
+var _ hash.Hash = (*recordingHash)(nil)
+
+func (h *recordingHash) Sum(b []byte) []byte { return append(b, h.Bytes()...) }
+func (h *recordingHash) Reset()              { h.Buffer.Reset() }
+func (h *recordingHash) Size() int           { return h.Len() }
+func (h *recordingHash) BlockSize() int      { return 1 }
+
+func TestWindowsFileInfoLayouts(t *testing.T) {
+	require.Equal(t, uintptr(24), unsafe.Sizeof(fileIDInfo{}))
+	require.Equal(t, uintptr(0), unsafe.Offsetof(fileIDInfo{}.VolumeSerialNumber))
+	require.Equal(t, uintptr(8), unsafe.Offsetof(fileIDInfo{}.Identifier))
+
+	require.Equal(t, uintptr(24), unsafe.Sizeof(fileStandardInfo{}))
+	require.Equal(t, uintptr(0), unsafe.Offsetof(fileStandardInfo{}.AllocationSize))
+	require.Equal(t, uintptr(8), unsafe.Offsetof(fileStandardInfo{}.EndOfFile))
+	require.Equal(t, uintptr(16), unsafe.Offsetof(fileStandardInfo{}.NumberOfLinks))
+	require.Equal(t, uintptr(20), unsafe.Offsetof(fileStandardInfo{}.DeletePending))
+	require.Equal(t, uintptr(21), unsafe.Offsetof(fileStandardInfo{}.Directory))
+}
+
+func TestWindowsFileIDComparable(t *testing.T) {
+	id := FileID{
+		VolumeSerialNumber: 7,
+		Identifier:         [16]byte{15: 9},
+	}
+	ids := map[FileID]bool{id: true}
+	require.True(t, ids[id])
+}
+
+func TestWindowsFileIDBytesAndHash(t *testing.T) {
+	id := FileID{
+		VolumeSerialNumber: 0x0102030405060708,
+		Identifier: [16]byte{
+			0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+			0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+		},
+	}
+	want := []byte{
+		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+		0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+	}
+
+	require.Equal(t, want, id.Bytes())
+	require.Len(t, id.Bytes(), 24)
+
+	var got recordingHash
+	id.WriteToHash(&got)
+	require.Equal(t, want, got.Bytes())
+}
+
+func TestWindowsFileIDIsZero(t *testing.T) {
+	require.True(t, (FileID{}).IsZero())
+	require.False(t, (FileID{VolumeSerialNumber: 1 << 32}).IsZero())
+	require.False(t, (FileID{Identifier: [16]byte{15: 1}}).IsZero())
+}
+
+func TestWindowsFileIDLess(t *testing.T) {
+	lowVolume := FileID{VolumeSerialNumber: 1, Identifier: [16]byte{15: 0xff}}
+	highVolume := FileID{VolumeSerialNumber: 2}
+	require.True(t, lowVolume.Less(highVolume))
+	require.False(t, highVolume.Less(lowVolume))
+
+	lowIdentifier := FileID{VolumeSerialNumber: 2, Identifier: [16]byte{14: 1, 15: 0xff}}
+	highIdentifier := FileID{VolumeSerialNumber: 2, Identifier: [16]byte{14: 2}}
+	require.True(t, lowIdentifier.Less(highIdentifier))
+	require.False(t, highIdentifier.Less(lowIdentifier))
+	require.False(t, lowIdentifier.Less(lowIdentifier))
+}
+
+func TestGetFileIDWindows(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source")
+	hardlinkPath := filepath.Join(dir, "hardlink")
+	copyPath := filepath.Join(dir, "copy")
+	require.NoError(t, os.WriteFile(sourcePath, []byte("source"), 0o600))
+	require.NoError(t, os.Link(sourcePath, hardlinkPath))
+	require.NoError(t, os.WriteFile(copyPath, []byte("source"), 0o600))
+
+	sourceID, sourceLinks := getFileIDForTest(t, sourcePath)
+	hardlinkID, hardlinkLinks := getFileIDForTest(t, hardlinkPath)
+	copyID, copyLinks := getFileIDForTest(t, copyPath)
+
+	require.Equal(t, sourceID, hardlinkID)
+	require.NotEqual(t, sourceID, copyID)
+	require.Equal(t, uint64(2), sourceLinks)
+	require.Equal(t, uint64(2), hardlinkLinks)
+	require.Equal(t, uint64(1), copyLinks)
+	require.False(t, sourceID.IsZero())
+	require.False(t, copyID.IsZero())
+}
+
+func TestGetFileIDWindowsOpenFailure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "removed")
+	require.NoError(t, os.WriteFile(path, []byte("source"), 0o600))
+	fi, err := os.Stat(path)
+	require.NoError(t, err)
+	require.NoError(t, os.Remove(path))
+
+	id, links, err := GetFileID(fi, path)
+	require.Error(t, err)
+	require.True(t, id.IsZero())
+	require.Zero(t, links)
+}
+
+func getFileIDForTest(t *testing.T, path string) (FileID, uint64) {
+	t.Helper()
+
+	fi, err := os.Stat(path)
+	require.NoError(t, err)
+	id, links, err := GetFileID(fi, path)
+	require.NoError(t, err)
+	return id, links
+}

--- a/pkg/hardlink/fileid_windows_test.go
+++ b/pkg/hardlink/fileid_windows_test.go
@@ -14,6 +14,7 @@ import (
 	"unsafe"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
 )
 
 type recordingHash struct {
@@ -123,6 +124,64 @@ func TestGetFileIDWindowsOpenFailure(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, id.IsZero())
 	require.Zero(t, links)
+}
+
+// TestLegacyFileIDWindows covers the fallback taken on volumes that reject the
+// FileIdInfo query (FAT/exFAT, some SMB redirectors). It cannot be reached
+// through GetFileID on NTFS, so it is exercised directly.
+func TestLegacyFileIDWindows(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source")
+	hardlinkPath := filepath.Join(dir, "hardlink")
+	copyPath := filepath.Join(dir, "copy")
+	require.NoError(t, os.WriteFile(sourcePath, []byte("source"), 0o600))
+	require.NoError(t, os.Link(sourcePath, hardlinkPath))
+	require.NoError(t, os.WriteFile(copyPath, []byte("source"), 0o600))
+
+	sourceID, sourceLinks := legacyFileIDForTest(t, sourcePath)
+	hardlinkID, hardlinkLinks := legacyFileIDForTest(t, hardlinkPath)
+	copyID, copyLinks := legacyFileIDForTest(t, copyPath)
+
+	require.Equal(t, sourceID, hardlinkID)
+	require.NotEqual(t, sourceID, copyID)
+	require.Equal(t, uint64(2), sourceLinks)
+	require.Equal(t, uint64(2), hardlinkLinks)
+	require.Equal(t, uint64(1), copyLinks)
+	require.False(t, sourceID.IsZero())
+
+	// The legacy index occupies the low 8 bytes; the rest stays zeroed.
+	require.Equal(t, [8]byte{}, [8]byte(sourceID.Identifier[8:16]))
+}
+
+func TestLegacyFileIDWindowsPropagatesOriginalError(t *testing.T) {
+	id, links, err := legacyFileID(windows.InvalidHandle, windows.ERROR_INVALID_PARAMETER)
+	require.ErrorIs(t, err, windows.ERROR_INVALID_PARAMETER)
+	require.True(t, id.IsZero())
+	require.Zero(t, links)
+}
+
+func legacyFileIDForTest(t *testing.T, path string) (FileID, uint64) {
+	t.Helper()
+
+	pathp, err := windows.UTF16PtrFromString(path)
+	require.NoError(t, err)
+	h, err := windows.CreateFile(
+		pathp,
+		fileReadAttributes,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_FLAG_BACKUP_SEMANTICS,
+		0,
+	)
+	require.NoError(t, err)
+	defer func() {
+		_ = windows.CloseHandle(h)
+	}()
+
+	id, links, err := legacyFileID(h, windows.ERROR_INVALID_PARAMETER)
+	require.NoError(t, err)
+	return id, links
 }
 
 func getFileIDForTest(t *testing.T, path string) (FileID, uint64) {


### PR DESCRIPTION
## Summary

- Replace Windows `GetFileInformationByHandle` identity reads with `GetFileInformationByHandleEx(FileIdInfo)`.
- Query link counts from the same handle with `GetFileInformationByHandleEx(FileStandardInfo)`.
- Keep `FileID` comparable and encode its full Windows identity deterministically.
- Verify same-path dir-scan upserts replace legacy persisted IDs without a migration.

## Why

The previous Windows path compared `BY_HANDLE_FILE_INFORMATION.FileIndexHigh` and `FileIndexLow`. Microsoft documents that this 64-bit identifier is not guaranteed unique on ReFS and directs callers to `GetFileInformationByHandleEx` with `FileIdInfo`. `FILE_ID_INFO` combines a 64-bit volume serial number with a 128-bit file identifier.

- [BY_HANDLE_FILE_INFORMATION](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/ns-fileapi-by_handle_file_information)
- [FILE_ID_INFO](https://learn.microsoft.com/en-us/windows/win32/api/winbase/ns-winbase-file_id_info)
- [FILE_STANDARD_INFO](https://learn.microsoft.com/en-us/windows/win32/api/winbase/ns-winbase-file_standard_info)

```text
before: 32-bit volume serial + 64-bit file index = 12 encoded bytes
after:  64-bit volume serial + 128-bit file ID   = 24 encoded bytes
```

## Runtime evidence

Validated on this host against NTFS and ReFS 3.14 (64 KiB clusters):

- NTFS source and hardlink returned identical full IDs and link count 2.
- NTFS independent copy returned a different full ID and link count 1.
- ReFS source and hardlink returned identical full IDs and link count 2.
- ReFS independent copy returned a different full ID and link count 1.
- ReFS block clone returned a different full ID from its source. Its retrieval pointers still shared the source LCN runs, confirming file identity alone must not classify block clones.

## Persistence compatibility

`dir_scan_files.file_id` is an unbounded BLOB, so no schema migration is needed. Existing rows continue matching by path; the next same-path scan replaces the old 12-byte value with the new 24-byte value. A file renamed before its first post-upgrade scan cannot match its legacy identity and follows normal path/new-file handling. IDs are not globally cleared because persisted rows do not record their originating host platform.

## Validation

- `go test -race -count=1 ./internal/services/crossseed -run "Hardlink|LocalFileID"`
- `go test -race -count=1 ./pkg/hardlink`
- `go test -race -count=1 ./internal/models -run "UpsertFile_ReplacesChangedFileID"`
- `go test -race -count=1 ./internal/services/automations`
- `go test -race -count=1 ./internal/services/dirscan`
- `go test -race -count=1 ./internal/services/crossseed`
- `make precommit`
- `make build`

All passed. Existing frontend lint warnings remain warnings only.

## Merge order

Merge this PR before the independently branched ReFS shared-extent detection PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows file identity tracking using a platform-neutral 128-bit file identifier, improving hardlink matching.
  - File identity comparisons and ordering now align with the updated Windows identifier format.
  - Repeated updates for the same path now replace the stored file record (preventing duplicates).
- **Documentation**
  - Clarified how Windows file identifiers are represented across platforms.
- **Tests**
  - Added coverage to ensure file identity replacement behavior and expanded Windows hardlink identifier fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->