### PR TITLE
fix(crossseed): apply search aliases only to the source torrent

### DIFF
--- a/internal/services/crossseed/search_candidate_match_test.go
+++ b/internal/services/crossseed/search_candidate_match_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -712,8 +713,22 @@ func TestFindCandidatesScopesSearchSourceAliasesToSourceTorrent(t *testing.T) {
 	require.Len(t, response.Candidates[0].Torrents, 1)
 	require.Equal(t, sourceHash, response.Candidates[0].Torrents[0].Hash)
 
+	// Hash comparison is normalized, so casing differences still bind the
+	// aliases to the source torrent.
+	response, err = service.FindCandidates(context.Background(), request(strings.ToUpper(sourceHash)))
+	require.NoError(t, err)
+	require.Len(t, response.Candidates, 1)
+	require.Equal(t, sourceHash, response.Candidates[0].Torrents[0].Hash)
+
 	// Without a matching source hash the aliases attach to nothing.
 	response, err = service.FindCandidates(context.Background(), request("different-hash"))
+	require.NoError(t, err)
+	require.Empty(t, response.Candidates)
+
+	// A matching hash on the wrong instance attaches nothing either.
+	wrongInstance := request(sourceHash)
+	wrongInstance.SearchSourceInstanceID = instanceID + 1
+	response, err = service.FindCandidates(context.Background(), wrongInstance)
 	require.NoError(t, err)
 	require.Empty(t, response.Candidates)
 }

--- a/internal/services/crossseed/search_candidate_match_test.go
+++ b/internal/services/crossseed/search_candidate_match_test.go
@@ -668,6 +668,56 @@ func TestFindCandidatesExactSizeFallbackIsScopedAndContinuesToFileValidation(t *
 	require.Empty(t, incompatibleResponse.Candidates, "fallback must not bypass file-level release validation")
 }
 
