### PR TITLE
fix(dirscan): drop the year from the indexer search query

### DIFF
--- a/internal/services/crossseed/search_query.go
+++ b/internal/services/crossseed/search_query.go
@@ -23,6 +23,21 @@ var (
 	emptyParens       = regexp.MustCompile(`\(\s*\)`)
 )
 
+// BuildTorznabQuery derives the free-text q parameter for a Torznab search.
+// Cross-seed and dir scan both call it so the two paths cannot drift apart.
+//
+// The year is deliberately absent from q: it travels as the separate year
+// parameter instead. Trackers that search a movie database rather than release
+// names (PassThePopcorn, for example) match q against the movie title alone, so
+// a trailing year returns nothing.
+func BuildTorznabQuery(name string, release *rls.Release, isMusic bool) SearchQuery {
+	baseQuery := release.Title
+	if isMusic && baseQuery != "" && release.Artist != "" {
+		baseQuery = release.Artist + " " + baseQuery
+	}
+	return buildSafeSearchQuery(name, release, baseQuery)
+}
+
 // buildSafeSearchQuery constructs a conservative Torznab query for TV/anime when parsing is weak.
 // It tries to preserve parsed season/episode from rls, but when parsing fails (common for anime
 // absolute numbering), it cleans the torrent name and extracts an absolute episode number to

--- a/internal/services/crossseed/search_query_test.go
+++ b/internal/services/crossseed/search_query_test.go
@@ -106,3 +106,32 @@ func intPtr(v int) *int {
 	value := v
 	return &value
 }
+
+func TestBuildTorznabQueryOmitsYearForMovies(t *testing.T) {
+	// Trackers that search a movie database instead of release names
+	// (PassThePopcorn) match q against the title alone, so a trailing year
+	// returns nothing. The year travels as the separate year parameter.
+	release := rls.Release{Type: rls.Movie, Title: "The Matrix", Year: 1999}
+
+	got := BuildTorznabQuery("The.Matrix.1999.1080p.BluRay.x264-GROUP", &release, false)
+
+	require.Equal(t, "The Matrix", got.Query)
+	require.Nil(t, got.Season)
+	require.Nil(t, got.Episode)
+}
+
+func TestBuildTorznabQueryUsesArtistForMusic(t *testing.T) {
+	release := rls.Release{Type: rls.Music, Artist: "Some Artist", Title: "Some Album", Year: 2020}
+
+	got := BuildTorznabQuery("Some.Artist-Some.Album-2020-FLAC", &release, true)
+
+	require.Equal(t, "Some Artist Some Album", got.Query)
+}
+
+func TestBuildTorznabQueryFallsBackToName(t *testing.T) {
+	release := rls.Release{Type: rls.Unknown}
+
+	got := BuildTorznabQuery("  Untitled Thing  ", &release, false)
+
+	require.Equal(t, "untitled thing", got.Query)
+}

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -8295,34 +8295,8 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 		queryRelease = ParseMusicReleaseFromTorrentName(sourceRelease, sourceTorrent.Name)
 	}
 	if query == "" {
-		baseQuery := ""
-		if queryRelease.Title != "" {
-			if contentInfo.IsMusic {
-				// For music, use artist and title format if available
-				if queryRelease.Artist != "" {
-					baseQuery = queryRelease.Artist + " " + queryRelease.Title
-				} else {
-					baseQuery = queryRelease.Title
-				}
-			} else {
-				// For non-music, start with the title
-				baseQuery = queryRelease.Title
-			}
-		}
-
-		safeQuery := buildSafeSearchQuery(sourceTorrent.Name, queryRelease, baseQuery)
-		query = strings.TrimSpace(safeQuery.Query)
-		if query == "" {
-			// Fallback to a basic title-based query to avoid empty searches
-			switch {
-			case baseQuery != "":
-				query = strings.TrimSpace(baseQuery)
-			case queryRelease.Title != "":
-				query = queryRelease.Title
-			default:
-				query = sourceTorrent.Name
-			}
-		}
+		safeQuery := BuildTorznabQuery(sourceTorrent.Name, queryRelease, contentInfo.IsMusic)
+		query = safeQuery.Query
 		seasonPtr = safeQuery.Season
 		episodePtr = safeQuery.Episode
 

--- a/internal/services/dirscan/search.go
+++ b/internal/services/dirscan/search.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/autobrr/qui/internal/services/crossseed"
 	"github.com/autobrr/qui/internal/services/jackett"
 )
 
