### PR TITLE
perf(automations): update the hardlink index instead of rebuilding it

### DIFF
--- a/internal/services/automations/hardlink_index.go
+++ b/internal/services/automations/hardlink_index.go
@@ -337,6 +337,12 @@ func (s *Service) updateHardlinkIndex(ctx context.Context, instanceID int, cache
 
 	rescan, staleFileIDs := planTorrentRescan(previous.torrentInfoByHash, torrentByHash)
 
+	// Bail before reading anything when the changes alone already exceed the budget,
+	// so a mass addition does not read half the library off disk twice.
+	if len(rescan)*hardlinkIncrementalChangeRatio > len(torrents) {
+		return nil
+	}
+
 	// Torrents that arrived raise the link count on every file they hardlink to, so
 	// the holders of those files need a second look. Their identities are only known
 	// once the new torrents have been read, hence the two passes.
@@ -405,10 +411,18 @@ func (s *Service) updateHardlinkIndex(ctx context.Context, instanceID int, cache
 // link on it reads as a link outside the client. That is the answer that keeps the
 // torrent out of the delete-safe groups.
 func (idx *HardlinkIndex) scopeAfterRescan(info *torrentFileInfo) string {
-	if idx == nil || idx.buildState == nil || info == nil {
+	if idx == nil || info == nil {
 		return ""
 	}
 	if !info.allAccessible || len(info.fileIDs) == 0 {
+		return ""
+	}
+
+	// Cross-instance augmentation raises uniquePathCount in place, and a preview
+	// request can run it while a scheduled apply verifies its delete candidates.
+	idx.crossScopeMu.Lock()
+	defer idx.crossScopeMu.Unlock()
+	if idx.buildState == nil {
 		return ""
 	}
 

--- a/internal/services/automations/hardlink_index.go
+++ b/internal/services/automations/hardlink_index.go
@@ -12,6 +12,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -26,8 +27,18 @@ import (
 	"github.com/autobrr/qui/pkg/hardlink"
 )
 
-// hardlinkIndexTTL is the cache TTL for hardlink indices.
-const hardlinkIndexTTL = 2 * time.Minute
+// hardlinkIndexTTL bounds how long an index survives without a full rebuild.
+// Torrent set changes are folded in incrementally and do not wait for it, so this
+// only has to catch link counts that changed on disk without any torrent being
+// added or removed: a manual rm or ln, or a script moving data. Delete decisions
+// do not rely on it either, because verifyDeleteCandidates re-reads the disk for
+// the candidates before a rule deletes anything.
+const hardlinkIndexTTL = 10 * time.Minute
+
+// hardlinkIncrementalChangeRatio is the share of the torrent set that may change
+// before an incremental update stops being worthwhile. Past it, the update would
+// re-read most torrents anyway, and a full rebuild is the simpler path.
+const hardlinkIncrementalChangeRatio = 2
 
 // HardlinkIndex is a cached, single-build index of hardlink duplicate groups.
 // It enables O(1) lookups for hardlink expansion and FREE_SPACE projection dedupe.
@@ -79,17 +90,30 @@ type HardlinkIndex struct {
 	crossScopeMu sync.Mutex
 }
 
-// hardlinkBuildState holds intermediate state from the single-instance scan so that
-// cross-instance augmentation can update uniquePathCount without re-scanning.
+// hardlinkBuildState holds the per-torrent scan results plus the link counts derived
+// from them. Cross-instance augmentation updates uniquePathCount in place without
+// re-scanning, and an incremental update rebuilds the derived counts from
+// torrentInfoByHash so it only has to re-read the torrents whose links changed.
 type hardlinkBuildState struct {
 	globalFileIDMap   map[hardlink.FileID]*fileIDTracker
 	seenPaths         map[string]struct{}
 	torrentInfoByHash map[string]*torrentFileInfo
 }
 
+// linkedFile records one hardlinked file exactly as the disk reported it. Keeping
+// these lets an incremental update rebuild the global link counts in memory, so a
+// torrent that nothing linked to or from is never re-read.
+type linkedFile struct {
+	path   string
+	fileID hardlink.FileID
+	nlink  uint64
+}
+
 // torrentFileInfo tracks per-torrent file identity data during hardlink index build.
 type torrentFileInfo struct {
+	savePath       string // the save path this scan used; a change invalidates the scan
 	fileIDs        []hardlink.FileID
+	linkedFiles    []linkedFile // files seen with nlink > 1, in scan order
 	allAccessible  bool
 	hasHardlinks   bool // at least one file has nlink > 1
 	hasInvalidPath bool // at least one file path escapes save path
@@ -106,11 +130,12 @@ var globalHardlinkIndexCache = &hardlinkIndexCache{
 	indices: make(map[int]*HardlinkIndex),
 }
 
-// GetHardlinkIndex returns a cached or freshly built hardlink index for the given instance.
-// The index is cached for 2 minutes and invalidated when the torrent set changes.
-// When needsCrossScope is true, the index retains intermediate build state so that
-// augmentCrossInstanceScope can later augment it without re-scanning the current instance.
-func (s *Service) GetHardlinkIndex(ctx context.Context, instanceID int, torrents []qbt.Torrent, needsCrossScope bool) *HardlinkIndex {
+// GetHardlinkIndex returns a cached, incrementally updated, or freshly built hardlink
+// index for the given instance. A change to the torrent set is folded in by re-reading
+// only the torrents whose links it can have changed; the full rebuild runs when the
+// index ages past hardlinkIndexTTL, when too much of the set changed at once, or when
+// no previous scan is available to build on.
+func (s *Service) GetHardlinkIndex(ctx context.Context, instanceID int, torrents []qbt.Torrent) *HardlinkIndex {
 	if s == nil || s.syncManager == nil {
 		return nil
 	}
@@ -123,31 +148,21 @@ func (s *Service) GetHardlinkIndex(ctx context.Context, instanceID int, torrents
 	cached := globalHardlinkIndexCache.indices[instanceID]
 	globalHardlinkIndexCache.mu.RUnlock()
 
-	cacheValid := cached != nil && time.Since(cached.builtAt) < hardlinkIndexTTL && cached.digest == currentDigest
-	if cacheValid && needsCrossScope {
-		// Check cross-scope fields under the per-index mutex to avoid racing with
-		// a concurrent augmentCrossInstanceScope that writes these fields.
-		cached.crossScopeMu.Lock()
-		needsRebuild := cached.CrossScopeByHash == nil && cached.buildState == nil
-		cached.crossScopeMu.Unlock()
-		if needsRebuild {
-			cacheValid = false
-		}
-	}
-	if cacheValid {
+	fresh := cached != nil && time.Since(cached.builtAt) < hardlinkIndexTTL
+	if fresh && cached.digest == currentDigest {
 		return cached
 	}
 
-	// Build index with singleflight to prevent duplicate builds.
-	// Include digest and cross-scope flag in key so concurrent calls with different
-	// scope requirements don't collide.
-	crossFlag := "0"
-	if needsCrossScope {
-		crossFlag = "1"
-	}
-	key := strconv.Itoa(instanceID) + ":" + currentDigest + ":" + crossFlag
+	// Build index with singleflight to prevent duplicate builds. The digest keys the
+	// call so concurrent callers looking at the same torrent set share one build.
+	key := strconv.Itoa(instanceID) + ":" + currentDigest
 	result, err, _ := globalHardlinkIndexCache.sf.Do(key, func() (any, error) {
-		return s.buildHardlinkIndex(ctx, instanceID, torrents, currentDigest, needsCrossScope), nil
+		if fresh {
+			if updated := s.updateHardlinkIndex(ctx, instanceID, cached, torrents, currentDigest); updated != nil {
+				return updated, nil
+			}
+		}
+		return s.buildHardlinkIndex(ctx, instanceID, torrents, currentDigest), nil
 	})
 	if err != nil {
 		return nil
@@ -161,7 +176,7 @@ func (s *Service) GetHardlinkIndex(ctx context.Context, instanceID int, torrents
 	// Validate digest matches (paranoid check for edge cases)
 	if idx.digest != currentDigest {
 		// Rebuild with correct digest
-		return s.buildHardlinkIndex(ctx, instanceID, torrents, currentDigest, needsCrossScope)
+		return s.buildHardlinkIndex(ctx, instanceID, torrents, currentDigest)
 	}
 	return idx
 }
@@ -204,11 +219,371 @@ type fileIDTracker struct {
 	uniquePathCount int
 }
 
+// scanTorrentFiles reads one torrent's files off disk and records what it found.
+// A torrent that could not be fully inspected keeps allAccessible false, which
+// leaves its scope unknown rather than guessing at "not hardlinked".
+func scanTorrentFiles(torrent qbt.Torrent, files qbt.TorrentFiles) *torrentFileInfo {
+	info := &torrentFileInfo{
+		savePath:      torrent.SavePath,
+		fileIDs:       make([]hardlink.FileID, 0, len(files)),
+		allAccessible: true,
+	}
+
+	// Reject empty or non-absolute save paths to prevent Lstat on unintended locations.
+	if torrent.SavePath == "" || !filepath.IsAbs(torrent.SavePath) {
+		info.allAccessible = false
+		info.hasInvalidPath = true
+		return info
+	}
+
+	for _, f := range files {
+		fullPath := buildFullPath(torrent.SavePath, f.Name)
+
+		// Reject paths that escape the torrent's save path to prevent malicious
+		// torrent metadata from causing Lstat on arbitrary filesystem locations.
+		if !isPathInsideBase(torrent.SavePath, fullPath) {
+			info.allAccessible = false
+			info.hasInvalidPath = true
+			continue
+		}
+
+		fi, err := os.Lstat(fullPath)
+		if err != nil {
+			info.allAccessible = false
+			continue
+		}
+		if !fi.Mode().IsRegular() {
+			continue
+		}
+
+		fileID, nlink, err := hardlink.GetFileID(fi, fullPath)
+		if err != nil {
+			info.allAccessible = false
+			continue
+		}
+
+		info.fileIDs = append(info.fileIDs, fileID)
+		if nlink > 1 {
+			// Only track hard-linked files. Files with nlink == 1 cannot have outside
+			// links, so leaving them out keeps the retained state small.
+			info.hasHardlinks = true
+			info.linkedFiles = append(info.linkedFiles, linkedFile{path: fullPath, fileID: fileID, nlink: nlink})
+		}
+	}
+
+	return info
+}
+
+// deriveLinkCounts rebuilds the global link counts from the per-torrent scans. It
+// touches no disk, so an incremental update can recompute every count after
+// re-reading only the torrents whose links actually changed.
+//
+// Scans taken at different moments can disagree on a file's link count. The higher
+// count wins, because it is the one that reports links outside the torrent set, and
+// that answer excludes the torrent from the delete-safe groups.
+func deriveLinkCounts(torrentInfoByHash map[string]*torrentFileInfo) *hardlinkBuildState {
+	globalFileIDMap := make(map[hardlink.FileID]*fileIDTracker)
+	seenPaths := make(map[string]struct{})
+
+	for _, info := range torrentInfoByHash {
+		for _, lf := range info.linkedFiles {
+			tracker := globalFileIDMap[lf.fileID]
+			if tracker == nil {
+				tracker = &fileIDTracker{nlink: lf.nlink}
+				globalFileIDMap[lf.fileID] = tracker
+			} else if lf.nlink > tracker.nlink {
+				tracker.nlink = lf.nlink
+			}
+
+			if _, seen := seenPaths[lf.path]; !seen {
+				seenPaths[lf.path] = struct{}{}
+				tracker.uniquePathCount++
+			}
+		}
+	}
+
+	return &hardlinkBuildState{
+		globalFileIDMap:   globalFileIDMap,
+		seenPaths:         seenPaths,
+		torrentInfoByHash: torrentInfoByHash,
+	}
+}
+
+// updateHardlinkIndex folds a torrent set change into the previous index instead of
+// rescanning every torrent. Adding or removing one torrent changes the link counts of
+// the torrents that share its files and of nothing else, so only those are re-read.
+//
+// Returns nil when the update cannot be trusted or would not pay for itself, leaving
+// the caller to run a full build: no previous scan to build on, a fetch failure, or
+// more than a fraction of the set changed at once.
+func (s *Service) updateHardlinkIndex(ctx context.Context, instanceID int, cached *HardlinkIndex, torrents []qbt.Torrent, digest string) *HardlinkIndex {
+	if cached == nil || len(torrents) == 0 {
+		return nil
+	}
+
+	cached.crossScopeMu.Lock()
+	previous := cached.buildState
+	cached.crossScopeMu.Unlock()
+	if previous == nil {
+		return nil
+	}
+
+	startTime := time.Now()
+
+	torrentByHash := make(map[string]qbt.Torrent, len(torrents))
+	for i := range torrents {
+		torrentByHash[torrents[i].Hash] = torrents[i]
+	}
+
+	rescan, staleFileIDs := planTorrentRescan(previous.torrentInfoByHash, torrentByHash)
+
+	// Torrents that arrived raise the link count on every file they hardlink to, so
+	// the holders of those files need a second look. Their identities are only known
+	// once the new torrents have been read, hence the two passes.
+	scanned, ok := s.scanHashes(ctx, instanceID, torrentByHash, rescan)
+	if !ok {
+		return nil
+	}
+	for _, info := range scanned {
+		for _, fileID := range info.fileIDs {
+			staleFileIDs[fileID] = struct{}{}
+		}
+	}
+
+	sharing := planSharingRescan(previous.torrentInfoByHash, torrentByHash, rescan, staleFileIDs)
+
+	if (len(rescan)+len(sharing))*hardlinkIncrementalChangeRatio > len(torrents) {
+		return nil
+	}
+
+	sharingScanned, ok := s.scanHashes(ctx, instanceID, torrentByHash, sharing)
+	if !ok {
+		return nil
+	}
+
+	torrentInfoByHash := make(map[string]*torrentFileInfo, len(torrents))
+	for hash, info := range previous.torrentInfoByHash {
+		if _, stillPresent := torrentByHash[hash]; stillPresent {
+			torrentInfoByHash[hash] = info
+		}
+	}
+	maps.Copy(torrentInfoByHash, scanned)
+	maps.Copy(torrentInfoByHash, sharingScanned)
+
+	// Deriving the counts from every retained scan discards whatever cross-instance
+	// augmentation added to the previous state, which is why CrossScopeByHash starts
+	// nil again and callers that need it re-augment.
+	index := &HardlinkIndex{digest: digest}
+	stats := index.applyLinkState(deriveLinkCounts(torrentInfoByHash))
+	index.builtAt = time.Now()
+
+	globalHardlinkIndexCache.mu.Lock()
+	globalHardlinkIndexCache.indices[instanceID] = index
+	globalHardlinkIndexCache.mu.Unlock()
+
+	log.Debug().
+		Int("instanceID", instanceID).
+		Int("totalTorrents", len(torrents)).
+		Int("rescanned", len(rescan)).
+		Int("resharedRescanned", len(sharing)).
+		Int("removed", len(previous.torrentInfoByHash)-len(torrentInfoByHash)+len(rescan)).
+		Int("scopeComputed", len(index.ScopeByHash)).
+		Int("deleteSafeDuplicateTorrents", len(index.DeleteSafeSignatureByHash)).
+		Int("outsideLinks", stats.outsideLinks).
+		Int("inaccessible", stats.inaccessible).
+		Dur("buildTime", time.Since(startTime)).
+		Msg("automations: hardlink index updated")
+
+	return index
+}
+
+// scopeAfterRescan recomputes one torrent's hardlink scope from a fresh disk read,
+// reusing the index's count of how many paths in the torrent set point at each file.
+// It returns an empty scope when the torrent could not be fully inspected.
+//
+// A file the index has never seen counts as held by this torrent alone, so any extra
+// link on it reads as a link outside the client. That is the answer that keeps the
+// torrent out of the delete-safe groups.
+func (idx *HardlinkIndex) scopeAfterRescan(info *torrentFileInfo) string {
+	if idx == nil || idx.buildState == nil || info == nil {
+		return ""
+	}
+	if !info.allAccessible || len(info.fileIDs) == 0 {
+		return ""
+	}
+
+	scope := HardlinkScopeNone
+	for _, lf := range info.linkedFiles {
+		uniquePaths := 1
+		if tracker := idx.buildState.globalFileIDMap[lf.fileID]; tracker != nil && tracker.uniquePathCount > 1 {
+			uniquePaths = tracker.uniquePathCount
+		}
+
+		if lf.nlink > uint64(uniquePaths) { //nolint:gosec // uniquePaths is always positive
+			return HardlinkScopeOutsideQBitTorrent
+		}
+		scope = HardlinkScopeTorrentsOnly
+	}
+
+	return scope
+}
+
+// verifyDeleteCandidates re-reads the given torrents' files and returns the hashes whose
+// hardlink scope no longer matches the index the rule decided on. Callers must not delete
+// those: between the index build and now, links were added or removed on disk, or the
+// files stopped being readable, and the rule's answer no longer describes them.
+//
+// This is the one place that must not trust the index. The index is allowed to lag by
+// hardlinkIndexTTL for changes nothing reports, which is harmless for tagging and not
+// harmless for deleting.
+func (s *Service) verifyDeleteCandidates(ctx context.Context, instanceID int, index *HardlinkIndex, torrentByHash map[string]qbt.Torrent, hashes []string) map[string]string {
+	if index == nil || len(hashes) == 0 {
+		return nil
+	}
+
+	filesByHash, err := s.syncManager.GetTorrentFilesBatch(ctx, instanceID, hashes)
+	if err != nil {
+		// Every candidate becomes unverifiable, and unverifiable must not be deleted.
+		log.Warn().Err(err).Int("instanceID", instanceID).Int("candidates", len(hashes)).
+			Msg("automations: failed to re-read delete candidates, holding the deletions")
+		blocked := make(map[string]string, len(hashes))
+		for _, hash := range hashes {
+			blocked[hash] = "file list unavailable"
+		}
+		return blocked
+	}
+
+	var blocked map[string]string
+	for _, hash := range hashes {
+		expected, known := index.ScopeByHash[hash]
+		if !known {
+			// The rule already treated this torrent's scope as unknown, so there is no
+			// hardlink answer to invalidate.
+			continue
+		}
+
+		files, present := filesByHash[hash]
+		actual := ""
+		if present {
+			actual = index.scopeAfterRescan(scanTorrentFiles(torrentByHash[hash], files))
+		}
+
+		if actual == expected {
+			continue
+		}
+
+		if blocked == nil {
+			blocked = make(map[string]string)
+		}
+		if actual == "" {
+			blocked[hash] = "files no longer readable"
+			continue
+		}
+		blocked[hash] = "hardlink scope changed from " + expected + " to " + actual
+	}
+
+	return blocked
+}
+
+// planTorrentRescan decides which torrents an incremental update must read off disk,
+// and which files it can no longer trust the link counts for.
+//
+// A torrent that left takes its link counts with it: the files it held may have lost a
+// link, or kept the link and lost the torrent that explained it. Either way the torrents
+// still holding those files need a fresh read. A torrent whose save path moved points at
+// different files now, so its previous scan is as stale as a removal plus an addition.
+func planTorrentRescan(previous map[string]*torrentFileInfo, torrentByHash map[string]qbt.Torrent) (map[string]struct{}, map[hardlink.FileID]struct{}) {
+	rescan := make(map[string]struct{})
+	staleFileIDs := make(map[hardlink.FileID]struct{})
+
+	for hash, info := range previous {
+		torrent, stillPresent := torrentByHash[hash]
+		if stillPresent && torrent.SavePath == info.savePath {
+			continue
+		}
+		if stillPresent {
+			rescan[hash] = struct{}{}
+		}
+		for _, fileID := range info.fileIDs {
+			staleFileIDs[fileID] = struct{}{}
+		}
+	}
+
+	for hash := range torrentByHash {
+		if _, scanned := previous[hash]; !scanned {
+			rescan[hash] = struct{}{}
+		}
+	}
+
+	return rescan, staleFileIDs
+}
+
+// planSharingRescan returns the torrents that hold one of the untrusted files and are
+// not already being re-read. These are the ones whose scope can flip without anything
+// happening to them directly.
+func planSharingRescan(
+	previous map[string]*torrentFileInfo,
+	torrentByHash map[string]qbt.Torrent,
+	rescan map[string]struct{},
+	staleFileIDs map[hardlink.FileID]struct{},
+) map[string]struct{} {
+	sharing := make(map[string]struct{})
+
+	for hash, info := range previous {
+		if _, alreadyScanned := rescan[hash]; alreadyScanned {
+			continue
+		}
+		if _, stillPresent := torrentByHash[hash]; !stillPresent {
+			continue
+		}
+		for _, fileID := range info.fileIDs {
+			if _, stale := staleFileIDs[fileID]; stale {
+				sharing[hash] = struct{}{}
+				break
+			}
+		}
+	}
+
+	return sharing
+}
+
+// scanHashes reads the given torrents' files off disk. It reports false when the file
+// lists could not be fetched, which must abandon the incremental update rather than
+// leave those torrents on their previous scan: a torrent silently kept at stale link
+// counts is exactly what an incremental update must not produce.
+func (s *Service) scanHashes(ctx context.Context, instanceID int, torrentByHash map[string]qbt.Torrent, hashes map[string]struct{}) (map[string]*torrentFileInfo, bool) {
+	if len(hashes) == 0 {
+		return nil, true
+	}
+
+	list := slices.Collect(maps.Keys(hashes))
+	filesByHash, err := s.syncManager.GetTorrentFilesBatch(ctx, instanceID, list)
+	if err != nil {
+		log.Warn().Err(err).Int("instanceID", instanceID).Int("hashes", len(list)).
+			Msg("automations: failed to fetch files for hardlink index update, falling back to a full build")
+		return nil, false
+	}
+
+	scanned := make(map[string]*torrentFileInfo, len(list))
+	for _, hash := range list {
+		files, present := filesByHash[hash]
+		if !present {
+			// A torrent with no file list has unknown links. Recording it as inspected
+			// would claim "no hardlinks" for it, so leave it unknown instead.
+			scanned[hash] = &torrentFileInfo{savePath: torrentByHash[hash].SavePath}
+			continue
+		}
+		scanned[hash] = scanTorrentFiles(torrentByHash[hash], files)
+	}
+
+	return scanned, true
+}
+
 // buildHardlinkIndex constructs a fresh hardlink index by scanning all torrent files once.
 // The complexity is inherent to the single-pass algorithm that avoids multiple filesystem scans.
 //
 //nolint:gocognit,gocyclo,funlen,revive // complexity is inherent to the single-pass design
-func (s *Service) buildHardlinkIndex(ctx context.Context, instanceID int, torrents []qbt.Torrent, digest string, retainBuildState bool) *HardlinkIndex {
+func (s *Service) buildHardlinkIndex(ctx context.Context, instanceID int, torrents []qbt.Torrent, digest string) *HardlinkIndex {
 	startTime := time.Now()
 	index := &HardlinkIndex{
 		SignatureByHash:            make(map[string]string),
@@ -256,153 +631,14 @@ func (s *Service) buildHardlinkIndex(ctx context.Context, instanceID int, torren
 	// Note: partial results (missing hashes) are handled implicitly; torrents with missing file lists
 	// will have unknown hardlink scope and won't participate in expansion.
 
-	// Phase 1: Single pass to collect FileID info across all files
-	// Track: fileID -> {nlink, uniquePathCount}
-	globalFileIDMap := make(map[hardlink.FileID]*fileIDTracker)
-	seenPaths := make(map[string]struct{})
-	torrentsInvalidPaths := 0
-
-	torrentInfoByHash := make(map[string]*torrentFileInfo)
-
+	// Phase 1: read every torrent's files off disk, then derive the link counts.
+	torrentInfoByHash := make(map[string]*torrentFileInfo, len(filesByHash))
 	for hash, files := range filesByHash {
-		torrent := torrentByHash[hash]
-		info := &torrentFileInfo{
-			fileIDs:       make([]hardlink.FileID, 0, len(files)),
-			allAccessible: true,
-		}
-		torrentInfoByHash[hash] = info
-
-		// Reject empty or non-absolute save paths to prevent Lstat on unintended locations.
-		if torrent.SavePath == "" || !filepath.IsAbs(torrent.SavePath) {
-			info.allAccessible = false
-			info.hasInvalidPath = true
-			torrentsInvalidPaths++
-			continue
-		}
-
-		for _, f := range files {
-			fullPath := buildFullPath(torrent.SavePath, f.Name)
-
-			// Reject paths that escape the torrent's save path to prevent malicious
-			// torrent metadata from causing Lstat on arbitrary filesystem locations.
-			if !isPathInsideBase(torrent.SavePath, fullPath) {
-				info.allAccessible = false
-				info.hasInvalidPath = true
-				continue
-			}
-
-			fi, err := os.Lstat(fullPath)
-			if err != nil {
-				info.allAccessible = false
-				continue
-			}
-			if !fi.Mode().IsRegular() {
-				continue
-			}
-
-			fileID, nlink, err := hardlink.GetFileID(fi, fullPath)
-			if err != nil {
-				info.allAccessible = false
-				continue
-			}
-
-			info.fileIDs = append(info.fileIDs, fileID)
-			if nlink > 1 {
-				info.hasHardlinks = true
-
-				// Only track global fileID info for hard-linked files (nlink > 1).
-				// Files with nlink == 1 can't have outside links, so skip them to save memory.
-				tracker := globalFileIDMap[fileID]
-				if tracker == nil {
-					tracker = &fileIDTracker{nlink: nlink}
-					globalFileIDMap[fileID] = tracker
-				}
-				// Count unique paths pointing to this fileID
-				if _, seen := seenPaths[fullPath]; !seen {
-					seenPaths[fullPath] = struct{}{}
-					tracker.uniquePathCount++
-				}
-			}
-		}
-
-		if info.hasInvalidPath {
-			torrentsInvalidPaths++
-		}
+		torrentInfoByHash[hash] = scanTorrentFiles(torrentByHash[hash], files)
 	}
 
-	// Phase 2: Compute scope and signature for each torrent
-	torrentsWithOutsideLinks := 0
-	torrentsInaccessible := 0
-
-	for hash, info := range torrentInfoByHash {
-		// If we couldn't inspect all files, treat scope as "unknown" by not adding to map.
-		// This ensures HARDLINK_SCOPE conditions never match for partially-inspected torrents.
-		if !info.allAccessible || len(info.fileIDs) == 0 {
-			// Only count as inaccessible if not already counted as invalid path
-			if !info.hasInvalidPath {
-				torrentsInaccessible++
-			}
-			continue
-		}
-
-		// Determine scope
-		scope := HardlinkScopeNone
-		hasOutsideLinks := false
-
-		for _, fileID := range info.fileIDs {
-			tracker := globalFileIDMap[fileID]
-			if tracker == nil {
-				continue
-			}
-			if tracker.nlink <= 1 {
-				continue // Not hard-linked
-			}
-
-			// File has hardlinks
-			if tracker.nlink > uint64(tracker.uniquePathCount) { //nolint:gosec // uniquePathCount is always positive
-				// Links exist outside the torrent set
-				scope = HardlinkScopeOutsideQBitTorrent
-				hasOutsideLinks = true
-				break
-			}
-			scope = HardlinkScopeTorrentsOnly
-		}
-
-		index.ScopeByHash[hash] = scope
-
-		// Only include in duplicate index if:
-		// 1. Has hardlinks (otherwise not a duplicate candidate)
-		if !info.hasHardlinks {
-			continue // Not a hardlink duplicate candidate
-		}
-
-		if hasOutsideLinks {
-			torrentsWithOutsideLinks++
-		}
-
-		// Compute signature once; feed broad grouping map plus delete-safe subset.
-		sig := computeFileIDSignature(info.fileIDs)
-		index.SignatureByHash[hash] = sig
-		index.GroupBySignature[sig] = append(index.GroupBySignature[sig], hash)
-		if !hasOutsideLinks {
-			index.DeleteSafeSignatureByHash[hash] = sig
-			index.DeleteSafeGroupBySignature[sig] = append(index.DeleteSafeGroupBySignature[sig], hash)
-		}
-	}
-
-	pruneSingletonHardlinkGroups(index.SignatureByHash, index.GroupBySignature)
-	pruneSingletonHardlinkGroups(index.DeleteSafeSignatureByHash, index.DeleteSafeGroupBySignature)
-
-	// Retain build state only when cross-instance augmentation (Phase 2) may be needed.
-	// This avoids keeping globalFileIDMap/seenPaths/torrentInfoByHash in memory for
-	// runs that only use HARDLINK_SCOPE or includeHardlinks.
-	if retainBuildState {
-		index.buildState = &hardlinkBuildState{
-			globalFileIDMap:   globalFileIDMap,
-			seenPaths:         seenPaths,
-			torrentInfoByHash: torrentInfoByHash,
-		}
-	}
+	// Phase 2: derive scope, signatures and groups from the scan results.
+	stats := index.applyLinkState(deriveLinkCounts(torrentInfoByHash))
 
 	// Set builtAt at the end of successful build (not start) to avoid TTL issues with slow builds
 	index.builtAt = time.Now()
@@ -420,13 +656,81 @@ func (s *Service) buildHardlinkIndex(ctx context.Context, instanceID int, torren
 		Int("groupingDuplicateTorrents", len(index.SignatureByHash)).
 		Int("deleteSafeDuplicateGroups", len(index.DeleteSafeGroupBySignature)).
 		Int("deleteSafeDuplicateTorrents", len(index.DeleteSafeSignatureByHash)).
-		Int("outsideLinks", torrentsWithOutsideLinks).
-		Int("inaccessible", torrentsInaccessible).
-		Int("invalidPaths", torrentsInvalidPaths).
+		Int("outsideLinks", stats.outsideLinks).
+		Int("inaccessible", stats.inaccessible).
+		Int("invalidPaths", stats.invalidPaths).
 		Dur("buildTime", time.Since(startTime)).
 		Msg("automations: hardlink index built")
 
 	return index
+}
+
+// indexStats counts what the derived maps left out, for the build log line.
+type indexStats struct {
+	outsideLinks int
+	inaccessible int
+	invalidPaths int
+}
+
+// applyLinkState fills the index's derived maps from a completed scan and adopts
+// the state as its own. Every map is rebuilt from scratch, so it is equally valid
+// after a full scan or after an incremental one that re-read a handful of torrents.
+func (idx *HardlinkIndex) applyLinkState(state *hardlinkBuildState) indexStats {
+	var stats indexStats
+
+	idx.SignatureByHash = make(map[string]string)
+	idx.GroupBySignature = make(map[string][]string)
+	idx.DeleteSafeSignatureByHash = make(map[string]string)
+	idx.DeleteSafeGroupBySignature = make(map[string][]string)
+	// Torrents that could not be fully inspected are left out, so their scope reads as
+	// unknown and HARDLINK_SCOPE conditions never match them.
+	idx.ScopeByHash = computeScopeMap(state)
+
+	for hash, info := range state.torrentInfoByHash {
+		if info.hasInvalidPath {
+			stats.invalidPaths++
+		}
+
+		scope, inspected := idx.ScopeByHash[hash]
+		if !inspected {
+			// Only count as inaccessible if not already counted as invalid path
+			if !info.hasInvalidPath {
+				stats.inaccessible++
+			}
+			continue
+		}
+
+		hasOutsideLinks := scope == HardlinkScopeOutsideQBitTorrent
+
+		// Only include in duplicate index if:
+		// 1. Has hardlinks (otherwise not a duplicate candidate)
+		if !info.hasHardlinks {
+			continue // Not a hardlink duplicate candidate
+		}
+
+		if hasOutsideLinks {
+			stats.outsideLinks++
+		}
+
+		// Compute signature once; feed broad grouping map plus delete-safe subset.
+		sig := computeFileIDSignature(info.fileIDs)
+		idx.SignatureByHash[hash] = sig
+		idx.GroupBySignature[sig] = append(idx.GroupBySignature[sig], hash)
+		if !hasOutsideLinks {
+			idx.DeleteSafeSignatureByHash[hash] = sig
+			idx.DeleteSafeGroupBySignature[sig] = append(idx.DeleteSafeGroupBySignature[sig], hash)
+		}
+	}
+
+	pruneSingletonHardlinkGroups(idx.SignatureByHash, idx.GroupBySignature)
+	pruneSingletonHardlinkGroups(idx.DeleteSafeSignatureByHash, idx.DeleteSafeGroupBySignature)
+
+	// The state is always retained: an incremental update needs the per-torrent scan
+	// results to avoid re-reading torrents whose links did not change, and cross-instance
+	// augmentation needs the link counts. It costs a few MB for a 5000-torrent instance.
+	idx.buildState = state
+
+	return stats
 }
 
 func pruneSingletonHardlinkGroups(signatureByHash map[string]string, groupsBySignature map[string][]string) {
@@ -593,9 +897,10 @@ func (s *Service) augmentCrossInstanceScope(ctx context.Context, instanceID int,
 		return
 	}
 
-	// Recompute scope for all torrents using augmented counts.
+	// Recompute scope for all torrents using augmented counts. The state stays so the
+	// next torrent set change can update incrementally; the counts this scan raised are
+	// discarded there, because deriveLinkCounts rebuilds them from the per-torrent scans.
 	index.CrossScopeByHash = computeScopeMap(state)
-	index.buildState = nil
 
 	var countNone, countTorrentsOnly, countOutside int
 	for _, scope := range index.CrossScopeByHash {
@@ -635,12 +940,11 @@ func collectDeficitFileIDs(state *hardlinkBuildState) map[hardlink.FileID]*fileI
 	return deficitSet
 }
 
-// finalizeCrossScope copies ScopeByHash to CrossScopeByHash and frees build state.
+// finalizeCrossScope copies ScopeByHash to CrossScopeByHash.
 // Used when Phase 2 cannot or does not need to scan other instances.
 func (idx *HardlinkIndex) finalizeCrossScope(instanceID int, reason string) {
 	idx.CrossScopeByHash = make(map[string]string, len(idx.ScopeByHash))
 	maps.Copy(idx.CrossScopeByHash, idx.ScopeByHash)
-	idx.buildState = nil
 	if reason != "" {
 		log.Debug().Int("instanceID", instanceID).
 			Msgf("automations: cross-instance scope matches single-instance (%s)", reason)

--- a/internal/services/automations/hardlink_index_incremental_test.go
+++ b/internal/services/automations/hardlink_index_incremental_test.go
@@ -1,0 +1,215 @@
+// Copyright (c) 2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package automations
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/pkg/hardlink"
+)
+
+// scanOne reads one torrent's files the way the index does, from real files on disk.
+func scanOne(t *testing.T, savePath string, names ...string) *torrentFileInfo {
+	t.Helper()
+	files := make(qbt.TorrentFiles, 0, len(names))
+	for _, name := range names {
+		files = append(files, qbt.TorrentFile{Name: name})
+	}
+	return scanTorrentFiles(qbt.Torrent{SavePath: savePath}, files)
+}
+
+// indexFrom derives the link counts and every derived map from a set of scans, exactly
+// as a full build or an incremental update does.
+func indexFrom(scans map[string]*torrentFileInfo) *HardlinkIndex {
+	index := &HardlinkIndex{}
+	index.applyLinkState(deriveLinkCounts(scans))
+	return index
+}
+
+// Two torrents holding the same physical file are hardlinked to each other and to
+// nothing else. Dropping one of them, files and all, leaves the survivor with a single
+// link, and the survivor's scope has to follow even though nothing happened to it
+// directly. This is what an incremental update has to get right.
+func TestIncrementalUpdate_RemovedTorrentChangesSurvivorScope(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pathA := filepath.Join(dir, "a", "movie.mkv")
+	pathB := filepath.Join(dir, "b", "movie.mkv")
+	createFile(t, pathA)
+	require.NoError(t, os.MkdirAll(filepath.Dir(pathB), 0o700))
+	require.NoError(t, os.Link(pathA, pathB))
+
+	scans := map[string]*torrentFileInfo{
+		"hashA": scanOne(t, filepath.Join(dir, "a"), "movie.mkv"),
+		"hashB": scanOne(t, filepath.Join(dir, "b"), "movie.mkv"),
+	}
+	before := indexFrom(scans)
+	require.Equal(t, HardlinkScopeTorrentsOnly, before.ScopeByHash["hashA"])
+	require.Equal(t, HardlinkScopeTorrentsOnly, before.ScopeByHash["hashB"])
+
+	// hashB leaves and takes its link with it.
+	require.NoError(t, os.Remove(pathB))
+	delete(scans, "hashB")
+	scans["hashA"] = scanOne(t, filepath.Join(dir, "a"), "movie.mkv")
+
+	after := indexFrom(scans)
+	require.Equal(t, HardlinkScopeNone, after.ScopeByHash["hashA"], "survivor is no longer hardlinked")
+	require.NotContains(t, after.DeleteSafeSignatureByHash, "hashA")
+	require.NotContains(t, after.ScopeByHash, "hashB", "the departed torrent is gone from the index")
+}
+
+// A torrent removed from qBittorrent while its files stay on disk leaves a link that
+// nothing in the client explains any more. The survivor has to read as linked outside
+// the client, which is what keeps it out of the delete-safe groups.
+func TestIncrementalUpdate_RemovedTorrentKeepingFilesMovesLinkOutside(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pathA := filepath.Join(dir, "a", "movie.mkv")
+	pathB := filepath.Join(dir, "b", "movie.mkv")
+	createFile(t, pathA)
+	require.NoError(t, os.MkdirAll(filepath.Dir(pathB), 0o700))
+	require.NoError(t, os.Link(pathA, pathB))
+
+	scans := map[string]*torrentFileInfo{
+		"hashA": scanOne(t, filepath.Join(dir, "a"), "movie.mkv"),
+		"hashB": scanOne(t, filepath.Join(dir, "b"), "movie.mkv"),
+	}
+	require.Equal(t, HardlinkScopeTorrentsOnly, indexFrom(scans).ScopeByHash["hashA"])
+
+	// hashB is removed from the client, the file it linked stays where it is.
+	delete(scans, "hashB")
+
+	after := indexFrom(scans)
+	require.Equal(t, HardlinkScopeOutsideQBitTorrent, after.ScopeByHash["hashA"])
+	require.NotContains(t, after.DeleteSafeSignatureByHash, "hashA", "outside links are never delete-safe")
+}
+
+func TestPlanTorrentRescan(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pathA := filepath.Join(dir, "a", "movie.mkv")
+	createFile(t, pathA)
+
+	previous := map[string]*torrentFileInfo{
+		"moved":  scanOne(t, filepath.Join(dir, "a"), "movie.mkv"),
+		"stayed": scanOne(t, filepath.Join(dir, "a"), "movie.mkv"),
+	}
+
+	current := map[string]qbt.Torrent{
+		"moved":   {Hash: "moved", SavePath: filepath.Join(dir, "elsewhere")},
+		"stayed":  {Hash: "stayed", SavePath: filepath.Join(dir, "a")},
+		"arrived": {Hash: "arrived", SavePath: filepath.Join(dir, "c")},
+	}
+
+	rescan, staleFileIDs := planTorrentRescan(previous, current)
+
+	require.Contains(t, rescan, "moved", "a save path change points the torrent at different files")
+	require.Contains(t, rescan, "arrived", "a torrent with no previous scan has to be read")
+	require.NotContains(t, rescan, "stayed", "an untouched torrent is not re-read")
+	require.NotEmpty(t, staleFileIDs, "the moved torrent's old files lose their explanation")
+}
+
+// The plan must not schedule work twice, and must not schedule torrents that left.
+func TestPlanSharingRescanSkipsAlreadyPlannedAndDepartedTorrents(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pathA := filepath.Join(dir, "a", "movie.mkv")
+	pathB := filepath.Join(dir, "b", "movie.mkv")
+	createFile(t, pathA)
+	require.NoError(t, os.MkdirAll(filepath.Dir(pathB), 0o700))
+	require.NoError(t, os.Link(pathA, pathB))
+
+	infoA := scanOne(t, filepath.Join(dir, "a"), "movie.mkv")
+	previous := map[string]*torrentFileInfo{
+		"planned":  infoA,
+		"departed": scanOne(t, filepath.Join(dir, "b"), "movie.mkv"),
+		"sharer":   scanOne(t, filepath.Join(dir, "b"), "movie.mkv"),
+	}
+	current := map[string]qbt.Torrent{
+		"planned": {Hash: "planned", SavePath: filepath.Join(dir, "a")},
+		"sharer":  {Hash: "sharer", SavePath: filepath.Join(dir, "b")},
+	}
+
+	staleFileIDs := map[hardlink.FileID]struct{}{}
+	for _, fileID := range infoA.fileIDs {
+		staleFileIDs[fileID] = struct{}{}
+	}
+
+	sharing := planSharingRescan(previous, current, map[string]struct{}{"planned": {}}, staleFileIDs)
+
+	require.Equal(t, map[string]struct{}{"sharer": {}}, sharing)
+}
+
+// A rule decides on the index, then the disk changes before the delete runs. The
+// verification has to see the new link count, not the one the index recorded.
+func TestScopeAfterRescanSeesLinksAddedSinceTheIndexWasBuilt(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pathA := filepath.Join(dir, "a", "movie.mkv")
+	createFile(t, pathA)
+
+	scans := map[string]*torrentFileInfo{"hashA": scanOne(t, filepath.Join(dir, "a"), "movie.mkv")}
+	index := indexFrom(scans)
+	require.Equal(t, HardlinkScopeNone, index.ScopeByHash["hashA"])
+
+	// Something outside qBittorrent hardlinks the file after the index was built.
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "library"), 0o700))
+	require.NoError(t, os.Link(pathA, filepath.Join(dir, "library", "movie.mkv")))
+
+	fresh := scanOne(t, filepath.Join(dir, "a"), "movie.mkv")
+	require.Equal(t, HardlinkScopeOutsideQBitTorrent, index.scopeAfterRescan(fresh),
+		"the fresh read must report the link the index never saw")
+}
+
+func TestScopeAfterRescanReportsUnknownForUnreadableFiles(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pathA := filepath.Join(dir, "a", "movie.mkv")
+	createFile(t, pathA)
+
+	scans := map[string]*torrentFileInfo{"hashA": scanOne(t, filepath.Join(dir, "a"), "movie.mkv")}
+	index := indexFrom(scans)
+
+	require.NoError(t, os.Remove(pathA))
+
+	fresh := scanOne(t, filepath.Join(dir, "a"), "movie.mkv")
+	require.Empty(t, index.scopeAfterRescan(fresh),
+		"a torrent whose files vanished has no scope, and must not read as unlinked")
+}
+
+// Scans taken at different moments can disagree about a file. The higher link count has
+// to win, because it is the one that reports a link outside the torrent set.
+func TestDeriveLinkCountsPrefersTheHigherLinkCount(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pathA := filepath.Join(dir, "a", "movie.mkv")
+	pathB := filepath.Join(dir, "b", "movie.mkv")
+	createFile(t, pathA)
+	require.NoError(t, os.MkdirAll(filepath.Dir(pathB), 0o700))
+	require.NoError(t, os.Link(pathA, pathB))
+
+	stale := scanOne(t, filepath.Join(dir, "a"), "movie.mkv")
+	fresh := scanOne(t, filepath.Join(dir, "b"), "movie.mkv")
+	stale.linkedFiles[0].nlink = 2
+	fresh.linkedFiles[0].nlink = 9
+
+	state := deriveLinkCounts(map[string]*torrentFileInfo{"stale": stale, "fresh": fresh})
+
+	tracker := state.globalFileIDMap[fresh.fileIDs[0]]
+	require.NotNil(t, tracker)
+	require.Equal(t, uint64(9), tracker.nlink)
+	require.Equal(t, 2, tracker.uniquePathCount, "two distinct paths point at the file")
+}

--- a/internal/services/automations/hardlink_index_incremental_test.go
+++ b/internal/services/automations/hardlink_index_incremental_test.go
@@ -11,6 +11,7 @@ import (
 	qbt "github.com/autobrr/go-qbittorrent"
 	"github.com/stretchr/testify/require"
 
+	"github.com/autobrr/qui/internal/models"
 	"github.com/autobrr/qui/pkg/hardlink"
 )
 
@@ -22,6 +23,18 @@ func scanOne(t *testing.T, savePath string, names ...string) *torrentFileInfo {
 		files = append(files, qbt.TorrentFile{Name: name})
 	}
 	return scanTorrentFiles(qbt.Torrent{SavePath: savePath}, files)
+}
+
+// linkPair creates one file under a/ and hardlinks it into b/, returning both paths.
+// Two paths to one inode is the shape every scope answer turns on.
+func linkPair(t *testing.T, dir string) (string, string) {
+	t.Helper()
+	pathA := filepath.Join(dir, "a", "movie.mkv")
+	pathB := filepath.Join(dir, "b", "movie.mkv")
+	createFile(t, pathA)
+	require.NoError(t, os.MkdirAll(filepath.Dir(pathB), 0o700))
+	require.NoError(t, os.Link(pathA, pathB))
+	return pathA, pathB
 }
 
 // indexFrom derives the link counts and every derived map from a set of scans, exactly
@@ -40,11 +53,7 @@ func TestIncrementalUpdate_RemovedTorrentChangesSurvivorScope(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	pathA := filepath.Join(dir, "a", "movie.mkv")
-	pathB := filepath.Join(dir, "b", "movie.mkv")
-	createFile(t, pathA)
-	require.NoError(t, os.MkdirAll(filepath.Dir(pathB), 0o700))
-	require.NoError(t, os.Link(pathA, pathB))
+	_, pathB := linkPair(t, dir)
 
 	scans := map[string]*torrentFileInfo{
 		"hashA": scanOne(t, filepath.Join(dir, "a"), "movie.mkv"),
@@ -72,11 +81,7 @@ func TestIncrementalUpdate_RemovedTorrentKeepingFilesMovesLinkOutside(t *testing
 	t.Parallel()
 
 	dir := t.TempDir()
-	pathA := filepath.Join(dir, "a", "movie.mkv")
-	pathB := filepath.Join(dir, "b", "movie.mkv")
-	createFile(t, pathA)
-	require.NoError(t, os.MkdirAll(filepath.Dir(pathB), 0o700))
-	require.NoError(t, os.Link(pathA, pathB))
+	linkPair(t, dir)
 
 	scans := map[string]*torrentFileInfo{
 		"hashA": scanOne(t, filepath.Join(dir, "a"), "movie.mkv"),
@@ -123,11 +128,7 @@ func TestPlanSharingRescanSkipsAlreadyPlannedAndDepartedTorrents(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	pathA := filepath.Join(dir, "a", "movie.mkv")
-	pathB := filepath.Join(dir, "b", "movie.mkv")
-	createFile(t, pathA)
-	require.NoError(t, os.MkdirAll(filepath.Dir(pathB), 0o700))
-	require.NoError(t, os.Link(pathA, pathB))
+	linkPair(t, dir)
 
 	infoA := scanOne(t, filepath.Join(dir, "a"), "movie.mkv")
 	previous := map[string]*torrentFileInfo{
@@ -172,6 +173,36 @@ func TestScopeAfterRescanSeesLinksAddedSinceTheIndexWasBuilt(t *testing.T) {
 		"the fresh read must report the link the index never saw")
 }
 
+// Cross-instance augmentation raises uniquePathCount in place under crossScopeMu. A
+// preview request can run it while a scheduled apply verifies its delete candidates, so
+// the read side has to take the same lock. Run with -race.
+func TestScopeAfterRescanIsSafeAgainstConcurrentAugmentation(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	linkPair(t, dir)
+
+	info := scanOne(t, filepath.Join(dir, "a"), "movie.mkv")
+	index := indexFrom(map[string]*torrentFileInfo{"hashA": info})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range 200 {
+			index.crossScopeMu.Lock()
+			for _, tracker := range index.buildState.globalFileIDMap {
+				tracker.uniquePathCount++
+			}
+			index.crossScopeMu.Unlock()
+		}
+	}()
+
+	for range 200 {
+		index.scopeAfterRescan(info)
+	}
+	<-done
+}
+
 func TestScopeAfterRescanReportsUnknownForUnreadableFiles(t *testing.T) {
 	t.Parallel()
 
@@ -189,17 +220,76 @@ func TestScopeAfterRescanReportsUnknownForUnreadableFiles(t *testing.T) {
 		"a torrent whose files vanished has no scope, and must not read as unlinked")
 }
 
+// A delete is only re-verified when the rule consulted the index to choose its
+// candidates. Every route into setupDeleteHardlinkContext has to count, or a rule that
+// sorts or groups by hardlink data deletes on an index nobody re-read.
+func TestDeleteUsesHardlinkData(t *testing.T) {
+	t.Parallel()
+
+	deleteRule := func(action *models.DeleteAction, sorting *models.SortingConfig) *models.Automation {
+		return &models.Automation{
+			Conditions:    &models.ActionConditions{Delete: action},
+			SortingConfig: sorting,
+		}
+	}
+
+	tests := []struct {
+		name string
+		rule *models.Automation
+		want bool
+	}{
+		{
+			name: "unregistered rule owes the index nothing",
+			rule: deleteRule(&models.DeleteAction{
+				Enabled:   true,
+				Condition: &models.RuleCondition{Field: models.FieldIsUnregistered},
+			}, nil),
+		},
+		{
+			name: "no delete action",
+			rule: deleteRule(nil, &models.SortingConfig{Type: models.SortingTypeSimple, Field: FieldHardlinkScope}),
+		},
+		{
+			name: "condition on the scope",
+			rule: deleteRule(&models.DeleteAction{
+				Enabled:   true,
+				Condition: &models.RuleCondition{Field: FieldHardlinkScope},
+			}, nil),
+			want: true,
+		},
+		{
+			name: "expands to the hardlink copies",
+			rule: deleteRule(&models.DeleteAction{Enabled: true, IncludeHardlinks: true}, nil),
+			want: true,
+		},
+		{
+			name: "sorted by the scope, which decides who wins a limited batch",
+			rule: deleteRule(&models.DeleteAction{Enabled: true},
+				&models.SortingConfig{Type: models.SortingTypeSimple, Field: FieldHardlinkScopeCross}),
+			want: true,
+		},
+		{
+			name: "grouped by the hardlink signature",
+			rule: deleteRule(&models.DeleteAction{Enabled: true, GroupID: GroupHardlinkSignature}, nil),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, deleteUsesHardlinkData(tt.rule))
+		})
+	}
+}
+
 // Scans taken at different moments can disagree about a file. The higher link count has
 // to win, because it is the one that reports a link outside the torrent set.
 func TestDeriveLinkCountsPrefersTheHigherLinkCount(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
-	pathA := filepath.Join(dir, "a", "movie.mkv")
-	pathB := filepath.Join(dir, "b", "movie.mkv")
-	createFile(t, pathA)
-	require.NoError(t, os.MkdirAll(filepath.Dir(pathB), 0o700))
-	require.NoError(t, os.Link(pathA, pathB))
+	linkPair(t, dir)
 
 	stale := scanOne(t, filepath.Join(dir, "a"), "movie.mkv")
 	fresh := scanOne(t, filepath.Join(dir, "b"), "movie.mkv")

--- a/internal/services/automations/hardlink_index_test.go
+++ b/internal/services/automations/hardlink_index_test.go
@@ -193,8 +193,10 @@ func TestAugmentCrossInstanceScope_NoDeficits(t *testing.T) {
 			t.Errorf("hash %s: expected %q, got %q", hash, expected, got)
 		}
 	}
-	if index.buildState != nil {
-		t.Error("expected buildState to be nil after augmentation")
+	// The scan results stay so the next torrent set change can update incrementally
+	// instead of re-reading every torrent off disk.
+	if index.buildState == nil {
+		t.Error("expected buildState to be retained after augmentation")
 	}
 }
 

--- a/internal/services/automations/service.go
+++ b/internal/services/automations/service.go
@@ -1042,7 +1042,7 @@ func (s *Service) setupDeleteHardlinkContext(ctx context.Context, instanceID int
 		return nil
 	}
 
-	hardlinkIndex := s.GetHardlinkIndex(ctx, instanceID, torrents, needsCrossScope)
+	hardlinkIndex := s.GetHardlinkIndex(ctx, instanceID, torrents)
 	if hardlinkIndex != nil {
 		evalCtx.HardlinkScopeByHash = hardlinkIndex.ScopeByHash
 		if needsHardlinkSignatureGrouping {
@@ -1689,7 +1689,7 @@ func (s *Service) setupCategoryHardlinkContext(ctx context.Context, instanceID i
 		return
 	}
 
-	hardlinkIndex := s.GetHardlinkIndex(ctx, instanceID, torrents, needsCrossScope)
+	hardlinkIndex := s.GetHardlinkIndex(ctx, instanceID, torrents)
 	if hardlinkIndex != nil {
 		evalCtx.HardlinkScopeByHash = hardlinkIndex.ScopeByHash
 		if needsHardlinkSignatureGrouping {
@@ -1904,6 +1904,51 @@ func (s *Service) buildCategoryPreviewResult(
 	return result
 }
 
+// deleteUsesHardlinkData reports whether a rule's delete decision rests on hardlink
+// state, either through a condition on the scope or by expanding to the hardlink copies.
+func deleteUsesHardlinkData(rule *models.Automation) bool {
+	if rule == nil || rule.Conditions == nil || rule.Conditions.Delete == nil {
+		return false
+	}
+	if rule.Conditions.Delete.IncludeHardlinks {
+		return true
+	}
+	cond := rule.Conditions.Delete.Condition
+	return ConditionUsesField(cond, FieldHardlinkScope) || ConditionUsesField(cond, FieldHardlinkScopeCross)
+}
+
+// blockedDeleteCandidates returns the queued deletions that must not run because their
+// hardlink state no longer matches what the rule decided on. Only candidates chosen with
+// hardlink data are re-read: a rule deleting on ratio or an unregistered tracker owes
+// nothing to the index, and holding those back on an unreadable file would be a new way
+// to fail.
+func (s *Service) blockedDeleteCandidates(
+	ctx context.Context,
+	instanceID int,
+	hardlinkIndex *HardlinkIndex,
+	torrentByHash map[string]qbt.Torrent,
+	deleteHashesByMode map[string][]string,
+	pendingByHash map[string]pendingDeletion,
+	ruleByID map[int]*models.Automation,
+) map[string]string {
+	if hardlinkIndex == nil {
+		return nil
+	}
+
+	var candidates []string
+	for _, hashes := range deleteHashesByMode {
+		for _, hash := range hashes {
+			pending, queued := pendingByHash[hash]
+			if !queued || !deleteUsesHardlinkData(ruleByID[pending.ruleID]) {
+				continue
+			}
+			candidates = append(candidates, hash)
+		}
+	}
+
+	return s.verifyDeleteCandidates(ctx, instanceID, hardlinkIndex, torrentByHash, candidates)
+}
+
 func (s *Service) applyForInstance(ctx context.Context, instanceID int, force bool) error {
 	rules, err := s.ruleStore.ListByInstance(ctx, instanceID)
 	if err != nil {
@@ -2066,7 +2111,7 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 	needsHardlinkSignatureGrouping := rulesUseHardlinkSignatureGrouping(eligibleRules)
 	needsHardlinkIndex := needsHardlinkScope || needsHardlinkSignatureGrouping || needsCrossScope
 	if instance.HasLocalFilesystemAccess && needsHardlinkIndex {
-		hardlinkIndex = s.GetHardlinkIndex(ctx, instanceID, torrents, needsCrossScope)
+		hardlinkIndex = s.GetHardlinkIndex(ctx, instanceID, torrents)
 		if hardlinkIndex != nil {
 			evalCtx.HardlinkScopeByHash = hardlinkIndex.ScopeByHash
 			if needsHardlinkSignatureGrouping {
@@ -3844,6 +3889,34 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 	// - stop_tracker_timeout setting (default 2s) controls how long to wait for tracker ack
 	//
 	// This behavior is identical for both BitTorrent v1 and v2 torrents.
+	//
+	// Candidates chosen with hardlink data are re-read off disk first. The index may be
+	// up to hardlinkIndexTTL behind for link changes no torrent reported, which is fine
+	// for tagging and not fine here.
+	if blocked := s.blockedDeleteCandidates(ctx, instanceID, hardlinkIndex, torrentByHash, deleteHashesByMode, pendingByHash, ruleByID); len(blocked) > 0 {
+		for mode, hashes := range deleteHashesByMode {
+			kept := hashes[:0]
+			for _, hash := range hashes {
+				reason, isBlocked := blocked[hash]
+				if !isBlocked {
+					kept = append(kept, hash)
+					continue
+				}
+
+				pending := pendingByHash[hash]
+				delete(pendingByHash, hash)
+				log.Warn().
+					Int("instanceID", instanceID).
+					Str("hash", hash).
+					Str("name", pending.torrentName).
+					Str("ruleName", pending.ruleName).
+					Str("reason", reason).
+					Msg("automations: skipped delete, hardlink state changed since the rule decided")
+			}
+			deleteHashesByMode[mode] = kept
+		}
+	}
+
 	for mode, hashes := range deleteHashesByMode {
 		if len(hashes) == 0 {
 			continue
@@ -5261,7 +5334,7 @@ func (s *Service) recordDryRunActivities(
 					}
 				}
 				if needsHardlinkSignature || needsDryRunCrossScope {
-					hardlinkIndex := s.GetHardlinkIndex(ctx, instanceID, torrents, needsDryRunCrossScope)
+					hardlinkIndex := s.GetHardlinkIndex(ctx, instanceID, torrents)
 					if hardlinkIndex != nil {
 						dryRunEvalCtx.HardlinkScopeByHash = hardlinkIndex.ScopeByHash
 						if needsHardlinkSignature {

--- a/internal/services/automations/service.go
+++ b/internal/services/automations/service.go
@@ -1027,17 +1027,7 @@ func (s *Service) setupDeleteHardlinkContext(ctx context.Context, instanceID int
 	if instance == nil || !instance.HasLocalFilesystemAccess {
 		return nil
 	}
-	if rule.Conditions == nil || rule.Conditions.Delete == nil {
-		return nil
-	}
-
-	cond := rule.Conditions.Delete.Condition
-	needsHardlinkScope := ConditionUsesField(cond, FieldHardlinkScope) ||
-		sortingConfigUsesField(rule.SortingConfig, FieldHardlinkScope) ||
-		rule.Conditions.Delete.IncludeHardlinks
-	needsCrossScope := ConditionUsesField(cond, FieldHardlinkScopeCross) ||
-		sortingConfigUsesField(rule.SortingConfig, FieldHardlinkScopeCross)
-	needsHardlinkSignatureGrouping := ruleUsesHardlinkSignatureGrouping(rule)
+	needsHardlinkScope, needsCrossScope, needsHardlinkSignatureGrouping := deleteHardlinkNeeds(rule)
 	if !needsHardlinkScope && !needsHardlinkSignatureGrouping && !needsCrossScope {
 		return nil
 	}
@@ -1904,17 +1894,30 @@ func (s *Service) buildCategoryPreviewResult(
 	return result
 }
 
-// deleteUsesHardlinkData reports whether a rule's delete decision rests on hardlink
-// state, either through a condition on the scope or by expanding to the hardlink copies.
-func deleteUsesHardlinkData(rule *models.Automation) bool {
+// deleteHardlinkNeeds reports which hardlink data a rule's delete needs: the
+// single-instance scope, the cross-instance scope, and the signature groups. A rule that
+// sorts or groups by that data picks its delete batch from the index just as surely as
+// one that conditions on it.
+//
+// Both the code that loads the data and the code that re-verifies the deletions must
+// agree on this answer, so they read it from here rather than each deciding again.
+func deleteHardlinkNeeds(rule *models.Automation) (scope, cross, grouping bool) {
 	if rule == nil || rule.Conditions == nil || rule.Conditions.Delete == nil {
-		return false
-	}
-	if rule.Conditions.Delete.IncludeHardlinks {
-		return true
+		return false, false, false
 	}
 	cond := rule.Conditions.Delete.Condition
-	return ConditionUsesField(cond, FieldHardlinkScope) || ConditionUsesField(cond, FieldHardlinkScopeCross)
+	scope = rule.Conditions.Delete.IncludeHardlinks ||
+		ConditionUsesField(cond, FieldHardlinkScope) ||
+		sortingConfigUsesField(rule.SortingConfig, FieldHardlinkScope)
+	cross = ConditionUsesField(cond, FieldHardlinkScopeCross) ||
+		sortingConfigUsesField(rule.SortingConfig, FieldHardlinkScopeCross)
+	return scope, cross, ruleUsesHardlinkSignatureGrouping(rule)
+}
+
+// deleteUsesHardlinkData reports whether a rule's delete decision rests on hardlink state.
+func deleteUsesHardlinkData(rule *models.Automation) bool {
+	scope, cross, grouping := deleteHardlinkNeeds(rule)
+	return scope || cross || grouping
 }
 
 // blockedDeleteCandidates returns the queued deletions that must not run because their


### PR DESCRIPTION
The hardlink index records which torrent files share data on disk. Building it reads every torrent's file list from the database and stats every file, which measures at about 700 ms for 5000 torrents. It was discarded whenever any torrent was added or removed, and every two minutes regardless. Profiling an idle instance and one running a cross-seed library scan put it at the top of the CPU profile in both cases: 28% of the process during the scan, where every added torrent forced another full rebuild, against a scan that is otherwise waiting on indexers. Adding or removing a torrent changes the link counts of the torrents that share its files and of nothing else, so only those are re-read now, and the derived maps are recomputed in memory from the retained scans. The full rebuild remains as a backstop for link changes that no torrent reports, at a longer interval, and the update falls back to it when there is no previous scan, when a file list cannot be fetched, or when more than half the set changed at once.

Deletes must not inherit that lag, so they no longer trust the index. Candidates chosen with hardlink data are re-read off disk immediately before the delete runs, and any whose scope changed since the rule decided, or whose files stopped being readable, are held back and logged. This is stricter than what is on develop today, where a delete can already act on an index up to two minutes old with no verification at all. Rules that delete on ratio or an unregistered tracker never consult the index and are untouched.

## Field results

Measured on an instance with 5163 torrents, 4255 outside links and 1075 duplicate groups, against the same host running develop.

During a cross-seed library scan, `buildHardlinkIndex` was 27.7% of a 180 second profile on develop and does not appear at all here. `updateHardlinkIndex` is 1.76%. A torrent arrival costs about 48 ms instead of about 1110 ms, because the update re-reads the one changed torrent plus the six or seven that share its files, rather than all 5147. Over a 91 minute window, seven of ten arrivals took the incremental path at 19 to 32 ms each, and the three full rebuilds were all the interval backstop. Those rebuilds measured 2432 to 4256 ms on this host, so the stall they remove is longer than the 700 ms figure above suggests.

Removals were verified separately by deleting two torrents whose files stayed on disk through other torrents' hardlinks. The update ran in 15 ms, re-read the three surviving sharers, and left the outside-link count unchanged at 4255. That count is the discriminator: had the survivors kept their stale link counts instead of being re-read, each would have carried more links than the torrent set could explain and flipped to `outside_qbittorrent`, raising it.

Total process CPU is not a useful measure of this change. It sits near 1.4% of one core with or without it, and the periodic spikes on this host come from cross-seed candidate matching, which does over a thousand title lookups in a five minute burst. The case for this change is the work it stops doing, not the CPU it returns.

The delete verification did not run in the field. It only engages for rules that consult the index, and the only delete rule on the test host selects on unregistered trackers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved hardlink index updates with faster incremental rescans and a 10-minute refresh period.
  * Preserved scan results to avoid rereading unchanged torrent files, with full rebuilds when needed.

* **Reliability**
  * Added safer handling for moved, removed, inaccessible, or newly linked files.
  * Delete actions and previews now revalidate hardlink-dependent decisions before execution.

* **Consistency**
  * Applied consistent hardlink behavior across live runs, previews, and dry runs.
  * Improved cross-instance hardlink scope tracking and link-count accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
