### PR TITLE
feat(crossseed): page RSS feeds until a page is fully known

### DIFF
--- a/internal/services/crossseed/rss_feed_paging.go
+++ b/internal/services/crossseed/rss_feed_paging.go
@@ -1,0 +1,181 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package crossseed
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/autobrr/qui/internal/services/jackett"
+)
+
+const (
+	// rssFeedPageSize is the fixed page length for automation feed fetches.
+	// Offsets build on the number of items an indexer actually returned, so
+	// the value only bounds one round trip and does not have to match an
+	// indexer's own clamp.
+	rssFeedPageSize = 100
+	// rssFeedMaxPages bounds feed pages per indexer per run. Paging exists to
+	// walk back to the last handled item after a gap between runs; a gap
+	// deeper than this is treated as lost.
+	rssFeedMaxPages = 5
+	// rssFeedPageTimeout bounds one deeper page round trip. Deeper pages are
+	// best effort, so a slow indexer stops paging instead of stalling the run.
+	rssFeedPageTimeout = 3 * time.Minute
+)
+
+type feedItemKey struct {
+	guid      string
+	indexerID int
+}
+
+// feedPageContinuation walks one fetched feed page. It returns the results
+// that are new to this run (fresh) and the indexers whose page carried at
+// least one fresh item that the feed-item store has not handled yet — only
+// those can still gain from a deeper page. collected is extended in place
+// with every fresh key, so an indexer that ignores the offset parameter and
+// returns the same page again yields nothing fresh and stops. Results
+// without a GUID cannot be deduplicated, so they are never fresh and never
+// extend paging.
+func feedPageContinuation(pageResults []jackett.SearchResult, collected map[feedItemKey]struct{}, handled func(guid string, indexerID int) bool) ([]jackett.SearchResult, []int) {
+	var fresh []jackett.SearchResult
+	var continueIndexers []int
+	continueSeen := make(map[int]struct{})
+
+	for _, result := range pageResults {
+		if result.GUID == "" || result.IndexerID == 0 {
+			continue
+		}
+		key := feedItemKey{guid: result.GUID, indexerID: result.IndexerID}
+		if _, ok := collected[key]; ok {
+			continue
+		}
+		collected[key] = struct{}{}
+		fresh = append(fresh, result)
+		if handled(result.GUID, result.IndexerID) {
+			continue
+		}
+		if _, ok := continueSeen[result.IndexerID]; !ok {
+			continueSeen[result.IndexerID] = struct{}{}
+			continueIndexers = append(continueIndexers, result.IndexerID)
+		}
+	}
+
+	return fresh, continueIndexers
+}
+
+// groupIndexersByOffset buckets the still-active indexers by their next feed
+// offset. Indexers clamp the requested page size, so offsets drift apart and
+// each distinct offset needs its own request.
+func groupIndexersByOffset(active []int, offsets map[int]int) map[int][]int {
+	groups := make(map[int][]int)
+	for _, id := range active {
+		groups[offsets[id]] = append(groups[offsets[id]], id)
+	}
+	return groups
+}
+
+// pageAutomationFeed extends the first feed page with deeper pages, so
+// announces that scrolled past one page between runs are still handled. Each
+// indexer pages on while its previous page contained at least one item the
+// feed-item store has not seen, and stops on an empty page, a fully known
+// page, or the page cap. Offsets advance by the number of items the indexer
+// actually returned. Deeper pages run at background priority and are best
+// effort: an error, timeout, or queue skip keeps everything fetched so far.
+func (s *Service) pageAutomationFeed(ctx context.Context, firstPage *jackett.SearchResponse, maxPages int) {
+	if maxPages <= 1 || s.automationStore == nil || s.jackettService == nil {
+		return
+	}
+
+	handled := func(guid string, indexerID int) bool {
+		seen, _, err := s.automationStore.HasProcessedFeedItem(ctx, guid, indexerID)
+		if err != nil {
+			// Unknown store state must not extend paging.
+			return true
+		}
+		return seen
+	}
+
+	collected := make(map[feedItemKey]struct{})
+	_, active := feedPageContinuation(firstPage.Results, collected, handled)
+
+	pageOneCounts := make(map[int]int)
+	for _, result := range firstPage.Results {
+		pageOneCounts[result.IndexerID]++
+	}
+	offsets := make(map[int]int, len(active))
+	for _, id := range active {
+		offsets[id] = pageOneCounts[id]
+	}
+
+	deepCtx := jackett.WithSearchPriority(ctx, jackett.RateLimitPriorityBackground)
+	for page := 2; len(active) > 0 && page <= maxPages; page++ {
+		var nextActive []int
+		for offset, ids := range groupIndexersByOffset(active, offsets) {
+			resp, err := s.recentFeedPage(deepCtx, offset, ids)
+			if err != nil {
+				log.Debug().
+					Err(err).
+					Int("page", page).
+					Int("offset", offset).
+					Ints("indexerIDs", ids).
+					Msg("[RSS] Deeper feed page failed; keeping results fetched so far")
+				continue
+			}
+			firstPage.Partial = firstPage.Partial || resp.Partial
+
+			fresh, cont := feedPageContinuation(resp.Results, collected, handled)
+			firstPage.Results = append(firstPage.Results, fresh...)
+
+			pageCounts := make(map[int]int)
+			for _, result := range resp.Results {
+				pageCounts[result.IndexerID]++
+			}
+			for _, id := range cont {
+				offsets[id] += pageCounts[id]
+				nextActive = append(nextActive, id)
+			}
+
+			log.Debug().
+				Int("page", page).
+				Int("offset", offset).
+				Ints("indexerIDs", ids).
+				Int("pageResults", len(resp.Results)).
+				Int("freshResults", len(fresh)).
+				Ints("continuing", cont).
+				Msg("[RSS] Fetched deeper feed page")
+		}
+		active = nextActive
+	}
+}
+
+// recentFeedPage fetches one feed page synchronously.
+func (s *Service) recentFeedPage(ctx context.Context, offset int, indexerIDs []int) (*jackett.SearchResponse, error) {
+	respCh := make(chan *jackett.SearchResponse, 1)
+	errCh := make(chan error, 1)
+	err := s.jackettService.Recent(ctx, rssFeedPageSize, offset, indexerIDs, func(resp *jackett.SearchResponse, respErr error) {
+		if respErr != nil {
+			errCh <- respErr
+			return
+		}
+		respCh <- resp
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	select {
+	case resp := <-respCh:
+		return resp, nil
+	case respErr := <-errCh:
+		return nil, respErr
+	case <-time.After(rssFeedPageTimeout):
+		return nil, errors.New("feed page timed out")
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}

--- a/internal/services/crossseed/rss_feed_paging.go
+++ b/internal/services/crossseed/rss_feed_paging.go
@@ -95,6 +95,11 @@ func (s *Service) pageAutomationFeed(ctx context.Context, firstPage *jackett.Sea
 		seen, _, err := s.automationStore.HasProcessedFeedItem(ctx, guid, indexerID)
 		if err != nil {
 			// Unknown store state must not extend paging.
+			log.Debug().
+				Err(err).
+				Str("guid", guid).
+				Int("indexerID", indexerID).
+				Msg("[RSS] Feed-item store check failed; not extending paging")
 			return true
 		}
 		return seen
@@ -130,6 +135,7 @@ func (s *Service) pageAutomationFeed(ctx context.Context, firstPage *jackett.Sea
 
 			fresh, cont := feedPageContinuation(resp.Results, collected, handled)
 			firstPage.Results = append(firstPage.Results, fresh...)
+			firstPage.Total = len(firstPage.Results)
 
 			pageCounts := make(map[int]int)
 			for _, result := range resp.Results {

--- a/internal/services/crossseed/rss_feed_paging_test.go
+++ b/internal/services/crossseed/rss_feed_paging_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package crossseed
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/services/jackett"
+)
+
+func feedResult(guid string, indexerID int) jackett.SearchResult {
+	return jackett.SearchResult{GUID: guid, IndexerID: indexerID, Title: guid}
+}
+
+func TestFeedPageContinuation(t *testing.T) {
+	neverHandled := func(string, int) bool { return false }
+	alwaysHandled := func(string, int) bool { return true }
+
+	t.Run("unhandled items extend paging", func(t *testing.T) {
+		collected := make(map[feedItemKey]struct{})
+		fresh, cont := feedPageContinuation([]jackett.SearchResult{
+			feedResult("a", 1),
+			feedResult("b", 1),
+		}, collected, neverHandled)
+		require.Len(t, fresh, 2)
+		require.Equal(t, []int{1}, cont)
+	})
+
+	t.Run("fully known page stops paging but still returns fresh results", func(t *testing.T) {
+		collected := make(map[feedItemKey]struct{})
+		fresh, cont := feedPageContinuation([]jackett.SearchResult{
+			feedResult("a", 1),
+		}, collected, alwaysHandled)
+		require.Len(t, fresh, 1, "known items are still new to this run and must be kept")
+		require.Empty(t, cont)
+	})
+
+	t.Run("repeated page yields nothing fresh and stops", func(t *testing.T) {
+		collected := make(map[feedItemKey]struct{})
+		page := []jackett.SearchResult{feedResult("a", 1), feedResult("b", 1)}
+		fresh, cont := feedPageContinuation(page, collected, neverHandled)
+		require.Len(t, fresh, 2)
+		require.Equal(t, []int{1}, cont)
+
+		// An indexer that ignores the offset parameter returns the same page.
+		fresh, cont = feedPageContinuation(page, collected, neverHandled)
+		require.Empty(t, fresh)
+		require.Empty(t, cont)
+	})
+
+	t.Run("indexers decide independently", func(t *testing.T) {
+		collected := make(map[feedItemKey]struct{})
+		handled := func(guid string, _ int) bool { return guid == "known" }
+		fresh, cont := feedPageContinuation([]jackett.SearchResult{
+			feedResult("known", 1),
+			feedResult("new", 2),
+		}, collected, handled)
+		require.Len(t, fresh, 2)
+		require.Equal(t, []int{2}, cont)
+	})
+
+	t.Run("results without a GUID never extend paging", func(t *testing.T) {
+		collected := make(map[feedItemKey]struct{})
+		fresh, cont := feedPageContinuation([]jackett.SearchResult{
+			{IndexerID: 1, Title: "no guid"},
+			{GUID: "x", Title: "no indexer"},
+		}, collected, neverHandled)
+		require.Empty(t, fresh)
+		require.Empty(t, cont)
+	})
+
+	t.Run("same GUID on two indexers stays distinct", func(t *testing.T) {
+		collected := make(map[feedItemKey]struct{})
+		fresh, cont := feedPageContinuation([]jackett.SearchResult{
+			feedResult("a", 1),
+			feedResult("a", 2),
+		}, collected, neverHandled)
+		require.Len(t, fresh, 2)
+		require.Equal(t, []int{1, 2}, cont)
+	})
+}
+
+func TestGroupIndexersByOffset(t *testing.T) {
+	groups := groupIndexersByOffset([]int{1, 2, 3}, map[int]int{1: 100, 2: 50, 3: 100})
+	require.Equal(t, map[int][]int{100: {1, 3}, 50: {2}}, groups)
+}

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -3573,7 +3573,7 @@ func (s *Service) executeAutomationRun(ctx context.Context, run *models.CrossSee
 		return run, ErrNoIndexersConfigured
 	}
 
-	err := s.jackettService.Recent(searchCtx, 0, resolvedIndexerIDs, func(resp *jackett.SearchResponse, err error) {
+	err := s.jackettService.Recent(searchCtx, rssFeedPageSize, 0, resolvedIndexerIDs, func(resp *jackett.SearchResponse, err error) {
 		if err != nil {
 			errCh <- err
 		} else {
@@ -3631,6 +3631,16 @@ func (s *Service) executeAutomationRun(ctx context.Context, run *models.CrossSee
 		runErr = ctx.Err()
 		return run, ctx.Err()
 	}
+
+	// One page misses announces that scrolled past the feed head between
+	// runs, so walk deeper pages per indexer until a page is fully known.
+	// The very first run has no handled boundary to walk back to, so it
+	// stays on one page instead of paging blindly into history.
+	feedPageCap := rssFeedMaxPages
+	if runs, listErr := s.automationStore.ListRuns(ctx, 2, 0); listErr != nil || len(runs) <= 1 {
+		feedPageCap = 1
+	}
+	s.pageAutomationFeed(searchCtx, searchResp, feedPageCap)
 
 	// Pre-fetch all indexer info (names and domains) for performance
 	indexerInfo, err := s.jackettService.GetEnabledIndexersInfo(ctx)

--- a/internal/services/jackett/service.go
+++ b/internal/services/jackett/service.go
@@ -866,12 +866,18 @@ func (s *Service) GetIndexers(ctx context.Context) (*IndexersResponse, error) {
 	}, nil
 }
 
-// Recent fetches the latest releases across selected indexers without a search query.
-func (s *Service) Recent(ctx context.Context, limit int, indexerIDs []int, callback func(*SearchResponse, error)) error {
+// Recent fetches the latest releases across selected indexers without a search
+// query. A positive offset requests a deeper feed page; every selected indexer
+// receives the same offset, so callers that page indexers with different
+// positions must group them per offset.
+func (s *Service) Recent(ctx context.Context, limit, offset int, indexerIDs []int, callback func(*SearchResponse, error)) error {
 	params := url.Values{}
 	params.Set("t", "search")
 	if limit > 0 {
 		params.Set("limit", strconv.Itoa(limit))
+	}
+	if offset > 0 {
+		params.Set("offset", strconv.Itoa(offset))
 	}
 
 	indexersToSearch, err := s.resolveIndexerSelection(ctx, indexerIDs)

--- a/internal/services/jackett/service_test.go
+++ b/internal/services/jackett/service_test.go
@@ -3239,7 +3239,7 @@ func TestRecentSurfacesTotalIndexerFailure(t *testing.T) {
 
 	respCh := make(chan *SearchResponse, 1)
 	errCh := make(chan error, 1)
-	if err := service.Recent(context.Background(), 0, nil, func(resp *SearchResponse, err error) {
+	if err := service.Recent(context.Background(), 0, 0, nil, func(resp *SearchResponse, err error) {
 		if err != nil {
 			errCh <- err
 		} else {
@@ -3284,7 +3284,7 @@ func TestRecentPartialCoverageMarksPartial(t *testing.T) {
 
 	respCh := make(chan *SearchResponse, 1)
 	errCh := make(chan error, 1)
-	if err := service.Recent(context.Background(), 0, nil, func(resp *SearchResponse, err error) {
+	if err := service.Recent(context.Background(), 0, 0, nil, func(resp *SearchResponse, err error) {
 		if err != nil {
 			errCh <- err
 		} else {


### PR DESCRIPTION
The RSS automation read only the first page of each feed. A release that scrolled past that page between two runs was never processed. The automation now requests deeper pages per indexer while the previous page contained at least one item that the feed-item store has not handled. Paging stops on a fully known page, an empty page, or a cap of 5 pages, and the first run ever stays on one page because it has no handled boundary to walk back to.

Offsets advance by the number of items an indexer actually returned, so indexers that clamp the page size do not skip items. An indexer that ignores the offset parameter returns the same page, which yields nothing new and stops its paging. Deeper pages run at background priority and are best effort: an error or timeout keeps the results that were already fetched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RSS automation can scan multiple feed pages, up to the configured page limit.
  * Additional pages use appropriate offsets to discover more recent items across selected indexers.
  * Results are consolidated to prevent duplicate entries.

* **Bug Fixes**
  * Improved handling of incomplete, repeated, empty, or unavailable feed pages.
  * Invalid or incomplete feed entries are skipped.
  * Initial automation runs remain limited to a single page for predictable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->