### PR TITLE
fix(logging): make DEBUG the supported diagnostic level

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/issue-triage.yml
+++ b/.github/DISCUSSION_TEMPLATE/issue-triage.yml
@@ -59,7 +59,7 @@ body:
         - **Docker** - `docker logs qui`
         - **Stdout** - If running the binary directly
 
-        Set log level to TRACE for more detail (Settings > Logs > gear icon).
+        Set log level to DEBUG for more detail (Settings > Logs > gear icon).
       render: text
 
   - type: checkboxes

--- a/cmd/qui/main.go
+++ b/cmd/qui/main.go
@@ -753,11 +753,8 @@ func (app *Application) runServer() {
 
 				// Trigger connection by trying to get client
 				// This will populate the pool for GetClientOffline calls
-				_, err := clientPool.GetClient(connCtx, instanceID)
-				if err != nil {
+				if _, err := clientPool.GetClient(connCtx, instanceID); err != nil {
 					log.Debug().Err(err).Int("instanceID", instanceID).Msg("Failed to connect to instance on startup")
-				} else {
-					log.Debug().Int("instanceID", instanceID).Msg("Successfully connected to instance on startup")
 				}
 			}(instance.ID)
 		}

--- a/documentation/docs/configuration/environment.md
+++ b/documentation/docs/configuration/environment.md
@@ -41,7 +41,7 @@ QUI__LOG_MAX_SIZE=50     # Optional: rotate when log file exceeds N megabytes (d
 QUI__LOG_MAX_BACKUPS=10  # Optional: retain N rotated files (default: 10, 0 keeps all)
 ```
 
-When `logPath` is set the server writes to disk using size-based rotation. Adjust `logMaxSize` and `logMaxBackups` in `config.toml` or the corresponding environment variables to control the rotation thresholds and retention. Rotated files are gzipped, so each one uses about 1/20th of `logMaxSize`.
+When `logPath` is set the server writes to disk using size-based rotation. Adjust `logMaxSize` and `logMaxBackups` in `config.toml` or the corresponding environment variables to control the rotation thresholds and retention. Rotated files are gzipped, so each one is much smaller than `logMaxSize`. The compressed size depends on the log content.
 
 Rotation and retention apply only when `logPath` is set. If you run qui in Docker with the default stdout logging, set `QUI__LOG_PATH`, or set a `max-size` option on the container log driver, to stop the container log from growing without limit.
 

--- a/documentation/docs/configuration/environment.md
+++ b/documentation/docs/configuration/environment.md
@@ -41,7 +41,7 @@ QUI__LOG_MAX_SIZE=50     # Optional: rotate when log file exceeds N megabytes (d
 QUI__LOG_MAX_BACKUPS=10  # Optional: retain N rotated files (default: 10, 0 keeps all)
 ```
 
-When `logPath` is set the server writes to disk using size-based rotation. Adjust `logMaxSize` and `logMaxBackups` in `config.toml` or the corresponding environment variables to control the rotation thresholds and retention. Rotated files are gzipped, so each one is much smaller than `logMaxSize`. The compressed size depends on the log content.
+When `logPath` is set the server writes to disk using size-based rotation. Adjust `logMaxSize` and `logMaxBackups` in `config.toml` or the corresponding environment variables to control the rotation thresholds and retention. Rotated files are gzip-compressed, so their size depends on the log content.
 
 Rotation and retention apply only when `logPath` is set. If you run qui in Docker with the default stdout logging, set `QUI__LOG_PATH`, or set a `max-size` option on the container log driver, to stop the container log from growing without limit.
 

--- a/documentation/docs/configuration/environment.md
+++ b/documentation/docs/configuration/environment.md
@@ -38,10 +38,12 @@ QUI__SESSION_SECRET=...       # Auto-generated if not set
 QUI__LOG_LEVEL=DEBUG     # Options: ERROR, DEBUG, INFO, WARN, TRACE (default: DEBUG)
 QUI__LOG_PATH=...        # Optional: log file path
 QUI__LOG_MAX_SIZE=50     # Optional: rotate when log file exceeds N megabytes (default: 50)
-QUI__LOG_MAX_BACKUPS=3   # Optional: retain N rotated files (default: 3, 0 keeps all)
+QUI__LOG_MAX_BACKUPS=10  # Optional: retain N rotated files (default: 10, 0 keeps all)
 ```
 
-When `logPath` is set the server writes to disk using size-based rotation. Adjust `logMaxSize` and `logMaxBackups` in `config.toml` or the corresponding environment variables to control the rotation thresholds and retention.
+When `logPath` is set the server writes to disk using size-based rotation. Adjust `logMaxSize` and `logMaxBackups` in `config.toml` or the corresponding environment variables to control the rotation thresholds and retention. Rotated files are gzipped, so each one uses about 1/20th of `logMaxSize`.
+
+Rotation and retention apply only when `logPath` is set. If you run qui in Docker with the default stdout logging, set `QUI__LOG_PATH`, or set a `max-size` option on the container log driver, to stop the container log from growing without limit.
 
 ## Storage
 

--- a/documentation/docs/configuration/environment.md
+++ b/documentation/docs/configuration/environment.md
@@ -37,13 +37,13 @@ QUI__SESSION_SECRET=...       # Auto-generated if not set
 ```bash
 QUI__LOG_LEVEL=DEBUG     # Options: ERROR, DEBUG, INFO, WARN, TRACE (default: DEBUG)
 QUI__LOG_PATH=...        # Optional: log file path
-QUI__LOG_MAX_SIZE=50     # Optional: rotate when log file exceeds N megabytes (default: 50)
+QUI__LOG_MAX_SIZE=50     # Optional: rotate when the log file is larger than N MB (default: 50)
 QUI__LOG_MAX_BACKUPS=10  # Optional: retain N rotated files (default: 10, 0 keeps all)
 ```
 
-When `logPath` is set the server writes to disk using size-based rotation. Adjust `logMaxSize` and `logMaxBackups` in `config.toml` or the corresponding environment variables to control the rotation thresholds and retention. Rotated files are gzip-compressed. Measured on qui's own logs, a 50 MB rotation stores as 2 to 3 MB, so ten backups cost about 25 MB. Your ratio depends on what your log holds.
+When `logPath` is set, the server writes to disk with size-based rotation. Adjust `logMaxSize` and `logMaxBackups` in `config.toml`, or set the equivalent environment variables. Rotated files are gzip-compressed. Measured on the logs of qui, a 50 MB file compresses to 2 to 3 MB, thus ten backups use about 25 MB. The ratio depends on the content of your log.
 
-Rotation and retention apply only when `logPath` is set. If you run qui in Docker with the default stdout logging, set `QUI__LOG_PATH`, or set a `max-size` option on the container log driver, to stop the container log from growing without limit.
+Rotation and retention apply only when `logPath` is set. If you run qui in Docker, it writes the logs to stdout by default. Rotation does not apply to these logs. To limit the size of the container log, set `QUI__LOG_PATH`. As an alternative, set the `max-size` option on the container log driver.
 
 ## Storage
 

--- a/documentation/docs/configuration/environment.md
+++ b/documentation/docs/configuration/environment.md
@@ -41,7 +41,7 @@ QUI__LOG_MAX_SIZE=50     # Optional: rotate when log file exceeds N megabytes (d
 QUI__LOG_MAX_BACKUPS=10  # Optional: retain N rotated files (default: 10, 0 keeps all)
 ```
 
-When `logPath` is set the server writes to disk using size-based rotation. Adjust `logMaxSize` and `logMaxBackups` in `config.toml` or the corresponding environment variables to control the rotation thresholds and retention. Rotated files are gzip-compressed, so their size depends on the log content.
+When `logPath` is set the server writes to disk using size-based rotation. Adjust `logMaxSize` and `logMaxBackups` in `config.toml` or the corresponding environment variables to control the rotation thresholds and retention. Rotated files are gzip-compressed. Measured on qui's own logs, a 50 MB rotation stores as 2 to 3 MB, so ten backups cost about 25 MB. Your ratio depends on what your log holds.
 
 Rotation and retention apply only when `logPath` is set. If you run qui in Docker with the default stdout logging, set `QUI__LOG_PATH`, or set a `max-size` option on the container log driver, to stop the container log from growing without limit.
 

--- a/documentation/docs/configuration/environment.md
+++ b/documentation/docs/configuration/environment.md
@@ -35,7 +35,7 @@ QUI__SESSION_SECRET=...       # Auto-generated if not set
 ## Logging
 
 ```bash
-QUI__LOG_LEVEL=INFO      # Options: ERROR, DEBUG, INFO, WARN, TRACE
+QUI__LOG_LEVEL=DEBUG     # Options: ERROR, DEBUG, INFO, WARN, TRACE (default: DEBUG)
 QUI__LOG_PATH=...        # Optional: log file path
 QUI__LOG_MAX_SIZE=50     # Optional: rotate when log file exceeds N megabytes (default: 50)
 QUI__LOG_MAX_BACKUPS=3   # Optional: retain N rotated files (default: 3, 0 keeps all)

--- a/documentation/docs/configuration/reference.md
+++ b/documentation/docs/configuration/reference.md
@@ -49,7 +49,7 @@ qui watches `config.toml` for changes. Some settings are applied immediately (fo
 | `logLevel` | `QUI__LOG_LEVEL` | string | `DEBUG` | `ERROR`, `DEBUG`, `INFO`, `WARN`, `TRACE`. Applied immediately. `DEBUG` records enough to diagnose most reports. `TRACE` adds per-request and per-sync-tick detail and grows the file quickly. |
 | `logPath` | `QUI__LOG_PATH` | string | empty | If empty: logs to stdout. Relative paths resolve relative to the config directory. Applied immediately. |
 | `logMaxSize` | `QUI__LOG_MAX_SIZE` | int | `50` | MiB threshold before rotation. Applied immediately. |
-| `logMaxBackups` | `QUI__LOG_MAX_BACKUPS` | int | `10` | Rotated files retained. Rotated files are gzipped, so each uses about 1/20th of `logMaxSize`. `0` keeps all. Applied immediately. |
+| `logMaxBackups` | `QUI__LOG_MAX_BACKUPS` | int | `10` | Rotated files retained. Rotated files are gzipped, so each is much smaller than `logMaxSize` by an amount that depends on the log content. `0` keeps all. Applied immediately. |
 | `dataDir` | `QUI__DATA_DIR` | string | empty | If empty: uses the directory containing `config.toml`. Always used for non-database assets (logs, tracker icon cache, etc.). When `databaseEngine=sqlite`, `qui.db` also lives here. Restart recommended. |
 | `customThemesDir` | `QUI__CUSTOM_THEMES_DIR` | string | empty | Directory for sideloaded [custom theme](../features/custom-themes.md) `.css` files. If empty: `<config-dir>/themes` (auto-created). Relative paths resolve against the config directory. Listing requires premium access. Config changes applied on next request. |
 | `databaseEngine` | `QUI__DATABASE_ENGINE` | string | `sqlite` | `sqlite` or `postgres`. Existing installs should keep `sqlite` unless you migrate. Restart required. |

--- a/documentation/docs/configuration/reference.md
+++ b/documentation/docs/configuration/reference.md
@@ -49,7 +49,7 @@ qui watches `config.toml` for changes. Some settings are applied immediately (fo
 | `logLevel` | `QUI__LOG_LEVEL` | string | `DEBUG` | `ERROR`, `DEBUG`, `INFO`, `WARN`, `TRACE`. Applied immediately. `DEBUG` records enough to diagnose most reports. `TRACE` adds per-request and per-sync-tick detail and grows the file quickly. |
 | `logPath` | `QUI__LOG_PATH` | string | empty | If empty: logs to stdout. Relative paths resolve relative to the config directory. Applied immediately. |
 | `logMaxSize` | `QUI__LOG_MAX_SIZE` | int | `50` | MiB threshold before rotation. Applied immediately. |
-| `logMaxBackups` | `QUI__LOG_MAX_BACKUPS` | int | `10` | Rotated files retained. Rotated files are gzipped, so each is much smaller than `logMaxSize` by an amount that depends on the log content. `0` keeps all. Applied immediately. |
+| `logMaxBackups` | `QUI__LOG_MAX_BACKUPS` | int | `10` | Rotated files retained. Rotated files are gzip-compressed, so their size depends on the log content. `0` keeps all. Applied immediately. |
 | `dataDir` | `QUI__DATA_DIR` | string | empty | If empty: uses the directory containing `config.toml`. Always used for non-database assets (logs, tracker icon cache, etc.). When `databaseEngine=sqlite`, `qui.db` also lives here. Restart recommended. |
 | `customThemesDir` | `QUI__CUSTOM_THEMES_DIR` | string | empty | Directory for sideloaded [custom theme](../features/custom-themes.md) `.css` files. If empty: `<config-dir>/themes` (auto-created). Relative paths resolve against the config directory. Listing requires premium access. Config changes applied on next request. |
 | `databaseEngine` | `QUI__DATABASE_ENGINE` | string | `sqlite` | `sqlite` or `postgres`. Existing installs should keep `sqlite` unless you migrate. Restart required. |

--- a/documentation/docs/configuration/reference.md
+++ b/documentation/docs/configuration/reference.md
@@ -49,7 +49,7 @@ qui watches `config.toml` for changes. Some settings are applied immediately (fo
 | `logLevel` | `QUI__LOG_LEVEL` | string | `DEBUG` | `ERROR`, `DEBUG`, `INFO`, `WARN`, `TRACE`. Applied immediately. `DEBUG` records enough to diagnose most reports. `TRACE` adds per-request and per-sync-tick detail and grows the file quickly. |
 | `logPath` | `QUI__LOG_PATH` | string | empty | If empty: logs to stdout. Relative paths resolve relative to the config directory. Applied immediately. |
 | `logMaxSize` | `QUI__LOG_MAX_SIZE` | int | `50` | MiB threshold before rotation. Applied immediately. |
-| `logMaxBackups` | `QUI__LOG_MAX_BACKUPS` | int | `10` | Rotated files retained. Rotated files are gzip-compressed, so their size depends on the log content. `0` keeps all. Applied immediately. |
+| `logMaxBackups` | `QUI__LOG_MAX_BACKUPS` | int | `10` | Rotated files retained. Rotated files are gzip-compressed: measured on qui's own logs, a 50 MB rotation stores as 2 to 3 MB. `0` keeps all. Applied immediately. |
 | `dataDir` | `QUI__DATA_DIR` | string | empty | If empty: uses the directory containing `config.toml`. Always used for non-database assets (logs, tracker icon cache, etc.). When `databaseEngine=sqlite`, `qui.db` also lives here. Restart recommended. |
 | `customThemesDir` | `QUI__CUSTOM_THEMES_DIR` | string | empty | Directory for sideloaded [custom theme](../features/custom-themes.md) `.css` files. If empty: `<config-dir>/themes` (auto-created). Relative paths resolve against the config directory. Listing requires premium access. Config changes applied on next request. |
 | `databaseEngine` | `QUI__DATABASE_ENGINE` | string | `sqlite` | `sqlite` or `postgres`. Existing installs should keep `sqlite` unless you migrate. Restart required. |

--- a/documentation/docs/configuration/reference.md
+++ b/documentation/docs/configuration/reference.md
@@ -46,10 +46,10 @@ qui watches `config.toml` for changes. Some settings are applied immediately (fo
 | `baseUrl` | `QUI__BASE_URL` | string | `/` | Serve qui from a subdirectory (example: `/qui/`). |
 | `corsAllowedOrigins` | `QUI__CORS_ALLOWED_ORIGINS` | string[] | empty list | Explicit CORS allowlist. Empty disables CORS. Origins must be `http(s)://host[:port]`; wildcards are rejected; default ports are normalized. Restart required. |
 | `sessionSecret` | `QUI__SESSION_SECRET` / `QUI__SESSION_SECRET_FILE` | string | auto-generated | WARNING: changing breaks decryption of stored instance passwords; you must re-enter them in the UI. |
