### PR TITLE
fix(crossseed): match titles whose punctuation scene naming drops

### DIFF
--- a/internal/services/crossseed/seasonpack_matching_settings_test.go
+++ b/internal/services/crossseed/seasonpack_matching_settings_test.go
@@ -236,6 +236,24 @@ func TestSeasonPackReleasesMatchWithReason_AliasTitles(t *testing.T) {
 	}
 }
 
+// TestSeasonPackReleasesMatchWithReason_SceneNameDropsTitlePunctuation proves a scene-style
+// pack name that drops the title's trailing punctuation ("Overtake!" announced as
+// "Overtake.S01...") still matches local fansub episodes that keep it. Reported for
+// BTN's Overtake pack, which failed while BHD's punctuation-keeping name matched.
+func TestSeasonPackReleasesMatchWithReason_SceneNameDropsTitlePunctuation(t *testing.T) {
+	matcher := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
+
+	pack := parseSeasonPackTestRelease(t, "Overtake.S01.1080p.CR.WEB-DL.AAC2.0.H.264-SubsPlease")
+	episode := parseSeasonPackTestRelease(t, "[SubsPlease] Overtake! - 01 (1080p) [F5A70A05]")
+	// matchEpisodeCandidatesDetailed stamps the pack season onto seasonless locals
+	// before matching; mirror that here.
+	episode.Series = pack.Series
+
+	ok, reason := matcher.seasonPackReleasesMatchWithReason(pack, episode, true, nil, nil)
+	require.True(t, ok, "expected match, got reason %q", reason)
+	require.Empty(t, reason)
+}
+
 // TestSeasonPackReleasesMatchWithReason_OriginalLanguageTag proves a pack that labels the
 // original audio language still matches episodes published without a language tag. Trackers
 // like Aither tag JAPANESE on anime that every other tracker leaves untagged, which used to

--- a/internal/services/crossseed/seasonpack_regression_test.go
+++ b/internal/services/crossseed/seasonpack_regression_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/autobrr/qui/internal/models"
 	internalqb "github.com/autobrr/qui/internal/qbittorrent"
 	"github.com/autobrr/qui/pkg/hardlinktree"
