### PR TITLE
fix(crossseed): skip Gazelle lookups for content that RED/OPS cannot host

### DIFF
--- a/internal/services/crossseed/gazelle_content_gate_test.go
+++ b/internal/services/crossseed/gazelle_content_gate_test.go
@@ -1,0 +1,179 @@
+// Copyright (c) 2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package crossseed
+
+import (
+	"context"
+	"testing"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/services/crossseed/gazellemusic"
+	"github.com/autobrr/qui/pkg/stringutils"
+)
+
+func TestGazellePlausibleContent(t *testing.T) {
+	normalizer := stringutils.NewDefaultNormalizer()
+
+	tests := []struct {
+		name  string
+		files qbt.TorrentFiles
+		want  bool
+	}{
+		{
+			name: "movie mkv",
+			files: qbt.TorrentFiles{
+				{Name: "Some.Movie.2019.1080p.BluRay.x264-GRP/some.movie.2019.mkv", Size: 8_000_000_000},
+				{Name: "Some.Movie.2019.1080p.BluRay.x264-GRP/some.movie.2019.nfo", Size: 4_000},
+			},
+			want: false,
+		},
+		{
+			name: "movie with mp3 soundtrack folder",
+			files: qbt.TorrentFiles{
+				{Name: "Movie/movie.mkv", Size: 8_000_000_000},
+				{Name: "Movie/Soundtrack/01 - theme.mp3", Size: 9_000_000},
+			},
+			want: false,
+		},
+		{
+			name: "flac album with badly parsed name",
+			files: qbt.TorrentFiles{
+				{Name: "weird_name_2019/01.flac", Size: 40_000_000},
+				{Name: "weird_name_2019/cover.jpg", Size: 900_000},
+			},
+			want: true,
+		},
+		{
+			name: "m4b audiobook",
+			files: qbt.TorrentFiles{
+				{Name: "Author - Book/book.m4b", Size: 300_000_000},
+				{Name: "Author - Book/cover.jpg", Size: 100_000},
+			},
+			want: true,
+		},
+		{
+			name:  "epub book",
+			files: qbt.TorrentFiles{{Name: "Author - Book.epub", Size: 2_000_000}},
+			want:  true,
+		},
+		{
+			name:  "game iso",
+			files: qbt.TorrentFiles{{Name: "Game/game.iso", Size: 50_000_000_000}},
+			want:  false,
+		},
+		{
+			name:  "no usable files",
+			files: qbt.TorrentFiles{{Name: "release/release.nfo", Size: 4_000}},
+			want:  false,
+		},
+		{
+			name:  "empty file list",
+			files: qbt.TorrentFiles{},
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, gazellePlausibleContent(tt.files, normalizer))
+		})
+	}
+}
+
+func newGazelleGateService(t *testing.T, sourceTorrent qbt.Torrent, sourceFiles qbt.TorrentFiles) (*Service, *int) {
+	t.Helper()
+
+	callCount := 0
+	prevFindMatch := findGazelleMatch
+	findGazelleMatch = func(_ context.Context, _ *gazellemusic.Client, _ []byte, _ map[string]int64, _ int64) (*gazellemusic.Match, error) {
+		callCount++
+		return nil, nil
+	}
+	t.Cleanup(func() {
+		findGazelleMatch = prevFindMatch
+	})
+
+	svc := &Service{
+		releaseCache:     NewReleaseCache(),
+		stringNormalizer: stringutils.NewDefaultNormalizer(),
+		syncManager: &gazelleSkipHashSyncManager{
+			torrents: []qbt.Torrent{sourceTorrent},
+			filesByHash: map[string]qbt.TorrentFiles{
+				normalizeHash(sourceTorrent.Hash): sourceFiles,
+			},
+		},
+	}
+	return svc, &callCount
+}
+
+func TestSearchGazelleMatches_NonGazelleVideoSourceSkipsRemoteLookup(t *testing.T) {
+	sourceTorrent := qbt.Torrent{
+		Hash:     "223759985c562a644428312c8cd3585d04686847",
+		Name:     "Some.Movie.2019.1080p.BluRay.x264-GRP",
+		Progress: 1.0,
+		Size:     8_000_000_000,
+		Tracker:  "https://tracker.example.org/announce",
+	}
+	sourceFiles := qbt.TorrentFiles{
+		{Name: "Some.Movie.2019.1080p.BluRay.x264-GRP/some.movie.2019.mkv", Size: 8_000_000_000},
+	}
+
+	svc, callCount := newGazelleGateService(t, sourceTorrent, sourceFiles)
+	clients, err := gazelleClientsForTest()
+	require.NoError(t, err)
+
+	results, gazelleConfigured, lookupAttempted := svc.searchGazelleMatches(context.Background(), 1, &sourceTorrent, sourceFiles, "", false, clients)
+	require.True(t, gazelleConfigured, "gazelle stays configured so gazelle-only runs do not error")
+	require.False(t, lookupAttempted)
+	require.Empty(t, results)
+	require.Equal(t, 0, *callCount, "video torrent from non-Gazelle source must not hit RED/OPS")
+}
+
+func TestSearchGazelleMatches_NonGazelleMusicSourceStillSearches(t *testing.T) {
+	sourceTorrent := qbt.Torrent{
+		Hash:     "223759985c562a644428312c8cd3585d04686847",
+		Name:     "weird_name_2019",
+		Progress: 1.0,
+		Size:     40_000_000,
+		Tracker:  "https://tracker.example.org/announce",
+	}
+	sourceFiles := qbt.TorrentFiles{
+		{Name: "weird_name_2019/01.flac", Size: 40_000_000},
+	}
+
+	svc, callCount := newGazelleGateService(t, sourceTorrent, sourceFiles)
+	clients, err := gazelleClientsForTest()
+	require.NoError(t, err)
+
+	_, gazelleConfigured, lookupAttempted := svc.searchGazelleMatches(context.Background(), 1, &sourceTorrent, sourceFiles, "", false, clients)
+	require.True(t, gazelleConfigured)
+	require.True(t, lookupAttempted)
+	require.Equal(t, 1, *callCount)
+}
+
+func TestSearchGazelleMatches_GazelleSourceBypassesContentGate(t *testing.T) {
+	// E-learning videos exist on RED; a RED-sourced torrent must be searched on
+	// the sibling site regardless of file extensions.
+	sourceTorrent := qbt.Torrent{
+		Hash:     "223759985c562a644428312c8cd3585d04686847",
+		Name:     "Some Course (2019)",
+		Progress: 1.0,
+		Size:     2_000_000_000,
+		Tracker:  "https://flacsfor.me/abc/announce",
+	}
+	sourceFiles := qbt.TorrentFiles{
+		{Name: "Some Course (2019)/lesson01.mp4", Size: 2_000_000_000},
+	}
+
+	svc, callCount := newGazelleGateService(t, sourceTorrent, sourceFiles)
+	clients, err := gazelleClientsForTest()
+	require.NoError(t, err)
+
+	_, gazelleConfigured, lookupAttempted := svc.searchGazelleMatches(context.Background(), 1, &sourceTorrent, sourceFiles, "redacted.sh", true, clients)
+	require.True(t, gazelleConfigured)
+	require.True(t, lookupAttempted)
+	require.Equal(t, 1, *callCount)
+}