-| `logLevel` | `QUI__LOG_LEVEL` | string | `INFO` | `ERROR`, `DEBUG`, `INFO`, `WARN`, `TRACE`. Applied immediately. |
+| `logLevel` | `QUI__LOG_LEVEL` | string | `DEBUG` | `ERROR`, `DEBUG`, `INFO`, `WARN`, `TRACE`. Applied immediately. `DEBUG` records enough to diagnose most reports. `TRACE` adds per-request and per-sync-tick detail and grows the file quickly. |
 | `logPath` | `QUI__LOG_PATH` | string | empty | If empty: logs to stdout. Relative paths resolve relative to the config directory. Applied immediately. |
 | `logMaxSize` | `QUI__LOG_MAX_SIZE` | int | `50` | MiB threshold before rotation. Applied immediately. |
-| `logMaxBackups` | `QUI__LOG_MAX_BACKUPS` | int | `3` | Rotated files retained. `0` keeps all. Applied immediately. |
+| `logMaxBackups` | `QUI__LOG_MAX_BACKUPS` | int | `10` | Rotated files retained. Rotated files are gzipped, so each uses about 1/20th of `logMaxSize`. `0` keeps all. Applied immediately. |
 | `dataDir` | `QUI__DATA_DIR` | string | empty | If empty: uses the directory containing `config.toml`. Always used for non-database assets (logs, tracker icon cache, etc.). When `databaseEngine=sqlite`, `qui.db` also lives here. Restart recommended. |
 | `customThemesDir` | `QUI__CUSTOM_THEMES_DIR` | string | empty | Directory for sideloaded [custom theme](../features/custom-themes.md) `.css` files. If empty: `<config-dir>/themes` (auto-created). Relative paths resolve against the config directory. Listing requires premium access. Config changes applied on next request. |
 | `databaseEngine` | `QUI__DATABASE_ENGINE` | string | `sqlite` | `sqlite` or `postgres`. Existing installs should keep `sqlite` unless you migrate. Restart required. |
@@ -147,10 +147,10 @@ host = "0.0.0.0"
 port = 7476
 baseUrl = "/qui/"
 
-logLevel = "INFO"
+logLevel = "DEBUG"
 logPath = "log/qui.log"
 logMaxSize = 50
-logMaxBackups = 3
+logMaxBackups = 10
 
 trackerIconsFetchEnabled = false
 

