### PR TITLE
feat(backups): reclaim orphaned torrent cache blobs at startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,7 @@ Frontend-specific rules live in `web/AGENTS.md`. Read that file before editing `
 
 - Conventional commits: `feat(scope):`, `fix(scope):`, etc.
 - Keep commits focused; split backend/frontend when practical.
+- Update PR branches by merging develop into them, never rebase/force-push. PRs are squash-merged, so rebase gains nothing and force-pushes break review history and contributors' local branches.
 - Never add AI advertising/attribution/co-author lines.
 - PRs need clear summary, testing checklist, and screenshots for visual UI changes.
 

--- a/internal/backups/service.go
+++ b/internal/backups/service.go
@@ -1184,11 +1184,11 @@ func (s *Service) cleanupOrphanedBlobs(ctx context.Context) {
 	cutoff := s.now().Add(-orphanBlobMinAge)
 	removed := 0
 	var freed int64
-	_ = fs.WalkDir(root.FS(), ".", func(p string, d fs.DirEntry, walkErr error) error {
+	walkErr := fs.WalkDir(root.FS(), ".", func(p string, d fs.DirEntry, entryErr error) error {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if walkErr != nil || d.IsDir() {
+		if entryErr != nil || d.IsDir() {
 			return nil
 		}
 		if _, ok := referenced[filepath.Join(s.cacheDir, filepath.FromSlash(p))]; ok {
@@ -1204,6 +1204,9 @@ func (s *Service) cleanupOrphanedBlobs(ctx context.Context) {
 		}
 		return nil
 	})
+	if walkErr != nil {
+		log.Warn().Err(walkErr).Str("cacheDir", s.cacheDir).Msg("Torrent cache cleanup stopped early")
+	}
 	if removed > 0 {
 		log.Info().Int("removed", removed).Int64("freedBytes", freed).Str("cacheDir", s.cacheDir).Msg("Removed orphaned torrent cache blobs")
 	}

--- a/internal/backups/service.go
+++ b/internal/backups/service.go
@@ -1872,7 +1872,7 @@ func (s *Service) ImportManifestFromDir(ctx context.Context, instanceID int, man
 		s.progressMu.Unlock()
 		log.Info().Int64("runID", run.ID).Int("total", len(missing)).Msg("Initialized import progress")
 		s.wg.Go(func() {
-			s.downloadMissingTorrents(run.ID, instanceID, missing)
+			s.downloadMissingTorrents(run.ID, instanceID, dataDir, missing)
 		})
 	} else {
 		// No missing torrents, mark as completed immediately
@@ -1925,8 +1925,10 @@ func (s *Service) copyTorrentFromTemp(srcPath, dataDir, relPath string) error {
 	return cacheTorrentBlob(dataDir, relPath, data)
 }
 
-// downloadMissingTorrents downloads torrent blobs in the background for imported manifests
-func (s *Service) downloadMissingTorrents(runID int64, instanceID int, missing []missingTorrent) {
+// downloadMissingTorrents downloads torrent blobs in the background for
+// imported manifests. dataDir is the import's normalized data directory, the
+// same root missingTorrent.absPath was built from.
+func (s *Service) downloadMissingTorrents(runID int64, instanceID int, dataDir string, missing []missingTorrent) {
 	if s.reader == nil {
 		log.Warn().Int64("runID", runID).Msg("No sync manager available for background torrent downloads")
 		s.markImportComplete(instanceID, runID)
@@ -1966,7 +1968,7 @@ func (s *Service) downloadMissingTorrents(runID int64, instanceID int, missing [
 			ctx = context.Background()
 		}
 		if data, _, _, err := s.reader.ExportTorrent(ctx, instanceID, mt.hash); err == nil {
-			if err := cacheTorrentBlob(s.cfg.DataDir, mt.relPath, data); err == nil {
+			if err := cacheTorrentBlob(dataDir, mt.relPath, data); err == nil {
 				log.Trace().Int("downloaded", successCount+1).Int("total", total).Int64("runID", runID).Str("hash", mt.hash).Str("path", mt.absPath).Msg("Successfully cached missing torrent blob")
 				totalTorrentBytes += int64(len(data))
 				successCount++

--- a/internal/backups/service.go
+++ b/internal/backups/service.go
@@ -308,13 +308,18 @@ func (s *Service) Start(ctx context.Context) {
 		log.Warn().Err(err).Msg("Failed to recover incomplete backup runs")
 	}
 
-	// Reclaim cache blobs stranded by failed runs before workers start writing.
-	s.cleanupOrphanedBlobs(ctx)
-
-	for i := 0; i < s.cfg.WorkerCount; i++ {
-		s.wg.Add(1)
-		go s.worker(ctx)
-	}
+	// Reclaim cache blobs stranded by failed runs before workers start
+	// writing, but off the startup path so a large cache cannot hold up the
+	// HTTP listener. Workers only spawn once the sweep finishes; a canceled
+	// ctx stops the sweep mid-walk, and the pre-registered wg count keeps
+	// Stop waiting for the late-spawned workers.
+	s.wg.Add(s.cfg.WorkerCount)
+	go func() {
+		s.cleanupOrphanedBlobs(ctx)
+		for i := 0; i < s.cfg.WorkerCount; i++ {
+			go s.worker(ctx)
+		}
+	}()
 
 	// Check for missed backups and queue exactly one if applicable
 	s.wg.Go(func() {
@@ -1153,9 +1158,10 @@ const orphanBlobMinAge = 24 * time.Hour
 // cleanupOrphanedBlobs removes cache files no backup item references. Blobs
 // are written to the cache during export but only referenced in the database
 // once the whole run succeeds, so every failed run strands its already-written
-// blobs and nothing else ever deletes them. Runs at startup before any backup
-// workers exist; the age guard keeps it clear of files written around the
-// sweep. All access goes through os.Root so paths cannot escape the cache.
+// blobs and nothing else ever deletes them. Runs in the background at startup,
+// before any backup workers spawn; the age guard keeps it clear of files
+// written around the sweep. All access goes through os.Root so paths cannot
+// escape the cache.
 func (s *Service) cleanupOrphanedBlobs(ctx context.Context) {
 	if s.cacheDir == "" {
 		return

--- a/internal/backups/service.go
+++ b/internal/backups/service.go
@@ -308,6 +308,9 @@ func (s *Service) Start(ctx context.Context) {
 		log.Warn().Err(err).Msg("Failed to recover incomplete backup runs")
 	}
 
+	// Reclaim cache blobs stranded by failed runs before workers start writing.
+	s.cleanupOrphanedBlobs(ctx)
+
 	for i := 0; i < s.cfg.WorkerCount; i++ {
 		s.wg.Add(1)
 		go s.worker(ctx)
@@ -1142,6 +1145,68 @@ func cacheTorrentBlob(rootDir, relBlob string, data []byte) error {
 		return fmt.Errorf("cache torrent blob: %w", err)
 	}
 	return nil
+}
+
+// orphanBlobMinAge shields just-written blobs from the startup orphan sweep.
+const orphanBlobMinAge = 24 * time.Hour
+
+// cleanupOrphanedBlobs removes cache files no backup item references. Blobs
+// are written to the cache during export but only referenced in the database
+// once the whole run succeeds, so every failed run strands its already-written
+// blobs and nothing else ever deletes them. Runs at startup before any backup
+// workers exist; the age guard keeps it clear of files written around the
+// sweep. All access goes through os.Root so paths cannot escape the cache.
+func (s *Service) cleanupOrphanedBlobs(ctx context.Context) {
+	if s.cacheDir == "" {
+		return
+	}
+
+	refs, err := s.store.ListTorrentBlobPaths(ctx)
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to list referenced torrent blobs; skipping cache cleanup")
+		return
+	}
+	// Stored paths are relative to the data dir, with legacy entries relative
+	// to backups/ (see loadCachedTorrent); accept both interpretations.
+	referenced := make(map[string]struct{}, len(refs)*2)
+	for _, rel := range refs {
+		referenced[filepath.Join(s.cfg.DataDir, filepath.FromSlash(rel))] = struct{}{}
+		referenced[filepath.Join(s.cfg.DataDir, "backups", filepath.FromSlash(rel))] = struct{}{}
+	}
+
+	root, err := os.OpenRoot(s.cacheDir)
+	if err != nil {
+		log.Warn().Err(err).Str("cacheDir", s.cacheDir).Msg("Failed to open torrent cache for cleanup")
+		return
+	}
+	defer root.Close()
+
+	cutoff := s.now().Add(-orphanBlobMinAge)
+	removed := 0
+	var freed int64
+	_ = fs.WalkDir(root.FS(), ".", func(p string, d fs.DirEntry, walkErr error) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if walkErr != nil || d.IsDir() {
+			return nil
+		}
+		if _, ok := referenced[filepath.Join(s.cacheDir, filepath.FromSlash(p))]; ok {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil || info.ModTime().After(cutoff) {
+			return nil
+		}
+		if root.Remove(filepath.FromSlash(p)) == nil {
+			removed++
+			freed += info.Size()
+		}
+		return nil
+	})
+	if removed > 0 {
+		log.Info().Int("removed", removed).Int64("freedBytes", freed).Str("cacheDir", s.cacheDir).Msg("Removed orphaned torrent cache blobs")
+	}
 }
 
 // adaptiveExportDelay waits between export API calls with back-pressure.

--- a/internal/backups/service.go
+++ b/internal/backups/service.go
@@ -311,15 +311,15 @@ func (s *Service) Start(ctx context.Context) {
 	// Reclaim cache blobs stranded by failed runs before workers start
 	// writing, but off the startup path so a large cache cannot hold up the
 	// HTTP listener. Workers only spawn once the sweep finishes; a canceled
-	// ctx stops the sweep mid-walk, and the pre-registered wg count keeps
-	// Stop waiting for the late-spawned workers.
+	// ctx stops the sweep mid-walk, and the pre-registered wg count plus the
+	// tracked sweep goroutine keep Stop waiting for both.
 	s.wg.Add(s.cfg.WorkerCount)
-	go func() {
+	s.wg.Go(func() {
 		s.cleanupOrphanedBlobs(ctx)
 		for i := 0; i < s.cfg.WorkerCount; i++ {
 			go s.worker(ctx)
 		}
-	}()
+	})
 
 	// Check for missed backups and queue exactly one if applicable
 	s.wg.Go(func() {

--- a/internal/backups/service_test.go
+++ b/internal/backups/service_test.go
@@ -1407,6 +1407,18 @@ func TestCleanupOrphanedBlobs(t *testing.T) {
 	require.ErrorIs(t, err, os.ErrNotExist, "aged orphan blobs must be removed")
 	_, err = os.Stat(freshOrphanAbs)
 	require.NoError(t, err, "fresh files stay inside the age guard")
+
+	// A canceled context stops the cleanup before it removes anything.
+	lateOrphanAbs := filepath.Join(cacheDir, "late-orphan.torrent")
+	require.NoError(t, os.WriteFile(lateOrphanAbs, []byte("blob"), 0o600))
+	require.NoError(t, os.Chtimes(lateOrphanAbs, old, old))
+
+	canceledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	svc.cleanupOrphanedBlobs(canceledCtx)
+
+	_, err = os.Stat(lateOrphanAbs)
+	require.NoError(t, err, "cleanup must not remove files once the context is canceled")
 }
 
 type stubBackupSyncManager struct {

--- a/internal/backups/service_test.go
+++ b/internal/backups/service_test.go
@@ -1408,18 +1408,26 @@ func TestCleanupOrphanedBlobs(t *testing.T) {
 	_, err = os.Stat(freshOrphanAbs)
 	require.NoError(t, err, "fresh files stay inside the age guard")
 
-	// A canceled context stops the cleanup before it removes anything.
+	// Cancellation observed mid-walk stops the cleanup before it removes
+	// anything. A plain canceled context would already fail the store query,
+	// so walkCanceledCtx lets the query through and only reports the
+	// cancellation to the walk's ctx.Err() polls.
 	lateOrphanAbs := filepath.Join(cacheDir, "late-orphan.torrent")
 	require.NoError(t, os.WriteFile(lateOrphanAbs, []byte("blob"), 0o600))
 	require.NoError(t, os.Chtimes(lateOrphanAbs, old, old))
 
-	canceledCtx, cancel := context.WithCancel(ctx)
-	cancel()
-	svc.cleanupOrphanedBlobs(canceledCtx)
+	svc.cleanupOrphanedBlobs(walkCanceledCtx{})
 
 	_, err = os.Stat(lateOrphanAbs)
 	require.NoError(t, err, "cleanup must not remove files once the context is canceled")
 }
+
+type walkCanceledCtx struct{}
+
+func (walkCanceledCtx) Deadline() (time.Time, bool) { return time.Time{}, false }
+func (walkCanceledCtx) Done() <-chan struct{}       { return nil }
+func (walkCanceledCtx) Err() error                  { return context.Canceled }
+func (walkCanceledCtx) Value(any) any               { return nil }
 
 type stubBackupSyncManager struct {
 	torrents    []qbt.Torrent

--- a/internal/backups/service_test.go
+++ b/internal/backups/service_test.go
@@ -1355,6 +1355,60 @@ func TestCleanupTorrentBlobsKeepsReferencedBlobs(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestCleanupOrphanedBlobs(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestBackupDB(t)
+	ctx := context.Background()
+	instanceID := insertTestInstance(t, db, "blob-gc")
+	store := models.NewBackupStore(db)
+
+	dataDir := t.TempDir()
+	cacheDir := filepath.Join(dataDir, "backups", "torrents", "aa", "bb", "cc")
+	require.NoError(t, os.MkdirAll(cacheDir, 0o755))
+
+	referencedRel := filepath.ToSlash(filepath.Join("backups", "torrents", "aa", "bb", "cc", "referenced.torrent"))
+	referencedAbs := filepath.Join(dataDir, filepath.FromSlash(referencedRel))
+	orphanAbs := filepath.Join(cacheDir, "orphan.torrent")
+	freshOrphanAbs := filepath.Join(cacheDir, "fresh.torrent")
+	for _, p := range []string{referencedAbs, orphanAbs, freshOrphanAbs} {
+		require.NoError(t, os.WriteFile(p, []byte("blob"), 0o600))
+	}
+	// Age the referenced and orphaned blobs past the guard; only the orphan
+	// may be removed. The fresh orphan stays inside the age guard.
+	old := time.Now().Add(-48 * time.Hour)
+	require.NoError(t, os.Chtimes(referencedAbs, old, old))
+	require.NoError(t, os.Chtimes(orphanAbs, old, old))
+
+	now := time.Now().UTC()
+	run := &models.BackupRun{
+		InstanceID:  instanceID,
+		Kind:        models.BackupRunKindManual,
+		Status:      models.BackupRunStatusSuccess,
+		RequestedBy: "tester",
+		RequestedAt: now,
+		StartedAt:   &now,
+		CompletedAt: &now,
+	}
+	require.NoError(t, store.CreateRun(ctx, run))
+	require.NoError(t, store.InsertItems(ctx, run.ID, []models.BackupItem{{
+		RunID:           run.ID,
+		TorrentHash:     "hash-1",
+		Name:            "Referenced",
+		TorrentBlobPath: &referencedRel,
+	}}))
+
+	svc := NewService(store, &stubBackupSyncManager{}, nil, Config{WorkerCount: 1, DataDir: dataDir}, nil)
+	svc.cleanupOrphanedBlobs(ctx)
+
+	_, err := os.Stat(referencedAbs)
+	require.NoError(t, err, "referenced blobs must survive")
+	_, err = os.Stat(orphanAbs)
+	require.ErrorIs(t, err, os.ErrNotExist, "aged orphan blobs must be removed")
+	_, err = os.Stat(freshOrphanAbs)
+	require.NoError(t, err, "fresh files stay inside the age guard")
+}
+
 type stubBackupSyncManager struct {
 	torrents    []qbt.Torrent
 	categories  map[string]qbt.Category

--- a/internal/models/backups.go
+++ b/internal/models/backups.go
@@ -1175,6 +1175,32 @@ func (s *BackupStore) FindCachedTorrentBlob(ctx context.Context, instanceID int,
 	return &trimmed, nil
 }
 
+// ListTorrentBlobPaths returns every distinct blob path referenced by any
+// backup item across all runs and instances.
+func (s *BackupStore) ListTorrentBlobPaths(ctx context.Context) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT DISTINCT torrent_blob_path
+		FROM instance_backup_items_view
+		WHERE torrent_blob_path IS NOT NULL
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var paths []string
+	for rows.Next() {
+		var path sql.NullString
+		if err := rows.Scan(&path); err != nil {
+			return nil, err
+		}
+		if trimmed := strings.TrimSpace(path.String); path.Valid && trimmed != "" {
+			paths = append(paths, trimmed)
+		}
+	}
+	return paths, rows.Err()
+}
+
 func (s *BackupStore) CountBlobReferences(ctx context.Context, relPath string) (int, error) {
 	var count int
 	err := s.db.QueryRowContext(ctx, `


