### PR TITLE
fix(crossseed): recover season structure from metainfo files when a torrent is applied

### DIFF
--- a/internal/services/crossseed/apply_file_derived_target_test.go
+++ b/internal/services/crossseed/apply_file_derived_target_test.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package crossseed
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/anacrolix/torrent/bencode"
+	"github.com/anacrolix/torrent/metainfo"
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/moistari/rls"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/pkg/stringutils"
+)
+
+// Bracket-anime pack names parse as non-TV; the season structure lives only in
+// the episode file names. Trackers retitle listings but keep the original
+// info.name, so apply always compares the bracket name against an identical
+// local name: the release prefilter passes trivially, then match typing fails
+// because the target parses as a movie while the candidate files parse as
+// episodes. Field report: 19 packs found by search, all rejected on add with
+// "No matching torrents found with required files".
+var bracketAnimePackFiles = []struct {
+	name string
+	size int64
+}{
+	// Episodes must dominate the extras: content-type detection keys off the
+	// largest file, mirroring real packs (multi-GB episodes vs small NC clips).
+	{"Extras/[smol] Sakura Trick - NCED 1 - Kiss (and) Love [BD 1080p HEVC Opus] [8CD26C4D].mkv", 300},
+	{"Extras/[smol] Sakura Trick - NCED 2 - Sakura Sweet Kiss [BD 1080p HEVC Opus] [24D89805].mkv", 280},
+	{"Extras/[smol] Sakura Trick - NCOP - Won Chu KissMe! [BD 1080p HEVC Opus] [4FB63779].mkv", 260},
+	{"[smol] Sakura Trick - S01E01 (BD 1080p HEVC Opus) [66D67F99].mkv", 5001},
+	{"[smol] Sakura Trick - S01E02 (BD 1080p HEVC Opus) [D04DC641].mkv", 5002},
+	{"[smol] Sakura Trick - S01E03 (BD 1080p HEVC Opus) [D8103511].mkv", 5003},
+	{"[smol] Sakura Trick - S01E04 (BD 1080p HEVC Opus) [E9F9AD61].mkv", 5004},
+	{"[smol] Sakura Trick - S01E05 (BD 1080p HEVC Opus) [628D01BC].mkv", 5005},
+	{"[smol] Sakura Trick - S01E06 (BD 1080p HEVC Opus) [B22641EB].mkv", 5006},
+	{"[smol] Sakura Trick - S01E07 (BD 1080p HEVC Opus) [22362963].mkv", 5007},
+	{"[smol] Sakura Trick - S01E08 (BD 1080p HEVC Opus) [DF06DEC0].mkv", 5008},
+	{"[smol] Sakura Trick - S01E09 (BD 1080p HEVC Opus) [E428CB49].mkv", 5009},
+	{"[smol] Sakura Trick - S01E10 (BD 1080p HEVC Opus) [70BC4B46].mkv", 5010},
+	{"[smol] Sakura Trick - S01E11 (BD 1080p HEVC Opus) [67A75E7E].mkv", 5011},
+	{"[smol] Sakura Trick - S01E12 (BD 1080p HEVC Opus) [82720957].mkv", 5012},
+}
+
+const bracketAnimePackName = "[smol] Sakura Trick (BD 1080p HEVC Opus)"
+
+func bracketAnimePackTorrentFiles() qbt.TorrentFiles {
+	files := make(qbt.TorrentFiles, 0, len(bracketAnimePackFiles))
+	for _, f := range bracketAnimePackFiles {
+		files = append(files, qbt.TorrentFile{
+			Name: bracketAnimePackName + "/" + f.name,
+			Size: f.size,
+		})
+	}
+	return files
+}
+
+// createSizedTestTorrent builds torrent bytes whose files carry the exact sizes
+// above, so the metainfo file list and the fake qbit candidate agree byte for
+// byte the way a real cross-seed pairing does.
+func createSizedTestTorrent(t *testing.T, name string) []byte {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	for _, f := range bracketAnimePackFiles {
+		path := filepath.Join(tempDir, name, filepath.FromSlash(f.name))
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, bytes.Repeat([]byte("x"), int(f.size)), 0o600))
+	}
+
+	info := metainfo.Info{Name: name, PieceLength: 16384}
+	require.NoError(t, info.BuildFromFilePath(filepath.Join(tempDir, name)))
+	info.Name = name
+
+	infoBytes, err := bencode.Marshal(info)
+	require.NoError(t, err)
+	mi := metainfo.MetaInfo{InfoBytes: infoBytes}
+
+	var buf bytes.Buffer
+	require.NoError(t, mi.Write(&buf))
+	return buf.Bytes()
+}
+
+func TestDeriveTVReleaseFromFiles(t *testing.T) {
+	service := &Service{
+		releaseCache:     NewReleaseCache(),
+		stringNormalizer: stringutils.NewDefaultNormalizer(),
+	}
+
+	parsed := service.releaseCache.Parse(bracketAnimePackName)
+	require.False(t, isTVRelease(parsed), "bracket-anime pack name should parse as non-TV for this regression to mean anything")
+
+	derived := service.deriveTVReleaseFromFiles(bracketAnimePackName, parsed, bracketAnimePackTorrentFiles())
+	require.NotNil(t, derived)
+	require.Equal(t, rls.Series, derived.Type)
+	require.Equal(t, 1, derived.Series)
+	require.Zero(t, derived.Episode)
+
+	require.Nil(t, service.deriveTVReleaseFromFiles(bracketAnimePackName, parsed, nil))
+}
+
+// applyFakeSyncManager extends fakeSyncManager just far enough for the add
+// stage: matching is the regression under test, the qbit add only has to not
+// error.
+type applyFakeSyncManager struct {
+	*fakeSyncManager
+}
+
+func (f *applyFakeSyncManager) GetTorrentProperties(context.Context, int, string) (*qbt.TorrentProperties, error) {
+	return &qbt.TorrentProperties{SavePath: "/downloads"}, nil
+}
+
+func (f *applyFakeSyncManager) AddTorrent(context.Context, int, []byte, map[string]string) (*qbt.TorrentAddResponse, error) {
+	return nil, nil
+}
+
+func TestCrossSeedDerivesTargetStructureFromMetainfoFiles(t *testing.T) {
+	const (
+		instanceID = 1
+		sourceHash = "c6d7f67e4726bc80b43cad4a471f36a8de32d456"
+	)
+
+	torrentBytes := createSizedTestTorrent(t, bracketAnimePackName)
+
+	instance := &models.Instance{ID: instanceID, Name: "main"}
+	existing := qbt.Torrent{
+		Hash:     sourceHash,
+		Name:     bracketAnimePackName,
+		SavePath: "/downloads",
+		Progress: 1,
+	}
+	service := &Service{
+		instanceStore: &fakeInstanceStore{instances: map[int]*models.Instance{instanceID: instance}},
+		syncManager: &applyFakeSyncManager{newFakeSyncManager(instance, []qbt.Torrent{existing}, map[string]qbt.TorrentFiles{
+			sourceHash: bracketAnimePackTorrentFiles(),
+		})},
+		releaseCache:     NewReleaseCache(),
+		stringNormalizer: stringutils.NewDefaultNormalizer(),
+	}
+
+	resp, err := service.CrossSeed(context.Background(), &CrossSeedRequest{
+		TorrentData:                  base64.StdEncoding.EncodeToString(torrentBytes),
+		TargetInstanceIDs:            []int{instanceID},
+		SkipPieceBoundarySafetyCheck: true,
+		SearchDecisionClass:          searchCandidateClassStrict,
+		SearchSourceInstanceID:       instanceID,
+		SearchSourceHash:             sourceHash,
+	})
+	require.NoError(t, err)
+	require.True(t, resp.Success, "apply rejected the pack: %+v", resp.Results)
+}

