### PR TITLE
chore(crossseed): log byte sizes in season pack size mismatch demotions

### DIFF
--- a/internal/services/crossseed/seasonpack.go
+++ b/internal/services/crossseed/seasonpack.go
@@ -1262,7 +1262,7 @@ func (s *Service) resolveSeasonPackLocalFilesForCandidates(
 				continue
 			}
 			if localFile.size != expectedFile.file.Size {
-				lastErr = fmt.Errorf("%w: file size mismatch for %s", errLayoutMismatch, expectedFile.file.Name)
+				lastErr = fmt.Errorf("%w: file size mismatch for %s: pack declares %d bytes, local file is %d bytes", errLayoutMismatch, expectedFile.file.Name, expectedFile.file.Size, localFile.size)
 				continue
 			}
 			if ok, reason := matcher.seasonPackReleasesMatchWithReason(expectedFile.release, localFile.release, false, settings, aliasTitles); !ok {


### PR DESCRIPTION
Adds the pack-declared and local byte counts to the season pack size-mismatch demotion log, so drift reports show the exact delta instead of a bare "file size mismatch".