### PR TITLE
fix(torznab): keep structured season/ep params when indexer caps support them

### DIFF
--- a/internal/services/jackett/service.go
+++ b/internal/services/jackett/service.go
@@ -2620,6 +2620,29 @@ func (s *Service) applyProwlarrTVTokenWorkaround(idx *models.TorznabIndexer, par
 	}
 
 	currentQuery := strings.TrimSpace(params["q"])
+	if prowlarrStructuredTVSupported(idx.Capabilities, params) {
+		// The indexer's caps advertise native season/ep params, so let Prowlarr
+		// translate them per-indexer. Folding an SxxEyy token into q returns zero
+		// results on API-based indexers (e.g. BTN) whose free-text search matches
+		// release names (discussion #2036).
+		if currentQuery == "" && !hasTorznabIDParams(params) && meta != nil {
+			restored := strings.TrimSpace(meta.originalQuery)
+			if restored == "" {
+				restored = strings.TrimSpace(meta.releaseName)
+			}
+			if restored != "" {
+				params["q"] = restored
+			}
+		}
+
+		log.Debug().
+			Int("indexer_id", idx.ID).
+			Str("indexer_name", idx.Name).
+			Str("tv_token", token).
+			Msg("Keeping structured TV season/episode parameters supported by indexer caps")
+		return
+	}
+
 	if hasTorznabIDParams(params) {
 		// IDs identify the series; q only needs the season/episode token. Never append a
 		// resolution token here: indexers whose free-text search matches the series name
@@ -2666,6 +2689,19 @@ func (s *Service) applyProwlarrTVTokenWorkaround(idx *models.TorznabIndexer, par
 
 func hasTorznabIDParams(params map[string]string) bool {
 	return params["imdbid"] != "" || params["tvdbid"] != "" || params["tmdbid"] != "" || params["tvmazeid"] != ""
+}
+
+// prowlarrStructuredTVSupported reports whether the indexer's advertised caps cover
+// every structured TV param present in the request. Empty caps (never fetched) fail
+// the check, keeping the token workaround as the fallback.
+func prowlarrStructuredTVSupported(capabilities []string, params map[string]string) bool {
+	if strings.TrimSpace(params["season"]) != "" && !supportsAnyCapability(capabilities, []string{"tv-search-season"}) {
+		return false
+	}
+	if strings.TrimSpace(params["ep"]) != "" && !supportsAnyCapability(capabilities, []string{"tv-search-ep"}) {
+		return false
+	}
+	return true
 }
 
 func prowlarrTVToken(seasonStr, episodeStr string) string {

--- a/internal/services/jackett/service_test.go
+++ b/internal/services/jackett/service_test.go
@@ -2229,12 +2229,13 @@ func TestSearch_AllIndexersSkippedByRateLimitWaitReturnsError(t *testing.T) {
 
 func TestProwlarrYearParameterWorkaround(t *testing.T) {
 	tests := []struct {
-		name        string
-		backend     models.TorznabBackend
-		inputParams map[string]string
-		expected    map[string]string
-		meta        *searchContext
-		description string
+		name         string
+		backend      models.TorznabBackend
+		capabilities []string
+		inputParams  map[string]string
+		expected     map[string]string
+		meta         *searchContext
+		description  string
 	}{
 		{
 			name:    "prowlarr with year parameter",
@@ -2412,16 +2413,87 @@ func TestProwlarrYearParameterWorkaround(t *testing.T) {
 			},
 			description: "Prowlarr indexer should drop title and resolution from q when IDs are present",
 		},
+		{
+			name:         "prowlarr id driven tv keeps structured season when caps support it",
+			backend:      models.TorznabBackendProwlarr,
+			capabilities: []string{"tv-search", "tv-search-tvdbid", "tv-search-season"},
+			inputParams: map[string]string{
+				"t":      "tvsearch",
+				"season": "5",
+				"tvdbid": "153021",
+			},
+			expected: map[string]string{
+				"t":      "tvsearch",
+				"season": "5",
+				"tvdbid": "153021",
+				// q must stay absent: BTN-style free-text search matches release
+				// names, so an injected "S05" token returns zero results (#2036)
+			},
+			description: "Prowlarr indexer with season caps should keep structured season param and not inject a token into q",
+		},
+		{
+			name:         "prowlarr tv keeps structured season and title query when caps support it",
+			backend:      models.TorznabBackendProwlarr,
+			capabilities: []string{"tv-search", "tv-search-season", "tv-search-ep"},
+			inputParams: map[string]string{
+				"t":      "tvsearch",
+				"q":      "Some Show",
+				"season": "22",
+				"ep":     "3",
+			},
+			expected: map[string]string{
+				"t":      "tvsearch",
+				"q":      "Some Show",
+				"season": "22",
+				"ep":     "3",
+			},
+			description: "Prowlarr indexer with season/ep caps should keep structured params alongside the title query",
+		},
+		{
+			name:         "prowlarr tv falls back to token when ep cap missing",
+			backend:      models.TorznabBackendProwlarr,
+			capabilities: []string{"tv-search", "tv-search-season"},
+			inputParams: map[string]string{
+				"t":      "tvsearch",
+				"q":      "Some Show",
+				"season": "22",
+				"ep":     "3",
+			},
+			expected: map[string]string{
+				"t": "tvsearch",
+				"q": "Some Show S22E03",
+			},
+			description: "Prowlarr indexer missing the ep cap should fall back to the token workaround for season+episode searches",
+		},
+		{
+			name:         "prowlarr tv restores title query when structured params supported and q empty",
+			backend:      models.TorznabBackendProwlarr,
+			capabilities: []string{"tv-search", "tv-search-season"},
+			inputParams: map[string]string{
+				"t":      "tvsearch",
+				"season": "17",
+			},
+			meta: &searchContext{
+				originalQuery: "Some Show",
+			},
+			expected: map[string]string{
+				"t":      "tvsearch",
+				"q":      "Some Show",
+				"season": "17",
+			},
+			description: "Prowlarr indexer with season caps should restore the title query instead of a season-only search",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create a test indexer with the specified backend
 			indexer := &models.TorznabIndexer{
-				ID:        1,
-				Name:      "Test Indexer",
-				Backend:   tt.backend,
-				IndexerID: "test",
+				ID:           1,
+				Name:         "Test Indexer",
+				Backend:      tt.backend,
+				IndexerID:    "test",
+				Capabilities: tt.capabilities,
 			}
 
 			// Set up mock store


### PR DESCRIPTION
Cross-seed TV searches against Prowlarr fold season/episode into the free-text query as an `SxxEyy` token for every indexer. API-based indexers whose search field matches release names return zero results for that token (BTN gets `{"Search":"S05","Tvdb":...}` → 0 results, while `{season:5}{tvdbId:...}` returns everything), which made BTN cross-seeding effectively dead for TV. This also blinds the new ensemble season searches on exactly the trackers where season packs live.

Now, when an indexer's advertised Torznab caps cover every structured TV param in the request (`tv-search-season`, and `tv-search-ep` when an episode is set), the params stay structured and Prowlarr translates them to the indexer's native syntax. Indexers without those caps (or with caps never fetched) keep the existing token workaround unchanged. Fixes #2036.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Prowlarr TV searches by preserving season and episode filters when supported by the indexer.
  - Added fallback handling for indexers with missing or unsupported capabilities.
  - Restored the original title query when structured search parameters leave the query empty.
- **Tests**
  - Expanded coverage for supported, unsupported, and missing TV search capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->