### PR TITLE
perf(crossseed): cache the AKA title parse

### DIFF
--- a/internal/services/crossseed/matching.go
+++ b/internal/services/crossseed/matching.go
@@ -281,8 +281,9 @@ func normalizedReleaseTitles(release *rls.Release, rawName string) map[string]st
 	addNormalizedTitle(titles, releaseTitle(release))
 	addNormalizedTitle(titles, releaseAlt(release))
 
+	// Cached parse: this runs once per library torrent per search.
 	for _, rawTitle := range rawAKATitleParts(rawName) {
-		parsed := rls.ParseString(rawTitle)
+		parsed := releases.DefaultParser.Parse(rawTitle)
 		addNormalizedTitle(titles, parsed.Title)
 		addNormalizedTitle(titles, parsed.Alt)
 	}

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -65,6 +65,7 @@ import (
 	"github.com/autobrr/qui/pkg/pathutil"
 	"github.com/autobrr/qui/pkg/redact"
 	"github.com/autobrr/qui/pkg/reflinktree"
+	"github.com/autobrr/qui/pkg/releases"
 	"github.com/autobrr/qui/pkg/sharedextents"
 	"github.com/autobrr/qui/pkg/stringutils"
 )
@@ -7904,7 +7905,7 @@ func AlternateTitleQuery(primaryQuery string, release *rls.Release, arrTitles []
 	candidates = append(candidates, arrTitles...)
 	candidates = append(candidates, releaseAlt(release))
 	for _, part := range rawAKATitleParts(releaseName) {
-		parsed := rls.ParseString(part)
+		parsed := releases.DefaultParser.Parse(part)
 		candidates = append(candidates, parsed.Title, parsed.Alt)
 	}
 	for _, candidate := range candidates {

--- a/pkg/releases/parser.go
+++ b/pkg/releases/parser.go
@@ -52,6 +52,10 @@ func NewDefaultParser() *Parser {
 	return NewParser(defaultParserTTL)
 }
 
+// DefaultParser is a statically allocated default parser; constructing one per call
+// leaks a ttlcache goroutine.
+var DefaultParser = NewDefaultParser()
+
 // Parse returns the parsed release metadata for name.
 func (p *Parser) Parse(name string) *rls.Release {
 	if p == nil {


### PR DESCRIPTION
## What this fixes, in plain words

Some trackers put two names in one release title, the local name and the original name, joined by "AKA". An English title followed by the original Japanese or Portuguese one, for example.

When cross-seed looks for a match, it compares the new release against every torrent you have. To compare them, qui must first read the release name and break it into parts: title, year, resolution, group. Reading a name is slow, so qui keeps the result and only reads each name once.

The "AKA" part was missed. qui read that piece again for every single torrent in the library. On a library of 5147 torrents, one search read the same name 5147 times. Those searches took 1.5 to 2 seconds instead of a few milliseconds.

qui runs about 1060 of these searches in one minute, once an hour. About 23 of them hit the slow path. That is why such an instance gets busy for one minute every hour and is quiet the rest of the time.

qui now reads the "AKA" part once and keeps it, the same way it already treats every other release name. Nothing changes about which torrents cross-seed finds or adds. Only the speed changes.

## The code

`normalizedReleaseTitles` in `internal/services/crossseed/matching.go` builds the set of titles a release can be known by. `validateTitleArtistAndDates` calls it once per candidate torrent, for the source side and the candidate side.

For a name holding " AKA ", it called `rls.ParseString` on each segment. That is the raw parser, not the cached one. The source name is the same for every candidate in a search, so a single search paid a full rls parse per torrent in the library.

The fix routes those segments through the cached parser. `AlternateTitleQuery` in `service.go` had the same uncached call on the same helper. It runs once per search rather than once per candidate, so it was never hot, but it is the other half of the same mistake and is fixed here too.

`normalizedReleaseTitles` is a package-level function with no parser of its own, so this adds `releases.DefaultParser` rather than constructing one per call. That is not a style choice: every `NewParser` starts a ttlcache expiration goroutine that lives as long as the process, the same trap `normalizerForService` documents a few lines above.

## Results against develop

Measured on an instance with 5147 torrents, about 1060 cross-seed searches per hourly burst.

qui logs `FindCandidates completed` at DEBUG for any search over 200 ms. Counting those per hour, the last row is this branch and the rest are develop:

```
hour   slow_searches  sum_s   p50ms   max_ms
02          27         36.7    1267     2671
03          22         28.6    1281     2026
04          25         32.0    1324     2044
05          25         32.5    1259     2106
06          18         25.8    1399     2129
07           1          0.6     554      554
```

Search volume did not change across the switch, 1076 in the last burst against about 1060 before, so this is not the result of less work.

CPU profile, 150 s captured at the same point in the hourly cycle:

| | develop | this branch |
| --- | --- | --- |
| total samples | 51 s (34% of a core) | 11.22 s (7.48%) |
| `rls.ParseString` | 75.98% | 9.09% |
| `regexp.doExecute` | 69.59% | 9.27% |
| `normalizedReleaseTitles` | 79.78% | 24.51% |

Process CPU during the burst dropped 78%.

What is left in `normalizedReleaseTitles` is ttlcache lookups and map building, not parsing. That is a much smaller number and a separate change if it is ever worth making.

## Benchmarks

`releasesMatchWithReasonAndNamesAndTitles`, one source and candidate pair:

| source name | before | after |
| --- | --- | --- |
| contains " AKA " | 309652 ns/op, 200 allocs | 1057 ns/op, 6 allocs |
| plain | 465 ns/op | 484 ns/op |

Plain names were never affected. Extrapolated to one `FindCandidates` over 5147 torrents: 1.6 s to about 5 ms.

## Which searches were affected

Only indexers that put alternate titles in the release name. Of 748 searches over 200 ms in 33 hours of logs, 553 came from one such indexer. Shape of the slow ones, names replaced:

```
elapsed 1721ms  "English Title AKA Foreign Tîtle 1985 1080i Blu-ray AVC TrueHD 2.0-GRP"
elapsed 2023ms  "English Title AKA Título Estrangeiro 2016 1080p WEB-DL AAC 2.0 H.264-GRP"
elapsed 1818ms  "English Title AKA Gaikoku no Taitoru 1972 1080p WEB-DL DDP 2.0 H.264-GRP"
```

The larger the library, the larger the saving, because the wasted work grew with the torrent count.

## Behaviour change

The cached parser sanitizes its key, so an AKA segment holding invalid UTF-8 now parses the way every other release name in qui does instead of reaching `regexp.MustCompile` in `enrichReleaseHDR`. `Title` and `Alt` are otherwise identical: the parser's enrichment only touches HDR tags.
