### PR TITLE
fix(web): offer both toggle directions when selection is partly loaded

### DIFF
--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -51,7 +51,7 @@ import { buildTrackerCustomizationLookup, extractTrackerHost, getTrackerCustomiz
 import { resolveTrackerHealthSupport } from "@/lib/tracker-health-support"
 import { resolveTrackerIconSrc } from "@/lib/tracker-icons"
 import { buildTorrentActionTargets } from "@/lib/torrent-action-targets"
-import { anyTorrentHasTag, getCommonCategory, getCommonSavePath, getTorrentHashesWithTag } from "@/lib/torrent-utils"
+import { anyTorrentHasTag, getCommonCategory, getCommonSavePath, getToggleSelectionState, getTorrentHashesWithTag } from "@/lib/torrent-utils"
 import { isAllInstancesScope } from "@/lib/instances"
 import { useNavigate, useSearch } from "@tanstack/react-router"
 import { navigateWithSearch } from "@/lib/router-search"
@@ -2352,10 +2352,7 @@ export function TorrentCardsMobile({
           </SheetHeader>
           <div className="grid gap-2 py-4 px-4">
             {(() => {
-              const forceStartStates = getSelectedTorrents?.map(t => t.force_start) ?? []
-              const allForceStarted = forceStartStates.length > 0 && forceStartStates.every(state => state === true)
-              const allForceDisabled = forceStartStates.length > 0 && forceStartStates.every(state => state === false)
-              const forceStartMixed = stateUnknownForSelection || (forceStartStates.length > 0 && !allForceStarted && !allForceDisabled)
+              const { allEnabled: allForceStarted, mixed: forceStartMixed } = getToggleSelectionState(getSelectedTorrents.map(t => t.force_start), stateUnknownForSelection)
 
               if (forceStartMixed) {
                 return (
@@ -2408,10 +2405,7 @@ export function TorrentCardsMobile({
               {t("managementBar.reannounce")}
             </Button>
             {(() => {
-              const seqDlStates = getSelectedTorrents?.map(t => t.seq_dl) ?? []
-              const allSeqDlEnabled = seqDlStates.length > 0 && seqDlStates.every(state => state === true)
-              const allSeqDlDisabled = seqDlStates.length > 0 && seqDlStates.every(state => state === false)
-              const seqDlMixed = stateUnknownForSelection || (seqDlStates.length > 0 && !allSeqDlEnabled && !allSeqDlDisabled)
+              const { allEnabled: allSeqDlEnabled, mixed: seqDlMixed } = getToggleSelectionState(getSelectedTorrents.map(t => t.seq_dl), stateUnknownForSelection)
 
               if (seqDlMixed) {
                 return (
@@ -2511,11 +2505,7 @@ export function TorrentCardsMobile({
               {t("managementBar.bottomPriority")}
             </Button>
             {(() => {
-              // Check TMM state across selected torrents
-              const tmmStates = getSelectedTorrents?.map(t => t.auto_tmm) ?? []
-              const allEnabled = tmmStates.length > 0 && tmmStates.every(state => state === true)
-              const allDisabled = tmmStates.length > 0 && tmmStates.every(state => state === false)
-              const mixed = stateUnknownForSelection || (tmmStates.length > 0 && !allEnabled && !allDisabled)
+              const { allEnabled, mixed } = getToggleSelectionState(getSelectedTorrents.map(t => t.auto_tmm), stateUnknownForSelection)
 
               if (mixed) {
                 return (

--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -2062,6 +2062,9 @@ export function TorrentCardsMobile({
 
   const singleSelectedTorrent = getSelectedTorrents[0] ?? null
 
+  // select-all: unloaded rows have unknown state, so offer both directions.
+  const stateUnknownForSelection = isAllSelected && getSelectedTorrents.length < effectiveSelectionCount
+
   const handleClearSearch = useCallback(() => {
     setGlobalFilter("")
 
@@ -2352,7 +2355,7 @@ export function TorrentCardsMobile({
               const forceStartStates = getSelectedTorrents?.map(t => t.force_start) ?? []
               const allForceStarted = forceStartStates.length > 0 && forceStartStates.every(state => state === true)
               const allForceDisabled = forceStartStates.length > 0 && forceStartStates.every(state => state === false)
-              const forceStartMixed = forceStartStates.length > 0 && !allForceStarted && !allForceDisabled
+              const forceStartMixed = stateUnknownForSelection || (forceStartStates.length > 0 && !allForceStarted && !allForceDisabled)
 
               if (forceStartMixed) {
                 return (
@@ -2407,6 +2410,32 @@ export function TorrentCardsMobile({
             {(() => {
               const seqDlStates = getSelectedTorrents?.map(t => t.seq_dl) ?? []
               const allSeqDlEnabled = seqDlStates.length > 0 && seqDlStates.every(state => state === true)
+              const allSeqDlDisabled = seqDlStates.length > 0 && seqDlStates.every(state => state === false)
+              const seqDlMixed = stateUnknownForSelection || (seqDlStates.length > 0 && !allSeqDlEnabled && !allSeqDlDisabled)
+
+              if (seqDlMixed) {
+                return (
+                  <>
+                    <Button
+                      variant="outline"
+                      onClick={() => handleBulkAction(TORRENT_ACTIONS.TOGGLE_SEQUENTIAL_DOWNLOAD, { enable: true })}
+                      className="justify-start"
+                    >
+                      <Blocks className="mr-2 h-4 w-4" />
+                      {t("managementBar.sequentialDownload.enable")} {t("contextMenu.mixed")}
+                    </Button>
+                    <Button
+                      variant="outline"
+                      onClick={() => handleBulkAction(TORRENT_ACTIONS.TOGGLE_SEQUENTIAL_DOWNLOAD, { enable: false })}
+                      className="justify-start"
+                    >
+                      <Blocks className="mr-2 h-4 w-4" />
+                      {t("managementBar.sequentialDownload.disable")} {t("contextMenu.mixed")}
+                    </Button>
+                  </>
+                )
+              }
+
               return (
                 <Button
                   variant="outline"
@@ -2486,7 +2515,7 @@ export function TorrentCardsMobile({
               const tmmStates = getSelectedTorrents?.map(t => t.auto_tmm) ?? []
               const allEnabled = tmmStates.length > 0 && tmmStates.every(state => state === true)
               const allDisabled = tmmStates.length > 0 && tmmStates.every(state => state === false)
-              const mixed = tmmStates.length > 0 && !allEnabled && !allDisabled
+              const mixed = stateUnknownForSelection || (tmmStates.length > 0 && !allEnabled && !allDisabled)
 
               if (mixed) {
                 return (

--- a/web/src/components/torrents/TorrentContextMenu.tsx
+++ b/web/src/components/torrents/TorrentContextMenu.tsx
@@ -19,7 +19,7 @@ import { TORRENT_ACTIONS } from "@/hooks/useTorrentActions"
 import { api } from "@/lib/api"
 import { getLinuxIsoName, getLinuxSavePath, useIncognitoMode } from "@/lib/incognito"
 import { buildTorrentActionTargets } from "@/lib/torrent-action-targets"
-import { getTorrentDisplayHash } from "@/lib/torrent-utils"
+import { getToggleSelectionState, getTorrentDisplayHash } from "@/lib/torrent-utils"
 import { copyTextToClipboard } from "@/lib/utils"
 import type { Category, ExternalProgram, InstanceCapabilities, Torrent, TorrentFilters } from "@/types"
 import { useMutation, useQueries, useQuery } from "@tanstack/react-query"
@@ -329,22 +329,9 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
   // select-all: unloaded rows have unknown state, so offer both directions.
   const stateUnknownForSelection = isAllSelected && torrents.length < effectiveSelectionCount
 
-  const forceStartStates = torrents.map(t => t.force_start)
-  const allForceStarted = forceStartStates.length > 0 && forceStartStates.every(state => state === true)
-  const allForceDisabled = forceStartStates.length > 0 && forceStartStates.every(state => state === false)
-  const forceStartMixed = stateUnknownForSelection || (forceStartStates.length > 0 && !allForceStarted && !allForceDisabled)
-
-  // TMM state calculation
-  const tmmStates = torrents.map(t => t.auto_tmm)
-  const allEnabled = tmmStates.length > 0 && tmmStates.every(state => state === true)
-  const allDisabled = tmmStates.length > 0 && tmmStates.every(state => state === false)
-  const mixed = stateUnknownForSelection || (tmmStates.length > 0 && !allEnabled && !allDisabled)
-
-  // Sequential download state calculation
-  const seqDlStates = torrents.map(t => t.seq_dl)
-  const allSeqDlEnabled = seqDlStates.length > 0 && seqDlStates.every(state => state === true)
-  const allSeqDlDisabled = seqDlStates.length > 0 && seqDlStates.every(state => state === false)
-  const seqDlMixed = stateUnknownForSelection || (seqDlStates.length > 0 && !allSeqDlEnabled && !allSeqDlDisabled)
+  const { allEnabled: allForceStarted, mixed: forceStartMixed } = getToggleSelectionState(torrents.map(t => t.force_start), stateUnknownForSelection)
+  const { allEnabled, mixed } = getToggleSelectionState(torrents.map(t => t.auto_tmm), stateUnknownForSelection)
+  const { allEnabled: allSeqDlEnabled, mixed: seqDlMixed } = getToggleSelectionState(torrents.map(t => t.seq_dl), stateUnknownForSelection)
 
   const handleQueueAction = useCallback((action: "topPriority" | "increasePriority" | "decreasePriority" | "bottomPriority") => {
     onAction(action as TorrentAction, hashes, { targets: actionTargets })

--- a/web/src/components/torrents/TorrentContextMenu.tsx
+++ b/web/src/components/torrents/TorrentContextMenu.tsx
@@ -163,6 +163,7 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
   })
 
   const count = isAllSelected ? effectiveSelectionCount : hashes.length
+  const mixedLabel = count > 1 ? `${t("contextMenu.mixed")} (${count})` : t("contextMenu.mixed")
 
   // State for cross-seed search
   const { isFilteringCrossSeeds, filterCrossSeeds } = useCrossSeedFilter({
@@ -325,22 +326,25 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
     void onExport(hashes, torrents)
   }, [hashes, onExport, torrents])
 
+  // select-all: unloaded rows have unknown state, so offer both directions.
+  const stateUnknownForSelection = isAllSelected && torrents.length < effectiveSelectionCount
+
   const forceStartStates = torrents.map(t => t.force_start)
   const allForceStarted = forceStartStates.length > 0 && forceStartStates.every(state => state === true)
   const allForceDisabled = forceStartStates.length > 0 && forceStartStates.every(state => state === false)
-  const forceStartMixed = forceStartStates.length > 0 && !allForceStarted && !allForceDisabled
+  const forceStartMixed = stateUnknownForSelection || (forceStartStates.length > 0 && !allForceStarted && !allForceDisabled)
 
   // TMM state calculation
   const tmmStates = torrents.map(t => t.auto_tmm)
   const allEnabled = tmmStates.length > 0 && tmmStates.every(state => state === true)
   const allDisabled = tmmStates.length > 0 && tmmStates.every(state => state === false)
-  const mixed = tmmStates.length > 0 && !allEnabled && !allDisabled
+  const mixed = stateUnknownForSelection || (tmmStates.length > 0 && !allEnabled && !allDisabled)
 
   // Sequential download state calculation
   const seqDlStates = torrents.map(t => t.seq_dl)
   const allSeqDlEnabled = seqDlStates.length > 0 && seqDlStates.every(state => state === true)
   const allSeqDlDisabled = seqDlStates.length > 0 && seqDlStates.every(state => state === false)
-  const seqDlMixed = seqDlStates.length > 0 && !allSeqDlEnabled && !allSeqDlDisabled
+  const seqDlMixed = stateUnknownForSelection || (seqDlStates.length > 0 && !allSeqDlEnabled && !allSeqDlDisabled)
 
   const handleQueueAction = useCallback((action: "topPriority" | "increasePriority" | "decreasePriority" | "bottomPriority") => {
     onAction(action as TorrentAction, hashes, { targets: actionTargets })
@@ -427,14 +431,14 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
                   disabled={isPending}
                 >
                   <FastForward className="mr-2 h-4 w-4" />
-                  {t("contextMenu.forceStart")} {count > 1 ? `(${count} ${t("contextMenu.mixed")})` : t("contextMenu.mixed")}
+                  {t("contextMenu.forceStart")} {mixedLabel}
                 </ContextMenuItem>
                 <ContextMenuItem
                   onClick={() => handleForceStartToggle(false)}
                   disabled={isPending}
                 >
                   <FastForward className="mr-2 h-4 w-4" />
-                  {t("contextMenu.disableForceStart")} {count > 1 ? `(${count} ${t("contextMenu.mixed")})` : t("contextMenu.mixed")}
+                  {t("contextMenu.disableForceStart")} {mixedLabel}
                 </ContextMenuItem>
               </>
             ) : (
@@ -474,14 +478,14 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
                   disabled={isPending}
                 >
                   <Blocks className="mr-2 h-4 w-4" />
-                  {t("contextMenu.enableSequentialDownload")} {count > 1 ? `(${count} ${t("contextMenu.mixed")})` : t("contextMenu.mixed")}
+                  {t("contextMenu.enableSequentialDownload")} {mixedLabel}
                 </ContextMenuItem>
                 <ContextMenuItem
                   onClick={() => handleSeqDlToggle(false)}
                   disabled={isPending}
                 >
                   <Blocks className="mr-2 h-4 w-4" />
-                  {t("contextMenu.disableSequentialDownload")} {count > 1 ? `(${count} ${t("contextMenu.mixed")})` : t("contextMenu.mixed")}
+                  {t("contextMenu.disableSequentialDownload")} {mixedLabel}
                 </ContextMenuItem>
               </>
             ) : (
@@ -592,14 +596,14 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
                   disabled={isPending}
                 >
                   <Sparkles className="mr-2 h-4 w-4" />
-                  {t("contextMenu.enableTmm")} {count > 1 ? `(${count} ${t("contextMenu.mixed")})` : t("contextMenu.mixed")}
+                  {t("contextMenu.enableTmm")} {mixedLabel}
                 </ContextMenuItem>
                 <ContextMenuItem
                   onClick={() => handleTmmToggle(false)}
                   disabled={isPending}
                 >
                   <Settings2 className="mr-2 h-4 w-4" />
-                  {t("contextMenu.disableTmm")} {count > 1 ? `(${count} ${t("contextMenu.mixed")})` : t("contextMenu.mixed")}
+                  {t("contextMenu.disableTmm")} {mixedLabel}
                 </ContextMenuItem>
               </>
             ) : (

--- a/web/src/lib/torrent-utils.test.ts
+++ b/web/src/lib/torrent-utils.test.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { describe, expect, it } from "vitest"
+import { getToggleSelectionState } from "./torrent-utils"
+
+describe("getToggleSelectionState", () => {
+  const cases: Array<{ name: string; values: boolean[]; stateUnknown: boolean; allEnabled: boolean; mixed: boolean }> = [
+    { name: "all enabled offers the disable direction", values: [true, true], stateUnknown: false, allEnabled: true, mixed: false },
+    { name: "all disabled offers the enable direction", values: [false, false], stateUnknown: false, allEnabled: false, mixed: false },
+    { name: "disagreeing values are mixed", values: [true, false, true], stateUnknown: false, allEnabled: false, mixed: true },
+    { name: "an empty selection is neither enabled nor mixed", values: [], stateUnknown: false, allEnabled: false, mixed: false },
+    // Select-all over more torrents than are loaded: the loaded rows can agree by
+    // chance, so a direction read from them would be applied to unseen torrents.
+    { name: "unloaded rows make an all-enabled window mixed", values: [true, true], stateUnknown: true, allEnabled: true, mixed: true },
+    { name: "unloaded rows make an all-disabled window mixed", values: [false, false], stateUnknown: true, allEnabled: false, mixed: true },
+    { name: "unloaded rows with nothing loaded are mixed", values: [], stateUnknown: true, allEnabled: false, mixed: true },
+  ]
+
+  for (const { name, values, stateUnknown, allEnabled, mixed } of cases) {
+    it(name, () => {
+      expect(getToggleSelectionState(values, stateUnknown)).toEqual({ allEnabled, mixed })
+    })
+  }
+})

--- a/web/src/lib/torrent-utils.ts
+++ b/web/src/lib/torrent-utils.ts
@@ -199,3 +199,16 @@ export function getTotalSize(torrents: Torrent[]): number {
   // Use reduce to sum up all torrent sizes
   return torrents.reduce((total, torrent) => total + (torrent.size || 0), 0)
 }
+
+/**
+ * Resolve how a boolean toggle (force start, sequential download, auto TMM)
+ * should be presented for the current selection. `stateUnknown` is true when
+ * rows in the selection are still unloaded, so the sampled values say nothing
+ * about the rest.
+ */
+export function getToggleSelectionState(values: boolean[], stateUnknown: boolean): { allEnabled: boolean; mixed: boolean } {
+  return {
+    allEnabled: values.length > 0 && values.every(Boolean),
+    mixed: stateUnknown || values.some(value => value !== values[0]),
+  }
+}


### PR DESCRIPTION
Force start, sequential download and automatic torrent management picked their direction from the loaded rows only, so under select-all a uniform-looking sample decided the direction for every torrent in the selection. On an instance with 5574 torrents and 300 rows loaded, the desktop menu offered a single "Force Start (5574)". The menus now offer both directions whenever rows are still unloaded, which is what they already do for a genuinely mixed selection.

This also adds the missing mixed branch to mobile sequential download, and fixes the desktop mixed label that read "(3 (Mixed))" because the translated value carries its own brackets. The two icon toggles in the selection toolbar keep the current behaviour on purpose: a single icon has no room to offer both directions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bulk torrent actions when selecting all torrents, including items not yet loaded.
  * Force start, sequential download, and automatic management controls now correctly show mixed or incomplete states.
  * Added separate enable and disable options with accurate selection counts for mixed selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->