### PR TITLE
feat(crossseed): curb season pack churn in automation flows

### DIFF
--- a/internal/models/crossseed.go
+++ b/internal/models/crossseed.go
@@ -1585,6 +1585,30 @@ func (s *CrossSeedStore) GetSearchHistory(ctx context.Context, instanceID int, t
 	return last, true, nil
 }
 
+// GetLatestSearchHistory returns the most recent search timestamp for a key
+// across all instances. Used for pseudo-keys whose verdict is global, like
+// season-pack diversion failures.
+func (s *CrossSeedStore) GetLatestSearchHistory(ctx context.Context, torrentHash string) (time.Time, bool, error) {
+	const query = `
+		SELECT last_searched_at
+		FROM cross_seed_search_history
+		WHERE torrent_hash = ?
+		ORDER BY last_searched_at DESC
+		LIMIT 1
+	`
+
+	var last time.Time
+	err := s.db.QueryRowContext(ctx, query, torrentHash).Scan(&last)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return time.Time{}, false, nil
+		}
+		return time.Time{}, false, fmt.Errorf("get latest search history: %w", err)
+	}
+
+	return last, true, nil
+}
+
 // HasProcessedFeedItem reports whether a GUID/indexer pair has been handled.
 func (s *CrossSeedStore) HasProcessedFeedItem(ctx context.Context, guid string, indexerID int) (bool, CrossSeedFeedItemStatus, error) {
 	query := `

--- a/internal/services/crossseed/ensemble_season.go
+++ b/internal/services/crossseed/ensemble_season.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -50,6 +51,21 @@ func isEnsembleSeasonCandidate(hash string) bool {
 	return strings.HasPrefix(hash, ensembleSeasonHashPrefix)
 }
 
+// seasonRangeRe matches multi-season range markers: S01-S05, S01-05,
+// Season 1-5. rls only surfaces the range for the S01-S05 form (as a second
+// series tag), so detection works on the raw name instead.
+var seasonRangeRe = regexp.MustCompile(`(?i)\bS(?:eason[ ._-]?)?(\d{1,2})[ ._-]?-[ ._-]?S?(\d{1,2})\b`)
+
+func isSeasonRangePack(name string) bool {
+	m := seasonRangeRe.FindStringSubmatch(name)
+	if m == nil {
+		return false
+	}
+	start, _ := strconv.Atoi(m[1])
+	end, _ := strconv.Atoi(m[2])
+	return end > start
+}
+
 func ensembleSeasonPseudoHash(key ensembleGroupKey) string {
 	return fmt.Sprintf("%s%s:s%02d", ensembleSeasonHashPrefix, key.normalizedTitle, key.season)
 }
@@ -77,8 +93,10 @@ func parseEnsembleSeasonPseudoHash(hash string) (ensembleGroupKey, bool) {
 // show title + season and returns one virtual queue entry per group with at
 // least ensembleMinEpisodes distinct episodes and no seeded pack for the same
 // key. Input torrents have already passed the run's category/tag filters and
-// content dedup, so groups inherit the run scoping.
-func (s *Service) buildEnsembleSeasonCandidates(torrents []qbt.Torrent) []qbt.Torrent {
+// content dedup, so groups inherit the run scoping. packSource is the
+// instance's full torrent list: a seeded pack outside the run scope must still
+// suppress its group, or the search re-downloads a pack the user already has.
+func (s *Service) buildEnsembleSeasonCandidates(torrents, packSource []qbt.Torrent) []qbt.Torrent {
 	type groupInfo struct {
 		displayTitle string
 		episodes     map[int]struct{}
@@ -86,12 +104,31 @@ func (s *Service) buildEnsembleSeasonCandidates(torrents []qbt.Torrent) []qbt.To
 	groups := make(map[ensembleGroupKey]*groupInfo)
 	packs := make(map[ensembleGroupKey]struct{})
 
+	// Any seeded or downloading pack suppresses its group; progress does not
+	// matter because the pack's presence already makes a search pointless.
+	for i := range packSource {
+		release := s.releaseCache.Parse(packSource[i].Name)
+		if !isTVSeasonPack(release) {
+			continue
+		}
+		key := ensembleGroupKey{
+			normalizedTitle: s.stringNormalizer.Normalize(release.Title),
+			season:          release.Series,
+		}
+		if key.normalizedTitle != "" {
+			packs[key] = struct{}{}
+		}
+	}
+
 	for i := range torrents {
 		torrent := &torrents[i]
 		if torrent.Progress < 1.0 {
 			continue
 		}
 		release := s.releaseCache.Parse(torrent.Name)
+		if !isTVEpisode(release) {
+			continue
+		}
 		key := ensembleGroupKey{
 			normalizedTitle: s.stringNormalizer.Normalize(release.Title),
 			season:          release.Series,
@@ -99,20 +136,15 @@ func (s *Service) buildEnsembleSeasonCandidates(torrents []qbt.Torrent) []qbt.To
 		if key.normalizedTitle == "" {
 			continue
 		}
-		switch {
-		case isTVSeasonPack(release):
-			packs[key] = struct{}{}
-		case isTVEpisode(release):
-			group := groups[key]
-			if group == nil {
-				group = &groupInfo{episodes: make(map[int]struct{})}
-				groups[key] = group
-			}
-			if group.displayTitle == "" {
-				group.displayTitle = release.Title
-			}
-			group.episodes[release.Episode] = struct{}{}
+		group := groups[key]
+		if group == nil {
+			group = &groupInfo{episodes: make(map[int]struct{})}
+			groups[key] = group
 		}
+		if group.displayTitle == "" {
+			group.displayTitle = release.Title
+		}
+		group.episodes[release.Episode] = struct{}{}
 	}
 
 	virtual := make([]qbt.Torrent, 0, len(groups))
@@ -214,10 +246,16 @@ func (s *Service) applyEnsembleSearchResults(ctx context.Context, state *searchR
 	failedAttempt := false
 	indexerAdds := make(map[int]int)
 	indexerFails := make(map[int]int)
+	attemptedNames := make(map[string]struct{})
 
 	for _, res := range resp.Results {
 		candidate := s.releaseCache.Parse(res.Title)
 		if !isTVSeasonPack(candidate) {
+			continue
+		}
+		// A multi-season range pack can never assemble from one season's
+		// episodes; admitting one is a guaranteed wasted download.
+		if isSeasonRangePack(res.Title) {
 			continue
 		}
 		if s.stringNormalizer.Normalize(candidate.Title) != key.normalizedTitle {
@@ -226,11 +264,22 @@ func (s *Service) applyEnsembleSearchResults(ctx context.Context, state *searchR
 		if key.season > 0 && candidate.Series != key.season {
 			continue
 		}
+		// The same pack circulates under one name with a distinct GUID per
+		// indexer; retrying an identical name from another indexer fails the
+		// same way and must not consume another cap slot.
+		normName := canonicalReleaseNameKey(res.Title)
+		if _, dup := attemptedNames[normName]; dup {
+			continue
+		}
+		attemptedNames[normName] = struct{}{}
 		hashes := torrentSearchResultInfoHashes(res.InfoHashV1, res.InfoHashV2)
 		if len(hashes) > 0 && s.syncManager != nil {
 			if _, exists, hashErr := s.syncManager.HasTorrentByAnyHash(ctx, state.opts.InstanceID, hashes); hashErr == nil && exists {
 				continue
 			}
+		}
+		if s.seasonPackFailCooldownActive(ctx, res.Title, time.Duration(state.opts.CooldownMinutes)*time.Minute) {
+			continue
 		}
 
 		admitted++

--- a/internal/services/crossseed/ensemble_season_test.go
+++ b/internal/services/crossseed/ensemble_season_test.go
@@ -67,6 +67,7 @@ func TestBuildEnsembleSeasonCandidates(t *testing.T) {
 	tests := []struct {
 		name       string
 		torrents   []qbt.Torrent
+		packSource []qbt.Torrent // defaults to torrents when nil
 		wantHashes []string
 		wantNames  []string
 	}{
@@ -118,6 +119,34 @@ func TestBuildEnsembleSeasonCandidates(t *testing.T) {
 			wantNames:  []string{"Show Title S02"},
 		},
 		{
+			name: "seeded pack outside the run scope suppresses its group",
+			torrents: []qbt.Torrent{
+				episode("Show.Title.S01E01.1080p.WEB.H264-GRP"),
+				episode("Show.Title.S01E02.1080p.WEB.H264-GRP"),
+				episode("Show.Title.S01E03.1080p.WEB.H264-GRP"),
+			},
+			packSource: []qbt.Torrent{
+				episode("Show.Title.S01E01.1080p.WEB.H264-GRP"),
+				episode("Show.Title.S01E02.1080p.WEB.H264-GRP"),
+				episode("Show.Title.S01E03.1080p.WEB.H264-GRP"),
+				episode("Show.Title.S01.1080p.WEB.H264-GRP"),
+			},
+		},
+		{
+			name: "downloading pack still suppresses its group",
+			torrents: []qbt.Torrent{
+				episode("Show.Title.S01E01.1080p.WEB.H264-GRP"),
+				episode("Show.Title.S01E02.1080p.WEB.H264-GRP"),
+				episode("Show.Title.S01E03.1080p.WEB.H264-GRP"),
+			},
+			packSource: []qbt.Torrent{
+				episode("Show.Title.S01E01.1080p.WEB.H264-GRP"),
+				episode("Show.Title.S01E02.1080p.WEB.H264-GRP"),
+				episode("Show.Title.S01E03.1080p.WEB.H264-GRP"),
+				{Hash: "pack", Name: "Show.Title.S01.1080p.WEB.H264-GRP", Progress: 0.3},
+			},
+		},
+		{
 			name: "absolute numbered episodes group without a season",
 			torrents: []qbt.Torrent{
 				episode("[SubsPlease] Overtake! - 01 (1080p) [F5A70A05]"),
@@ -149,7 +178,11 @@ func TestBuildEnsembleSeasonCandidates(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			virtual := service.buildEnsembleSeasonCandidates(tt.torrents)
+			packSource := tt.packSource
+			if packSource == nil {
+				packSource = tt.torrents
+			}
+			virtual := service.buildEnsembleSeasonCandidates(tt.torrents, packSource)
 			var gotHashes, gotNames []string
 			for _, v := range virtual {
 				require.InDelta(t, 1.0, v.Progress, 0, "virtual entries must pass the completeness skip")
@@ -276,6 +309,18 @@ func TestProcessEnsembleSeasonCandidate_NoIndexers(t *testing.T) {
 	require.Equal(t, "no eligible indexers", state.run.Results[len(state.run.Results)-1].Message)
 }
 
+// packSearchResult builds a torznab search result for a season pack candidate.
+func packSearchResult(title, guid string) jackett.SearchResult {
+	return jackett.SearchResult{
+		Indexer:     "Example",
+		IndexerID:   10,
+		Title:       title,
+		DownloadURL: "https://example.invalid/" + guid + ".torrent",
+		GUID:        guid,
+		Size:        3 << 30,
+	}
+}
+
 // existingHashSyncManager reports one infohash as already present in the client.
 type existingHashSyncManager struct {
 	*episodeSyncManager
@@ -297,14 +342,7 @@ func TestApplyEnsembleSearchResults(t *testing.T) {
 	key := ensembleGroupKey{normalizedTitle: stringutils.NewDefaultNormalizer().Normalize("Show Title"), season: 1}
 	torrent := &qbt.Torrent{Hash: ensembleSeasonPseudoHash(key), Name: "Show Title S01", Progress: 1.0}
 	packResult := func(guid string) jackett.SearchResult {
-		return jackett.SearchResult{
-			Indexer:     "Example",
-			IndexerID:   10,
-			Title:       "Show.Title.S01.1080p.WEB.H264-GRP",
-			DownloadURL: "https://example.invalid/" + guid + ".torrent",
-			GUID:        guid,
-			Size:        3 << 30,
-		}
+		return packSearchResult("Show.Title.S01.1080p.WEB.H264-GRP", guid)
 	}
 
 	tests := []struct {
@@ -333,9 +371,12 @@ func TestApplyEnsembleSearchResults(t *testing.T) {
 			wantAdded:     1,
 		},
 		{
-			name:          "stops after first successful add",
-			key:           key,
-			results:       []jackett.SearchResult{packResult("first"), packResult("second")},
+			name: "stops after first successful add",
+			key:  key,
+			results: []jackett.SearchResult{
+				packSearchResult("Show.Title.S01.1080p.WEB.H264-GRP", "first"),
+				packSearchResult("Show.Title.S01.720p.WEB.H264-OTHER", "second"),
+			},
 			applySuccess:  true,
 			wantDownloads: []string{"first"},
 			wantAdded:     1,
@@ -344,11 +385,41 @@ func TestApplyEnsembleSearchResults(t *testing.T) {
 			name: "caps apply attempts per group",
 			key:  key,
 			results: []jackett.SearchResult{
-				packResult("a"), packResult("b"), packResult("c"), packResult("d"), packResult("e"),
+				packSearchResult("Show.Title.S01.1080p.WEB.H264-A", "a"),
+				packSearchResult("Show.Title.S01.1080p.WEB.H264-B", "b"),
+				packSearchResult("Show.Title.S01.1080p.WEB.H264-C", "c"),
+				packSearchResult("Show.Title.S01.1080p.WEB.H264-D", "d"),
+				packSearchResult("Show.Title.S01.1080p.WEB.H264-E", "e"),
 			},
 			applySuccess:  false,
 			wantDownloads: []string{"a", "b", "c"},
 			wantFailed:    1,
+		},
+		{
+			// Gachiakuta case: the same pack carries a distinct GUID per
+			// indexer; duplicates must not consume cap slots and starve
+			// later variants.
+			name: "duplicate names across indexers share one cap slot",
+			key:  key,
+			results: []jackett.SearchResult{
+				packSearchResult("Show.Title.S01.1080p.WEB.H264-GRP", "n1-indexer1"),
+				packSearchResult("Show Title S01 1080p WEB H264-GRP", "n1-indexer2"),
+				packSearchResult("Show.Title.S01.720p.WEB.H264-OTHER", "n2-indexer1"),
+				packSearchResult("Show.Title.S01.1080p.WEB.H264-GRP", "n1-indexer3"),
+				packSearchResult("Show.Title.S01.2160p.WEB.H265-THIRD", "n3-indexer1"),
+			},
+			applySuccess:  false,
+			wantDownloads: []string{"n1-indexer1", "n2-indexer1", "n3-indexer1"},
+			wantFailed:    1,
+		},
+		{
+			name: "multi-season range packs are rejected",
+			key:  key,
+			results: []jackett.SearchResult{
+				packSearchResult("Show.Title.S01-S05.1080p.WEB.H264-GRP", "range"),
+			},
+			wantSkipped: 1,
+			wantMessage: "no season pack candidates",
 		},
 		{
 			name:          "seasonless group admits any season pack",
@@ -415,6 +486,106 @@ func TestApplyEnsembleSearchResults(t *testing.T) {
 				require.NotEmpty(t, state.run.Results)
 				require.Equal(t, tt.wantMessage, state.run.Results[len(state.run.Results)-1].Message)
 			}
+		})
+	}
+}
+
+func TestCanonicalReleaseNameKey(t *testing.T) {
+	t.Parallel()
+
+	// Cooldowns are recorded under the torrent's internal (dotted) name but
+	// checked against feed/indexer titles, which may use spaces.
+	require.Equal(t,
+		canonicalReleaseNameKey("Show.Title.S01.1080p.WEB.H264-GRP"),
+		canonicalReleaseNameKey("Show Title S01 1080p WEB H264-GRP"))
+	require.NotEqual(t,
+		canonicalReleaseNameKey("Show.Title.S01.1080p.WEB.H264-GRP"),
+		canonicalReleaseNameKey("Show.Title.S01.1080p.WEB.H264-OTHER"))
+	require.Equal(t, "packfail:show title s01 1080p web h264 grp", seasonPackFailKey("Show.Title.S01.1080p.WEB.H264-GRP"))
+
+	// Names with no ASCII alphanumerics must not all collapse onto one key.
+	require.NotEqual(t, canonicalReleaseNameKey("進撃の巨人"), canonicalReleaseNameKey("鬼滅の刃"))
+}
+
+func TestIsSeasonRangePack(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"Hotellet.DANiSH.S01-S05.720p.WEB-DL.H.264", true},
+		{"Show.Name.S01-05.1080p.WEB-DL", true},
+		{"Show.Name.Season.1-5.1080p.WEB-DL", true},
+		{"Show Name Season 1-5 1080p WEB-DL", true},
+		{"Show.Title.S01.1080p.WEB.H264-GRP", false},
+		{"Show.Title.S01E01.1080p.WEB.H264-GRP", false},
+		{"Show.Title.S01E01-E10.1080p.WEB.H264-GRP", false},
+		{"Show.Title.S02-S01.1080p.WEB.H264-GRP", false},
+		{"Top.5-1.Countdown.S01.1080p.WEB.H264-GRP", false},
+	}
+	for _, tt := range tests {
+		require.Equal(t, tt.want, isSeasonRangePack(tt.name), "name: %s", tt.name)
+	}
+}
+
+// TestApplyEnsembleSearchResults_PackFailCooldown covers the ensemble side of
+// the failed-diversion cooldown: a cooling release name is skipped before its
+// .torrent download and does not consume a cap slot; an expired stamp retries.
+func TestApplyEnsembleSearchResults_PackFailCooldown(t *testing.T) {
+	t.Parallel()
+
+	key := ensembleGroupKey{normalizedTitle: stringutils.NewDefaultNormalizer().Normalize("Show Title"), season: 1}
+	cooledTitle := "Show.Title.S01.1080p.WEB.H264-GRP"
+
+	tests := []struct {
+		name          string
+		stampAge      time.Duration
+		wantDownloads []string
+	}{
+		{
+			// Cooled name skipped pre-download; the three fresh variants all
+			// get cap slots, proving the skip does not consume one.
+			name:          "cooling name is skipped without consuming a cap slot",
+			stampAge:      time.Hour,
+			wantDownloads: []string{"fresh-a", "fresh-b", "fresh-c"},
+		},
+		{
+			// All four names admissible again; the cap trims to three.
+			name:          "expired stamp retries the name",
+			stampAge:      13 * time.Hour,
+			wantDownloads: []string{"cooled", "fresh-a", "fresh-b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			service, state, instanceID := newEnsembleSearchState(t, "crossseed-ensemble-packfail", nil, true)
+
+			require.NoError(t, service.automationStore.UpsertSearchHistory(
+				ctx, instanceID, seasonPackFailKey(cooledTitle), time.Now().UTC().Add(-tt.stampAge)))
+
+			var downloads []string
+			service.torrentDownloadFunc = func(_ context.Context, req jackett.TorrentDownloadRequest) ([]byte, error) {
+				downloads = append(downloads, req.GUID)
+				return []byte("torrent"), nil
+			}
+			service.crossSeedInvoker = func(_ context.Context, _ *CrossSeedRequest) (*CrossSeedResponse, error) {
+				return &CrossSeedResponse{Success: false}, nil
+			}
+
+			results := []jackett.SearchResult{
+				packSearchResult(cooledTitle, "cooled"),
+				packSearchResult("Show.Title.S01.720p.WEB.H264-A", "fresh-a"),
+				packSearchResult("Show.Title.S01.2160p.WEB.H265-B", "fresh-b"),
+				packSearchResult("Show.Title.S01.1080p.BluRay.x264-C", "fresh-c"),
+			}
+			torrent := &qbt.Torrent{Hash: ensembleSeasonPseudoHash(key), Name: "Show Title S01", Progress: 1.0}
+			service.applyEnsembleSearchResults(ctx, state, torrent, key, "query", &jackett.SearchResponse{Results: results}, time.Now().UTC())
+
+			require.Equal(t, tt.wantDownloads, downloads)
 		})
 	}
 }

--- a/internal/services/crossseed/ensemble_season_test.go
+++ b/internal/services/crossseed/ensemble_season_test.go
@@ -505,6 +505,10 @@ func TestCanonicalReleaseNameKey(t *testing.T) {
 	require.NotEqual(t,
 		canonicalReleaseNameKey("Show.Title.S01.1080p.WEB.H264-GRP"),
 		canonicalReleaseNameKey("Show.Title.S01.1080p.WEB.H264-OTHER"))
+	// Documented tradeoff, not a bug: the mapping is many-to-one, so names
+	// differing only in token boundaries collide. Accepted because real
+	// variants differ by tokens and a collision costs one cooldown window.
+	require.Equal(t, canonicalReleaseNameKey("ab-c"), canonicalReleaseNameKey("a-bc"))
 	require.Equal(t, "packfail:showtitles011080pwebh264grp", seasonPackFailKey("Show.Title.S01.1080p.WEB.H264-GRP"))
 
 	// Names with no ASCII alphanumerics must not all collapse onto one key.

--- a/internal/services/crossseed/ensemble_season_test.go
+++ b/internal/services/crossseed/ensemble_season_test.go
@@ -513,6 +513,11 @@ func TestCanonicalReleaseNameKey(t *testing.T) {
 
 	// Names with no ASCII alphanumerics must not all collapse onto one key.
 	require.NotEqual(t, canonicalReleaseNameKey("進撃の巨人"), canonicalReleaseNameKey("鬼滅の刃"))
+
+	// Punctuation-only names carry no identity: no key, no cooldown
+	// bookkeeping, so "!!!" can never suppress "???".
+	require.Empty(t, seasonPackFailKey("!!!"))
+	require.Empty(t, seasonPackFailKey("???"))
 }
 
 func TestIsSeasonRangePack(t *testing.T) {

--- a/internal/services/crossseed/ensemble_season_test.go
+++ b/internal/services/crossseed/ensemble_season_test.go
@@ -494,14 +494,18 @@ func TestCanonicalReleaseNameKey(t *testing.T) {
 	t.Parallel()
 
 	// Cooldowns are recorded under the torrent's internal (dotted) name but
-	// checked against feed/indexer titles, which may use spaces.
+	// checked against feed/indexer titles, which restyle separators between
+	// AND inside tokens (field case: BeyondHD's "DDP 5.1" vs "DDP5.1").
+	require.Equal(t,
+		canonicalReleaseNameKey("Stranger.Things.S05.2160p.NF.WEB-DL.DDP5.1.Atmos.H.265-Draken02"),
+		canonicalReleaseNameKey("Stranger Things S05 2160p NF WEB-DL DDP 5.1 Atmos H.265-Draken02"))
 	require.Equal(t,
 		canonicalReleaseNameKey("Show.Title.S01.1080p.WEB.H264-GRP"),
 		canonicalReleaseNameKey("Show Title S01 1080p WEB H264-GRP"))
 	require.NotEqual(t,
 		canonicalReleaseNameKey("Show.Title.S01.1080p.WEB.H264-GRP"),
 		canonicalReleaseNameKey("Show.Title.S01.1080p.WEB.H264-OTHER"))
-	require.Equal(t, "packfail:show title s01 1080p web h264 grp", seasonPackFailKey("Show.Title.S01.1080p.WEB.H264-GRP"))
+	require.Equal(t, "packfail:showtitles011080pwebh264grp", seasonPackFailKey("Show.Title.S01.1080p.WEB.H264-GRP"))
 
 	// Names with no ASCII alphanumerics must not all collapse onto one key.
 	require.NotEqual(t, canonicalReleaseNameKey("進撃の巨人"), canonicalReleaseNameKey("鬼滅の刃"))

--- a/internal/services/crossseed/seasonpack.go
+++ b/internal/services/crossseed/seasonpack.go
@@ -381,7 +381,14 @@ func (s *Service) ApplySeasonPackWebhook(ctx context.Context, req *SeasonPackApp
 
 	winner := selectWinner(matches, prep.threshold)
 	if winner == nil {
-		s.recordApplyRun(ctx, req.TorrentName, "drifted", "no instance meets coverage threshold at apply time", 0, 0, prep.totalEpisodes, 0, "")
+		// Record the best real partial coverage instead of a flat 0/N, so run
+		// rows distinguish "3 of 21 episodes seeded" from "nothing matched".
+		best := selectWinner(matches, 0)
+		bestInstance, bestMatched, bestCoverage := 0, 0, 0.0
+		if best != nil {
+			bestInstance, bestMatched, bestCoverage = best.InstanceID, best.MatchedEpisodes, best.Coverage
+		}
+		s.recordApplyRun(ctx, req.TorrentName, "drifted", "no instance meets coverage threshold at apply time", bestInstance, bestMatched, prep.totalEpisodes, bestCoverage, "")
 		return &SeasonPackApplyResponse{
 			Reason:  "drifted",
 			Message: "coverage no longer meets threshold",

--- a/internal/services/crossseed/seasonpack_cooldown.go
+++ b/internal/services/crossseed/seasonpack_cooldown.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package crossseed
+
+import (
+	"context"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// Season-pack diversion failures cool down by normalized release name, not by
+// result GUID: the same pack circulates under one name with a distinct GUID
+// per indexer, and a per-GUID key would re-download it from every other
+// indexer. Rows reuse cross_seed_search_history under a "packfail:" pseudo-key
+// (the same trick as the "season:" ensemble pseudo-hashes, zero migrations).
+// The verdict is global — coverage is computed across all eligible instances —
+// so reads take the latest row for the key regardless of which instance owns
+// it; the instance column only satisfies the table's FK.
+const seasonPackFailHashPrefix = "packfail:"
+
+var releaseNameKeyRe = regexp.MustCompile(`[^\p{L}\p{N}]+`)
+
+// canonicalReleaseNameKey collapses case and separator differences so a feed
+// title ("Show Title S01 ...") and the torrent's internal name
+// ("Show.Title.S01...") key identically: cooldowns are recorded under the
+// latter but checked against the former.
+func canonicalReleaseNameKey(name string) string {
+	return strings.TrimSpace(releaseNameKeyRe.ReplaceAllString(strings.ToLower(name), " "))
+}
+
+func seasonPackFailKey(torrentName string) string {
+	return seasonPackFailHashPrefix + canonicalReleaseNameKey(torrentName)
+}
+
+// seasonPackFailCooldownActive reports whether a season pack release name
+// failed diversion within the cooldown window. Callers check this before
+// downloading a .torrent whose only purpose is another diversion attempt.
+func (s *Service) seasonPackFailCooldownActive(ctx context.Context, torrentName string, cooldown time.Duration) bool {
+	if s.automationStore == nil || cooldown <= 0 {
+		return false
+	}
+	last, found, err := s.automationStore.GetLatestSearchHistory(ctx, seasonPackFailKey(torrentName))
+	if err != nil {
+		log.Debug().Err(err).Str("torrentName", torrentName).Msg("failed to read season pack failure cooldown")
+		return false
+	}
+	return found && time.Since(last) < cooldown
+}
+
+// recordSeasonPackFailCooldown stamps a failed diversion for a release name.
+// The first valid instance in the response owns the row (the verdict itself is
+// not tied to one instance). invalid_torrent deliberately never lands here:
+// the same name from another indexer can serve a valid payload.
+func (s *Service) recordSeasonPackFailCooldown(ctx context.Context, torrentName string, response *CrossSeedResponse) {
+	if s.automationStore == nil {
+		return
+	}
+	for i := range response.Results {
+		if response.Results[i].InstanceID <= 0 {
+			continue
+		}
+		if err := s.automationStore.UpsertSearchHistory(ctx, response.Results[i].InstanceID, seasonPackFailKey(torrentName), time.Now().UTC()); err != nil {
+			log.Debug().Err(err).Str("torrentName", torrentName).Msg("failed to record season pack failure cooldown")
+		}
+		return
+	}
+}

--- a/internal/services/crossseed/seasonpack_cooldown.go
+++ b/internal/services/crossseed/seasonpack_cooldown.go
@@ -39,18 +39,26 @@ func canonicalReleaseNameKey(name string) string {
 	return releaseNameKeyRe.ReplaceAllString(strings.ToLower(name), "")
 }
 
+// seasonPackFailKey returns "" for names with no letters or digits at all:
+// they carry no identity, and a shared bare key would let one such name
+// suppress another. Callers skip cooldown bookkeeping on "".
 func seasonPackFailKey(torrentName string) string {
-	return seasonPackFailHashPrefix + canonicalReleaseNameKey(torrentName)
+	key := canonicalReleaseNameKey(torrentName)
+	if key == "" {
+		return ""
+	}
+	return seasonPackFailHashPrefix + key
 }
 
 // seasonPackFailCooldownActive reports whether a season pack release name
 // failed diversion within the cooldown window. Callers check this before
 // downloading a .torrent whose only purpose is another diversion attempt.
 func (s *Service) seasonPackFailCooldownActive(ctx context.Context, torrentName string, cooldown time.Duration) bool {
-	if s.automationStore == nil || cooldown <= 0 {
+	key := seasonPackFailKey(torrentName)
+	if s.automationStore == nil || cooldown <= 0 || key == "" {
 		return false
 	}
-	last, found, err := s.automationStore.GetLatestSearchHistory(ctx, seasonPackFailKey(torrentName))
+	last, found, err := s.automationStore.GetLatestSearchHistory(ctx, key)
 	if err != nil {
 		log.Debug().Err(err).Str("torrentName", torrentName).Msg("failed to read season pack failure cooldown")
 		return false
@@ -63,14 +71,15 @@ func (s *Service) seasonPackFailCooldownActive(ctx context.Context, torrentName 
 // not tied to one instance). invalid_torrent deliberately never lands here:
 // the same name from another indexer can serve a valid payload.
 func (s *Service) recordSeasonPackFailCooldown(ctx context.Context, torrentName string, response *CrossSeedResponse) {
-	if s.automationStore == nil {
+	key := seasonPackFailKey(torrentName)
+	if s.automationStore == nil || key == "" {
 		return
 	}
 	for i := range response.Results {
 		if response.Results[i].InstanceID <= 0 {
 			continue
 		}
-		if err := s.automationStore.UpsertSearchHistory(ctx, response.Results[i].InstanceID, seasonPackFailKey(torrentName), time.Now().UTC()); err != nil {
+		if err := s.automationStore.UpsertSearchHistory(ctx, response.Results[i].InstanceID, key, time.Now().UTC()); err != nil {
 			log.Debug().Err(err).Str("torrentName", torrentName).Msg("failed to record season pack failure cooldown")
 		}
 		return

--- a/internal/services/crossseed/seasonpack_cooldown.go
+++ b/internal/services/crossseed/seasonpack_cooldown.go
@@ -29,7 +29,12 @@ var releaseNameKeyRe = regexp.MustCompile(`[^\p{L}\p{N}]+`)
 // ("Show.Title.S01...DDP5.1...") key identically: cooldowns are recorded
 // under the latter but checked against the former, and indexers restyle
 // separators inside tokens too (BeyondHD's "DDP 5.1"), so separators are
-// removed rather than collapsed.
+// removed rather than collapsed. That mapping is many-to-one by design:
+// distinct releases with the same letter-digit sequence under different
+// boundaries would share a key, which at worst skips one attempt for one
+// cooldown window. Real variants differ by tokens (group, codec, REPACK),
+// while same-release respacing recurs hourly in feeds, so the collapse is
+// the cheaper side of the trade.
 func canonicalReleaseNameKey(name string) string {
 	return releaseNameKeyRe.ReplaceAllString(strings.ToLower(name), "")
 }

--- a/internal/services/crossseed/seasonpack_cooldown.go
+++ b/internal/services/crossseed/seasonpack_cooldown.go
@@ -24,12 +24,14 @@ const seasonPackFailHashPrefix = "packfail:"
 
 var releaseNameKeyRe = regexp.MustCompile(`[^\p{L}\p{N}]+`)
 
-// canonicalReleaseNameKey collapses case and separator differences so a feed
-// title ("Show Title S01 ...") and the torrent's internal name
-// ("Show.Title.S01...") key identically: cooldowns are recorded under the
-// latter but checked against the former.
+// canonicalReleaseNameKey strips case and separator differences so a feed
+// title ("Show Title S01 ... DDP 5.1 ...") and the torrent's internal name
+// ("Show.Title.S01...DDP5.1...") key identically: cooldowns are recorded
+// under the latter but checked against the former, and indexers restyle
+// separators inside tokens too (BeyondHD's "DDP 5.1"), so separators are
+// removed rather than collapsed.
 func canonicalReleaseNameKey(name string) string {
-	return strings.TrimSpace(releaseNameKeyRe.ReplaceAllString(strings.ToLower(name), " "))
+	return releaseNameKeyRe.ReplaceAllString(strings.ToLower(name), "")
 }
 
 func seasonPackFailKey(torrentName string) string {

--- a/internal/services/crossseed/seasonpack_diversion_test.go
+++ b/internal/services/crossseed/seasonpack_diversion_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/base64"
 	"testing"
+	"time"
 
 	"github.com/anacrolix/torrent/bencode"
 	"github.com/anacrolix/torrent/metainfo"
@@ -291,6 +292,135 @@ func TestProcessAutomationCandidate_DownloadsPackForDiversion(t *testing.T) {
 			if tt.wantLastMessage != "" {
 				require.NotEmpty(t, run.Results)
 				require.Equal(t, tt.wantLastMessage, run.Results[len(run.Results)-1].Message)
+			}
+		})
+	}
+}
+
+// TestMaybeDivertSeasonPack_RecordsFailCooldown verifies which diversion
+// outcomes stamp the packfail cooldown: verdict-style failures cool, while
+// invalid_torrent (another indexer may serve a valid payload) and success
+// leave no stamp.
+func TestMaybeDivertSeasonPack_RecordsFailCooldown(t *testing.T) {
+	t.Parallel()
+
+	packName := "Show.Title.S01.1080p.WEB.H264-GRP"
+
+	tests := []struct {
+		name         string
+		reason       string
+		applied      bool
+		wantCooldown bool
+	}{
+		{"drifted cools", "drifted", false, true},
+		{"layout_mismatch cools", "layout_mismatch", false, true},
+		{"already_exists cools", "already_exists", false, true},
+		{"invalid_torrent does not cool", "invalid_torrent", false, false},
+		{"applied does not cool", "applied", true, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			service, _, instanceID := newEnsembleSearchState(t, "crossseed-divert-cooldown", nil, true)
+
+			settings := models.DefaultCrossSeedAutomationSettings()
+			settings.SeasonPackAutomationEnabled = true
+			service.automationSettingsLoader = func(context.Context) (*models.CrossSeedAutomationSettings, error) {
+				return settings, nil
+			}
+			service.seasonPackApplier = func(context.Context, *SeasonPackApplyRequest) (*SeasonPackApplyResponse, error) {
+				return &SeasonPackApplyResponse{Applied: tt.applied, Reason: tt.reason, InstanceID: instanceID}, nil
+			}
+
+			response := &CrossSeedResponse{
+				Results: []InstanceCrossSeedResult{
+					{InstanceID: instanceID, InstanceName: "Test", Success: false, Status: "no_match"},
+				},
+			}
+			service.maybeDivertSeasonPack(ctx, &CrossSeedRequest{}, packName, response)
+
+			_, found, err := service.automationStore.GetLatestSearchHistory(ctx, seasonPackFailKey(packName))
+			require.NoError(t, err)
+			require.Equal(t, tt.wantCooldown, found, "cooldown stamp presence mismatch")
+		})
+	}
+}
+
+// TestProcessAutomationCandidate_PackFailCooldownSkipsDownload covers the RSS
+// chokepoint: when diversion is the only reason to download and the release
+// name recently failed diversion, the item is skipped before the .torrent
+// download; an expired stamp downloads again.
+func TestProcessAutomationCandidate_PackFailCooldownSkipsDownload(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		stampAge      time.Duration
+		wantDownloads int
+		wantInvoked   bool
+	}{
+		{name: "cooling name skips before download", stampAge: time.Hour, wantDownloads: 0, wantInvoked: false},
+		{name: "expired stamp downloads again", stampAge: 13 * time.Hour, wantDownloads: 1, wantInvoked: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+
+			service, _, instanceID := newEnsembleSearchState(t, "crossseed-rss-packfail", []qbt.Torrent{
+				{Hash: "ep1", Name: "Show.Title.S01E01.1080p.WEB.H264-GRP", Progress: 1.0},
+			}, true)
+			sync := service.syncManager.(*episodeSyncManager)
+			sync.files[instanceID] = map[string]qbt.TorrentFiles{
+				"ep1": {{Name: "Show.Title.S01E01.1080p.WEB.H264-GRP.mkv", Size: 1 << 30}},
+			}
+			service.instanceStore = &episodeInstanceStore{
+				instances: map[int]*models.Instance{
+					instanceID: {ID: instanceID, Name: "Test"},
+				},
+			}
+
+			packTitle := "Show.Title.S01.1080p.WEB.H264-GRP"
+			require.NoError(t, service.automationStore.UpsertSearchHistory(
+				ctx, instanceID, seasonPackFailKey(packTitle), time.Now().UTC().Add(-tt.stampAge)))
+
+			var invoked bool
+			var downloads int
+			service.torrentDownloadFunc = func(context.Context, jackett.TorrentDownloadRequest) ([]byte, error) {
+				downloads++
+				return []byte("torrent"), nil
+			}
+			service.crossSeedInvoker = func(_ context.Context, _ *CrossSeedRequest) (*CrossSeedResponse, error) {
+				invoked = true
+				return &CrossSeedResponse{Success: false}, nil
+			}
+
+			settings := &models.CrossSeedAutomationSettings{
+				TargetInstanceIDs:           []int{instanceID},
+				FindIndividualEpisodes:      true,
+				SeasonPackAutomationEnabled: true,
+			}
+			run := &models.CrossSeedRun{}
+			result := jackett.SearchResult{
+				Indexer:     "Example",
+				IndexerID:   10,
+				Title:       packTitle,
+				DownloadURL: "https://example.invalid/pack.torrent",
+				GUID:        "guid-pack",
+				Size:        3 << 30,
+			}
+
+			status, _, err := service.processAutomationCandidate(ctx, run, settings, nil, result, AutomationRunOptions{}, map[int]jackett.EnabledIndexerInfo{})
+			require.NoError(t, err)
+			require.Equal(t, tt.wantDownloads, downloads, "torrent download count mismatch")
+			require.Equal(t, tt.wantInvoked, invoked, "CrossSeed invocation mismatch")
+			if !tt.wantInvoked {
+				require.Equal(t, models.CrossSeedFeedItemStatusSkipped, status)
+				require.NotEmpty(t, run.Results)
+				require.Contains(t, run.Results[len(run.Results)-1].Message, "cooldown")
 			}
 		})
 	}

--- a/internal/services/crossseed/seasonpack_test.go
+++ b/internal/services/crossseed/seasonpack_test.go
@@ -1281,6 +1281,11 @@ func TestApplySeasonPackWebhook_HardFailsWhenCoverageDrifts(t *testing.T) {
 	require.Equal(t, "apply", store.runs[0].Phase)
 	require.Equal(t, "failed", store.runs[0].Status)
 	require.Equal(t, "drifted", store.runs[0].Reason)
+	// The run row must carry the real partial coverage, not a flat 0/N.
+	require.Equal(t, 1, store.runs[0].MatchedEpisodes)
+	require.InDelta(t, 0.25, store.runs[0].Coverage, 0.001)
+	require.NotNil(t, store.runs[0].InstanceID)
+	require.Equal(t, inst.ID, *store.runs[0].InstanceID)
 }
 
 func TestApplySeasonPackWebhook_UsesHardlinkMode(t *testing.T) {

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -3779,6 +3779,21 @@ func (s *Service) processAutomationCandidate(ctx context.Context, run *models.Cr
 	// candidates but can still be assembled by the diversion inside CrossSeed,
 	// so they must proceed to download instead of skipping.
 	seasonPackDivertible := candidatesResp.seasonPackEpisodeCandidates && settings.SeasonPackAutomationEnabled
+	// When diversion is the only reason to download, a recent diversion failure
+	// for the same release name makes the download a guaranteed waste until the
+	// cooldown lapses. Feed items marked skipped are re-evaluated every run, so
+	// the item retries once the cooldown expires.
+	if candidateCount == 0 && seasonPackDivertible && s.seasonPackFailCooldownActive(ctx, result.Title, minSearchCooldownMinutes*time.Minute) {
+		run.TorrentsSkipped++
+		run.Results = append(run.Results, models.CrossSeedRunResult{
+			InstanceName: result.Indexer,
+			IndexerName:  result.Indexer,
+			Success:      false,
+			Status:       "skipped",
+			Message:      "Season pack diversion recently failed for " + result.Title + "; waiting out cooldown",
+		})
+		return models.CrossSeedFeedItemStatusSkipped, nil, nil
+	}
 	if candidateCount == 0 && !seasonPackDivertible {
 		run.TorrentsSkipped++
 		run.Results = append(run.Results, models.CrossSeedRunResult{
@@ -4677,6 +4692,10 @@ func (s *Service) maybeDivertSeasonPack(ctx context.Context, req *CrossSeedReque
 				Str("torrentName", torrentName).
 				Str("reason", resp.Reason).
 				Msg("Season pack diversion did not apply")
+			switch resp.Reason {
+			case "drifted", "layout_mismatch", "already_exists":
+				s.recordSeasonPackFailCooldown(ctx, torrentName, response)
+			}
 		}
 		return
 	}
@@ -9884,7 +9903,19 @@ func (s *Service) refreshSearchQueue(ctx context.Context, state *searchRunState)
 
 	state.queue = deduplicated
 	if state.opts.EnsembleSeasonSearch {
-		if virtual := s.buildEnsembleSeasonCandidates(deduplicated); len(virtual) > 0 {
+		// Pack suppression needs the instance's full torrent list: when the
+		// fetch above was server-side filtered by category/tag, a seeded pack
+		// outside the run scope is missing from it. The sync manager serves
+		// this from memory.
+		packSource := torrents
+		if filterOpts.Category != "" || filterOpts.Tag != "" {
+			if all, allErr := s.syncManager.GetTorrents(ctx, state.opts.InstanceID, qbt.TorrentFilterOptions{Filter: qbt.TorrentFilterAll}); allErr == nil {
+				packSource = all
+			} else {
+				log.Warn().Err(allErr).Int("instanceID", state.opts.InstanceID).Msg("Failed to list all torrents for ensemble pack suppression; using run-scoped list")
+			}
+		}
+		if virtual := s.buildEnsembleSeasonCandidates(deduplicated, packSource); len(virtual) > 0 {
 			// deduplicated can be cache-backed; never append to it in place.
 			// Virtual entries go last so real torrents search first.
 			queue := make([]qbt.Torrent, 0, len(deduplicated)+len(virtual))


### PR DESCRIPTION
The first ensemble field run downloaded 47 season packs and applied 2, and each later RSS run downloaded the same failed packs again. This PR adds a cooldown for failed diversions. The key is the canonical release name, because the same pack has a different GUID on each indexer. The outcomes `drifted`, `layout_mismatch`, and `already_exists` write a `packfail:` row to `cross_seed_search_history` (no migration), and both automation flows check this row before they download a `.torrent`. An `invalid_torrent` outcome does not start a cooldown, because a different indexer can serve a valid payload. The cooldown expires after 720 minutes, and then the next run tries the pack again.

Four more fixes come from the same field run. Ensemble results with the same name now use one attempt slot, so duplicates from many indexers cannot starve later variants. Ensemble admission now rejects multi-season range packs such as `S01-S05`. Pack suppression now reads the full torrent list of the instance, so a seeded pack outside the run scope also suppresses its search. Drifted season pack runs now record their best real coverage instead of a flat 0/N.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cooldown handling for failed season-pack diversions, with automatic retries after expiration.
  * Improved multi-season detection and suppression of existing seeded or downloading packs.

* **Bug Fixes**
  * Prevented duplicate or unsuitable season packs from appearing in search results.
  * RSS automation now skips recently failed downloads for later reevaluation.
  * Drifted runs preserve partial match details, including matched episodes and coverage.
  * Filtered searches now more reliably detect existing season packs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->