### PR TITLE
fix(torrents): keep stored view mode when a restricted consumer mounts

### DIFF
--- a/web/src/hooks/usePersistedCompactViewState.test.ts
+++ b/web/src/hooks/usePersistedCompactViewState.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { act, cleanup, renderHook } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+import { usePersistedCompactViewState } from "./usePersistedCompactViewState"
+
+const STORAGE_KEY = "qui-torrent-view-mode"
+const CARD_MODES = ["normal", "compact", "ultra-compact"] as const
+const TABLE_MODES = ["normal", "dense", "compact"] as const
+
+afterEach(() => {
+  cleanup()
+  window.localStorage.clear()
+})
+
+describe("usePersistedCompactViewState", () => {
+  it("keeps a stored mode a restricted consumer cannot render", () => {
+    window.localStorage.setItem(STORAGE_KEY, "dense")
+
+    // MobileFooterNav mounts on desktop too and has no "dense" option.
+    const restricted = renderHook(() => usePersistedCompactViewState("compact", CARD_MODES))
+    const table = renderHook(() => usePersistedCompactViewState("normal"))
+
+    expect(restricted.result.current.viewMode).toBe("compact")
+    expect(table.result.current.viewMode).toBe("dense")
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("dense")
+  })
+
+  it("broadcasts a user change to every consumer", () => {
+    const table = renderHook(() => usePersistedCompactViewState("normal", TABLE_MODES))
+    const restricted = renderHook(() => usePersistedCompactViewState("compact", CARD_MODES))
+
+    act(() => table.result.current.setViewMode("dense"))
+
+    expect(table.result.current.viewMode).toBe("dense")
+    expect(restricted.result.current.viewMode).toBe("compact")
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("dense")
+
+    act(() => restricted.result.current.setViewMode("ultra-compact"))
+
+    expect(table.result.current.viewMode).toBe("normal")
+    expect(restricted.result.current.viewMode).toBe("ultra-compact")
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("ultra-compact")
+  })
+
+  it("restores the stored mode after a narrow-then-wide resize", () => {
+    window.localStorage.setItem(STORAGE_KEY, "dense")
+
+    // FilterSidebar swaps allowedModes on the useIsMobile breakpoint.
+    const { result, rerender } = renderHook(
+      ({ mobile }: { mobile: boolean }) => usePersistedCompactViewState("compact", mobile ? CARD_MODES : undefined),
+      { initialProps: { mobile: false } }
+    )
+
+    expect(result.current.viewMode).toBe("dense")
+
+    rerender({ mobile: true })
+    expect(result.current.viewMode).toBe("compact")
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("dense")
+
+    rerender({ mobile: false })
+    expect(result.current.viewMode).toBe("dense")
+  })
+
+  it("cycles within the allowed modes", () => {
+    const { result } = renderHook(() => usePersistedCompactViewState("normal", TABLE_MODES))
+
+    act(() => result.current.cycleViewMode())
+    expect(result.current.viewMode).toBe("dense")
+
+    act(() => result.current.cycleViewMode())
+    expect(result.current.viewMode).toBe("compact")
+
+    act(() => result.current.cycleViewMode())
+    expect(result.current.viewMode).toBe("normal")
+  })
+})

