### PR TITLE
fix(web): don't hijack Cmd/Ctrl+Shift+A as select-all in torrent table

### DIFF
--- a/web/src/components/torrents/SelectAllHotkey.test.tsx
+++ b/web/src/components/torrents/SelectAllHotkey.test.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { render, cleanup } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { SelectAllHotkey } from "./SelectAllHotkey"
+
+describe("SelectAllHotkey", () => {
+  afterEach(cleanup)
+
+  it.each([
+    { name: "Cmd+A on Mac", isMac: true, init: { key: "a", metaKey: true }, fires: true },
+    { name: "Ctrl+A on non-Mac", isMac: false, init: { key: "a", ctrlKey: true }, fires: true },
+    { name: "Cmd+Shift+A (Chrome tab search)", isMac: true, init: { key: "A", metaKey: true, shiftKey: true }, fires: false },
+    { name: "Ctrl+Shift+A on non-Mac", isMac: false, init: { key: "A", ctrlKey: true, shiftKey: true }, fires: false },
+    { name: "Cmd+Alt+A", isMac: true, init: { key: "a", metaKey: true, altKey: true }, fires: false },
+    { name: "plain A without modifier", isMac: true, init: { key: "a" }, fires: false },
+  ])("$name fires=$fires", ({ isMac, init, fires }) => {
+    const onSelectAll = vi.fn()
+    render(<SelectAllHotkey onSelectAll={onSelectAll} isMac={isMac} />)
+
+    const event = new KeyboardEvent("keydown", { cancelable: true, ...init })
+    window.dispatchEvent(event)
+
+    expect(onSelectAll).toHaveBeenCalledTimes(fires ? 1 : 0)
+    expect(event.defaultPrevented).toBe(fires)
+  })
+})

--- a/web/src/components/torrents/SelectAllHotkey.tsx
+++ b/web/src/components/torrents/SelectAllHotkey.tsx
@@ -40,6 +40,11 @@ export function SelectAllHotkey({
         return
       }
 
+      // Shift/Alt combos are browser shortcuts (e.g. Cmd+Shift+A tab search), not select-all
+      if (event.shiftKey || event.altKey) {
+        return
+      }
+
       const target = event.target
       const elementTarget = target instanceof Element ? target : null
 


### PR DESCRIPTION
The global select-all hotkey listener (`SelectAllHotkey`) only checked the platform modifier and the `a`/`A` key, never `shiftKey`/`altKey`. Cmd+Shift+A (Chrome's tab search shortcut, Ctrl+Shift+A on Windows/Linux) therefore selected every torrent in the table. Now bails on any Shift/Alt combo; regression tests verified red against the unfixed code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved select-all keyboard shortcut handling by ignoring combinations that include Shift or Alt.
  - Standardized behavior for supported Cmd+A and Ctrl+A shortcuts.

- **Tests**
  - Added coverage for valid and invalid keyboard combinations, callback invocation, and default browser behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->