### PR TITLE
fix(crossseed): demote unlinkable season pack episodes to missing

### DIFF
--- a/documentation/docs/features/cross-seed/season-packs.md
+++ b/documentation/docs/features/cross-seed/season-packs.md
@@ -26,7 +26,7 @@ The webhook flow below is one of two triggers. The other is [Automatic Assembly]
    - `404 Not Found` - local coverage is too low, the release is not a season pack, or the feature is disabled
 7. On `200 OK`, autobrr sends the torrent file to `/api/cross-seed/season-pack/apply`
 8. qui links the matched episodes, applies your configured season-pack tags, and adds the season pack torrent. qui never links a local episode file whose size or release details differ from its pack file. qui treats that episode as missing and downloads it instead. If these demotions drop coverage below the threshold, the apply fails as `drifted`
-9. If episodes or extras are still missing, qui adds the torrent paused, attempts an automatic recheck, and queues automatic resume. After recheck, qui resumes the torrent when qBittorrent reports progress at or above your configured season-pack coverage threshold. If recheck finishes below that threshold, qui leaves the torrent paused for manual review. Best-effort fallbacks are reported by name, including `automatic recheck failed`, `automatic resume is unavailable`, and `automatic resume queue is full`.
+9. If episodes or extras are still missing, qui adds the torrent paused, attempts an automatic recheck, and queues automatic resume. After the recheck, qui resumes the torrent when qBittorrent confirms the bytes that qui linked. Then qBittorrent downloads the missing files. If the recheck reports much less than the linked bytes, some links are bad, and qui leaves the torrent paused for manual review. Best-effort fallbacks are reported by name, including `automatic recheck failed`, `automatic resume is unavailable`, and `automatic resume queue is full`.
 
 ## Automatic Assembly
 
@@ -118,7 +118,7 @@ When `/apply` runs, qui:
 - Leaves unmatched episodes and extras for qBittorrent to download
 - Adds the torrent paused when anything is still missing
 - Attempts an automatic recheck so qBittorrent can discover the linked bytes
-- Queues automatic resume after recheck. qui resumes the torrent when qBittorrent reports progress at or above the configured season-pack coverage threshold, so qBittorrent can download the remaining files or pieces. If recheck finishes below that threshold, qui leaves the torrent paused for manual review.
+- Queues automatic resume after recheck. qui resumes the torrent when qBittorrent confirms the bytes that qui linked, so qBittorrent can download the remaining files or pieces. If the recheck reports much less than the linked bytes, some links are bad, and qui leaves the torrent paused for manual review.
 
 If automatic recheck or resume queueing cannot be started, qui reports `automatic recheck failed`, `automatic resume is unavailable`, or `automatic resume queue is full`.
 
@@ -270,7 +270,7 @@ When qui applies a season pack, it:
 
 - Always adds the torrent with an explicit `savepath` pointing at the linked tree
 - Applies the tags configured in **Cross-Seed > Rules > Season packs**
-- Adds incomplete packs paused, then best-effort attempts automatic recheck and queues automatic resume. After recheck, qui resumes at or above the configured season-pack coverage threshold; below that threshold, the torrent stays paused for manual review.
+- Adds incomplete packs paused, then best-effort attempts automatic recheck and queues automatic resume. After the recheck, qui resumes when qBittorrent confirms the linked bytes. If the recheck reports much less, the torrent stays paused for manual review.
 - Resolves the category in this order:
   - The category from the matching **Category routing** rule under **Cross-Seed > Rules > Season packs**, choosing the most specific rule when several apply (an explicit-source rule beats an Any-source rule at the same resolution). Recommended for Sonarr integration so the pack lands in Sonarr's download-client category and inherits hardlink-aware imports
   - Otherwise the **Anything else** fallback category, if set
@@ -323,6 +323,6 @@ Look for messages containing the torrent name and these clues:
 - `load cached torrents for instance` - qBittorrent cache lookup failed, so the check/apply is an operational failure
 - `unsafe piece boundary with pending files` - hardlink mode blocked an incomplete pack for safety
 - `torrent added paused; recheck queued` - qui added the pack and queued automatic resume