--- a/internal/services/crossseed/gazelle_content_gate_test.go
+++ b/internal/services/crossseed/gazelle_content_gate_test.go
@@ -15,8 +15,6 @@ import (
 )
 
 func TestGazellePlausibleContent(t *testing.T) {
-	normalizer := stringutils.NewDefaultNormalizer()
-
 	tests := []struct {
 		name  string
 		files qbt.TorrentFiles
@@ -74,11 +72,47 @@ func TestGazellePlausibleContent(t *testing.T) {
 			files: qbt.TorrentFiles{},
 			want:  false,
 		},
+		{
+			// The cross-seed ignore keywords match on the whole path, so a
+			// release directory named "[Bonus Tracks]" hides every file below it.
+			name: "flac album under a bonus tracks directory",
+			files: qbt.TorrentFiles{
+				{Name: "Artist - Album (Deluxe) [Bonus Tracks]/01 - Track.flac", Size: 40_000_000},
+				{Name: "Artist - Album (Deluxe) [Bonus Tracks]/cover.jpg", Size: 900_000},
+			},
+			want: true,
+		},
+		{
+			// Booklet scans outweigh individual tracks in many lossy releases.
+			name: "mp3 album with booklet scans larger than any track",
+			files: qbt.TorrentFiles{
+				{Name: "Artist - Album [MP3 V0]/01.mp3", Size: 9_000_000},
+				{Name: "Artist - Album [MP3 V0]/02.mp3", Size: 8_000_000},
+				{Name: "Artist - Album [MP3 V0]/03.mp3", Size: 9_000_000},
+				{Name: "Artist - Album [MP3 V0]/04.mp3", Size: 8_000_000},
+				{Name: "Artist - Album [MP3 V0]/Scans/booklet-01.tif", Size: 24_000_000},
+				{Name: "Artist - Album [MP3 V0]/Scans/booklet-02.tif", Size: 8_000_000},
+			},
+			want: true,
+		},
+		{
+			name: "concert video with a separate flac audio track",
+			files: qbt.TorrentFiles{
+				{Name: "Live/show.mkv", Size: 20_000_000_000},
+				{Name: "Live/audio.flac", Size: 800_000_000},
+			},
+			want: false,
+		},
+		{
+			name:  "uppercase extension",
+			files: qbt.TorrentFiles{{Name: "Artist - Album/01 - Track.FLAC", Size: 40_000_000}},
+			want:  true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, gazellePlausibleContent(tt.files, normalizer))
+			require.Equal(t, tt.want, gazellePlausibleContent(tt.files))
 		})
 	}
 }
