### PR TITLE
fix(crossseed): retry zero-result searches with alternate titles

### DIFF
--- a/internal/services/crossseed/search_alt_title_retry_test.go
+++ b/internal/services/crossseed/search_alt_title_retry_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package crossseed
+
+import (
+	"testing"
+
+	"github.com/moistari/rls"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlternateTitleQuery(t *testing.T) {
+	tests := []struct {
+		name         string
+		primaryQuery string
+		releaseName  string
+		arrTitles    []string
+		wantTitle    string
+		wantOK       bool
+	}{
+		{
+			name:         "arr alternate title is preferred",
+			primaryQuery: "Shingeki no Kyojin",
+			releaseName:  "Shingeki.no.Kyojin.S04E01.1080p.WEB.h264-GRP",
+			arrTitles:    []string{"Shingeki no Kyojin", "Attack on Titan"},
+			wantTitle:    "Attack on Titan",
+			wantOK:       true,
+		},
+		{
+			// The retry must never repeat the query that already returned
+			// nothing: an arr title that only differs in casing normalizes
+			// to the primary query and is skipped.
+			name:         "arr title equal to primary after normalization is skipped",
+			primaryQuery: "Attack on Titan",
+			arrTitles:    []string{"ATTACK ON TITAN", "L'Attaque des Titans"},
+			wantTitle:    "L'Attaque des Titans",
+			wantOK:       true,
+		},
+		{
+			name:         "AKA segment of the release name is used when no arr titles exist",
+			primaryQuery: "The Foreign Name",
+			releaseName:  "The Foreign Name AKA The English Name 2020 1080p BluRay x264-GRP",
+			wantTitle:    "The English Name",
+			wantOK:       true,
+		},
+		{
+			// rls leaves a multi-AKA chain unsplit (Title carries the whole
+			// chain, Alt stays empty), so the name-segment fallback is the
+			// only source of an alternate title here.
+			name:         "multi-AKA chain unsplit by the release parser falls back to name segments",
+			primaryQuery: "Der Film AKA The Movie AKA La Pelicula",
+			releaseName:  "Der Film AKA The Movie AKA La Pelicula 2020 1080p WEB h264-GRP",
+			wantTitle:    "Der Film",
+			wantOK:       true,
+		},
+		{
+			name:         "no distinct alternate title",
+			primaryQuery: "Breaking Bad",
+			releaseName:  "Breaking.Bad.S01E01.1080p.BluRay.x264-GRP",
+			arrTitles:    []string{"Breaking Bad"},
+			wantOK:       false,
+		},
+		{
+			name:         "empty inputs yield no retry",
+			primaryQuery: "Some Movie",
+			wantOK:       false,
+		},
+		{
+			name:         "blank arr titles are skipped",
+			primaryQuery: "Some Movie",
+			arrTitles:    []string{"", "   ", "Another Movie"},
+			wantTitle:    "Another Movie",
+			wantOK:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			release := rls.ParseString(tt.releaseName)
+			got, ok := alternateTitleQuery(tt.primaryQuery, &release, tt.arrTitles, tt.releaseName)
+			require.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				require.Equal(t, tt.wantTitle, got)
+			}
+		})
+	}
+}

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -7435,6 +7435,35 @@ func alternateConnectorQuery(query string) (string, bool) {
 	return "", false
 }
 
