### PR TITLE
fix: land on the app when entering through /index.html under a base URL

### DIFF
--- a/documentation/docs/configuration/base-url.md
+++ b/documentation/docs/configuration/base-url.md
@@ -7,6 +7,8 @@ title: Base URL
 
 If you need to serve qui from a subdirectory (e.g., `https://example.com/qui/`), you can configure the base URL.
 
+qui normalizes the value at startup. `/qui/`, `/qui`, and `qui` all become `/qui/`.
+
 ## Using Environment Variable
 
 ```bash

--- a/documentation/docs/configuration/reference.md
+++ b/documentation/docs/configuration/reference.md
@@ -43,7 +43,7 @@ qui watches `config.toml` for changes. Some settings are applied immediately (fo
 |---|---|---:|---|---|
 | `host` | `QUI__HOST` | string | `localhost` (or `0.0.0.0` in containers) | Bind address for the main HTTP server. |
 | `port` | `QUI__PORT` | int | `7476` | Port for the main HTTP server. |
-| `baseUrl` | `QUI__BASE_URL` | string | `/` | Serve qui from a subdirectory (example: `/qui/`). |
+| `baseUrl` | `QUI__BASE_URL` | string | `/` | Serve qui from a subdirectory (example: `/qui/`). Normalized at startup: leading and trailing slashes are added when missing. |
 | `corsAllowedOrigins` | `QUI__CORS_ALLOWED_ORIGINS` | string[] | empty list | Explicit CORS allowlist. Empty disables CORS. Origins must be `http(s)://host[:port]`; wildcards are rejected; default ports are normalized. Restart required. |
 | `sessionSecret` | `QUI__SESSION_SECRET` / `QUI__SESSION_SECRET_FILE` | string | auto-generated | WARNING: changing breaks decryption of stored instance passwords; you must re-enter them in the UI. |
 | `logLevel` | `QUI__LOG_LEVEL` | string | `DEBUG` | `ERROR`, `DEBUG`, `INFO`, `WARN`, `TRACE`. Applied immediately. `DEBUG` records sufficient detail to diagnose most reports. `TRACE` adds per-request and per-sync-tick detail and makes the file grow quickly. |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/autobrr/qui/internal/domain"
+	"github.com/autobrr/qui/pkg/httphelpers"
 )
 
 var envPrefix = "QUI__"
@@ -320,7 +321,8 @@ func (c *AppConfig) applyDynamicChanges(previousAuthSettings authReloadSettings)
 func (c *AppConfig) hydrateConfigFromViper() {
 	c.Config.Host = c.viper.GetString("host")
 	c.Config.Port = c.viper.GetInt("port")
-	c.Config.BaseURL = c.viper.GetString("baseUrl")
+	// Canonical "/prefix/" form; the index.html redirect breaks on a slashless base.
+	c.Config.BaseURL = httphelpers.NormalizeBasePath(c.viper.GetString("baseUrl")) + "/"
 	c.Config.CORSAllowedOrigins = c.getNormalizedStringSlice("corsAllowedOrigins")
 	c.Config.SessionSecret = c.viper.GetString("sessionSecret")
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -605,3 +605,26 @@ func TestHydrateConfigFromViperSplitsStringSlices(t *testing.T) {
 		})
 	}
 }
+
+func TestBaseURLNormalization(t *testing.T) {
+	tests := map[string]string{
+		"":          "/",
+		"/":         "/",
+		"/qui/":     "/qui/",
+		"/qui":      "/qui/",
+		"qui":       "/qui/",
+		"qui/":      "/qui/",
+		" /qui ":    "/qui/", //nolint:gocritic // the whitespace is the input under test
+		"/apps/qui": "/apps/qui/",
+	}
+
+	for input, want := range tests {
+		v := viper.New()
+		v.Set("baseUrl", input)
+		cfg := &AppConfig{Config: &domain.Config{}, viper: v}
+
+		cfg.hydrateConfigFromViper()
+
+		assert.Equal(t, want, cfg.Config.BaseURL, "input %q", input)
+	}
+}

--- a/web/src/routes/__root.test.ts
+++ b/web/src/routes/__root.test.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { isRedirect } from "@tanstack/react-router"
+import { describe, expect, it } from "vitest"
+
+import { Route } from "./__root"
+
+function runBeforeLoad(pathname: string, search: Record<string, unknown> = {}) {
+  try {
+    Route.options.beforeLoad?.({ location: { pathname, search } } as never)
+  } catch (thrown) {
+    return thrown
+  }
+  return undefined
+}
+
+describe("root beforeLoad", () => {
+  it("redirects /index.html to the SPA root and keeps the search", () => {
+    const thrown = runBeforeLoad("/qui/index.html", { returnTo: "/x", tab: "peers" })
+
+    expect(isRedirect(thrown)).toBe(true)
+    if (isRedirect(thrown)) {
+      expect(thrown.options.to).toBe("/")
+      expect(thrown.options.search).toEqual({ returnTo: "/x", tab: "peers" })
+    }
+  })
+
+  it("leaves normal routes alone", () => {
+    expect(runBeforeLoad("/qui/instances/1")).toBeUndefined()
+    expect(runBeforeLoad("/")).toBeUndefined()
+    expect(runBeforeLoad("/qui/")).toBeUndefined()
+  })
+})

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -3,10 +3,19 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { createRootRoute, Outlet } from "@tanstack/react-router"
+import { createRootRoute, Outlet, redirect } from "@tanstack/react-router"
 import { NotFound } from "@/pages/NotFound"
 
 export const Route = createRootRoute({
+  beforeLoad: ({ location }) => {
+    // SSO proxies (Pangolin, Cloudflare Access) preserve /index.html as the
+    // request path. The server redirects it to the SPA root, but a registered
+    // service worker answers with the app shell before that redirect can run,
+    // which strands the router on the not-found screen. Bounce it ourselves.
+    if (location.pathname.endsWith("/index.html")) {
+      throw redirect({ to: "/", search: location.search })
+    }
+  },
   component: () => (
     <>
       <Outlet />


### PR DESCRIPTION
Opening qui through /index.html (SSO proxies such as Pangolin and Cloudflare Access preserve that path) could land on the not-found screen in two ways. With a base URL configured without a trailing slash (`baseUrl = "/qui"`), the server redirect targeted the slashless base; BaseURL is now normalized once at config load so every consumer sees the canonical `/qui/` form. For PWA clients the redirect never ran at all: the registered service worker answers /index.html with the precached app shell, so the root route now bounces /index.html to the SPA root itself (a navigateFallbackDenylist entry cannot fix this because the shell URL is itself precached, and a precache hit wins over the fallback).

Verified live across six base-URL spellings (41-check matrix: redirect, SPA, nested-route hard load, assets, API mount) plus browser tests with and without an active service worker, authenticated and unauthenticated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Requests using an `/index.html` path now redirect cleanly to the site root while preserving query parameters.
  * Configured base URLs are normalized consistently, including leading and trailing slashes and whitespace handling.

* **Documentation**
  * Clarified base URL normalization behavior in the configuration documentation.

* **Tests**
  * Added coverage for URL normalization and root-route redirect behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->