### PR TITLE
fix(crossseed): compare the search size band against the full torrent size

### DIFF
--- a/internal/services/crossseed/search_source_size_test.go
+++ b/internal/services/crossseed/search_source_size_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package crossseed
+
+import (
+	"testing"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSearchSourceSize(t *testing.T) {
+	tests := []struct {
+		name    string
+		torrent qbt.Torrent
+		want    int64
+	}{
+		{
+			// A torrent with deselected files reports the smaller wanted size
+			// in Size while Progress still reads 1.0. Torznab candidates
+			// advertise the full release size, so the band must compare
+			// against TotalSize.
+			name:    "deselected files use the full size",
+			torrent: qbt.Torrent{Size: 7 << 30, TotalSize: 10 << 30},
+			want:    10 << 30,
+		},
+		{
+			name:    "fully selected torrent sizes are equal",
+			torrent: qbt.Torrent{Size: 10 << 30, TotalSize: 10 << 30},
+			want:    10 << 30,
+		},
+		{
+			name:    "missing total size falls back to wanted size",
+			torrent: qbt.Torrent{Size: 10 << 30},
+			want:    10 << 30,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, searchSourceSize(&tt.torrent))
+		})
+	}
+}

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -7475,6 +7475,18 @@ func indexersWithoutResults(requestedIDs []int, results []jackett.SearchResult) 
 	return missing
 }
 
+// searchSourceSize returns the source-side size for the search size band.
+// Torznab advertises the full release size, so the comparison must use the
+// torrent's full size: Size only counts wanted files, which misreports every
+// torrent with deselected files while its Progress still reads 1.0. TotalSize
+// can be zero when a client predates the field, so fall back to Size.
+func searchSourceSize(t *qbt.Torrent) int64 {
+	if t.TotalSize > 0 {
+		return t.TotalSize
+	}
+	return t.Size
+}
+
 // searchResultUsable reports whether the shared search classifier accepts a
 // primary-pass result. Keeping this a boolean projection prevents alternate-query
 // scheduling from drifting from the main result loop.
@@ -8218,7 +8230,7 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 	// ID-based searches, which do not rely on title text.
 	if !opts.DisableTorznab && !searchReq.OmitQueryForIDs {
 		if altQuery, ok := alternateConnectorQuery(searchReq.Query); ok {
-			altIndexerIDs := s.indexersWithoutUsableResults(searchReq.IndexerIDs, searchResults, searchRelease, sourceTorrent.Name, sourceTorrent.Size, arrTitles, tolerancePercent, opts.FindIndividualEpisodes)
+			altIndexerIDs := s.indexersWithoutUsableResults(searchReq.IndexerIDs, searchResults, searchRelease, sourceTorrent.Name, searchSourceSize(sourceTorrent), arrTitles, tolerancePercent, opts.FindIndividualEpisodes)
 			if len(altIndexerIDs) > 0 {
 				altReq := *searchReq
 				altReq.Query = altQuery
@@ -8268,9 +8280,10 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 	exactSizeFallbackAccepted := 0
 	exactSizeHardRejected := 0
 
+	sourceSizeForSearch := searchSourceSize(sourceTorrent)
 	for _, res := range searchResults {
 		candidateRelease := s.releaseCache.Parse(res.Title)
-		// Search has only qBittorrent's wanted source size and Torznab's advertised
+		// Search has only the source torrent's full size and Torznab's advertised
 		// candidate size. Positive exact equality may replace soft release metadata;
 		// the downloaded torrent is inspected later by the normal apply pipeline.
 		decision := s.classifySearchCandidate(searchCandidateInput{
@@ -8279,7 +8292,7 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 			SourceName:             sourceTorrent.Name,
 			CandidateName:          res.Title,
 			SourceTitles:           arrTitles,
-			SourceSize:             sourceTorrent.Size,
+			SourceSize:             sourceSizeForSearch,
 			CandidateSize:          res.Size,
 			TolerancePercent:       tolerancePercent,
 			FindIndividualEpisodes: opts.FindIndividualEpisodes,
@@ -8315,9 +8328,9 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 				Str("indexer", res.Indexer).
 				Str("sourceTitle", sourceTorrent.Name).
 				Str("candidateTitle", res.Title).
-				Int64("sourceSize", sourceTorrent.Size).
+				Int64("sourceSize", sourceSizeForSearch).
 				Int64("candidateSize", res.Size).
-				Int64("sizeDeltaBytes", res.Size-sourceTorrent.Size).
+				Int64("sizeDeltaBytes", res.Size-sourceSizeForSearch).
 				Str("sizeEvidence", string(decision.SizeEvidence)).
 				Str("decisionClass", string(decision.Class)).
 				Str("strictMismatchReason", decision.StrictMismatchReason).
@@ -8334,9 +8347,9 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 			Str("indexer", res.Indexer).
 			Str("sourceTitle", sourceTorrent.Name).
 			Str("candidateTitle", res.Title).
-			Int64("sourceSize", sourceTorrent.Size).
+			Int64("sourceSize", sourceSizeForSearch).
 			Int64("candidateSize", res.Size).
-			Int64("sizeDeltaBytes", res.Size-sourceTorrent.Size).
+			Int64("sizeDeltaBytes", res.Size-sourceSizeForSearch).
 			Str("sizeEvidence", string(decision.SizeEvidence)).
 			Str("decisionClass", string(decision.Class)).
 			Str("strictMismatchReason", decision.StrictMismatchReason).


### PR DESCRIPTION
The search size band compared the Torznab candidate size against the source torrent's wanted size. A torrent with deselected files reports a smaller wanted size while its progress reads 1.0, so every candidate for it failed the band and the search found nothing. Torznab advertises the full release size, so the band now compares against the torrent's full size, with a fallback to the wanted size when the client does not report it.

The apply pipeline is unchanged. It still inspects the downloaded torrent and its per-file sizes before an injection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved torrent size comparisons by using the complete source size when available.
  * Added fallback handling when complete size information is unavailable.
  * Improved candidate matching and exact-size fallback decisions.
  * Enhanced diagnostic logging for size differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->