### PR TITLE
fix(indexers): prevent incorrect autodiscovery updates

### DIFF
--- a/web/src/components/indexers/AutodiscoveryDialog.test.tsx
+++ b/web/src/components/indexers/AutodiscoveryDialog.test.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { AutodiscoveryDialog } from "@/components/indexers/AutodiscoveryDialog"
+import { api } from "@/lib/api"
+import type { JackettIndexer, TorznabIndexer } from "@/types"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { expect, it, vi } from "vitest"
+
+vi.mock("@/lib/api")
+vi.mock("@/components/ui/scroll-area", () => ({ ScrollArea: "div" }))
+vi.mock("react-i18next", () => ({ useTranslation: () => ({ t: (key: string) => key }) }))
+
+it("imports only the selected usable row into its matching connection", async () => {
+  vi.mocked(api.discoverJackettIndexers).mockResolvedValue({
+    indexers: [
+      { id: "shared", name: "Target", backend: "prowlarr" },
+      { id: "shared", name: "Other", backend: "prowlarr" },
+      { id: " ", name: "Missing", backend: "prowlarr" },
+    ] as JackettIndexer[],
+  })
+  const existing = [
+    { id: 9, name: "Wrong", base_url: "http://localhost:9696/", backend: "prowlarr", indexer_id: "shared" },
+    { id: 2, name: "Target", base_url: "http://localhost:9696/", backend: "prowlarr", indexer_id: "shared" },
+    { id: 4, name: "Target", base_url: "http://other:9696", backend: "prowlarr", indexer_id: "shared" },
+    { id: 3, name: "Target", base_url: "http://localhost:9696", backend: "jackett", indexer_id: "shared" },
+    { id: 1, name: "Target", base_url: "http://localhost:9696", backend: "prowlarr", indexer_id: "other" },
+  ] as TorznabIndexer[]
+  vi.mocked(api.listTorznabIndexers).mockResolvedValue(existing)
+  vi.mocked(api.updateTorznabIndexer).mockResolvedValue(existing[1])
+
+  render(<AutodiscoveryDialog open onClose={vi.fn()} indexers={[existing[0]]} />)
+  fireEvent.click(screen.getByText("http://localhost:9696/"))
+  fireEvent.click(screen.getByText("indexers.autodiscovery.buttons.discover"))
+
+  const checkboxes = await screen.findAllByRole("checkbox")
+  expect(screen.queryByText("Missing")).toBeNull()
+  expect(checkboxes).toHaveLength(2)
+  fireEvent.click(checkboxes[0])
+  fireEvent.click(screen.getByText("indexers.autodiscovery.buttons.import"))
+
+  await screen.findByText("indexers.autodiscovery.buttons.discover")
+  expect(api.updateTorznabIndexer).toHaveBeenCalledExactlyOnceWith(2, expect.objectContaining({
+    backend: "prowlarr",
+    base_url: "http://localhost:9696",
+    indexer_id: "shared",
+  }))
+  expect(api.createTorznabIndexer).not.toHaveBeenCalled()
+})

--- a/web/src/components/indexers/AutodiscoveryDialog.tsx
+++ b/web/src/components/indexers/AutodiscoveryDialog.tsx
@@ -41,9 +41,8 @@ export function AutodiscoveryDialog({ open, onClose, indexers }: AutodiscoveryDi
   const [showBasicAuth, setShowBasicAuth] = useState(false)
   const [basicUsername, setBasicUsername] = useState("")
   const [basicPassword, setBasicPassword] = useState("")
-  const [discoveredIndexers, setDiscoveredIndexers] = useState<JackettIndexer[]>([])
+  const [discoveredIndexers, setDiscoveredIndexers] = useState<(JackettIndexer & { rowKey: string; existing?: TorznabIndexer })[]>([])
   const [selectedIndexers, setSelectedIndexers] = useState<Set<string>>(new Set())
-  const [existingIndexersMap, setExistingIndexersMap] = useState<Map<string, TorznabIndexer>>(new Map())
   const [selectedSourceId, setSelectedSourceId] = useState<number | null>(null)
   const [manualOpen, setManualOpen] = useState(false)
 
@@ -108,21 +107,30 @@ export function AutodiscoveryDialog({ open, onClose, indexers }: AutodiscoveryDi
         api.listTorznabIndexers(),
       ])
 
-      setDiscoveredIndexers(response.indexers)
+      const discovered = response.indexers.flatMap((indexer, rowIndex) => {
+        const id = indexer.id.trim()
+        if (!id) return []
 
-      // Build map of existing indexers by name with full indexer data
-      const existingMap = new Map<string, TorznabIndexer>()
-      for (const idx of existing) {
-        existingMap.set(idx.name, idx)
-      }
-      setExistingIndexersMap(existingMap)
+        const candidates = existing.filter(candidate =>
+          candidate.backend === (indexer.backend ?? "jackett") &&
+          normalizeBaseUrl(candidate.base_url) === normalizedBaseUrl &&
+          candidate.name === indexer.name
+        )
+        const idMatches = candidates.filter(candidate => candidate.indexer_id === id)
+        let existingIndexer = candidates.length === 1 ? candidates[0] : undefined
+        if (idMatches.length === 1) existingIndexer = idMatches[0]
+
+        return [{ ...indexer, id, rowKey: `discovered-indexer-${rowIndex}`, existing: existingIndexer }]
+      })
+      setDiscoveredIndexers(discovered)
+      setSelectedIndexers(new Set())
 
       setStep("select")