--- a/documentation/docs/configuration/reference.md
+++ b/documentation/docs/configuration/reference.md
@@ -46,10 +46,10 @@ qui watches `config.toml` for changes. Some settings are applied immediately (fo
 | `baseUrl` | `QUI__BASE_URL` | string | `/` | Serve qui from a subdirectory (example: `/qui/`). |
 | `corsAllowedOrigins` | `QUI__CORS_ALLOWED_ORIGINS` | string[] | empty list | Explicit CORS allowlist. Empty disables CORS. Origins must be `http(s)://host[:port]`; wildcards are rejected; default ports are normalized. Restart required. |
 | `sessionSecret` | `QUI__SESSION_SECRET` / `QUI__SESSION_SECRET_FILE` | string | auto-generated | WARNING: changing breaks decryption of stored instance passwords; you must re-enter them in the UI. |
-| `logLevel` | `QUI__LOG_LEVEL` | string | `DEBUG` | `ERROR`, `DEBUG`, `INFO`, `WARN`, `TRACE`. Applied immediately. `DEBUG` records enough to diagnose most reports. `TRACE` adds per-request and per-sync-tick detail and grows the file quickly. |
+| `logLevel` | `QUI__LOG_LEVEL` | string | `DEBUG` | `ERROR`, `DEBUG`, `INFO`, `WARN`, `TRACE`. Applied immediately. `DEBUG` records sufficient detail to diagnose most reports. `TRACE` adds per-request and per-sync-tick detail and makes the file grow quickly. |
 | `logPath` | `QUI__LOG_PATH` | string | empty | If empty: logs to stdout. Relative paths resolve relative to the config directory. Applied immediately. |
-| `logMaxSize` | `QUI__LOG_MAX_SIZE` | int | `50` | MiB threshold before rotation. Applied immediately. |
-| `logMaxBackups` | `QUI__LOG_MAX_BACKUPS` | int | `10` | Rotated files retained. Rotated files are gzip-compressed: measured on qui's own logs, a 50 MB rotation stores as 2 to 3 MB. `0` keeps all. Applied immediately. |
+| `logMaxSize` | `QUI__LOG_MAX_SIZE` | int | `50` | Size in MB that starts a rotation. Applied immediately. |
+| `logMaxBackups` | `QUI__LOG_MAX_BACKUPS` | int | `10` | Number of rotated files that qui keeps. `0` keeps all. Rotated files are gzip-compressed. Measured on the logs of qui, a 50 MB file compresses to 2 to 3 MB. Applied immediately. |
 | `dataDir` | `QUI__DATA_DIR` | string | empty | If empty: uses the directory containing `config.toml`. Always used for non-database assets (logs, tracker icon cache, etc.). When `databaseEngine=sqlite`, `qui.db` also lives here. Restart recommended. |
 | `customThemesDir` | `QUI__CUSTOM_THEMES_DIR` | string | empty | Directory for sideloaded [custom theme](../features/custom-themes.md) `.css` files. If empty: `<config-dir>/themes` (auto-created). Relative paths resolve against the config directory. Listing requires premium access. Config changes applied on next request. |
 | `databaseEngine` | `QUI__DATABASE_ENGINE` | string | `sqlite` | `sqlite` or `postgres`. Existing installs should keep `sqlite` unless you migrate. Restart required. |

--- a/documentation/docs/features/cross-seed/season-packs.md
+++ b/documentation/docs/features/cross-seed/season-packs.md
@@ -325,4 +325,4 @@ Look for messages containing the torrent name and these clues:
 - `torrent added paused; recheck queued` - qui added the pack and queued automatic resume
 - `Recheck completed below threshold, torrent left paused for manual review` - the recheck reported less than the bytes that qui linked, so some links are bad
 
-Field-level matching details are logged at `DEBUG`, which is the default level. If you upgraded from an older version, open `config.toml` and set `logLevel` to `DEBUG` if it holds another value. Look for `[CROSSSEED-MATCH] Release filtered` entries to see which release field caused an episode to be rejected.
+Field-level matching details are logged at `DEBUG`, which is the default level. If you upgraded from an older version, open `config.toml`. If `logLevel` holds another value, set it to `DEBUG`. Then look for `[CROSSSEED-MATCH] Release filtered` entries. Each entry names the release field that did not match.

--- a/documentation/docs/features/cross-seed/season-packs.md
+++ b/documentation/docs/features/cross-seed/season-packs.md
@@ -325,4 +325,4 @@ Look for messages containing the torrent name and these clues:
 - `torrent added paused; recheck queued` - qui added the pack and queued automatic resume
 - `Recheck completed below threshold, torrent left paused for manual review` - the recheck reported less than the bytes that qui linked, so some links are bad
 
-Use `TRACE` when you need field-level matching details. Then look for `[CROSSSEED-MATCH] Release filtered` entries to see which release field caused an episode to be rejected.
+Field-level matching details are logged at `DEBUG`, which is the default level. Look for `[CROSSSEED-MATCH] Release filtered` entries to see which release field caused an episode to be rejected.

--- a/documentation/docs/features/cross-seed/season-packs.md
+++ b/documentation/docs/features/cross-seed/season-packs.md
@@ -325,4 +325,4 @@ Look for messages containing the torrent name and these clues:
 - `torrent added paused; recheck queued` - qui added the pack and queued automatic resume
 - `Recheck completed below threshold, torrent left paused for manual review` - the recheck reported less than the bytes that qui linked, so some links are bad
 
-Field-level matching details are logged at `DEBUG`, which is the default level. Look for `[CROSSSEED-MATCH] Release filtered` entries to see which release field caused an episode to be rejected.
+Field-level matching details are logged at `DEBUG`, which is the default level. If you upgraded from an older version, open `config.toml` and set `logLevel` to `DEBUG` if it holds another value. Look for `[CROSSSEED-MATCH] Release filtered` entries to see which release field caused an episode to be rejected.

--- a/documentation/docs/features/cross-seed/troubleshooting.md
+++ b/documentation/docs/features/cross-seed/troubleshooting.md
@@ -86,7 +86,9 @@ Rejection reasons are logged at debug, which is the default level:
 logLevel = 'DEBUG'
 ```
 
-For **season-pack** checks, look for `[CROSSSEED-MATCH] Release filtered` entries. Each carries the `pack`, `season`, and `candidate` it compared plus a `reason` field naming the mismatch (e.g. `title mismatch`, `group mismatch`, `resolution mismatch`, `hdr mismatch`, `source mismatch`, `episode not in pack`, or `episode numbering mismatch`). For regular cross-seed search, look for `[CROSSSEED-SEARCH] Candidate rejected by search classifier`, which names each rejected candidate and the reason it failed; `[CROSSSEED-SEARCH] Release filtering rejection summary` additionally reports per-reason counts.
+If you upgraded from an older version, open `config.toml` and set `logLevel` to `DEBUG` if it holds another value.
+
+For **season-pack** checks, look for `[CROSSSEED-MATCH] Release filtered` entries. Each carries the `pack`, `season`, and `candidate` it compared plus a `reason` field naming the mismatch (e.g. `title mismatch`, `group mismatch`, `resolution mismatch`, `hdr mismatch`, `source mismatch`, `episode not in pack`, or `episode numbering mismatch`). Two reasons mean the candidate belongs to something else: `title mismatch` is a different show, and `episode not in pack` is an episode this pack does not contain. Together they are most of your library, so they show only at `TRACE`. All other reasons show at `DEBUG`. For regular cross-seed search, look for `[CROSSSEED-SEARCH] Candidate rejected by search classifier`, which names each rejected candidate and the reason it failed; `[CROSSSEED-SEARCH] Release filtering rejection summary` additionally reports per-reason counts.
 
 For content-prefilter decisions, `DEBUG` is enough. Look for messages such as:
 

--- a/documentation/docs/features/cross-seed/troubleshooting.md
+++ b/documentation/docs/features/cross-seed/troubleshooting.md
@@ -40,7 +40,7 @@ Library scan and completion search rows use **added**, **skipped**, or **failed*
 | `below_threshold` | Skipped | The matched local files cover less than 95% of the release in hardlink or reflink mode. qui skips the match before it adds the torrent. | See [release matching](#release-didnt-match) and [Hardlink Mode](./hardlink-mode.md). This limit is fixed and is not a setting. |
 | `requires_hardlink_reflink` | Skipped | The torrent layout would scatter rootless or extra files in regular reuse mode. | Enable [Hardlink Mode](./hardlink-mode.md) or [Reflink Mode](./hardlink-mode.md#reflink-mode-alternative), or download the torrent normally. |
 | `size_mismatch` | Failed | A search result already exists by infohash, but the earlier content prefilter rejected it because the torrent file list did not match the source sizes. | Compare the torrent files on the trackers. This protects you from treating different content as a valid cross-seed. See [release matching](#release-didnt-match). |
-| `content_mismatch` | Failed | A search result already exists by infohash, but the earlier content prefilter rejected it for a non-size file-level reason. | Review the row message and enable trace logging if needed. See [How do I see why a release was filtered?](#how-do-i-see-why-a-release-was-filtered). |
+| `content_mismatch` | Failed | A search result already exists by infohash, but the earlier content prefilter rejected it for a non-size file-level reason. | Review the row message. See [How do I see why a release was filtered?](#how-do-i-see-why-a-release-was-filtered). |
 | `hardlink_error` | Failed | Hardlink mode was enabled but qui could not create or use the hardlink tree. | See [Hardlink mode failed](#hardlink-mode-failed) and [Hardlink Mode requirements](./hardlink-mode.md#requirements). |
 | `reflink_error` | Failed | Reflink mode was enabled but qui could not create or use the reflink tree. | See [Reflink mode failed](#reflink-mode-failed) and [Reflink Requirements](./hardlink-mode.md#reflink-requirements). |
 | `no_save_path` | Failed | qui could not find a valid target save path for the cross-seed. The matched torrent has no usable SavePath and the category does not provide an explicit SavePath. | Verify the matched torrent's save path and category save path in qBittorrent, then review [category behavior](./rules.md#category-behavior-details). |
@@ -80,13 +80,13 @@ See [Season Packs](./season-packs.md) for the full flow, setup requirements, and
 
 ## How do I see why a release was filtered?
 
-Enable trace logging to see detailed rejection reasons:
+Rejection reasons are logged at debug, which is the default level:
 
 ```toml
-loglevel = 'TRACE'
+logLevel = 'DEBUG'
 ```
 
-For **season-pack** checks, look for `[CROSSSEED-MATCH] Release filtered` entries. Each carries the `pack`, `season`, and `candidate` it compared plus a `reason` field naming the mismatch (e.g. `title mismatch`, `group mismatch`, `resolution mismatch`, `hdr mismatch`, `source mismatch`, `episode not in pack`, or `episode numbering mismatch`). For regular cross-seed search, look for `[CROSSSEED-SEARCH] Candidate rejected by search classifier` (at `TRACE`), which names each rejected candidate and the reason it failed; `[CROSSSEED-SEARCH] Release filtering rejection summary` (at `DEBUG`) additionally reports per-reason counts.
+For **season-pack** checks, look for `[CROSSSEED-MATCH] Release filtered` entries. Each carries the `pack`, `season`, and `candidate` it compared plus a `reason` field naming the mismatch (e.g. `title mismatch`, `group mismatch`, `resolution mismatch`, `hdr mismatch`, `source mismatch`, `episode not in pack`, or `episode numbering mismatch`). For regular cross-seed search, look for `[CROSSSEED-SEARCH] Candidate rejected by search classifier`, which names each rejected candidate and the reason it failed; `[CROSSSEED-SEARCH] Release filtering rejection summary` additionally reports per-reason counts.
 
 For content-prefilter decisions, `DEBUG` is enough. Look for messages such as:
 

--- a/documentation/docs/features/cross-seed/troubleshooting.md
+++ b/documentation/docs/features/cross-seed/troubleshooting.md
@@ -80,15 +80,19 @@ See [Season Packs](./season-packs.md) for the full flow, setup requirements, and
 
 ## How do I see why a release was filtered?
 
-Rejection reasons are logged at debug, which is the default level:
+Rejection reasons are logged at `DEBUG`, which is the default level:
 
 ```toml
 logLevel = 'DEBUG'
 ```
 
-If you upgraded from an older version, open `config.toml` and set `logLevel` to `DEBUG` if it holds another value.
+If you upgraded from an older version, open `config.toml`. If `logLevel` holds another value, set it to `DEBUG`.
 
-For **season-pack** checks, look for `[CROSSSEED-MATCH] Release filtered` entries. Each carries the `pack`, `season`, and `candidate` it compared plus a `reason` field naming the mismatch (e.g. `title mismatch`, `group mismatch`, `resolution mismatch`, `hdr mismatch`, `source mismatch`, `episode not in pack`, or `episode numbering mismatch`). Two reasons mean the candidate belongs to something else: `title mismatch` is a different show, and `episode not in pack` is an episode this pack does not contain. Together they are most of your library, so they show only at `TRACE`. All other reasons show at `DEBUG`. For regular cross-seed search, look for `[CROSSSEED-SEARCH] Candidate rejected by search classifier`, which names each rejected candidate and the reason it failed; `[CROSSSEED-SEARCH] Release filtering rejection summary` additionally reports per-reason counts.
+For **season-pack** checks, look for `[CROSSSEED-MATCH] Release filtered` entries. Each entry carries the `pack`, `season`, and `candidate` that qui compared. Each entry also has a `reason` field for the mismatch (for example `title mismatch`, `group mismatch`, `resolution mismatch`, `hdr mismatch`, `source mismatch`, `episode not in pack`, or `episode numbering mismatch`).
+
+Two of these reasons show that the candidate belongs to different content. `title mismatch` means a different show. `episode not in pack` means an episode that this pack does not contain. These two reasons apply to most of a library, thus qui logs them at `TRACE`. All other reasons appear at `DEBUG`.
+
+For regular cross-seed search, look for `[CROSSSEED-SEARCH] Candidate rejected by search classifier`. Each entry names the rejected candidate and the reason it failed. The entry `[CROSSSEED-SEARCH] Release filtering rejection summary` reports the count for each reason.
 
 For content-prefilter decisions, `DEBUG` is enough. Look for messages such as:
 

--- a/documentation/docs/features/cross-seed/troubleshooting.md
+++ b/documentation/docs/features/cross-seed/troubleshooting.md
@@ -92,7 +92,7 @@ For **season-pack** checks, look for `[CROSSSEED-MATCH] Release filtered` entrie
 
 Two of these reasons show that the candidate belongs to different content. `title mismatch` means a different show. `episode not in pack` means an episode that this pack does not contain. These two reasons apply to most of a library, thus qui logs them at `TRACE`. All other reasons appear at `DEBUG`.
 
-For regular cross-seed search, look for `[CROSSSEED-SEARCH] Candidate rejected by search classifier`. Each entry names the rejected candidate and the reason it failed. The entry `[CROSSSEED-SEARCH] Release filtering rejection summary` reports the count for each reason.
+For regular cross-seed search, look for `[CROSSSEED-SEARCH] Candidate rejected`. Each entry names the indexer, the rejected candidate, the two sizes, and the reason. The entry `[CROSSSEED-SEARCH] Release filtering rejection summary` reports the count for each reason. `TRACE` adds `[CROSSSEED-SEARCH] Candidate rejected by search classifier`, which shows the parsed fields of both releases.
 
 For content-prefilter decisions, `DEBUG` is enough. Look for messages such as:
 

--- a/internal/api/handlers/logs.go
+++ b/internal/api/handlers/logs.go
@@ -65,6 +65,9 @@ func isQuiLogFile(name, base string) bool {
 	}
 	ext := filepath.Ext(base)
 	prefix := strings.TrimSuffix(base, ext) + "-"
+	// Only a rotation carries lumberjack's ".gz": the live file returned above is
+	// never compressed, so trimming here cannot widen what the live name matches.
+	name = strings.TrimSuffix(name, ".gz")
 	if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, ext) {
 		return false
 	}
@@ -151,7 +154,12 @@ func (h *LogsHandler) DownloadLogFile(w http.ResponseWriter, r *http.Request) {
 		disposition = fmt.Sprintf("attachment; filename=%q", filename)
 	}
 
-	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	contentType := "text/plain; charset=utf-8"
+	if strings.HasSuffix(filename, ".gz") {
+		contentType = "application/gzip"
+	}
+
+	w.Header().Set("Content-Type", contentType)
 	w.Header().Set("Content-Disposition", disposition)
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("Cache-Control", "no-store")

--- a/internal/api/handlers/logs_test.go
+++ b/internal/api/handlers/logs_test.go
@@ -193,6 +193,30 @@ func TestLogsHandler_StreamLogs_WritesToHub(t *testing.T) {
 	}
 }
 
+func TestIsQuiLogFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		want     bool
+	}{
+		{"live file", "qui.log", true},
+		{"rotated", "qui-2026-01-01T00-00-00.000.log", true},
+		{"rotated compressed", "qui-2026-01-01T00-00-00.000.log.gz", true},
+		{"live file compressed", "qui.log.gz", false},
+		{"bogus timestamp compressed", "qui-notatimestamp.log.gz", false},
+		{"foreign compressed log", "other-service.log.gz", false},
+		{"double gzip", "qui-2026-01-01T00-00-00.000.log.gz.gz", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isQuiLogFile(tt.filename, "qui.log"); got != tt.want {
+				t.Errorf("isQuiLogFile(%q) = %v, want %v", tt.filename, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestLogsHandler_ListLogFiles_NoLogPath(t *testing.T) {
 	handler := NewLogsHandler(createTestConfig(t))
 

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -31,15 +31,12 @@ func IsAuthenticated(authService *auth.Service, sessionManager *scs.SessionManag
 			apiKey := r.Header.Get("X-API-Key")
 			if apiKey != "" {
 				// Validate API key
-				apiKeyModel, err := authService.ValidateAPIKey(r.Context(), apiKey)
-				if err != nil {
+				if _, err := authService.ValidateAPIKey(r.Context(), apiKey); err != nil {
 					log.Warn().Err(err).Msg("Invalid API key")
 					http.Error(w, "Unauthorized", http.StatusUnauthorized)
 					return
 				}
 
-				// Set API key info in context (optional, for logging)
-				log.Debug().Int("apiKeyID", apiKeyModel.ID).Str("name", apiKeyModel.Name).Msg("API key authenticated")
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/internal/api/middleware/logger.go
+++ b/internal/api/middleware/logger.go
@@ -36,8 +36,7 @@ func Logger(logger zerolog.Logger) func(next http.Handler) http.Handler {
 					http.Error(ww, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 				}
 
-				// log end request. Guarded so the redaction and header lookups below
-				// are skipped entirely when trace logging is off.
+				// Guarded so the redaction and header lookups are skipped when off.
 				if e := l.Trace(); e.Enabled() {
 					e.Str("type", "access").
 						Str("remote_ip", r.RemoteAddr).

--- a/internal/api/middleware/logger.go
+++ b/internal/api/middleware/logger.go
@@ -14,6 +14,8 @@ import (
 	"github.com/autobrr/qui/pkg/redact"
 )
 
+var slowRequestThreshold = time.Second
+
 // Logger logs HTTP requests using a local zerolog logger
 func Logger(logger zerolog.Logger) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
@@ -36,8 +38,17 @@ func Logger(logger zerolog.Logger) func(next http.Handler) http.Handler {
 					http.Error(ww, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 				}
 
+				// Server errors and slow requests carry the evidence a report
+				// needs, so they surface at the default level. Healthy traffic
+				// stays at TRACE.
+				latency := t2.Sub(t1)
+				level := zerolog.TraceLevel
+				if ww.Status() >= http.StatusInternalServerError || latency > slowRequestThreshold {
+					level = zerolog.DebugLevel
+				}
+
 				// Guarded so the redaction and header lookups are skipped when off.
-				if e := l.Trace(); e.Enabled() {
+				if e := l.WithLevel(level); e.Enabled() {
 					e.Str("type", "access").
 						Str("remote_ip", r.RemoteAddr).
 						Str("url", redact.ProxyPath(r.URL.EscapedPath())).
@@ -45,7 +56,7 @@ func Logger(logger zerolog.Logger) func(next http.Handler) http.Handler {
 						Str("method", r.Method).
 						Str("user_agent", r.Header.Get("User-Agent")).
 						Int("status", ww.Status()).
-						Float64("latency_ms", float64(t2.Sub(t1).Nanoseconds())/1000000.0).
+						Float64("latency_ms", float64(latency.Nanoseconds())/1000000.0).
 						Str("bytes_in", r.Header.Get("Content-Length")).
 						Int("bytes_out", ww.BytesWritten()).
 						Msg("incoming_request")

--- a/internal/api/middleware/logger.go
+++ b/internal/api/middleware/logger.go
@@ -30,29 +30,27 @@ func Logger(logger zerolog.Logger) func(next http.Handler) http.Handler {
 				if rec := recover(); rec != nil {
 					l.Error().
 						Str("type", "error").
-						Timestamp().
 						Interface("recover_info", rec).
 						Bytes("debug_stack", debug.Stack()).
 						Msg("log system error")
 					http.Error(ww, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 				}
 
-				// log end request
-				l.Trace().
-					Str("type", "access").
-					Timestamp().
-					Fields(map[string]any{
-						"remote_ip":  r.RemoteAddr,
-						"url":        redact.ProxyPath(r.URL.EscapedPath()),
-						"proto":      r.Proto,
-						"method":     r.Method,
-						"user_agent": r.Header.Get("User-Agent"),
-						"status":     ww.Status(),
-						"latency_ms": float64(t2.Sub(t1).Nanoseconds()) / 1000000.0,
-						"bytes_in":   r.Header.Get("Content-Length"),
-						"bytes_out":  ww.BytesWritten(),
-					}).
-					Msg("incoming_request")
+				// log end request. Guarded so the redaction and header lookups below
+				// are skipped entirely when trace logging is off.
+				if e := l.Trace(); e.Enabled() {
+					e.Str("type", "access").
+						Str("remote_ip", r.RemoteAddr).
+						Str("url", redact.ProxyPath(r.URL.EscapedPath())).
+						Str("proto", r.Proto).
+						Str("method", r.Method).
+						Str("user_agent", r.Header.Get("User-Agent")).
+						Int("status", ww.Status()).
+						Float64("latency_ms", float64(t2.Sub(t1).Nanoseconds())/1000000.0).
+						Str("bytes_in", r.Header.Get("Content-Length")).
+						Int("bytes_out", ww.BytesWritten()).
+						Msg("incoming_request")
+				}
 			}()
 
 			next.ServeHTTP(ww, r)

--- a/internal/api/middleware/logger_test.go
+++ b/internal/api/middleware/logger_test.go
@@ -5,13 +5,37 @@ package middleware
 
 import (
 	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
+
+// The production logger already carries a timestamp in its context, so the
+// middleware must not add its own. A second Timestamp() call emits a duplicate
+// "time" key, which strict JSON consumers reject.
+func TestLoggerEmitsSingleTimestamp(t *testing.T) {
+	var buf bytes.Buffer
+	logger := zerolog.New(&buf).With().Timestamp().Logger().Level(zerolog.TraceLevel)
+	handler := Logger(logger)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/instances", nil)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	logLine := strings.TrimSpace(buf.String())
+	require.Equal(t, 1, strings.Count(logLine, `"time":`), "duplicate time key in %s", logLine)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal([]byte(logLine), &decoded))
+	require.Equal(t, "incoming_request", decoded["message"])
+	require.NotEmpty(t, decoded["time"])
+}
 
 func TestLoggerLogsPathOnly(t *testing.T) {
 	const secretAPIKey = "SECRET-API-KEY"

--- a/internal/api/middleware/logger_test.go
+++ b/internal/api/middleware/logger_test.go
@@ -15,9 +15,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// The production logger already carries a timestamp in its context, so the
-// middleware must not add its own. A second Timestamp() call emits a duplicate
-// "time" key, which strict JSON consumers reject.
+// The production logger already carries a timestamp in its context, so a
+// Timestamp() call here emits a duplicate "time" key.
 func TestLoggerEmitsSingleTimestamp(t *testing.T) {
 	var buf bytes.Buffer
 	logger := zerolog.New(&buf).With().Timestamp().Logger().Level(zerolog.TraceLevel)
@@ -31,10 +30,13 @@ func TestLoggerEmitsSingleTimestamp(t *testing.T) {
 	logLine := strings.TrimSpace(buf.String())
 	require.Equal(t, 1, strings.Count(logLine, `"time":`), "duplicate time key in %s", logLine)
 
-	var decoded map[string]any
+	var decoded struct {
+		Message string `json:"message"`
+		Time    string `json:"time"`
+	}
 	require.NoError(t, json.Unmarshal([]byte(logLine), &decoded))
-	require.Equal(t, "incoming_request", decoded["message"])
-	require.NotEmpty(t, decoded["time"])
+	require.Equal(t, "incoming_request", decoded.Message)
+	require.NotEmpty(t, decoded.Time)
 }
 
 func TestLoggerLogsPathOnly(t *testing.T) {

--- a/internal/api/middleware/logger_test.go
+++ b/internal/api/middleware/logger_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
@@ -37,6 +38,48 @@ func TestLoggerEmitsSingleTimestamp(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(logLine), &decoded))
 	require.Equal(t, "incoming_request", decoded.Message)
 	require.NotEmpty(t, decoded.Time)
+}
+
+// A DEBUG-level logger stays silent for healthy traffic.
+func TestLoggerLevelBySeverity(t *testing.T) {
+	tests := []struct {
+		name      string
+		status    int
+		delay     time.Duration
+		threshold time.Duration
+		wantLine  bool
+	}{
+		{name: "fast success stays at trace", status: http.StatusOK, threshold: time.Second},
+		{name: "server error surfaces", status: http.StatusInternalServerError, threshold: time.Second, wantLine: true},
+		{name: "client error stays at trace", status: http.StatusUnauthorized, threshold: time.Second},
+		{name: "slow request surfaces", status: http.StatusOK, delay: 5 * time.Millisecond, threshold: time.Millisecond, wantLine: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := slowRequestThreshold
+			slowRequestThreshold = tt.threshold
+			t.Cleanup(func() { slowRequestThreshold = original })
+
+			var buf bytes.Buffer
+			logger := zerolog.New(&buf).Level(zerolog.DebugLevel)
+			handler := Logger(logger)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				time.Sleep(tt.delay)
+				w.WriteHeader(tt.status)
+			}))
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/instances", nil)
+			handler.ServeHTTP(httptest.NewRecorder(), req)
+
+			logLine := strings.TrimSpace(buf.String())
+			if !tt.wantLine {
+				require.Empty(t, logLine)
+				return
+			}
+			require.Contains(t, logLine, `"level":"debug"`)
+			require.Contains(t, logLine, `"message":"incoming_request"`)
+		})
+	}
 }
 
 func TestLoggerLogsPathOnly(t *testing.T) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -689,9 +689,7 @@ func (s *Server) Handler() (*chi.Mux, error) {
 	})
 
 	// Proxy routes (outside of /api and not requiring authentication).
-	// The access logger gives proxy traffic the same status and latency record
-	// that API traffic has. It is trace level, so per-request proxy detail at
-	// debug still comes from the handler lines.
+	// Wrapped so proxy traffic gets the same status and latency record as /api.
 	proxyHandler.Routes(r.With(middleware.Logger(s.logger)))
 
 	swaggerHandler, err := swagger.NewHandler(s.config.Config.BaseURL)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -688,8 +688,11 @@ func (s *Server) Handler() (*chi.Mux, error) {
 		})
 	})
 
-	// Proxy routes (outside of /api and not requiring authentication)
-	proxyHandler.Routes(r)
+	// Proxy routes (outside of /api and not requiring authentication).
+	// The access logger gives proxy traffic the same status and latency record
+	// that API traffic has. It is trace level, so per-request proxy detail at
+	// debug still comes from the handler lines.
+	proxyHandler.Routes(r.With(middleware.Logger(s.logger)))
 
 	swaggerHandler, err := swagger.NewHandler(s.config.Config.BaseURL)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -495,7 +495,7 @@ sessionSecret = "{{ .sessionSecret }}"
 #logMaxSize = {{ .logMaxSize }}
 
 # Number of rotated log files to retain (0 keeps all)
-# Rotated files are gzip-compressed, so their size depends on the log content.
+# Rotated files are gzip-compressed. A 50 MB rotation stores as about 2 to 3 MB.
 # Default: {{ .logMaxBackups }}
 #logMaxBackups = {{ .logMaxBackups }}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -103,10 +103,10 @@ func (c *AppConfig) defaults() {
 	c.viper.SetDefault("baseUrl", "/")
 	c.viper.SetDefault("corsAllowedOrigins", []string{})
 	c.viper.SetDefault("sessionSecret", sessionSecret)
-	c.viper.SetDefault("logLevel", "INFO")
+	c.viper.SetDefault("logLevel", "DEBUG")
 	c.viper.SetDefault("logPath", "")
 	c.viper.SetDefault("logMaxSize", 50)
-	c.viper.SetDefault("logMaxBackups", 3)
+	c.viper.SetDefault("logMaxBackups", 10)
 	c.viper.SetDefault("dataDir", "") // Empty means auto-detect (next to config file)
 	c.viper.SetDefault("databaseEngine", "sqlite")
 	c.viper.SetDefault("databaseDsn", "")
@@ -495,6 +495,7 @@ sessionSecret = "{{ .sessionSecret }}"
 #logMaxSize = {{ .logMaxSize }}
 
 # Number of rotated log files to retain (0 keeps all)
+# Rotated files are gzipped, so each one uses about 1/20th of logMaxSize.
 # Default: {{ .logMaxBackups }}
 #logMaxBackups = {{ .logMaxBackups }}
 
@@ -542,8 +543,10 @@ sessionSecret = "{{ .sessionSecret }}"
 #crossSeedRecoverErroredTorrents = false
 
 # Log level
-# Default: "INFO"
+# Default: "DEBUG"
 # Options: "ERROR", "DEBUG", "INFO", "WARN", "TRACE"
+# DEBUG records enough detail to diagnose most reports without a restart.
+# TRACE adds per-request and per-sync-tick detail and grows the file quickly.
 logLevel = "{{ .logLevel }}"
 
 # Prometheus Metrics

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -495,7 +495,7 @@ sessionSecret = "{{ .sessionSecret }}"
 #logMaxSize = {{ .logMaxSize }}
 
 # Number of rotated log files to retain (0 keeps all)
-# Rotated files are gzipped, so each one uses about 1/20th of logMaxSize.
+# Rotated files are gzipped, so each one is much smaller than logMaxSize.
 # Default: {{ .logMaxBackups }}
 #logMaxBackups = {{ .logMaxBackups }}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -495,7 +495,7 @@ sessionSecret = "{{ .sessionSecret }}"
 #logMaxSize = {{ .logMaxSize }}
 
 # Number of rotated log files to retain (0 keeps all)
-# Rotated files are gzipped, so each one is much smaller than logMaxSize.
+# Rotated files are gzip-compressed, so their size depends on the log content.
 # Default: {{ .logMaxBackups }}
 #logMaxBackups = {{ .logMaxBackups }}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -547,7 +547,7 @@ sessionSecret = "{{ .sessionSecret }}"
 # Options: "ERROR", "DEBUG", "INFO", "WARN", "TRACE"
 # DEBUG records enough detail to diagnose most reports without a restart.
 # TRACE adds per-request and per-sync-tick detail and grows the file quickly.
-logLevel = "{{ .logLevel }}"
+#logLevel = "{{ .logLevel }}"
 
 # Prometheus Metrics
 # Enable Prometheus metrics on separate port (no authentication required)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -490,12 +490,13 @@ sessionSecret = "{{ .sessionSecret }}"
 #logPath = "log/qui.log"
 
 # Log rotation
-# Maximum log file size in megabytes before rotation
+# Size in MB that starts a rotation
 # Default: {{ .logMaxSize }}
 #logMaxSize = {{ .logMaxSize }}
 
-# Number of rotated log files to retain (0 keeps all)
-# Rotated files are gzip-compressed. A 50 MB rotation stores as about 2 to 3 MB.
+# Number of rotated log files that qui keeps (0 keeps all)
+# Rotated files are gzip-compressed. Measured on the logs of qui, a 50 MB file
+# compresses to 2 to 3 MB.
 # Default: {{ .logMaxBackups }}
 #logMaxBackups = {{ .logMaxBackups }}
 
@@ -545,8 +546,8 @@ sessionSecret = "{{ .sessionSecret }}"
 # Log level
 # Default: "DEBUG"
 # Options: "ERROR", "DEBUG", "INFO", "WARN", "TRACE"
-# DEBUG records enough detail to diagnose most reports without a restart.
-# TRACE adds per-request and per-sync-tick detail and grows the file quickly.
+# DEBUG records sufficient detail to diagnose most reports.
+# TRACE adds per-request and per-sync-tick detail and makes the file grow quickly.
 #logLevel = "{{ .logLevel }}"
 
 # Prometheus Metrics

--- a/internal/config/generate_test.go
+++ b/internal/config/generate_test.go
@@ -4,12 +4,40 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
+
+// A commented log key falls back to the built-in default, so a changed default
+// reaches installs that never edited the line.
+func TestWriteDefaultConfigCommentsOutLogKeys(t *testing.T) {
+	c := &AppConfig{viper: viper.New()}
+	c.defaults()
+
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := c.writeDefaultConfig(path); err != nil {
+		t.Fatalf("writeDefaultConfig: %v", err)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+
+	for line := range strings.SplitSeq(string(content), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		assert.Empty(t, canonicalLogKey(extractKey(trimmed)), "log key must stay commented: %s", line)
+	}
+}
 
 func TestGetDefaultConfigDirRespectsXDGConfigHome(t *testing.T) {
 	tmpDir := t.TempDir()

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -110,10 +110,7 @@ func (lm *LogManager) buildWriter(baseWriter io.Writer, logPath string, maxSize,
 		Filename:   logPath,
 		MaxSize:    maxSize,
 		MaxBackups: maxBackups,
-		// Rotated backups gzip to roughly 1/20th of their size, so retention
-		// costs disk in proportion to the compressed set, not the raw set.
-		// The live file stays plain text for tail and grep.
-		Compress: true,
+		Compress:   true,
 	}
 	return io.MultiWriter(baseWriter, rotator), rotator, nil
 }

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -110,6 +110,10 @@ func (lm *LogManager) buildWriter(baseWriter io.Writer, logPath string, maxSize,
 		Filename:   logPath,
 		MaxSize:    maxSize,
 		MaxBackups: maxBackups,
+		// Rotated backups gzip to roughly 1/20th of their size, so retention
+		// costs disk in proportion to the compressed set, not the raw set.
+		// The live file stays plain text for tail and grep.
+		Compress: true,
 	}
 	return io.MultiWriter(baseWriter, rotator), rotator, nil
 }

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -142,7 +142,6 @@ func NewHandler(clientPool *qbittorrent.ClientPool, clientAPIKeyStore *models.Cl
 
 // ServeHTTP handles the reverse proxy request (fallback for non-intercepted routes)
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	log.Debug().Msg("Forwarding to qBittorrent via reverse proxy")
 	h.proxy.ServeHTTP(w, r)
 }
 

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -170,7 +170,7 @@ func (h *Handler) rewriteRequest(pr *httputil.ProxyRequest) {
 	originalPath := pr.In.URL.Path
 	strippedPath := h.stripProxyPrefix(originalPath, apiKey)
 
-	log.Debug().
+	log.Trace().
 		Str("client", clientAPIKey.ClientName).
 		Int("instanceId", instanceID).
 		Str("strippedPath", redact.ProxyPath(strippedPath)).
@@ -300,7 +300,7 @@ func (h *Handler) handleSyncMainData(w http.ResponseWriter, r *http.Request) {
 	instanceID := GetInstanceIDFromContext(ctx)
 	clientAPIKey := GetClientAPIKeyFromContext(ctx)
 
-	log.Debug().
+	log.Trace().
 		Int("instanceId", instanceID).
 		Str("client", clientAPIKey.ClientName).
 		Msg("Proxying sync/maindata request")
@@ -339,7 +339,7 @@ func (h *Handler) handleSyncMainData(w http.ResponseWriter, r *http.Request) {
 
 		if isFullUpdate {
 			h.syncManager.HintMainDataRefresh(instanceID, "proxy_sync_maindata")
-			log.Debug().
+			log.Trace().
 				Int("instanceId", instanceID).
 				Int64("rid", mainData.Rid).
 				Int("torrentCount", len(mainData.Torrents)).
@@ -348,7 +348,7 @@ func (h *Handler) handleSyncMainData(w http.ResponseWriter, r *http.Request) {
 				Int("tagCount", len(mainData.Tags)).
 				Msg("Queued maindata refresh hint from full sync/maindata response")
 		} else {
-			log.Debug().
+			log.Trace().
 				Int("instanceId", instanceID).
 				Int64("rid", mainData.Rid).
 				Msg("Skipping incremental sync/maindata update")
@@ -1218,7 +1218,7 @@ func (h *Handler) handleTorrentsInfo(w http.ResponseWriter, r *http.Request) {
 		order = "desc"
 	}
 
-	log.Debug().
+	log.Trace().
 		Int("instanceId", instanceID).
 		Str("client", clientAPIKey.ClientName).
 		Strs("filter", filterValues).
@@ -1327,7 +1327,7 @@ func (h *Handler) handleTorrentSearch(w http.ResponseWriter, r *http.Request) {
 		limit = 100000 // Large limit to get all results
 	}
 
-	log.Debug().
+	log.Trace().
 		Int("instanceId", instanceID).
 		Str("client", clientAPIKey.ClientName).
 		Str("search", search).
@@ -1382,7 +1382,7 @@ func (h *Handler) handleCategories(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Debug().
+	log.Trace().
 		Int("instanceId", instanceID).
 		Str("client", clientAPIKey.ClientName).
 		Msg("Handling categories request via qui sync manager")
@@ -1420,7 +1420,7 @@ func (h *Handler) handleTags(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Debug().
+	log.Trace().
 		Int("instanceId", instanceID).
 		Str("client", clientAPIKey.ClientName).
 		Msg("Handling tags request via qui sync manager")
@@ -1462,7 +1462,7 @@ func (h *Handler) handleTorrentProperties(w http.ResponseWriter, r *http.Request
 
 	hash := r.URL.Query().Get("hash")
 
-	log.Debug().
+	log.Trace().
 		Int("instanceId", instanceID).
 		Str("client", clientAPIKey.ClientName).
 		Str("hash", hash).
@@ -1506,7 +1506,7 @@ func (h *Handler) handleTorrentTrackers(w http.ResponseWriter, r *http.Request) 
 
 	hash := r.URL.Query().Get("hash")
 
-	log.Debug().
+	log.Trace().
 		Int("instanceId", instanceID).
 		Str("client", clientAPIKey.ClientName).
 		Str("hash", hash).
@@ -1543,7 +1543,7 @@ func (h *Handler) handleTorrentPeers(w http.ResponseWriter, r *http.Request) {
 
 	hash := r.URL.Query().Get("hash")
 
-	log.Debug().
+	log.Trace().
 		Int("instanceId", instanceID).
 		Str("client", clientAPIKey.ClientName).
 		Str("hash", hash).
@@ -1594,14 +1594,14 @@ func (h *Handler) handleTorrentPeers(w http.ResponseWriter, r *http.Request) {
 			// Update peer state using the same pattern as maindata
 			client.UpdateWithPeersData(hash, &peersData)
 
-			log.Debug().
+			log.Trace().
 				Int("instanceId", instanceID).
 				Str("hash", hash).
 				Int64("rid", peersData.Rid).
 				Int("peerCount", len(peersData.Peers)).
 				Msg("Updated local peer state from full sync/torrentPeers response")
 		} else {
-			log.Debug().
+			log.Trace().
 				Int("instanceId", instanceID).
 				Str("hash", hash).
 				Int64("rid", peersData.Rid).
@@ -1626,7 +1626,7 @@ func (h *Handler) handleTorrentFiles(w http.ResponseWriter, r *http.Request) {
 
 	hash := r.URL.Query().Get("hash")
 
-	log.Debug().
+	log.Trace().
 		Int("instanceId", instanceID).
 		Str("client", clientAPIKey.ClientName).
 		Str("hash", hash).
@@ -1699,7 +1699,7 @@ func (h *Handler) handleTorrentMediaInfo(w http.ResponseWriter, r *http.Request)
 		clientName = clientAPIKey.ClientName
 	}
 
-	log.Debug().
+	log.Trace().
 		Int("instanceId", instanceID).
 		Str("client", clientName).
 		Str("contentPath", contentPath).
@@ -1739,7 +1739,7 @@ func (h *Handler) handleAuthLogin(w http.ResponseWriter, r *http.Request) {
 	instanceID := GetInstanceIDFromContext(ctx)
 	clientAPIKey := GetClientAPIKeyFromContext(ctx)
 
-	log.Debug().
+	log.Trace().
 		Int("instanceId", instanceID).
 		Str("client", clientAPIKey.ClientName).
 		Msg("Handling ceremonial auth/login request")
@@ -1778,7 +1778,7 @@ func (h *Handler) handleAuthLogin(w http.ResponseWriter, r *http.Request) {
 
 	http.SetCookie(w, cookie)
 
-	log.Debug().
+	log.Trace().
 		Str("client", clientAPIKey.ClientName).
 		Int("instanceId", instanceID).
 		Str("cookieName", cookie.Name).

--- a/internal/proxy/middleware.go
+++ b/internal/proxy/middleware.go
@@ -103,15 +103,8 @@ func cleanupStaleDebouncers() {
 func ClientAPIKeyMiddleware(store *models.ClientAPIKeyStore) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			log.Debug().
-				Str("method", r.Method).
-				Msg("ClientAPIKeyMiddleware called")
-
 			// Extract API key from URL path parameter
 			apiKey := chi.URLParam(r, "api-key")
-			log.Debug().
-				Bool("hasKey", apiKey != "").
-				Msg("Checking API key from URL parameter")
 
 			if apiKey == "" {
 				log.Warn().
@@ -147,12 +140,6 @@ func ClientAPIKeyMiddleware(store *models.ClientAPIKeyStore) func(http.Handler) 
 					}
 				})
 			}
-
-			log.Debug().
-				Str("client", clientAPIKey.ClientName).
-				Int("instanceId", clientAPIKey.InstanceID).
-				Str("method", r.Method).
-				Msg("Client API key validated successfully")
 
 			// Add client API key and instance ID to request context
 			ctx = context.WithValue(ctx, ClientAPIKeyContextKey, clientAPIKey)

--- a/internal/qbittorrent/filter_types.go
+++ b/internal/qbittorrent/filter_types.go
@@ -16,3 +16,18 @@ type FilterOptions struct {
 	ExcludeTrackers   []string `json:"excludeTrackers"`
 	Expr              string   `json:"expr"`
 }
+
+// IsEmpty reports whether no filter is set. Used to keep an all-null filter
+// block out of hot-path log lines.
+func (f FilterOptions) IsEmpty() bool {
+	return len(f.Hashes) == 0 &&
+		len(f.Status) == 0 &&
+		len(f.ExcludeStatus) == 0 &&
+		len(f.Categories) == 0 &&
+		len(f.ExcludeCategories) == 0 &&
+		len(f.Tags) == 0 &&
+		len(f.ExcludeTags) == 0 &&
+		len(f.Trackers) == 0 &&
+		len(f.ExcludeTrackers) == 0 &&
+		f.Expr == ""
+}

--- a/internal/qbittorrent/filter_types.go
+++ b/internal/qbittorrent/filter_types.go
@@ -17,8 +17,7 @@ type FilterOptions struct {
 	Expr              string   `json:"expr"`
 }
 
-// IsEmpty reports whether no filter is set. Used to keep an all-null filter
-// block out of hot-path log lines.
+// IsEmpty reports whether no filter is set.
 func (f FilterOptions) IsEmpty() bool {
 	return len(f.Hashes) == 0 &&
 		len(f.Status) == 0 &&

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -644,11 +644,6 @@ func (sm *SyncManager) refreshTrackerHealthCounts(ctx context.Context, instanceI
 		}
 		sm.trackerHealthMu.Unlock()
 		sm.setValidatedTrackerMappingWithMetrics(instanceID, newValidatedTrackerMapping(), 0, started, "empty")
-		log.Debug().
-			Int("instanceID", instanceID).
-			Int("torrentCount", 0).
-			Dur("elapsed", time.Since(started)).
-			Msg("Refreshed empty tracker health counts")
 		sm.notifyTrackerHealthUpdated(instanceID)
 		return
 	}
@@ -965,11 +960,6 @@ func (sm *SyncManager) seedValidatedTrackerMappingFromMainData(instanceID int, t
 // authoritative mapping or driving counts and filters.
 func (sm *SyncManager) seedFallbackTrackerMappingFromMainData(instanceID int, torrents []qbt.Torrent, mainData *qbt.MainData, started time.Time) {
 	if sm.hasAuthoritativeTrackerMapping(instanceID) {
-		log.Debug().
-			Int("instanceID", instanceID).
-			Int("torrentCount", len(torrents)).
-			Dur("elapsed", time.Since(started)).
-			Msg("Preserved authoritative tracker mapping instead of storing fallback seed")
 		return
 	}
 	sm.seedTrackerMappingFromMainData(instanceID, torrents, mainData, started, true)
@@ -1589,11 +1579,6 @@ func (sm *SyncManager) GetTorrentsWithFilters(ctx context.Context, instanceID in
 		filteredTorrents = sm.filterTorrentsBySearch(filteredTorrents, search)
 	}
 
-	log.Trace().
-		Int("instanceID", instanceID).
-		Int("filtered", len(filteredTorrents)).
-		Msg("Applied search filtering")
-
 	if sort == "name" {
 		sm.sortTorrentsByNameCaseInsensitive(filteredTorrents, order == "desc")
 	}
@@ -1653,20 +1638,22 @@ func (sm *SyncManager) GetTorrentsWithFilters(ctx context.Context, instanceID in
 	// Check if there are more pages (only meaningful when limit > 0)
 	hasMore := limit > 0 && end < totalTorrents
 
-	// Calculate counts from ALL torrents (not filtered) for sidebar
-	// This uses the same cached data, so it's very fast
-	var allTorrents []qbt.Torrent
-	if useManualFiltering {
-		allTorrents = allTorrentsForCounts
-	} else {
-		allTorrents = getTorrents(qbt.TorrentFilterOptions{})
-	}
-
 	var enrichedAll []qbt.Torrent
 
 	if !includeCachedCounts {
 		counts = nil
 	} else {
+		// Counts come from ALL torrents (not filtered) for the sidebar.
+		// Materialized inside this branch on purpose: stream ticks leave
+		// includeCachedCounts false, so hoisting this above the branch cloned
+		// the full torrent slice on every tick and then discarded it.
+		var allTorrents []qbt.Torrent
+		if useManualFiltering {
+			allTorrents = allTorrentsForCounts
+		} else {
+			allTorrents = getTorrents(qbt.TorrentFilterOptions{})
+		}
+
 		if len(allTorrents) == 0 {
 			log.Trace().
 				Int("instanceID", instanceID).
@@ -1779,14 +1766,16 @@ func (sm *SyncManager) GetTorrentsWithFilters(ctx context.Context, instanceID in
 	// This ensures real-time updates are always reflected
 	// The sync manager is the single source of truth
 
-	log.Trace().
+	freshEvent := log.Trace().
 		Int("instanceID", instanceID).
 		Int("count", len(paginatedViews)).
 		Int("total", len(filteredTorrents)).
 		Str("search", search).
-		Interface("filters", filters).
-		Bool("hasMore", hasMore).
-		Msg("Fresh torrent data fetched and cached")
+		Bool("hasMore", hasMore)
+	if !filters.IsEmpty() {
+		freshEvent = freshEvent.Interface("filters", filters)
+	}
+	freshEvent.Msg("Fresh torrent data fetched and cached")
 
 	return response, nil
 }
@@ -3750,11 +3739,6 @@ func (sm *SyncManager) calculateCountsFromTorrentsWithTrackers(_ context.Context
 	}
 
 	if validatedMapping != nil {
-		log.Trace().
-			Int("domainCount", len(validatedMapping.DomainToHashes)).
-			Time("updatedAt", validatedMapping.UpdatedAt).
-			Msg("Using validated tracker mapping for counting")
-
 		// Count torrents per tracker domain using pre-validated mapping
 		trackerDomainCounts := make(map[string]map[string]bool) // domain -> set of torrent hashes
 		for domain, hashSet := range validatedMapping.DomainToHashes {
@@ -4695,6 +4679,11 @@ func (sm *SyncManager) applyManualFiltersWithTrackerHealth(
 ) []qbt.Torrent {
 	var filtered []qbt.Torrent
 
+	// A bad expression fails identically for every torrent, so record the first
+	// failure and report once after the loop instead of per torrent.
+	var exprErr error
+	exprFailures := 0
+
 	hashFilterSet := make(map[string]struct{}, len(filters.Hashes))
 	for _, h := range filters.Hashes {
 		if h == "" {
@@ -5052,13 +5041,19 @@ torrentsLoop:
 		if len(filters.Expr) > 0 && compileErr == nil {
 			result, err := expr.Run(program, torrent)
 			if err != nil {
-				log.Error().Err(err).Msg("Failed to evaluate expression")
+				if exprErr == nil {
+					exprErr = err
+				}
+				exprFailures++
 				continue
 			}
 
 			expResult, ok := result.(bool)
 			if !ok {
-				log.Error().Msg("Expression result is not a boolean")
+				if exprErr == nil {
+					exprErr = errors.New("expression result is not a boolean")
+				}
+				exprFailures++
 				continue
 			}
 
@@ -5069,6 +5064,15 @@ torrentsLoop:
 
 		// If we reach here, torrent passed all active filters
 		filtered = append(filtered, torrent)
+	}
+
+	if exprFailures > 0 {
+		log.Error().
+			Err(exprErr).
+			Int("failedTorrents", exprFailures).
+			Int("totalTorrents", len(torrents)).
+			Str("expr", filters.Expr).
+			Msg("Failed to evaluate expression")
 	}
 
 	log.Trace().

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -1645,8 +1645,8 @@ func (sm *SyncManager) GetTorrentsWithFilters(ctx context.Context, instanceID in
 	} else {
 		// Counts come from ALL torrents (not filtered) for the sidebar.
 		// Materialized inside this branch on purpose: stream ticks leave
-		// includeCachedCounts false, so hoisting this above the branch cloned
-		// the full torrent slice on every tick and then discarded it.
+		// includeCachedCounts false, so hoisting it above cloned every torrent
+		// on every tick and discarded the result.
 		var allTorrents []qbt.Torrent
 		if useManualFiltering {
 			allTorrents = allTorrentsForCounts

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -26,6 +26,7 @@ import (
 	"github.com/expr-lang/expr"
 	"github.com/expr-lang/expr/vm"
 	"github.com/lithammer/fuzzysearch/fuzzy"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/sync/errgroup"
 
@@ -78,8 +79,16 @@ const (
 	postAddRecheckReadyInterval = 500 * time.Millisecond
 	postAddRecheckSyncTimeout   = 5 * time.Second
 	trackerHealthRefreshTimeout = 30 * time.Second
+	trackerHealthRefreshSlow    = 10 * time.Second
 	torrentResponseFreshWindow  = 2 * time.Second
 )
+
+func trackerHealthRefreshLevel(elapsed time.Duration) zerolog.Level {
+	if elapsed >= trackerHealthRefreshSlow {
+		return zerolog.WarnLevel
+	}
+	return zerolog.DebugLevel
+}
 
 var errPostAddRecheckNotReady = errors.New("torrent still checking resume data after post-add wait")
 
@@ -604,21 +613,12 @@ func (sm *SyncManager) refreshTrackerHealthCounts(ctx context.Context, instanceI
 
 	// Only refresh for clients that support IncludeTrackers (qBittorrent 5.1+)
 	supportsTrackerInclude := client.supportsTrackerInclude()
-	log.Debug().
-		Int("instanceID", instanceID).
-		Bool("supportsTrackerInclude", supportsTrackerInclude).
-		Msg("Starting tracker health refresh")
 
 	// Get all torrents from the sync manager
 	torrents := syncManager.GetTorrents(qbt.TorrentFilterOptions{})
-	log.Debug().
-		Int("instanceID", instanceID).
-		Int("torrentCount", len(torrents)).
-		Bool("supportsTrackerInclude", supportsTrackerInclude).
-		Msg("Tracker health refresh loaded cached torrents")
 	if !supportsTrackerInclude {
 		sm.seedValidatedTrackerMappingFromMainData(instanceID, torrents, syncManager.GetDataUnchecked(), started)
-		log.Debug().
+		log.Trace().
 			Int("instanceID", instanceID).
 			Bool("supportsTrackerInclude", false).
 			Dur("elapsed", time.Since(started)).
@@ -743,14 +743,17 @@ func (sm *SyncManager) applyTrackerHealthRefreshResult(instanceID int, torrents,
 		trackericons.QueueFetch(domain, "")
 	}
 
-	log.Debug().
+	// The one summary line per pass. It escalates on its own when a pass runs
+	// long, because no per-pass start line remains to show a stalled instance.
+	elapsed := time.Since(started)
+	log.WithLevel(trackerHealthRefreshLevel(elapsed)).
 		Int("instanceID", instanceID).
 		Int("unregistered", counts.Unregistered).
 		Int("trackerDown", counts.TrackerDown).
 		Int("trackerError", counts.TrackerError).
 		Int("trackerDomains", len(mapping.DomainToHashes)).
 		Int("totalTorrents", len(torrents)).
-		Dur("elapsed", time.Since(started)).
+		Dur("elapsed", elapsed).
 		Msg("Refreshed tracker health counts and validated tracker mapping")
 	return true
 }
@@ -926,7 +929,7 @@ func (sm *SyncManager) setValidatedTrackerMappingWithMetrics(instanceID int, map
 	}
 	sm.validatedTrackerMu.Unlock()
 
-	event := log.Debug().
+	event := log.Trace().
 		Int("instanceID", instanceID).
 		Int("domainCount", domainCount).
 		Int("hashCount", hashCount).
@@ -2528,7 +2531,7 @@ func waitForPostAddRecheckReady(
 			return err
 		}
 		if syncErr != nil {
-			log.Debug().Err(syncErr).Int("instanceID", instanceID).
+			log.Trace().Err(syncErr).Int("instanceID", instanceID).
 				Int("attempt", attempt).Msg("Post-add recheck readiness sync failed")
 		}
 
@@ -2540,7 +2543,7 @@ func waitForPostAddRecheckReady(
 			return errPostAddRecheckNotReady
 		}
 
-		log.Debug().Int("instanceID", instanceID).Int("attempt", attempt).
+		log.Trace().Int("instanceID", instanceID).Int("attempt", attempt).
 			Int("maxAttempts", maxAttempts).Msg("Waiting for post-add resume-data check before recheck")
 
 		select {
@@ -2620,7 +2623,7 @@ func bulkActionSyncRetry(
 		syncErr := syncManager.Sync(syncCtx)
 		cancel()
 		if syncErr != nil {
-			log.Debug().Err(syncErr).Int("instanceID", instanceID).Str("action", action).
+			log.Trace().Err(syncErr).Int("instanceID", instanceID).Str("action", action).
 				Int("attempt", attempt).Msg("BulkAction: forced sync failed")
 			// Continue to retry even if sync failed
 		}
@@ -3418,7 +3421,7 @@ func (sm *SyncManager) enrichTorrentsWithTrackerData(ctx context.Context, client
 	// that has the IncludeTrackers option. Older versions would require individual API
 	// calls per torrent which is catastrophic for performance on large instances.
 	if !client.supportsTrackerInclude() {
-		log.Debug().
+		log.Trace().
 			Int("instanceID", client.instanceID).
 			Str("webAPIVersion", client.GetWebAPIVersion()).
 			Msg("Skipping tracker hydration - version does not support IncludeTrackers (requires qBittorrent 5.1+)")
@@ -3770,7 +3773,7 @@ func (sm *SyncManager) calculateCountsFromTorrentsWithTrackers(_ context.Context
 
 			stats, missingCount := trackerTransferStatsForHashes(hashSet, torrentMap)
 			if missingCount > 0 {
-				log.Debug().
+				log.Trace().
 					Str("domain", domain).
 					Int("missing", missingCount).
 					Int("total", len(hashSet)).
@@ -3798,7 +3801,7 @@ func (sm *SyncManager) calculateCountsFromTorrentsWithTrackers(_ context.Context
 		}
 	} else if mainData != nil && mainData.Trackers != nil {
 		// Fallback: Use MainData.Trackers with validation (first request before cache populated)
-		log.Debug().
+		log.Trace().
 			Int("trackerCount", len(mainData.Trackers)).
 			Msg("Using MainData.Trackers for counting (fallback, cache not yet populated)")
 
@@ -3857,7 +3860,7 @@ func (sm *SyncManager) calculateCountsFromTorrentsWithTrackers(_ context.Context
 
 			stats, missingCount := trackerTransferStatsForHashes(hashSet, torrentMap)
 			if missingCount > 0 {
-				log.Debug().
+				log.Trace().
 					Str("domain", domain).
 					Int("missing", missingCount).
 					Int("total", len(hashSet)).
@@ -3994,7 +3997,7 @@ func (sm *SyncManager) GetTorrentCounts(ctx context.Context, instanceID int) (*T
 		return nil, fmt.Errorf("failed to get all torrents for counts: %w", err)
 	}
 
-	log.Debug().Int("instanceID", instanceID).Int("torrents", len(allTorrents)).Msg("GetTorrentCounts: got fresh torrents from sync manager")
+	log.Trace().Int("instanceID", instanceID).Int("torrents", len(allTorrents)).Msg("GetTorrentCounts: got fresh torrents from sync manager")
 
 	// Calculate counts using the shared function - pass mainData for tracker information
 	trackerHealthSupported := client != nil && client.supportsTrackerInclude()
@@ -4006,7 +4009,7 @@ func (sm *SyncManager) GetTorrentCounts(ctx context.Context, instanceID int) (*T
 	// Don't cache counts separately - they're always derived from the cached torrent data
 	// This ensures sidebar and table are always in sync
 
-	log.Debug().
+	log.Trace().
 		Int("instanceID", instanceID).
 		Int("total", counts.Total).
 		Int("statusCount", len(counts.Status)).
@@ -4373,7 +4376,7 @@ func (sm *SyncManager) getAllTorrentsForStats(ctx context.Context, instanceID in
 				// Clear if backend state indicates the operation was successful
 				if sm.shouldClearOptimisticUpdate(torrent.State, optimisticUpdate.OriginalState, optimisticUpdate.State, optimisticUpdate.Action) {
 					shouldClear = true
-					log.Debug().
+					log.Trace().
 						Str("hash", hash).
 						Str("state", string(torrent.State)).
 						Str("originalState", string(optimisticUpdate.OriginalState)).
@@ -4385,14 +4388,14 @@ func (sm *SyncManager) getAllTorrentsForStats(ctx context.Context, instanceID in
 				} else if timeSinceUpdate > 60*time.Second {
 					// Safety net: still clear after 60 seconds if something went wrong
 					shouldClear = true
-					log.Debug().
+					log.Trace().
 						Str("hash", hash).
 						Time("optimisticAt", optimisticUpdate.UpdatedAt).
 						Dur("timeSinceUpdate", timeSinceUpdate).
 						Msg("Clearing stale optimistic update (safety net)")
 				} else {
 					// Debug: show why we're not clearing yet
-					log.Debug().
+					log.Trace().
 						Str("hash", hash).
 						Time("optimisticAt", optimisticUpdate.UpdatedAt).
 						Time("lastSyncAt", lastSyncTime).
@@ -4408,7 +4411,7 @@ func (sm *SyncManager) getAllTorrentsForStats(ctx context.Context, instanceID in
 					removedCount++
 				} else {
 					// Apply the optimistic state change to the torrent in our slice
-					log.Debug().
+					log.Trace().
 						Str("hash", hash).
 						Str("oldState", string(torrent.State)).
 						Str("newState", string(optimisticUpdate.State)).
@@ -4420,7 +4423,7 @@ func (sm *SyncManager) getAllTorrentsForStats(ctx context.Context, instanceID in
 				}
 			} else {
 				// Torrent no longer exists - clear the optimistic update
-				log.Debug().
+				log.Trace().
 					Str("hash", hash).
 					Str("action", optimisticUpdate.Action).
 					Time("optimisticAt", optimisticUpdate.UpdatedAt).
@@ -4578,7 +4581,7 @@ func (sm *SyncManager) filterTorrentsBySearch(torrents []qbt.Torrent, search str
 	for i, match := range matches {
 		filtered[i] = match.torrent
 		if i < 5 { // Log first 5 matches for debugging
-			log.Debug().
+			log.Trace().
 				Str("name", match.torrent.Name).
 				Int("score", match.score).
 				Str("method", match.method).
@@ -4586,7 +4589,7 @@ func (sm *SyncManager) filterTorrentsBySearch(torrents []qbt.Torrent, search str
 		}
 	}
 
-	log.Debug().
+	log.Trace().
 		Str("search", search).
 		Int("totalTorrents", len(torrents)).
 		Int("matchedTorrents", len(filtered)).
@@ -4609,7 +4612,7 @@ func (sm *SyncManager) filterTorrentsByGlob(torrents []qbt.Torrent, pattern stri
 		matched, err := filepath.Match(patternLower, nameLower)
 		if err != nil {
 			// Invalid pattern, log and skip
-			log.Debug().
+			log.Trace().
 				Str("pattern", pattern).
 				Err(err).
 				Msg("Invalid glob pattern")
@@ -4643,7 +4646,7 @@ func (sm *SyncManager) filterTorrentsByGlob(torrents []qbt.Torrent, pattern stri
 		}
 	}
 
-	log.Debug().
+	log.Trace().
 		Str("pattern", pattern).
 		Int("totalTorrents", len(torrents)).
 		Int("matchedTorrents", len(filtered)).
@@ -4843,7 +4846,7 @@ func (sm *SyncManager) applyManualFiltersWithTrackerHealth(
 	var compileErr error
 	if len(filters.Expr) > 0 {
 		if p, ok := sm.exprCache.Get(filters.Expr); ok {
-			log.Debug().Str("expr", filters.Expr).Msg("Using cached expression")
+			log.Trace().Str("expr", filters.Expr).Msg("Using cached expression")
 			program = p
 		} else {
 			// User expressions see raw qbt.Torrent fields, including the
@@ -5223,7 +5226,7 @@ func (sm *SyncManager) shouldClearOptimisticUpdate(currentState qbt.TorrentState
 		// Clear the optimistic update if the current state is different from the original state
 		// This indicates that the backend has acknowledged and processed the operation
 		if currentState != originalState {
-			log.Debug().
+			log.Trace().
 				Str("currentState", string(currentState)).
 				Str("originalState", string(originalState)).
 				Str("optimisticState", string(optimisticState)).
@@ -5236,7 +5239,7 @@ func (sm *SyncManager) shouldClearOptimisticUpdate(currentState qbt.TorrentState
 		if successCategory, exists := actionSuccessCategories[action]; exists {
 			if categoryStates, categoryExists := torrentStateCategories[qbt.TorrentFilter(successCategory)]; categoryExists {
 				if slices.Contains(categoryStates, currentState) {
-					log.Debug().
+					log.Trace().
 						Str("currentState", string(currentState)).
 						Str("originalState", string(originalState)).
 						Str("optimisticState", string(optimisticState)).

--- a/internal/qbittorrent/sync_manager_test.go
+++ b/internal/qbittorrent/sync_manager_test.go
@@ -18,6 +18,7 @@ import (
 	"unicode/utf8"
 
 	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -2381,4 +2382,11 @@ func TestDebouncedSyncFetchesFreshDataAfterCollapsingOntoInFlightSync(t *testing
 		return maindataCalls.Load() >= 2
 	}, time.Second, 5*time.Millisecond,
 		"debounced sync collapsed onto the pre-mutation in-flight sync and never fetched fresh data")
+}
+
+// A stalled instance must still be visible now that the per-pass start line is
+// gone.
+func TestTrackerHealthRefreshLevel(t *testing.T) {
+	require.Equal(t, zerolog.DebugLevel, trackerHealthRefreshLevel(trackerHealthRefreshSlow-time.Millisecond))
+	require.Equal(t, zerolog.WarnLevel, trackerHealthRefreshLevel(trackerHealthRefreshSlow))
 }

--- a/internal/services/crossseed/align.go
+++ b/internal/services/crossseed/align.go
@@ -179,7 +179,7 @@ func (s *Service) alignCrossSeedContentPaths(
 				Msg("Got torrent files from qBittorrent")
 			break
 		} else {
-			log.Trace().
+			log.Debug().
 				Int("instanceID", instanceID).
 				Str("torrentHash", activeHash).
 				Int("attempt", attempt+1).
@@ -193,7 +193,7 @@ func (s *Service) alignCrossSeedContentPaths(
 	// Fallback to expected files if we couldn't get them from qBittorrent
 	if len(sourceFiles) == 0 {
 		if ctx.Err() != nil {
-			log.Trace().
+			log.Debug().
 				Err(ctx.Err()).
 				Int("instanceID", instanceID).
 				Str("torrentHash", activeHash).

--- a/internal/services/crossseed/batch_matching.go
+++ b/internal/services/crossseed/batch_matching.go
@@ -266,7 +266,7 @@ func (s *Service) matchAgainstIndex(source *qbt.Torrent, idx *matchIndex, exclud
 					continue
 				}
 				match, reason := s.releasesMatchWithReason(sourceRelease, c.release, false)
-				traceReleaseMatchDecision(
+				logReleaseMatchDecision(
 					source.Name,
 					c.name,
 					false,

--- a/internal/services/crossseed/batch_matching_test.go
+++ b/internal/services/crossseed/batch_matching_test.go
@@ -171,12 +171,14 @@ func TestMatchAgainstIndex_ReleaseMetadata(t *testing.T) {
 	})
 }
 
-func TestMatchAgainstIndex_ReleaseMetadataTraceLogsRejection(t *testing.T) {
+// Cross-seed rejection reasons log at debug so a user who reports a match
+// problem can capture them without switching the whole server to trace.
+func TestMatchAgainstIndex_ReleaseMetadataDebugLogsRejection(t *testing.T) {
 	previousLogger := log.Logger
 	previousLevel := zerolog.GlobalLevel()
 	var buf bytes.Buffer
-	log.Logger = zerolog.New(&buf).Level(zerolog.TraceLevel)
-	zerolog.SetGlobalLevel(zerolog.TraceLevel)
+	log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
+	zerolog.SetGlobalLevel(zerolog.DebugLevel)
 	t.Cleanup(func() {
 		log.Logger = previousLogger
 		zerolog.SetGlobalLevel(previousLevel)
@@ -200,14 +202,14 @@ func TestMatchAgainstIndex_ReleaseMetadataTraceLogsRejection(t *testing.T) {
 	}
 
 	logOutput := buf.String()
-	if !strings.Contains(logOutput, `"level":"trace"`) {
-		t.Fatalf("expected trace log, got %s", logOutput)
+	if !strings.Contains(logOutput, `"level":"debug"`) {
+		t.Fatalf("expected debug log, got %s", logOutput)
 	}
 	if !strings.Contains(logOutput, `"message":"crossseed: release metadata candidate evaluated"`) {
-		t.Fatalf("expected release metadata trace message, got %s", logOutput)
+		t.Fatalf("expected release metadata debug message, got %s", logOutput)
 	}
 	if !strings.Contains(logOutput, `"reason":"group mismatch"`) {
-		t.Fatalf("expected mismatch reason in trace log, got %s", logOutput)
+		t.Fatalf("expected mismatch reason in debug log, got %s", logOutput)
 	}
 }
 

--- a/internal/services/crossseed/batch_matching_test.go
+++ b/internal/services/crossseed/batch_matching_test.go
@@ -171,12 +171,12 @@ func TestMatchAgainstIndex_ReleaseMetadata(t *testing.T) {
 	})
 }
 
-func TestMatchAgainstIndex_ReleaseMetadataDebugLogsRejection(t *testing.T) {
+func TestMatchAgainstIndex_ReleaseMetadataTraceLogsRejection(t *testing.T) {
 	previousLogger := log.Logger
 	previousLevel := zerolog.GlobalLevel()
 	var buf bytes.Buffer
-	log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
-	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	log.Logger = zerolog.New(&buf).Level(zerolog.TraceLevel)
+	zerolog.SetGlobalLevel(zerolog.TraceLevel)
 	t.Cleanup(func() {
 		log.Logger = previousLogger
 		zerolog.SetGlobalLevel(previousLevel)
@@ -200,14 +200,14 @@ func TestMatchAgainstIndex_ReleaseMetadataDebugLogsRejection(t *testing.T) {
 	}
 
 	logOutput := buf.String()
-	if !strings.Contains(logOutput, `"level":"debug"`) {
-		t.Fatalf("expected debug log, got %s", logOutput)
+	if !strings.Contains(logOutput, `"level":"trace"`) {
+		t.Fatalf("expected trace log, got %s", logOutput)
 	}
 	if !strings.Contains(logOutput, `"message":"crossseed: release metadata candidate evaluated"`) {
-		t.Fatalf("expected release metadata debug message, got %s", logOutput)
+		t.Fatalf("expected release metadata trace message, got %s", logOutput)
 	}
 	if !strings.Contains(logOutput, `"reason":"group mismatch"`) {
-		t.Fatalf("expected mismatch reason in debug log, got %s", logOutput)
+		t.Fatalf("expected mismatch reason in trace log, got %s", logOutput)
 	}
 }
 

--- a/internal/services/crossseed/batch_matching_test.go
+++ b/internal/services/crossseed/batch_matching_test.go
@@ -171,8 +171,6 @@ func TestMatchAgainstIndex_ReleaseMetadata(t *testing.T) {
 	})
 }
 
-// Cross-seed rejection reasons log at debug so a user who reports a match
-// problem can capture them without switching the whole server to trace.
 func TestMatchAgainstIndex_ReleaseMetadataDebugLogsRejection(t *testing.T) {
 	previousLogger := log.Logger
 	previousLevel := zerolog.GlobalLevel()

--- a/internal/services/crossseed/content_prefilter.go
+++ b/internal/services/crossseed/content_prefilter.go
@@ -112,7 +112,7 @@ func (s *Service) findLayoutAwareContentPrefilterMatches(
 		})
 		contentMatches = append(contentMatches, fmt.Sprintf("%s (%s)", candidate.view.Name, candidate.view.InstanceName))
 
-		log.Debug().
+		log.Trace().
 			Str("sourceHash", sourceHash).
 			Str("sourceName", sourceTorrent.Name).
 			Str("candidateHash", candidate.view.Hash).

--- a/internal/services/crossseed/gazellemusic/client.go
+++ b/internal/services/crossseed/gazellemusic/client.go
@@ -254,7 +254,7 @@ func (c *Client) SearchByHash(ctx context.Context, hash string) (*TorrentSearchR
 		if strings.Contains(lower, "bad id parameter") ||
 			strings.Contains(lower, "bad parameters") ||
 			strings.Contains(lower, "bad hash parameter") {
-			log.Trace().Str("hash", hash).Str("site", c.host).Msg("gazelle: no match by hash")
+			log.Debug().Str("hash", hash).Str("site", c.host).Msg("gazelle: no match by hash")
 			return nil, nil
 		}
 		return nil, err

--- a/internal/services/crossseed/seasonpack.go
+++ b/internal/services/crossseed/seasonpack.go
@@ -1103,7 +1103,7 @@ func (s *Service) matchEpisodeCandidatesDetailed(
 	// grep target the season-pack troubleshooting docs point users at. Only episode
 	// torrents (isTVEpisode) reach it, so it does not fire for every unrelated torrent.
 	logFiltered := func(candidateName, reason string) {
-		log.Trace().
+		log.Debug().
 			Str("pack", packRelease.Title).
 			Int("season", packRelease.Series).
 			Str("candidate", candidateName).

--- a/internal/services/crossseed/seasonpack.go
+++ b/internal/services/crossseed/seasonpack.go
@@ -18,6 +18,7 @@ import (
 	"github.com/anacrolix/torrent/metainfo"
 	qbt "github.com/autobrr/go-qbittorrent"
 	"github.com/moistari/rls"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
 	"github.com/autobrr/qui/internal/models"
@@ -763,13 +764,17 @@ func parseSeasonPackEpisodePayload(
 	return enriched, seasonlessOrigin, true
 }
 
+// notInPackReason is the rejection reason for a local episode the pack does not
+// contain. The log-level split keys off this exact value.
+const notInPackReason = "episode not in pack"
+
 // packEpisodeRejectReason names why a local episode failed the pack-episode gate.
 // Both strings are documented grep targets in the cross-seed troubleshooting docs.
 func packEpisodeRejectReason(inPack bool) string {
 	if inPack {
 		return "episode numbering mismatch"
 	}
-	return "episode not in pack"
+	return notInPackReason
 }
 
 // packEpisodeOrigin records which numbering scheme a pack episode identity came from.
@@ -1099,11 +1104,17 @@ func (s *Service) matchEpisodeCandidatesDetailed(
 		matcher = &Service{stringNormalizer: stringutils.DefaultNormalizer}
 	}
 
-	// logFiltered emits the field that filtered an episode candidate. It is the
-	// grep target the season-pack troubleshooting docs point users at. Only episode
-	// torrents (isTVEpisode) reach it, so it does not fire for every unrelated torrent.
+	// logFiltered emits the field that filtered an episode candidate. It is the grep
+	// target the season-pack troubleshooting docs point users at. The loop below reads
+	// every cached episode on the instance, so "title mismatch" and "episode not in
+	// pack" fire once per unrelated torrent and stay off the default level. Every other
+	// reason is bounded by the pack size and is what a user debugs, so it logs at Debug.
 	logFiltered := func(candidateName, reason string) {
-		log.Debug().
+		level := zerolog.DebugLevel
+		if reason == titleMismatchReason || reason == notInPackReason {
+			level = zerolog.TraceLevel
+		}
+		log.WithLevel(level).
 			Str("pack", packRelease.Title).
 			Int("season", packRelease.Series).
 			Str("candidate", candidateName).

--- a/internal/services/crossseed/seasonpack.go
+++ b/internal/services/crossseed/seasonpack.go
@@ -1099,7 +1099,7 @@ func (s *Service) matchEpisodeCandidatesDetailed(
 		matcher = &Service{stringNormalizer: stringutils.DefaultNormalizer}
 	}
 
-	// logFiltered emits the field that filtered an episode candidate at TRACE, the
+	// logFiltered emits the field that filtered an episode candidate. It is the
 	// grep target the season-pack troubleshooting docs point users at. Only episode
 	// torrents (isTVEpisode) reach it, so it does not fire for every unrelated torrent.
 	logFiltered := func(candidateName, reason string) {
@@ -1171,8 +1171,7 @@ func (s *Service) matchEpisodeCandidatesDetailed(
 		}
 
 		// Checked last so it only fires for episodes that would otherwise satisfy
-		// the pack (announce raced the episode's download), and at DEBUG because
-		// that near-miss is the one rejection users ask about without trace on.
+		// the pack (announce raced the episode's download).
 		if torrent.Progress < 1.0 {
 			log.Debug().
 				Str("pack", packRelease.Title).

--- a/internal/services/crossseed/seasonpack_test.go
+++ b/internal/services/crossseed/seasonpack_test.go
@@ -10,10 +10,13 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	qbt "github.com/autobrr/go-qbittorrent"
 	"github.com/moistari/rls"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 
 	"github.com/autobrr/qui/internal/models"
@@ -683,6 +686,97 @@ func TestMatchEpisodeCandidates_ExcludesIncompleteEpisodes(t *testing.T) {
 	require.Len(t, got, 1, "incomplete episode must not count as a candidate")
 	_, ok := got[episodeIdentity{series: 3, episode: 1}]
 	require.True(t, ok, "complete episode must count")
+}
+
+// TestMatchEpisodeCandidates_FilterLogLevels pins the level split for filtered episode
+// candidates. The loop reads every cached episode, so a reason that means "belongs to
+// another show or another pack" must stay off the default level.
+func TestMatchEpisodeCandidates_FilterLogLevels(t *testing.T) {
+	parsedPack := rls.ParseString("Cool.Show.S03.1080p.WEB.x264-GRP")
+	packRelease := &parsedPack
+
+	type want struct {
+		reason string
+		level  string
+		count  int
+	}
+
+	tests := []struct {
+		name         string
+		packEpisodes map[episodeIdentity]packEpisodeOrigin
+		locals       []qbt.Torrent
+		want         []want
+	}{
+		{
+			// Light check: no torrent data, so the release match is the only gate.
+			name: "no pack episodes",
+			locals: []qbt.Torrent{
+				{Hash: "ok", Name: "Cool.Show.S03E01.1080p.WEB.x264-GRP", Progress: 1.0},
+				{Hash: "grp", Name: "Cool.Show.S03E02.1080p.WEB.x264-OTHER", Progress: 1.0},
+				{Hash: "other1", Name: "Other.Show.S03E01.1080p.WEB.x264-GRP", Progress: 1.0},
+				{Hash: "other2", Name: "Third.Show.S01E05.1080p.WEB.x264-GRP", Progress: 1.0},
+			},
+			want: []want{
+				{titleMismatchReason, "trace", 2},
+				{"group mismatch", "debug", 1},
+			},
+		},
+		{
+			// The path every real caller takes: the pack-episode gate runs first. 1140 is
+			// listed as seasoned, so the absolute-numbered local reaches the gate in-pack
+			// and only the scheme guard rejects it. That case is bounded by the pack size.
+			name: "pack episodes set",
+			packEpisodes: map[episodeIdentity]packEpisodeOrigin{
+				{series: 3, episode: 1}:    {seasoned: true},
+				{series: 3, episode: 2}:    {seasoned: true},
+				{series: 3, episode: 1140}: {seasoned: true},
+			},
+			locals: []qbt.Torrent{
+				{Hash: "ok", Name: "Cool.Show.S03E01.1080p.WEB.x264-GRP", Progress: 1.0},
+				{Hash: "away1", Name: "Third.Show.S01E05.1080p.WEB.x264-GRP", Progress: 1.0},
+				{Hash: "away2", Name: "Fourth.Show.S09E11.1080p.WEB.x264-GRP", Progress: 1.0},
+				{Hash: "absolute", Name: "Cool Show - 1140 [1080p][WEB][x264]-GRP", Progress: 1.0},
+			},
+			want: []want{
+				{notInPackReason, "trace", 2},
+				{"episode numbering mismatch", "debug", 1},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			previousLogger := log.Logger
+			previousLevel := zerolog.GlobalLevel()
+			var buf bytes.Buffer
+			log.Logger = zerolog.New(&buf).Level(zerolog.TraceLevel)
+			zerolog.SetGlobalLevel(zerolog.TraceLevel)
+			t.Cleanup(func() {
+				log.Logger = previousLogger
+				zerolog.SetGlobalLevel(previousLevel)
+			})
+
+			inst := &models.Instance{ID: 1, Name: "Test", IsActive: true}
+			cached := buildCrossInstanceViews(inst, tt.locals)
+			svc := &Service{releaseCache: NewReleaseCache()}
+			settings := &models.CrossSeedAutomationSettings{SeasonPackEnabled: true}
+
+			got := svc.matchEpisodeCandidatesDetailed(cached, packRelease, tt.packEpisodes, settings, nil)
+			require.Len(t, got, 1, "only the fully matching episode may count")
+
+			for _, w := range tt.want {
+				count := 0
+				for line := range strings.SplitSeq(strings.TrimSpace(buf.String()), "\n") {
+					if !strings.Contains(line, `"reason":"`+w.reason+`"`) {
+						continue
+					}
+					require.Contains(t, line, `"level":"`+w.level+`"`, "%q must log at %s", w.reason, w.level)
+					count++
+				}
+				require.Equal(t, w.count, count, "line count for %q", w.reason)
+			}
+		})
+	}
 }
 
 func TestCheckSeasonPackWebhook_ReturnsNotFoundBelowThreshold(t *testing.T) {

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -12882,7 +12882,10 @@ func logReleaseMatchDecision(
 			reason = "release mismatch"
 		}
 	}
-	if evt := log.Debug(); evt.Enabled() {
+	// TRACE, not DEBUG: the only caller runs this for every source torrent
+	// against every candidate in the same release-key bucket. The key has no
+	// title, so one bucket can hold a full library of episodes.
+	if evt := log.Trace(); evt.Enabled() {
 		evt.
 			Str("sourceTitle", sourceTitle).
 			Str("candidateTitle", candidateTitle).

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -4580,7 +4580,7 @@ func (s *Service) findCandidates(ctx context.Context, req *FindCandidatesRequest
 
 			matchedTorrents = append(matchedTorrents, torrent)
 			matchTypeCounts[matchType]++
-			log.Debug().
+			log.Trace().
 				Str("targetTitle", req.TorrentName).
 				Str("existingTorrent", torrent.Name).
 				Int("instanceID", instanceID).
@@ -6624,7 +6624,7 @@ func (s *Service) getTorrentFilesCached(ctx context.Context, instanceID int, has
 
 	if s.torrentFilesCache != nil {
 		if cached, ok := s.torrentFilesCache.Get(key); ok {
-			log.Debug().
+			log.Trace().
 				Int("instanceID", instanceID).
 				Str("hash", normalizeHash(hash)).
 				Msg("Using cached torrent files")
@@ -6646,7 +6646,7 @@ func (s *Service) getTorrentFilesCached(ctx context.Context, instanceID int, has
 		_ = s.torrentFilesCache.Set(key, cloneTorrentFiles(files), ttlcache.DefaultTTL)
 	}
 
-	log.Debug().
+	log.Trace().
 		Int("instanceID", instanceID).
 		Str("hash", normalizeHash(hash)).
 		Msg("Fetched torrent files from qbittorrent")
@@ -7055,7 +7055,7 @@ func (s *Service) AnalyzeTorrentForSearchAsync(ctx context.Context, instanceID i
 		FilteringState: filteringState,
 	}
 
-	log.Debug().
+	log.Trace().
 		Str("torrentHash", hash).
 		Int("instanceID", instanceID).
 		Ints("allIndexers", allIndexers).
@@ -7083,7 +7083,7 @@ func (s *Service) AnalyzeTorrentForSearchAsync(ctx context.Context, instanceID i
 			if existing, found := s.asyncFilteringCache.Get(cacheKey); found {
 				existingSnapshot := existing.Clone()
 				if existingSnapshot != nil && existingSnapshot.ContentCompleted {
-					log.Debug().
+					log.Trace().
 						Str("torrentHash", hash).
 						Int("instanceID", instanceID).
 						Str("cacheKey", cacheKey).
@@ -7104,39 +7104,19 @@ func (s *Service) AnalyzeTorrentForSearchAsync(ctx context.Context, instanceID i
 					ContentMatches:        make([]string, 0),
 				}
 				s.asyncFilteringCache.Set(cacheKey, cachedState, ttlcache.DefaultTTL)
-
-				log.Debug().
-					Str("torrentHash", hash).
-					Int("instanceID", instanceID).
-					Str("cacheKey", cacheKey).
-					Bool("contentCompleted", cachedState.ContentCompleted).
-					Int("capabilityIndexersCount", len(cachedState.CapabilityIndexers)).
-					Int("filteredIndexersCount", len(cachedState.FilteredIndexers)).
-					Msg("[CROSSSEED-ASYNC] Stored initial filtering state in cache")
 			}
 		}
 
-		log.Debug().
+		log.Trace().
 			Str("torrentHash", hash).
 			Int("instanceID", instanceID).
 			Int("allIndexersCount", len(allIndexers)).
 			Int("capabilityIndexersCount", len(capabilityIndexers)).
-			Msg("[CROSSSEED-ASYNC] Capability filtering completed synchronously")
-
-		log.Debug().
-			Str("torrentHash", hash).
-			Int("instanceID", instanceID).
 			Bool("enableContentFiltering", enableContentFiltering).
-			Int("capabilityIndexersCount", len(capabilityIndexers)).
-			Msg("[CROSSSEED-ASYNC] Phase 2: Content filtering decision")
+			Msg("[CROSSSEED-ASYNC] Capability filtering completed synchronously")
 
 		if enableContentFiltering {
 			if len(capabilityIndexers) > 0 {
-				log.Debug().
-					Str("torrentHash", hash).
-					Int("instanceID", instanceID).
-					Int("capabilityIndexersCount", len(capabilityIndexers)).
-					Msg("[CROSSSEED-ASYNC] Starting background content filtering")
 				go s.performAsyncContentFiltering(context.Background(), instanceID, hash, capabilityIndexers, indexerInfo, filteringState)
 			} else {
 				filteringState.Lock()
@@ -7170,7 +7150,7 @@ func (s *Service) AnalyzeTorrentForSearchAsync(ctx context.Context, instanceID i
 // performAsyncContentFiltering performs content filtering in the background and updates the filtering state
 // This method handles concurrent access to the state safely
 func (s *Service) performAsyncContentFiltering(ctx context.Context, instanceID int, hash string, indexerIDs []int, indexerInfo map[int]jackett.EnabledIndexerInfo, state *AsyncIndexerFilteringState) {
-	log.Debug().
+	log.Trace().
 		Str("torrentHash", hash).
 		Int("instanceID", instanceID).
 		Ints("indexerIDs", indexerIDs).
@@ -7210,7 +7190,7 @@ func (s *Service) performAsyncContentFiltering(ctx context.Context, instanceID i
 	snapshot = state.cloneLocked()
 	state.Unlock()
 
-	log.Debug().
+	log.Trace().
 		Str("torrentHash", hash).
 		Int("instanceID", instanceID).
 		Int("originalIndexerCount", len(indexerIDs)).
@@ -7227,21 +7207,7 @@ func (s *Service) performAsyncContentFiltering(ctx context.Context, instanceID i
 			cachedState = &AsyncIndexerFilteringState{}
 		}
 
-		log.Debug().
-			Str("torrentHash", hash).
-			Int("instanceID", instanceID).
-			Str("cacheKey", cacheKey).
-			Bool("contentCompleted", cachedState.ContentCompleted).
-			Int("filteredIndexersCount", len(cachedState.FilteredIndexers)).
-			Msg("[CROSSSEED-ASYNC] Storing completed content filtering state in cache")
-
 		s.asyncFilteringCache.Set(cacheKey, cachedState, ttlcache.DefaultTTL)
-
-		log.Debug().
-			Str("torrentHash", hash).
-			Int("instanceID", instanceID).
-			Str("cacheKey", cacheKey).
-			Msg("[CROSSSEED-ASYNC] Stored completed filtering state in cache")
 	}
 
 	log.Debug().
@@ -10369,9 +10335,12 @@ func (s *Service) deduplicateSourceTorrents(ctx context.Context, instanceID int,
 		deduplicated = append(deduplicated, rep.torrent)
 		if len(group.duplicates) > 0 {
 			totalDuplicates += len(group.duplicates)
-			log.Debug().
+			log.Trace().
 				Str("representative", rep.torrent.Name).
 				Str("representativeHash", rep.torrent.Hash).
+				// A top-level folder wins first, and the oldest torrent breaks
+				// the tie. Both fields are here so the entry explains its choice.
+				Bool("representativeHasRootFolder", group.hasRootFolder).
 				Int64("addedOn", rep.torrent.AddedOn).
 				Int("duplicateCount", len(group.duplicates)).
 				Strs("duplicateHashes", group.duplicates).
@@ -11480,7 +11449,7 @@ func (s *Service) filterIndexerIDsForTorrentAsync(ctx context.Context, instanceI
 		}
 	}
 
-	log.Debug().
+	log.Trace().
 		Str("torrentHash", hash).
 		Int("instanceID", instanceID).
 		Str("cacheKey", cacheKey).
@@ -11508,7 +11477,7 @@ func (s *Service) GetAsyncFilteringStatus(ctx context.Context, instanceID int, h
 		if cached, found := s.asyncFilteringCache.Get(cacheKey); found {
 			cachedSnapshot := cached.Clone()
 			if cachedSnapshot != nil {
-				log.Debug().
+				log.Trace().
 					Str("torrentHash", hash).
 					Int("instanceID", instanceID).
 					Bool("capabilitiesCompleted", cachedSnapshot.CapabilitiesCompleted).
@@ -11527,7 +11496,7 @@ func (s *Service) GetAsyncFilteringStatus(ctx context.Context, instanceID int, h
 	}
 
 	if snapshot := asyncResult.FilteringState.Clone(); snapshot != nil {
-		log.Debug().
+		log.Trace().
 			Str("torrentHash", hash).
 			Int("instanceID", instanceID).
 			Bool("capabilitiesCompleted", snapshot.CapabilitiesCompleted).
@@ -11568,7 +11537,7 @@ func (s *Service) filterIndexersByExistingContent(ctx context.Context, instanceI
 		indexerInfo = make(map[int]jackett.EnabledIndexerInfo)
 	}
 
-	log.Debug().
+	log.Trace().
 		Str("torrentHash", hash).
 		Int("instanceID", instanceID).
 		Int("indexerCount", len(indexerIDs)).
@@ -11626,7 +11595,7 @@ func (s *Service) filterIndexersByExistingContent(ctx context.Context, instanceI
 			continue
 		}
 
-		log.Debug().
+		log.Trace().
 			Str("torrentHash", hash).
 			Int("instanceID", instanceID).
 			Int("indexerID", indexerID).
@@ -11637,7 +11606,7 @@ func (s *Service) filterIndexersByExistingContent(ctx context.Context, instanceI
 		// Skip searching indexers that already provided the source torrent
 		if sourceTorrent != nil {
 			if matched, trackerDomain := s.torrentMatchesIndexerDomain(sourceTorrent, indexerName, indexerDomain); matched {
-				log.Debug().
+				log.Trace().
 					Str("torrentHash", hash).
 					Int("instanceID", instanceID).
 					Int("indexerID", indexerID).
@@ -11658,7 +11627,7 @@ func (s *Service) filterIndexersByExistingContent(ctx context.Context, instanceI
 				if matched, trackerDomain := s.trackerDomainsMatchIndexerWithDomain(match.trackerDomains, indexerName, indexerDomain); matched {
 					exclusionReason = fmt.Sprintf("has matching content from %s (%s)", match.view.InstanceName, match.view.Name)
 					shouldIncludeIndexer = false
-					log.Debug().
+					log.Trace().
 						Str("torrentHash", hash).
 						Int("instanceID", instanceID).
 						Int("indexerID", indexerID).
@@ -11771,13 +11740,6 @@ func (s *Service) trackerDomainsMatchIndexerDomain(trackerDomains []string, inde
 				// Check if mapped domain matches indexer name or specific indexer domain
 				if normalizedMappedDomain == normalizedIndexerName ||
 					(specificIndexerDomain != "" && strings.EqualFold(normalizedMappedDomain, specificIndexerDomain)) {
-					log.Debug().
-						Str("matchType", "hardcoded_mapping").
-						Str("trackerDomain", trackerDomain).
-						Str("mappedDomain", mappedDomain).
-						Str("indexerName", indexerName).
-						Str("specificIndexerDomain", specificIndexerDomain).
-						Msg("[CROSSSEED-DOMAIN] *** MATCH FOUND - Hardcoded domain mapping ***")
 					return true
 				}
 			}
@@ -11790,11 +11752,6 @@ func (s *Service) trackerDomainsMatchIndexerDomain(trackerDomains []string, inde
 
 		// 1. Direct match: normalized indexer name matches domain
 		if normalizedIndexerName != "" && normalizedIndexerName == normalizedDomain {
-			log.Debug().
-				Str("matchType", "direct").
-				Str("domain", domain).
-				Str("indexerName", indexerName).
-				Msg("[CROSSSEED-DOMAIN] *** MATCH FOUND - Direct match ***")
 			return true
 		}
 
@@ -11804,12 +11761,6 @@ func (s *Service) trackerDomainsMatchIndexerDomain(trackerDomains []string, inde
 
 			// Direct domain match
 			if normalizedDomain == normalizedSpecificDomain {
-				log.Debug().
-					Str("matchType", "specific_indexer_domain_direct").
-					Str("torrentDomain", domain).
-					Str("indexerDomain", specificIndexerDomain).
-					Str("indexerName", indexerName).
-					Msg("[CROSSSEED-DOMAIN] *** MATCH FOUND - Specific indexer domain direct match ***")
 				return true
 			}
 
@@ -11817,19 +11768,9 @@ func (s *Service) trackerDomainsMatchIndexerDomain(trackerDomains []string, inde
 
 		// 3. Partial match: domain contains normalized indexer name or vice versa
 		if normalizedIndexerName != "" && strings.Contains(normalizedDomain, normalizedIndexerName) {
-			log.Debug().
-				Str("matchType", "domain_contains_indexer").
-				Str("domain", domain).
-				Str("indexerName", indexerName).
-				Msg("[CROSSSEED-DOMAIN] *** MATCH FOUND - Domain contains indexer ***")
 			return true
 		}
 		if normalizedIndexerName != "" && strings.Contains(normalizedIndexerName, normalizedDomain) {
-			log.Debug().
-				Str("matchType", "indexer_contains_domain").
-				Str("domain", domain).
-				Str("indexerName", indexerName).
-				Msg("[CROSSSEED-DOMAIN] *** MATCH FOUND - Indexer contains domain ***")
 			return true
 		}
 
@@ -11839,21 +11780,9 @@ func (s *Service) trackerDomainsMatchIndexerDomain(trackerDomains []string, inde
 
 			// Check if torrent domain contains indexer domain or vice versa
 			if strings.Contains(normalizedDomain, normalizedSpecificDomain) {
-				log.Debug().
-					Str("matchType", "torrent_domain_contains_specific_indexer_domain").
-					Str("torrentDomain", domain).
-					Str("indexerDomain", specificIndexerDomain).
-					Str("indexerName", indexerName).
-					Msg("[CROSSSEED-DOMAIN] *** MATCH FOUND - Torrent domain contains specific indexer domain ***")
 				return true
 			}
 			if strings.Contains(normalizedSpecificDomain, normalizedDomain) {
-				log.Debug().
-					Str("matchType", "specific_indexer_domain_contains_torrent_domain").
-					Str("torrentDomain", domain).
-					Str("indexerDomain", specificIndexerDomain).
-					Str("indexerName", indexerName).
-					Msg("[CROSSSEED-DOMAIN] *** MATCH FOUND - Specific indexer domain contains torrent domain ***")
 				return true
 			}
 		} // Handle TLD variations and domain normalization
@@ -11870,32 +11799,14 @@ func (s *Service) trackerDomainsMatchIndexerDomain(trackerDomains []string, inde
 
 		// Direct match after normalization
 		if normalizedIndexerName != "" && normalizedIndexerName == normalizedDomainName {
-			log.Debug().
-				Str("matchType", "normalized_match").
-				Str("domain", domain).
-				Str("normalizedDomainName", normalizedDomainName).
-				Str("indexerName", indexerName).
-				Msg("[CROSSSEED-DOMAIN] *** MATCH FOUND - Normalized domain match ***")
 			return true
 		}
 
 		// Partial match after normalization
 		if normalizedIndexerName != "" && strings.Contains(normalizedDomainName, normalizedIndexerName) {
-			log.Debug().
-				Str("matchType", "normalized_domain_contains_indexer").
-				Str("domain", domain).
-				Str("normalizedDomainName", normalizedDomainName).
-				Str("indexerName", indexerName).
-				Msg("[CROSSSEED-DOMAIN] *** MATCH FOUND - Normalized domain contains indexer ***")
 			return true
 		}
 		if normalizedIndexerName != "" && strings.Contains(normalizedIndexerName, normalizedDomainName) {
-			log.Debug().
-				Str("matchType", "normalized_indexer_contains_domain").
-				Str("domain", domain).
-				Str("normalizedDomainName", normalizedDomainName).
-				Str("indexerName", indexerName).
-				Msg("[CROSSSEED-DOMAIN] *** MATCH FOUND - Normalized indexer contains domain ***")
 			return true
 		}
 
@@ -11917,61 +11828,23 @@ func (s *Service) trackerDomainsMatchIndexerDomain(trackerDomains []string, inde
 
 			// Compare normalized torrent domain with normalized indexer domain
 			if normalizedDomainName == normalizedIndexerDomainName {
-				log.Debug().
-					Str("matchType", "normalized_specific_indexer_domain_match").
-					Str("torrentDomain", domain).
-					Str("indexerDomain", specificIndexerDomain).
-					Str("normalizedTorrentDomain", normalizedDomainName).
-					Str("normalizedIndexerDomain", normalizedIndexerDomainName).
-					Str("indexerName", indexerName).
-					Msg("[CROSSSEED-DOMAIN] *** MATCH FOUND - Normalized specific indexer domain match ***")
 				return true
 			}
 
 			// Partial matches with normalized indexer domains
 			if strings.Contains(normalizedDomainName, normalizedIndexerDomainName) {
-				log.Debug().
-					Str("matchType", "normalized_torrent_domain_contains_specific_indexer").
-					Str("torrentDomain", domain).
-					Str("indexerDomain", specificIndexerDomain).
-					Str("normalizedTorrentDomain", normalizedDomainName).
-					Str("normalizedIndexerDomain", normalizedIndexerDomainName).
-					Str("indexerName", indexerName).
-					Msg("[CROSSSEED-DOMAIN] *** MATCH FOUND - Normalized torrent domain contains specific indexer domain ***")
 				return true
 			}
 			if strings.Contains(normalizedIndexerDomainName, normalizedDomainName) {
-				log.Debug().
-					Str("matchType", "normalized_specific_indexer_domain_contains_torrent").
-					Str("torrentDomain", domain).
-					Str("indexerDomain", specificIndexerDomain).
-					Str("normalizedTorrentDomain", normalizedDomainName).
-					Str("normalizedIndexerDomain", normalizedIndexerDomainName).
-					Str("indexerName", indexerName).
-					Msg("[CROSSSEED-DOMAIN] *** MATCH FOUND - Normalized specific indexer domain contains torrent domain ***")
 				return true
 			}
 
 			// Check TLD-stripped match against specific indexer domain
 			if domainWithoutTLD == indexerDomainWithoutTLD {
-				log.Debug().
-					Str("matchType", "tld_stripped_specific_indexer_domain").
-					Str("torrentDomain", domain).
-					Str("indexerDomain", specificIndexerDomain).
-					Str("torrentDomainWithoutTLD", domainWithoutTLD).
-					Str("indexerDomainWithoutTLD", indexerDomainWithoutTLD).
-					Str("indexerName", indexerName).
-					Msg("[CROSSSEED-DOMAIN] *** MATCH FOUND - TLD stripped specific indexer domain match ***")
 				return true
 			}
 		} // Check original TLD-stripped match for backward compatibility
 		if normalizedIndexerName != "" && normalizedIndexerName == domainWithoutTLD {
-			log.Debug().
-				Str("matchType", "tld_stripped").
-				Str("domain", domain).
-				Str("domainWithoutTLD", domainWithoutTLD).
-				Str("indexerName", indexerName).
-				Msg("[CROSSSEED-DOMAIN] *** MATCH FOUND - TLD stripped match ***")
 			return true
 		}
 	}
@@ -12853,7 +12726,8 @@ func recordReleaseRejection(
 		reason = "release mismatch"
 	}
 	releaseFilterReasons[reason]++
-	if evt := log.Debug(); evt.Enabled() {
+	// The parsed release pair is developer detail. The caller logs the reason.
+	if evt := log.Trace(); evt.Enabled() {
 		evt.
 			Str("sourceTitle", sourceTitle).
 			Str("candidateTitle", candidateTitle).

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -1354,7 +1354,7 @@ func (s *Service) determineLocalMatchType(
 					return matchTypeContentPath
 				case sourceIsAmbiguousDir || candidateIsAmbiguousDir:
 					// Log diagnostics when ambiguous content_path match fails overlap threshold
-					log.Trace().
+					log.Debug().
 						Str("sourceHash", normalizeHash(source.Hash)).
 						Str("candidateHash", normalizeHash(candidate.Hash)).
 						Int("candidateInstanceID", candidate.InstanceID).
@@ -4618,7 +4618,7 @@ func (s *Service) findCandidates(ctx context.Context, req *FindCandidatesRequest
 		}
 	}
 
-	log.Trace().
+	log.Debug().
 		Str("targetTitle", req.TorrentName).
 		Str("sourceIndexer", req.SourceIndexer).
 		Int("instancesSearched", len(searchInstanceIDs)).
@@ -6624,7 +6624,7 @@ func (s *Service) getTorrentFilesCached(ctx context.Context, instanceID int, has
 
 	if s.torrentFilesCache != nil {
 		if cached, ok := s.torrentFilesCache.Get(key); ok {
-			log.Trace().
+			log.Debug().
 				Int("instanceID", instanceID).
 				Str("hash", normalizeHash(hash)).
 				Msg("Using cached torrent files")
@@ -6646,7 +6646,7 @@ func (s *Service) getTorrentFilesCached(ctx context.Context, instanceID int, has
 		_ = s.torrentFilesCache.Set(key, cloneTorrentFiles(files), ttlcache.DefaultTTL)
 	}
 
-	log.Trace().
+	log.Debug().
 		Int("instanceID", instanceID).
 		Str("hash", normalizeHash(hash)).
 		Msg("Fetched torrent files from qbittorrent")
@@ -10193,7 +10193,7 @@ func (s *Service) deduplicateSourceTorrents(ctx context.Context, instanceID int,
 	cacheKey := dedupCacheKey(instanceID, torrents)
 	if s.dedupCache != nil {
 		if entry, ok := s.dedupCache.Get(cacheKey); ok && entry != nil {
-			log.Trace().
+			log.Debug().
 				Int("instanceID", instanceID).
 				Int("cachedCount", len(entry.deduplicated)).
 				Msg("[CROSSSEED-DEDUP] Using cached deduplication result")
@@ -10369,7 +10369,7 @@ func (s *Service) deduplicateSourceTorrents(ctx context.Context, instanceID int,
 		deduplicated = append(deduplicated, rep.torrent)
 		if len(group.duplicates) > 0 {
 			totalDuplicates += len(group.duplicates)
-			log.Trace().
+			log.Debug().
 				Str("representative", rep.torrent.Name).
 				Str("representativeHash", rep.torrent.Hash).
 				Int64("addedOn", rep.torrent.AddedOn).
@@ -10379,7 +10379,7 @@ func (s *Service) deduplicateSourceTorrents(ctx context.Context, instanceID int,
 		}
 	}
 
-	log.Trace().
+	log.Debug().
 		Int("originalCount", len(torrents)).
 		Int("deduplicatedCount", len(deduplicated)).
 		Int("duplicatesRemoved", totalDuplicates).
@@ -11427,7 +11427,7 @@ func (s *Service) filterIndexerIDsForTorrentAsync(ctx context.Context, instanceI
 		if existing, found := s.asyncFilteringCache.Get(cacheKey); found {
 			existingSnapshot := existing.Clone()
 			if existingSnapshot != nil && existingSnapshot.ContentCompleted {
-				log.Trace().
+				log.Debug().
 					Str("torrentHash", hash).
 					Int("instanceID", instanceID).
 					Str("cacheKey", cacheKey).
@@ -12853,8 +12853,8 @@ func recordReleaseRejection(
 		reason = "release mismatch"
 	}
 	releaseFilterReasons[reason]++
-	if trace := log.Trace(); trace.Enabled() {
-		trace.
+	if evt := log.Debug(); evt.Enabled() {
+		evt.
 			Str("sourceTitle", sourceTitle).
 			Str("candidateTitle", candidateTitle).
 			Str("reason", reason).
@@ -12865,7 +12865,7 @@ func recordReleaseRejection(
 	}
 }
 
-func traceReleaseMatchDecision(
+func logReleaseMatchDecision(
 	sourceTitle string,
 	candidateTitle string,
 	findIndividualEpisodes bool,
@@ -12882,8 +12882,8 @@ func traceReleaseMatchDecision(
 			reason = "release mismatch"
 		}
 	}
-	if trace := log.Trace(); trace.Enabled() {
-		trace.
+	if evt := log.Debug(); evt.Enabled() {
+		evt.
 			Str("sourceTitle", sourceTitle).
 			Str("candidateTitle", candidateTitle).
 			Bool("matched", matched).


### PR DESCRIPTION
TRACE was 86% of qui log volume, but only cross-seed diagnostics needed it. Those diagnostics come from about 16 log sites. The volume made the evidence unreachable. A busy install on TRACE wrote 27.7 MB every 5 hours, rotated a 50 MB file every 5 to 8 hours, and kept about 30 hours of history. The diagnostics move to DEBUG, DEBUG becomes the default, and a first bug report carries the evidence without a level change. qui also compresses rotated files with gzip and keeps 10 of them.

A default level is only useful when it stays readable. A per-event line is no longer logged at DEBUG, whether it fires per request, per timer tick, per torrent, or per loop pass. In the proxy and the sync manager, 36 lines move to TRACE and two with constant content are deleted. In cross-seed, one evaluation of one torrent wrote about 1,200 lines, and it now writes about 12. Proxy mutations, retries, failures, and one summary line per loop stay at DEBUG. This work includes three more changes:

- the access log writes at DEBUG for a 5xx, or for a request slower than one second
- the tracker health summary escalates to WARN at 10 seconds, because no start line remains to show a stalled instance
- four hot-path defects are fixed, from a duplicate `time` key to a needless clone of the torrent list

One upgrade note: the generated config wrote `logLevel` as an active key, so the new default reached no existing install. The key is a comment now, and the docs tell users to look at the value after an upgrade.
