### PR TITLE
fix(backups): write cache blobs atomically

### DIFF
--- a/internal/backups/service.go
+++ b/internal/backups/service.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"net/url"
 	"os"
@@ -60,6 +59,7 @@ type BackupProgress struct {
 type missingTorrent struct {
 	hash    string
 	name    string
+	relPath string
 	absPath string
 }
 
@@ -1077,12 +1077,14 @@ func sweepStaleBlobTemps(cacheDir string) {
 }
 
 // cacheTorrentBlob persists data at the content-addressed path relBlob inside
-// cacheDir via a temp file plus rename, so a crash mid-write can never leave a
+// rootDir via a temp file plus rename, so a crash mid-write can never leave a
 // truncated file at a path later runs would trust (#2187). An existing
 // destination is kept as-is: same address means same content. All access goes
-// through os.Root, which guarantees the path cannot escape cacheDir.
-func cacheTorrentBlob(cacheDir, relBlob string, data []byte) error {
-	root, err := os.OpenRoot(cacheDir)
+// through os.Root, which guarantees the path cannot escape rootDir. Every
+// writer of the blob cache (live export, temp-dir import, background import
+// download) must go through this helper.
+func cacheTorrentBlob(rootDir, relBlob string, data []byte) error {
+	root, err := os.OpenRoot(rootDir)
 	if err != nil {
 		return fmt.Errorf("open torrent cache: %w", err)
 	}
@@ -1736,7 +1738,7 @@ func (s *Service) ImportManifestFromDir(ctx context.Context, instanceID int, man
 			// Check if torrent file path was provided from temp directory
 			if torrentPaths != nil && item.ArchivePath != "" {
 				if tempPath, ok := torrentPaths[item.ArchivePath]; ok {
-					if err := s.copyTorrentFromTemp(tempPath, absPath); err == nil {
+					if err := s.copyTorrentFromTemp(tempPath, dataDir, rel); err == nil {
 						if info, statErr := os.Stat(absPath); statErr == nil {
 							totalTorrentFileBytes += info.Size()
 						}
@@ -1751,7 +1753,7 @@ func (s *Service) ImportManifestFromDir(ctx context.Context, instanceID int, man
 			}
 
 			// Mark for background download from qBittorrent
-			missing = append(missing, missingTorrent{hash: item.Hash, name: item.Name, absPath: absPath})
+			missing = append(missing, missingTorrent{hash: item.Hash, name: item.Name, relPath: rel, absPath: absPath})
 		}
 
 		items = append(items, backupItem)
@@ -1822,51 +1824,22 @@ func (s *Service) ImportManifestFromDir(ctx context.Context, instanceID int, man
 	return run, nil
 }
 
-// copyTorrentFromTemp copies a torrent from temp file to final blob cache location.
-func (s *Service) copyTorrentFromTemp(srcPath, destPath string) error {
-	srcFile, err := os.Open(srcPath)
+// copyTorrentFromTemp validates a torrent from the import temp dir and caches
+// it at the final blob location through the same atomic write as live exports.
+func (s *Service) copyTorrentFromTemp(srcPath, dataDir, relPath string) error {
+	data, err := os.ReadFile(srcPath)
 	if err != nil {
-		return fmt.Errorf("open temp file: %w", err)
+		return fmt.Errorf("read temp file: %w", err)
 	}
-	defer srcFile.Close()
-
-	// Check minimum file size (valid torrents are at least ~50 bytes)
-	info, err := srcFile.Stat()
-	if err != nil {
-		return fmt.Errorf("stat temp file: %w", err)
+	// Valid torrents are at least ~50 bytes and start with 'd' (bencoded dict).
+	if len(data) < 50 {
+		return fmt.Errorf("invalid torrent data: too small (%d bytes)", len(data))
 	}
-	if info.Size() < 50 {
-		return fmt.Errorf("invalid torrent data: too small (%d bytes)", info.Size())
-	}
-
-	// Validate torrent starts with 'd' (bencoded dict)
-	header := make([]byte, 1)
-	if _, err := srcFile.Read(header); err != nil {
-		return fmt.Errorf("read header: %w", err)
-	}
-	if header[0] != 'd' {
+	if data[0] != 'd' {
 		return fmt.Errorf("invalid torrent data: not a bencoded dict")
 	}
-	if _, err := srcFile.Seek(0, io.SeekStart); err != nil {
-		return err
-	}
 
-	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
-		return fmt.Errorf("create dir: %w", err)
-	}
-
-	destFile, err := os.Create(destPath)
-	if err != nil {
-		return fmt.Errorf("create dest: %w", err)
-	}
-	defer destFile.Close()
-
-	if _, err := io.Copy(destFile, srcFile); err != nil {
-		os.Remove(destPath)
-		return fmt.Errorf("copy: %w", err)
-	}
-
-	return nil
+	return cacheTorrentBlob(dataDir, relPath, data)
 }
 
 // downloadMissingTorrents downloads torrent blobs in the background for imported manifests
@@ -1910,13 +1883,7 @@ func (s *Service) downloadMissingTorrents(runID int64, instanceID int, missing [
 			ctx = context.Background()
 		}
 		if data, _, _, err := s.reader.ExportTorrent(ctx, instanceID, mt.hash); err == nil {
-			// Ensure directory exists
-			if err := os.MkdirAll(filepath.Dir(mt.absPath), 0o755); err != nil {
-				log.Error().Err(err).Int("downloaded", successCount).Int("total", total).Int64("runID", runID).Str("hash", mt.hash).Str("path", mt.absPath).Msg("Failed to create directory for torrent blob")
-				s.updateProgress(runID, i+1)
-				continue
-			}
-			if err := os.WriteFile(mt.absPath, data, 0o644); err == nil {
+			if err := cacheTorrentBlob(s.cfg.DataDir, mt.relPath, data); err == nil {
 				log.Trace().Int("downloaded", successCount+1).Int("total", total).Int64("runID", runID).Str("hash", mt.hash).Str("path", mt.absPath).Msg("Successfully cached missing torrent blob")
 				totalTorrentBytes += int64(len(data))
 				successCount++

--- a/internal/backups/service.go
+++ b/internal/backups/service.go
@@ -1120,8 +1120,11 @@ func cacheTorrentBlob(cacheDir, relBlob string, data []byte) error {
 	}
 
 	if err := root.Rename(tmpName, relBlob); err != nil {
-		// Rename over an existing file fails on Windows; if the blob appeared
-		// in the meantime it holds the identical payload.
+		// The destination can only exist here if a concurrent worker
+		// published the identical payload after the existence check above,
+		// so losing the rename race is success. Rename atomically replaces
+		// existing files on POSIX and Windows alike; the stat covers any
+		// filesystem that refuses the replace regardless.
 		if _, statErr := root.Stat(relBlob); statErr == nil {
 			return nil
 		}

--- a/internal/backups/service.go
+++ b/internal/backups/service.go
@@ -170,7 +170,7 @@ func NewService(store *models.BackupStore, reader backupReader, jackettSvc any, 
 		if err := os.MkdirAll(cacheDir, 0o755); err != nil {
 			log.Warn().Err(err).Str("cacheDir", cacheDir).Msg("Failed to prepare torrent cache directory")
 		} else {
-			sweepStaleBlobTemps(cacheDir)
+			go sweepStaleBlobTemps(cacheDir)
 		}
 	}
 
@@ -1049,10 +1049,15 @@ func (s *Service) exportBackupTorrent(ctx context.Context, j job, torrent qbt.To
 // same payload at once.
 var blobTmpSeq atomic.Int64
 
+// blobTmpMinAge shields temp files a live writer is about to rename into
+// place from the sweep; anything older is crash litter.
+const blobTmpMinAge = time.Hour
+
 // sweepStaleBlobTemps removes *.tmp-* files a crashed run may have left in
 // the blob cache. They are never trusted or served; this is litter
-// collection, so every failure is best-effort. Runs once at service creation,
-// before any backup workers exist.
+// collection, so every failure is best-effort. Runs in the background so a
+// large cache does not stall startup; the age guard keeps it clear of temp
+// files concurrent writers are about to rename into place.
 func sweepStaleBlobTemps(cacheDir string) {
 	root, err := os.OpenRoot(cacheDir)
 	if err != nil {
@@ -1061,9 +1066,13 @@ func sweepStaleBlobTemps(cacheDir string) {
 	}
 	defer root.Close()
 
+	cutoff := time.Now().Add(-blobTmpMinAge)
 	removed := 0
 	_ = fs.WalkDir(root.FS(), ".", func(p string, d fs.DirEntry, err error) error {
 		if err != nil || d.IsDir() || !strings.Contains(d.Name(), ".tmp-") {
+			return nil
+		}
+		if info, err := d.Info(); err != nil || info.ModTime().After(cutoff) {
 			return nil
 		}
 		if root.Remove(filepath.FromSlash(p)) == nil {

--- a/internal/backups/service.go
+++ b/internal/backups/service.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -168,6 +169,8 @@ func NewService(store *models.BackupStore, reader backupReader, jackettSvc any, 
 		cacheDir = filepath.Join(cfg.DataDir, "backups", "torrents")
 		if err := os.MkdirAll(cacheDir, 0o755); err != nil {
 			log.Warn().Err(err).Str("cacheDir", cacheDir).Msg("Failed to prepare torrent cache directory")
+		} else {
+			sweepStaleBlobTemps(cacheDir)
 		}
 	}
 
@@ -1028,18 +1031,8 @@ func (s *Service) exportBackupTorrent(ctx context.Context, j job, torrent qbt.To
 		if len(hash) >= 6 {
 			subdir = filepath.Join(hash[0:2], hash[2:4], hash[4:6])
 		}
-		// absBlob is derived from hex-encoded sha256 output, so it cannot
-		// escape cacheDir; 0o644 matches the other blob writes in this file.
-		absBlob := filepath.Join(s.cacheDir, subdir, blobName)
-		if _, err := os.Stat(absBlob); errors.Is(err, os.ErrNotExist) { //nolint:gosec // content-addressed path, no user input
-			if subdir != "" {
-				if err := os.MkdirAll(filepath.Dir(absBlob), 0o755); err != nil { //nolint:gosec // content-addressed path, no user input
-					return exportedTorrent{}, fmt.Errorf("create torrent cache subdir: %w", err)
-				}
-			}
-			if err := os.WriteFile(absBlob, data, 0o644); err != nil && !errors.Is(err, os.ErrExist) { //nolint:gosec // world-readable cache blob, pre-existing mode
-				return exportedTorrent{}, fmt.Errorf("cache torrent blob: %w", err)
-			}
+		if err := cacheTorrentBlob(s.cacheDir, filepath.Join(subdir, blobName), data); err != nil {
+			return exportedTorrent{}, err
 		}
 		rel := filepath.ToSlash(filepath.Join("backups", "torrents", subdir, blobName))
 		blobRelPath = &rel
@@ -1050,6 +1043,89 @@ func (s *Service) exportBackupTorrent(ctx context.Context, j job, torrent qbt.To
 		filename:    torrentname.SanitizeExportFilename(suggestedName, torrent.Hash, trackerDomain, torrent.Hash),
 		blobRelPath: blobRelPath,
 	}, nil
+}
+
+// blobTmpSeq distinguishes temp file names when several writers cache the
+// same payload at once.
+var blobTmpSeq atomic.Int64
+
+// sweepStaleBlobTemps removes *.tmp-* files a crashed run may have left in
+// the blob cache. They are never trusted or served; this is litter
+// collection, so every failure is best-effort. Runs once at service creation,
+// before any backup workers exist.
+func sweepStaleBlobTemps(cacheDir string) {
+	root, err := os.OpenRoot(cacheDir)
+	if err != nil {
+		log.Warn().Err(err).Str("cacheDir", cacheDir).Msg("Failed to open torrent cache for temp sweep")
+		return
+	}
+	defer root.Close()
+
+	removed := 0
+	_ = fs.WalkDir(root.FS(), ".", func(p string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.Contains(d.Name(), ".tmp-") {
+			return nil
+		}
+		if root.Remove(filepath.FromSlash(p)) == nil {
+			removed++
+		}
+		return nil
+	})
+	if removed > 0 {
+		log.Info().Int("removed", removed).Str("cacheDir", cacheDir).Msg("Removed stale torrent cache temp files")
+	}
+}
+
+// cacheTorrentBlob persists data at the content-addressed path relBlob inside
+// cacheDir via a temp file plus rename, so a crash mid-write can never leave a
+// truncated file at a path later runs would trust (#2187). An existing
+// destination is kept as-is: same address means same content. All access goes
+// through os.Root, which guarantees the path cannot escape cacheDir.
+func cacheTorrentBlob(cacheDir, relBlob string, data []byte) error {
+	root, err := os.OpenRoot(cacheDir)
+	if err != nil {
+		return fmt.Errorf("open torrent cache: %w", err)
+	}
+	defer root.Close()
+
+	if _, err := root.Stat(relBlob); !errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if dir := filepath.Dir(relBlob); dir != "." {
+		if err := root.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("create torrent cache subdir: %w", err)
+		}
+	}
+
+	// 0o644 matches the manifest and archive writes in this file.
+	tmpName := fmt.Sprintf("%s.tmp-%d-%d", relBlob, os.Getpid(), blobTmpSeq.Add(1))
+	tmp, err := root.OpenFile(tmpName, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		return fmt.Errorf("cache torrent blob: %w", err)
+	}
+	// Best-effort cleanup: after a successful rename the temp name is gone
+	// and this remove is a no-op.
+	defer func() { _ = root.Remove(tmpName) }()
+
+	_, err = tmp.Write(data)
+	if err == nil {
+		err = tmp.Close()
+	} else {
+		tmp.Close()
+	}
+	if err != nil {
+		return fmt.Errorf("cache torrent blob: %w", err)
+	}
+
+	if err := root.Rename(tmpName, relBlob); err != nil {
+		// Rename over an existing file fails on Windows; if the blob appeared
+		// in the meantime it holds the identical payload.
+		if _, statErr := root.Stat(relBlob); statErr == nil {
+			return nil
+		}
+		return fmt.Errorf("cache torrent blob: %w", err)
+	}
+	return nil
 }
 
 // adaptiveExportDelay waits between export API calls with back-pressure.

--- a/internal/backups/service.go
+++ b/internal/backups/service.go
@@ -1088,8 +1088,10 @@ func cacheTorrentBlob(cacheDir, relBlob string, data []byte) error {
 	}
 	defer root.Close()
 
-	if _, err := root.Stat(relBlob); !errors.Is(err, os.ErrNotExist) {
+	if _, err := root.Stat(relBlob); err == nil {
 		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("cache torrent blob: %w", err)
 	}
 	if dir := filepath.Dir(relBlob); dir != "." {
 		if err := root.MkdirAll(dir, 0o755); err != nil {

--- a/internal/backups/service_export_test.go
+++ b/internal/backups/service_export_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -65,6 +66,35 @@ func TestSweepStaleBlobTemps(t *testing.T) {
 	_, err = os.Stat(stale)
 	require.ErrorIs(t, err, os.ErrNotExist)
 	_, err = os.Stat(staleRoot)
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestCopyTorrentFromTempAtomicWrite(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{}
+	dataDir := t.TempDir()
+	src := filepath.Join(t.TempDir(), "upload.torrent")
+	payload := []byte("d" + strings.Repeat("x", 63))
+	require.NoError(t, os.WriteFile(src, payload, 0o600))
+
+	rel := filepath.Join("backups", "torrents", "aa", "bb", "cc", "deadbeef.torrent")
+	require.NoError(t, svc.copyTorrentFromTemp(src, dataDir, rel))
+
+	got, err := os.ReadFile(filepath.Join(dataDir, rel))
+	require.NoError(t, err)
+	require.Equal(t, payload, got)
+
+	// No temp files may remain next to the blob.
+	entries, err := os.ReadDir(filepath.Join(dataDir, filepath.Dir(rel)))
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+
+	// Invalid payloads are rejected before anything is written.
+	badSrc := filepath.Join(t.TempDir(), "bad.torrent")
+	require.NoError(t, os.WriteFile(badSrc, []byte("not bencoded, but long enough to pass the size check"), 0o600))
+	require.ErrorContains(t, svc.copyTorrentFromTemp(badSrc, dataDir, filepath.Join("backups", "torrents", "bad.torrent")), "not a bencoded dict")
+	_, err = os.Stat(filepath.Join(dataDir, "backups", "torrents", "bad.torrent"))
 	require.ErrorIs(t, err, os.ErrNotExist)
 }
 

--- a/internal/backups/service_export_test.go
+++ b/internal/backups/service_export_test.go
@@ -58,11 +58,21 @@ func TestSweepStaleBlobTemps(t *testing.T) {
 	require.NoError(t, os.WriteFile(stale, []byte("partial"), 0o600))
 	staleRoot := filepath.Join(dir, "cafe.torrent.tmp-123-2")
 	require.NoError(t, os.WriteFile(staleRoot, []byte("partial"), 0o600))
+	fresh := filepath.Join(blobDir, "cafebabe.torrent.tmp-123-3")
+	require.NoError(t, os.WriteFile(fresh, []byte("inflight"), 0o600))
+
+	// Age everything but the fresh temp past the guard.
+	old := time.Now().Add(-2 * blobTmpMinAge)
+	for _, p := range []string{blob, stale, staleRoot} {
+		require.NoError(t, os.Chtimes(p, old, old))
+	}
 
 	sweepStaleBlobTemps(dir)
 
 	_, err := os.Stat(blob)
 	require.NoError(t, err, "real blobs must survive the sweep")
+	_, err = os.Stat(fresh)
+	require.NoError(t, err, "temp files inside the age guard must survive")
 	_, err = os.Stat(stale)
 	require.ErrorIs(t, err, os.ErrNotExist)
 	_, err = os.Stat(staleRoot)

--- a/internal/backups/service_export_test.go
+++ b/internal/backups/service_export_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -18,6 +19,54 @@ import (
 	"github.com/autobrr/qui/internal/models"
 	"github.com/autobrr/qui/pkg/torrentname"
 )
+
+func TestCacheTorrentBlobAtomicWrite(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	relBlob := filepath.Join("aa", "bb", "cc", "deadbeef.torrent")
+	absBlob := filepath.Join(dir, relBlob)
+
+	require.NoError(t, cacheTorrentBlob(dir, relBlob, []byte("payload")))
+	got, err := os.ReadFile(absBlob)
+	require.NoError(t, err)
+	require.Equal(t, []byte("payload"), got)
+
+	// No temp files may remain next to the blob.
+	entries, err := os.ReadDir(filepath.Dir(absBlob))
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+
+	// An existing destination is trusted and never rewritten.
+	require.NoError(t, os.WriteFile(absBlob, []byte("sentinel"), 0o600))
+	require.NoError(t, cacheTorrentBlob(dir, relBlob, []byte("payload")))
+	got, err = os.ReadFile(absBlob)
+	require.NoError(t, err)
+	require.Equal(t, []byte("sentinel"), got)
+}
+
+func TestSweepStaleBlobTemps(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	blobDir := filepath.Join(dir, "aa", "bb", "cc")
+	require.NoError(t, os.MkdirAll(blobDir, 0o755))
+	blob := filepath.Join(blobDir, "deadbeef.torrent")
+	require.NoError(t, os.WriteFile(blob, []byte("payload"), 0o600))
+	stale := filepath.Join(blobDir, "deadbeef.torrent.tmp-123-1")
+	require.NoError(t, os.WriteFile(stale, []byte("partial"), 0o600))
+	staleRoot := filepath.Join(dir, "cafe.torrent.tmp-123-2")
+	require.NoError(t, os.WriteFile(staleRoot, []byte("partial"), 0o600))
+
+	sweepStaleBlobTemps(dir)
+
+	_, err := os.Stat(blob)
+	require.NoError(t, err, "real blobs must survive the sweep")
+	_, err = os.Stat(stale)
+	require.ErrorIs(t, err, os.ErrNotExist)
+	_, err = os.Stat(staleRoot)
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
 
 func TestIsExportMetadataUnavailable(t *testing.T) {
 	if !isExportMetadataUnavailable(qbt.ErrTorrentMetadataNotDownloadedYet) {


### PR DESCRIPTION
Closes #2187.

The backup blob cache stores exported .torrent payloads at content-addressed paths (`backups/torrents/xx/yy/zz/<sha256>.torrent`) and wrote them with `os.WriteFile` directly at the final path. `os.WriteFile` truncates and writes in place, so a crash mid-write or a partial write (for example ENOSPC) leaves a truncated file at the final path. Because the cache trusts any existing file at a content-addressed path, a later run exporting the same payload would stat the truncated file, skip the rewrite, and record it in its manifest, and restore or archive downloads would then serve the corrupt .torrent. Details and reproduction in #2187.

The fix writes the payload to a uniquely named temp file in the same directory and renames it into place. A failed write now cleans up its temp file, where the old code left the truncated file behind at the trusted path. A hard crash can still leave a `*.tmp` file, but nothing trusts or serves those, and service startup now sweeps any such leftovers from the cache directory. Behavior is otherwise unchanged: an existing destination is kept as-is (same address means same content), the file mode stays 0644, and error wrapping is preserved. A rename that fails because the destination appeared in the meantime is tolerated, which also covers Windows, where rename over an existing file fails.

For reviewers: filesystem access in the new helper goes through `os.Root` opened on the cache directory rather than plain `os.*` calls. gosec's taint analysis flags stat/rename on joined paths even for this content-addressed case, and rather than adding `nolint` suppressions I used the API that makes escape structurally impossible, so the linter passes on its own merits.

Note: #2188 moves this same block of code into a helper as part of the backup throughput work. The two PRs are deliberately independent since they solve different problems; whichever merges second will need a small rebase of this block, which I'll handle.

**Testing**

- `go test -race -count=1 ./internal/backups/` passes, `make precommit` passes.
- New `TestCacheTorrentBlobAtomicWrite` covers: blob written with correct content, no temp files left behind on success, and an existing destination is never rewritten.
- New `TestSweepStaleBlobTemps` covers: stale temp files removed at any depth, real blobs untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup export and restore reliability by introducing crash-safe, content-addressed torrent blob caching.
  * Safer handling of rename race conditions to prevent corrupted or missing cached blobs, including on Windows.
  * Avoids overwriting existing valid cached data and cleans only stale temporary cache artifacts.

* **Tests**
  * Added coverage to ensure cached blob writes are atomic (no leftover temp files), stale-temp sweeping behaves correctly, and invalid temp torrent payloads are rejected without writing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

**Update 2026-07-30 (soup):** rebased onto develop after #2188 (the blob write now runs inside `exportBackupTorrent`, resolving the rebase note above), and review turned up two follow-ups pushed as separate commits: the temp-dir import copy and the background import download wrote the same content-addressed cache non-atomically at the final path, so both now route through `cacheTorrentBlob`; and the startup temp sweep now runs in the background with a 1h age guard, so a large cache no longer delays the HTTP listener on every boot.
