### PR TITLE
feat(crossseed): match torrents whose files pair by exact size

### DIFF
--- a/internal/services/crossseed/add_plan.go
+++ b/internal/services/crossseed/add_plan.go
@@ -57,7 +57,7 @@ func buildCrossSeedAddPlan(
 	// candidateRoot != "" shape, the episode maps into the season-pack content path
 	// instead of a qBittorrent-created subfolder, so classifying it as Subfolder
 	// would misrepresent an episode-to-season-pack mapping.
-	isEpisodeInPack := matchType == "partial-in-pack" &&
+	isEpisodeInPack := (matchType == "partial-in-pack" || matchType == "size-partial-in-pack") &&
 		isTVEpisode(sourceRelease) &&
 		isTVSeasonPack(candidateRelease)
 

--- a/internal/services/crossseed/matching.go
+++ b/internal/services/crossseed/matching.go
@@ -964,6 +964,23 @@ func (s *Service) getMatchTypeWithReason(sourceRelease, candidateRelease *rls.Re
 		}
 	}
 
+	// Size-only containment: one side's files all pair 1:1 by exact size into
+	// the other side. Rescues subset-of-pack matches whose file names rls cannot
+	// parse (music albums in packs, renamed season packs). It runs before the
+	// tolerant total-size tier because with unequal file counts a strict per-file
+	// pairing is better evidence than totals landing inside the tolerance, and
+	// the containment type engages the episode-in-pack layout at apply. Equal
+	// counts cannot strictly contain (a full both-side pairing means equal
+	// totals), so they stay with the size tier below.
+	if len(filteredSourceFiles) != len(filteredCandidateFiles) {
+		if containment := sizeContainmentMatchType(filteredSourceFiles, filteredCandidateFiles); containment != "" {
+			if s.metrics != nil {
+				s.metrics.GetMatchTypeSizeMatch.Inc()
+			}
+			return MatchResult{MatchType: containment, Reason: ""}
+		}
+	}
+
 	// Size match with tolerance
 	if totalSourceSize > 0 && len(filteredSourceFiles) > 0 {
 		if s.isSizeWithinTolerance(totalSourceSize, totalCandidateSize, tolerancePercent) {
@@ -983,16 +1000,6 @@ func (s *Service) getMatchTypeWithReason(sourceRelease, candidateRelease *rls.Re
 			}
 			return MatchResult{MatchType: "size", Reason: ""}
 		}
-	}
-
-	// Size-only containment: one side's files all pair 1:1 by exact size into
-	// the other side. Rescues subset-of-pack matches whose file names rls cannot
-	// parse (music albums in packs, renamed season packs).
-	if containment := sizeContainmentMatchType(filteredSourceFiles, filteredCandidateFiles); containment != "" {
-		if s.metrics != nil {
-			s.metrics.GetMatchTypeSizeMatch.Inc()
-		}
-		return MatchResult{MatchType: containment, Reason: ""}
 	}
 
 	// Build detailed reason for no match

--- a/internal/services/crossseed/matching.go
+++ b/internal/services/crossseed/matching.go
@@ -787,6 +787,17 @@ func (s *Service) getMatchTypeFromTitle(targetName, candidateName string, target
 
 	}
 
+	// Renamed-file fallback: the torrent-level release gate already matched this
+	// candidate, but its files parse no episode-level keys (renamed files only
+	// inherit the pack's series through enrichment, never an episode). Pass the
+	// candidate through; the file-level matcher decides by size containment at
+	// apply. Candidates with parseable episode keys skip this, so a well-named
+	// pack that simply lacks the target episode still rejects here.
+	if targetRelease.Series > 0 && candidateRelease.Series == targetRelease.Series &&
+		!hasEpisodeLevelKeys(candidateReleases) {
+		return "release-match"
+	}
+
 	// Fallback: rls couldn't derive usable release keys from the files, but the titles match and
 	// the episode number encoded in the raw torrent names also matches (e.g. anime releases where
 	// rls fails to parse " - 1150 " as an episode).