+func TestFindCandidatesScopesSearchSourceAliasesToSourceTorrent(t *testing.T) {
+	const (
+		instanceID    = 1
+		targetName    = "Money.Heist.S01E01.1080p.NF.WEB-DL.DDP5.1.H.264-NTb"
+		sourceName    = "La.Casa.De.Papel.S01E01.1080p.NF.WEB-DL.DDP5.1.H.264-NTb"
+		unrelatedName = "The.Bear.S01E01.1080p.NF.WEB-DL.DDP5.1.H.264-NTb"
+		sourceHash    = "source"
+		unrelatedHash = "unrelated"
+		fileSize      = int64(1_500_000_000)
+	)
+	instance := &models.Instance{ID: instanceID, Name: "main"}
+	source := qbt.Torrent{Hash: sourceHash, Name: sourceName, Size: fileSize, Progress: 1}
+	unrelated := qbt.Torrent{Hash: unrelatedHash, Name: unrelatedName, Size: fileSize, Progress: 1}
+	files := map[string]qbt.TorrentFiles{
+		sourceHash:    {{Name: "La.Casa.De.Papel.S01E01.1080p.NF.WEB-DL.DDP5.1.H.264-NTb.mkv", Size: fileSize}},
+		unrelatedHash: {{Name: "The.Bear.S01E01.1080p.NF.WEB-DL.DDP5.1.H.264-NTb.mkv", Size: fileSize}},
+	}
+	service := &Service{
+		instanceStore:    &fakeInstanceStore{instances: map[int]*models.Instance{instanceID: instance}},
+		syncManager:      newFakeSyncManager(instance, []qbt.Torrent{source, unrelated}, files),
+		releaseCache:     NewReleaseCache(),
+		stringNormalizer: stringutils.NewDefaultNormalizer(),
+	}
+
+	request := func(hash string) *FindCandidatesRequest {
+		return &FindCandidatesRequest{
+			TorrentName:            targetName,
+			TargetInstanceIDs:      []int{instanceID},
+			SearchSourceInstanceID: instanceID,
+			SearchSourceHash:       hash,
+			SearchSourceTitles:     []string{"Money Heist"},
+		}
+	}
+
+	// The aliases admit exactly the torrent the search resolved them for. The
+	// unrelated same-season torrent must not inherit them: with the aliases on
+	// every candidate, the target's own alias satisfies the title overlap and
+	// the whole library passes discovery.
+	response, err := service.FindCandidates(context.Background(), request(sourceHash))
+	require.NoError(t, err)
+	require.Len(t, response.Candidates, 1)
+	require.Len(t, response.Candidates[0].Torrents, 1)
+	require.Equal(t, sourceHash, response.Candidates[0].Torrents[0].Hash)
+
+	// Without a matching source hash the aliases attach to nothing.
+	response, err = service.FindCandidates(context.Background(), request("different-hash"))
+	require.NoError(t, err)
+	require.Empty(t, response.Candidates)
+}
+
 func TestCrossSeedRevalidatesARRSourceTitles(t *testing.T) {
 	const (
 		instanceID   = 1
@@ -699,10 +749,12 @@ func TestCrossSeedRevalidatesARRSourceTitles(t *testing.T) {
 
 	apply := func(sourceTitles []string) *CrossSeedResponse {
 		response, applyErr := service.CrossSeed(context.Background(), &CrossSeedRequest{
-			TorrentData:         base64.StdEncoding.EncodeToString(torrentData),
-			TargetInstanceIDs:   []int{instanceID},
-			SearchDecisionClass: searchCandidateClassStrict,
-			SearchSourceTitles:  sourceTitles,
+			TorrentData:            base64.StdEncoding.EncodeToString(torrentData),
+			TargetInstanceIDs:      []int{instanceID},
+			SearchDecisionClass:    searchCandidateClassStrict,
+			SearchSourceInstanceID: instanceID,
+			SearchSourceHash:       existingHash,
+			SearchSourceTitles:     sourceTitles,
 		})
 		require.NoError(t, applyErr)
 		require.Len(t, response.Results, 1)

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -4411,17 +4411,27 @@ func (s *Service) findCandidates(ctx context.Context, req *FindCandidatesRequest
 			}
 
 			// Check if releases are related (quick filter). Search-origin ARR aliases
-			// belong to the existing torrent, which is the candidate in this reversed
-			// apply-stage comparison. Exact-size provenance may relax only the recorded
-			// soft differences for the specific torrent whose qBittorrent size supplied
-			// the search evidence. File matching and later safety checks still run.
+			// describe ONE existing torrent: the search source whose lookup produced
+			// them. Handing them to every candidate would let the new torrent's own
+			// alias set satisfy the title overlap for unrelated torrents, so the
+			// aliases ride along only for the search-source torrent itself, mirroring
+			// the exact-size relaxation below. Exact-size provenance may relax only
+			// the recorded soft differences for the specific torrent whose
+			// qBittorrent size supplied the search evidence. File matching and later
+			// safety checks still run.
+			var candidateAliasTitles []string
+			if len(req.SearchSourceTitles) > 0 && req.SearchSourceInstanceID == instanceID {
+				if sourceHash := normalizeHash(req.SearchSourceHash); sourceHash != "" && normalizeHash(torrent.Hash) == sourceHash {
+					candidateAliasTitles = req.SearchSourceTitles
+				}
+			}
 			releasesMatch, mismatchReason := s.releasesMatchWithReasonAndNamesAndTitles(
 				targetRelease,
 				candidateRelease,
 				req.TorrentName,
 				torrent.Name,
 				nil,
-				req.SearchSourceTitles,
+				candidateAliasTitles,
 				req.FindIndividualEpisodes,
 			)
 			if !releasesMatch {


### PR DESCRIPTION
Candidate discovery handed the search-origin ARR aliases to every candidate torrent. The new torrent's own alias then satisfied the title check for unrelated torrents, so every complete torrent in the library passed discovery on a search-origin apply. The file matcher rejected them later, so no wrong torrents were added, but each apply loaded files for the whole library and logged a false match line for every same-season show.

The aliases describe one torrent: the search source that produced them. They now attach only to that torrent, keyed on instance and hash, the same way the exact-size relaxation next to it works. Alias-admitted applies still match their source torrent. A regression test pins the unrelated torrent out, and the existing alias round-trip tests still pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release matching so search-source aliases apply only to the specific torrent that provided the matching evidence.
  * Prevented unrelated torrents from inheriting aliases, improving matching accuracy and reducing incorrect candidate associations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->