### PR TITLE
fix(web): add force start to mobile actions

### DIFF
--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -65,6 +65,7 @@ import {
   Clock,
   Eye,
   EyeOff,
+  FastForward,
   FileEdit,
   Filter,
   Folder,
@@ -2347,6 +2348,46 @@ export function TorrentCardsMobile({
             </SheetTitle>
           </SheetHeader>
           <div className="grid gap-2 py-4 px-4">
+            {(() => {
+              const forceStartStates = getSelectedTorrents?.map(t => t.force_start) ?? []
+              const allForceStarted = forceStartStates.length > 0 && forceStartStates.every(state => state === true)
+              const allForceDisabled = forceStartStates.length > 0 && forceStartStates.every(state => state === false)
+              const forceStartMixed = forceStartStates.length > 0 && !allForceStarted && !allForceDisabled
+
+              if (forceStartMixed) {
+                return (
+                  <>
+                    <Button
+                      variant="outline"
+                      onClick={() => handleBulkAction(TORRENT_ACTIONS.FORCE_START, { enable: true })}
+                      className="justify-start"
+                    >
+                      <FastForward className="mr-2 h-4 w-4" />
+                      {t("contextMenu.forceStart")} {t("contextMenu.mixed")}
+                    </Button>
+                    <Button
+                      variant="outline"
+                      onClick={() => handleBulkAction(TORRENT_ACTIONS.FORCE_START, { enable: false })}
+                      className="justify-start"
+                    >
+                      <FastForward className="mr-2 h-4 w-4" />
+                      {t("contextMenu.disableForceStart")} {t("contextMenu.mixed")}
+                    </Button>
+                  </>
+                )
+              }
+
+              return (
+                <Button
+                  variant="outline"
+                  onClick={() => handleBulkAction(TORRENT_ACTIONS.FORCE_START, { enable: !allForceStarted })}
+                  className="justify-start"
+                >
+                  <FastForward className="mr-2 h-4 w-4" />
+                  {allForceStarted ? t("contextMenu.disableForceStart") : t("contextMenu.forceStart")}
+                </Button>
+              )
+            })()}
             <Button
               variant="outline"
               onClick={() => handleBulkAction(TORRENT_ACTIONS.RECHECK)}


### PR DESCRIPTION
## Summary

The mobile torrent view omitted **Force Start** from its _More actions_ sheet even though the desktop view and action API support it.

Add **Force Start** and **Disable Force Start** with the same behavior as desktop, including explicit enable and disable actions for mixed selections. The action reuses the existing mobile bulk-selection path.

## Testing

- [x] `pnpm eslint src/components/torrents/TorrentCardsMobile.tsx`
- [x] `make build`
- [x] `make precommit`
- [x] Manual mobile test

## Screenshots

<img width="350" alt="Force Start" src="https://github.com/user-attachments/assets/4cd45bff-b175-4867-982b-db00941e518a" />
<img width="350" alt="(Disable) Force Start (Mixed)" src="https://github.com/user-attachments/assets/669b1c0e-c173-4fcc-8f7f-34a35a13a0d9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a force-start action to the mobile torrent actions menu.
  - Supports enabling or disabling force-start for selected torrents.
  - Provides separate controls when the selection has mixed force-start states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->