--- a/internal/services/crossseed/models.go
+++ b/internal/services/crossseed/models.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/moistari/rls"
 
 	"github.com/autobrr/qui/internal/services/jackett"
 )
@@ -156,6 +157,11 @@ type TorrentFile struct {
 type FindCandidatesRequest struct {
 	// TorrentName is the title/name of the torrent you want to add (just a string, torrent doesn't exist yet)
 	TorrentName string `json:"torrent_name"`
+	// TargetRelease optionally overrides the release parsed from TorrentName.
+	// Apply file-derives TV structure from the incoming torrent's metainfo
+	// (bracket-anime pack names parse as non-TV, structure lives in file names),
+	// so candidate matching sees the same structure search matched with.
+	TargetRelease *rls.Release `json:"-"`
 	// SourceIndexer optionally records where the request originated (e.g., automation feed indexer)
 	SourceIndexer string `json:"source_indexer,omitempty"`
 	// TargetInstanceIDs specifies which instances to search for EXISTING torrents with matching files

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -4278,7 +4278,10 @@ func (s *Service) findCandidates(ctx context.Context, req *FindCandidatesRequest
 	}
 
 	// Parse the title string to understand what we're looking for
-	targetRelease := s.releaseCache.Parse(req.TorrentName)
+	targetRelease := req.TargetRelease
+	if targetRelease == nil {
+		targetRelease = s.releaseCache.Parse(req.TorrentName)
+	}
 
 	// Build basic info for response
 	sourceTorrentInfo := &TorrentInfo{
@@ -4604,11 +4607,23 @@ func (s *Service) CrossSeed(ctx context.Context, req *CrossSeedRequest) (*CrossS
 	}
 	sourceRelease := s.releaseCache.Parse(meta.Name)
 
+	// Trackers retitle listings but keep the original info.name, so apply always
+	// sees the bracket-anime pack name that parses as non-TV even when search
+	// matched a retitled listing. Recover the structure from the metainfo file
+	// list the same way search does, so every downstream consumer (release
+	// prefilter, match typing, plan building) sees a season pack, not a movie.
+	if !isTVRelease(sourceRelease) {
+		if derived := s.deriveTVReleaseFromFiles(meta.Name, sourceRelease, meta.Files); derived != nil {
+			sourceRelease = derived
+		}
+	}
+
 	// Carry private search provenance into candidate discovery. Source identity
 	// and recorded soft differences constrain the release-prefilter relaxation;
 	// existing file and apply safety checks still run normally.
 	findReq := &FindCandidatesRequest{
 		TorrentName:                meta.Name,
+		TargetRelease:              sourceRelease,
 		TargetInstanceIDs:          req.TargetInstanceIDs,
 		FindIndividualEpisodes:     req.FindIndividualEpisodes,
 		SearchDecisionClass:        req.SearchDecisionClass,

--- a/internal/services/crossseed/source_release_inference.go
+++ b/internal/services/crossseed/source_release_inference.go
@@ -83,7 +83,17 @@ func mergeSeasonPackSearchStructure(sourceRelease, inferredRelease *rls.Release)
 // don't establish a TV release, so callers keep the raw parse.
 func (s *Service) deriveSearchSourceTVRelease(ctx context.Context, instanceID int, hash, name string, parsed *rls.Release) *rls.Release {
 	files, err := s.getTorrentFilesCached(ctx, instanceID, hash)
-	if err != nil || len(files) == 0 {
+	if err != nil {
+		return nil
+	}
+	return s.deriveTVReleaseFromFiles(name, parsed, files)
+}
+
+// deriveTVReleaseFromFiles is the file-list core of deriveSearchSourceTVRelease
+// for callers that already hold the files (e.g. apply, which has the incoming
+// torrent's metainfo). Returns nil when the files don't establish a TV release.
+func (s *Service) deriveTVReleaseFromFiles(name string, parsed *rls.Release, files qbt.TorrentFiles) *rls.Release {
+	if len(files) == 0 {
 		return nil
 	}
 


### PR DESCRIPTION
A user reported 19 bracket-anime season packs (for example `[smol] Sakura Trick (BD 1080p HEVC Opus)`) that the cross-seed search finds but every add rejects with "No matching torrents found with required files". The cause sits one stage past #2232: trackers retitle their listings but keep the original `info.name`, so the apply step always parses the bracket name, which reads as a movie with no season. Match typing then requires season structure on the target, finds none, and silently drops every candidate, even the exact same pack. We reproduced this live with an LST listing whose torrent carried the original name.

The fix derives the season structure from the incoming torrent's own metainfo file list at the `CrossSeed` entry point, with the same inference the search side already trusts, so every apply flow (interactive, completion, RSS, autobrr) sees a season pack. Movies keep their guard and cannot get promoted. The regression test reproduces the exact field failure and goes red without the fix.

- [x] Field test: the `pr-2235` image applied the reported Sakura Trick pack live (LST retitled listing, strict exact-size accept, 15/15 files hardlinked, torrent added; the same pairing failed three times on the previous build)