+	"github.com/autobrr/qui/pkg/stringutils"
 )
 
 type seasonPackRegressionSyncManager struct {
@@ -117,6 +118,45 @@ func TestBuildSeasonPackPlan_RejectsEscapingTargetPaths(t *testing.T) {
 
 	require.ErrorIs(t, err, errLayoutMismatch)
 	require.ErrorContains(t, err, "invalid pack target path")
+}
+
+// TestSeasonPack_PunctuationOnlySequelTitles documents the deliberate tradeoff from
+// stripping !/? in title normalization: sequels distinguished only by punctuation
+// (K-On! vs K-On!!) now title-match, because scene naming drops the punctuation
+// anyway. The apply path still cannot link the wrong show's episodes:
+// buildSeasonPackPlan requires exact per-episode byte sizes.
+func TestSeasonPack_PunctuationOnlySequelTitles(t *testing.T) {
+	matcher := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
+
+	packRelease := rls.ParseString("K-On! S01 1080p BluRay FLAC x264-Fansub")
+	local := rls.ParseString("[Fansub] K-On!! - 05 (1080p) [ABC12345]")
+	// matchEpisodeCandidatesDetailed stamps the pack season onto seasonless locals.
+	local.Series = packRelease.Series
+
+	ok, reason := matcher.seasonPackReleasesMatchWithReason(&packRelease, &local, true, nil, nil)
+	require.True(t, ok, "expected punctuation-only titles to conflate, got reason %q", reason)
+
+	localFiles := map[episodeIdentity]seasonPackLocalFile{
+		{series: 1, episode: 5}: {
+			sourcePath: "/media/[Fansub] K-On!! - 05 (1080p) [ABC12345].mkv",
+			size:       10,
+			release:    &local,
+		},
+	}
+
+	_, err := buildSeasonPackPlan(
+		qbt.TorrentFiles{{Name: "K-On! S01 1080p BluRay/[Fansub] K-On! - 05 (1080p) [DEF67890].mkv", Size: 20}},
+		&packRelease,
+		"K-On! S01 1080p BluRay",
+		t.TempDir(),
+		localFiles,
+		seasonPackNormalizer(nil),
+		nil,
+		nil,
+	)
+
+	require.ErrorIs(t, err, errLayoutMismatch)
+	require.ErrorContains(t, err, "file size mismatch")
 }
 
 func TestApplySeasonPackWebhook_SelectsConcreteBaseDirFromCommaSeparatedConfig(t *testing.T) {

--- a/internal/services/crossseed/seasonpack_regression_test.go
+++ b/internal/services/crossseed/seasonpack_regression_test.go
@@ -123,8 +123,9 @@ func TestBuildSeasonPackPlan_RejectsEscapingTargetPaths(t *testing.T) {
 // TestSeasonPack_PunctuationOnlySequelTitles documents the deliberate tradeoff from
 // stripping !/? in title normalization: sequels distinguished only by punctuation
 // (K-On! vs K-On!!) now title-match, because scene naming drops the punctuation
-// anyway. The apply path still cannot link the wrong show's episodes:
-// buildSeasonPackPlan requires exact per-episode byte sizes.
+// anyway. buildSeasonPackPlan still requires exact per-episode byte sizes before
+// linking - the same size-identity trust cross-seeding rests on everywhere - so a
+// wrong link needs two different encodes with byte-identical sizes.
 func TestSeasonPack_PunctuationOnlySequelTitles(t *testing.T) {
 	matcher := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
 

--- a/pkg/stringutils/unicode.go
+++ b/pkg/stringutils/unicode.go
@@ -109,6 +109,11 @@ func normalized(s string) string {
 	// Remove colons - "csi: miami" → "csi miami"
 	s = strings.ReplaceAll(s, ":", "")
 
+	// Remove exclamation and question marks - scene naming drops them,
+	// so "Overtake!" announces as "Overtake.S01..."
+	s = strings.ReplaceAll(s, "!", "")
+	s = strings.ReplaceAll(s, "?", "")
+
 	// Normalize commas to spaces - "show,title" → "show title"
 	s = strings.ReplaceAll(s, ",", " ")
 
@@ -145,7 +150,7 @@ func NormalizeUnicode(s string) string {
 //   - Unicode normalization (removes diacritics, decomposes ligatures)
 //   - Lowercase
 //   - Strip apostrophes (including Unicode variants)
-//   - Strip colons
+//   - Strip colons, exclamation and question marks
 //   - Convert commas to spaces
 //   - Convert ampersand to "and"
 //   - Convert hyphens to spaces

--- a/pkg/stringutils/unicode_test.go
+++ b/pkg/stringutils/unicode_test.go
@@ -267,6 +267,16 @@ func TestNormalizeForMatching_RealWorldPairs(t *testing.T) {
 			"Love♪Live",
 			"Love Live",
 		},
+		{
+			"trailing exclamation dropped by scene naming",
+			"Overtake! S01 1080p",
+			"Overtake S01 1080p",
+		},
+		{
+			"question mark dropped by scene naming",
+			"Is the Order a Rabbit? S01",
+			"Is the Order a Rabbit S01",
+		},
 	}
 
 	for _, tt := range pairs {


### PR DESCRIPTION
NormalizeForMatching stripped apostrophes, colons, commas, hyphens, and ampersands, but not exclamation or question marks. Scene-style names drop those characters ("Overtake!" announces as "Overtake.S01.1080p.CR.WEB-DL..."), so any title ending in !/? failed the season-pack and cross-seed title match against fansub or BHD-style names that keep the punctuation, exactly the split a user hit where the same SubsPlease files matched on BHD but not BTN.

Strip ! and ? in the shared normalizer, which covers cross-seed, season packs, dirscan, and automations in one place. Sequel titles distinguished only by punctuation (K-On! vs K-On!!) remain separated by the season/episode structure checks.

## Testing
- [x] New normalizer pairs and a season-pack regression test using the reported release names (red before the fix, green after)
- [x] `go test -race -count=1` for pkg/stringutils, crossseed (incl. gazellemusic), dirscan, automations
- [x] `make precommit` and `make build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved season-pack release matching by treating titles as equivalent when they differ only by trailing `!` or `?` punctuation, including cases where scene-style names drop that punctuation.
* **Tests**
  * Added real-world normalization coverage for `!`/`?` equivalence.
  * Added regression coverage to ensure punctuation-only sequel-title differences match correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->