### PR DESCRIPTION
Backup blobs are written to the content-addressed cache (`backups/torrents/xx/yy/zz/<sha256>.torrent`) while the export loop runs, but the database rows that reference them (`InsertItems`) are only written once the whole run succeeds. A run that fails partway therefore strands every blob it already wrote: no `backup_items` row points at them, and the existing cleanup (`cleanupTorrentBlobs`) works from database records of deleted runs, so it can never see them. Nothing else deletes cache files.

This is not hypothetical. My backups failed for about a month (see #2186 for why) and I recently deleted roughly 10 GB of stranded blob data by hand.

The fix is a startup sweep: when the service starts, before any backup workers exist, it lists every blob path referenced by any backup item, walks the cache directory, and removes unreferenced files older than 24 hours. The age guard keeps the sweep clear of anything written around startup, and running before the workers means it cannot race an in-flight backup. Filesystem access goes through `os.Root` opened on the cache directory, so paths cannot escape it and gosec passes without suppressions.

The new `ListTorrentBlobPaths` store method reads through the existing `instance_backup_items_view`, so there are no schema changes and no migrations.

Related: #2189 makes blob writes atomic so failures cannot leave truncated files at trusted paths; this PR reclaims the disk those failures leak. Both are independent of #2188.

**Testing**

- `go test -race -count=1 ./internal/backups/ ./internal/models/` passes, `make precommit` passes.
- New `TestCleanupOrphanedBlobs` covers: referenced blobs survive regardless of age, aged orphans are removed, files younger than the age guard are kept.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup cleanup to remove stale, unreferenced torrent cache files while preserving referenced and recently created entries.
  * Cleanup now honors cancellation more safely, preventing deletion of newly orphaned files during shutdown/interruption.
  * Backup service shutdown now waits for both cleanup sweeping and export workers to finish.
* **New Features**
  * Export and import/background downloads now use consistent, atomic cache writes for exported torrent data.
  * Added cleanup for stale temporary cache files (older than ~1 hour).
* **Tests**
  * Added unit coverage for orphan blob cleanup, including ensuring aged-orphan removal is skipped when cancellation occurs mid-cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

**Update 2026-07-30 (soup):** rebased onto develop after #2188. The cleanup now runs in a background goroutine that spawns the backup workers only once it finishes, so the HTTP listener is no longer held up by a large cache walk while the run-before-workers invariant is preserved. The cancellation half of `TestCleanupOrphanedBlobs` now exercises the in-walk `ctx.Err()` guard; previously a pre-canceled context failed the store query before the walk ever ran.