@@ -137,27 +138,9 @@ func (s *Searcher) applyExternalIDs(req *jackett.TorznabSearchRequest, meta *Sea
 }
 
 // buildSearchQuery constructs a search query string from metadata.
+// Shared with cross-seed so the two search paths cannot drift apart.
 func buildSearchQuery(meta *SearcheeMetadata) string {
-	var parts []string
-
-	// Use the parsed title
-	title := meta.Title
-	if title == "" {
-		title = meta.CleanedName
-	}
-
-	// Clean the title for searching
-	title = cleanForSearch(title)
-	if title != "" {
-		parts = append(parts, title)
-	}
-
-	// Add year if available and this looks like a movie
-	if meta.Year > 0 && meta.IsMovie {
-		parts = append(parts, strconv.Itoa(meta.Year))
-	}
-
-	return strings.Join(parts, " ")
+	return crossseed.BuildTorznabQuery(meta.CleanedName, meta.Release, meta.IsMusic).Query
 }
 
 // cleanForSearch removes characters that might interfere with search.

--- a/internal/services/dirscan/search_test.go
+++ b/internal/services/dirscan/search_test.go
@@ -18,3 +18,29 @@ func TestCalculateSizeRange_NonPositiveSize_IsZero(t *testing.T) {
 		t.Fatalf("expected (0,0), got (%d,%d)", minSize, maxSize)
 	}
 }
+
+// TestBuildSearchQuery pins the q dir scan sends to indexers. Dir scan used to
+// append the year for movies, which returned zero results on trackers that
+// search a movie database rather than release names. The year travels as the
+// separate year parameter instead.
+func TestBuildSearchQuery(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{name: "The.Matrix.1999.1080p.BluRay.x264-GROUP", want: "The Matrix"},
+		{name: "Some Movie (2021) {imdb-tt1234567} [1080p]", want: "Some Movie"},
+		{name: "Some.Show.S01E02.1080p.WEB-DL.DDP5.1.H.264-GROUP", want: "Some Show"},
+		{name: "[Fansub] Example Show - 1140 (1080p) [EEC80774]", want: "Example Show"},
+		{name: "Some.Artist-Some.Album-2020-FLAC", want: "Some Artist Some Album"},
+	}
+
+	parser := NewParser(nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildSearchQuery(parser.Parse(tt.name)); got != tt.want {
+				t.Fatalf("buildSearchQuery(%q) = %q, want %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Dir scan put the year in the free-text query for movies, so it asked indexers for `The Matrix 1999` where cross-seed asked for `The Matrix`. Trackers that search a movie database instead of release names, PassThePopcorn for example, match the query against the movie title alone, so the longer form finds nothing. The year is not lost: it is already sent as the separate `year` parameter. A user reported that PassThePopcorn gives results for a usual cross-seed search but not for a dir scan, which is this difference. The two paths agreed when dir scan had an IMDb ID from an arr, because the ID then replaces the query, so the fault only showed for content the arrs do not know.

Both paths now build the query with one function, `crossseed.BuildTorznabQuery`, so they cannot drift apart again. This also changes the dir scan query for names that the release parser cannot read a title from: dir scan sent the full name with the quality words in it, and now sends the same cleaned form as cross-seed. Season, episode and category parameters are still built in each package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search query generation for movies, TV, anime, and music releases.
  * Excludes release years and unrelated metadata from free-text searches.
  * Preserves season and episode details for more accurate TV searches.
  * Uses artist and title information for music searches.
  * Falls back to the cleaned release name when details are unavailable.

* **Tests**
  * Added coverage for movie, TV, anime, music, and unknown release formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->