### PR TITLE
fix(torznab): keep rate-limited caps searches uncovered

### DIFF
--- a/internal/services/jackett/caps_rate_limit_test.go
+++ b/internal/services/jackett/caps_rate_limit_test.go
@@ -26,6 +26,16 @@ const bookOnlyCapsXML = `<?xml version="1.0" encoding="UTF-8"?>
   </categories>
 </caps>`
 
+func assertSingleCapsFetch(t *testing.T, requests <-chan string) {
+	t.Helper()
+	if got := len(requests); got != 1 {
+		t.Fatalf("requests = %d, want 1", got)
+	}
+	if got, want := <-requests, "/api/v1/indexer/1/newznab?apikey=mock-api-key&t=caps"; got != want {
+		t.Fatalf("request = %q, want %q", got, want)
+	}
+}
+
 // A rate-limited caps fetch must skip the indexer and engage the backoff
 // ladder instead of failing open (rationale at the skip site in service.go).
 func TestApplyIndexerRestrictionsCapsFetchRateLimit(t *testing.T) {
@@ -122,9 +132,9 @@ func TestApplyIndexerRestrictionsCapsFetchRateLimit(t *testing.T) {
 }
 
 func TestSearchMultipleIndexersCapsRateLimitIsNotCovered(t *testing.T) {
-	var capsCalls atomic.Int32
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		capsCalls.Add(1)
+	requests := make(chan string, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- r.URL.RequestURI()
 		w.WriteHeader(http.StatusTooManyRequests)
 	}))
 	defer server.Close()
@@ -162,13 +172,13 @@ func TestSearchMultipleIndexersCapsRateLimitIsNotCovered(t *testing.T) {
 	if len(covered) != 1 || covered[0] != 2 {
 		t.Fatalf("covered indexers = %v, want [2]", covered)
 	}
-	if got := capsCalls.Load(); got != 1 {
-		t.Fatalf("caps fetches = %d, want 1", got)
-	}
+	assertSingleCapsFetch(t, requests)
 }
 
 func TestScheduledSearchCapsRateLimitIsNotCovered(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	requests := make(chan string, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests <- r.URL.RequestURI()
 		w.WriteHeader(http.StatusTooManyRequests)
 	}))
 	defer server.Close()
@@ -220,4 +230,5 @@ func TestScheduledSearchCapsRateLimitIsNotCovered(t *testing.T) {
 	case <-time.After(3 * time.Second):
 		t.Fatal("scheduled search timed out")
 	}
+	assertSingleCapsFetch(t, requests)
 }

--- a/internal/services/jackett/caps_rate_limit_test.go
+++ b/internal/services/jackett/caps_rate_limit_test.go
@@ -7,8 +7,10 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/autobrr/qui/internal/models"
 )