-      const existingCount = response.indexers.filter(idx => existingMap.has(idx.name)).length
+      const existingCount = discovered.filter(indexer => indexer.existing).length
       if (existingCount > 0) {
-        toast.success(t("indexers.autodiscovery.toast.discoveredWithExisting", { total: response.indexers.length, existing: existingCount }))
+        toast.success(t("indexers.autodiscovery.toast.discoveredWithExisting", { total: discovered.length, existing: existingCount }))
       } else {
-        toast.success(t("indexers.autodiscovery.toast.discovered", { count: response.indexers.length }))
+        toast.success(t("indexers.autodiscovery.toast.discovered", { count: discovered.length }))
       }
 
       // Show discovery warnings if any
@@ -175,14 +183,12 @@ export function AutodiscoveryDialog({ open, onClose, indexers }: AutodiscoveryDi
     const warningDetails: string[] = []
 
     for (const indexer of discoveredIndexers) {
-      if (!selectedIndexers.has(indexer.id)) continue
+      if (!selectedIndexers.has(indexer.rowKey)) continue
 
       const backend = indexer.backend ?? "jackett"
-      const indexerId = indexer.id?.trim() ?? ""
-      const normalizedIndexerId = indexerId !== "" ? indexerId : undefined
 
       try {
-        const existing = existingIndexersMap.get(indexer.name)
+        const existing = indexer.existing
         if (existing) {
           // Update existing indexer - keep base URL, API key, and backend aligned
           // Omit enabled to preserve the user's current enabled state
@@ -191,7 +197,7 @@ export function AutodiscoveryDialog({ open, onClose, indexers }: AutodiscoveryDi
             api_key: apiKey, // empty + source copies the saved connection's credentials
             source_indexer_id: selectedSourceId ?? undefined,
             backend,
-            indexer_id: normalizedIndexerId,
+            indexer_id: indexer.id,
             capabilities: indexer.caps, // Include capabilities if discovered
             categories: indexer.categories, // Include categories if discovered
           }
@@ -213,7 +219,7 @@ export function AutodiscoveryDialog({ open, onClose, indexers }: AutodiscoveryDi
             source_indexer_id: selectedSourceId ?? undefined,
             backend,
             enabled: true,
-            indexer_id: normalizedIndexerId,
+            indexer_id: indexer.id,
             capabilities: indexer.caps, // Include capabilities if discovered
             categories: indexer.categories, // Include categories if discovered
           }
@@ -272,7 +278,7 @@ export function AutodiscoveryDialog({ open, onClose, indexers }: AutodiscoveryDi
   }
 
   const handleSelectAll = () => {
-    const allIds = new Set(discoveredIndexers.map(idx => idx.id))
+    const allIds = new Set(discoveredIndexers.map(idx => idx.rowKey))
     setSelectedIndexers(allIds)
   }
 
@@ -488,23 +494,23 @@ export function AutodiscoveryDialog({ open, onClose, indexers }: AutodiscoveryDi
                 ) : (
                   discoveredIndexers.map((indexer) => (
                     <div
-                      key={indexer.id}
+                      key={indexer.rowKey}
                       className="flex items-start space-x-3 rounded-lg border p-3 hover:bg-accent"
                     >
                       <Checkbox
-                        id={indexer.id}
-                        checked={selectedIndexers.has(indexer.id)}
-                        onCheckedChange={() => toggleIndexer(indexer.id)}
+                        id={indexer.rowKey}
+                        checked={selectedIndexers.has(indexer.rowKey)}
+                        onCheckedChange={() => toggleIndexer(indexer.rowKey)}
                       />
                       <div className="flex-1">
                         <div className="flex items-center gap-2">
                           <label
-                            htmlFor={indexer.id}
+                            htmlFor={indexer.rowKey}
                             className="text-sm font-medium leading-none cursor-pointer"
                           >
                             {indexer.name}
                           </label>
-                          {existingIndexersMap.has(indexer.name) && (
+                          {indexer.existing && (
                             <span className="text-xs bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 px-2 py-0.5 rounded">
                               {t("indexers.autodiscovery.willUpdate")}
                             </span>


### PR DESCRIPTION
Indexer names are not unique, and upstream services can return duplicate or blank IDs. The old lookup can update the wrong database row or select multiple results.

Discovery reads the current indexer list and matches the backend, normalized base URL, and name. The upstream ID resolves ambiguous matches without an arbitrary update. A separate row key keeps duplicate results independent, and blank IDs stop before import. Closes #2233.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved indexer autodiscovery matching to more accurately identify existing Torznab indexers.
  * Prevented unusable discovery results from appearing for selection.
  * Updated matching existing indexers instead of creating duplicates when importing discovered entries.
  * Improved handling of connection details and indexer identifiers during import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->