@@ -839,9 +850,18 @@ func (s *Service) getMatchTypeFromTitle(targetName, candidateName string, target
 	return ""
 }
 
+func hasEpisodeLevelKeys(keys map[releaseKey]int64) bool {
+	for key := range keys {
+		if key.episode > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // MatchResult holds both the match type and a human-readable reason when there's no match.
 type MatchResult struct {
-	MatchType string // "exact", "partial-in-pack", "partial-contains", "size", or ""
+	MatchType string // "exact", "partial-in-pack", "partial-contains", "size", "size-partial-in-pack", "size-partial-contains", or ""
 	Reason    string // Human-readable reason when MatchType is "" (no match)
 }
 
@@ -965,6 +985,16 @@ func (s *Service) getMatchTypeWithReason(sourceRelease, candidateRelease *rls.Re
 		}
 	}
 
+	// Size-only containment: one side's files all pair 1:1 by exact size into
+	// the other side. Rescues subset-of-pack matches whose file names rls cannot
+	// parse (music albums in packs, renamed season packs).
+	if containment := sizeContainmentMatchType(filteredSourceFiles, filteredCandidateFiles); containment != "" {
+		if s.metrics != nil {
+			s.metrics.GetMatchTypeSizeMatch.Inc()
+		}
+		return MatchResult{MatchType: containment, Reason: ""}
+	}
+
 	// Build detailed reason for no match
 	if s.metrics != nil {
 		s.metrics.GetMatchTypeNoMatch.Inc()
@@ -1039,6 +1069,42 @@ func buildNoMatchReason(
 	}
 
 	return "Files don't match (structure or naming differs)"
+}
+
+// sizeContainmentMatchType reports a size-only containment between the usable
+// file lists: "size-partial-in-pack" when every source file pairs 1:1 by exact
+// size into the candidate files, "size-partial-contains" for the reverse.
+// Runs only after every name-aware tier failed. Ambiguous same-size pairs stay
+// unmatched (the pairing takes a size-only pair only when it is the sole
+// candidate), so size collisions reject instead of guessing; the recheck on
+// apply is the final safety net.
+func sizeContainmentMatchType(sourceFiles, candidateFiles []TorrentFile) string {
+	if len(sourceFiles) == 0 || len(candidateFiles) == 0 {
+		return ""
+	}
+	if sizeContainmentPairsAll(sourceFiles, candidateFiles) {
+		return "size-partial-in-pack"
+	}
+	if sizeContainmentPairsAll(candidateFiles, sourceFiles) {
+		return "size-partial-contains"
+	}
+	return ""
+}
+
+func sizeContainmentPairsAll(contained, container []TorrentFile) bool {
+	if len(contained) > len(container) {
+		return false
+	}
+	_, unmatched := matchSourceFilesToCandidates(toQbtTorrentFiles(contained), toQbtTorrentFiles(container))
+	return len(unmatched) == 0
+}
+
+func toQbtTorrentFiles(files []TorrentFile) qbt.TorrentFiles {
+	converted := make(qbt.TorrentFiles, 0, len(files))
+	for _, f := range files {
+		converted = append(converted, qbt.TorrentFile{Name: f.Name, Size: f.Size})
+	}
+	return converted
 }
 
 // getMatchType determines if files match for cross-seeding.

--- a/internal/services/crossseed/matching_size_containment_test.go
+++ b/internal/services/crossseed/matching_size_containment_test.go
@@ -1,0 +1,198 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package crossseed
+
+import (
+	"context"
+	"testing"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/moistari/rls"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/pkg/releases"
+	"github.com/autobrr/qui/pkg/stringutils"
+)
+
+func newMatcherService() *Service {
+	return &Service{
+		releaseCache:     releases.NewDefaultParser(),
+		stringNormalizer: stringutils.NewDefaultNormalizer(),
+	}
+}
+
+func TestGetMatchTypeWithReason_SizeContainment(t *testing.T) {
+	t.Parallel()
+
+	episodeRelease := rls.Release{Title: "Show", Series: 1, Episode: 1}
+	packRelease := rls.Release{Title: "Renamed Pack", Series: 1}
+	albumRelease := rls.Release{Title: "Artist Album"}
+	albumPackRelease := rls.Release{Title: "Renamed Album Pack"}
+
+	episodeFiles := qbt.TorrentFiles{
+		{Name: "Show.S01E01.1080p.mkv", Size: 1 << 30},
+	}
+	renamedPackFiles := qbt.TorrentFiles{
+		{Name: "pack/ep1_renamed.mkv", Size: 1 << 30},
+		{Name: "pack/ep2_renamed.mkv", Size: 2 << 30},
+	}
+
+	tests := []struct {
+		name             string
+		sourceRelease    *rls.Release
+		candidateRelease *rls.Release
+		sourceFiles      qbt.TorrentFiles
+		candidateFiles   qbt.TorrentFiles
+		want             string
+	}{
+		{
+			name:             "single file pairs by size into renamed pack",
+			sourceRelease:    &episodeRelease,
+			candidateRelease: &packRelease,
+			sourceFiles:      episodeFiles,
+			candidateFiles:   renamedPackFiles,
+			want:             "size-partial-in-pack",
+		},
+		{
+			name:             "pack contains the candidate file by size",
+			sourceRelease:    &packRelease,
+			candidateRelease: &episodeRelease,
+			sourceFiles:      renamedPackFiles,
+			candidateFiles:   episodeFiles,
+			want:             "size-partial-contains",
+		},
+		{
+			name:             "no candidate file with a matching size",
+			sourceRelease:    &episodeRelease,
+			candidateRelease: &packRelease,
+			sourceFiles:      qbt.TorrentFiles{{Name: "Show.S01E01.1080p.mkv", Size: 4 << 30}},
+			candidateFiles:   renamedPackFiles,
+			want:             "",
+		},
+		{
+			name:             "ambiguous same-size candidates reject instead of guessing",
+			sourceRelease:    &episodeRelease,
+			candidateRelease: &packRelease,
+			sourceFiles:      episodeFiles,
+			candidateFiles: qbt.TorrentFiles{
+				{Name: "pack/first_renamed.mkv", Size: 1 << 30},
+				{Name: "pack/second_renamed.mkv", Size: 1 << 30},
+			},
+			want: "",
+		},
+		{
+			// Track names parse no release keys, so every name-aware tier fails,
+			// and the candidate's largest file differs so the largest-file fallback
+			// stays out. The shared base name then breaks the same-size tie inside
+			// the size-only pairing.
+			name:             "same base name breaks the same-size tie",
+			sourceRelease:    &albumRelease,
+			candidateRelease: &albumPackRelease,
+			sourceFiles:      qbt.TorrentFiles{{Name: "intro_song.flac", Size: 1 << 30}},
+			candidateFiles: qbt.TorrentFiles{
+				{Name: "album/intro_song.flac", Size: 1 << 30},
+				{Name: "album/other_track.flac", Size: 1 << 30},
+				{Name: "album/big_track.flac", Size: 2 << 30},
+			},
+			want: "size-partial-in-pack",
+		},
+		{
+			name:             "full both-side pairing stays a size match",
+			sourceRelease:    &episodeRelease,
+			candidateRelease: &packRelease,
+			sourceFiles:      episodeFiles,
+			candidateFiles:   qbt.TorrentFiles{{Name: "pack/ep1_renamed.mkv", Size: 1 << 30}},
+			want:             "size",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			svc := newMatcherService()
+			result := svc.getMatchTypeWithReason(tt.sourceRelease, tt.candidateRelease, tt.sourceFiles, tt.candidateFiles, 5.0)
+			if tt.want == "" {
+				require.Empty(t, result.MatchType)
+				require.NotEmpty(t, result.Reason)
+				return
+			}
+			require.Equal(t, tt.want, result.MatchType)
+		})
+	}
+}
+
+func TestFindBestCandidateMatch_SizeContainmentAgainstRenamedPack(t *testing.T) {
+	t.Parallel()
+
+	svc := newMatcherService()
+	svc.syncManager = &candidateSelectionSyncManager{
+		files: map[string]qbt.TorrentFiles{
+			"pack": {
+				{Name: "pack/ep1_renamed.mkv", Size: 1 << 30},
+				{Name: "pack/ep2_renamed.mkv", Size: 2 << 30},
+			},
+		},
+	}
+
+	sourceRelease := rls.Release{Title: "Show", Series: 1, Episode: 1}
+	sourceFiles := qbt.TorrentFiles{{Name: "Show.S01E01.1080p.mkv", Size: 1 << 30}}
+
+	candidate := CrossSeedCandidate{
+		Torrents: []qbt.Torrent{
+			// Same show and season as the source: the discovery gates only pass
+			// same-release packs, so the fixture must model one.
+			{Hash: "pack", Name: "Show.S01.1080p.WEB-DL", Progress: 1.0},
+		},
+	}
+
+	filesByHash := svc.batchLoadCandidateFiles(context.Background(), 1, candidate.Torrents)
+	require.NotEmpty(t, filesByHash)
+
+	matched, matchedFiles, matchType, rejectReason := svc.findBestCandidateMatch(
+		context.Background(), candidate, &sourceRelease, sourceFiles, filesByHash, 5.0,
+	)
+	require.NotNil(t, matched, "expected a match, got reject reason: %s", rejectReason)
+	require.Len(t, matchedFiles, 2)
+	// The matcher runs with swapped sides at apply, so the swapped-back type must
+	// read as "the new torrent's files are inside the existing pack".
+	require.Equal(t, "size-partial-in-pack", matchType)
+}
+
+func TestGetMatchTypeFromTitle_RenamedPackFallback(t *testing.T) {
+	t.Parallel()
+
+	episode := rls.Release{Title: "Show", Series: 1, Episode: 2}
+	pack := rls.Release{Title: "Show", Series: 1}
+	otherSeasonPack := rls.Release{Title: "Show", Series: 3}
+
+	renamedFiles := qbt.TorrentFiles{
+		{Name: "pack/first_video.mkv", Size: 1 << 30},
+		{Name: "pack/second_video.mkv", Size: 2 << 30},
+	}
+	wellNamedFiles := qbt.TorrentFiles{
+		{Name: "pack/Show.S01E01.mkv", Size: 1 << 30},
+		{Name: "pack/Show.S01E03.mkv", Size: 2 << 30},
+	}
+
+	svc := newMatcherService()
+
+	got := svc.getMatchTypeFromTitle("Show.S01E02.mkv", "Show.S01.Pack", &episode, &pack, renamedFiles)
+	require.Equal(t, "release-match", got, "renamed same-season pack must pass discovery for the file-level matcher")
+
+	got = svc.getMatchTypeFromTitle("Show.S01E02.mkv", "Show.S01.Pack", &episode, &pack, wellNamedFiles)
+	require.Empty(t, got, "well-named pack without the target episode must still reject at discovery")
+
+	got = svc.getMatchTypeFromTitle("Show.S01E02.mkv", "Show.S03.Pack", &episode, &otherSeasonPack, renamedFiles)
+	require.Empty(t, got, "renamed pack from another season must not pass")
+}
+
+func TestMatchTypePriority_SizeContainmentRanksBelowSize(t *testing.T) {
+	t.Parallel()
+
+	require.Greater(t, matchTypePriority("size"), matchTypePriority("size-partial-in-pack"))
+	require.Greater(t, matchTypePriority("size-partial-in-pack"), matchTypePriority("size-partial-contains"))
+	require.Positive(t, matchTypePriority("size-partial-contains"))
+	require.Greater(t, matchTypePriority("partial-contains"), matchTypePriority("size"))
+}