-- `Recheck completed below threshold, torrent left paused for manual review` - qBittorrent rechecked below the configured season-pack coverage threshold
+- `Recheck completed below threshold, torrent left paused for manual review` - the recheck reported less than the bytes that qui linked, so some links are bad
 
 Use `TRACE` when you need field-level matching details. Then look for `[CROSSSEED-MATCH] Release filtered` entries to see which release field caused an episode to be rejected.

--- a/documentation/docs/features/cross-seed/season-packs.md
+++ b/documentation/docs/features/cross-seed/season-packs.md
@@ -25,7 +25,7 @@ The webhook flow below is one of two triggers. The other is [Automatic Assembly]
    - `200 OK` - coverage meets the threshold, ready to apply
    - `404 Not Found` - local coverage is too low, the release is not a season pack, or the feature is disabled
 7. On `200 OK`, autobrr sends the torrent file to `/api/cross-seed/season-pack/apply`
-8. qui links the matched episodes, applies your configured season-pack tags, and adds the season pack torrent
+8. qui links the matched episodes, applies your configured season-pack tags, and adds the season pack torrent. A local episode file that does not byte-match its pack file is never linked; it is treated as missing and downloaded instead, as long as coverage still meets the threshold
 9. If episodes or extras are still missing, qui adds the torrent paused, attempts an automatic recheck, and queues automatic resume. After recheck, qui resumes the torrent when qBittorrent reports progress at or above your configured season-pack coverage threshold. If recheck finishes below that threshold, qui leaves the torrent paused for manual review. Best-effort fallbacks are reported by name, including `automatic recheck failed`, `automatic resume is unavailable`, and `automatic resume queue is full`.
 
 ## Automatic Assembly

--- a/documentation/docs/features/cross-seed/season-packs.md
+++ b/documentation/docs/features/cross-seed/season-packs.md
@@ -25,7 +25,7 @@ The webhook flow below is one of two triggers. The other is [Automatic Assembly]
    - `200 OK` - coverage meets the threshold, ready to apply
    - `404 Not Found` - local coverage is too low, the release is not a season pack, or the feature is disabled
 7. On `200 OK`, autobrr sends the torrent file to `/api/cross-seed/season-pack/apply`
-8. qui links the matched episodes, applies your configured season-pack tags, and adds the season pack torrent. A local episode file that does not byte-match its pack file is never linked; it is treated as missing and downloaded instead, as long as coverage still meets the threshold
+8. qui links the matched episodes, applies your configured season-pack tags, and adds the season pack torrent. qui never links a local episode file whose size or release details differ from its pack file. qui treats that episode as missing and downloads it instead. If these demotions drop coverage below the threshold, the apply fails as `drifted`
 9. If episodes or extras are still missing, qui adds the torrent paused, attempts an automatic recheck, and queues automatic resume. After recheck, qui resumes the torrent when qBittorrent reports progress at or above your configured season-pack coverage threshold. If recheck finishes below that threshold, qui leaves the torrent paused for manual review. Best-effort fallbacks are reported by name, including `automatic recheck failed`, `automatic resume is unavailable`, and `automatic resume queue is full`.
 
 ## Automatic Assembly

--- a/internal/services/crossseed/seasonpack.go
+++ b/internal/services/crossseed/seasonpack.go
@@ -52,6 +52,11 @@ var errSkippedRecheck = errors.New("skipped_recheck")
 // coverage below the threshold during apply.
 var errCoverageDrifted = errors.New("coverage_drifted")
 
