### PR TITLE
chore(docs): forbid tracker links and copied torrent names in published text

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,13 @@ Frontend-specific rules live in `web/AGENTS.md`. Read that file before editing `
 - Update PR branches by merging develop into them, never rebase/force-push. PRs are squash-merged, so rebase gains nothing and force-pushes break review history and contributors' local branches.
 - Never add AI advertising/attribution/co-author lines.
 - PRs need clear summary, testing checklist, and screenshots for visual UI changes.
+- Never publish private tracker links or torrent names taken from a client. This covers PR and issue titles, bodies, and comments, commit messages, and `documentation/`.
+  - No tracker URL that carries a path, query, or key: torrent pages, announce URLs, passkeys, `.torrent` links. Bare hostnames and tracker names stay allowed; the code and docs use them.
+  - No release name copied word for word from a user report or a torrent client. Build an equivalent name: keep each token that matters, change the title and the group. Make sure the new name still causes the bug before you publish it.
+  - Naming a work in prose, or building a name from a real title and group tag, is allowed. The rule is about strings copied from someone's client, not about which words you use.
+  - Scrub reports from Discord or DMs the same way before you quote them. Keep the real string in notes outside the repo so the repro stays runnable; `docs/` is committed and counts as published.
+  - New test fixtures and code comments use names built by the rule above. Do not sweep the existing ones.
+  - Screenshots: capture from an instance you fill with synthetic torrents. If the bug shows only on a real library, blur the name, tracker, and save path columns.
 
 ## Final Report
 

--- a/internal/qbittorrent/integration_test.go
+++ b/internal/qbittorrent/integration_test.go
@@ -172,7 +172,7 @@ func TestSyncManager_TorrentTrackerIsDown_TrackerUpdating(t *testing.T) {
 			Trackers: []qbt.TorrentTracker{
 				{
 					Status:  qbt.TrackerStatusNotWorking,
-					Message: "Trumped: https://beyond-hd.me/torrents/paradise-2025-s02e07-the-final-countdown-1080p",
+					Message: "Trumped: https://tracker.example.com/torrents/example-show-2025-s02e07-the-final-countdown-1080p",
 				},
 			},
 		}
@@ -241,7 +241,7 @@ func TestSyncManager_CountTorrentStatuses_TrackerHealthExclusive(t *testing.T) {
 		Trackers: []qbt.TorrentTracker{
 			{
 				Status:  qbt.TrackerStatusNotWorking,
-				Message: "Trumped: https://beyond-hd.me/torrents/paradise-2025-s02e07-the-final-countdown-1080p",
+				Message: "Trumped: https://tracker.example.com/torrents/example-show-2025-s02e07-the-final-countdown-1080p",
 			},
 		},
 	}


### PR DESCRIPTION
Adds an AGENTS.md rule so PR bodies, issues, commit messages and docs never carry a private tracker URL or a release name copied out of someone's client, and scrubs the one tracker URL already committed in a test fixture.

Tracker names themselves stay allowed: the repo keys code paths, DB columns and API fields on them, so banning the words would mean a schema change rather than a writing rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated tracker error test scenarios with safe, synthetic example URLs.
  * Preserved validation for unregistered trackers and tracker availability classifications.

* **Documentation**
  * Added publication-safety guidance requiring sanitized or synthetic data in project materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->