### PR TITLE
fix(crossseed): recover season structure from files when a search result is applied

### DIFF
--- a/internal/services/crossseed/search_candidate_match_test.go
+++ b/internal/services/crossseed/search_candidate_match_test.go
@@ -25,6 +25,114 @@ import (
 	"github.com/autobrr/qui/pkg/stringutils"
 )
 
+func TestFindCandidatesSearchSourceUsesFileDerivedTVStructure(t *testing.T) {
+	// Bracket-anime pack names carry no season token, so the raw name parses as
+	// non-TV. Search matched these via file-derived TV structure; the apply
+	// prefilter must re-derive the same structure for the search-source torrent
+	// instead of hard-rejecting on "not recognized as TV".
+	const (
+		instanceID = 1
+		sourceHash = "existing"
+	)
+	instance := &models.Instance{ID: instanceID, Name: "main"}
+
+	newService := func(existing qbt.Torrent, files map[string]qbt.TorrentFiles) *Service {
+		return &Service{
+			instanceStore:    &fakeInstanceStore{instances: map[int]*models.Instance{instanceID: instance}},
+			syncManager:      newFakeSyncManager(instance, []qbt.Torrent{existing}, files),
+			releaseCache:     NewReleaseCache(),
+			stringNormalizer: stringutils.NewDefaultNormalizer(),
+		}
+	}
+
+	t.Run("strict class pack matches after derivation", func(t *testing.T) {
+		const (
+			existingName = "[smol] Sakura Trick (BD 1080p HEVC Opus)"
+			targetName   = "Sakura Trick S01 JAPANESE 1080p BluRay Opus 2.0 x265-smol"
+		)
+		existing := qbt.Torrent{Hash: sourceHash, Name: existingName, Size: 28_408_496_978, Progress: 1}
+		files := map[string]qbt.TorrentFiles{
+			sourceHash: {
+				{Name: existingName + "/[smol] Sakura Trick - S01E01 (BD 1080p HEVC Opus) [DF06DEC0].mkv", Size: 2_367_374_748},
+				{Name: existingName + "/[smol] Sakura Trick - S01E02 (BD 1080p HEVC Opus) [DF06DEC1].mkv", Size: 2_367_374_748},
+			},
+		}
+		service := newService(existing, files)
+
+		// Without search provenance the raw-name prefilter stays strict.
+		direct, err := service.FindCandidates(context.Background(), &FindCandidatesRequest{
+			TorrentName:       targetName,
+			TargetInstanceIDs: []int{instanceID},
+		})
+		require.NoError(t, err)
+		require.Empty(t, direct.Candidates)
+
+		response, err := service.FindCandidates(context.Background(), &FindCandidatesRequest{
+			TorrentName:            targetName,
+			TargetInstanceIDs:      []int{instanceID},
+			SearchDecisionClass:    searchCandidateClassStrict,
+			SearchSourceInstanceID: instanceID,
+			SearchSourceHash:       sourceHash,
+		})
+		require.NoError(t, err)
+		require.Len(t, response.Candidates, 1)
+		require.Len(t, response.Candidates[0].Torrents, 1)
+		require.Equal(t, sourceHash, response.Candidates[0].Torrents[0].Hash)
+	})
+
+	t.Run("exact size fallback pack relaxes recorded differences after derivation", func(t *testing.T) {
+		const (
+			existingName = "[McBalls] Neon Genesis Evangelion (BD 1080p Hi10 FLAC)"
+			targetName   = "Neon Genesis Evangelion AKA Shin Seiki Evangelion S01 1080p BluRay Dual-Audio FLAC 5.1 Hi10P x264-McBalls"
+		)
+		existing := qbt.Torrent{Hash: sourceHash, Name: existingName, Size: 113_637_402_129, Progress: 1}
+		files := map[string]qbt.TorrentFiles{
+			sourceHash: {
+				{Name: existingName + "/[McBalls] Neon Genesis Evangelion - S01E01 - Angel Attack (BD 1080p Hi10 FLAC) [E1D6774A].mkv", Size: 4_368_361_620},
+				{Name: existingName + "/[McBalls] Neon Genesis Evangelion - S01E21 - The Birth of NERV [DC] (BD 1080p Hi10 FLAC) [E1D6774B].mkv", Size: 4_368_361_620},
+			},
+		}
+		service := newService(existing, files)
+
+		response, err := service.FindCandidates(context.Background(), &FindCandidatesRequest{
+			TorrentName:                targetName,
+			TargetInstanceIDs:          []int{instanceID},
+			SearchDecisionClass:        searchCandidateClassExactSizeFallback,
+			SearchSourceInstanceID:     instanceID,
+			SearchSourceHash:           sourceHash,
+			SearchStrictMismatchReason: "hdr mismatch",
+			SearchRelaxedDifferences:   []string{"codec", "hdr"},
+		})
+		require.NoError(t, err)
+		require.Len(t, response.Candidates, 1)
+		require.Equal(t, sourceHash, response.Candidates[0].Torrents[0].Hash)
+	})
+
+	t.Run("derivation keeps hard mismatches strict", func(t *testing.T) {
+		const existingName = "[smol] Sakura Trick (BD 1080p HEVC Opus)"
+		existing := qbt.Torrent{Hash: sourceHash, Name: existingName, Size: 28_408_496_978, Progress: 1}
+		files := map[string]qbt.TorrentFiles{
+			sourceHash: {
+				{Name: existingName + "/[smol] Sakura Trick - S01E01 (BD 1080p HEVC Opus) [DF06DEC0].mkv", Size: 2_367_374_748},
+				{Name: existingName + "/[smol] Sakura Trick - S01E02 (BD 1080p HEVC Opus) [DF06DEC1].mkv", Size: 2_367_374_748},
+			},
+		}
+		service := newService(existing, files)
+
+		response, err := service.FindCandidates(context.Background(), &FindCandidatesRequest{
+			TorrentName:                "Different Show S01 JAPANESE 1080p BluRay Opus 2.0 x265-smol",
+			TargetInstanceIDs:          []int{instanceID},
+			SearchDecisionClass:        searchCandidateClassExactSizeFallback,
+			SearchSourceInstanceID:     instanceID,
+			SearchSourceHash:           sourceHash,
+			SearchStrictMismatchReason: "hdr mismatch",
+			SearchRelaxedDifferences:   []string{"codec", "hdr"},
+		})
+		require.NoError(t, err)
+		require.Empty(t, response.Candidates)
+	})
+}
+
 func TestClassifySearchCandidateExactSizeFallback(t *testing.T) {
 	service := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
 	const (

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -4431,23 +4431,50 @@ func (s *Service) findCandidates(ctx context.Context, req *FindCandidatesRequest
 			if !releasesMatch {
 				hashKey := normalizeHash(torrent.Hash)
 				searchSourceHash := normalizeHash(req.SearchSourceHash)
-				isExactSizeSource := req.SearchDecisionClass == searchCandidateClassExactSizeFallback &&
+				isSearchSource := req.SearchDecisionClass != "" &&
+					req.SearchDecisionClass != searchCandidateClassRejected &&
 					req.SearchSourceInstanceID == instanceID &&
 					searchSourceHash != "" && hashKey == searchSourceHash
-				if !isExactSizeSource {
+				if !isSearchSource {
 					continue
 				}
 
-				fallbackInput := searchCandidateInput{
-					SourceRelease:          candidateRelease,
-					CandidateRelease:       targetRelease,
-					SourceName:             torrent.Name,
-					CandidateName:          req.TorrentName,
-					SourceTitles:           req.SearchSourceTitles,
-					FindIndividualEpisodes: req.FindIndividualEpisodes,
+				// Search matched this pairing against a file-derived source release;
+				// bracket-anime pack names parse as non-TV, so the raw-name re-match
+				// hard-fails on TV structure search already resolved. Re-derive the
+				// same structure before judging the search-source pairing.
+				sourceRelease := candidateRelease
+				if !isTVRelease(candidateRelease) {
+					if derived := s.deriveSearchSourceTVRelease(ctx, instanceID, torrent.Hash, torrent.Name, candidateRelease); derived != nil {
+						sourceRelease = derived
+						releasesMatch, mismatchReason = s.releasesMatchWithReasonAndNamesAndTitles(
+							targetRelease,
+							sourceRelease,
+							req.TorrentName,
+							torrent.Name,
+							nil,
+							candidateAliasTitles,
+							req.FindIndividualEpisodes,
+						)
+					}
 				}
-				if ok, _ := s.validateExactSizeFallback(fallbackInput, mismatchReason, req.SearchRelaxedDifferences); !ok {
-					continue
+
+				if !releasesMatch {
+					if req.SearchDecisionClass != searchCandidateClassExactSizeFallback {
+						continue
+					}
+
+					fallbackInput := searchCandidateInput{
+						SourceRelease:          sourceRelease,
+						CandidateRelease:       targetRelease,
+						SourceName:             torrent.Name,
+						CandidateName:          req.TorrentName,
+						SourceTitles:           req.SearchSourceTitles,
+						FindIndividualEpisodes: req.FindIndividualEpisodes,
+					}
+					if ok, _ := s.validateExactSizeFallback(fallbackInput, mismatchReason, req.SearchRelaxedDifferences); !ok {
+						continue
+					}
 				}
 				log.Debug().
 					Str("targetTitle", req.TorrentName).
@@ -4456,7 +4483,7 @@ func (s *Service) findCandidates(ctx context.Context, req *FindCandidatesRequest
 					Str("searchMismatchReason", req.SearchStrictMismatchReason).
 					Str("applyMismatchReason", mismatchReason).
 					Strs("relaxedDifferences", req.SearchRelaxedDifferences).
-					Msg("[CROSSSEED] Search-origin exact-size fallback relaxed release prefilter")
+					Msg("[CROSSSEED] Search-origin decision relaxed release prefilter")
 			}
 
 			hashKey := normalizeHash(torrent.Hash)

--- a/internal/services/crossseed/source_release_inference.go
+++ b/internal/services/crossseed/source_release_inference.go
@@ -4,6 +4,8 @@
 package crossseed
 
 import (
+	"context"
+
 	qbt "github.com/autobrr/go-qbittorrent"
 	"github.com/moistari/rls"
 
@@ -73,6 +75,25 @@ func mergeSeasonPackSearchStructure(sourceRelease, inferredRelease *rls.Release)
 	merged.Series = inferredRelease.Series
 	merged.Episode = 0
 	return &merged
+}
+
+// deriveSearchSourceTVRelease recovers TV structure from a torrent's files the
+// same way search does, for names that parse as non-TV (bracket-anime packs
+// carry season/episode markers only in file names). Returns nil when the files
+// don't establish a TV release, so callers keep the raw parse.
+func (s *Service) deriveSearchSourceTVRelease(ctx context.Context, instanceID int, hash, name string, parsed *rls.Release) *rls.Release {
+	files, err := s.getTorrentFilesCached(ctx, instanceID, hash)
+	if err != nil || len(files) == 0 {
+		return nil
+	}
+
+	contentDetectionRelease, _ := s.selectContentDetectionRelease(name, parsed, files)
+	contentInfo := DetermineContentType(contentDetectionRelease)
+	derived := s.selectSourceReleaseForSearch(parsed, contentDetectionRelease, files, contentInfo)
+	if !isTVRelease(derived) {
+		return nil
+	}
+	return derived
 }
 
 func (s *Service) inferTVSeriesEpisodeFromFiles(torrentRelease *rls.Release, files qbt.TorrentFiles) (series, episode int, isPack, ok bool) {


### PR DESCRIPTION
A user reported 19 anime season packs that the cross-seed search finds but the add step rejects with "No matching torrents found with required files". Pack names such as `[smol] Sakura Trick (BD 1080p HEVC Opus)` carry no season token, so the raw name parses as non-TV. Search compensates for this: it derives the season structure from the episode file names and matches with that. The apply prefilter re-matched raw names only, so every search-approved pairing hard-failed on TV structure before file validation could run. This hit both strict and exact-size search results.

Apply now re-derives the same file-based structure through the search pipeline, but only for the recorded search-source torrent and only when the raw name does not parse as TV. This narrow gate keeps the deliberate apply-side guarantees intact: hard identity mismatches (title, season, group, resolution) stay strict, the exact-size fallback still honors only the relaxations the search recorded, and a blind derivation would flip single-file sources to episode type and break those pins. The regression test uses the exact release names from the field report.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search-source candidate matching for TV and anime content with enhanced file-derived metadata extraction
  * Refined matching logic to better validate TV release structures with more flexible matching criteria

<!-- end of auto-generated comment: release notes by coderabbit.ai -->