@@ -34,15 +36,17 @@ func TestApplyIndexerRestrictionsCapsFetchRateLimit(t *testing.T) {
 		storedCaps       []string
 		storedCategories []models.TorznabIndexerCategory
 		wantSkip         bool
+		wantRateLimited  bool
 		wantCooldown     bool
 		wantCapsCalls    int32
 	}{
 		{
-			name:          "caps 429 skips indexer and applies cooldown",
-			capsStatus:    http.StatusTooManyRequests,
-			wantSkip:      true,
-			wantCooldown:  true,
-			wantCapsCalls: 1,
+			name:            "caps 429 skips indexer and applies cooldown",
+			capsStatus:      http.StatusTooManyRequests,
+			wantSkip:        true,
+			wantRateLimited: true,
+			wantCooldown:    true,
+			wantCapsCalls:   1,
 		},
 		{
 			name:          "caps 500 keeps fail-open",
@@ -98,10 +102,13 @@ func TestApplyIndexerRestrictionsCapsFetchRateLimit(t *testing.T) {
 			meta := &searchContext{searchMode: "tvsearch", categories: []int{5000}}
 			params := map[string]string{"q": "some show", "season": "1"}
 
-			skipped := service.applyIndexerRestrictions(context.Background(), client, idx, "42", meta, params)
+			skipped, rateLimited := service.applyIndexerRestrictions(context.Background(), client, idx, "42", meta, params)
 
 			if skipped != tt.wantSkip {
 				t.Fatalf("applyIndexerRestrictions skip = %v, want %v", skipped, tt.wantSkip)
+			}
+			if rateLimited != tt.wantRateLimited {
+				t.Fatalf("applyIndexerRestrictions rateLimited = %v, want %v", rateLimited, tt.wantRateLimited)
 			}
 			inCooldown, _ := service.rateLimiter.IsInCooldown(idx.ID)
 			if inCooldown != tt.wantCooldown {
@@ -111,5 +118,106 @@ func TestApplyIndexerRestrictionsCapsFetchRateLimit(t *testing.T) {
 				t.Fatalf("caps fetches = %d, want %d", got, tt.wantCapsCalls)
 			}
 		})
+	}
+}
+
+func TestSearchMultipleIndexersCapsRateLimitIsNotCovered(t *testing.T) {
+	var capsCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		capsCalls.Add(1)
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	indexers := []*models.TorznabIndexer{
+		{
+			ID:        1,
+			Name:      "Rate limited",
+			BaseURL:   server.URL,
+			Backend:   models.TorznabBackendProwlarr,
+			IndexerID: "1",
+			Enabled:   true,
+		},
+		{
+			ID:           2,
+			Name:         "Books only",
+			BaseURL:      server.URL,
+			Backend:      models.TorznabBackendProwlarr,
+			IndexerID:    "2",
+			Enabled:      true,
+			Capabilities: []string{"book-search"},
+			Categories:   []models.TorznabIndexerCategory{{CategoryID: 7000, CategoryName: "Books"}},
+		},
+	}
+	service := NewService(&mockTorznabIndexerStore{indexers: indexers})
+	t.Cleanup(service.searchScheduler.Stop)
+
+	params := url.Values{"q": {"some show"}, "season": {"1"}, "cat": {"5000"}}
+	meta := &searchContext{searchMode: "tvsearch", categories: []int{5000}}
+	_, covered, err := service.searchMultipleIndexers(context.Background(), indexers, params, meta)
+
+	if err != nil {
+		t.Fatalf("searchMultipleIndexers error = %v", err)
+	}
+	if len(covered) != 1 || covered[0] != 2 {
+		t.Fatalf("covered indexers = %v, want [2]", covered)
+	}
+	if got := capsCalls.Load(); got != 1 {
+		t.Fatalf("caps fetches = %d, want 1", got)
+	}
+}
+
+func TestScheduledSearchCapsRateLimitIsNotCovered(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	indexers := []*models.TorznabIndexer{
+		{
+			ID:        1,
+			Name:      "Rate limited",
+			BaseURL:   server.URL,
+			Backend:   models.TorznabBackendProwlarr,
+			IndexerID: "1",
+			Enabled:   true,
+		},
+		{
+			ID:           2,
+			Name:         "Books only",
+			BaseURL:      server.URL,
+			Backend:      models.TorznabBackendProwlarr,
+			IndexerID:    "2",
+			Enabled:      true,
+			Capabilities: []string{"book-search"},
+			Categories:   []models.TorznabIndexerCategory{{CategoryID: 7000, CategoryName: "Books"}},
+		},
+	}
+	service := NewService(&mockTorznabIndexerStore{indexers: indexers})
+	t.Cleanup(service.searchScheduler.Stop)
+
+	type searchResult struct {
+		covered []int
+		err     error
+	}
+	done := make(chan searchResult, 1)
+	params := url.Values{"q": {"some show"}, "season": {"1"}, "cat": {"5000"}}
+	meta := &searchContext{searchMode: "tvsearch", categories: []int{5000}}
+	if err := service.searchIndexersWithScheduler(context.Background(), indexers, params, meta, nil, func(_ uint64, _ []Result, covered []int, err error) {
+		done <- searchResult{covered: covered, err: err}
+	}); err != nil {
+		t.Fatalf("searchIndexersWithScheduler error = %v", err)
+	}
+
+	select {
+	case result := <-done:
+		if result.err != nil {
+			t.Fatalf("scheduled search error = %v", result.err)
+		}
+		if len(result.covered) != 1 || result.covered[0] != 2 {
+			t.Fatalf("covered indexers = %v, want [2]", result.covered)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("scheduled search timed out")
 	}
 }

--- a/internal/services/jackett/service.go
+++ b/internal/services/jackett/service.go
@@ -432,10 +432,7 @@ func (s *Service) searchIndexersWithScheduler(ctx context.Context, indexers []*m
 					return
 				}
 
-				// Track coverage
-				if indexer != nil {
-					coverage[indexer.ID] = struct{}{}
-				}
+				// Track only the indexers that the executor reports as covered.
 				for _, id := range cov {
 					coverage[id] = struct{}{}
 				}
@@ -1916,10 +1913,10 @@ func validateIndexerBaseURL(idx *models.TorznabIndexer) error {
 }
 
 type indexerExecResult struct {
-	results []Result
-	id      int
-	skipped bool
-	err     error
+	results   []Result
+	id        int
+	uncovered bool
+	err       error
 }
 
 type indexerExecOptions struct {
@@ -1981,8 +1978,8 @@ func (s *Service) executeIndexerSearch(ctx context.Context, idx *models.TorznabI
 	var searchFn func() ([]Result, error)
 	switch idx.Backend {
 	case models.TorznabBackendNative:
-		if s.applyIndexerRestrictions(ctx, client, idx, "", meta, paramsMap) {
-			return indexerExecResult{id: idx.ID, skipped: true}
+		if skipped, rateLimited := s.applyIndexerRestrictions(ctx, client, idx, "", meta, paramsMap); skipped {
+			return indexerExecResult{id: idx.ID, uncovered: rateLimited}
 		}
 
 		// Note: the prowlarr workaround only applies to the prowlarr backend.
@@ -2010,8 +2007,8 @@ func (s *Service) executeIndexerSearch(ctx context.Context, idx *models.TorznabI
 			return indexerExecResult{id: idx.ID, err: fmt.Errorf("missing prowlarr indexer identifier")}
 		}
 
-		if s.applyIndexerRestrictions(ctx, client, idx, indexerID, meta, paramsMap) {
-			return indexerExecResult{id: idx.ID, skipped: true}
+		if skipped, rateLimited := s.applyIndexerRestrictions(ctx, client, idx, indexerID, meta, paramsMap); skipped {
+			return indexerExecResult{id: idx.ID, uncovered: rateLimited}
 		}
 
 		// Apply the Prowlarr query workaround after capability processing so that
@@ -2044,8 +2041,8 @@ func (s *Service) executeIndexerSearch(ctx context.Context, idx *models.TorznabI
 			return indexerExecResult{id: idx.ID, err: fmt.Errorf("missing indexer identifier")}
 		}
 
-		if s.applyIndexerRestrictions(ctx, client, idx, indexerID, meta, paramsMap) {
-			return indexerExecResult{id: idx.ID, skipped: true}
+		if skipped, rateLimited := s.applyIndexerRestrictions(ctx, client, idx, indexerID, meta, paramsMap); skipped {
+			return indexerExecResult{id: idx.ID, uncovered: rateLimited}
 		}
 
 		if opts.logSearchActivity {
@@ -2251,7 +2248,7 @@ func (s *Service) searchMultipleIndexers(ctx context.Context, indexers []*models
 				continue
 			}
 			successes++
-			if result.id != 0 {
+			if result.id != 0 && !result.uncovered {
 				coverage[result.id] = struct{}{}
 			}
 			allResults = append(allResults, result.results...)
@@ -2307,10 +2304,7 @@ func (s *Service) runIndexerSearch(ctx context.Context, idx *models.TorznabIndex
 	if result.err != nil {
 		return nil, nil, result.err
 	}
-	if result.skipped {
-		return nil, nil, nil
-	}
-	if result.id == 0 {
+	if result.uncovered || result.id == 0 {
 		return result.results, nil, nil
 	}
 	return result.results, []int{result.id}, nil
@@ -2343,7 +2337,7 @@ func mergeIndexerCoverage(groups ...[]int) []int {
 	return slices.Compact(merged)
 }
 
-func (s *Service) applyIndexerRestrictions(ctx context.Context, client *Client, idx *models.TorznabIndexer, identifier string, meta *searchContext, params map[string]string) bool {
+func (s *Service) applyIndexerRestrictions(ctx context.Context, client *Client, idx *models.TorznabIndexer, identifier string, meta *searchContext, params map[string]string) (skip, rateLimited bool) {
 	requiredCaps := requiredCapabilities(meta)
 	requested := requestedCategories(meta, params)
 
@@ -2356,7 +2350,7 @@ func (s *Service) applyIndexerRestrictions(ctx context.Context, client *Client, 
 			// searching anyway doubles the load on an indexer already telling
 			// us to back off, and keeps the metadata from ever healing.
 			s.handleRateLimit(ctx, idx, cooldown, err)
-			return true
+			return true, true
 		}
 	}
 
@@ -2429,7 +2423,7 @@ func (s *Service) applyIndexerRestrictions(ctx context.Context, client *Client, 
 				Strs("indexer_caps", idx.Capabilities).
 				Bool("enhanced_checking", usingEnhanced).
 				Msg("Skipping torznab indexer due to missing capabilities")
-			return true
+			return true, false
 		} else if usingEnhanced {
 			log.Debug().
 				Int("indexer_id", idx.ID).
@@ -2443,12 +2437,12 @@ func (s *Service) applyIndexerRestrictions(ctx context.Context, client *Client, 
 
 	// If no categories requested, continue with search
 	if len(requested) == 0 {
-		return false
+		return false, false
 	}
 
 	// If indexer has no categories stored, continue (will use requested categories as-is)
 	if len(idx.Categories) == 0 {
-		return false
+		return false, false
 	}
 
 	// Map requested categories to what this indexer actually supports
@@ -2463,7 +2457,7 @@ func (s *Service) applyIndexerRestrictions(ctx context.Context, client *Client, 
 			Ints("requested_categories", requested).
 			Ints("mapped_categories", mappedCategories).
 			Msg("Skipping torznab indexer due to unsupported categories")
-		return true
+		return true, false
 	}
 
 	// Update the params with the filtered categories
@@ -2488,7 +2482,7 @@ func (s *Service) applyIndexerRestrictions(ctx context.Context, client *Client, 
 		Interface("final_params", params).
 		Msg("Final search parameters after capability processing")
 
-	return false
+	return false, false
 }
 
 func (s *Service) applyCapabilitySpecificParams(idx *models.TorznabIndexer, meta *searchContext, params map[string]string) {


### PR DESCRIPTION
A caps fetch that returned 429 used the same skip path as an unsupported indexer. This marked the indexer as covered and could prevent a later search after the repeat-search age limit. Rate-limited skips now stay uncovered, while capability exclusions remain covered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rate-limited indexers are now correctly reported as uncovered instead of completed.
  * Search results more accurately reflect partial coverage when an indexer responds with a rate-limit error.
  * Direct and scheduled searches continue without errors while preserving coverage from eligible indexers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->