### PR TITLE
fix(mobile): keep the last card clear of the selection bar and guard footer scroll registration

### DIFF
--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -35,7 +35,7 @@ import { Progress } from "@/components/ui/progress"
 import { ScrollToTopButton } from "@/components/ui/scroll-to-top-button"
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
 import { Switch } from "@/components/ui/switch"
-import { useMobileScroll } from "@/contexts/MobileScrollContext"
+import { useMobileScroll, useRegisterMobileScrollContainer } from "@/contexts/MobileScrollContext"
 import { useSyncStream } from "@/contexts/SyncStreamContext"
 import { useCrossSeedWarning } from "@/hooks/useCrossSeedWarning"
 import { useCrossSeedBlocklistActions } from "@/hooks/useCrossSeedBlocklistActions"
@@ -1090,12 +1090,8 @@ export function TorrentCardsMobile({
   const { setIsSelectionMode } = useTorrentSelection()
 
   const parentRef = useRef<HTMLDivElement>(null)
-  const { isFooterVisible, setScrollContainer } = useMobileScroll()
-
-  useEffect(() => {
-    setScrollContainer(parentRef.current)
-    return () => setScrollContainer(null)
-  }, [setScrollContainer])
+  const { isFooterVisible } = useMobileScroll()
+  useRegisterMobileScrollContainer(parentRef)
 
   const [torrentToDelete, setTorrentToDelete] = useState<Torrent | null>(null)
   const [showActionsSheet, setShowActionsSheet] = useState(false)
@@ -2213,7 +2209,9 @@ export function TorrentCardsMobile({
       <div
         ref={parentRef}
         className="flex-1 overflow-y-auto overscroll-contain transition-[padding] duration-300"
-        style={{ paddingBottom: isFooterVisible? "calc(8rem + env(safe-area-inset-bottom))": "env(safe-area-inset-bottom)" }}
+        style={{
+          paddingBottom: isFooterVisible? "calc(8rem + env(safe-area-inset-bottom))": selectionMode && effectiveSelectionCount > 0? "calc(4rem + env(safe-area-inset-bottom))": "env(safe-area-inset-bottom)",
+        }}
       >
         <div
           style={{

--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -2210,11 +2210,7 @@ export function TorrentCardsMobile({
         ref={parentRef}
         className="flex-1 overflow-y-auto overscroll-contain transition-[padding] duration-300"
         style={{
-          paddingBottom: selectionMode && effectiveSelectionCount > 0
-            ? "calc(4rem + env(safe-area-inset-bottom))"
-            : isFooterVisible
-              ? "calc(8rem + env(safe-area-inset-bottom))"
-              : "env(safe-area-inset-bottom)",
+          paddingBottom: selectionMode && effectiveSelectionCount > 0? "calc(4rem + env(safe-area-inset-bottom))": isFooterVisible? "calc(8rem + env(safe-area-inset-bottom))": "env(safe-area-inset-bottom)",
         }}
       >
         <div
@@ -2935,7 +2931,7 @@ export function TorrentCardsMobile({
           scrollContainerRef={parentRef}
           className={cn(
             "right-8 z-[60]",
-            isFooterVisible || selectionMode? "bottom-[calc(8.5rem+env(safe-area-inset-bottom))]": "bottom-[calc(1.5rem+env(safe-area-inset-bottom))]"
+            selectionMode && effectiveSelectionCount > 0? "bottom-[calc(5rem+env(safe-area-inset-bottom))]": isFooterVisible? "bottom-[calc(8.5rem+env(safe-area-inset-bottom))]": "bottom-[calc(1.5rem+env(safe-area-inset-bottom))]"
           )}
         />
       </div>

--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -2210,7 +2210,11 @@ export function TorrentCardsMobile({
         ref={parentRef}
         className="flex-1 overflow-y-auto overscroll-contain transition-[padding] duration-300"
         style={{
-          paddingBottom: isFooterVisible? "calc(8rem + env(safe-area-inset-bottom))": selectionMode && effectiveSelectionCount > 0? "calc(4rem + env(safe-area-inset-bottom))": "env(safe-area-inset-bottom)",
+          paddingBottom: selectionMode && effectiveSelectionCount > 0
+            ? "calc(4rem + env(safe-area-inset-bottom))"
+            : isFooterVisible
+              ? "calc(8rem + env(safe-area-inset-bottom))"
+              : "env(safe-area-inset-bottom)",
         }}
       >
         <div

--- a/web/src/contexts/MobileScrollContext.test.tsx
+++ b/web/src/contexts/MobileScrollContext.test.tsx
@@ -3,10 +3,11 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { act, cleanup, renderHook } from "@testing-library/react"
+import { act, cleanup, render, renderHook } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { useRef } from "react"
 import type { ReactNode } from "react"
-import { MobileScrollProvider, useMobileScroll } from "./MobileScrollContext"
+import { MobileScrollProvider, useMobileScroll, useRegisterMobileScrollContainer } from "./MobileScrollContext"
 
 const wrapper = ({ children }: { children: ReactNode }) => (
   <MobileScrollProvider>{children}</MobileScrollProvider>
@@ -66,6 +67,41 @@ describe("useMobileScroll", () => {
     act(() => result.current.setScrollContainer(container))
     act(() => scrollTo(container, 5))
     expect(result.current.isFooterVisible).toBe(true)
+  })
+
+  it("keeps the new list registered when the old list unmounts after it", () => {
+    const oldEl = document.createElement("div")
+    const newEl = document.createElement("div")
+    let footerVisible = true
+
+    function List({ el }: { el: HTMLElement }) {
+      const ref = useRef(el)
+      useRegisterMobileScrollContainer(ref)
+      return null
+    }
+    function Probe() {
+      footerVisible = useMobileScroll().isFooterVisible
+      return null
+    }
+    function Harness({ phase }: { phase: number }) {
+      return (
+        <MobileScrollProvider>
+          {phase <= 1 && <List el={oldEl} />}
+          {phase >= 1 && <List el={newEl} />}
+          <Probe />
+        </MobileScrollProvider>
+      )
+    }
+
+    // Old list mounts, new list mounts beside it, then the old one unmounts —
+    // the route-transition interleaving where cleanup runs after the takeover.
+    const { rerender } = render(<Harness phase={0} />)
+    rerender(<Harness phase={1} />)
+    rerender(<Harness phase={2} />)
+
+    // The new list must still drive footer visibility
+    act(() => scrollTo(newEl, 100))
+    expect(footerVisible).toBe(false)
   })
 
   it("cancels a queued frame when the container unregisters", () => {

--- a/web/src/contexts/MobileScrollContext.tsx
+++ b/web/src/contexts/MobileScrollContext.tsx
@@ -4,11 +4,11 @@
  */
 
 import { createContext, useContext, useState, useEffect, useRef } from "react"
-import type { ReactNode } from "react"
+import type { Dispatch, ReactNode, RefObject, SetStateAction } from "react"
 
 interface MobileScrollContextType {
   isFooterVisible: boolean
-  setScrollContainer: (element: HTMLElement | null) => void
+  setScrollContainer: Dispatch<SetStateAction<HTMLElement | null>>
 }
 
 const MobileScrollContext = createContext<MobileScrollContextType | undefined>(undefined)
@@ -80,4 +80,16 @@ export function useMobileScroll() {
     throw new Error("useMobileScroll must be used within a MobileScrollProvider")
   }
   return context
+}
+
+export function useRegisterMobileScrollContainer(ref: RefObject<HTMLElement | null>) {
+  const { setScrollContainer } = useMobileScroll()
+
+  useEffect(() => {
+    const el = ref.current
+    setScrollContainer(el)
+    // On fast route changes the next list may register before this cleanup
+    // runs, so only clear our own registration.
+    return () => setScrollContainer(prev => (prev === el ? null : prev))
+  }, [ref, setScrollContainer])
 }


### PR DESCRIPTION
# Description

Fixes two mobile footer defects introduced by #2265 (auto-hide bottom bars), surfaced by the Ito QA run on #2263 (https://github.com/autobrr/qui/pull/2263#issuecomment-5228363086).

When the bottom bars were auto-hidden, the torrent list reserved no space for the fixed selection action bar, so the last card could end up underneath it with no way to scroll clear. The list now reserves the bar's height while a selection is active.

The scroll-container registration also cleared the shared context unconditionally on cleanup, so a fast route change could let the outgoing list wipe the incoming list's registration, leaving the footer stuck visible and unresponsive to scroll. Registration now lives in a `useRegisterMobileScrollContainer` hook whose cleanup only clears its own element.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

* New regression test: mounts the old list, mounts the new list beside it, unmounts the old list, and asserts the new list still drives footer visibility. Mutation-checked: reverting the cleanup guard turns it red.
* The padding reserve matches the action bar's height (`h-16` = 4rem) plus the safe-area inset; no visual change outside the hidden-footer + selection corner case.

## Checklist

- [x] My PR title follows the Conventional Commits format (it becomes the squashed commit message)
- [x] `make precommit` and the targeted frontend tests pass locally
- [x] I have linked the related context

## AI disclosure

Essentially the whole diff was written with Claude Code (Claude Fable 5), from verifying the QA findings through the fix and tests, under human direction and review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile torrent list behavior during navigation and overlapping view transitions.
  * Kept footer visibility tied to the currently active list.
  * Adjusted bottom spacing so the list displays correctly when selection actions are visible.

* **Tests**
  * Added regression coverage for mobile scroll container switching during route transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->