### PR TITLE
perf(instances): report all-time totals from transfer-info

### DIFF
--- a/internal/api/handlers/instances.go
+++ b/internal/api/handlers/instances.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	qbt "github.com/autobrr/go-qbittorrent"
 	"github.com/go-chi/chi/v5"
 	"github.com/rs/zerolog/log"
 
@@ -147,6 +148,35 @@ func (h *InstancesHandler) GetReannounceCandidates(w http.ResponseWriter, r *htt
 	RespondJSON(w, http.StatusOK, normalized)
 }
 
+// transferInfoResponse adds qBittorrent's all-time totals, which only
+// /sync/maindata carries, to the /transfer/info statistics. The totals are
+// pointers so the fallback path omits them instead of reporting zero.
+type transferInfoResponse struct {
+	qbt.TransferInfo
+	AlltimeDl *int64 `json:"alltime_dl,omitempty"`
+	AlltimeUl *int64 `json:"alltime_ul,omitempty"`
+}
+
+// newTransferInfoResponse exposes only the transfer fields and the totals: the
+// rest of the server state belongs to the dashboard payload, not to a stats
+// endpoint clients poll every few seconds.
+func newTransferInfoResponse(state *qbt.ServerState) transferInfoResponse {
+	return transferInfoResponse{
+		TransferInfo: qbt.TransferInfo{
+			ConnectionStatus: qbt.ConnectionStatus(state.ConnectionStatus),
+			DHTNodes:         state.DhtNodes,
+			DlInfoData:       state.DlInfoData,
+			DlInfoSpeed:      state.DlInfoSpeed,
+			DlRateLimit:      state.DlRateLimit,
+			UpInfoData:       state.UpInfoData,
+			UpInfoSpeed:      state.UpInfoSpeed,
+			UpRateLimit:      state.UpRateLimit,
+		},
+		AlltimeDl: &state.AlltimeDl,
+		AlltimeUl: &state.AlltimeUl,
+	}
+}
+
 // GetTransferInfo returns lightweight transfer stats for an instance.
 func (h *InstancesHandler) GetTransferInfo(w http.ResponseWriter, r *http.Request) {
 	instanceID, err := strconv.Atoi(chi.URLParam(r, "instanceID"))
@@ -168,6 +198,24 @@ func (h *InstancesHandler) GetTransferInfo(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	// Prefer the synced server state: one maindata sync answers this endpoint and
+	// the all-time totals, sparing clients a full torrent-list request for the
+	// totals alone. The cache only advances on a completed sync, so instances
+	// nobody is streaming need this explicit one to report live speeds. Sync with
+	// the request context rather than the library's checked accessor, which syncs
+	// on context.Background() and would outlive this handler's deadline against a
+	// saturated WebUI. A failed sync still leaves the last good state to serve.
+	if syncManager := client.GetSyncManager(); syncManager != nil {
+		if err := syncManager.Sync(ctx); err != nil {
+			log.Debug().Err(err).Int("instanceID", instanceID).Msg("Failed to sync before reading server state; serving cached state")
+		}
+
+		if state := client.GetCachedServerState(); state != nil {
+			RespondJSON(w, http.StatusOK, newTransferInfoResponse(state))
+			return
+		}
+	}
+
 	info, err := client.GetTransferInfoCtx(ctx)
 	if err != nil {
 		log.Error().Err(err).Int("instanceID", instanceID).Msg("Failed to get transfer info")
@@ -175,7 +223,7 @@ func (h *InstancesHandler) GetTransferInfo(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	RespondJSON(w, http.StatusOK, info)
+	RespondJSON(w, http.StatusOK, transferInfoResponse{TransferInfo: *info})
 }
 
 func (h *InstancesHandler) buildInstanceResponsesParallel(ctx context.Context, instances []*models.Instance) []InstanceResponse {

--- a/internal/api/handlers/instances_transfer_info_test.go
+++ b/internal/api/handlers/instances_transfer_info_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package handlers
+
+import (
+	"encoding/json"
+	"testing"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/stretchr/testify/require"
+)
+
+// The transfer-info contract is consumed by the dashboard, the title bar and by
+// external clients that poll it instead of requesting a full torrent list for the
+// all-time totals. Every key below is load-bearing for one of them.
+func TestTransferInfoResponseFromServerState(t *testing.T) {
+	state := &qbt.ServerState{
+		AlltimeDl:        111,
+		AlltimeUl:        222,
+		ConnectionStatus: "connected",
+		DhtNodes:         333,
+		DlInfoData:       444,
+		DlInfoSpeed:      555,
+		DlRateLimit:      666,
+		UpInfoData:       777,
+		UpInfoSpeed:      888,
+		UpRateLimit:      999,
+		FreeSpaceOnDisk:  1234,
+	}
+
+	payload, err := json.Marshal(newTransferInfoResponse(state))
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(payload, &decoded))
+
+	require.Equal(t, map[string]any{
+		"alltime_dl":        float64(111),
+		"alltime_ul":        float64(222),
+		"connection_status": "connected",
+		"dht_nodes":         float64(333),
+		"dl_info_data":      float64(444),
+		"dl_info_speed":     float64(555),
+		"dl_rate_limit":     float64(666),
+		"up_info_data":      float64(777),
+		"up_info_speed":     float64(888),
+		"up_rate_limit":     float64(999),
+	}, decoded, "server state must project onto the transfer-info keys and nothing else")
+}
+
+// qBittorrent's /transfer/info carries no all-time totals. Emitting zeros there
+// would overwrite a client's last known totals with 0, so the keys must be absent
+// and let the client keep the value it already has.
+func TestTransferInfoResponseFallbackOmitsAlltimeTotals(t *testing.T) {
+	payload, err := json.Marshal(transferInfoResponse{
+		TransferInfo: qbt.TransferInfo{ConnectionStatus: "connected", DlInfoSpeed: 42},
+	})
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(payload, &decoded))
+
+	require.NotContains(t, decoded, "alltime_dl")
+	require.NotContains(t, decoded, "alltime_ul")
+	require.InDelta(t, float64(42), decoded["dl_info_speed"], 0)
+}

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -1205,7 +1205,9 @@ paths:
       tags:
         - Instances
       summary: Get transfer info
-      description: Retrieve lightweight transfer statistics for a qBittorrent instance.
+      description: >-
+        Retrieve lightweight transfer statistics and the all-time transferred
+        totals for a qBittorrent instance.
       parameters:
         - $ref: '#/components/parameters/instanceID'
       responses:
@@ -6060,6 +6062,12 @@ components:
           type: integer
         up_rate_limit:
           type: integer
+        alltime_dl:
+          type: integer
+          description: All-time downloaded bytes. Absent until the instance completes its first sync.
+        alltime_ul:
+          type: integer
+          description: All-time uploaded bytes. Absent until the instance completes its first sync.
 
 
     Torrent:


### PR DESCRIPTION
qBittorrent reports the all-time transferred totals only in the server state that `/sync/maindata` carries, never in `/transfer/info`. A client that wants those two numbers has to request a torrent list to reach the server state, which makes qui filter, sort and count its whole torrent set to answer them. On a 5000-torrent instance polled every 30 seconds that was the single heaviest repeated request the server handled, and the client throws the list away.

The handler now serves the synced server state, which already holds every `transfer/info` field plus the totals, and falls back to the direct call when no sync has completed yet. It syncs with the request context rather than the library's checked accessor, because that one syncs on `context.Background()` and would outlive this handler's deadline against a saturated WebUI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transfer information now includes optional all-time downloaded and uploaded totals.
  * Transfer data remains available using cached server state when synchronization is temporarily unavailable.
* **Documentation**
  * Updated API documentation to describe the new all-time transfer fields and when they are provided.
* **Tests**
  * Added coverage for transfer metrics, serialization, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->