### PR TITLE
fix(web): use relative base path for assets in Vite config

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -19,6 +19,7 @@ const workboxMode = nodeMajor >= 24 ? "development" : "production"
 
 // https://vite.dev/config/
 export default defineConfig(() => ({
+  base: "./",
   plugins: [
     react({
       // React 19 requires the new JSX transform


### PR DESCRIPTION
## Summary

Sets `base: "./"` in `web/vite.config.ts` so asset references inside compiled CSS files (such as complex SVG flag icons from `flag-icons`) resolve relative to the stylesheet bundle location instead of forcing absolute domain-root paths (`/assets/...`).

### Problem
When hosting `qui` under a subpath (e.g., `https://example.com/qui/`), smaller flag icons (< 4 KiB, e.g. Sweden `se.svg`) are inlined as Data URIs directly into the CSS, but larger flag icons (> 4 KiB, e.g. Portugal `pt.svg`) are extracted by Vite into external SVG files. 

Because Vite defaulted to absolute root paths (`base: "/"`), the CSS contained `url(/assets/pt-DZ2ADgIR.svg)`. When accessed under a subpath, the browser resolved the path against the domain root (`https://example.com/assets/...`) instead of the subpath (`https://example.com/qui/assets/...`), resulting in 404 errors.

### Solution
Adding `base: "./"` in `web/vite.config.ts` instructs Vite to emit relative asset URLs (`url(./pt-DZ2ADgIR.svg)`) inside compiled CSS files. The browser then resolves asset paths relative to `/qui/assets/index-*.css` $\rightarrow$ `/qui/assets/pt-DZ2ADgIR.svg`.

## Screenshots

| Before | After |
| :---: | :---: |
| <img width="400" height="268" alt="image" src="https://github.com/user-attachments/assets/3d89db46-6543-49f7-92f2-d0c699578e7d" /> | <img width="402" height="269" alt="image" src="https://github.com/user-attachments/assets/76db1074-ccc4-4240-8513-3e5c674143dc" /> |

## Testing Checklist

- [x] Tested locally with `QUI__BASE_URL="/qui/"`
- [x] Verified external SVG flag icons (e.g. `pt.svg`) load successfully (`200 OK`) under subpath routing
- [x] Verified inline SVG flag icons continue to render as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asset and route loading when the application is served from different paths or locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->