### PR TITLE
fix(crossseed): roll back only the files a failed link attempt created

### DIFF
--- a/internal/api/handlers/crossseed_apply_handler_test.go
+++ b/internal/api/handlers/crossseed_apply_handler_test.go
@@ -231,7 +231,7 @@ func TestSeasonPackApply_Returns500ForFailedApplyResponse(t *testing.T) {
 			SeasonPackCoverageThreshold: 1,
 		}, nil
 	})
-	setServiceField(t, svc, "seasonPackLinkCreator", func(*hardlinktree.TreePlan) error { return nil })
+	setServiceField(t, svc, "seasonPackLinkCreator", func(*hardlinktree.TreePlan) (*hardlinktree.Created, error) { return &hardlinktree.Created{}, nil })
 
 	handler := &CrossSeedHandler{service: svc}
 

--- a/internal/services/crossseed/seasonpack.go
+++ b/internal/services/crossseed/seasonpack.go
@@ -81,7 +81,8 @@ type seasonPackLocalFile struct {
 
 type seasonPackPlanBuild struct {
 	plan              *hardlinktree.TreePlan
-	packDir           string // on-disk pack root folder (<RootDir>/<packName>); used for rollback cleanup
+	created           *hardlinktree.Created // what the link creator actually made; rollback removes only this
+	packDir           string                // on-disk pack root folder (<RootDir>/<packName>); used for rollback cleanup
 	materializedPaths map[string]struct{}
 	linkedBytes       int64
 	totalBytes        int64
@@ -424,7 +425,7 @@ func (s *Service) ApplySeasonPackWebhook(ctx context.Context, req *SeasonPackApp
 		opts["tags"] = strings.Join(tags, ",")
 	}
 	if _, err := s.syncManager.AddTorrent(ctx, inst.ID, torrentBytes, opts); err != nil {
-		if rollbackErr := rollbackSeasonPackTree(linkMode, planBuild.plan, planBuild.packDir); rollbackErr != nil {
+		if rollbackErr := rollbackSeasonPackTree(planBuild.created, planBuild.packDir); rollbackErr != nil {
 			log.Warn().Err(rollbackErr).Str("torrentName", req.TorrentName).Msg("season pack: failed to rollback after add failure")
 		}
 		s.recordApplyRun(ctx, req.TorrentName, "add_failed", err.Error(), winner.InstanceID, winner.MatchedEpisodes, prep.totalEpisodes, winner.Coverage, linkMode)
@@ -541,12 +542,14 @@ func (s *Service) assembleSeasonPack(
 	if createFn == nil {
 		createFn = linkCreatorForMode(linkMode)
 	}
-	if err := createFn(planBuild.plan); err != nil {
-		if rollbackErr := rollbackSeasonPackTree(linkMode, planBuild.plan, planBuild.packDir); rollbackErr != nil {
+	created, err := createFn(planBuild.plan)
+	if err != nil {
+		if rollbackErr := rollbackSeasonPackTree(created, planBuild.packDir); rollbackErr != nil {
 			return nil, nil, nil, fmt.Errorf("link_failed: %w", errors.Join(err, fmt.Errorf("rollback failed: %w", rollbackErr)))
 		}
 		return nil, nil, nil, fmt.Errorf("link_failed: %w", err)
 	}
+	planBuild.created = created
 
 	return planBuild, prep.torrentBytes, episodes, nil
 }
@@ -708,7 +711,7 @@ func seasonPackAddOptions(plan *hardlinktree.TreePlan, category string, paused b
 }
 
 // linkCreatorForMode returns the appropriate link-tree creator function.
-func linkCreatorForMode(mode string) func(*hardlinktree.TreePlan) error {
+func linkCreatorForMode(mode string) func(*hardlinktree.TreePlan) (*hardlinktree.Created, error) {
 	if mode == "reflink" {
 		return reflinktree.Create
 	}
@@ -1535,26 +1538,14 @@ func safeSeasonPackJoin(rootDir, relativePath string) (string, bool) {
 	return candidatePath, true
 }
 
-// rollbackSeasonPackTree removes a created link tree on failure. packDir is the on-disk
-// pack root folder (<RootDir>/<packName>); it is removed only when empty so the parent
-// RootDir (a shared base/tracker/instance dir) is never touched.
-func rollbackSeasonPackTree(linkMode string, plan *hardlinktree.TreePlan, packDir string) error {
-	if plan == nil || plan.RootDir == "" {
-		return nil
-	}
-
+// rollbackSeasonPackTree removes a created link tree on failure. It only removes
+// what the creator recorded in the handle, never the whole plan (discussion #2282).
+// packDir is the on-disk pack root folder (<RootDir>/<packName>); it is removed only
+// when empty so the parent RootDir (a shared base/tracker/instance dir) is never touched.
+func rollbackSeasonPackTree(created *hardlinktree.Created, packDir string) error {
 	var errs []error
-	switch linkMode {
-	case "hardlink":
-		if err := hardlinktree.Rollback(plan); err != nil {
-			errs = append(errs, err)
-		}
-	case "reflink":
-		if err := reflinktree.Rollback(plan); err != nil {
-			errs = append(errs, err)
-		}
-	default:
-		return nil
+	if err := created.Rollback(); err != nil {
+		errs = append(errs, err)
 	}
 
 	if packDir != "" {

--- a/internal/services/crossseed/seasonpack_regression_test.go
+++ b/internal/services/crossseed/seasonpack_regression_test.go
@@ -81,11 +81,8 @@ func TestRollbackSeasonPackTree_PreservesUnrelatedFilesInRoot(t *testing.T) {
 	require.NoError(t, os.WriteFile(plannedFile, []byte("planned"), 0o600))
 	require.NoError(t, os.WriteFile(unrelatedFile, []byte("keep"), 0o600))
 
-	err := rollbackSeasonPackTree("hardlink", &hardlinktree.TreePlan{
-		RootDir: rootDir,
-		Files: []hardlinktree.FilePlan{
-			{TargetPath: plannedFile},
-		},
+	err := rollbackSeasonPackTree(&hardlinktree.Created{
+		Files: []string{plannedFile},
 	}, rootDir)
 
 	require.NoError(t, err)
@@ -263,9 +260,9 @@ func TestApplySeasonPackWebhook_SelectsConcreteBaseDirFromCommaSeparatedConfig(t
 		releaseCache:             NewReleaseCache(),
 		automationSettingsLoader: defaultSettings(true, 1.0),
 		seasonPackRunStore:       store,
-		seasonPackLinkCreator: func(plan *hardlinktree.TreePlan) error {
+		seasonPackLinkCreator: func(plan *hardlinktree.TreePlan) (*hardlinktree.Created, error) {
 			capturedPlan = plan
-			return nil
+			return &hardlinktree.Created{}, nil
 		},
 	}
 
@@ -495,11 +492,14 @@ func TestApplySeasonPackWebhook_RollsBackPartialTreeWhenLinkCreationFails(t *tes
 		syncManager:              sm,
 		releaseCache:             NewReleaseCache(),
 		automationSettingsLoader: defaultSettings(true, 1.0),
-		seasonPackLinkCreator: func(plan *hardlinktree.TreePlan) error {
+		seasonPackLinkCreator: func(plan *hardlinktree.TreePlan) (*hardlinktree.Created, error) {
 			require.NotEmpty(t, plan.Files)
 			require.NoError(t, os.MkdirAll(filepath.Dir(plan.Files[0].TargetPath), 0o755))
 			require.NoError(t, os.WriteFile(plan.Files[0].TargetPath, []byte("partial"), 0o600))
-			return errors.New("link creator failed")
+			return &hardlinktree.Created{
+				Files: []string{plan.Files[0].TargetPath},
+				Dirs:  []string{filepath.Dir(plan.Files[0].TargetPath)},
+			}, errors.New("link creator failed")
 		},
 	}
 

--- a/internal/services/crossseed/seasonpack_test.go
+++ b/internal/services/crossseed/seasonpack_test.go
@@ -589,7 +589,7 @@ func TestFixC_CRCollection_CheckAndApplyBothAccept(t *testing.T) {
 		releaseCache:             NewReleaseCache(),
 		automationSettingsLoader: defaultSettings(true, 0.75),
 		seasonPackRunStore:       &stubSeasonPackRunStore{},
-		seasonPackLinkCreator:    func(_ *hardlinktree.TreePlan) error { return nil },
+		seasonPackLinkCreator:    func(_ *hardlinktree.TreePlan) (*hardlinktree.Created, error) { return &hardlinktree.Created{}, nil },
 	}
 
 	checkResp, err := svc.CheckSeasonPackWebhook(context.Background(), &SeasonPackCheckRequest{
@@ -1325,7 +1325,7 @@ func TestApplySeasonPackWebhook_SelectsDeterministicWinner(t *testing.T) {
 		releaseCache:             NewReleaseCache(),
 		automationSettingsLoader: defaultSettings(true, 0.75),
 		seasonPackRunStore:       store,
-		seasonPackLinkCreator:    func(_ *hardlinktree.TreePlan) error { return nil },
+		seasonPackLinkCreator:    func(_ *hardlinktree.TreePlan) (*hardlinktree.Created, error) { return &hardlinktree.Created{}, nil },
 	}
 
 	resp, err := svc.ApplySeasonPackWebhook(context.Background(), &SeasonPackApplyRequest{
@@ -1434,9 +1434,9 @@ func TestApplySeasonPackWebhook_UsesHardlinkMode(t *testing.T) {
 		releaseCache:             NewReleaseCache(),
 		automationSettingsLoader: defaultSettings(true, 0.75),
 		seasonPackRunStore:       store,
-		seasonPackLinkCreator: func(plan *hardlinktree.TreePlan) error {
+		seasonPackLinkCreator: func(plan *hardlinktree.TreePlan) (*hardlinktree.Created, error) {
 			capturedPlan = plan
-			return nil
+			return &hardlinktree.Created{}, nil
 		},
 	}
 
@@ -1531,9 +1531,9 @@ func TestApplySeasonPackWebhook_SavePathHonorsDirPreset(t *testing.T) {
 				syncManager:              sm,
 				releaseCache:             NewReleaseCache(),
 				automationSettingsLoader: defaultSettings(true, 0.75),
-				seasonPackLinkCreator: func(plan *hardlinktree.TreePlan) error {
+				seasonPackLinkCreator: func(plan *hardlinktree.TreePlan) (*hardlinktree.Created, error) {
 					capturedPlan = plan
-					return nil
+					return &hardlinktree.Created{}, nil
 				},
 			}
 
@@ -1594,7 +1594,7 @@ func TestApplySeasonPackWebhook_UsesReflinkMode(t *testing.T) {
 		releaseCache:             NewReleaseCache(),
 		automationSettingsLoader: defaultSettings(true, 0.75),
 		seasonPackRunStore:       store,
-		seasonPackLinkCreator:    func(_ *hardlinktree.TreePlan) error { return nil },
+		seasonPackLinkCreator:    func(_ *hardlinktree.TreePlan) (*hardlinktree.Created, error) { return &hardlinktree.Created{}, nil },
 	}
 
 	resp, err := svc.ApplySeasonPackWebhook(context.Background(), &SeasonPackApplyRequest{
@@ -1728,7 +1728,7 @@ func TestApplySeasonPackWebhook_UsesResolvedCategory(t *testing.T) {
 				automationSettingsLoader: func(context.Context) (*models.CrossSeedAutomationSettings, error) {
 					return tt.settings, nil
 				},
-				seasonPackLinkCreator: func(_ *hardlinktree.TreePlan) error { return nil },
+				seasonPackLinkCreator: func(_ *hardlinktree.TreePlan) (*hardlinktree.Created, error) { return &hardlinktree.Created{}, nil },
 			}
 
 			resp, err := svc.ApplySeasonPackWebhook(context.Background(), &SeasonPackApplyRequest{
@@ -1782,9 +1782,9 @@ func TestApplySeasonPackWebhook_DemotesSizeMismatchedEpisodeToMissing(t *testing
 		syncManager:              sm,
 		releaseCache:             NewReleaseCache(),
 		automationSettingsLoader: defaultSettings(true, 0.75),
-		seasonPackLinkCreator: func(plan *hardlinktree.TreePlan) error {
+		seasonPackLinkCreator: func(plan *hardlinktree.TreePlan) (*hardlinktree.Created, error) {
 			capturedPlan = plan
-			return nil
+			return &hardlinktree.Created{}, nil
 		},
 	}
 
@@ -1846,7 +1846,7 @@ func TestApplySeasonPackWebhook_PieceBoundaryVetoesDemotionOnUnalignedPack(t *te
 		syncManager:              sm,
 		releaseCache:             NewReleaseCache(),
 		automationSettingsLoader: defaultSettings(true, 0.75),
-		seasonPackLinkCreator:    func(_ *hardlinktree.TreePlan) error { return nil },
+		seasonPackLinkCreator:    func(_ *hardlinktree.TreePlan) (*hardlinktree.Created, error) { return &hardlinktree.Created{}, nil },
 	}
 
 	resp, err := svc.ApplySeasonPackWebhook(context.Background(), &SeasonPackApplyRequest{
@@ -1896,7 +1896,7 @@ func TestApplySeasonPackWebhook_DriftsWhenDemotionDropsCoverageBelowThreshold(t 
 		syncManager:              sm,
 		releaseCache:             NewReleaseCache(),
 		automationSettingsLoader: defaultSettings(true, 1.0),
-		seasonPackLinkCreator:    func(_ *hardlinktree.TreePlan) error { return nil },
+		seasonPackLinkCreator:    func(_ *hardlinktree.TreePlan) (*hardlinktree.Created, error) { return &hardlinktree.Created{}, nil },
 	}
 
 	resp, err := svc.ApplySeasonPackWebhook(context.Background(), &SeasonPackApplyRequest{
@@ -1954,7 +1954,7 @@ func TestApplySeasonPackWebhook_TriesNextEpisodeCandidateAfterValidationFailure(
 		syncManager:              sm,
 		releaseCache:             NewReleaseCache(),
 		automationSettingsLoader: defaultSettings(true, 1.0),
-		seasonPackLinkCreator:    func(_ *hardlinktree.TreePlan) error { return nil },
+		seasonPackLinkCreator:    func(_ *hardlinktree.TreePlan) (*hardlinktree.Created, error) { return &hardlinktree.Created{}, nil },
 	}
 
 	resp, err := svc.ApplySeasonPackWebhook(context.Background(), &SeasonPackApplyRequest{
@@ -2005,7 +2005,7 @@ func TestApplySeasonPackWebhook_RejectsUnsafePieceBoundariesInHardlinkMode(t *te
 		syncManager:              sm,
 		releaseCache:             NewReleaseCache(),
 		automationSettingsLoader: defaultSettings(true, 0.75),
-		seasonPackLinkCreator:    func(_ *hardlinktree.TreePlan) error { return nil },
+		seasonPackLinkCreator:    func(_ *hardlinktree.TreePlan) (*hardlinktree.Created, error) { return &hardlinktree.Created{}, nil },
 	}
 
 	resp, err := svc.ApplySeasonPackWebhook(context.Background(), &SeasonPackApplyRequest{
@@ -2064,7 +2064,7 @@ func TestApplySeasonPackWebhook_RespectsSkipPieceBoundarySafetyCheck(t *testing.
 				SkipPieceBoundarySafetyCheck: true,
 			}, nil
 		},
-		seasonPackLinkCreator: func(_ *hardlinktree.TreePlan) error { return nil },
+		seasonPackLinkCreator: func(_ *hardlinktree.TreePlan) (*hardlinktree.Created, error) { return &hardlinktree.Created{}, nil },
 		recheckResumeChan:     make(chan *pendingResume, 1),
 	}
 
@@ -2179,7 +2179,7 @@ func TestApplySeasonPackWebhook_AllowsPartialPackAndQueuesRecheck(t *testing.T) 
 		releaseCache:             NewReleaseCache(),
 		automationSettingsLoader: defaultSettings(true, 0.75),
 		seasonPackRunStore:       store,
-		seasonPackLinkCreator:    func(_ *hardlinktree.TreePlan) error { return nil },
+		seasonPackLinkCreator:    func(_ *hardlinktree.TreePlan) (*hardlinktree.Created, error) { return &hardlinktree.Created{}, nil },
 		recheckResumeChan:        make(chan *pendingResume, 1),
 	}
 
@@ -2250,7 +2250,7 @@ func TestApplySeasonPackWebhook_PausesForSafeExtrasAndQueuesRecheck(t *testing.T
 		syncManager:              sm,
 		releaseCache:             NewReleaseCache(),
 		automationSettingsLoader: defaultSettings(true, 0.75),
-		seasonPackLinkCreator:    func(_ *hardlinktree.TreePlan) error { return nil },
+		seasonPackLinkCreator:    func(_ *hardlinktree.TreePlan) (*hardlinktree.Created, error) { return &hardlinktree.Created{}, nil },
 		recheckResumeChan:        make(chan *pendingResume, 1),
 	}
 
@@ -2316,9 +2316,9 @@ func TestApplySeasonPackWebhook_ResolvesEpisodeFileFromDirectoryContentPath(t *t
 		syncManager:              sm,
 		releaseCache:             NewReleaseCache(),
 		automationSettingsLoader: defaultSettings(true, 1.0),
-		seasonPackLinkCreator: func(plan *hardlinktree.TreePlan) error {
+		seasonPackLinkCreator: func(plan *hardlinktree.TreePlan) (*hardlinktree.Created, error) {
 			capturedPlan = plan
-			return nil
+			return &hardlinktree.Created{}, nil
 		},
 	}
 
@@ -2793,7 +2793,7 @@ func TestApplySeasonPackWebhook_MatchesEpisodesViaARRAlternateTitles(t *testing.
 		releaseCache:             NewReleaseCache(),
 		automationSettingsLoader: defaultSettings(true, 0.75),
 		seasonPackRunStore:       &stubSeasonPackRunStore{},
-		seasonPackLinkCreator:    func(_ *hardlinktree.TreePlan) error { return nil },
+		seasonPackLinkCreator:    func(_ *hardlinktree.TreePlan) (*hardlinktree.Created, error) { return &hardlinktree.Created{}, nil },
 		arrService:               spy,
 	}
 

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -427,7 +427,7 @@ type Service struct {
 	seasonPackApplier       func(ctx context.Context, req *SeasonPackApplyRequest) (*SeasonPackApplyResponse, error)
 	torrentDownloadFunc     func(ctx context.Context, req jackett.TorrentDownloadRequest) ([]byte, error)
 	completionSearchInvoker func(context.Context, int, *qbt.Torrent, *models.CrossSeedAutomationSettings, *models.InstanceCrossSeedCompletionSettings) error
-	seasonPackLinkCreator   func(plan *hardlinktree.TreePlan) error
+	seasonPackLinkCreator   func(plan *hardlinktree.TreePlan) (*hardlinktree.Created, error)
 	postInjectionHook       func(context.Context, int, string)
 	filesShareAllocation    func(sourcePath, candidatePath string) (bool, error)
 
@@ -14240,7 +14240,8 @@ func (s *Service) processHardlinkMode(
 	}
 
 	// Create hardlink tree on disk
-	if err := hardlinktree.Create(plan); err != nil {
+	created, err := hardlinktree.Create(plan)
+	if err != nil {
 		log.Error().
 			Err(err).
 			Int("instanceID", candidate.InstanceID).
@@ -14340,8 +14341,9 @@ func (s *Service) processHardlinkMode(
 
 	// Add the torrent
 	if _, err := s.syncManager.AddTorrent(ctx, candidate.InstanceID, torrentBytes, options); err != nil {
-		// Rollback hardlink tree on failure
-		if rollbackErr := hardlinktree.Rollback(plan); rollbackErr != nil {
+		// Rollback only what this attempt created: the destination can be shared
+		// with an earlier successful add for the same release (discussion #2282)
+		if rollbackErr := created.Rollback(); rollbackErr != nil {
 			log.Warn().
 				Err(rollbackErr).
 				Str("destDir", destDir).
@@ -14351,6 +14353,7 @@ func (s *Service) processHardlinkMode(
 			Err(err).
 			Int("instanceID", candidate.InstanceID).
 			Str("torrentName", torrentName).
+			Int("rolledBackFiles", len(created.Files)).
 			Msg("[CROSSSEED] Hardlink mode: failed to add torrent, aborting")
 		return handleError(fmt.Sprintf("Failed to add torrent: %v", err))
 	}
@@ -14927,7 +14930,8 @@ func (s *Service) processReflinkMode(
 	}
 
 	// Create reflink tree on disk
-	if err := reflinktree.Create(plan); err != nil {
+	created, err := reflinktree.Create(plan)
+	if err != nil {
 		logEvent := log.Error()
 		if shouldWarnForReflinkCreateError(err) {
 			logEvent = log.Warn()
@@ -15033,8 +15037,8 @@ func (s *Service) processReflinkMode(
 
 	// Add the torrent
 	if _, err := s.syncManager.AddTorrent(ctx, candidate.InstanceID, torrentBytes, options); err != nil {
-		// Rollback reflink tree on failure
-		if rollbackErr := reflinktree.Rollback(plan); rollbackErr != nil {
+		// Rollback only what this attempt created (discussion #2282)
+		if rollbackErr := created.Rollback(); rollbackErr != nil {
 			log.Warn().
 				Err(rollbackErr).
 				Str("destDir", destDir).
@@ -15044,6 +15048,7 @@ func (s *Service) processReflinkMode(
 			Err(err).
 			Int("instanceID", candidate.InstanceID).
 			Str("torrentName", torrentName).
+			Int("rolledBackFiles", len(created.Files)).
 			Msg("[CROSSSEED] Reflink mode: failed to add torrent, aborting")
 		return handleError(fmt.Sprintf("Failed to add torrent: %v", err))
 	}

--- a/internal/services/crossseed/service_local_matches_reflink_test.go
+++ b/internal/services/crossseed/service_local_matches_reflink_test.go
@@ -540,13 +540,14 @@ func TestLocalLinkedMatchTypeReFS(t *testing.T) {
 	require.NoError(t, os.WriteFile(sourcePath, data, 0o600)) //nolint:gosec // Path is under verified test temp directory.
 	require.NoError(t, os.WriteFile(copyPath, data, 0o600))   //nolint:gosec // Path is under verified test temp directory.
 	require.NoError(t, os.Link(sourcePath, hardlinkPath))
-	require.NoError(t, reflinktree.Create(&hardlinktree.TreePlan{
+	_, err = reflinktree.Create(&hardlinktree.TreePlan{
 		RootDir: cloneDir,
 		Files: []hardlinktree.FilePlan{{
 			SourcePath: sourcePath,
 			TargetPath: clonePath,
 		}},
-	}))
+	})
+	require.NoError(t, err)
 
 	files := qbt.TorrentFiles{{Name: fileName, Size: int64(len(data))}}
 	service := hardlinkTestService(map[string]qbt.TorrentFiles{

--- a/internal/services/dirscan/inject.go
+++ b/internal/services/dirscan/inject.go
@@ -210,7 +210,7 @@ func (i *Injector) Inject(ctx context.Context, req *InjectRequest) (*InjectResul
 		return result, fmt.Errorf("get instance: %w", err)
 	}
 
-	savePath, addMode, linkPlan, err := i.prepareInjection(ctx, instance, req)
+	savePath, addMode, linkCreated, err := i.prepareInjection(ctx, instance, req)
 	if err != nil {
 		result.ErrorMessage = err.Error()
 		return result, err
@@ -237,7 +237,7 @@ func (i *Injector) Inject(ctx context.Context, req *InjectRequest) (*InjectResul
 
 	// Reject partial link tree injections when downloading missing files is disabled.
 	if partialLinkTree && !req.DownloadMissingFiles {
-		i.rollbackLinkTree(addMode, linkPlan)
+		i.rollbackLinkTree(linkCreated, savePath)
 		return result, fmt.Errorf("partial match has %d missing files; enable 'Download missing files' to allow",
 			len(req.MatchResult.UnmatchedTorrentFiles))
 	}
@@ -268,7 +268,7 @@ func (i *Injector) Inject(ctx context.Context, req *InjectRequest) (*InjectResul
 
 	// Add the torrent to qBittorrent
 	if _, err := i.syncManager.AddTorrent(ctx, req.InstanceID, req.TorrentBytes, options); err != nil {
-		i.rollbackLinkTree(addMode, linkPlan)
+		i.rollbackLinkTree(linkCreated, savePath)
 		result.ErrorMessage = fmt.Sprintf("failed to add torrent: %v", err)
 		return result, fmt.Errorf("add torrent: %w", err)
 	}
@@ -552,7 +552,7 @@ func (i *Injector) prepareInjection(
 	ctx context.Context,
 	instance *models.Instance,
 	req *InjectRequest,
-) (savePath, mode string, linkPlan *hardlinktree.TreePlan, err error) {
+) (savePath, mode string, linkCreated *hardlinktree.Created, err error) {
 	if instance == nil {
 		return "", "", nil, errors.New("instance is nil")
 	}
@@ -561,12 +561,12 @@ func (i *Injector) prepareInjection(
 		return i.calculateSavePath(req), injectModeRegular, nil, nil
 	}
 
-	plan, linkMode, linkErr := i.materializeLinkTree(ctx, instance, req)
+	plan, linkMode, created, linkErr := i.materializeLinkTree(ctx, instance, req)
 	if linkErr == nil {
 		if plan == nil || plan.RootDir == "" {
 			return "", "", nil, errors.New("link-tree plan missing root dir")
 		}
-		return plan.RootDir, linkMode, plan, nil
+		return plan.RootDir, linkMode, created, nil
 	}
 
 	if !instance.FallbackToRegularMode {
@@ -597,25 +597,19 @@ func (i *Injector) logLinkTreeFallback(instance *models.Instance, err error) {
 		Msg("dirscan: falling back to regular mode")
 }
 
-func (i *Injector) rollbackLinkTree(mode string, plan *hardlinktree.TreePlan) {
-	if plan == nil || plan.RootDir == "" {
+// rollbackLinkTree removes what the link-tree creator recorded in the handle,
+// never the whole plan: target paths can be shared with an earlier successful
+// injection for the same release (discussion #2282). The root dir is removed
+// only when empty.
+func (i *Injector) rollbackLinkTree(created *hardlinktree.Created, rootDir string) {
+	if created == nil || rootDir == "" {
 		return
 	}
 
-	var rollbackErr error
-	switch mode {
-	case injectModeHardlink:
-		rollbackErr = hardlinktree.Rollback(plan)
-	case injectModeReflink:
-		rollbackErr = reflinktree.Rollback(plan)
-	default:
-		return
+	if err := created.Rollback(); err != nil {
+		log.Warn().Err(err).Str("rootDir", rootDir).Msg("dirscan: failed to rollback link tree")
 	}
-
-	if rollbackErr != nil {
-		log.Warn().Err(rollbackErr).Str("rootDir", plan.RootDir).Str("mode", mode).Msg("dirscan: failed to rollback link tree")
-	}
-	_ = os.Remove(plan.RootDir)
+	_ = os.Remove(rootDir)
 }
 
 // calculateSavePath determines the save path for the torrent.
@@ -726,12 +720,12 @@ func addPolicyForInjectRequest(req *InjectRequest) crossseed.AddPolicy {
 	return crossseed.PolicyForSourceFiles(files)
 }
 
-func (i *Injector) materializeLinkTree(ctx context.Context, instance *models.Instance, req *InjectRequest) (*hardlinktree.TreePlan, string, error) {
+func (i *Injector) materializeLinkTree(ctx context.Context, instance *models.Instance, req *InjectRequest) (*hardlinktree.TreePlan, string, *hardlinktree.Created, error) {
 	if err := validateLinkTreeInstance(instance); err != nil {
-		return nil, "", err
+		return nil, "", nil, err
 	}
 	if req == nil || req.ParsedTorrent == nil || req.MatchResult == nil {
-		return nil, "", errors.New("link-tree request is missing required data")
+		return nil, "", nil, errors.New("link-tree request is missing required data")
 	}
 
 	incomingFiles := buildLinkTreeIncomingFiles(req.ParsedTorrent)
@@ -739,15 +733,15 @@ func (i *Injector) materializeLinkTree(ctx context.Context, instance *models.Ins
 
 	linkableFiles, existingFiles, err := buildLinkTreeMatchedFiles(req.MatchResult)
 	if err != nil {
-		return nil, "", err
+		return nil, "", nil, err
 	}
 
 	selectedBaseDir, err := crossseed.FindMatchingBaseDir(instance.HardlinkBaseDir, existingFiles[0].AbsPath)
 	if err != nil {
-		return nil, "", fmt.Errorf("select hardlink base dir: %w", err)
+		return nil, "", nil, fmt.Errorf("select hardlink base dir: %w", err)
 	}
 	if err := os.MkdirAll(selectedBaseDir, fsutil.LinkTreeBaseDirMode); err != nil {
-		return nil, "", fmt.Errorf("create hardlink base dir: %w", err)
+		return nil, "", nil, fmt.Errorf("create hardlink base dir: %w", err)
 	}
 
 	incomingTrackerDomain := crossseed.ParseTorrentAnnounceDomain(req.TorrentBytes)
@@ -778,15 +772,15 @@ func (i *Injector) materializeLinkTree(ctx context.Context, instance *models.Ins
 			Str("instanceName", instance.Name).
 			Str("torrentName", req.ParsedTorrent.Name).
 			Msg("dirscan: failed to build link plan")
-		return nil, "", humanizeLinkPlanError(err)
+		return nil, "", nil, humanizeLinkPlanError(err)
 	}
 
-	mode, err := i.createLinkTree(instance, selectedBaseDir, existingFiles, plan)
+	mode, created, err := i.createLinkTree(instance, selectedBaseDir, existingFiles, plan)
 	if err != nil {
-		return nil, "", err
+		return nil, "", nil, err
 	}
 
-	return plan, mode, nil
+	return plan, mode, created, nil
 }
 
 func humanizeLinkPlanError(err error) error {
@@ -887,43 +881,45 @@ func buildLinkTreeMatchedFiles(match *MatchResult) ([]hardlinktree.TorrentFile, 
 	return linkableFiles, existingFiles, nil
 }
 
-func (i *Injector) createLinkTree(instance *models.Instance, selectedBaseDir string, existingFiles []hardlinktree.ExistingFile, plan *hardlinktree.TreePlan) (string, error) {
+func (i *Injector) createLinkTree(instance *models.Instance, selectedBaseDir string, existingFiles []hardlinktree.ExistingFile, plan *hardlinktree.TreePlan) (string, *hardlinktree.Created, error) {
 	if instance.UseReflinks {
 		if supported, reason := reflinktree.SupportsReflink(selectedBaseDir); !supported {
-			return "", fmt.Errorf("%w: %s", reflinktree.ErrReflinkUnsupported, reason)
+			return "", nil, fmt.Errorf("%w: %s", reflinktree.ErrReflinkUnsupported, reason)
 		}
-		if err := reflinktree.Create(plan); err != nil {
-			return "", fmt.Errorf("create reflink tree: %w", err)
+		created, err := reflinktree.Create(plan)
+		if err != nil {
+			return "", nil, fmt.Errorf("create reflink tree: %w", err)
 		}
-		return injectModeReflink, nil
+		return injectModeReflink, created, nil
 	}
 
 	if instance.UseHardlinks {
 		sameFS, err := fsutil.SameFilesystem(existingFiles[0].AbsPath, selectedBaseDir)
 		if err != nil {
-			return "", fmt.Errorf("verify same filesystem: %w", err)
+			return "", nil, fmt.Errorf("verify same filesystem: %w", err)
 		}
 		if !sameFS {
-			return "", fmt.Errorf(
+			return "", nil, fmt.Errorf(
 				"hardlink source (%s) and destination (%s) are on different filesystems",
 				existingFiles[0].AbsPath,
 				selectedBaseDir,
 			)
 		}
 
-		if err := hardlinktree.Create(plan); err != nil {
+		created, err := hardlinktree.Create(plan)
+		if err != nil {
 			if errors.Is(err, syscall.EXDEV) {
-				return "", fmt.Errorf(
+				return "", nil, fmt.Errorf(
 					"create hardlink tree: %w (hardlinks cannot cross filesystems; put your scanned directory and hardlink base dir on the same mount, or enable reflinks if supported)",
 					err,
 				)
 			}
-			return "", fmt.Errorf("create hardlink tree: %w", err)
+			return "", nil, fmt.Errorf("create hardlink tree: %w", err)
 		}
-		return injectModeHardlink, nil
+		return injectModeHardlink, created, nil
 	}
 
-	return "", errors.New("no link mode enabled")
+	return "", nil, errors.New("no link mode enabled")
 }
 
 func buildLinkDestDir(baseDir string, instance *models.Instance, torrentHash, torrentName string, needsIsolation bool, trackerDisplayName string) string {

--- a/pkg/hardlinktree/create.go
+++ b/pkg/hardlinktree/create.go
@@ -34,6 +34,38 @@ func (c *Created) Rollback() error {
 	return rollback(c.Files, c.Dirs)
 }
 
+// MkdirAllTracked creates dir and any missing ancestors, like os.MkdirAll,
+// and returns the directories it actually created (shallowest first).
+// Pre-existing directories are not returned, so rollback never removes a
+// directory another attempt made.
+func MkdirAllTracked(dir string) ([]string, error) {
+	var created []string
+	err := mkdirAllTracked(dir, &created)
+	return created, err
+}
+
+func mkdirAllTracked(dir string, created *[]string) error {
+	if _, err := os.Lstat(dir); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	if parent := filepath.Dir(dir); parent != dir {
+		if err := mkdirAllTracked(parent, created); err != nil {
+			return err
+		}
+	}
+	if err := os.Mkdir(dir, fsutil.ContentDirMode); err != nil {
+		if os.IsExist(err) {
+			// Lost a race with a concurrent attempt: it exists, but not ours
+			return nil
+		}
+		return err
+	}
+	*created = append(*created, dir)
+	return nil
+}
+
 // Create materializes the hardlink tree plan on disk.
 // Creates necessary directories and hardlinks files from source to target paths.
 // On failure, attempts best-effort rollback of created files and returns a nil handle.
@@ -66,25 +98,20 @@ func Create(plan *TreePlan) (*Created, error) {
 	}
 
 	// Create root directory if needed
-	if err := os.MkdirAll(plan.RootDir, fsutil.ContentDirMode); err != nil {
-		return nil, fmt.Errorf("create root directory %s: %w", plan.RootDir, err)
+	rootDirs, err := MkdirAllTracked(plan.RootDir)
+	createdDirs = append(createdDirs, rootDirs...)
+	if err != nil {
+		return nil, rollbackOnError(fmt.Errorf("create root directory %s: %w", plan.RootDir, err))
 	}
 
 	// Process each file in the plan
 	for _, fp := range plan.Files {
-		// Create parent directory if needed; only pre-existing dirs are left
-		// untracked so rollback never removes a directory another attempt made.
+		// Create parent directory if needed
 		parentDir := filepath.Dir(fp.TargetPath)
-		if parentDir != plan.RootDir && !slices.Contains(createdDirs, parentDir) {
-			if _, err := os.Lstat(parentDir); err != nil {
-				if !os.IsNotExist(err) {
-					return nil, rollbackOnError(fmt.Errorf("check directory %s: %w", parentDir, err))
-				}
-				if err := os.MkdirAll(parentDir, fsutil.ContentDirMode); err != nil {
-					return nil, rollbackOnError(fmt.Errorf("create directory %s: %w", parentDir, err))
-				}
-				createdDirs = append(createdDirs, parentDir)
-			}
+		parentDirs, err := MkdirAllTracked(parentDir)
+		createdDirs = append(createdDirs, parentDirs...)
+		if err != nil {
+			return nil, rollbackOnError(fmt.Errorf("create directory %s: %w", parentDir, err))
 		}
 
 		// Check if target already exists

--- a/pkg/hardlinktree/create.go
+++ b/pkg/hardlinktree/create.go
@@ -8,26 +8,48 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"syscall"
 
 	"github.com/autobrr/qui/pkg/fsutil"
 )
 
+// Created records the files and directories a single Create call actually
+// made on disk. Rollback removes exactly those and nothing else: destinations
+// can be shared between torrents, and a plan-wide cleanup would delete links
+// belonging to a sibling torrent that succeeded (discussion #2282).
+type Created struct {
+	Files []string
+	Dirs  []string
+}
+
+// Rollback removes the files and directories recorded in c. Best-effort:
+// continues even if some removals fail. Directories are only removed when
+// empty. Safe to call on a nil or empty handle.
+func (c *Created) Rollback() error {
+	if c == nil {
+		return nil
+	}
+	return rollback(c.Files, c.Dirs)
+}
+
 // Create materializes the hardlink tree plan on disk.
 // Creates necessary directories and hardlinks files from source to target paths.
-// On failure, attempts best-effort rollback of created files.
+// On failure, attempts best-effort rollback of created files and returns a nil handle.
 //
-// Returns nil if all hardlinks were created successfully.
-// Returns an error if any hardlink creation fails (after attempting rollback).
-func Create(plan *TreePlan) error {
+// On success, returns a handle recording what this call created. Targets that
+// already were hardlinks to the source are skipped and NOT recorded: they
+// belong to whoever created them first.
+func Create(plan *TreePlan) (*Created, error) {
 	if plan == nil {
-		return errors.New("plan is nil")
+		return nil, errors.New("plan is nil")
 	}
 	if plan.RootDir == "" {
-		return errors.New("plan root directory is empty")
+		return nil, errors.New("plan root directory is empty")
 	}
 	if len(plan.Files) == 0 {
-		return errors.New("plan has no files")
+		return nil, errors.New("plan has no files")
 	}
 
 	// Track created items for rollback
@@ -45,19 +67,22 @@ func Create(plan *TreePlan) error {
 
 	// Create root directory if needed
 	if err := os.MkdirAll(plan.RootDir, fsutil.ContentDirMode); err != nil {
-		return fmt.Errorf("create root directory %s: %w", plan.RootDir, err)
+		return nil, fmt.Errorf("create root directory %s: %w", plan.RootDir, err)
 	}
 
 	// Process each file in the plan
 	for _, fp := range plan.Files {
-		// Create parent directory if needed
+		// Create parent directory if needed; only pre-existing dirs are left
+		// untracked so rollback never removes a directory another attempt made.
 		parentDir := filepath.Dir(fp.TargetPath)
-		if parentDir != plan.RootDir {
-			if err := os.MkdirAll(parentDir, fsutil.ContentDirMode); err != nil {
-				return rollbackOnError(fmt.Errorf("create directory %s: %w", parentDir, err))
-			}
-			// Track directories for rollback (only track new ones)
-			if !containsPath(createdDirs, parentDir) {
+		if parentDir != plan.RootDir && !slices.Contains(createdDirs, parentDir) {
+			if _, err := os.Lstat(parentDir); err != nil {
+				if !os.IsNotExist(err) {
+					return nil, rollbackOnError(fmt.Errorf("check directory %s: %w", parentDir, err))
+				}
+				if err := os.MkdirAll(parentDir, fsutil.ContentDirMode); err != nil {
+					return nil, rollbackOnError(fmt.Errorf("create directory %s: %w", parentDir, err))
+				}
 				createdDirs = append(createdDirs, parentDir)
 			}
 		}
@@ -73,47 +98,19 @@ func Create(plan *TreePlan) error {
 				}
 			}
 			// Different file exists at target - this is an error
-			return rollbackOnError(fmt.Errorf("target already exists: %s", fp.TargetPath))
+			return nil, rollbackOnError(fmt.Errorf("target already exists: %s", fp.TargetPath))
 		} else if !os.IsNotExist(err) {
-			return rollbackOnError(fmt.Errorf("check target %s: %w", fp.TargetPath, err))
+			return nil, rollbackOnError(fmt.Errorf("check target %s: %w", fp.TargetPath, err))
 		}
 
 		// Create hardlink
 		if err := os.Link(fp.SourcePath, fp.TargetPath); err != nil {
-			return rollbackOnError(fmt.Errorf("hardlink %s -> %s: %w", fp.SourcePath, fp.TargetPath, err))
+			return nil, rollbackOnError(fmt.Errorf("hardlink %s -> %s: %w", fp.SourcePath, fp.TargetPath, err))
 		}
 		createdFiles = append(createdFiles, fp.TargetPath)
 	}
 
-	return nil
-}
-
-// Rollback removes created files and directories from a failed plan execution.
-// Best-effort: continues even if some removals fail.
-func Rollback(plan *TreePlan) error {
-	if plan == nil {
-		return nil
-	}
-
-	var files []string
-	for _, fp := range plan.Files {
-		files = append(files, fp.TargetPath)
-	}
-
-	// Collect unique directories
-	dirSet := make(map[string]bool)
-	for _, fp := range plan.Files {
-		dir := filepath.Dir(fp.TargetPath)
-		if dir != plan.RootDir {
-			dirSet[dir] = true
-		}
-	}
-	var dirs []string
-	for d := range dirSet {
-		dirs = append(dirs, d)
-	}
-
-	return rollback(files, dirs)
+	return &Created{Files: createdFiles, Dirs: createdDirs}, nil
 }
 
 // rollback removes files and directories, returning first error encountered.
@@ -129,17 +126,11 @@ func rollback(files, dirs []string) error {
 		}
 	}
 
-	// Sort directories by depth (deepest first) to remove children before parents
+	// Sort directories by depth (deepest first) to remove children before parents;
+	// length descending approximates depth
 	sortedDirs := make([]string, len(dirs))
 	copy(sortedDirs, dirs)
-	// Sort by length descending (approximates depth)
-	for i := 0; i < len(sortedDirs)-1; i++ {
-		for j := i + 1; j < len(sortedDirs); j++ {
-			if len(sortedDirs[j]) > len(sortedDirs[i]) {
-				sortedDirs[i], sortedDirs[j] = sortedDirs[j], sortedDirs[i]
-			}
-		}
-	}
+	slices.SortFunc(sortedDirs, func(a, b string) int { return len(b) - len(a) })
 
 	// Remove directories (only if empty)
 	for _, d := range sortedDirs {
@@ -154,16 +145,6 @@ func rollback(files, dirs []string) error {
 	return firstErr
 }
 
-// containsPath checks if a path is in the slice.
-func containsPath(paths []string, path string) bool {
-	for _, p := range paths {
-		if p == path {
-			return true
-		}
-	}
-	return false
-}
-
 // isDirNotEmpty checks if an error indicates a non-empty directory.
 func isDirNotEmpty(err error) bool {
 	if err == nil {
@@ -174,20 +155,7 @@ func isDirNotEmpty(err error) bool {
 	}
 	// Different OS have different error messages
 	errStr := err.Error()
-	return containsStr(errStr, "not empty") ||
-		containsStr(errStr, "directory not empty") ||
-		containsStr(errStr, "The directory is not empty")
-}
-
-func containsStr(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && findSubstr(s, substr))
-}
-
-func findSubstr(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
+	return strings.Contains(errStr, "not empty") ||
+		strings.Contains(errStr, "directory not empty") ||
+		strings.Contains(errStr, "The directory is not empty")
 }

--- a/pkg/hardlinktree/create_test.go
+++ b/pkg/hardlinktree/create_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestCreate_NilPlan(t *testing.T) {
-	err := Create(nil)
+	_, err := Create(nil)
 	if err == nil {
 		t.Error("Expected error for nil plan")
 	}
@@ -21,7 +21,7 @@ func TestCreate_EmptyRootDir(t *testing.T) {
 		RootDir: "",
 		Files:   []FilePlan{{SourcePath: "/src", TargetPath: "/dst"}},
 	}
-	err := Create(plan)
+	_, err := Create(plan)
 	if err == nil {
 		t.Error("Expected error for empty root directory")
 	}
@@ -32,7 +32,7 @@ func TestCreate_NoFiles(t *testing.T) {
 		RootDir: "/tmp/test",
 		Files:   []FilePlan{},
 	}
-	err := Create(plan)
+	_, err := Create(plan)
 	if err == nil {
 		t.Error("Expected error for plan with no files")
 	}
@@ -60,7 +60,7 @@ func TestCreate_SingleFile(t *testing.T) {
 	}
 
 	// Execute
-	err := Create(plan)
+	_, err := Create(plan)
 	if err != nil {
 		t.Fatalf("Create error: %v", err)
 	}
@@ -110,7 +110,7 @@ func TestCreate_MultipleFiles(t *testing.T) {
 	}
 
 	// Execute
-	err := Create(plan)
+	_, err := Create(plan)
 	if err != nil {
 		t.Fatalf("Create error: %v", err)
 	}
@@ -143,7 +143,7 @@ func TestCreate_NestedDirectories(t *testing.T) {
 	}
 
 	// Execute
-	err := Create(plan)
+	_, err := Create(plan)
 	if err != nil {
 		t.Fatalf("Create error: %v", err)
 	}
@@ -178,11 +178,16 @@ func TestCreate_Idempotent(t *testing.T) {
 	}
 
 	// Execute twice
-	if err := Create(plan); err != nil {
+	if _, err := Create(plan); err != nil {
 		t.Fatalf("First Create error: %v", err)
 	}
-	if err := Create(plan); err != nil {
+	second, err := Create(plan)
+	if err != nil {
 		t.Fatalf("Second Create error (should be idempotent): %v", err)
+	}
+	// The second call skipped the existing link, so it owns nothing
+	if len(second.Files) != 0 {
+		t.Errorf("Second Create should not claim ownership of skipped files, got %v", second.Files)
 	}
 
 	// Verify it's still a valid hardlink
@@ -203,7 +208,7 @@ func TestCreate_SourceNotFound(t *testing.T) {
 		},
 	}
 
-	err := Create(plan)
+	_, err := Create(plan)
 	if err == nil {
 		t.Error("Expected error when source file doesn't exist")
 	}
@@ -232,7 +237,7 @@ func TestCreate_TargetExistsDifferentFile(t *testing.T) {
 		},
 	}
 
-	err := Create(plan)
+	_, err := Create(plan)
 	if err == nil {
 		t.Error("Expected error when target exists with different content")
 	}
@@ -262,7 +267,8 @@ func TestRollback(t *testing.T) {
 	}
 
 	// Create first
-	if err := Create(plan); err != nil {
+	created, err := Create(plan)
+	if err != nil {
 		t.Fatalf("Create error: %v", err)
 	}
 
@@ -272,7 +278,7 @@ func TestRollback(t *testing.T) {
 	}
 
 	// Rollback
-	if err := Rollback(plan); err != nil {
+	if err := created.Rollback(); err != nil {
 		t.Fatalf("Rollback error: %v", err)
 	}
 
@@ -285,22 +291,17 @@ func TestRollback(t *testing.T) {
 	}
 }
 
-func TestRollback_NilPlan(t *testing.T) {
+func TestRollback_NilHandle(t *testing.T) {
 	// Should not panic or error
-	err := Rollback(nil)
-	if err != nil {
-		t.Errorf("Rollback(nil) should not error, got: %v", err)
+	var created *Created
+	if err := created.Rollback(); err != nil {
+		t.Errorf("nil handle Rollback should not error, got: %v", err)
 	}
 }
 
-func TestRollback_NoFiles(t *testing.T) {
-	plan := &TreePlan{
-		RootDir: "/tmp",
-		Files:   []FilePlan{},
-	}
+func TestRollback_EmptyHandle(t *testing.T) {
 	// Should not panic or error
-	err := Rollback(plan)
-	if err != nil {
-		t.Errorf("Rollback with empty files should not error, got: %v", err)
+	if err := (&Created{}).Rollback(); err != nil {
+		t.Errorf("empty handle Rollback should not error, got: %v", err)
 	}
 }

--- a/pkg/hardlinktree/create_test.go
+++ b/pkg/hardlinktree/create_test.go
@@ -289,6 +289,49 @@ func TestRollback(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(dstDir, "subdir", "file2.txt")); !os.IsNotExist(err) {
 		t.Error("File2 should be removed after rollback")
 	}
+
+	// The created subdir is removed; the pre-existing root is not ours to remove
+	if _, err := os.Stat(filepath.Join(dstDir, "subdir")); !os.IsNotExist(err) {
+		t.Error("Created subdir should be removed after rollback")
+	}
+	if _, err := os.Stat(dstDir); err != nil {
+		t.Errorf("Pre-existing root should survive rollback: %v", err)
+	}
+}
+
+func TestRollback_RemovesCreatedRootChain(t *testing.T) {
+	srcDir := t.TempDir()
+	srcFile := filepath.Join(srcDir, "file.txt")
+	if err := os.WriteFile(srcFile, []byte("test"), 0o600); err != nil {
+		t.Fatalf("Failed to create source file: %v", err)
+	}
+
+	// Root dir and its ancestors do not exist yet; Create must own the whole chain
+	base := t.TempDir()
+	rootDir := filepath.Join(base, "a", "b", "c")
+	plan := &TreePlan{
+		RootDir: rootDir,
+		Files: []FilePlan{
+			{SourcePath: srcFile, TargetPath: filepath.Join(rootDir, "pack", "file.txt")},
+		},
+	}
+
+	created, err := Create(plan)
+	if err != nil {
+		t.Fatalf("Create error: %v", err)
+	}
+	if err := created.Rollback(); err != nil {
+		t.Fatalf("Rollback error: %v", err)
+	}
+
+	// Everything this attempt created is gone, down to the first ancestor it made
+	if _, err := os.Stat(filepath.Join(base, "a")); !os.IsNotExist(err) {
+		t.Error("Created ancestor chain should be removed after rollback")
+	}
+	// The pre-existing base survives
+	if _, err := os.Stat(base); err != nil {
+		t.Errorf("Pre-existing base should survive rollback: %v", err)
+	}
 }
 
 func TestRollback_NilHandle(t *testing.T) {

--- a/pkg/hardlinktree/create_umask_test.go
+++ b/pkg/hardlinktree/create_umask_test.go
@@ -42,7 +42,7 @@ func TestCreate_RespectsUmask(t *testing.T) {
 		RootDir: rootDir,
 		Files:   []FilePlan{{SourcePath: srcFile, TargetPath: target}},
 	}
-	if err := Create(plan); err != nil {
+	if _, err := Create(plan); err != nil {
 		t.Fatalf("Create error: %v", err)
 	}
 

--- a/pkg/hardlinktree/repro_2282_test.go
+++ b/pkg/hardlinktree/repro_2282_test.go
@@ -1,0 +1,61 @@
+package hardlinktree
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Regression test for discussion #2282: two concurrent same-release plans share
+// target paths (common-root multi-file torrent, by-tracker preset); the second
+// attempt's add fails and its rollback must not delete the first attempt's links.
+func TestCreate_SharedDestRollbackKeepsSiblingFiles(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Source library files (same inodes for both attempts, as when dirscan
+	// matches two local copies backed by the same content files).
+	srcDir := filepath.Join(tmp, "library", "Pack.S01")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	files := make([]FilePlan, 0, 2)
+	destRoot := filepath.Join(tmp, "linkDir", "Tracker")
+	for _, name := range []string{"e01.mkv", "e02.mkv"} {
+		src := filepath.Join(srcDir, name)
+		if err := os.WriteFile(src, []byte("data-"+name), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		files = append(files, FilePlan{
+			SourcePath: src,
+			TargetPath: filepath.Join(destRoot, "Pack.S01", name),
+		})
+	}
+
+	// Both attempts compute the identical plan (common root folder, so no
+	// per-hash isolation folder on by-tracker preset).
+	plan1 := &TreePlan{RootDir: destRoot, Files: files}
+	plan2 := &TreePlan{RootDir: destRoot, Files: files}
+
+	// Attempt 1: creates the tree, torrent adds successfully.
+	if _, err := Create(plan1); err != nil {
+		t.Fatalf("attempt 1 Create: %v", err)
+	}
+
+	// Attempt 2: "creates" the tree (idempotent same-inode skips)...
+	created2, err := Create(plan2)
+	if err != nil {
+		t.Fatalf("attempt 2 Create: %v", err)
+	}
+	// ...then qBittorrent rejects the duplicate add, and the service rolls
+	// back attempt 2's handle.
+	if err := created2.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+
+	// Attempt 1's already-added torrent must still have its files.
+	for _, fp := range plan1.Files {
+		if _, err := os.Stat(fp.TargetPath); err != nil {
+			t.Errorf("attempt 1's file gone after sibling rollback: %v", err)
+		}
+	}
+}

--- a/pkg/reflinktree/reflink.go
+++ b/pkg/reflinktree/reflink.go
@@ -16,8 +16,6 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"strings"
-	"syscall"
 
 	"github.com/autobrr/qui/pkg/fsutil"
 	"github.com/autobrr/qui/pkg/hardlinktree"
@@ -29,34 +27,33 @@ var ErrReflinkUnsupported = errors.New("reflink not supported on this platform o
 
 // Create materializes a reflink tree plan on disk.
 // Creates necessary directories and reflinks files from source to target paths.
-// On failure, attempts best-effort rollback of created files.
+// On failure, attempts best-effort rollback of created files and returns a nil handle.
 //
-// Returns nil if all reflinks were created successfully.
-// Returns an error if any reflink creation fails (after attempting rollback).
-func Create(plan *hardlinktree.TreePlan) error {
+// On success, returns a handle recording what this call created; rolling back
+// that handle removes exactly those files and directories (discussion #2282).
+func Create(plan *hardlinktree.TreePlan) (*hardlinktree.Created, error) {
 	if plan == nil {
-		return errors.New("plan is nil")
+		return nil, errors.New("plan is nil")
 	}
 	if plan.RootDir == "" {
-		return errors.New("plan root directory is empty")
+		return nil, errors.New("plan root directory is empty")
 	}
 	if len(plan.Files) == 0 {
-		return errors.New("plan has no files")
+		return nil, errors.New("plan has no files")
 	}
 
 	// Check reflink support before creating any files
 	supported, reason := SupportsReflink(plan.RootDir)
 	if !supported {
-		return fmt.Errorf("%w: %s", ErrReflinkUnsupported, reason)
+		return nil, fmt.Errorf("%w: %s", ErrReflinkUnsupported, reason)
 	}
 
 	// Track created items for rollback
-	createdFiles := make([]string, 0, len(plan.Files))
-	createdDirs := make([]string, 0, len(plan.Files))
+	created := &hardlinktree.Created{}
 
 	// Cleanup on failure
 	rollbackOnError := func(err error) error {
-		rollbackErr := rollback(createdFiles, createdDirs)
+		rollbackErr := created.Rollback()
 		if rollbackErr != nil {
 			return errors.Join(err, fmt.Errorf("rollback also failed: %w", rollbackErr))
 		}
@@ -65,20 +62,23 @@ func Create(plan *hardlinktree.TreePlan) error {
 
 	// Create root directory if needed
 	if err := os.MkdirAll(plan.RootDir, fsutil.ContentDirMode); err != nil {
-		return fmt.Errorf("create root directory %s: %w", plan.RootDir, err)
+		return nil, fmt.Errorf("create root directory %s: %w", plan.RootDir, err)
 	}
 
 	// Process each file in the plan
 	for _, fp := range plan.Files {
-		// Create parent directory if needed
+		// Create parent directory if needed; only pre-existing dirs are left
+		// untracked so rollback never removes a directory another attempt made.
 		parentDir := filepath.Dir(fp.TargetPath)
-		if parentDir != plan.RootDir {
-			if err := os.MkdirAll(parentDir, fsutil.ContentDirMode); err != nil {
-				return rollbackOnError(fmt.Errorf("create directory %s: %w", parentDir, err))
-			}
-			// Track directories for rollback (only track new ones)
-			if !containsPath(createdDirs, parentDir) {
-				createdDirs = append(createdDirs, parentDir)
+		if parentDir != plan.RootDir && !slices.Contains(created.Dirs, parentDir) {
+			if _, err := os.Lstat(parentDir); err != nil {
+				if !os.IsNotExist(err) {
+					return nil, rollbackOnError(fmt.Errorf("check directory %s: %w", parentDir, err))
+				}
+				if err := os.MkdirAll(parentDir, fsutil.ContentDirMode); err != nil {
+					return nil, rollbackOnError(fmt.Errorf("create directory %s: %w", parentDir, err))
+				}
+				created.Dirs = append(created.Dirs, parentDir)
 			}
 		}
 
@@ -86,103 +86,17 @@ func Create(plan *hardlinktree.TreePlan) error {
 		if _, err := os.Lstat(fp.TargetPath); err == nil {
 			// File exists at target - this is an error for reflinks
 			// (unlike hardlinks, we can't easily check if it's the same content)
-			return rollbackOnError(fmt.Errorf("target already exists: %s", fp.TargetPath))
+			return nil, rollbackOnError(fmt.Errorf("target already exists: %s", fp.TargetPath))
 		} else if !os.IsNotExist(err) {
-			return rollbackOnError(fmt.Errorf("check target %s: %w", fp.TargetPath, err))
+			return nil, rollbackOnError(fmt.Errorf("check target %s: %w", fp.TargetPath, err))
 		}
 
 		// Create reflink
 		if err := cloneFile(fp.SourcePath, fp.TargetPath); err != nil {
-			return rollbackOnError(fmt.Errorf("reflink %s -> %s: %w", fp.SourcePath, fp.TargetPath, err))
+			return nil, rollbackOnError(fmt.Errorf("reflink %s -> %s: %w", fp.SourcePath, fp.TargetPath, err))
 		}
-		createdFiles = append(createdFiles, fp.TargetPath)
+		created.Files = append(created.Files, fp.TargetPath)
 	}
 
-	return nil
-}
-
-// Rollback removes created files and directories from a failed plan execution.
-// Best-effort: continues even if some removals fail.
-func Rollback(plan *hardlinktree.TreePlan) error {
-	if plan == nil {
-		return nil
-	}
-
-	files := make([]string, 0, len(plan.Files))
-	for _, fp := range plan.Files {
-		files = append(files, fp.TargetPath)
-	}
-
-	// Collect unique directories
-	dirSet := make(map[string]bool)
-	for _, fp := range plan.Files {
-		dir := filepath.Dir(fp.TargetPath)
-		if dir != plan.RootDir {
-			dirSet[dir] = true
-		}
-	}
-	dirs := make([]string, 0, len(dirSet))
-	for d := range dirSet {
-		dirs = append(dirs, d)
-	}
-
-	return rollback(files, dirs)
-}
-
-// rollback removes files and directories, returning first error encountered.
-func rollback(files, dirs []string) error {
-	var firstErr error
-
-	// Remove files first
-	for _, f := range files {
-		if err := os.Remove(f); err != nil && !os.IsNotExist(err) {
-			if firstErr == nil {
-				firstErr = fmt.Errorf("remove file %s: %w", f, err)
-			}
-		}
-	}
-
-	// Sort directories by depth (deepest first) to remove children before parents
-	sortedDirs := make([]string, len(dirs))
-	copy(sortedDirs, dirs)
-	// Sort by length descending (approximates depth)
-	for i := range len(sortedDirs) - 1 {
-		for j := i + 1; j < len(sortedDirs); j++ {
-			if len(sortedDirs[j]) > len(sortedDirs[i]) {
-				sortedDirs[i], sortedDirs[j] = sortedDirs[j], sortedDirs[i]
-			}
-		}
-	}
-
-	// Remove directories (only if empty)
-	for _, d := range sortedDirs {
-		if err := os.Remove(d); err != nil && !os.IsNotExist(err) {
-			// Ignore "directory not empty" errors - expected if other files exist
-			if !isDirNotEmpty(err) && firstErr == nil {
-				firstErr = fmt.Errorf("remove directory %s: %w", d, err)
-			}
-		}
-	}
-
-	return firstErr
-}
-
-// containsPath checks if a path is in the slice.
-func containsPath(paths []string, path string) bool {
-	return slices.Contains(paths, path)
-}
-
-// isDirNotEmpty checks if an error indicates a non-empty directory.
-func isDirNotEmpty(err error) bool {
-	if err == nil {
-		return false
-	}
-	if errors.Is(err, syscall.ENOTEMPTY) {
-		return true
-	}
-	// Different OS have different error messages
-	errStr := err.Error()
-	return strings.Contains(errStr, "not empty") ||
-		strings.Contains(errStr, "directory not empty") ||
-		strings.Contains(errStr, "The directory is not empty")
+	return created, nil
 }

--- a/pkg/reflinktree/reflink.go
+++ b/pkg/reflinktree/reflink.go
@@ -15,9 +15,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 
-	"github.com/autobrr/qui/pkg/fsutil"
 	"github.com/autobrr/qui/pkg/hardlinktree"
 )
 
@@ -61,25 +59,20 @@ func Create(plan *hardlinktree.TreePlan) (*hardlinktree.Created, error) {
 	}
 
 	// Create root directory if needed
-	if err := os.MkdirAll(plan.RootDir, fsutil.ContentDirMode); err != nil {
-		return nil, fmt.Errorf("create root directory %s: %w", plan.RootDir, err)
+	rootDirs, err := hardlinktree.MkdirAllTracked(plan.RootDir)
+	created.Dirs = append(created.Dirs, rootDirs...)
+	if err != nil {
+		return nil, rollbackOnError(fmt.Errorf("create root directory %s: %w", plan.RootDir, err))
 	}
 
 	// Process each file in the plan
 	for _, fp := range plan.Files {
-		// Create parent directory if needed; only pre-existing dirs are left
-		// untracked so rollback never removes a directory another attempt made.
+		// Create parent directory if needed
 		parentDir := filepath.Dir(fp.TargetPath)
-		if parentDir != plan.RootDir && !slices.Contains(created.Dirs, parentDir) {
-			if _, err := os.Lstat(parentDir); err != nil {
-				if !os.IsNotExist(err) {
-					return nil, rollbackOnError(fmt.Errorf("check directory %s: %w", parentDir, err))
-				}
-				if err := os.MkdirAll(parentDir, fsutil.ContentDirMode); err != nil {
-					return nil, rollbackOnError(fmt.Errorf("create directory %s: %w", parentDir, err))
-				}
-				created.Dirs = append(created.Dirs, parentDir)
-			}
+		parentDirs, err := hardlinktree.MkdirAllTracked(parentDir)
+		created.Dirs = append(created.Dirs, parentDirs...)
+		if err != nil {
+			return nil, rollbackOnError(fmt.Errorf("create directory %s: %w", parentDir, err))
 		}
 
 		// Check if target already exists

--- a/pkg/reflinktree/reflink_test.go
+++ b/pkg/reflinktree/reflink_test.go
@@ -166,4 +166,9 @@ func TestRollback(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(dstDir, "subdir", "test.txt")); !os.IsNotExist(err) {
 		t.Error("file should not exist after rollback")
 	}
+
+	// Create made dstDir and subdir, so rollback removes both
+	if _, err := os.Stat(dstDir); !os.IsNotExist(err) {
+		t.Error("created root dir should be removed after rollback")
+	}
 }

--- a/pkg/reflinktree/reflink_test.go
+++ b/pkg/reflinktree/reflink_test.go
@@ -38,7 +38,7 @@ func TestSupportsReflink(t *testing.T) {
 }
 
 func TestCreate_NilPlan(t *testing.T) {
-	err := Create(nil)
+	_, err := Create(nil)
 	if err == nil {
 		t.Error("expected error for nil plan")
 	}
@@ -49,7 +49,7 @@ func TestCreate_EmptyRootDir(t *testing.T) {
 		RootDir: "",
 		Files:   []hardlinktree.FilePlan{{SourcePath: "/src", TargetPath: "/dst"}},
 	}
-	err := Create(plan)
+	_, err := Create(plan)
 	if err == nil {
 		t.Error("expected error for empty root dir")
 	}
@@ -60,7 +60,7 @@ func TestCreate_EmptyFiles(t *testing.T) {
 		RootDir: "/tmp",
 		Files:   []hardlinktree.FilePlan{},
 	}
-	err := Create(plan)
+	_, err := Create(plan)
 	if err == nil {
 		t.Error("expected error for empty files")
 	}
@@ -99,7 +99,7 @@ func TestCreate_Success(t *testing.T) {
 		},
 	}
 
-	err := Create(plan)
+	_, err := Create(plan)
 	if err != nil {
 		t.Fatalf("Create failed: %v", err)
 	}
@@ -147,7 +147,8 @@ func TestRollback(t *testing.T) {
 		},
 	}
 
-	if err := Create(plan); err != nil {
+	created, err := Create(plan)
+	if err != nil {
 		t.Fatalf("Create failed: %v", err)
 	}
 
@@ -157,7 +158,7 @@ func TestRollback(t *testing.T) {
 	}
 
 	// Rollback
-	if err := Rollback(plan); err != nil {
+	if err := created.Rollback(); err != nil {
 		t.Fatalf("Rollback failed: %v", err)
 	}
 


### PR DESCRIPTION
## Description

A failed torrent add rolled back every path in the link-tree plan. When two concurrent matches for the same release shared a destination folder (multi-file torrents with a common root skip the per-hash isolation folder), the failed duplicate deleted the files of the torrent that was already added, leaving it at 0% with missing files. `Create` in `hardlinktree` and `reflinktree` now returns an ownership handle that records exactly what each attempt created, and rollback removes only that. All four caller flows (cross-seed hardlink and reflink apply, season pack, dir scan inject) use the handle; the plan-wide `Rollback` functions are gone.

Fixes the bug reported in discussion #2282, present since hardlink mode shipped in #849.

## How has this been tested?

`TestCreate_SharedDestRollbackKeepsSiblingFiles` reproduces the reported sequence (shared destination, idempotent second create, duplicate add rejected, rollback) and fails on the old code. `TestCreate_Idempotent` now also asserts that a second attempt owns nothing. Both were mutation-checked: making `Create` claim skipped files turns them red.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [x] I ran `make precommit` and the tests pass locally
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

## AI disclosure

Was any AI used in this PR? Roughly how much of the code was AI-written, and what model/tool?

Yes. The code was written with Claude Code, directed and reviewed by me.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved rollback behavior so failed link or torrent operations remove only files and directories created by that attempt.
  - Prevented cleanup from deleting resources created by earlier or concurrent successful operations.
  - Improved handling of partial failures during hardlink and reflink creation.
  - Added clearer failure reporting, including the number of items successfully rolled back.

- **Reliability**
  - Improved idempotent link creation by preserving existing matching links and directories during rollback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->