--- a/internal/services/crossseed/matching_size_containment_test.go
+++ b/internal/services/crossseed/matching_size_containment_test.go
@@ -98,6 +98,20 @@ func TestGetMatchTypeWithReason_SizeContainment(t *testing.T) {
 			want: "size-partial-in-pack",
 		},
 		{
+			// The extra file keeps the totals inside the 5% tolerance, so the
+			// total-size tier would claim this pair. Containment must win when the
+			// file counts differ, or apply misses the episode-in-pack layout.
+			name:             "containment beats tolerant total-size when counts differ",
+			sourceRelease:    &episodeRelease,
+			candidateRelease: &packRelease,
+			sourceFiles:      episodeFiles,
+			candidateFiles: qbt.TorrentFiles{
+				{Name: "pack/ep1_renamed.mkv", Size: 1 << 30},
+				{Name: "pack/short_film.mkv", Size: 40 << 20},
+			},
+			want: "size-partial-in-pack",
+		},
+		{
 			name:             "full both-side pairing stays a size match",
 			sourceRelease:    &episodeRelease,
 			candidateRelease: &packRelease,

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -5199,7 +5199,7 @@ func (s *Service) processCrossSeedCandidate(
 	// Detect episode matched to season pack - these need special handling
 	// to use the season pack's content path instead of category save path
 	matchedRelease := s.releaseCache.Parse(matchedTorrent.Name)
-	isEpisodeInPack := matchType == "partial-in-pack" &&
+	isEpisodeInPack := (matchType == "partial-in-pack" || matchType == "size-partial-in-pack") &&
 		sourceRelease.Series > 0 && sourceRelease.Episode > 0 &&
 		matchedRelease.Series > 0 && matchedRelease.Episode == 0
 	rootlessContentDir := ""
@@ -6389,14 +6389,18 @@ func (s *Service) selectContentDetectionRelease(torrentName string, sourceReleas
 func matchTypePriority(matchType string) int {
 	switch matchType {
 	case "exact":
-		return 4
+		return 6
 	case "partial-in-pack":
-		return 3
+		return 5
 	case "partial-contains":
 		// Allows cross-seeding when folder structures differ but content matches
 		// (e.g., /movie1/movie1.mkv vs /movie1.mkv)
-		return 2
+		return 4
 	case "size":
+		return 3
+	case "size-partial-in-pack":
+		return 2
+	case "size-partial-contains":
 		return 1
 	default:
 		// Unknown/unsupported match types (e.g. "release-match")
@@ -6511,6 +6515,10 @@ func (s *Service) selectBestCandidateAddPlan(
 			actualMatchType = "partial-contains"
 		case "partial-contains":
 			actualMatchType = "partial-in-pack"
+		case "size-partial-in-pack":
+			actualMatchType = "size-partial-contains"
+		case "size-partial-contains":
+			actualMatchType = "size-partial-in-pack"
 		}
 
 		score := matchTypePriority(actualMatchType)


### PR DESCRIPTION
The file matcher gets a size-only tier. It runs after the name-based tiers fail. The tier pairs files 1:1 on exact byte size, with file names only as a tie break. When all files of one torrent pair into the files of another torrent, the two torrents match. This works for any content type. Examples: a seeded episode whose file was renamed inside a full-season torrent, album tracks inside a bigger torrent, or any release whose file names the parser cannot read.

Candidate discovery now also passes same-season torrents whose file names parse no episode numbers, so renamed files reach the file matcher. The size-only tier runs before the total-size tolerance tier, because an exact per-file pairing is stronger evidence than totals that land inside the tolerance. When two files have the same size and no name tie break, the matcher rejects the pair instead of a guess. The new match types rank below all name-based types, and the normal recheck on apply protects against wrong pairs.
