### PR TITLE
refactor(web): move notification and RSS field help into label tooltips

### DIFF
--- a/web/src/components/settings/NotificationsManager.tsx
+++ b/web/src/components/settings/NotificationsManager.tsx
@@ -26,6 +26,7 @@ import {
   DialogTitle,
   DialogTrigger
 } from "@/components/ui/dialog"
+import { FieldHelp } from "@/components/ui/field-help"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
@@ -245,18 +246,20 @@ function NotificationTargetForm({ initial, eventDefinitions, onSubmit, onCancel,
       </div>
 
       <div className="space-y-2">
-        <Label htmlFor="notification-url">{t("notifications.form.url")}</Label>
+        <Label htmlFor="notification-url" className="flex items-center gap-1">
+          {t("notifications.form.url")}
+          <FieldHelp>
+            {t("notifications.form.urlDescriptionPrefix")} <span className="font-mono">{t("notifications.form.examples.notifiarr")}</span>.
+            {" "}
+            {t("notifications.form.urlDescriptionSuffix")} <span className="font-mono">{t("notifications.form.examples.discord")}</span>.
+          </FieldHelp>
+        </Label>
         <Input
           id="notification-url"
           placeholder={t("notifications.form.urlPlaceholder")}
           value={url}
           onChange={(e) => setUrl(normalizeNotificationUrl(e.target.value))}
         />
-        <p className="text-xs text-muted-foreground">
-          {t("notifications.form.urlDescriptionPrefix")} <span className="font-mono">{t("notifications.form.examples.notifiarr")}</span>.
-          {" "}
-          {t("notifications.form.urlDescriptionSuffix")} <span className="font-mono">{t("notifications.form.examples.discord")}</span>.
-        </p>
       </div>
 
       <div className="flex items-center justify-between rounded-md border px-3 py-2">

--- a/web/src/pages/RSSPage.tsx
+++ b/web/src/pages/RSSPage.tsx
@@ -49,6 +49,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu"
+import { FieldHelp } from "@/components/ui/field-help"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
@@ -1829,16 +1830,16 @@ function RuleFormFields({
       </div>
 
       <div className="space-y-2">
-        <Label htmlFor={`${idPrefix}-episode-filter`}>{t("ruleForm.episodeFilter")}</Label>
+        <Label htmlFor={`${idPrefix}-episode-filter`} className="flex items-center gap-1">
+          {t("ruleForm.episodeFilter")}
+          <FieldHelp>{t("ruleForm.episodeFilterHelp")}</FieldHelp>
+        </Label>
         <Input
           id={`${idPrefix}-episode-filter`}
           placeholder={t("ruleForm.episodeFilterPlaceholder")}
           value={state.episodeFilter}
           onChange={(e) => onChange("episodeFilter", e.target.value)}
         />
-        <p className="text-xs text-muted-foreground">
-          {t("ruleForm.episodeFilterHelp")}
-        </p>
       </div>
 
       <div className="flex items-center gap-6">


### PR DESCRIPTION
## Description

Moves the two smallest areas of #2250 into label tooltips: the Shoutrrr URL help in the notification target form, and the episode-filter help in the RSS rule form. Every string keeps its key, so the locale files do not change. The URL tooltip keeps the fact that a pasted Discord webhook URL converts to `discord://token@id` on each keystroke.

Part of #2250

## How has this been tested?

Opened both forms in a browser against a live instance. Each icon opens its tooltip on hover, and the full text is intact, including the `font-mono` example URLs. The per-event checkbox text stays inline, as the issue requires.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [x] eslint and tsc pass on the changed files (`make precommit`'s frontend half cannot run in a worktree)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

## AI disclosure

Yes, the whole diff. Claude Opus wrote the edits. Claude Fable 5 orchestrated, reviewed the diff, and checked both forms in a browser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Moved notification URL format guidance into an inline help popover beside the field label.
  * Added inline help for the RSS episode filter setting, keeping guidance accessible without adding page clutter.
  * Preserved existing URL input normalization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->