### PR TITLE
fix(crossseed): match titles whose word boundaries differ

### DIFF
--- a/internal/services/crossseed/matching.go
+++ b/internal/services/crossseed/matching.go
@@ -332,9 +332,16 @@ func rawAKATitleParts(rawName string) []string {
 
 func addNormalizedTitle(titles map[string]struct{}, title string) {
 	normalized := stringutils.NormalizeForMatching(title)
-	if normalized != "" {
-		titles[normalized] = struct{}{}
+	if normalized == "" {
+		return
 	}
+	titles[normalized] = struct{}{}
+
+	// Trackers disagree with scene names about where the word boundaries are:
+	// "KissXSis" for "Kiss.X.Sis", and "Re:ZERO" normalizes to "rezero" because
+	// NormalizeForMatching drops the colon instead of turning it into a space.
+	// Store the space-free spelling too so the two readings can overlap.
+	titles[strings.ReplaceAll(normalized, " ", "")] = struct{}{}
 }
 
 func normalizedTitleSetsOverlap(sourceTitles, candidateTitles map[string]struct{}) bool {

--- a/internal/services/crossseed/matching_title_test.go
+++ b/internal/services/crossseed/matching_title_test.go
@@ -451,6 +451,54 @@ func TestReleasesMatch_AKAVariants(t *testing.T) {
 	}
 }
 
+// Trackers place word boundaries differently from scene names, and
+// NormalizeForMatching drops a colon rather than turning it into a space, so
+// exact-size candidates from the same group were rejected as title mismatches.
+func TestReleasesMatch_TitleWordBoundaryDiffers(t *testing.T) {
+	tests := []struct {
+		name       string
+		sourceName string
+		candidate  string
+		wantMatch  bool
+	}{
+		{
+			name:       "tracker writes the title without spaces",
+			sourceName: "Kiss.X.Sis.S01.1080p.BluRay.Opus2.0.x265-Headpatter",
+			candidate:  "KissXSis S01 JAPANESE 1080p BluRay Opus 2.0 x265-Headpatter",
+			wantMatch:  true,
+		},
+		{
+			name:       "dropped colon closes a word gap",
+			sourceName: "Re.ZERO.Starting.Life.in.Another.World.S03.1080p.BluRay.Opus.2.0.x265-Headpatter",
+			candidate:  "Re:ZERO -Starting Life in Another World- AKA Re:Zero kara Hajimeru Isekai Seikatsu S03 1080p BluRay Dual-Audio Opus 2.0 x265-Headpatter",
+			wantMatch:  true,
+		},
+		{
+			name:       "a genuinely different title stays rejected",
+			sourceName: "Ef.A.Tale.of.Melodies.S01.1080p.BluRay.Dual-Audio.Opus.2.0.x265-Headpatter",
+			candidate:  "Ef: A Tale Of Memories & Melodies S01 1080p BluRay Dual-Audio Opus 2.0 x265-Headpatter",
+			wantMatch:  false,
+		},
+	}
+
+	s := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := rls.ParseString(tt.sourceName)
+			candidate := rls.ParseString(tt.candidate)
+
+			match, reason := s.releasesMatchWithReasonAndNames(&source, &candidate, tt.sourceName, tt.candidate, false)
+
+			if tt.wantMatch {
+				require.True(t, match, "got reason %q", reason)
+				return
+			}
+			require.False(t, match)
+			require.Equal(t, titleMismatchReason, reason)
+		})
+	}
+}
+
 func TestReleasesMatch_ARRTitleAliasesOnlyWidenTitleCheck(t *testing.T) {
 	s := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
 	source := rls.Release{


### PR DESCRIPTION
Trackers do not put the word boundaries of a show name where the scene name puts them, and the title check compared the two spellings literally. `Kiss.X.Sis` parses to the title `Kiss X Sis`, while Aither lists the same release as `KissXSis`. `Re.ZERO.Starting.Life.in.Another.World` parses to `Re ZERO Starting Life in Another World`, while Aither lists `Re:ZERO -Starting Life in Another World-`, and `NormalizeForMatching` deletes the colon instead of turning it into a space, so the candidate normalizes to `rezero starting life in another world`. Both candidates were byte-identical in size and from the same release group, and both were rejected as `title mismatch`. Reported on Discord by Asinine

The title check compares sets of normalized titles and accepts any overlap, so the fix stores the space-free spelling of each title next to the normal one. The set only grows, so this cannot turn a match into a rejection. Distinct shows still stay apart once the spaces are gone, which the tests pin: `ef a tale of melodies` does not equal `ef a tale of memories and melodies`, and `fbi` does not equal `fbimostwanted`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved title matching when spacing, punctuation, or word boundaries differ between releases.
  * Prevented genuinely different titles from being incorrectly treated as matches.

* **Tests**
  * Added coverage for title variations involving removed spaces and punctuation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->