@@ -126,10 +160,34 @@ func TestSearchGazelleMatches_NonGazelleVideoSourceSkipsRemoteLookup(t *testing.
 	require.NoError(t, err)
 
 	results, gazelleConfigured, lookupAttempted := svc.searchGazelleMatches(context.Background(), 1, &sourceTorrent, sourceFiles, "", false, clients)
-	require.True(t, gazelleConfigured, "gazelle stays configured so gazelle-only runs do not error")
+	require.True(t, gazelleConfigured, "Gazelle stays configured, so Gazelle-only runs do not fail")
 	require.False(t, lookupAttempted)
 	require.Empty(t, results)
-	require.Equal(t, 0, *callCount, "video torrent from non-Gazelle source must not hit RED/OPS")
+	require.Equal(t, 0, *callCount, "qui must not query RED/OPS for a video torrent from a source that is not Gazelle")
+}
+
+func TestSearchGazelleMatches_BonusDirectoryStillSearches(t *testing.T) {
+	// The cross-seed ignore keywords match on the whole path. A release
+	// directory named "[Bonus Tracks]" must not hide the album from Gazelle.
+	sourceTorrent := qbt.Torrent{
+		Hash:     "223759985c562a644428312c8cd3585d04686847",
+		Name:     "Artist - Album (Deluxe) [Bonus Tracks]",
+		Progress: 1.0,
+		Size:     40_000_000,
+		Tracker:  "https://tracker.example.org/announce",
+	}
+	sourceFiles := qbt.TorrentFiles{
+		{Name: "Artist - Album (Deluxe) [Bonus Tracks]/01 - Track.flac", Size: 40_000_000},
+	}
+
+	svc, callCount := newGazelleGateService(t, sourceTorrent, sourceFiles)
+	clients, err := gazelleClientsForTest()
+	require.NoError(t, err)
+
+	_, gazelleConfigured, lookupAttempted := svc.searchGazelleMatches(context.Background(), 1, &sourceTorrent, sourceFiles, "", false, clients)
+	require.True(t, gazelleConfigured)
+	require.True(t, lookupAttempted)
+	require.Equal(t, 1, *callCount)
 }
 
 func TestSearchGazelleMatches_NonGazelleMusicSourceStillSearches(t *testing.T) {
@@ -155,8 +213,8 @@ func TestSearchGazelleMatches_NonGazelleMusicSourceStillSearches(t *testing.T) {
 }
 
 func TestSearchGazelleMatches_GazelleSourceBypassesContentGate(t *testing.T) {
-	// E-learning videos exist on RED; a RED-sourced torrent must be searched on
-	// the sibling site regardless of file extensions.
+	// E-learning videos exist on RED. Therefore qui must search the sibling site
+	// for a torrent from RED, and the file extensions do not matter.
 	sourceTorrent := qbt.Torrent{
 		Hash:     "223759985c562a644428312c8cd3585d04686847",
 		Name:     "Some Course (2019)",

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -6957,6 +6957,47 @@ func gazelleTargetsForSource(sourceSiteHost string, isGazelleSource bool) []stri
 	return []string{"redacted.sh", "orpheus.network"}
 }
 
+// gazellePlausibleExtensions covers content RED/OPS host: audio (music,
+// audiobooks, comedy) and e-books/comics. Applications and e-learning videos
+// are deliberately excluded; admitting video or archive extensions would
+// re-admit every movie/TV/game torrent the gate exists to keep out.
+var gazellePlausibleExtensions = map[string]bool{
+	// audio
+	".flac": true,
+	".mp3":  true,
+	".m4a":  true,
+	".m4b":  true,
+	".aac":  true,
+	".ac3":  true,
+	".dts":  true,
+	".ogg":  true,
+	".opus": true,
+	".wav":  true,
+	".aiff": true,
+	".dsf":  true,
+	".dff":  true,
+	// e-books / comics
+	".epub": true,
+	".mobi": true,
+	".azw3": true,
+	".pdf":  true,
+	".cbr":  true,
+	".cbz":  true,
+	".djvu": true,
+}
+
+// gazellePlausibleContent reports whether a torrent's largest usable file looks
+// like content RED/OPS could host. Extension-based on purpose: release names
+// for music/audiobooks/books often defeat rls parsing, but file extensions
+// don't lie.
+func gazellePlausibleContent(files qbt.TorrentFiles, normalizer *stringutils.Normalizer[string, string]) bool {
+	largest := contentPrefilterLargestUsableFileName(files, normalizer)
+	if largest == "" {
+		return false
+	}
+	return gazellePlausibleExtensions[strings.ToLower(path.Ext(largest))]
+}
+
 func shouldUseGazelleOnlyForCompletion(settings *models.CrossSeedAutomationSettings, clients *gazelleClientSet, sourceSiteHost string) bool {
 	if settings == nil || !settings.GazelleEnabled {
 		return false
@@ -7029,6 +7070,13 @@ func (s *Service) searchGazelleMatches(
 	}
 	if len(configuredTargetHosts) == 0 {
 		return []TorrentSearchResult{}, false, false
+	}
+
+	// Torrents already on RED/OPS bypass the content gate: the tracker itself is
+	// proof the content is Gazelle-hostable. Everything else must look like
+	// content those sites carry before we spend rate-limited API calls on it.
+	if !isGazelleSource && !gazellePlausibleContent(sourceFiles, normalizerForService(s)) {
+		return []TorrentSearchResult{}, true, false
 	}
 
 	results := make([]TorrentSearchResult, 0, len(configuredTargetHosts))

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -6957,10 +6957,10 @@ func gazelleTargetsForSource(sourceSiteHost string, isGazelleSource bool) []stri
 	return []string{"redacted.sh", "orpheus.network"}
 }
 
-// gazellePlausibleExtensions covers content RED/OPS host: audio (music,
-// audiobooks, comedy) and e-books/comics. Applications and e-learning videos
-// are deliberately excluded; admitting video or archive extensions would
-// re-admit every movie/TV/game torrent the gate exists to keep out.
+// gazellePlausibleExtensions lists the extensions of content that RED/OPS host:
+// audio (music, audiobooks, comedy) and e-books or comics. The list excludes
+// applications and e-learning videos on purpose. Video and archive extensions
+// re-admit every movie, TV, and game torrent that the gate excludes.
 var gazellePlausibleExtensions = map[string]bool{
 	// audio
 	".flac": true,
@@ -6976,7 +6976,7 @@ var gazellePlausibleExtensions = map[string]bool{
 	".aiff": true,
 	".dsf":  true,
 	".dff":  true,
-	// e-books / comics
+	// e-books or comics
 	".epub": true,
 	".mobi": true,
 	".azw3": true,
@@ -6986,16 +6986,25 @@ var gazellePlausibleExtensions = map[string]bool{
 	".djvu": true,
 }
 
-// gazellePlausibleContent reports whether a torrent's largest usable file looks
-// like content RED/OPS could host. Extension-based on purpose: release names
-// for music/audiobooks/books often defeat rls parsing, but file extensions
-// don't lie.
-func gazellePlausibleContent(files qbt.TorrentFiles, normalizer *stringutils.Normalizer[string, string]) bool {
-	largest := contentPrefilterLargestUsableFileName(files, normalizer)
-	if largest == "" {
-		return false
+// gazellePlausibleContent reports whether the bulk of a torrent is content that
+// RED/OPS can host. The gate reads file extensions on purpose. Release names for
+// music, audiobooks, and books often defeat the rls parser, but file extensions
+// are reliable.
+//
+// The gate weighs bytes instead of picking the single largest file, because
+// booklet scans and cover art outweigh individual tracks in many music releases.
+// It also skips the cross-seed ignore lists on purpose: those match on the whole
+// path, so a release directory named "[Bonus Tracks]" hides every file below it.
+func gazellePlausibleContent(files qbt.TorrentFiles) bool {
+	var plausibleBytes, otherBytes int64
+	for _, file := range files {
+		if gazellePlausibleExtensions[strings.ToLower(path.Ext(file.Name))] {
+			plausibleBytes += file.Size
+			continue
+		}
+		otherBytes += file.Size
 	}
-	return gazellePlausibleExtensions[strings.ToLower(path.Ext(largest))]
+	return plausibleBytes > 0 && plausibleBytes >= otherBytes
 }
 
 func shouldUseGazelleOnlyForCompletion(settings *models.CrossSeedAutomationSettings, clients *gazelleClientSet, sourceSiteHost string) bool {
@@ -7072,10 +7081,11 @@ func (s *Service) searchGazelleMatches(
 		return []TorrentSearchResult{}, false, false
 	}
 
-	// Torrents already on RED/OPS bypass the content gate: the tracker itself is
-	// proof the content is Gazelle-hostable. Everything else must look like
-	// content those sites carry before we spend rate-limited API calls on it.
-	if !isGazelleSource && !gazellePlausibleContent(sourceFiles, normalizerForService(s)) {
+	// Torrents that are already on RED/OPS skip the content gate, because the
+	// tracker proves that RED/OPS can host the content. Every other torrent must
+	// look like content that these sites carry before we spend rate-limited API
+	// calls on it.
+	if !isGazelleSource && !gazellePlausibleContent(sourceFiles) {
 		return []TorrentSearchResult{}, true, false
 	}
 


### PR DESCRIPTION
With Gazelle enabled, seeded search runs and manual searches queried RED/OPS for every torrent, movies and TV included. A Radarr library scan used the shared rate-limit budget (OPS: 1 req/2s) on one hash search and up to 5 filename searches per host per torrent. These searches can never match. Simpuhl reported this on Discord.

This change gates `searchGazelleMatches` on file extensions. qui searches only content that RED/OPS can host: audio, which includes `.m4b` audiobooks, and e-books or comics. The gate reads extensions on purpose, because release names for music, audiobooks, and books often defeat the rls parser, but file extensions are reliable. The gate weighs the bytes of files with a plausible extension against the bytes of everything else, so booklet scans and cover art cannot outvote the tracks. Torrents that are already on RED/OPS skip the gate, so RED to OPS and OPS to RED flows do not change, and they still include e-learning videos and applications. qui no longer searches applications and e-learning videos from other sources. Video and archive extensions must stay out of the list, because they re-admit every torrent that the gate excludes.

- [x] Table-driven tests for the gate helper and `searchGazelleMatches`: zero remote calls for video, a search for flac, a search for an album under a `[Bonus Tracks]` directory, a search for an album with large booklet scans, and no gate for a Gazelle source
- [x] The three regression rows fail against the previous implementation
- [x] `go test -race -count=1 ./internal/services/crossseed/...`
- [x] `make precommit`, `make build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved content detection across mixed torrents by evaluating the overall balance of supported and unsupported files.
  * Prevented unnecessary external music-platform searches for torrents dominated by video, applications, archives, or other unsupported content.
  * Preserved searches for recognized music-platform sources and valid audio, e-book, and comic content.
  * Improved handling of bonus directories, booklet scans, uppercase file extensions, and malformed or empty file lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->