+// alternateTitleQuery returns the first alternate title under which the same
+// content can be indexed: *arr alternate titles first (scene, localized, and
+// renamed forms), then the release's own parsed Alt title, then "AKA" segments
+// of the release name. A candidate counts only when its normalized form
+// differs from the primary query, so the retry never repeats the query that
+// already returned nothing. Returns ("", false) when no distinct alternate
+// title exists.
+func alternateTitleQuery(primaryQuery string, release *rls.Release, arrTitles []string, releaseName string) (string, bool) {
+	primary := stringutils.NormalizeForMatching(primaryQuery)
+	candidates := make([]string, 0, len(arrTitles)+3)
+	candidates = append(candidates, arrTitles...)
+	candidates = append(candidates, releaseAlt(release))
+	for _, part := range rawAKATitleParts(releaseName) {
+		parsed := rls.ParseString(part)
+		candidates = append(candidates, parsed.Title, parsed.Alt)
+	}
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		if normalized := stringutils.NormalizeForMatching(candidate); normalized == "" || normalized == primary {
+			continue
+		}
+		return candidate, true
+	}
+	return "", false
+}
+
 // effectiveSearchYear returns the year actually used by the latest search pass: 0
 // once the yearless retry has run, otherwise the originally requested year. The
 // alternate connector pass uses this so it does not re-apply a year the primary
@@ -8165,8 +8194,11 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 
 	yearlessRetryRan := false
 
-	// Retry without year for single-indexer searches when the first pass returned zero.
-	if len(searchResults) == 0 && searchReq.Year > 0 && len(filteredIndexerIDs) <= 1 {
+	// Retry without year when the first pass returned zero results. The year is
+	// the narrowest primary-query constraint, so it is the first fallback to
+	// drop. Together with the alternate-title retry below this caps the
+	// zero-result fallback chain at two extra queries per search.
+	if len(searchResults) == 0 && searchReq.Year > 0 {
 		log.Debug().
 			Str("torrentName", sourceTorrent.Name).
 			Int("year", searchReq.Year).
@@ -8208,6 +8240,39 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 			return nil, gazelleLookupAttempted, remoteRequestsMade, wrapCrossSeedSearchError(waitCtx.Err())
 		}
 		yearlessRetryRan = true
+	}
+
+	// Alternate-title retry: a tracker can index the same content under a
+	// different title (localized, romanized, or an *arr scene alias). When the
+	// primary query (and the yearless retry, when it ran) returned nothing,
+	// re-query once with the first distinct alternate title. A failed extra
+	// pass is not fatal: the primary search already completed with zero
+	// results, so log and continue. Skipped for ID-based searches, which do
+	// not rely on title text.
+	if len(searchResults) == 0 && !searchReq.OmitQueryForIDs {
+		if altTitle, ok := alternateTitleQuery(searchReq.Query, searchRelease, arrTitles, sourceTorrent.Name); ok {
+			log.Debug().
+				Str("torrentName", sourceTorrent.Name).
+				Str("query", searchReq.Query).
+				Str("altTitleQuery", altTitle).
+				Msg("[CROSSSEED-SEARCH] Zero results for primary title; retrying with alternate title")
+
+			altTitleReq := *searchReq
+			altTitleReq.Query = altTitle
+			altTitleReq.Year = effectiveSearchYear(searchReq.Year, yearlessRetryRan)
+			// Internal continuation of the primary search: skip history recording
+			// like the alternate connector-spelling pass below.
+			altTitleReq.SkipHistory = true
+			if altResp, altErr := s.searchOnce(waitCtx, &altTitleReq); altErr != nil {
+				log.Debug().
+					Err(altErr).
+					Str("altTitleQuery", altTitle).
+					Msg("[CROSSSEED-SEARCH] Alternate-title retry failed; continuing with primary results")
+			} else if altResp != nil {
+				searchResp = altResp
+				searchResults = altResp.Results
+			}
+		}
 	}
 
 	// Cross-tracker title-variant coverage: some trackers index a show with "&"


### PR DESCRIPTION
A cross-seed search that returns zero results now retries with broader queries. The retry without a year now runs for multi-indexer searches, not only single-indexer searches. A second retry queries an alternate title for the same content: an *arr alternate title, the parsed Alt title, or an AKA segment of the release name.

The fallback chain is capped at two extra queries per torrent per run. The chain only runs when the primary query found nothing, so a successful search costs no extra indexer requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added alternate-title search support using Arr titles, release metadata, and AKA titles.
  * Automatically retries searches without the year when no results are found.
  * Falls back to alternate-title searches while preserving the original results when no match is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->