--- a/web/src/hooks/usePersistedCompactViewState.ts
+++ b/web/src/hooks/usePersistedCompactViewState.ts
@@ -28,14 +28,17 @@ export function usePersistedCompactViewState(
   const allowedModes = useMemo(() => sanitizeAllowedModes(allowedModesInput), [allowedModesInput])
   const effectiveDefaultMode = allowedModes.includes(defaultMode) ? defaultMode : allowedModes[0]
 
-  const [viewMode, setViewModeState] = useState<ViewMode>(() => {
+  // The stored mode is global across every consumer; `allowedModes` only narrows what
+  // this consumer can render. Never persist the narrowing, or a mounted-but-hidden
+  // consumer (e.g. MobileFooterNav on desktop) clobbers the user's choice on reload.
+  const [storedMode, setStoredMode] = useState<ViewMode>(() => {
     if (typeof window === "undefined") {
       return effectiveDefaultMode
     }
 
     try {
       const stored = window.localStorage.getItem(STORAGE_KEY)
-      if (stored && allowedModes.includes(stored as ViewMode)) {
+      if (stored && ALL_VIEW_MODES.includes(stored as ViewMode)) {
         return stored as ViewMode
       }
     } catch (error) {
@@ -45,11 +48,24 @@ export function usePersistedCompactViewState(
     return effectiveDefaultMode
   })
 
-  const setViewMode = useCallback((updater: ViewMode | ((prev: ViewMode) => ViewMode)) => {
-    setViewModeState(prev => {
-      const requested = typeof updater === "function" ? updater(prev) : updater
-      return allowedModes.includes(requested) ? requested : allowedModes[0]
-    })
+  const viewMode = allowedModes.includes(storedMode) ? storedMode : effectiveDefaultMode
+
+  const setViewMode = useCallback((requested: ViewMode) => {
+    const next = allowedModes.includes(requested) ? requested : allowedModes[0]
+
+    setStoredMode(next)
+
+    if (typeof window === "undefined") {
+      return
+    }
+
+    try {
+      window.localStorage.setItem(STORAGE_KEY, next)
+    } catch (error) {
+      console.error("Failed to save view mode state to localStorage:", error)
+    }
+
+    window.dispatchEvent(new CustomEvent(STORAGE_KEY, { detail: { viewMode: next } }))
   }, [allowedModes])
 
   useEffect(() => {
@@ -57,64 +73,21 @@ export function usePersistedCompactViewState(
       return
     }
 
-    try {
-      window.localStorage.setItem(STORAGE_KEY, viewMode)
-    } catch (error) {
-      console.error("Failed to save view mode state to localStorage:", error)
-    }
-
-    const evt = new CustomEvent(STORAGE_KEY, { detail: { viewMode } })
-    window.dispatchEvent(evt)
-  }, [viewMode])
-
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return
-    }
-
     const handleEvent = (e: Event) => {
-      const custom = e as CustomEvent<{ viewMode: ViewMode }>
-      const nextMode = custom.detail?.viewMode
+      const nextMode = (e as CustomEvent<{ viewMode: ViewMode }>).detail?.viewMode
 
-      if (!nextMode) {
-        return
-      }
-
-      if (allowedModes.includes(nextMode)) {
-        setViewModeState(prev => (prev === nextMode ? prev : nextMode))
-        return
-      }
-
-      if (allowedModes.length > 0) {
-        setViewMode(allowedModes[0])
+      if (nextMode && ALL_VIEW_MODES.includes(nextMode)) {
+        setStoredMode(nextMode)
       }
     }
 
     window.addEventListener(STORAGE_KEY, handleEvent as EventListener)
     return () => window.removeEventListener(STORAGE_KEY, handleEvent as EventListener)
-  }, [allowedModes, setViewMode])
-
-  useEffect(() => {
-    if (allowedModes.includes(viewMode)) {
-      return
-    }
-
-    if (allowedModes.length > 0) {
-      setViewMode(allowedModes[0])
-    }
-  }, [allowedModes, setViewMode, viewMode])
+  }, [])
 
   const cycleViewMode = useCallback(() => {
-    if (allowedModes.length === 0) {
-      return
-    }
-
-    setViewMode(prev => {
-      const currentIndex = allowedModes.indexOf(prev)
-      const nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % allowedModes.length
-      return allowedModes[nextIndex]
-    })
-  }, [allowedModes, setViewMode])
+    setViewMode(allowedModes[(allowedModes.indexOf(viewMode) + 1) % allowedModes.length])
+  }, [allowedModes, setViewMode, viewMode])
 
   return {
     viewMode,


### PR DESCRIPTION
The view mode hook shares one localStorage key across consumers with different allowedModes, and on mount each consumer persisted its clamped fallback, so any consumer that cannot render the stored mode erased it: FilterSidebar under 768px dropped Dense since #643, and #2265 made the always-mounted MobileFooterNav reset Dense to Stacked on every desktop reload. allowedModes is now a render-time clamp only and localStorage writes happen solely in setViewMode, so only a user action changes the stored mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compact view mode persistence across responsive layout changes.
  * Prevented invalid or restricted view modes from being applied while preserving valid shared settings.
  * Improved synchronization of view mode changes between consumers.

* **Tests**
  * Added coverage for restricted modes, cross-consumer updates, persistence, and mode cycling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->