### PR TITLE
feat(indexers): remember Prowlarr and Jackett connections in the discover dialog

### DIFF
--- a/internal/api/handlers/jackett.go
+++ b/internal/api/handlers/jackett.go
@@ -334,18 +334,19 @@ func (h *JackettHandler) ListIndexers(w http.ResponseWriter, r *http.Request) {
 // @Router /api/torznab/indexers [post]
 func (h *JackettHandler) CreateIndexer(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		Name           string                          `json:"name"`
-		BaseURL        string                          `json:"base_url"`
-		IndexerID      string                          `json:"indexer_id"`
-		APIKey         string                          `json:"api_key"`
-		BasicUsername  *string                         `json:"basic_username,omitempty"`
-		BasicPassword  *string                         `json:"basic_password,omitempty"`
-		Backend        string                          `json:"backend"`
-		Enabled        *bool                           `json:"enabled"`
-		Priority       *int                            `json:"priority"`
-		TimeoutSeconds *int                            `json:"timeout_seconds"`
-		Capabilities   []string                        `json:"capabilities,omitempty"`
-		Categories     []models.TorznabIndexerCategory `json:"categories,omitempty"`
+		Name            string                          `json:"name"`
+		BaseURL         string                          `json:"base_url"`
+		IndexerID       string                          `json:"indexer_id"`
+		APIKey          string                          `json:"api_key"`
+		BasicUsername   *string                         `json:"basic_username,omitempty"`
+		BasicPassword   *string                         `json:"basic_password,omitempty"`
+		Backend         string                          `json:"backend"`
+		Enabled         *bool                           `json:"enabled"`
+		Priority        *int                            `json:"priority"`
+		TimeoutSeconds  *int                            `json:"timeout_seconds"`
+		Capabilities    []string                        `json:"capabilities,omitempty"`
+		Categories      []models.TorznabIndexerCategory `json:"categories,omitempty"`
+		SourceIndexerID *int                            `json:"source_indexer_id,omitempty"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -369,6 +370,17 @@ func (h *JackettHandler) CreateIndexer(w http.ResponseWriter, r *http.Request) {
 	if baseURL == "" {
 		RespondError(w, http.StatusBadRequest, "base_url is required")
 		return
+	}
+	if apiKey == "" && req.SourceIndexerID != nil {
+		creds, ok := h.sourceCredsOrRespond(r.Context(), w, *req.SourceIndexerID)
+		if !ok {
+			return
+		}
+		apiKey = creds.apiKey
+		if req.BasicUsername == nil && req.BasicPassword == nil {
+			req.BasicUsername = creds.basicUsername
+			req.BasicPassword = creds.basicPassword
+		}
 	}
 	if apiKey == "" {
 		RespondError(w, http.StatusBadRequest, "api_key is required")
@@ -851,9 +863,60 @@ func (h *JackettHandler) SyncIndexerCaps(w http.ResponseWriter, r *http.Request)
 	RespondJSON(w, http.StatusOK, indexer)
 }
 
+type sourceCredentials struct {
+	baseURL       string
+	apiKey        string
+	basicUsername *string
+	basicPassword *string
+}
+
+// resolveSourceIndexerCredentials loads a stored indexer and returns its
+// decrypted connection credentials for reuse by discovery and create.
+func resolveSourceIndexerCredentials(ctx context.Context, store *models.TorznabIndexerStore, id int) (*sourceCredentials, error) {
+	indexer, err := store.Get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	apiKey, err := store.GetDecryptedAPIKey(indexer)
+	if err != nil {
+		return nil, err
+	}
+
+	creds := &sourceCredentials{
+		baseURL:       indexer.BaseURL,
+		apiKey:        apiKey,
+		basicUsername: indexer.BasicUsername,
+	}
+	if indexer.BasicPasswordEncrypted != nil {
+		password, err := store.GetDecryptedBasicPassword(indexer)
+		if err != nil {
+			return nil, err
+		}
+		creds.basicPassword = &password
+	}
+	return creds, nil
+}
+
+// sourceCredsOrRespond resolves stored credentials for a source indexer id and
+// writes the error response itself when resolution fails.
+func (h *JackettHandler) sourceCredsOrRespond(ctx context.Context, w http.ResponseWriter, id int) (*sourceCredentials, bool) {
+	creds, err := resolveSourceIndexerCredentials(ctx, h.indexerStore, id)
+	if err != nil {
+		if errors.Is(err, models.ErrTorznabIndexerNotFound) {
+			RespondError(w, http.StatusBadRequest, "source indexer not found")
+			return nil, false
+		}
+		log.Error().Err(err).Int("source_indexer_id", id).Msg("Failed to load source indexer credentials")
+		RespondError(w, http.StatusInternalServerError, "Failed to load source indexer credentials")
+		return nil, false
+	}
+	return creds, true
+}
+
 // DiscoverIndexers godoc
 // @Summary Discover indexers from a Jackett/Prowlarr instance
-// @Description Discovers all configured indexers from a Jackett or Prowlarr instance using its API
+// @Description Discovers all configured indexers from a Jackett or Prowlarr instance using its API. Credentials can be reused from an existing indexer via source_indexer_id.
 // @Tags torznab
 // @Accept json
 // @Produce json
@@ -864,16 +927,32 @@ func (h *JackettHandler) SyncIndexerCaps(w http.ResponseWriter, r *http.Request)
 // @Router /api/torznab/indexers/discover [post]
 func (h *JackettHandler) DiscoverIndexers(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		BaseURL       string  `json:"base_url"`
-		APIKey        string  `json:"api_key"`
-		BasicUsername *string `json:"basic_username,omitempty"`
-		BasicPassword *string `json:"basic_password,omitempty"`
+		BaseURL         string  `json:"base_url"`
+		APIKey          string  `json:"api_key"`
+		BasicUsername   *string `json:"basic_username,omitempty"`
+		BasicPassword   *string `json:"basic_password,omitempty"`
+		SourceIndexerID *int    `json:"source_indexer_id,omitempty"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		log.Error().Err(err).Msg("Failed to decode discover request")
 		RespondError(w, http.StatusBadRequest, "Invalid request body")
 		return
+	}
+
+	if req.SourceIndexerID != nil {
+		creds, ok := h.sourceCredsOrRespond(r.Context(), w, *req.SourceIndexerID)
+		if !ok {
+			return
+		}
+		req.APIKey = creds.apiKey
+		if req.BaseURL == "" {
+			req.BaseURL = creds.baseURL
+		}
+		if req.BasicUsername == nil && req.BasicPassword == nil {
+			req.BasicUsername = creds.basicUsername
+			req.BasicPassword = creds.basicPassword
+		}
 	}
 
 	if req.BaseURL == "" {

--- a/internal/api/handlers/jackett.go
+++ b/internal/api/handlers/jackett.go
@@ -4,6 +4,7 @@
 package handlers
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -376,11 +377,12 @@ func (h *JackettHandler) CreateIndexer(w http.ResponseWriter, r *http.Request) {
 		if !ok {
 			return
 		}
+		// The source connection is authoritative: URL, key, and basic auth
+		// move together so the new row cannot mix servers.
+		baseURL = creds.baseURL
 		apiKey = creds.apiKey
-		if req.BasicUsername == nil && req.BasicPassword == nil {
-			req.BasicUsername = creds.basicUsername
-			req.BasicPassword = creds.basicPassword
-		}
+		req.BasicUsername = creds.basicUsername
+		req.BasicPassword = creds.basicPassword
 	}
 	if apiKey == "" {
 		RespondError(w, http.StatusBadRequest, "api_key is required")
@@ -536,18 +538,19 @@ func (h *JackettHandler) UpdateIndexer(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req struct {
-		Name           string                          `json:"name"`
-		BaseURL        string                          `json:"base_url"`
-		IndexerID      *string                         `json:"indexer_id"`
-		APIKey         string                          `json:"api_key"`
-		BasicUsername  *string                         `json:"basic_username,omitempty"`
-		BasicPassword  *string                         `json:"basic_password,omitempty"`
-		Backend        *string                         `json:"backend"`
-		Enabled        *bool                           `json:"enabled"`
-		Priority       *int                            `json:"priority"`
-		TimeoutSeconds *int                            `json:"timeout_seconds"`
-		Capabilities   []string                        `json:"capabilities,omitempty"`
-		Categories     []models.TorznabIndexerCategory `json:"categories,omitempty"`
+		Name            string                          `json:"name"`
+		BaseURL         string                          `json:"base_url"`
+		IndexerID       *string                         `json:"indexer_id"`
+		APIKey          string                          `json:"api_key"`
+		BasicUsername   *string                         `json:"basic_username,omitempty"`
+		BasicPassword   *string                         `json:"basic_password,omitempty"`
+		Backend         *string                         `json:"backend"`
+		Enabled         *bool                           `json:"enabled"`
+		Priority        *int                            `json:"priority"`
+		TimeoutSeconds  *int                            `json:"timeout_seconds"`
+		Capabilities    []string                        `json:"capabilities,omitempty"`
+		Categories      []models.TorznabIndexerCategory `json:"categories,omitempty"`
+		SourceIndexerID *int                            `json:"source_indexer_id,omitempty"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -598,6 +601,21 @@ func (h *JackettHandler) UpdateIndexer(w http.ResponseWriter, r *http.Request) {
 	req.BasicUsername, req.BasicPassword = normalizeBasicAuthForUpdate(req.BasicUsername, req.BasicPassword)
 	params.BasicUsername = req.BasicUsername
 	params.BasicPassword = req.BasicPassword
+
+	// Saved-connection import: an empty key with a source copies the source's
+	// URL, key, and basic auth, so credentials move between servers together.
+	// An empty basic auth pointer pair clears the target's stored basic auth.
+	if params.APIKey == "" && req.SourceIndexerID != nil {
+		creds, ok := h.sourceCredsOrRespond(r.Context(), w, *req.SourceIndexerID)
+		if !ok {
+			return
+		}
+		empty := ""
+		params.BaseURL = creds.baseURL
+		params.APIKey = creds.apiKey
+		params.BasicUsername = cmp.Or(creds.basicUsername, &empty)
+		params.BasicPassword = cmp.Or(creds.basicPassword, &empty)
+	}
 
 	indexer, err := h.indexerStore.Update(r.Context(), id, params)
 	if err != nil {
@@ -945,14 +963,12 @@ func (h *JackettHandler) DiscoverIndexers(w http.ResponseWriter, r *http.Request
 		if !ok {
 			return
 		}
+		// The source connection is authoritative: stored credentials cannot be
+		// re-paired with another server via the request body.
+		req.BaseURL = creds.baseURL
 		req.APIKey = creds.apiKey
-		if req.BaseURL == "" {
-			req.BaseURL = creds.baseURL
-		}
-		if req.BasicUsername == nil && req.BasicPassword == nil {
-			req.BasicUsername = creds.basicUsername
-			req.BasicPassword = creds.basicPassword
-		}
+		req.BasicUsername = creds.basicUsername
+		req.BasicPassword = creds.basicPassword
 	}
 
 	if req.BaseURL == "" {

--- a/internal/api/handlers/jackett_source_credentials_test.go
+++ b/internal/api/handlers/jackett_source_credentials_test.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/testutil/testdb"
+)
+
+func newTorznabStore(t *testing.T) *models.TorznabIndexerStore {
+	t.Helper()
+	db := testdb.NewMigratedSQLite(t, "torznab-source-creds")
+	store, err := models.NewTorznabIndexerStore(db, []byte("01234567890123456789012345678901"))
+	require.NoError(t, err)
+	return store
+}
+
+func TestResolveSourceIndexerCredentials(t *testing.T) {
+	ctx := t.Context()
+	store := newTorznabStore(t)
+
+	user := "proxyuser"
+	pass := "proxypass"
+	created, err := store.CreateWithIndexerID(ctx, "Aither", "http://localhost:9696", "aither", "prowlarr-key", &user, &pass, true, 0, 30, models.TorznabBackendProwlarr)
+	require.NoError(t, err)
+
+	creds, err := resolveSourceIndexerCredentials(ctx, store, created.ID)
+	require.NoError(t, err)
+	require.Equal(t, "http://localhost:9696", creds.baseURL)
+	require.Equal(t, "prowlarr-key", creds.apiKey)
+	require.NotNil(t, creds.basicUsername)
+	require.Equal(t, "proxyuser", *creds.basicUsername)
+	require.NotNil(t, creds.basicPassword)
+	require.Equal(t, "proxypass", *creds.basicPassword)
+}
+
+func TestDiscoverIndexersRejectsUnknownSource(t *testing.T) {
+	ctx := t.Context()
+	store := newTorznabStore(t)
+	handler := &JackettHandler{indexerStore: store}
+
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/api/torznab/indexers/discover", strings.NewReader(`{"source_indexer_id": 12345}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	handler.DiscoverIndexers(resp, req)
+	require.Equal(t, http.StatusBadRequest, resp.Code)
+	require.Contains(t, resp.Body.String(), "source indexer not found")
+}
+
+func TestCreateIndexerCopiesKeyFromSource(t *testing.T) {
+	ctx := t.Context()
+	store := newTorznabStore(t)
+
+	user := "proxyuser"
+	pass := "proxypass"
+	source, err := store.CreateWithIndexerID(ctx, "Aither", "http://localhost:9696", "aither", "prowlarr-key", &user, &pass, true, 0, 30, models.TorznabBackendProwlarr)
+	require.NoError(t, err)
+
+	handler := &JackettHandler{indexerStore: store} // service nil: caps provided in request, sync skipped
+
+	body := fmt.Sprintf(`{
+		"name": "Blutopia",
+		"base_url": "http://localhost:9696",
+		"indexer_id": "blutopia",
+		"backend": "prowlarr",
+		"source_indexer_id": %d,
+		"capabilities": ["search"]
+	}`, source.ID)
+
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/api/torznab/indexers", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	handler.CreateIndexer(resp, req)
+	require.Equal(t, http.StatusCreated, resp.Code, resp.Body.String())
+
+	var created models.TorznabIndexer
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &created))
+
+	stored, err := store.Get(ctx, created.ID)
+	require.NoError(t, err)
+
+	apiKey, err := store.GetDecryptedAPIKey(stored)
+	require.NoError(t, err)
+	require.Equal(t, "prowlarr-key", apiKey)
+
+	require.NotNil(t, stored.BasicUsername)
+	require.Equal(t, "proxyuser", *stored.BasicUsername)
+	password, err := store.GetDecryptedBasicPassword(stored)
+	require.NoError(t, err)
+	require.Equal(t, "proxypass", password)
+}
+
+func TestCreateIndexerStillRequiresKeyWithoutSource(t *testing.T) {
+	ctx := t.Context()
+	store := newTorznabStore(t)
+	handler := &JackettHandler{indexerStore: store}
+
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/api/torznab/indexers", strings.NewReader(`{
+		"name": "Blutopia",
+		"base_url": "http://localhost:9696",
+		"backend": "prowlarr",
+		"indexer_id": "blutopia"
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	handler.CreateIndexer(resp, req)
+	require.Equal(t, http.StatusBadRequest, resp.Code)
+}

--- a/internal/api/handlers/jackett_source_credentials_test.go
+++ b/internal/api/handlers/jackett_source_credentials_test.go
@@ -4,13 +4,16 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/require"
 
 	"github.com/autobrr/qui/internal/models"
@@ -98,6 +101,55 @@ func TestCreateIndexerCopiesKeyFromSource(t *testing.T) {
 	password, err := store.GetDecryptedBasicPassword(stored)
 	require.NoError(t, err)
 	require.Equal(t, "proxypass", password)
+}
+
+// Two servers can expose the same indexer name (e.g. Jackett and Prowlarr side
+// by side). Importing via a saved connection must move the URL, API key, and
+// basic auth together, not keep the old server's credentials.
+func TestUpdateIndexerCopiesCredentialsFromSource(t *testing.T) {
+	ctx := t.Context()
+	store := newTorznabStore(t)
+
+	aUser := "a-user"
+	aPass := "a-pass"
+	target, err := store.CreateWithIndexerID(ctx, "Aither", "http://server-a:9117", "aither", "a-key", &aUser, &aPass, true, 0, 30, models.TorznabBackendJackett)
+	require.NoError(t, err)
+
+	source, err := store.CreateWithIndexerID(ctx, "Blutopia", "http://server-b:9696", "blutopia", "b-key", nil, nil, true, 0, 30, models.TorznabBackendProwlarr)
+	require.NoError(t, err)
+
+	handler := &JackettHandler{indexerStore: store}
+
+	body := fmt.Sprintf(`{
+		"name": "Aither",
+		"base_url": "http://server-b:9696",
+		"indexer_id": "aither",
+		"backend": "prowlarr",
+		"api_key": "",
+		"source_indexer_id": %d,
+		"capabilities": ["search"]
+	}`, source.ID)
+
+	req := httptest.NewRequestWithContext(ctx, http.MethodPut, fmt.Sprintf("/api/torznab/indexers/%d", target.ID), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("indexerID", strconv.Itoa(target.ID))
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	resp := httptest.NewRecorder()
+	handler.UpdateIndexer(resp, req)
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+
+	stored, err := store.Get(ctx, target.ID)
+	require.NoError(t, err)
+	require.Equal(t, "http://server-b:9696", stored.BaseURL)
+
+	apiKey, err := store.GetDecryptedAPIKey(stored)
+	require.NoError(t, err)
+	require.Equal(t, "b-key", apiKey)
+
+	// The source has no basic auth, so the copied connection must clear it.
+	require.Nil(t, stored.BasicUsername)
+	require.Nil(t, stored.BasicPasswordEncrypted)
 }
 
 func TestCreateIndexerStillRequiresKeyWithoutSource(t *testing.T) {

--- a/web/src/components/indexers/AutodiscoveryDialog.tsx
+++ b/web/src/components/indexers/AutodiscoveryDialog.tsx
@@ -418,7 +418,7 @@ export function AutodiscoveryDialog({ open, onClose, indexers }: AutodiscoveryDi
                       >
                         <span className="truncate font-medium">{connection.baseUrl}</span>
                         <span className="ml-2 shrink-0 text-xs text-muted-foreground">
-                          {connection.backend} • {t("indexers.autodiscovery.savedConnections.indexerCount", { count: connection.indexerCount })}
+                          {t(`indexers.dialog.backends.${connection.backend}`)} • {t("indexers.autodiscovery.savedConnections.indexerCount", { count: connection.indexerCount })}
                         </span>
                       </button>
                     ))}

--- a/web/src/components/indexers/AutodiscoveryDialog.tsx
+++ b/web/src/components/indexers/AutodiscoveryDialog.tsx
@@ -188,7 +188,8 @@ export function AutodiscoveryDialog({ open, onClose, indexers }: AutodiscoveryDi
           // Omit enabled to preserve the user's current enabled state
           const updateData: TorznabIndexerUpdate = {
             base_url: normalizedBaseUrl,
-            api_key: apiKey, // empty (saved connection) keeps the stored key
+            api_key: apiKey, // empty + source copies the saved connection's credentials
+            source_indexer_id: selectedSourceId ?? undefined,
             backend,
             indexer_id: normalizedIndexerId,
             capabilities: indexer.caps, // Include capabilities if discovered

--- a/web/src/components/indexers/AutodiscoveryDialog.tsx
+++ b/web/src/components/indexers/AutodiscoveryDialog.tsx
@@ -18,17 +18,20 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Checkbox } from "@/components/ui/checkbox"
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Switch } from "@/components/ui/switch"
 import type { JackettIndexer, TorznabIndexer, TorznabIndexerFormData, TorznabIndexerUpdate } from "@/types"
 import { api } from "@/lib/api"
+import { deriveSavedConnections, type SavedDiscoveryConnection } from "@/lib/discovery-connections"
 
 interface AutodiscoveryDialogProps {
   open: boolean
   onClose: () => void
+  indexers: TorznabIndexer[]
 }
 
-export function AutodiscoveryDialog({ open, onClose }: AutodiscoveryDialogProps) {
+export function AutodiscoveryDialog({ open, onClose, indexers }: AutodiscoveryDialogProps) {
   const { t } = useTranslation("settings")
   const [step, setStep] = useState<"input" | "select">("input")
   const [loading, setLoading] = useState(false)
@@ -41,6 +44,32 @@ export function AutodiscoveryDialog({ open, onClose }: AutodiscoveryDialogProps)
   const [discoveredIndexers, setDiscoveredIndexers] = useState<JackettIndexer[]>([])
   const [selectedIndexers, setSelectedIndexers] = useState<Set<string>>(new Set())
   const [existingIndexersMap, setExistingIndexersMap] = useState<Map<string, TorznabIndexer>>(new Map())
+  const [selectedSourceId, setSelectedSourceId] = useState<number | null>(null)
+  const [manualOpen, setManualOpen] = useState(false)
+
+  const savedConnections = deriveSavedConnections(indexers)
+
+  // Selecting a connection wipes the manual credentials, so the plain apiKey /
+  // showBasicAuth reads below stay correct in both modes.
+  const selectConnection = (connection: SavedDiscoveryConnection) => {
+    setSelectedSourceId(connection.sourceIndexerId)
+    setManualOpen(false)
+    setBaseUrl(connection.baseUrl)
+    setBaseUrlError(null)
+    setApiKey("")
+    setShowBasicAuth(false)
+    setBasicUsername("")
+    setBasicPassword("")
+  }
+
+  const handleManualToggle = (nextOpen: boolean) => {
+    setManualOpen(nextOpen)
+    if (nextOpen) {
+      setSelectedSourceId(null)
+      setBaseUrl("http://localhost:9696")
+      setBaseUrlError(null)
+    }
+  }
 
   const normalizeBaseUrl = (value: string) => {
     const trimmed = value.trim()
@@ -73,7 +102,8 @@ export function AutodiscoveryDialog({ open, onClose }: AutodiscoveryDialogProps)
           normalizedBaseUrl,
           apiKey,
           showBasicAuth ? trimmedBasicUser : undefined,
-          showBasicAuth ? trimmedBasicPass : undefined
+          showBasicAuth ? trimmedBasicPass : undefined,
+          selectedSourceId ?? undefined
         ),
         api.listTorznabIndexers(),
       ])
@@ -158,7 +188,7 @@ export function AutodiscoveryDialog({ open, onClose }: AutodiscoveryDialogProps)
           // Omit enabled to preserve the user's current enabled state
           const updateData: TorznabIndexerUpdate = {
             base_url: normalizedBaseUrl,
-            api_key: apiKey,
+            api_key: apiKey, // empty (saved connection) keeps the stored key
             backend,
             indexer_id: normalizedIndexerId,
             capabilities: indexer.caps, // Include capabilities if discovered
@@ -179,6 +209,7 @@ export function AutodiscoveryDialog({ open, onClose }: AutodiscoveryDialogProps)
             name: indexer.name,
             base_url: normalizedBaseUrl,
             api_key: apiKey,
+            source_indexer_id: selectedSourceId ?? undefined,
             backend,
             enabled: true,
             indexer_id: normalizedIndexerId,
@@ -253,6 +284,8 @@ export function AutodiscoveryDialog({ open, onClose }: AutodiscoveryDialogProps)
     setBaseUrl("http://localhost:9696")
     setBaseUrlError(null)
     setApiKey("")
+    setSelectedSourceId(null)
+    setManualOpen(false)
     setShowBasicAuth(false)
     setBasicUsername("")
     setBasicPassword("")
@@ -260,6 +293,100 @@ export function AutodiscoveryDialog({ open, onClose }: AutodiscoveryDialogProps)
     setSelectedIndexers(new Set())
     onClose()
   }
+
+  const manualFields = (
+    <>
+      <div className="grid gap-2">
+        <Label htmlFor="torznabUrl">{t("indexers.autodiscovery.labels.indexerUrl")}</Label>
+        <Input
+          id="torznabUrl"
+          type="url"
+          value={baseUrl}
+          onChange={(e) => {
+            setBaseUrl(e.target.value)
+            if (baseUrlError) {
+              setBaseUrlError(null)
+            }
+          }}
+          placeholder={t("indexers.autodiscovery.placeholders.indexerUrl")}
+          className={baseUrlError ? "border-destructive focus-visible:ring-destructive" : undefined}
+          aria-invalid={baseUrlError ? "true" : "false"}
+          autoComplete="off"
+          data-1p-ignore
+          required
+        />
+        {baseUrlError && (
+          <p className="text-xs text-destructive">
+            {baseUrlError}
+          </p>
+        )}
+        <p className="text-xs text-muted-foreground">
+          {t("indexers.autodiscovery.hints.indexerUrl")}
+        </p>
+      </div>
+      <div className="grid gap-2">
+        <Label htmlFor="torznabApiKey">{t("indexers.autodiscovery.labels.apiKey")}</Label>
+        <Input
+          id="torznabApiKey"
+          type="password"
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          placeholder={t("indexers.autodiscovery.placeholders.apiKey")}
+          autoComplete="off"
+          data-1p-ignore
+          required
+        />
+      </div>
+      <div className="flex items-center justify-between gap-4 rounded-lg border bg-muted/40 p-4">
+        <div className="space-y-1">
+          <Label htmlFor="torznab-basic-auth">{t("indexers.autodiscovery.labels.basicAuth")}</Label>
+          <p className="text-sm text-muted-foreground max-w-prose">
+            {t("indexers.autodiscovery.labels.basicAuthDescription")}
+          </p>
+        </div>
+        <Switch
+          id="torznab-basic-auth"
+          checked={showBasicAuth}
+          onCheckedChange={(checked) => {
+            setShowBasicAuth(checked)
+            if (!checked) {
+              setBasicUsername("")
+              setBasicPassword("")
+            }
+          }}
+        />
+      </div>
+      {showBasicAuth && (
+        <div className="grid gap-4 rounded-lg border bg-muted/20 p-4">
+          <div className="grid gap-2">
+            <Label htmlFor="torznab-basic-username">{t("indexers.autodiscovery.labels.basicUsername")}</Label>
+            <Input
+              id="torznab-basic-username"
+              value={basicUsername}
+              onChange={(e) => setBasicUsername(e.target.value)}
+              placeholder={t("indexers.autodiscovery.placeholders.username")}
+              autoComplete="off"
+              data-1p-ignore
+              required
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="torznab-basic-password">{t("indexers.autodiscovery.labels.basicPassword")}</Label>
+            <Input
+              id="torznab-basic-password"
+              type="password"
+              value={basicPassword}
+              onChange={(e) => setBasicPassword(e.target.value)}
+              placeholder={t("indexers.autodiscovery.placeholders.password")}
+              autoComplete="off"
+              data-1p-ignore
+              required
+            />
+          </div>
+        </div>
+      )}
+    </>
+  )
 
   return (
     <Dialog open={open} onOpenChange={(open) => { if (!open) handleClose(); }}>
@@ -274,101 +401,54 @@ export function AutodiscoveryDialog({ open, onClose }: AutodiscoveryDialogProps)
         {step === "input" ? (
           <form onSubmit={handleDiscover} autoComplete="off" data-1p-ignore className="flex-1 flex flex-col min-h-0">
             <div className="grid gap-4 py-4 flex-1 overflow-y-auto">
-              <div className="grid gap-2">
-                <Label htmlFor="torznabUrl">{t("indexers.autodiscovery.labels.indexerUrl")}</Label>
-                <Input
-                  id="torznabUrl"
-                  type="url"
-                  value={baseUrl}
-                  onChange={(e) => {
-                    setBaseUrl(e.target.value)
-                    if (baseUrlError) {
-                      setBaseUrlError(null)
-                    }
-                  }}
-                  placeholder={t("indexers.autodiscovery.placeholders.indexerUrl")}
-                  className={baseUrlError ? "border-destructive focus-visible:ring-destructive" : undefined}
-                  aria-invalid={baseUrlError ? "true" : "false"}
-                  autoComplete="off"
-                  data-1p-ignore
-                  required
-                />
-                {baseUrlError && (
-                  <p className="text-xs text-destructive">
-                    {baseUrlError}
+              {savedConnections.length > 0 && (
+                <div className="grid gap-2">
+                  <Label>{t("indexers.autodiscovery.savedConnections.title")}</Label>
+                  <p className="text-xs text-muted-foreground">
+                    {t("indexers.autodiscovery.savedConnections.description")}
                   </p>
-                )}
-                <p className="text-xs text-muted-foreground">
-                  {t("indexers.autodiscovery.hints.indexerUrl")}
-                </p>
-              </div>
-              <div className="grid gap-2">
-                <Label htmlFor="torznabApiKey">{t("indexers.autodiscovery.labels.apiKey")}</Label>
-                <Input
-                  id="torznabApiKey"
-                  type="password"
-                  value={apiKey}
-                  onChange={(e) => setApiKey(e.target.value)}
-                  placeholder={t("indexers.autodiscovery.placeholders.apiKey")}
-                  autoComplete="off"
-                  data-1p-ignore
-                  required
-                />
-              </div>
-              <div className="flex items-center justify-between gap-4 rounded-lg border bg-muted/40 p-4">
-                <div className="space-y-1">
-                  <Label htmlFor="torznab-basic-auth">{t("indexers.autodiscovery.labels.basicAuth")}</Label>
-                  <p className="text-sm text-muted-foreground max-w-prose">
-                    {t("indexers.autodiscovery.labels.basicAuthDescription")}
-                  </p>
-                </div>
-                <Switch
-                  id="torznab-basic-auth"
-                  checked={showBasicAuth}
-                  onCheckedChange={(checked) => {
-                    setShowBasicAuth(checked)
-                    if (!checked) {
-                      setBasicUsername("")
-                      setBasicPassword("")
-                    }
-                  }}
-                />
-              </div>
-              {showBasicAuth && (
-                <div className="grid gap-4 rounded-lg border bg-muted/20 p-4">
                   <div className="grid gap-2">
-                    <Label htmlFor="torznab-basic-username">{t("indexers.autodiscovery.labels.basicUsername")}</Label>
-                    <Input
-                      id="torznab-basic-username"
-                      value={basicUsername}
-                      onChange={(e) => setBasicUsername(e.target.value)}
-                      placeholder={t("indexers.autodiscovery.placeholders.username")}
-                      autoComplete="off"
-                      data-1p-ignore
-                      required
-                    />
+                    {savedConnections.map((connection) => (
+                      <button
+                        key={`${connection.backend}|${connection.baseUrl}`}
+                        type="button"
+                        onClick={() => selectConnection(connection)}
+                        className={`flex items-center justify-between rounded-lg border p-3 text-left text-sm hover:bg-accent ${selectedSourceId === connection.sourceIndexerId ? "border-primary bg-accent" : ""}`}
+                      >
+                        <span className="truncate font-medium">{connection.baseUrl}</span>
+                        <span className="ml-2 shrink-0 text-xs text-muted-foreground">
+                          {connection.backend} • {t("indexers.autodiscovery.savedConnections.indexerCount", { count: connection.indexerCount })}
+                        </span>
+                      </button>
+                    ))}
                   </div>
-                  <div className="grid gap-2">
-                    <Label htmlFor="torznab-basic-password">{t("indexers.autodiscovery.labels.basicPassword")}</Label>
-                    <Input
-                      id="torznab-basic-password"
-                      type="password"
-                      value={basicPassword}
-                      onChange={(e) => setBasicPassword(e.target.value)}
-                      placeholder={t("indexers.autodiscovery.placeholders.password")}
-                      autoComplete="off"
-                      data-1p-ignore
-                      required
-                    />
-                  </div>
+                  {selectedSourceId !== null && (
+                    <p className="text-xs text-muted-foreground">
+                      {t("indexers.autodiscovery.savedConnections.storedKey")}
+                    </p>
+                  )}
                 </div>
+              )}
+              {savedConnections.length > 0 ? (
+                <Collapsible open={manualOpen} onOpenChange={handleManualToggle}>
+                  <CollapsibleTrigger asChild>
+                    <Button type="button" variant="outline" size="sm" className="w-full">
+                      {t("indexers.autodiscovery.savedConnections.manual")}
+                    </Button>
+                  </CollapsibleTrigger>
+                  <CollapsibleContent className="grid gap-4 pt-4">
+                    {manualFields}
+                  </CollapsibleContent>
+                </Collapsible>
+              ) : (
+                manualFields
               )}
             </div>
             <DialogFooter className="flex-shrink-0">
               <Button type="button" variant="outline" onClick={handleClose}>
                 {t("indexers.autodiscovery.buttons.cancel")}
               </Button>
-              <Button type="submit" disabled={loading}>
+              <Button type="submit" disabled={loading || (savedConnections.length > 0 && selectedSourceId === null && !manualOpen)}>
                 {loading ? t("indexers.autodiscovery.buttons.discovering") : t("indexers.autodiscovery.buttons.discover")}
               </Button>
             </DialogFooter>

--- a/web/src/components/indexers/IndexersPage.tsx
+++ b/web/src/components/indexers/IndexersPage.tsx
@@ -292,6 +292,7 @@ export function IndexersPage({ withContainer = true }: IndexersPageProps) {
 
       <AutodiscoveryDialog
         open={autodiscoveryOpen}
+        indexers={indexers}
         onClose={() => {
           setAutodiscoveryOpen(false)
           loadIndexers()

--- a/web/src/i18n/locales/cs/settings.json
+++ b/web/src/i18n/locales/cs/settings.json
@@ -812,6 +812,14 @@
         "created": "{{count}} vytvořeno",
         "updated": "{{count}} aktualizováno",
         "failed": "{{count}} selhalo"
+      },
+      "savedConnections": {
+        "title": "Uložená připojení",
+        "description": "Použijte server, ze kterého jste už importovali. API klíč zůstává na serveru.",
+        "manual": "Zadat ručně",
+        "storedKey": "Použije se uložený API klíč pro tento server.",
+        "indexerCount_one": "{{count}} indexer",
+        "indexerCount_other": "{{count}} indexerů"
       }
     },
     "table": {

--- a/web/src/i18n/locales/de/settings.json
+++ b/web/src/i18n/locales/de/settings.json
@@ -833,6 +833,14 @@
         "created": "{{count}} erstellt",
         "updated": "{{count}} aktualisiert",
         "failed": "{{count}} fehlgeschlagen"
+      },
+      "savedConnections": {
+        "title": "Gespeicherte Verbindungen",
+        "description": "Einen bereits importierten Server verwenden. Der API-Key bleibt auf dem Server.",
+        "manual": "Manuell eingeben",
+        "storedKey": "Der gespeicherte API-Key für diesen Server wird verwendet.",
+        "indexerCount_one": "{{count}} Indexer",
+        "indexerCount_other": "{{count}} Indexer"
       }
     },
     "table": {

--- a/web/src/i18n/locales/en/settings.json
+++ b/web/src/i18n/locales/en/settings.json
@@ -833,6 +833,14 @@
         "created": "{{count}} created",
         "updated": "{{count}} updated",
         "failed": "{{count}} failed"
+      },
+      "savedConnections": {
+        "title": "Saved connections",
+        "description": "Use a server you imported from before. The API key stays on the server.",
+        "manual": "Enter manually",
+        "storedKey": "The stored API key for this server is used.",
+        "indexerCount_one": "{{count}} indexer",
+        "indexerCount_other": "{{count}} indexers"
       }
     },
     "table": {

--- a/web/src/i18n/locales/fr/settings.json
+++ b/web/src/i18n/locales/fr/settings.json
@@ -833,6 +833,14 @@
         "created": "{{count}} créés",
         "updated": "{{count}} mis à jour",
         "failed": "{{count}} échoués"
+      },
+      "savedConnections": {
+        "title": "Connexions enregistrées",
+        "description": "Utilisez un serveur déjà importé. La clé API reste sur le serveur.",
+        "manual": "Saisie manuelle",
+        "storedKey": "La clé API enregistrée pour ce serveur est utilisée.",
+        "indexerCount_one": "{{count}} indexeur",
+        "indexerCount_other": "{{count}} indexeurs"
       }
     },
     "table": {

--- a/web/src/i18n/locales/it/settings.json
+++ b/web/src/i18n/locales/it/settings.json
@@ -812,6 +812,14 @@
         "created": "{{count}} creati",
         "updated": "{{count}} aggiornati",
         "failed": "{{count}} non riusciti"
+      },
+      "savedConnections": {
+        "title": "Connessioni salvate",
+        "description": "Usa un server già importato. La chiave API resta sul server.",
+        "manual": "Inserisci manualmente",
+        "storedKey": "Viene usata la chiave API salvata per questo server.",
+        "indexerCount_one": "{{count}} indexer",
+        "indexerCount_other": "{{count}} indexer"
       }
     },
     "table": {

--- a/web/src/i18n/locales/ko/settings.json
+++ b/web/src/i18n/locales/ko/settings.json
@@ -831,6 +831,13 @@
         "created": "{{count}}개 생성됨",
         "updated": "{{count}}개 업데이트됨",
         "failed": "{{count}}개 실패"
+      },
+      "savedConnections": {
+        "title": "저장된 연결",
+        "description": "이전에 가져온 서버를 사용하세요. API 키는 서버에 보관됩니다.",
+        "manual": "직접 입력",
+        "storedKey": "이 서버에 저장된 API 키를 사용합니다.",
+        "indexerCount_other": "인덱서 {{count}}개"
       }
     },
     "table": {

--- a/web/src/i18n/locales/pt-BR/settings.json
+++ b/web/src/i18n/locales/pt-BR/settings.json
@@ -833,6 +833,14 @@
         "created": "{{count}} criados",
         "updated": "{{count}} atualizados",
         "failed": "{{count}} falharam"
+      },
+      "savedConnections": {
+        "title": "Conexões salvas",
+        "description": "Use um servidor já importado. A chave API permanece no servidor.",
+        "manual": "Inserir manualmente",
+        "storedKey": "A chave API salva para este servidor é usada.",
+        "indexerCount_one": "{{count}} indexador",
+        "indexerCount_other": "{{count}} indexadores"
       }
     },
     "table": {

--- a/web/src/i18n/locales/uk/settings.json
+++ b/web/src/i18n/locales/uk/settings.json
@@ -816,6 +816,16 @@
         "created": "{{count}} створено",
         "updated": "{{count}} оновлено",
         "failed": "{{count}} не вдалося"
+      },
+      "savedConnections": {
+        "title": "Збережені підключення",
+        "description": "Використайте сервер, з якого ви вже імпортували. Ключ API залишається на сервері.",
+        "manual": "Ввести вручну",
+        "storedKey": "Використовується збережений ключ API для цього сервера.",
+        "indexerCount_one": "{{count}} індексатор",
+        "indexerCount_few": "{{count}} індексатори",
+        "indexerCount_many": "{{count}} індексаторів",
+        "indexerCount_other": "{{count}} індексатора"
       }
     },
     "table": {

--- a/web/src/i18n/locales/zh-CN/settings.json
+++ b/web/src/i18n/locales/zh-CN/settings.json
@@ -831,6 +831,13 @@
         "created": "{{count}} 个已创建",
         "updated": "{{count}} 个已更新",
         "failed": "{{count}} 个失败"
+      },
+      "savedConnections": {
+        "title": "已保存的连接",
+        "description": "使用您之前导入过的服务器。API 密钥保存在服务器上。",
+        "manual": "手动输入",
+        "storedKey": "将使用该服务器已保存的 API 密钥。",
+        "indexerCount_other": "{{count}} 个索引器"
       }
     },
     "table": {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2249,12 +2249,15 @@ class ApiClient {
     return this.request<SearchHistoryResponse>(`/torznab/search/history${params}`)
   }
 
-  async discoverJackettIndexers(baseUrl: string, apiKey: string, basicUsername?: string, basicPassword?: string): Promise<DiscoverJackettResponse> {
+  async discoverJackettIndexers(baseUrl: string, apiKey: string, basicUsername?: string, basicPassword?: string, sourceIndexerId?: number): Promise<DiscoverJackettResponse> {
     const user = basicUsername?.trim() ?? ""
     const payload: Record<string, unknown> = { base_url: baseUrl, api_key: apiKey }
     if (user) {
       payload.basic_username = user
       payload.basic_password = basicPassword ?? ""
+    }
+    if (sourceIndexerId !== undefined) {
+      payload.source_indexer_id = sourceIndexerId
     }
     return this.request<DiscoverJackettResponse>("/torznab/indexers/discover", {
       method: "POST",

--- a/web/src/lib/discovery-connections.test.ts
+++ b/web/src/lib/discovery-connections.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { describe, expect, it } from "vitest"
+import type { TorznabIndexer } from "@/types"
+import { deriveSavedConnections } from "./discovery-connections"
+
+function indexer(overrides: Partial<TorznabIndexer>): TorznabIndexer {
+  return {
+    id: 1,
+    name: "Indexer",
+    base_url: "http://localhost:9696",
+    indexer_id: "idx",
+    backend: "prowlarr",
+    enabled: true,
+    priority: 0,
+    timeout_seconds: 30,
+    capabilities: [],
+    categories: [],
+    last_test_status: "",
+    created_at: "",
+    updated_at: "",
+    ...overrides,
+  }
+}
+
+describe("deriveSavedConnections", () => {
+  it("groups by base url and backend, keeping the first id seen", () => {
+    const connections = deriveSavedConnections([
+      indexer({ id: 7, base_url: "http://localhost:9696", backend: "prowlarr" }),
+      indexer({ id: 3, base_url: "http://localhost:9696", backend: "prowlarr" }),
+      indexer({ id: 5, base_url: "http://localhost:9117", backend: "jackett" }),
+    ])
+
+    expect(connections).toEqual([
+      { baseUrl: "http://localhost:9117", backend: "jackett", sourceIndexerId: 5, indexerCount: 1 },
+      { baseUrl: "http://localhost:9696", backend: "prowlarr", sourceIndexerId: 7, indexerCount: 2 },
+    ])
+  })
+
+  it("excludes native indexers", () => {
+    expect(deriveSavedConnections([indexer({ backend: "native" })])).toEqual([])
+  })
+})

--- a/web/src/lib/discovery-connections.ts
+++ b/web/src/lib/discovery-connections.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import type { TorznabIndexer } from "@/types"
+
+export interface SavedDiscoveryConnection {
+  baseUrl: string
+  backend: "jackett" | "prowlarr"
+  sourceIndexerId: number
+  indexerCount: number
+}
+
+// Native indexers point at the tracker itself, not a Prowlarr/Jackett server,
+// so they are not reusable discovery connections.
+export function deriveSavedConnections(indexers: TorznabIndexer[]): SavedDiscoveryConnection[] {
+  const groups = new Map<string, SavedDiscoveryConnection>()
+  for (const indexer of indexers) {
+    if (indexer.backend !== "jackett" && indexer.backend !== "prowlarr") continue
+    const key = `${indexer.backend}|${indexer.base_url}`
+    const existing = groups.get(key)
+    if (!existing) {
+      groups.set(key, {
+        baseUrl: indexer.base_url,
+        backend: indexer.backend,
+        sourceIndexerId: indexer.id,
+        indexerCount: 1,
+      })
+    } else {
+      existing.indexerCount++
+    }
+  }
+  return [...groups.values()].sort((a, b) => a.baseUrl.localeCompare(b.baseUrl))
+}

--- a/web/src/types/indexers.ts
+++ b/web/src/types/indexers.ts
@@ -142,6 +142,7 @@ export interface TorznabIndexerFormData {
   base_url: string
   indexer_id?: string
   api_key: string
+  source_indexer_id?: number
   basic_username?: string
   basic_password?: string
   backend?: "jackett" | "prowlarr" | "native"

--- a/web/src/types/indexers.ts
+++ b/web/src/types/indexers.ts
@@ -157,6 +157,7 @@ export interface TorznabIndexerUpdate {
   name?: string
   base_url?: string
   api_key?: string
+  source_indexer_id?: number
   indexer_id?: string
   basic_username?: string
   basic_password?: string


### PR DESCRIPTION
Users had to type the Prowlarr or Jackett URL and API key each time they opened the Discover Indexers dialog to add more indexers. The imported indexer rows already store these values, so the dialog now lists the servers you imported from before and one click reuses them. The manual form stays available behind an "Enter manually" toggle.

No new table: the backend resolves the stored credentials from an existing indexer row (`source_indexer_id` on the discover and create endpoints) and copies the API key and basic auth server-side, so the key never goes to the browser. If you delete all indexers from a server, that saved connection is gone; this is accepted. 

<img width="1004" height="588" alt="CleanShot 2026-08-04 at 15 02 28@2x" src="https://github.com/user-attachments/assets/a2ac8e2f-8981-4f71-be78-65e3fec1163b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Reuse credentials from existing Jackett indexers when discovering or creating new indexers.
  - Select saved indexer connections during autodiscovery, or enter credentials manually.
  - Automatically reuse stored API keys and connection details for matching services.
  - Added localized saved-connection messaging across supported languages.

- **Bug Fixes**
  - Improved validation and error handling for invalid saved connections.
  - Cleared outdated authentication details when the selected connection does not provide them.

- **Tests**
  - Added coverage for credential reuse, saved connection grouping, validation, and discovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->