### PR TITLE
refactor(mobile): share the selection bar condition and drop its dead transition

### DIFF
--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -1510,6 +1510,8 @@ export function TorrentCardsMobile({
     }
   }, [isAllSelected, totalCount, excludedFromSelectAll.size, selectedHashes.size])
 
+  const selectionBarVisible = selectionMode && effectiveSelectionCount > 0
+
   const selectedTotalSize = useMemo(() => {
     if (isAllSelected) {
       const aggregateTotalSize = stats?.totalSize ?? 0
@@ -1694,8 +1696,8 @@ export function TorrentCardsMobile({
 
   // Sync selection mode with context
   useEffect(() => {
-    setIsSelectionMode(selectionMode && effectiveSelectionCount > 0)
-  }, [selectionMode, effectiveSelectionCount, setIsSelectionMode])
+    setIsSelectionMode(selectionBarVisible)
+  }, [selectionBarVisible, setIsSelectionMode])
 
   // Cleanup on unmount
   useEffect(() => {
@@ -2210,7 +2212,7 @@ export function TorrentCardsMobile({
         ref={parentRef}
         className="flex-1 overflow-y-auto overscroll-contain transition-[padding] duration-300"
         style={{
-          paddingBottom: selectionMode && effectiveSelectionCount > 0? "calc(4rem + env(safe-area-inset-bottom))": isFooterVisible? "calc(8rem + env(safe-area-inset-bottom))": "env(safe-area-inset-bottom)",
+          paddingBottom: selectionBarVisible? "calc(4rem + env(safe-area-inset-bottom))": isFooterVisible? "calc(8rem + env(safe-area-inset-bottom))": "env(safe-area-inset-bottom)",
         }}
       >
         <div
@@ -2281,13 +2283,9 @@ export function TorrentCardsMobile({
       </div>
 
       {/* Fixed bottom action bar - visible in selection mode */}
-      {selectionMode && effectiveSelectionCount > 0 && (
+      {selectionBarVisible && (
         <div
-          className={cn(
-            "fixed bottom-0 left-0 right-0 z-40 lg:hidden bg-background/80 backdrop-blur-md border-t border-border/50",
-            "transition-transform duration-200 ease-in-out",
-            selectionMode && effectiveSelectionCount > 0 ? "translate-y-0" : "translate-y-full"
-          )}
+          className="fixed bottom-0 left-0 right-0 z-40 lg:hidden bg-background/80 backdrop-blur-md border-t border-border/50"
           style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
         >
           <div className="flex items-center justify-around h-16">
@@ -2931,7 +2929,7 @@ export function TorrentCardsMobile({
           scrollContainerRef={parentRef}
           className={cn(
             "right-8 z-[60]",
-            selectionMode && effectiveSelectionCount > 0? "bottom-[calc(5rem+env(safe-area-inset-bottom))]": isFooterVisible? "bottom-[calc(8.5rem+env(safe-area-inset-bottom))]": "bottom-[calc(1.5rem+env(safe-area-inset-bottom))]"
+            selectionBarVisible? "bottom-[calc(5rem+env(safe-area-inset-bottom))]": isFooterVisible? "bottom-[calc(8.5rem+env(safe-area-inset-bottom))]": "bottom-[calc(1.5rem+env(safe-area-inset-bottom))]"
           )}
         />
       </div>


### PR DESCRIPTION
# Description

Follow-up cleanup to #2279 (it merged while this was in review).

`selectionMode && effectiveSelectionCount > 0` was spelled out four times in `TorrentCardsMobile.tsx`; it is now a single `selectionBarVisible` const reused at the padding ternary, the bar's render guard, the scroll-to-top offset, and the selection-context sync effect. The bar's `translate-y-0 : translate-y-full` ternary was dead code — its parent block is gated on the identical condition, so the alternate was unreachable and the transition classes animated nothing; both are removed.

## Type of change

- [x] Refactor / maintenance (no functional change)

## How has this been tested?

* No behavior change: the dead branch was unreachable, the shared const is the identical expression, and the narrowed effect deps only drop runs that re-set the same value.
* `make precommit`, eslint and tsc clean.

## AI disclosure

Written with Claude Code (Claude Fable 5), under human direction and review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of selection controls on mobile torrent cards.
  * Updated spacing and scroll positioning when the selection action bar is visible.
  * Removed unnecessary action bar animation behavior for a smoother interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->