### PR TITLE
refactor(web): move preference field help into label tooltips

### DIFF
--- a/web/src/components/forms/NumberInputWithUnlimited.tsx
+++ b/web/src/components/forms/NumberInputWithUnlimited.tsx
@@ -4,6 +4,7 @@
  */
 
 import React from "react"
+import { FieldHelp } from "@/components/ui/field-help"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { useTranslation } from "react-i18next"
@@ -73,15 +74,15 @@ export function NumberInputWithUnlimited({
 
   return (
     <div className="space-y-2">
-      <div className="space-y-1">
-        <Label className="text-sm font-medium">{label}</Label>
+      <Label className="flex items-center gap-2 text-sm font-medium">
+        {label}
         {description && (
-          <p className="text-xs text-muted-foreground">
+          <FieldHelp>
             {description}
             {allowUnlimited && t("numberInput.useUnlimited")}
-          </p>
+          </FieldHelp>
         )}
-      </div>
+      </Label>
       <Input
         type="number"
         value={displayValue}

--- a/web/src/components/instances/preferences/AdvancedNetworkForm.tsx
+++ b/web/src/components/instances/preferences/AdvancedNetworkForm.tsx
@@ -10,6 +10,7 @@ import { Label } from "@/components/ui/label"
 import { Input } from "@/components/ui/input"
 import { Switch } from "@/components/ui/switch"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { FieldHelp } from "@/components/ui/field-help"
 import { Settings, HardDrive, Zap, Ban, Radio, AlertTriangle } from "lucide-react"
 import { useInstancePreferences } from "@/hooks/useInstancePreferences"
 import { useQBittorrentFieldVisibility } from "@/hooks/useQBittorrentAppInfo"
@@ -35,7 +36,6 @@ function SwitchSetting({
   onChange: (checked: boolean) => void
 }) {
   const switchId = React.useId()
-  const descriptionId = description ? `${switchId}-desc` : undefined
 
   return (
     <label
@@ -46,14 +46,9 @@ function SwitchSetting({
         id={switchId}
         checked={checked}
         onCheckedChange={onChange}
-        aria-describedby={descriptionId}
       />
-      <div className="space-y-0.5">
-        <span className="text-sm font-medium">{label}</span>
-        {description && (
-          <p id={descriptionId} className="text-xs text-muted-foreground">{description}</p>
-        )}
-      </div>
+      <span className="text-sm font-medium">{label}</span>
+      {description && <FieldHelp>{description}</FieldHelp>}
     </label>
   )
 }
@@ -78,17 +73,14 @@ function NumberInput({
   unit?: string
 }) {
   const inputId = React.useId()
-  const descriptionId = description ? `${inputId}-desc` : undefined
 
   return (
     <div className="space-y-2">
-      <Label htmlFor={inputId} className="text-sm font-medium">
+      <Label htmlFor={inputId} className="flex items-center gap-2 text-sm font-medium">
         {label}
-        {unit && <span className="text-muted-foreground ml-1">({unit})</span>}
+        {unit && <span className="text-muted-foreground">({unit})</span>}
+        {description && <FieldHelp>{description}</FieldHelp>}
       </Label>
-      {description && (
-        <p id={descriptionId} className="text-xs text-muted-foreground">{description}</p>
-      )}
       <Input
         id={inputId}
         type="number"
@@ -100,7 +92,6 @@ function NumberInput({
           onChange(isNaN(val) ? 0 : val)
         }}
         placeholder={placeholder}
-        aria-describedby={descriptionId}
       />
     </div>
   )

--- a/web/src/components/instances/preferences/ConnectionSettingsForm.tsx
+++ b/web/src/components/instances/preferences/ConnectionSettingsForm.tsx
@@ -6,6 +6,7 @@
 import { NumberInputWithUnlimited } from "@/components/forms/NumberInputWithUnlimited"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
+import { FieldHelp } from "@/components/ui/field-help"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
@@ -62,7 +63,6 @@ function SwitchSetting({
   onChange: (checked: boolean) => void
 }) {
   const switchId = React.useId()
-  const descriptionId = description ? `${switchId}-desc` : undefined
 
   return (
     <label
@@ -73,14 +73,9 @@ function SwitchSetting({
         id={switchId}
         checked={checked}
         onCheckedChange={onChange}
-        aria-describedby={descriptionId}
       />
-      <div className="space-y-0.5">
-        <span className="text-sm font-medium">{label}</span>
-        {description && (
-          <p id={descriptionId} className="text-xs text-muted-foreground">{description}</p>
-        )}
-      </div>
+      <span className="text-sm font-medium">{label}</span>
+      {description && <FieldHelp>{description}</FieldHelp>}
     </label>
   )
 }
@@ -103,14 +98,13 @@ function NumberInput({
   placeholder?: string
 }) {
   const inputId = React.useId()
-  const descriptionId = description ? `${inputId}-desc` : undefined
 
   return (
     <div className="space-y-2">
-      <Label htmlFor={inputId} className="text-sm font-medium">{label}</Label>
-      {description && (
-        <p id={descriptionId} className="text-xs text-muted-foreground">{description}</p>
-      )}
+      <Label htmlFor={inputId} className="flex items-center gap-2 text-sm font-medium">
+        {label}
+        {description && <FieldHelp>{description}</FieldHelp>}
+      </Label>
       <Input
         id={inputId}
         type="number"
@@ -122,7 +116,6 @@ function NumberInput({
           onChange(isNaN(val) ? 0 : val)
         }}
         placeholder={placeholder}
-        aria-describedby={descriptionId}
       />
     </div>
   )

--- a/web/src/components/instances/preferences/FileManagementForm.tsx
+++ b/web/src/components/instances/preferences/FileManagementForm.tsx
@@ -5,6 +5,7 @@
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { FieldHelp } from "@/components/ui/field-help"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import {
@@ -127,7 +128,6 @@ function SwitchSetting({
   disabled?: boolean
 }) {
   const switchId = React.useId()
-  const descriptionId = description ? `${switchId}-desc` : undefined
 
   return (
     <label
@@ -138,15 +138,10 @@ function SwitchSetting({
         id={switchId}
         checked={checked}
         onCheckedChange={onCheckedChange}
-        aria-describedby={descriptionId}
         disabled={disabled}
       />
-      <div className="space-y-0.5">
-        <span className="text-sm font-medium">{label}</span>
-        {description && (
-          <p id={descriptionId} className="text-xs text-muted-foreground">{description}</p>
-        )}
-      </div>
+      <span className="text-sm font-medium">{label}</span>
+      {description && <FieldHelp>{description}</FieldHelp>}
     </label>
   )
 }

--- a/web/src/components/instances/preferences/NetworkDiscoveryForm.tsx
+++ b/web/src/components/instances/preferences/NetworkDiscoveryForm.tsx
@@ -6,6 +6,7 @@
 import React from "react"
 import { useForm } from "@tanstack/react-form"
 import { Button } from "@/components/ui/button"
+import { FieldHelp } from "@/components/ui/field-help"
 import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
@@ -33,7 +34,6 @@ function SwitchSetting({
   onChange: (checked: boolean) => void
 }) {
   const switchId = React.useId()
-  const descriptionId = description ? `${switchId}-desc` : undefined
 
   return (
     <label
@@ -44,14 +44,9 @@ function SwitchSetting({
         id={switchId}
         checked={checked}
         onCheckedChange={onChange}
-        aria-describedby={descriptionId}
       />
-      <div className="space-y-0.5">
-        <span className="text-sm font-medium">{label}</span>
-        {description && (
-          <p id={descriptionId} className="text-xs text-muted-foreground">{description}</p>
-        )}
-      </div>
+      <span className="text-sm font-medium">{label}</span>
+      {description && <FieldHelp>{description}</FieldHelp>}
     </label>
   )
 }

--- a/web/src/components/instances/preferences/QueueManagementForm.tsx
+++ b/web/src/components/instances/preferences/QueueManagementForm.tsx
@@ -6,6 +6,7 @@
 import React from "react"
 import { useForm } from "@tanstack/react-form"
 import { Button } from "@/components/ui/button"
+import { FieldHelp } from "@/components/ui/field-help"
 import { Switch } from "@/components/ui/switch"
 import { useInstancePreferences } from "@/hooks/useInstancePreferences"
 import { useTranslation } from "react-i18next"
@@ -27,7 +28,6 @@ function SwitchSetting({
   description?: string
 }) {
   const switchId = React.useId()
-  const descriptionId = description ? `${switchId}-desc` : undefined
 
   return (
     <label
@@ -38,14 +38,9 @@ function SwitchSetting({
         id={switchId}
         checked={checked}
         onCheckedChange={onCheckedChange}
-        aria-describedby={descriptionId}
       />
-      <div className="space-y-0.5">
-        <span className="text-sm font-medium">{label}</span>
-        {description && (
-          <p id={descriptionId} className="text-xs text-muted-foreground">{description}</p>
-        )}
-      </div>
+      <span className="text-sm font-medium">{label}</span>
+      {description && <FieldHelp>{description}</FieldHelp>}
     </label>
   )
 }

--- a/web/src/components/instances/preferences/SeedingLimitsForm.tsx
+++ b/web/src/components/instances/preferences/SeedingLimitsForm.tsx
@@ -6,6 +6,7 @@
 import React from "react"
 import { useForm } from "@tanstack/react-form"
 import { Button } from "@/components/ui/button"
+import { FieldHelp } from "@/components/ui/field-help"
 import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
 import { useInstancePreferences } from "@/hooks/useInstancePreferences"
@@ -30,12 +31,8 @@ function SwitchSetting({
   return (
     <div className="flex items-center gap-3">
       <Switch checked={checked} onCheckedChange={onCheckedChange} />
-      <div className="space-y-0.5">
-        <Label className="text-sm font-medium">{label}</Label>
-        {description && (
-          <p className="text-xs text-muted-foreground">{description}</p>
-        )}
-      </div>
+      <Label className="text-sm font-medium">{label}</Label>
+      {description && <FieldHelp>{description}</FieldHelp>}
     </div>
   )
 }


### PR DESCRIPTION
## Description

Moves the field help in the instance preference forms into a tooltip on the label. Six local `SwitchSetting` / `NumberInput` helpers and the shared `NumberInputWithUnlimited` now render `FieldHelp` instead of a paragraph under the control, so all 63 call sites convert with no call-site edits.

The paragraph's `aria-describedby` link goes with the paragraph. There is no stable id to point a control at once the text lives in a tooltip, and the help stays reachable as a focusable button beside the label. `NumberInputWithUnlimited` still appends "(use -1 for unlimited)" to its help text, now inside the tooltip; clearing the field already sets unlimited without that hint.

The hand-written paragraphs in these same files stay for now. They are the next step in #2250, which is why a few panes still show one paragraph under a text field or a select.

Part of #2250

## How has this been tested?

Opened all six preference panes against a live instance. Every icon opens its tooltip on hover, the text is intact, and clicking the icon inside a switch row leaves the switch untouched, since label activation skips an interactive click target.

## Screenshots (for UI changes)

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [x] I ran `make precommit` and the tests pass locally
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

## AI disclosure

Yes. Claude Opus made the edits and checked each pane in a browser, under review at each step.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Standardized help text presentation across number inputs and instance preference settings.
  - Improved label layouts and consistency for explanatory guidance.
- **Accessibility**
  - Updated field descriptions to use a shared help component for clearer, more consistent assistance.
- **User Experience**
  - Guidance for advanced networking, connections, file management, discovery, queue management, seeding limits, and unlimited values is now displayed consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->