### PR TITLE
feat(mobile): auto-hide bottom bars, resurface view mode, improve selection visibility

### DIFF
--- a/web/src/components/layout/MobileFooterNav.tsx
+++ b/web/src/components/layout/MobileFooterNav.tsx
@@ -24,8 +24,10 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { isThemePremium, themes } from "@/config/themes"
+import { useMobileScroll } from "@/contexts/MobileScrollContext"
 import { useTorrentSelection } from "@/contexts/TorrentSelectionContext"
 import { useAuth } from "@/hooks/useAuth"
+import { usePersistedCompactViewState } from "@/hooks/usePersistedCompactViewState"
 import { useCrossSeedInstanceState } from "@/hooks/useCrossSeedInstanceState"
 import { useHasPremiumAccess } from "@/hooks/useLicense"
 import { usePersistedUnifiedInstanceFilter } from "@/hooks/usePersistedUnifiedInstanceFilter"
@@ -78,6 +80,8 @@ import { toast } from "sonner"
 import { useTranslation } from "react-i18next"
 
 
+const MOBILE_VIEW_MODES = ["normal", "compact", "ultra-compact"] as const
+
 // Custom hook for theme change detection
 const useThemeChange = () => {
   const [currentMode, setCurrentMode] = useState<ThemeMode>(getCurrentThemeMode())
@@ -104,11 +108,14 @@ const useThemeChange = () => {
 
 export function MobileFooterNav() {
   const { t, i18n } = useTranslation("common")
+  const { t: tTorrents } = useTranslation("torrents")
   const location = useLocation()
   const navigate = useNavigate()
   const routeSearch = useSearch({ strict: false }) as Record<string, unknown> | undefined
   const { logout } = useAuth()
   const { isSelectionMode } = useTorrentSelection()
+  const { isFooterVisible } = useMobileScroll()
+  const { viewMode, setViewMode } = usePersistedCompactViewState("compact", MOBILE_VIEW_MODES)
   const { currentMode, currentTheme } = useThemeChange()
   const { hasPremiumAccess, isLoading, isError } = useHasPremiumAccess()
   const canSwitchPremium = canSwitchToPremiumTheme({ hasPremiumAccess, isLoading, isError })
@@ -232,7 +239,9 @@ export function MobileFooterNav() {
     <nav
       className={cn(
         "fixed bottom-0 left-0 right-0 z-40 lg:hidden",
-        "bg-background/80 backdrop-blur-md border-t border-border/50"
+        "bg-background/80 backdrop-blur-md border-t border-border/50",
+        "transition-transform duration-300",
+        !isFooterVisible && "translate-y-full"
       )}
       style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
     >
@@ -622,6 +631,25 @@ export function MobileFooterNav() {
                   <span className="flex-1 text-left">{t("themeToggle.system")}</span>
                   {currentMode === "auto" && <Check className="h-4 w-4" />}
                 </button>
+              </div>
+            </div>
+
+            {/* Torrent list view mode */}
+            <div>
+              <div className="text-sm font-medium mb-2">{tTorrents("filterSidebar.viewMode")}</div>
+              <div className="grid grid-cols-3 gap-1">
+                {MOBILE_VIEW_MODES.map((mode) => (
+                  <button
+                    key={mode}
+                    onClick={() => setViewMode(mode)}
+                    className={cn(
+                      "px-3 py-2 rounded-md text-sm transition-colors",
+                      viewMode === mode ? "bg-accent" : "hover:bg-accent/50"
+                    )}
+                  >
+                    {mode === "normal"? tTorrents("filterSidebar.viewModeNormal"): mode === "compact"? tTorrents("filterSidebar.viewModeCompact"): tTorrents("filterSidebar.viewModeUltra")}
+                  </button>
+                ))}
               </div>
             </div>
 

--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -2209,8 +2209,8 @@ export function TorrentCardsMobile({
       {/* Torrent cards with virtual scrolling */}
       <div
         ref={parentRef}
-        className="flex-1 overflow-y-auto overscroll-contain"
-        style={{ paddingBottom: "calc(8rem + env(safe-area-inset-bottom))" }}
+        className="flex-1 overflow-y-auto overscroll-contain transition-[padding] duration-300"
+        style={{ paddingBottom: isFooterVisible? "calc(8rem + env(safe-area-inset-bottom))": "env(safe-area-inset-bottom)" }}
       >
         <div
           style={{
@@ -2874,7 +2874,7 @@ export function TorrentCardsMobile({
           scrollContainerRef={parentRef}
           className={cn(
             "right-8 z-[60]",
-            isFooterVisible? "bottom-[calc(8.5rem+env(safe-area-inset-bottom))]": "bottom-[calc(1.5rem+env(safe-area-inset-bottom))]"
+            isFooterVisible || selectionMode? "bottom-[calc(8.5rem+env(safe-area-inset-bottom))]": "bottom-[calc(1.5rem+env(safe-area-inset-bottom))]"
           )}
         />
       </div>

--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -35,6 +35,7 @@ import { Progress } from "@/components/ui/progress"
 import { ScrollToTopButton } from "@/components/ui/scroll-to-top-button"
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
 import { Switch } from "@/components/ui/switch"
+import { useMobileScroll } from "@/contexts/MobileScrollContext"
 import { useSyncStream } from "@/contexts/SyncStreamContext"
 import { useCrossSeedWarning } from "@/hooks/useCrossSeedWarning"
 import { useCrossSeedBlocklistActions } from "@/hooks/useCrossSeedBlocklistActions"
@@ -739,7 +740,8 @@ function SwipeableCard({
         "bg-card rounded-lg border cursor-pointer transition-all relative overflow-hidden select-none",
         viewMode === "ultra-compact" ? "px-3 py-1" : viewMode === "compact" ? "p-2" : "p-4",
         isSelected && "bg-accent/50",
-        !selectionMode && "active:scale-[0.98]"
+        !selectionMode && "active:scale-[0.98]",
+        selectionMode && viewMode !== "normal" && "pr-10"
       )}
       onTouchStart={!selectionMode ? handleTouchStart : undefined}
       onTouchMove={!selectionMode ? handleTouchMove : undefined}
@@ -757,9 +759,14 @@ function SwipeableCard({
       {isSelected && (
         <div className="absolute inset-0 rounded-lg ring-2 ring-primary ring-inset pointer-events-none" />
       )}
-      {/* Selection checkbox - visible in normal view selection mode */}
-      {selectionMode && viewMode === "normal" && (
-        <div className="absolute top-2 right-2 z-10">
+      {/* Selection checkbox - visible in selection mode */}
+      {selectionMode && (
+        <div
+          className={cn(
+            "absolute right-2 z-10",
+            viewMode === "normal" ? "top-2" : "top-1/2 -translate-y-1/2"
+          )}
+        >
           <Checkbox
             checked={isSelected}
             onCheckedChange={onSelect}
@@ -1082,6 +1089,13 @@ export function TorrentCardsMobile({
   const { setIsSelectionMode } = useTorrentSelection()
 
   const parentRef = useRef<HTMLDivElement>(null)
+  const { isFooterVisible, setScrollContainer } = useMobileScroll()
+
+  useEffect(() => {
+    setScrollContainer(parentRef.current)
+    return () => setScrollContainer(null)
+  }, [setScrollContainer])
+
   const [torrentToDelete, setTorrentToDelete] = useState<Torrent | null>(null)
   const [showActionsSheet, setShowActionsSheet] = useState(false)
   const [actionTorrents, setActionTorrents] = useState<Torrent[]>([]);
@@ -2779,7 +2793,9 @@ export function TorrentCardsMobile({
       {!selectionMode && (
         <div
           className={cn(
-            "fixed left-0 right-0 z-50 lg:hidden bg-background/80 backdrop-blur-md border-t border-border/50"
+            "fixed left-0 right-0 z-50 lg:hidden bg-background/80 backdrop-blur-md border-t border-border/50",
+            "transition-transform duration-300",
+            !isFooterVisible && "translate-y-[calc(100%+4rem+env(safe-area-inset-bottom))]"
           )}
           style={{ bottom: "calc(4rem + env(safe-area-inset-bottom))" }}
         >
@@ -2856,7 +2872,10 @@ export function TorrentCardsMobile({
       <div className="sm:hidden">
         <ScrollToTopButton
           scrollContainerRef={parentRef}
-          className="right-8 z-[60] bottom-[calc(8.5rem+env(safe-area-inset-bottom))]"
+          className={cn(
+            "right-8 z-[60]",
+            isFooterVisible? "bottom-[calc(8.5rem+env(safe-area-inset-bottom))]": "bottom-[calc(1.5rem+env(safe-area-inset-bottom))]"
+          )}
         />
       </div>
     </div>

--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -2080,100 +2080,9 @@ export function TorrentCardsMobile({
     <div className="relative flex h-full min-h-0 flex-col overflow-hidden">
       {/* Header with stats */}
       <div className="sticky top-0 z-40 bg-background">
-        {/* Stats bar */}
-        <div className="flex items-center justify-between text-xs mb-3">
-          <div className="text-muted-foreground">
-            {torrents.length === 0 && isLoading ? (
-              t("statusBar.loadingTorrents")
-            ) : totalCount === 0 ? (
-              t("mobileCards.noTorrentsFound")
-            ) : (
-              <>
-                {hasLoadedAll ? (
-                  t("statusBar.torrentCount", { count: torrents.length })
-                ) : isLoadingMore ? (
-                  t("statusBar.loadingMore")
-                ) : (
-                  t("statusBar.torrentsLoaded", { loaded: safeLoadedRows, total: totalCount })
-                )}
-              </>
-            )}
-          </div>
-          <div className="flex items-center gap-1">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-7 px-2 text-xs font-medium text-muted-foreground hover:text-foreground md:hidden"
-                >
-                  {t("mobileCards.sort")}: {currentSortOption.label}
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-48 max-h-100 overflow-y-auto">
-                <DropdownMenuLabel>{t("mobileCards.sortBy")}</DropdownMenuLabel>
-                <DropdownMenuRadioGroup
-                  value={sortField}
-                  onValueChange={(value) => handleSortFieldChange(value as TorrentSortOptionValue)}
-                >
-                  {TORRENT_SORT_OPTIONS.map(option => (
-                    <DropdownMenuRadioItem key={option.value} value={option.value} className="text-xs">
-                      {option.label}
-                    </DropdownMenuRadioItem>
-                  ))}
-                </DropdownMenuRadioGroup>
-              </DropdownMenuContent>
-            </DropdownMenu>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={toggleSortOrder}
-              className="h-7 w-7 p-0 text-muted-foreground hover:text-foreground md:hidden"
-              aria-label={`${t("sort.label")} ${sortOrder === "desc" ? t("sort.descending") : t("sort.ascending")}`}
-              title={`${t("sort.label")} ${sortOrder === "desc" ? t("sort.descending") : t("sort.ascending")}`}
-            >
-              {sortOrder === "desc" ? (
-                <ChevronDown className="h-3.5 w-3.5" />
-              ) : (
-                <ChevronUp className="h-3.5 w-3.5" />
-              )}
-            </Button>
-            <button
-              onClick={() => setSpeedUnit(speedUnit === "bytes" ? "bits" : "bytes")}
-              className="flex items-center gap-1 pl-1.5 py-0.5 rounded-sm transition-all hover:bg-muted/50"
-            >
-              <ArrowUpDown className="h-3.5 w-3.5 text-muted-foreground" />
-              <span className="text-xs text-muted-foreground">
-                {speedUnit === "bytes" ? "MiB/s" : "Mbps"}
-              </span>
-            </button>
-          </div>
-        </div>
-
-        {effectiveSearch && (
-          <div className="mb-3 flex items-center justify-between gap-2 rounded-md border border-primary/20 bg-primary/5 px-3 py-2 text-xs text-muted-foreground">
-            <div className="flex min-w-0 items-center gap-2">
-              <Search className="h-3.5 w-3.5 text-primary" aria-hidden="true" />
-              <span className="truncate text-sm text-foreground" title={effectiveSearch}>
-                {effectiveSearch}
-              </span>
-            </div>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={handleClearSearch}
-              className="h-7 px-2 text-xs font-medium text-primary hover:text-primary"
-              aria-label={t("mobileCards.clearSearchFilter")}
-            >
-              {t("mobileCards.clear")}
-              <X className="ml-1 h-3 w-3" aria-hidden="true" />
-            </Button>
-          </div>
-        )}
-
-        {/* Selection mode header */}
-        {selectionMode && (
-          <div className="bg-primary text-primary-foreground px-4 py-2 mb-3 flex items-center justify-between">
+        {/* Stats bar - swapped for the selection header in selection mode so the list doesn't shift */}
+        {selectionMode ? (
+          <div className="bg-primary text-primary-foreground px-4 mb-3 flex min-h-7 items-center justify-between">
             <div className="flex items-center gap-2">
               <button
                 onClick={() => {
@@ -2202,6 +2111,96 @@ export function TorrentCardsMobile({
             >
               {effectiveSelectionCount === totalCount ? t("detailsPanel.deselectAll") : t("detailsPanel.selectAll")}
             </button>
+          </div>
+        ) : (
+          <div className="flex items-center justify-between text-xs mb-3">
+            <div className="text-muted-foreground">
+              {torrents.length === 0 && isLoading ? (
+                t("statusBar.loadingTorrents")
+              ) : totalCount === 0 ? (
+                t("mobileCards.noTorrentsFound")
+              ) : (
+                <>
+                  {hasLoadedAll ? (
+                    t("statusBar.torrentCount", { count: torrents.length })
+                  ) : isLoadingMore ? (
+                    t("statusBar.loadingMore")
+                  ) : (
+                    t("statusBar.torrentsLoaded", { loaded: safeLoadedRows, total: totalCount })
+                  )}
+                </>
+              )}
+            </div>
+            <div className="flex items-center gap-1">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 px-2 text-xs font-medium text-muted-foreground hover:text-foreground md:hidden"
+                  >
+                    {t("mobileCards.sort")}: {currentSortOption.label}
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-48 max-h-100 overflow-y-auto">
+                  <DropdownMenuLabel>{t("mobileCards.sortBy")}</DropdownMenuLabel>
+                  <DropdownMenuRadioGroup
+                    value={sortField}
+                    onValueChange={(value) => handleSortFieldChange(value as TorrentSortOptionValue)}
+                  >
+                    {TORRENT_SORT_OPTIONS.map(option => (
+                      <DropdownMenuRadioItem key={option.value} value={option.value} className="text-xs">
+                        {option.label}
+                      </DropdownMenuRadioItem>
+                    ))}
+                  </DropdownMenuRadioGroup>
+                </DropdownMenuContent>
+              </DropdownMenu>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={toggleSortOrder}
+                className="h-7 w-7 p-0 text-muted-foreground hover:text-foreground md:hidden"
+                aria-label={`${t("sort.label")} ${sortOrder === "desc" ? t("sort.descending") : t("sort.ascending")}`}
+                title={`${t("sort.label")} ${sortOrder === "desc" ? t("sort.descending") : t("sort.ascending")}`}
+              >
+                {sortOrder === "desc" ? (
+                  <ChevronDown className="h-3.5 w-3.5" />
+                ) : (
+                  <ChevronUp className="h-3.5 w-3.5" />
+                )}
+              </Button>
+              <button
+                onClick={() => setSpeedUnit(speedUnit === "bytes" ? "bits" : "bytes")}
+                className="flex items-center gap-1 pl-1.5 py-0.5 rounded-sm transition-all hover:bg-muted/50"
+              >
+                <ArrowUpDown className="h-3.5 w-3.5 text-muted-foreground" />
+                <span className="text-xs text-muted-foreground">
+                  {speedUnit === "bytes" ? "MiB/s" : "Mbps"}
+                </span>
+              </button>
+            </div>
+          </div>
+        )}
+
+        {effectiveSearch && (
+          <div className="mb-3 flex items-center justify-between gap-2 rounded-md border border-primary/20 bg-primary/5 px-3 py-2 text-xs text-muted-foreground">
+            <div className="flex min-w-0 items-center gap-2">
+              <Search className="h-3.5 w-3.5 text-primary" aria-hidden="true" />
+              <span className="truncate text-sm text-foreground" title={effectiveSearch}>
+                {effectiveSearch}
+              </span>
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleClearSearch}
+              className="h-7 px-2 text-xs font-medium text-primary hover:text-primary"
+              aria-label={t("mobileCards.clearSearchFilter")}
+            >
+              {t("mobileCards.clear")}
+              <X className="ml-1 h-3 w-3" aria-hidden="true" />
+            </Button>
           </div>
         )}
       </div>

--- a/web/src/contexts/MobileScrollContext.test.tsx
+++ b/web/src/contexts/MobileScrollContext.test.tsx
@@ -85,16 +85,4 @@ describe("useMobileScroll", () => {
     act(() => flushRaf())
     expect(result.current.isFooterVisible).toBe(true)
   })
-
-  it("resets to visible when the scroll container unregisters", () => {
-    const container = document.createElement("div")
-    const { result } = renderHook(() => useMobileScroll(), { wrapper })
-
-    act(() => result.current.setScrollContainer(container))
-    act(() => scrollTo(container, 100))
-    expect(result.current.isFooterVisible).toBe(false)
-
-    act(() => result.current.setScrollContainer(null))
-    expect(result.current.isFooterVisible).toBe(true)
-  })
 })

--- a/web/src/contexts/MobileScrollContext.test.tsx
+++ b/web/src/contexts/MobileScrollContext.test.tsx
@@ -12,22 +12,31 @@ const wrapper = ({ children }: { children: ReactNode }) => (
   <MobileScrollProvider>{children}</MobileScrollProvider>
 )
 
-let rafCallbacks: FrameRequestCallback[] = []
+let rafQueue = new Map<number, FrameRequestCallback>()
+let rafId = 0
+
+function flushRaf() {
+  const pending = [...rafQueue.values()]
+  rafQueue.clear()
+  pending.forEach(cb => cb(0))
+}
 
 function scrollTo(container: HTMLElement, scrollTop: number) {
   container.scrollTop = scrollTop
   container.dispatchEvent(new Event("scroll"))
-  const pending = rafCallbacks
-  rafCallbacks = []
-  pending.forEach(cb => cb(0))
+  flushRaf()
 }
 
 describe("useMobileScroll", () => {
   beforeEach(() => {
-    rafCallbacks = []
+    rafQueue = new Map()
+    rafId = 0
     vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
-      rafCallbacks.push(cb)
-      return rafCallbacks.length
+      rafQueue.set(++rafId, cb)
+      return rafId
+    })
+    vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+      rafQueue.delete(id)
     })
   })
 
@@ -56,6 +65,24 @@ describe("useMobileScroll", () => {
 
     act(() => result.current.setScrollContainer(container))
     act(() => scrollTo(container, 5))
+    expect(result.current.isFooterVisible).toBe(true)
+  })
+
+  it("cancels a queued frame when the container unregisters", () => {
+    const container = document.createElement("div")
+    const { result } = renderHook(() => useMobileScroll(), { wrapper })
+
+    act(() => result.current.setScrollContainer(container))
+    act(() => scrollTo(container, 100))
+    expect(result.current.isFooterVisible).toBe(false)
+
+    // Queue a scroll-down frame but unregister before it runs
+    act(() => {
+      container.scrollTop = 200
+      container.dispatchEvent(new Event("scroll"))
+    })
+    act(() => result.current.setScrollContainer(null))
+    act(() => flushRaf())
     expect(result.current.isFooterVisible).toBe(true)
   })
 

--- a/web/src/contexts/MobileScrollContext.test.tsx
+++ b/web/src/contexts/MobileScrollContext.test.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { act, cleanup, renderHook } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { ReactNode } from "react"
+import { MobileScrollProvider, useMobileScroll } from "./MobileScrollContext"
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <MobileScrollProvider>{children}</MobileScrollProvider>
+)
+
+let rafCallbacks: FrameRequestCallback[] = []
+
+function scrollTo(container: HTMLElement, scrollTop: number) {
+  container.scrollTop = scrollTop
+  container.dispatchEvent(new Event("scroll"))
+  const pending = rafCallbacks
+  rafCallbacks = []
+  pending.forEach(cb => cb(0))
+}
+
+describe("useMobileScroll", () => {
+  beforeEach(() => {
+    rafCallbacks = []
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      rafCallbacks.push(cb)
+      return rafCallbacks.length
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    cleanup()
+  })
+
+  it("hides on scroll down and shows again on scroll up", () => {
+    const container = document.createElement("div")
+    const { result } = renderHook(() => useMobileScroll(), { wrapper })
+
+    act(() => result.current.setScrollContainer(container))
+    expect(result.current.isFooterVisible).toBe(true)
+
+    act(() => scrollTo(container, 100))
+    expect(result.current.isFooterVisible).toBe(false)
+
+    act(() => scrollTo(container, 50))
+    expect(result.current.isFooterVisible).toBe(true)
+  })
+
+  it("ignores movement below the threshold", () => {
+    const container = document.createElement("div")
+    const { result } = renderHook(() => useMobileScroll(), { wrapper })
+
+    act(() => result.current.setScrollContainer(container))
+    act(() => scrollTo(container, 5))
+    expect(result.current.isFooterVisible).toBe(true)
+  })
+
+  it("resets to visible when the scroll container unregisters", () => {
+    const container = document.createElement("div")
+    const { result } = renderHook(() => useMobileScroll(), { wrapper })
+
+    act(() => result.current.setScrollContainer(container))
+    act(() => scrollTo(container, 100))
+    expect(result.current.isFooterVisible).toBe(false)
+
+    act(() => result.current.setScrollContainer(null))
+    expect(result.current.isFooterVisible).toBe(true)
+  })
+})

--- a/web/src/contexts/MobileScrollContext.tsx
+++ b/web/src/contexts/MobileScrollContext.tsx
@@ -48,15 +48,23 @@ export function MobileScrollProvider({ children }: { children: ReactNode }) {
       ticking.current = false
     }
 
+    let animationFrame: number | null = null
+
     const onScroll = () => {
       if (!ticking.current) {
-        window.requestAnimationFrame(updateScrollDirection)
+        animationFrame = window.requestAnimationFrame(updateScrollDirection)
         ticking.current = true
       }
     }
 
     scrollContainer.addEventListener("scroll", onScroll)
-    return () => scrollContainer.removeEventListener("scroll", onScroll)
+    return () => {
+      scrollContainer.removeEventListener("scroll", onScroll)
+      if (animationFrame !== null) {
+        window.cancelAnimationFrame(animationFrame)
+      }
+      ticking.current = false
+    }
   }, [scrollContainer])
 
   return (

--- a/web/src/contexts/MobileScrollContext.tsx
+++ b/web/src/contexts/MobileScrollContext.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { createContext, useState, useEffect, useRef } from "react"
+import { createContext, useContext, useState, useEffect, useRef } from "react"
 import type { ReactNode } from "react"
 
 interface MobileScrollContextType {
@@ -21,7 +21,12 @@ export function MobileScrollProvider({ children }: { children: ReactNode }) {
   const threshold = 10
 
   useEffect(() => {
-    if (!scrollContainer) return
+    if (!scrollContainer) {
+      setIsFooterVisible(true)
+      return
+    }
+
+    lastScrollY.current = scrollContainer.scrollTop
 
     const updateScrollDirection = () => {
       const scrollY = scrollContainer.scrollTop
@@ -59,4 +64,12 @@ export function MobileScrollProvider({ children }: { children: ReactNode }) {
       {children}
     </MobileScrollContext.Provider>
   )
+}
+
+export function useMobileScroll() {
+  const context = useContext(MobileScrollContext)
+  if (!context) {
+    throw new Error("useMobileScroll must be used within a MobileScrollProvider")
+  }
+  return context
 }

--- a/web/src/layouts/AppLayout.tsx
+++ b/web/src/layouts/AppLayout.tsx
@@ -14,7 +14,7 @@ import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { cn } from "@/lib/utils"
 import { useTranslation } from "react-i18next"
-import { MobileScrollProvider } from "@/contexts/MobileScrollContext"
+import { MobileScrollProvider, useMobileScroll } from "@/contexts/MobileScrollContext"
 import { TorrentSelectionProvider } from "@/contexts/TorrentSelectionContext"
 import { ThemeValidator } from "@/components/themes/ThemeValidator"
 import { CustomThemesLoader } from "@/components/themes/CustomThemesLoader"
@@ -22,6 +22,7 @@ import { CustomThemesLoader } from "@/components/themes/CustomThemesLoader"
 function AppLayoutContent() {
   const { t } = useTranslation("common")
   const [sidebarCollapsed, setSidebarCollapsed] = usePersistedSidebarState(false) // Desktop: persisted state
+  const { isFooterVisible } = useMobileScroll()
 
   return (
     <div className="flex h-[100dvh] bg-background">
@@ -60,8 +61,9 @@ function AppLayoutContent() {
           </Tooltip>
         </Header>
         <main className={cn(
-          "flex-1 overflow-y-auto",
-          "pb-[calc(4rem+env(safe-area-inset-bottom))] lg:pb-0"
+          "flex-1 overflow-y-auto transition-[padding] duration-300",
+          isFooterVisible ? "pb-[calc(4rem+env(safe-area-inset-bottom))]" : "pb-0",
+          "lg:pb-0"
         )}>
           <Outlet />
         </main>


### PR DESCRIPTION
## Summary

Addresses some mobile UX feedback

- **Auto-hide bottom bars on scroll** — the footer nav (64px) and the torrents action bar (56px) now slide away together when scrolling down and return on scroll up, reclaiming ~120px of vertical space for the torrent list. This wires up the previously dead `MobileScrollContext` (mounted but consumed by nothing). The scroll-to-top FAB drops down to the freed space while the bars are hidden. No new setting — bars always reappear on scroll up or at rest near the top.
- **View mode discoverability** — the normal/compact/ultra-compact toggle was only findable inside the mobile filter sheet as a cycling button. It now also appears in the Appearance dialog (footer nav → Settings → Appearance) as an explicit three-way control showing all options. The filter-sheet cycler stays. Reuses existing i18n keys, no new strings.
- **Selection visibility** — the selection checkbox now renders in all view modes (previously `normal` only), with the card content padded right in compact/ultra-compact to make room. On low-contrast themes like Minimal dark, the `bg-accent/50` tint is nearly invisible, so compact-view users had no reliable selected indicator — matching Aurora's screenshot, which shows compact view in selection mode.

## Testing

- [x] New unit tests for `MobileScrollContext` (hide on scroll down, show on scroll up, threshold, reset on container unregister)
- [x] `npx vitest run src/contexts/MobileScrollContext.test.tsx` — 3 passed
- [x] `tsc --noEmit` clean, frontend lint clean (one pre-existing-pattern react-refresh warning, same as `TorrentSelectionContext`)
- [x] `make build` green
- [x] `pnpm check:i18n:hardcoded` clean
- [x] Manual smoke on a real phone (scroll hide/reveal, safe-area insets, checkbox in compact/ultra-compact) — jsdom can't exercise scroll/virtualization

## Screenshots

Visual change is mobile-only; screenshots to be added from a device (maintainer or reviewers with a phone handy — the three areas to capture: bars hiding on scroll, the Appearance dialog view-mode control, selected cards in compact view).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added normal, compact, and ultra-compact mobile torrent list views.
  * Added appearance controls to select and save the preferred view mode.
  * Mobile navigation now hides while scrolling and reappears when appropriate.
* **Improvements**
  * Updated torrent selection layouts to keep checkboxes visible across all view modes.
  * Adjusted content spacing, footer transitions, and the scroll-to-top button for different layout states.
  * Improved mobile scrolling behavior and footer positioning for a smoother browsing experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->