+// seasonPackResumeSlack absorbs the gap between the linked byte fraction and
+// what a recheck reports for it: piece-granularity loss at file boundaries and
+// pad-file accounting differences.
+const seasonPackResumeSlack = 0.98
+
 // episodeIdentity uniquely identifies an episode within a show by season and episode number.
 type episodeIdentity struct {
 	series  int
@@ -426,6 +431,13 @@ func (s *Service) ApplySeasonPackWebhook(ctx context.Context, req *SeasonPackApp
 
 	message = ""
 	if planBuild.hasPendingFiles() {
+		// Resume gate = the byte fraction the plan linked, not the episode-count
+		// coverage threshold: the two diverge when episode sizes are uneven
+		// (Hotellet: 14/20 episodes = 0.70 count but 0.63 bytes → stuck paused
+		// forever). A recheck materially below the linked fraction means links
+		// failed, and resuming would download over hardlinked files — those
+		// stay paused.
+		resumeThreshold := float64(planBuild.linkedBytes) / float64(planBuild.totalBytes) * seasonPackResumeSlack
 		recheckHashes := collectHashes(prep.meta)
 		switch {
 		case len(recheckHashes) == 0:
@@ -438,7 +450,7 @@ func (s *Service) ApplySeasonPackWebhook(ctx context.Context, req *SeasonPackApp
 				message = "torrent added paused; automatic resume could not be queued"
 			} else if s.recheckResumeChan == nil {
 				message = "torrent added paused; automatic resume is unavailable"
-			} else if err := s.queueRecheckResumeWithThreshold(ctx, inst.ID, activeHash, prep.threshold); err != nil {
+			} else if err := s.queueRecheckResumeWithThreshold(ctx, inst.ID, activeHash, resumeThreshold); err != nil {
 				message = "torrent added paused; automatic resume queue is full"
 			} else {
 				message = "torrent added paused; recheck queued"

--- a/internal/services/crossseed/seasonpack.go
+++ b/internal/services/crossseed/seasonpack.go
@@ -48,6 +48,10 @@ var errLayoutMismatch = errors.New("layout_mismatch")
 // errSkippedRecheck signals a partial season pack that requires recheck, but recheck is disabled.
 var errSkippedRecheck = errors.New("skipped_recheck")
 
+// errCoverageDrifted signals that demoting unusable local episode files pushed
+// coverage below the threshold during apply.
+var errCoverageDrifted = errors.New("coverage_drifted")
+
 // episodeIdentity uniquely identifies an episode within a show by season and episode number.
 type episodeIdentity struct {
 	series  int
@@ -442,15 +446,19 @@ func (s *Service) ApplySeasonPackWebhook(ctx context.Context, req *SeasonPackApp
 		}
 	}
 
-	s.recordApplyRun(ctx, req.TorrentName, "applied", message, winner.InstanceID, winner.MatchedEpisodes, prep.totalEpisodes, winner.Coverage, linkMode)
+	// Record what actually resolved: file validation may have demoted episodes
+	// below the name-level winner counts.
+	matched := len(episodes)
+	coverage := float64(matched) / float64(prep.totalEpisodes)
+	s.recordApplyRun(ctx, req.TorrentName, "applied", message, winner.InstanceID, matched, prep.totalEpisodes, coverage, linkMode)
 
 	return &SeasonPackApplyResponse{
 		Applied:         true,
 		Message:         message,
 		InstanceID:      winner.InstanceID,
-		MatchedEpisodes: winner.MatchedEpisodes,
+		MatchedEpisodes: matched,
 		TotalEpisodes:   prep.totalEpisodes,
-		Coverage:        winner.Coverage,
+		Coverage:        coverage,
 		LinkMode:        linkMode,
 	}, nil
 }
@@ -485,8 +493,10 @@ func (s *Service) assembleSeasonPack(
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	if len(episodes) < winner.MatchedEpisodes {
-		return nil, nil, nil, fmt.Errorf("%w: episode file validation drifted during apply", errLayoutMismatch)
+	// File validation may have demoted episodes to missing; re-check coverage
+	// with what actually resolved. Below the floor, drift as usual.
+	if float64(len(episodes)) < float64(prep.totalEpisodes)*prep.threshold {
+		return nil, nil, nil, fmt.Errorf("%w: local files cover %d/%d episodes, below coverage threshold", errCoverageDrifted, len(episodes), prep.totalEpisodes)
 	}
 
 	selectedBaseDir, err := selectSeasonPackBaseDir(inst.HardlinkBaseDir, localFiles)
@@ -655,6 +665,8 @@ func (s *Service) failApply(
 		reason = "layout_mismatch"
 	} else if errors.Is(err, errSkippedRecheck) {
 		reason = "skipped_recheck"
+	} else if errors.Is(err, errCoverageDrifted) {
+		reason = "drifted"
 	}
 	s.recordApplyRun(ctx, torrentName, reason, err.Error(), winner.InstanceID, winner.MatchedEpisodes, prep.totalEpisodes, winner.Coverage, "")
 	return &SeasonPackApplyResponse{Reason: reason, Message: err.Error()}, nil
@@ -1241,11 +1253,15 @@ func (s *Service) resolveSeasonPackLocalFilesForCandidates(
 			break
 		}
 
+		// No candidate validated: the episode is missing, its pack file stays
+		// unmaterialized and is downloaded like any other missing episode. The
+		// caller re-checks coverage against the threshold after demotions.
 		if _, ok := selected[id]; !ok {
-			if lastErr != nil {
-				return nil, nil, lastErr
-			}
-			return nil, nil, fmt.Errorf("%w: no valid episode file in matched candidates", errLayoutMismatch)
+			log.Debug().
+				Err(lastErr).
+				Int("season", id.series).
+				Int("episode", id.episode).
+				Msg("[SEASONPACK] no local file validated; episode demoted to missing")
 		}
 	}
 
@@ -1427,11 +1443,13 @@ func buildSeasonPackPlan(
 			continue
 		}
 
+		// A size- or release-mismatched file is never linked; it is left pending
+		// and downloaded via recheck.
 		if localFile.size != pf.Size {
-			return nil, fmt.Errorf("%w: file size mismatch for %s", errLayoutMismatch, pf.Name)
+			continue
 		}
-		if ok, reason := matcher.seasonPackReleasesMatchWithReason(packFileRelease, localFile.release, false, settings, aliasTitles); !ok {
-			return nil, fmt.Errorf("%w: release mismatch for %s: %s", errLayoutMismatch, pf.Name, reason)
+		if ok, _ := matcher.seasonPackReleasesMatchWithReason(packFileRelease, localFile.release, false, settings, aliasTitles); !ok {
+			continue
 		}
 
 		targetPath, ok := safeSeasonPackJoin(plan.RootDir, pf.Name)

--- a/internal/services/crossseed/seasonpack_regression_test.go
+++ b/internal/services/crossseed/seasonpack_regression_test.go
@@ -210,6 +210,10 @@ func TestBuildSeasonPackPlan_DemotesUnlinkableFilesToPending(t *testing.T) {
 	require.Contains(t, build.plan.Files[0].TargetPath, "S01E01")
 	require.True(t, build.hasPendingFiles())
 	require.Len(t, build.materializedPaths, 1)
+	// Demoted files count toward totalBytes but not linkedBytes — the resume
+	// gate derives from this split.
+	require.Equal(t, int64(10), build.linkedBytes)
+	require.Equal(t, int64(30), build.totalBytes)
 }
 
 func TestApplySeasonPackWebhook_SelectsConcreteBaseDirFromCommaSeparatedConfig(t *testing.T) {

--- a/internal/services/crossseed/seasonpack_regression_test.go
+++ b/internal/services/crossseed/seasonpack_regression_test.go
@@ -125,7 +125,9 @@ func TestBuildSeasonPackPlan_RejectsEscapingTargetPaths(t *testing.T) {
 // (K-On! vs K-On!!) now title-match, because scene naming drops the punctuation
 // anyway. buildSeasonPackPlan still requires exact per-episode byte sizes before
 // linking - the same size-identity trust cross-seeding rests on everywhere - so a
-// wrong link needs two different encodes with byte-identical sizes.
+// wrong link needs two different encodes with byte-identical sizes. A mismatched
+// file is demoted to pending (downloaded, never linked); with no other files the
+// plan comes up empty and the pack fails.
 func TestSeasonPack_PunctuationOnlySequelTitles(t *testing.T) {
 	matcher := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
 
@@ -157,7 +159,57 @@ func TestSeasonPack_PunctuationOnlySequelTitles(t *testing.T) {
 	)
 
 	require.ErrorIs(t, err, errLayoutMismatch)
-	require.ErrorContains(t, err, "file size mismatch")
+	require.ErrorContains(t, err, "no pack files could be mapped")
+}
+
+// A pack file whose resolved local file fails the size or release check is left
+// pending (downloaded via recheck) instead of failing the whole plan; only
+// verified files are linked.
+func TestBuildSeasonPackPlan_DemotesUnlinkableFilesToPending(t *testing.T) {
+	packRelease := rls.ParseString("Show.S01.1080p.WEB.x264-GRP")
+	release := func(name string) *rls.Release {
+		r := rls.ParseString(name)
+		return &r
+	}
+
+	localFiles := map[episodeIdentity]seasonPackLocalFile{
+		{series: 1, episode: 1}: {
+			sourcePath: "/media/Show.S01E01.1080p.WEB.x264-GRP.mkv",
+			size:       10,
+			release:    release("Show.S01E01.1080p.WEB.x264-GRP"),
+		},
+		{series: 1, episode: 2}: {
+			sourcePath: "/media/Show.S01E02.1080p.WEB.x264-GRP.mkv",
+			size:       99, // size mismatch against the pack file
+			release:    release("Show.S01E02.1080p.WEB.x264-GRP"),
+		},
+		{series: 1, episode: 3}: {
+			sourcePath: "/media/Show.S01E03.720p.WEB.x264-GRP.mkv",
+			size:       10,
+			release:    release("Show.S01E03.720p.WEB.x264-GRP"), // release mismatch (resolution)
+		},
+	}
+
+	build, err := buildSeasonPackPlan(
+		qbt.TorrentFiles{
+			{Name: "Show.S01.1080p.WEB.x264-GRP/Show.S01E01.1080p.WEB.x264-GRP.mkv", Size: 10},
+			{Name: "Show.S01.1080p.WEB.x264-GRP/Show.S01E02.1080p.WEB.x264-GRP.mkv", Size: 10},
+			{Name: "Show.S01.1080p.WEB.x264-GRP/Show.S01E03.1080p.WEB.x264-GRP.mkv", Size: 10},
+		},
+		&packRelease,
+		"Show.S01.1080p.WEB.x264-GRP",
+		t.TempDir(),
+		localFiles,
+		seasonPackNormalizer(nil),
+		nil,
+		nil,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, build.plan.Files, 1)
+	require.Contains(t, build.plan.Files[0].TargetPath, "S01E01")
+	require.True(t, build.hasPendingFiles())
+	require.Len(t, build.materializedPaths, 1)
 }
 
 func TestApplySeasonPackWebhook_SelectsConcreteBaseDirFromCommaSeparatedConfig(t *testing.T) {

--- a/internal/services/crossseed/seasonpack_test.go
+++ b/internal/services/crossseed/seasonpack_test.go
@@ -97,24 +97,43 @@ type seasonPackTestFixture struct {
 	torrentData string
 }
 
+const seasonPackFixtureName = "Cool.Show.S01.1080p.WEB.x264-GRP"
+
+var seasonPackFixtureFiles = []string{
+	"Cool.Show.S01E01.1080p.WEB.x264-GRP.mkv",
+	"Cool.Show.S01E02.1080p.WEB.x264-GRP.mkv",
+	"Cool.Show.S01E03.1080p.WEB.x264-GRP.mkv",
+	"Cool.Show.S01E04.1080p.WEB.x264-GRP.mkv",
+}
+
 func newSeasonPackFixture(t *testing.T) seasonPackTestFixture {
 	t.Helper()
 
-	packName := "Cool.Show.S01.1080p.WEB.x264-GRP"
-	packFiles := []string{
-		"Cool.Show.S01E01.1080p.WEB.x264-GRP.mkv",
-		"Cool.Show.S01E02.1080p.WEB.x264-GRP.mkv",
-		"Cool.Show.S01E03.1080p.WEB.x264-GRP.mkv",
-		"Cool.Show.S01E04.1080p.WEB.x264-GRP.mkv",
-	}
-
-	torrentBytes := createTestTorrent(t, packName, packFiles, 262144)
-	torrentData := base64.StdEncoding.EncodeToString(torrentBytes)
+	torrentBytes := createTestTorrent(t, seasonPackFixtureName, seasonPackFixtureFiles, 262144)
 
 	return seasonPackTestFixture{
-		packName:    packName,
-		packFiles:   packFiles,
-		torrentData: torrentData,
+		packName:    seasonPackFixtureName,
+		packFiles:   seasonPackFixtureFiles,
+		torrentData: base64.StdEncoding.EncodeToString(torrentBytes),
+	}
+}
+
+// alignedSeasonPackFixture builds a pack whose files are exactly one piece each,
+// so a demoted (pending) episode shares no pieces with linked neighbors and the
+// hardlink piece-boundary safety check passes.
+func alignedSeasonPackFixture(t *testing.T) seasonPackTestFixture {
+	t.Helper()
+
+	const pieceLen = 64
+	contents := make(map[string][]byte, len(seasonPackFixtureFiles))
+	for _, name := range seasonPackFixtureFiles {
+		contents[name] = bytes.Repeat([]byte("x"), pieceLen)
+	}
+
+	return seasonPackTestFixture{
+		packName:    seasonPackFixtureName,
+		packFiles:   seasonPackFixtureFiles,
+		torrentData: base64.StdEncoding.EncodeToString(buildMultiFileTorrent(t, seasonPackFixtureName, pieceLen, contents)),
 	}
 }
 
@@ -1633,8 +1652,75 @@ func TestApplySeasonPackWebhook_UsesResolvedCategory(t *testing.T) {
 	}
 }
 
-func TestApplySeasonPackWebhook_RejectsSizeMismatchedEpisodeFiles(t *testing.T) {
-	fix := newSeasonPackFixture(t)
+// A size-mismatched episode file is demoted to missing instead of failing the
+// whole pack (the Hotellet 18/20 case): the pack applies paused with the bad
+// episode left pending for download, and the mismatched file is never linked.
+func TestApplySeasonPackWebhook_DemotesSizeMismatchedEpisodeToMissing(t *testing.T) {
+	fix := alignedSeasonPackFixture(t)
+	baseDir := t.TempDir()
+
+	inst := &models.Instance{
+		ID: 1, Name: "Test", IsActive: true,
+		HasLocalFilesystemAccess: true,
+		UseHardlinks:             true,
+		HardlinkBaseDir:          baseDir,
+	}
+
+	episodeTorrents := []qbt.Torrent{
+		{Hash: "e01", Name: "Cool.Show.S01E01.1080p.WEB.x264-GRP", ContentPath: "/media/Cool.Show.S01E01.1080p.WEB.x264-GRP.mkv", Progress: 1.0},
+		{Hash: "e02", Name: "Cool.Show.S01E02.1080p.WEB.x264-GRP", ContentPath: "/media/Cool.Show.S01E02.1080p.WEB.x264-GRP.mkv", Progress: 1.0},
+		{Hash: "e03", Name: "Cool.Show.S01E03.1080p.WEB.x264-GRP", ContentPath: "/media/Cool.Show.S01E03.1080p.WEB.x264-GRP.mkv", Progress: 1.0},
+		{Hash: "e04", Name: "Cool.Show.S01E04.1080p.WEB.x264-GRP", ContentPath: "/media/Cool.Show.S01E04.1080p.WEB.x264-GRP.mkv", Progress: 1.0},
+	}
+
+	baseSM := newMultiFakeSyncManager(
+		map[int][]qbt.Torrent{inst.ID: episodeTorrents},
+		map[int]*models.Instance{inst.ID: inst},
+	)
+	sm := &seasonPackSyncManager{fakeSyncManager: baseSM}
+
+	sm.files = seasonPackEpisodeFiles(t, fix.torrentData, "e01", "e02", "e03", "e04")
+	sm.files[normalizeHash("e03")][0].Size++
+
+	var capturedPlan *hardlinktree.TreePlan
+	svc := &Service{
+		instanceStore:            &fakeInstanceStore{instances: map[int]*models.Instance{inst.ID: inst}},
+		syncManager:              sm,
+		releaseCache:             NewReleaseCache(),
+		automationSettingsLoader: defaultSettings(true, 0.75),
+		seasonPackLinkCreator: func(plan *hardlinktree.TreePlan) error {
+			capturedPlan = plan
+			return nil
+		},
+	}
+
+	resp, err := svc.ApplySeasonPackWebhook(context.Background(), &SeasonPackApplyRequest{
+		TorrentName: fix.packName,
+		TorrentData: fix.torrentData,
+		InstanceIDs: []int{inst.ID},
+	})
+
+	require.NoError(t, err)
+	require.True(t, resp.Applied)
+	require.Equal(t, 3, resp.MatchedEpisodes)
+	require.InDelta(t, 0.75, resp.Coverage, 0.001)
+
+	require.NotNil(t, capturedPlan)
+	require.Len(t, capturedPlan.Files, 3)
+	for _, file := range capturedPlan.Files {
+		require.NotContains(t, file.TargetPath, "S01E03")
+	}
+
+	require.Len(t, sm.addCalls, 1)
+	require.Equal(t, "true", sm.addCalls[0].options["paused"])
+	require.Len(t, sm.bulkCalls, 1)
+	require.Equal(t, "recheck", sm.bulkCalls[0].action)
+}
+
+// When demotions push resolved coverage below the threshold, the apply drifts
+// instead of linking a pack the instance can no longer cover.
+func TestApplySeasonPackWebhook_DriftsWhenDemotionDropsCoverageBelowThreshold(t *testing.T) {
+	fix := alignedSeasonPackFixture(t)
 	baseDir := t.TempDir()
 
 	inst := &models.Instance{
@@ -1664,7 +1750,7 @@ func TestApplySeasonPackWebhook_RejectsSizeMismatchedEpisodeFiles(t *testing.T) 
 		instanceStore:            &fakeInstanceStore{instances: map[int]*models.Instance{inst.ID: inst}},
 		syncManager:              sm,
 		releaseCache:             NewReleaseCache(),
-		automationSettingsLoader: defaultSettings(true, 0.75),
+		automationSettingsLoader: defaultSettings(true, 1.0),
 		seasonPackLinkCreator:    func(_ *hardlinktree.TreePlan) error { return nil },
 	}
 
@@ -1676,7 +1762,8 @@ func TestApplySeasonPackWebhook_RejectsSizeMismatchedEpisodeFiles(t *testing.T) 
 
 	require.NoError(t, err)
 	require.False(t, resp.Applied)
-	require.Equal(t, "layout_mismatch", resp.Reason)
+	require.Equal(t, "drifted", resp.Reason)
+	require.Contains(t, resp.Message, "3/4")
 	require.Empty(t, sm.addCalls)
 }
 

--- a/internal/services/crossseed/seasonpack_test.go
+++ b/internal/services/crossseed/seasonpack_test.go
@@ -1988,7 +1988,8 @@ func TestApplySeasonPackWebhook_RespectsSkipPieceBoundarySafetyCheck(t *testing.
 	require.Len(t, sm.bulkCalls, 1)
 	require.Equal(t, "recheck", sm.bulkCalls[0].action)
 	req := <-svc.recheckResumeChan
-	require.InDelta(t, 0.75, req.threshold, 0.0001)
+	// Resume gate = linked byte fraction (53-byte episode of a 64-byte pack), with slack.
+	require.InDelta(t, 53.0/64.0*seasonPackResumeSlack, req.threshold, 0.0001)
 }
 
 func TestApplySeasonPackWebhook_RejectsInstanceWithoutLinkMode(t *testing.T) {
@@ -2111,7 +2112,8 @@ func TestApplySeasonPackWebhook_AllowsPartialPackAndQueuesRecheck(t *testing.T) 
 	select {
 	case pending := <-svc.recheckResumeChan:
 		require.Equal(t, inst.ID, pending.instanceID)
-		require.InDelta(t, 0.75, pending.threshold, 0.001)
+		// Resume gate = linked byte fraction (3 of 4 equal episodes), with slack.
+		require.InDelta(t, 0.75*seasonPackResumeSlack, pending.threshold, 0.001)
 	default:
 		t.Fatal("expected season pack apply to queue recheck resume")
 	}
@@ -2175,7 +2177,8 @@ func TestApplySeasonPackWebhook_PausesForSafeExtrasAndQueuesRecheck(t *testing.T
 	select {
 	case pending := <-svc.recheckResumeChan:
 		require.Equal(t, inst.ID, pending.instanceID)
-		require.InDelta(t, 0.75, pending.threshold, 0.0001)
+		// Resume gate = linked byte fraction (64-byte episode of a 75-byte pack), with slack.
+		require.InDelta(t, 64.0/75.0*seasonPackResumeSlack, pending.threshold, 0.0001)
 	default:
 		t.Fatal("expected safe extras flow to queue recheck resume")
 	}

--- a/internal/services/crossseed/seasonpack_test.go
+++ b/internal/services/crossseed/seasonpack_test.go
@@ -1717,6 +1717,57 @@ func TestApplySeasonPackWebhook_DemotesSizeMismatchedEpisodeToMissing(t *testing
 	require.Equal(t, "recheck", sm.bulkCalls[0].action)
 }
 
+// On an unaligned pack (files share pieces) in hardlink mode, the piece-boundary
+// safety check vetoes a demotion: downloading the pending file would write into
+// pieces shared with linked (hardlinked) neighbors and corrupt seeded data.
+func TestApplySeasonPackWebhook_PieceBoundaryVetoesDemotionOnUnalignedPack(t *testing.T) {
+	fix := newSeasonPackFixture(t) // files share the single 256 KiB piece
+	baseDir := t.TempDir()
+
+	inst := &models.Instance{
+		ID: 1, Name: "Test", IsActive: true,
+		HasLocalFilesystemAccess: true,
+		UseHardlinks:             true,
+		HardlinkBaseDir:          baseDir,
+	}
+
+	episodeTorrents := []qbt.Torrent{
+		{Hash: "e01", Name: "Cool.Show.S01E01.1080p.WEB.x264-GRP", ContentPath: "/media/Cool.Show.S01E01.1080p.WEB.x264-GRP.mkv", Progress: 1.0},
+		{Hash: "e02", Name: "Cool.Show.S01E02.1080p.WEB.x264-GRP", ContentPath: "/media/Cool.Show.S01E02.1080p.WEB.x264-GRP.mkv", Progress: 1.0},
+		{Hash: "e03", Name: "Cool.Show.S01E03.1080p.WEB.x264-GRP", ContentPath: "/media/Cool.Show.S01E03.1080p.WEB.x264-GRP.mkv", Progress: 1.0},
+		{Hash: "e04", Name: "Cool.Show.S01E04.1080p.WEB.x264-GRP", ContentPath: "/media/Cool.Show.S01E04.1080p.WEB.x264-GRP.mkv", Progress: 1.0},
+	}
+
+	baseSM := newMultiFakeSyncManager(
+		map[int][]qbt.Torrent{inst.ID: episodeTorrents},
+		map[int]*models.Instance{inst.ID: inst},
+	)
+	sm := &seasonPackSyncManager{fakeSyncManager: baseSM}
+
+	sm.files = seasonPackEpisodeFiles(t, fix.torrentData, "e01", "e02", "e03", "e04")
+	sm.files[normalizeHash("e03")][0].Size++
+
+	svc := &Service{
+		instanceStore:            &fakeInstanceStore{instances: map[int]*models.Instance{inst.ID: inst}},
+		syncManager:              sm,
+		releaseCache:             NewReleaseCache(),
+		automationSettingsLoader: defaultSettings(true, 0.75),
+		seasonPackLinkCreator:    func(_ *hardlinktree.TreePlan) error { return nil },
+	}
+
+	resp, err := svc.ApplySeasonPackWebhook(context.Background(), &SeasonPackApplyRequest{
+		TorrentName: fix.packName,
+		TorrentData: fix.torrentData,
+		InstanceIDs: []int{inst.ID},
+	})
+
+	require.NoError(t, err)
+	require.False(t, resp.Applied)
+	require.Equal(t, "layout_mismatch", resp.Reason)
+	require.Contains(t, resp.Message, "unsafe piece boundary")
+	require.Empty(t, sm.addCalls)
+}
+
 // When demotions push resolved coverage below the threshold, the apply drifts
 // instead of linking a pack the instance can no longer cover.
 func TestApplySeasonPackWebhook_DriftsWhenDemotionDropsCoverageBelowThreshold(t *testing.T) {


### PR DESCRIPTION
Season pack apply treated a size-mismatched local episode file as fatal. One byte-different file killed the whole pack (field case: Hotellet S01, 18/20 coverage, one differently-muxed episode). qui already downloads missing episodes. Now, when no local candidate for an episode passes file validation, qui demotes that episode to missing. The pack file stays pending, and qui downloads it with the existing paused-add + recheck + auto-resume flow. The byte check does not change: qui never links a mismatched file.

After demotion, qui compares the resolved coverage with the threshold again. If coverage is below the threshold, qui records the apply as `drifted`. The post-recheck resume gate now compares qBittorrent progress with the bytes that qui linked, not with the episode-count threshold. With uneven episode sizes the two measures disagree: the field pack is 70% by episode count but 63% by bytes, so it stayed paused. In hardlink mode, the piece-boundary safety check still rejects unsafe demotions on unaligned packs. Applied run rows and webhook responses report the resolved episode count and coverage, not the name-level winner counts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Season-pack processing now links local episodes only when files match exactly.
  - Invalid or mismatched files are treated as missing and queued for recheck instead of causing immediate failure.
  - Coverage is recalculated after validation, with insufficient coverage reported as drifted.
  - Valid files remain linked while unmatched files are downloaded when coverage permits.
  - Demotions are prevented when they could compromise piece-boundary safety.

- **Documentation**
  - Updated season-pack guidance to explain exact file matching and download behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->