### PR TITLE
fix(backups): overlap export stalls and cap the adaptive delay

### DIFF
--- a/internal/backups/service.go
+++ b/internal/backups/service.go
@@ -20,10 +20,12 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	qbt "github.com/autobrr/go-qbittorrent"
 	"github.com/rs/zerolog/log"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/autobrr/qui/internal/models"
 	"github.com/autobrr/qui/internal/qbittorrent"
@@ -681,8 +683,6 @@ func (s *Service) executeBackup(ctx context.Context, j job) (*backupResult, erro
 		return nil, fmt.Errorf("failed to prepare backup directory: %w", err)
 	}
 
-	var lastExportElapsed time.Duration
-
 	var snapshotCategories map[string]models.CategorySnapshot
 	if settings.IncludeCategories {
 		categories, err := s.reader.GetCategories(ctx, j.instanceID)
@@ -751,78 +751,54 @@ func (s *Service) executeBackup(ctx context.Context, j job) (*backupResult, erro
 	}
 	s.progressMu.Unlock()
 
-	for idx, torrent := range torrents {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		default:
-		}
+	// Exports run concurrently: qBittorrent serves its WebAPI from a single
+	// thread, so a handful of workers lets fast exports drain while one waits
+	// out a stall behind another client's large response. Results land in a
+	// slice indexed by input position; all order-dependent bookkeeping
+	// (usedPaths, categoryCounts, items) happens afterwards in input order so
+	// the output is identical to a serial run.
+	results := make([]exportedTorrent, len(torrents))
+	var exportedCount atomic.Int64
 
-		var (
-			data          []byte
-			suggestedName string
-			trackerDomain string
-			blobRelPath   *string
-		)
-
-		cachedTorrent, cacheErr := s.loadCachedTorrent(ctx, j.instanceID, torrent.Hash)
-		if cacheErr != nil {
-			log.Warn().Err(cacheErr).Str("hash", torrent.Hash).Msg("Failed to load cached torrent blob")
-		}
-		if cachedTorrent != nil {
-			data = cachedTorrent.data
-			suggestedName = torrent.Name
-			trackerDomain = trackerDomainFromTorrent(torrent)
-			rel := cachedTorrent.relPath
-			blobRelPath = &rel
-		}
-
-		if data == nil {
-			if shouldSkipLiveExportForBackup(torrent, cachedTorrent != nil, cacheErr) {
-				log.Warn().
-					Str("hash", torrent.Hash).
-					Str("name", torrent.Name).
-					Int("instanceID", j.instanceID).
-					Msg("Skipping torrent export; live qBittorrent export disabled for hybrid torrents")
-				s.updateProgress(j.runID, idx+1)
-				continue
+	g, gctx := errgroup.WithContext(ctx)
+	indexes := make(chan int)
+	g.Go(func() error {
+		defer close(indexes)
+		for i := range torrents {
+			select {
+			case indexes <- i:
+			case <-gctx.Done():
+				return gctx.Err()
 			}
-			if err := adaptiveExportDelay(ctx, s.cfg.ExportThrottle, lastExportElapsed); err != nil {
-				return nil, err
-			}
-			exportStart := time.Now()
-			var tracker string
-			data, suggestedName, tracker, err = s.reader.ExportTorrent(ctx, j.instanceID, torrent.Hash)
-			lastExportElapsed = time.Since(exportStart)
-			if err != nil {
-				if isExportMetadataUnavailable(err) {
-					log.Warn().
-						Err(err).
-						Str("hash", torrent.Hash).
-						Str("name", torrent.Name).
-						Int("instanceID", j.instanceID).
-						Msg("Skipping torrent export; metadata not downloaded yet")
-					s.updateProgress(j.runID, idx+1)
-					continue
+		}
+		return nil
+	})
+	for range exportWorkers {
+		g.Go(func() error {
+			// Per-worker adaptive delay keeps the aggregate request rate
+			// bounded by exportWorkers regardless of how the pool schedules.
+			var lastExportElapsed time.Duration
+			for idx := range indexes {
+				res, err := s.exportBackupTorrent(gctx, j, torrents[idx], patchTrackers, webAPIVersion, &lastExportElapsed)
+				if err != nil {
+					return err
 				}
-				return nil, fmt.Errorf("export torrent %s: %w", torrent.Hash, err)
+				results[idx] = res
+				s.updateProgress(j.runID, int(exportedCount.Add(1)))
 			}
-			trackerDomain = tracker
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	for idx, torrent := range torrents {
+		res := results[idx]
+		if res.skipped {
+			continue
 		}
 
-		if patchTrackers {
-			trackers := gatherTrackerURLs(ctx, s.tracker, j.instanceID, torrent)
-			if patched, changed, err := patchTorrentTrackers(data, trackers); err != nil {
-				log.Warn().Err(err).Str("hash", torrent.Hash).Int("instanceID", j.instanceID).Msg("Failed to patch exported torrent trackers")
-			} else if changed {
-				data = patched
-				// ensure cached entry is rebuilt with the corrected payload
-				blobRelPath = nil
-				log.Debug().Str("hash", torrent.Hash).Int("instanceID", j.instanceID).Str("webAPIVersion", webAPIVersion).Msg("Injected tracker metadata into exported torrent")
-			}
-		}
-
-		filename := torrentname.SanitizeExportFilename(suggestedName, torrent.Hash, trackerDomain, torrent.Hash)
 		category := strings.TrimSpace(torrent.Category)
 		var categoryPtr *string
 		if category != "" {
@@ -837,39 +813,15 @@ func (s *Service) executeBackup(ctx context.Context, j job) (*backupResult, erro
 			rawTags = strings.TrimSpace(torrent.Tags)
 		}
 
-		archivePath := filename
+		archivePath := res.filename
 		if settings.IncludeCategories && category != "" {
-			archivePath = filepath.ToSlash(filepath.Join(safeSegment(category), filename))
+			archivePath = filepath.ToSlash(filepath.Join(safeSegment(category), res.filename))
 		}
 
 		uniquePath := ensureUniquePath(archivePath, usedPaths)
+		blobRelPath := res.blobRelPath
 
-		if blobRelPath == nil && s.cacheDir != "" {
-			sum := sha256.Sum256(data)
-			hash := hex.EncodeToString(sum[:])
-			blobName := hash + ".torrent"
-			subdir := ""
-			if len(hash) >= 6 {
-				subdir = filepath.Join(hash[0:2], hash[2:4], hash[4:6])
-			}
-			absBlob := filepath.Join(s.cacheDir, subdir, blobName)
-			if _, err := os.Stat(absBlob); errors.Is(err, os.ErrNotExist) {
-				if subdir != "" {
-					if err := os.MkdirAll(filepath.Dir(absBlob), 0o755); err != nil {
-						return nil, fmt.Errorf("create torrent cache subdir: %w", err)
-					}
-				}
-				if err := os.WriteFile(absBlob, data, 0o644); err != nil && !errors.Is(err, os.ErrExist) {
-					return nil, fmt.Errorf("cache torrent blob: %w", err)
-				}
-			}
-			rel := filepath.ToSlash(filepath.Join("backups", "torrents", subdir, blobName))
-			blobRelPath = &rel
-		}
-
-		// Note: Removed zip header creation for streaming interface
-
-		totalBytes += int64(len(data))
+		totalBytes += int64(res.dataLen)
 
 		infohashV1 := strings.TrimSpace(torrent.InfohashV1)
 		infohashV2 := strings.TrimSpace(torrent.InfohashV2)
@@ -939,9 +891,6 @@ func (s *Service) executeBackup(ctx context.Context, j job) (*backupResult, erro
 			manifestItem.SavePath = storeSavePath
 		}
 		manifestItems = append(manifestItems, manifestItem)
-
-		// Update progress after processing each torrent
-		s.updateProgress(j.runID, idx+1)
 	}
 
 	manifest := Manifest{
@@ -977,16 +926,142 @@ func (s *Service) executeBackup(ctx context.Context, j job) (*backupResult, erro
 	}, nil
 }
 
+// exportWorkers bounds concurrent torrents/export calls during a backup run.
+// Kept small on purpose: enough to overlap stalls on qBittorrent's
+// single-threaded WebAPI without flooding a struggling instance (#1101).
+const exportWorkers = 4
+
+// maxAdaptiveExportDelay caps the adaptive back-pressure delay. A slow export
+// usually means the request queued behind another client's large response, not
+// that qBittorrent is melting down; sleeping the full stall duration again
+// would just double the cost of every stall.
+const maxAdaptiveExportDelay = 500 * time.Millisecond
+
+// exportedTorrent is the order-independent result of exporting one torrent.
+type exportedTorrent struct {
+	skipped     bool
+	dataLen     int
+	filename    string
+	blobRelPath *string
+}
+
+// exportBackupTorrent produces the .torrent payload for one torrent (cached
+// blob or live export), patches trackers if needed, and persists the blob to
+// the cache. It touches no order-dependent backup state, so callers may run it
+// concurrently for distinct torrents. lastExportElapsed carries the adaptive
+// delay state between consecutive calls on the same worker.
+func (s *Service) exportBackupTorrent(ctx context.Context, j job, torrent qbt.Torrent, patchTrackers bool, webAPIVersion string, lastExportElapsed *time.Duration) (exportedTorrent, error) {
+	select {
+	case <-ctx.Done():
+		return exportedTorrent{}, ctx.Err()
+	default:
+	}
+
+	var (
+		data          []byte
+		suggestedName string
+		trackerDomain string
+		blobRelPath   *string
+	)
+
+	cachedTorrent, cacheErr := s.loadCachedTorrent(ctx, j.instanceID, torrent.Hash)
+	if cacheErr != nil {
+		log.Warn().Err(cacheErr).Str("hash", torrent.Hash).Msg("Failed to load cached torrent blob")
+	}
+	if cachedTorrent != nil {
+		data = cachedTorrent.data
+		suggestedName = torrent.Name
+		trackerDomain = trackerDomainFromTorrent(torrent)
+		rel := cachedTorrent.relPath
+		blobRelPath = &rel
+	}
+
+	if data == nil {
+		if shouldSkipLiveExportForBackup(torrent, cachedTorrent != nil, cacheErr) {
+			log.Warn().
+				Str("hash", torrent.Hash).
+				Str("name", torrent.Name).
+				Int("instanceID", j.instanceID).
+				Msg("Skipping torrent export; live qBittorrent export disabled for hybrid torrents")
+			return exportedTorrent{skipped: true}, nil
+		}
+		if err := adaptiveExportDelay(ctx, s.cfg.ExportThrottle, *lastExportElapsed); err != nil {
+			return exportedTorrent{}, err
+		}
+		exportStart := time.Now()
+		var tracker string
+		var err error
+		data, suggestedName, tracker, err = s.reader.ExportTorrent(ctx, j.instanceID, torrent.Hash)
+		*lastExportElapsed = time.Since(exportStart)
+		if err != nil {
+			if isExportMetadataUnavailable(err) {
+				log.Warn().
+					Err(err).
+					Str("hash", torrent.Hash).
+					Str("name", torrent.Name).
+					Int("instanceID", j.instanceID).
+					Msg("Skipping torrent export; metadata not downloaded yet")
+				return exportedTorrent{skipped: true}, nil
+			}
+			return exportedTorrent{}, fmt.Errorf("export torrent %s: %w", torrent.Hash, err)
+		}
+		trackerDomain = tracker
+	}
+
+	if patchTrackers {
+		trackers := gatherTrackerURLs(ctx, s.tracker, j.instanceID, torrent)
+		if patched, changed, err := patchTorrentTrackers(data, trackers); err != nil {
+			log.Warn().Err(err).Str("hash", torrent.Hash).Int("instanceID", j.instanceID).Msg("Failed to patch exported torrent trackers")
+		} else if changed {
+			data = patched
+			// ensure cached entry is rebuilt with the corrected payload
+			blobRelPath = nil
+			log.Debug().Str("hash", torrent.Hash).Int("instanceID", j.instanceID).Str("webAPIVersion", webAPIVersion).Msg("Injected tracker metadata into exported torrent")
+		}
+	}
+
+	if blobRelPath == nil && s.cacheDir != "" {
+		sum := sha256.Sum256(data)
+		hash := hex.EncodeToString(sum[:])
+		blobName := hash + ".torrent"
+		subdir := ""
+		if len(hash) >= 6 {
+			subdir = filepath.Join(hash[0:2], hash[2:4], hash[4:6])
+		}
+		// absBlob is derived from hex-encoded sha256 output, so it cannot
+		// escape cacheDir; 0o644 matches the other blob writes in this file.
+		absBlob := filepath.Join(s.cacheDir, subdir, blobName)
+		if _, err := os.Stat(absBlob); errors.Is(err, os.ErrNotExist) { //nolint:gosec // content-addressed path, no user input
+			if subdir != "" {
+				if err := os.MkdirAll(filepath.Dir(absBlob), 0o755); err != nil { //nolint:gosec // content-addressed path, no user input
+					return exportedTorrent{}, fmt.Errorf("create torrent cache subdir: %w", err)
+				}
+			}
+			if err := os.WriteFile(absBlob, data, 0o644); err != nil && !errors.Is(err, os.ErrExist) { //nolint:gosec // world-readable cache blob, pre-existing mode
+				return exportedTorrent{}, fmt.Errorf("cache torrent blob: %w", err)
+			}
+		}
+		rel := filepath.ToSlash(filepath.Join("backups", "torrents", subdir, blobName))
+		blobRelPath = &rel
+	}
+
+	return exportedTorrent{
+		dataLen:     len(data),
+		filename:    torrentname.SanitizeExportFilename(suggestedName, torrent.Hash, trackerDomain, torrent.Hash),
+		blobRelPath: blobRelPath,
+	}, nil
+}
+
 // adaptiveExportDelay waits between export API calls with back-pressure.
-// The delay is at least minDelay, but extends to match the previous export's
-// response time when qBittorrent is under load. This prevents overwhelming
-// qBittorrent during large backup operations.
+// The delay is at least minDelay and extends to match the previous export's
+// response time when qBittorrent is under load, capped at
+// maxAdaptiveExportDelay so a stalled request is not double-charged.
 func adaptiveExportDelay(ctx context.Context, minDelay, lastExportDuration time.Duration) error {
 	if minDelay <= 0 {
 		return nil
 	}
 
-	delay := max(minDelay, lastExportDuration)
+	delay := max(minDelay, min(lastExportDuration, maxAdaptiveExportDelay))
 	t := time.NewTimer(delay)
 	defer t.Stop()
 
@@ -1101,11 +1176,12 @@ func (s *Service) clearInstance(instanceID int, runID int64) {
 	s.progressMu.Unlock()
 }
 
-// updateProgress updates the progress for a run
+// updateProgress updates the progress for a run. Progress only moves forward:
+// concurrent export workers may report completion counts out of order.
 func (s *Service) updateProgress(runID int64, current int) {
 	s.progressMu.Lock()
 	defer s.progressMu.Unlock()
-	if p := s.progress[runID]; p != nil {
+	if p := s.progress[runID]; p != nil && current > p.Current {
 		p.Current = current
 		p.Percentage = float64(current) / float64(p.Total) * 100
 	}

--- a/internal/backups/service_export_test.go
+++ b/internal/backups/service_export_test.go
@@ -4,10 +4,19 @@
 package backups
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 
 	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/pkg/torrentname"
 )
 
 func TestIsExportMetadataUnavailable(t *testing.T) {
@@ -24,4 +33,317 @@ func TestIsExportMetadataUnavailable(t *testing.T) {
 	if isExportMetadataUnavailable(err) {
 		t.Fatal("expected non-409 status to be non-skippable")
 	}
+}
+
+func TestAdaptiveExportDelayCapsSlowExports(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	// A 10s stall must not be mirrored back as a 10s sleep.
+	require.NoError(t, adaptiveExportDelay(ctx, 20*time.Millisecond, 10*time.Second))
+	elapsed := time.Since(start)
+
+	require.GreaterOrEqual(t, elapsed, maxAdaptiveExportDelay)
+	require.Less(t, elapsed, 2*time.Second)
+}
+
+func TestAdaptiveExportDelayHonorsConfiguredMinAboveCap(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	minDelay := maxAdaptiveExportDelay + 200*time.Millisecond
+	start := time.Now()
+	require.NoError(t, adaptiveExportDelay(ctx, minDelay, 10*time.Second))
+	elapsed := time.Since(start)
+
+	require.GreaterOrEqual(t, elapsed, minDelay)
+}
+
+// concurrentExportStub is a thread-safe backupReader for exercising the
+// concurrent export path with per-hash latency, payload, and error behavior.
+type concurrentExportStub struct {
+	torrents []qbt.Torrent
+	latency  map[string]time.Duration
+	errs     map[string]error
+
+	mu          sync.Mutex
+	calls       int
+	inflight    int
+	maxInflight int
+}
+
+func (s *concurrentExportStub) GetAllTorrents(context.Context, int) ([]qbt.Torrent, error) {
+	return append([]qbt.Torrent(nil), s.torrents...), nil
+}
+
+func (s *concurrentExportStub) GetCategories(context.Context, int) (map[string]qbt.Category, error) {
+	return nil, nil
+}
+
+func (s *concurrentExportStub) GetTags(context.Context, int) ([]string, error) {
+	return nil, nil
+}
+
+func (s *concurrentExportStub) GetInstanceWebAPIVersion(context.Context, int) (string, error) {
+	return "", nil
+}
+
+func (s *concurrentExportStub) ExportTorrent(ctx context.Context, _ int, hash string) ([]byte, string, string, error) {
+	s.mu.Lock()
+	s.calls++
+	s.inflight++
+	if s.inflight > s.maxInflight {
+		s.maxInflight = s.inflight
+	}
+	delay := s.latency[hash]
+	s.mu.Unlock()
+
+	defer func() {
+		s.mu.Lock()
+		s.inflight--
+		s.mu.Unlock()
+	}()
+
+	if delay > 0 {
+		select {
+		case <-ctx.Done():
+			return nil, "", "", ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+
+	if err := s.errs[hash]; err != nil {
+		return nil, "", "", err
+	}
+	return []byte("payload-" + hash), "name-" + hash, "tracker.example", nil
+}
+
+func newExportTestService(t *testing.T, stub backupReader) (*Service, int) {
+	t.Helper()
+
+	db := setupTestBackupDB(t)
+	ctx := context.Background()
+	instanceID := insertTestInstance(t, db, "concurrent-export")
+	store := models.NewBackupStore(db)
+
+	require.NoError(t, store.UpsertSettings(ctx, &models.BackupSettings{
+		InstanceID:        instanceID,
+		Enabled:           true,
+		HourlyEnabled:     true,
+		KeepHourly:        1,
+		IncludeCategories: true,
+		IncludeTags:       true,
+	}))
+
+	svc := NewService(store, stub, nil, Config{
+		WorkerCount:    1,
+		DataDir:        t.TempDir(),
+		ExportThrottle: time.Millisecond,
+	}, nil)
+	svc.now = func() time.Time { return time.Unix(0, 0).UTC() }
+	return svc, instanceID
+}
+
+func TestExecuteBackupConcurrentMatchesSerialOrdering(t *testing.T) {
+	t.Parallel()
+
+	const torrentCount = 24
+
+	torrents := make([]qbt.Torrent, 0, torrentCount)
+	latency := make(map[string]time.Duration, torrentCount)
+	errs := map[string]error{}
+	for i := range torrentCount {
+		hash := fmt.Sprintf("hash-%02d", i)
+		var category string
+		switch i % 3 {
+		case 0:
+			category = "cat-a"
+		case 1:
+			category = "cat-b"
+		}
+		torrents = append(torrents, qbt.Torrent{
+			Hash: hash,
+			// Colliding names force ensureUniquePath to disambiguate in input order.
+			Name:      "Duplicate Name",
+			Category:  category,
+			Tags:      "tag1, tag2",
+			TotalSize: int64(1000 + i),
+		})
+		// Deterministic but varied latencies so completion order differs
+		// from input order.
+		latency[hash] = time.Duration((i*13)%40) * time.Millisecond
+	}
+	// Metadata-unavailable exports must be skipped without failing the run.
+	errs["hash-05"] = errors.New("could not get export; status code: 409: unexpected status code")
+	errs["hash-16"] = qbt.ErrTorrentMetadataNotDownloadedYet
+
+	// Serial reference: what the pre-concurrency loop would have produced.
+	var expectedHashes, expectedPaths []string
+	expectedCounts := map[string]int{}
+	var expectedBytes int64
+	used := map[string]int{}
+	for _, torrent := range torrents {
+		if errs[torrent.Hash] != nil {
+			continue
+		}
+		filename := torrentname.SanitizeExportFilename("name-"+torrent.Hash, torrent.Hash, "tracker.example", torrent.Hash)
+		archivePath := filename
+		if torrent.Category != "" {
+			expectedCounts[torrent.Category]++
+			archivePath = filepath.ToSlash(filepath.Join(safeSegment(torrent.Category), filename))
+		} else {
+			expectedCounts["(uncategorized)"]++
+		}
+		expectedHashes = append(expectedHashes, torrent.Hash)
+		expectedPaths = append(expectedPaths, ensureUniquePath(archivePath, used))
+		expectedBytes += int64(len("payload-" + torrent.Hash))
+	}
+
+	stub := &concurrentExportStub{torrents: torrents, latency: latency, errs: errs}
+	svc, instanceID := newExportTestService(t, stub)
+
+	for runID := int64(1); runID <= 2; runID++ {
+		result, err := svc.executeBackup(context.Background(), job{runID: runID, instanceID: instanceID, kind: models.BackupRunKindManual})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		var gotHashes, gotPaths []string
+		for _, item := range result.items {
+			gotHashes = append(gotHashes, item.TorrentHash)
+			require.NotNil(t, item.ArchiveRelPath)
+			gotPaths = append(gotPaths, *item.ArchiveRelPath)
+		}
+		require.Equal(t, expectedHashes, gotHashes, "archive item order must match input order")
+		require.Equal(t, expectedPaths, gotPaths, "unique archive paths must match a serial run")
+		require.Equal(t, expectedCounts, result.categoryCounts)
+		require.Equal(t, expectedBytes, result.totalBytes)
+		require.Equal(t, len(expectedHashes), result.torrentCount)
+
+		svc.progressMu.RLock()
+		progress := svc.progress[runID]
+		svc.progressMu.RUnlock()
+		require.NotNil(t, progress)
+		require.Equal(t, torrentCount, progress.Current, "skipped torrents still count toward progress")
+		require.Equal(t, torrentCount, progress.Total)
+	}
+
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+	require.LessOrEqual(t, stub.maxInflight, exportWorkers)
+	require.Equal(t, 2*torrentCount, stub.calls)
+}
+
+// rendezvousExportStub blocks every export until at least two are in flight at
+// once, so a serial implementation cannot pass.
+type rendezvousExportStub struct {
+	concurrentExportStub
+	ready     chan struct{}
+	readyOnce sync.Once
+}
+
+func (s *rendezvousExportStub) ExportTorrent(ctx context.Context, _ int, hash string) ([]byte, string, string, error) {
+	s.mu.Lock()
+	s.inflight++
+	if s.inflight >= 2 {
+		s.readyOnce.Do(func() { close(s.ready) })
+	}
+	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		s.inflight--
+		s.mu.Unlock()
+	}()
+
+	select {
+	case <-s.ready:
+		return []byte("payload-" + hash), "name-" + hash, "tracker.example", nil
+	case <-ctx.Done():
+		return nil, "", "", ctx.Err()
+	case <-time.After(5 * time.Second):
+		return nil, "", "", errors.New("export never overlapped with another export")
+	}
+}
+
+func TestExecuteBackupRunsExportsConcurrently(t *testing.T) {
+	t.Parallel()
+
+	torrents := make([]qbt.Torrent, 0, exportWorkers)
+	for i := range exportWorkers {
+		torrents = append(torrents, qbt.Torrent{
+			Hash: fmt.Sprintf("hash-%02d", i),
+			Name: fmt.Sprintf("Torrent %02d", i),
+		})
+	}
+	stub := &rendezvousExportStub{
+		concurrentExportStub: concurrentExportStub{torrents: torrents},
+		ready:                make(chan struct{}),
+	}
+	svc, instanceID := newExportTestService(t, stub)
+
+	result, err := svc.executeBackup(context.Background(), job{runID: 1, instanceID: instanceID, kind: models.BackupRunKindManual})
+	require.NoError(t, err)
+	require.Equal(t, len(torrents), result.torrentCount)
+}
+
+func TestExecuteBackupConcurrentFailsFastOnExportError(t *testing.T) {
+	t.Parallel()
+
+	// The first torrent fails instantly while every other export is slow but
+	// honors ctx.Done; if the error did not cancel outstanding work, all 12
+	// torrents would be exported and the run would take many seconds.
+	errBoom := errors.New("boom")
+	torrents := make([]qbt.Torrent, 0, 12)
+	latency := make(map[string]time.Duration, 12)
+	for i := range 12 {
+		hash := fmt.Sprintf("hash-%02d", i)
+		torrents = append(torrents, qbt.Torrent{Hash: hash, Name: fmt.Sprintf("Torrent %02d", i)})
+		latency[hash] = 5 * time.Second
+	}
+	latency["hash-00"] = 0
+	stub := &concurrentExportStub{
+		torrents: torrents,
+		latency:  latency,
+		errs:     map[string]error{"hash-00": errBoom},
+	}
+	svc, instanceID := newExportTestService(t, stub)
+
+	start := time.Now()
+	_, err := svc.executeBackup(context.Background(), job{runID: 1, instanceID: instanceID, kind: models.BackupRunKindManual})
+	require.ErrorIs(t, err, errBoom)
+	require.Contains(t, err.Error(), "export torrent hash-00")
+	require.Less(t, time.Since(start), 3*time.Second, "first error must cancel outstanding exports")
+
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+	require.Less(t, stub.calls, len(torrents), "error must stop the feed before all torrents export")
+}
+
+func TestExecuteBackupConcurrentStopsOnContextCancel(t *testing.T) {
+	t.Parallel()
+
+	torrents := make([]qbt.Torrent, 0, 40)
+	latency := make(map[string]time.Duration, 40)
+	for i := range 40 {
+		hash := fmt.Sprintf("hash-%02d", i)
+		torrents = append(torrents, qbt.Torrent{Hash: hash, Name: fmt.Sprintf("Torrent %02d", i)})
+		latency[hash] = 200 * time.Millisecond
+	}
+	stub := &concurrentExportStub{torrents: torrents, latency: latency}
+	svc, instanceID := newExportTestService(t, stub)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, err := svc.executeBackup(ctx, job{runID: 1, instanceID: instanceID, kind: models.BackupRunKindManual})
+	require.ErrorIs(t, err, context.Canceled)
+	require.Less(t, time.Since(start), 3*time.Second, "cancellation must stop workers promptly")
 }

--- a/internal/backups/service_export_test.go
+++ b/internal/backups/service_export_test.go
@@ -337,6 +337,7 @@ func TestExecuteBackupConcurrentStopsOnContextCancel(t *testing.T) {
 	svc, instanceID := newExportTestService(t, stub)
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	go func() {
 		time.Sleep(50 * time.Millisecond)
 		cancel()


### PR DESCRIPTION
Fixes #2186. Cold backups of large instances ran at ~1.5s per torrent because exports queue behind other clients' large responses on qBittorrent's single request thread, and our adaptive delay then mirrors every stall back as an equal sleep. Full analysis with measurements is in the issue; this PR is the two fixes.

## Fix 1: cap the adaptive delay

`adaptiveExportDelay` slept `max(throttle, lastExportDuration)` with no upper bound. A slow export means the request queued behind someone else's response, not that qBittorrent is melting down, so mirroring a 3.5s stall back as a 3.5s sleep just doubles the cost of every stall. The delay is now `max(throttle, min(lastExportDuration, 500ms))`. The configured throttle is still honored as the minimum, including values above the cap, and `throttle <= 0` still disables the delay entirely.

## Fix 2: run exports through a small worker pool

Exports now run on 4 workers instead of strictly serially. While one worker waits out a busy window on the server, the others keep draining fast items. Each worker keeps its own adaptive delay, so the aggregate request rate stays bounded and the original throttle intent (#1101, do not overwhelm a struggling instance) is preserved.

Implementation notes:

- The per-item work (blob-cache lookup, export call, tracker patching, blob write) was already independent per torrent. Workers write results into a slice indexed by input position, and all order-dependent bookkeeping (archive path dedup via `ensureUniquePath`, category counts, item/manifest ordering, byte totals) runs afterwards as a sequential pass in input order, so the produced backup is identical to what the serial loop produced. There is a determinism test asserting exactly this.
- Error semantics are unchanged: metadata-unavailable exports are still skipped, any other export error still fails the run, first error wins and cancels outstanding work (errgroup), and context cancellation stops workers promptly.
- Progress is tracked with an atomic counter so it never moves backward under concurrency.
- A side effect of collecting results first: the loop holds only the payload length per torrent instead of the payload itself, so memory stays flat on large runs.
- While working on this I found a pre-existing crash window in the blob cache (truncated file left at the content-addressed path gets trusted by later runs). Unrelated to this change and tracked in #2187; this PR moves that code verbatim.

## Results

Measured on my live instance: qBittorrent 5.2.3, 15,620 torrents, with its normal pollers (tracker health, arrs) running both times, cold blob cache both times (cache directory moved aside before the second run).

| | serial (main) | this PR |
| --- | --- | --- |
| cold backup | 6h 39m (15,620 torrents) | 18 min (15,642 torrents) |
| effective per-item cost | ~1.53s | ~69ms |

The patched run sustained 774 torrents/minute (7,740 exported in the first 10 minutes) and produced the same 673 MB archive as the baseline run. Warm backups already skip unchanged torrents via the blob cache and are unaffected.

## Testing

- `go test -race -count=1 ./...` passes.
- New tests in `internal/backups/service_export_test.go`:
  - delay cap, and configured throttle above the cap still honored;
  - a determinism test that computes the serial reference (order, unique archive paths, category counts, byte totals) and asserts the concurrent run matches it exactly, with varied per-hash latencies, colliding names, and metadata-unavailable skips mixed in;
  - a rendezvous test that fails unless two exports are actually in flight at once;
  - fail-fast on a hard export error, and prompt shutdown on context cancellation.
- `make precommit` and `make build` pass.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Backup exports now run concurrently to reduce total time for large backups.

* **Progress Updates**
  * Backup progress is now monotonic and won’t move backward during parallel exports.

* **Reliability / Bug Fixes**
  * Export failures trigger fast failure and stop further work promptly.
  * Backup ordering and archive-path layout remain consistent with previous behavior.
  * Improved handling for torrents whose metadata isn’t available yet, plus bounded adaptive export delays.

* **Cancellation**
  * Context cancellation stops export workers promptly and returns cancellation status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
