### PR TITLE
fix(web): emit CSS asset urls relative to the stylesheet

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -121,6 +121,14 @@ export default defineConfig(() => ({
       },
     }),
   ],
+  experimental: {
+    // The Go handler rewrites the absolute /assets/ paths in index.html for
+    // base-URL deployments, but never rewrites CSS content, so CSS url()
+    // assets (large flag icons) 404 under a subpath. Emit CSS urls relative
+    // to the stylesheet; they resolve correctly for any base. HTML keeps the
+    // absolute paths the handler rewrite depends on.
+    renderBuiltUrl: (_filename, { hostType }) => hostType === "css" ? { relative: true } : undefined,
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
Large flag icons (CSS url() assets above Vite's 4 KiB inline limit) 404 when qui is hosted under a base URL, because the Go handler rewrites asset paths in index.html but never in CSS content. This makes only the CSS urls relative to the stylesheet, which resolves correctly for any base, while index.html keeps the absolute paths the server-side rewrite depends on.

Replaces #2274, which fixed the icons but broke hard refresh on nested routes by making the index.html paths relative too. Credit to @MaKTaiL for the diagnosis. Verified on a production build under both root and subpath hosting: nested-route hard refresh works and the previously 404ing flag SVG loads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of asset URLs in built stylesheets.
  * CSS assets now resolve relative to their stylesheet, while other assets retain existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->