### PR TITLE
refactor(instances): move the hand-written field help into label tooltips

### DIFF
--- a/web/src/components/forms/NumberInputWithUnlimited.tsx
+++ b/web/src/components/forms/NumberInputWithUnlimited.tsx
@@ -4,6 +4,7 @@
  */
 
 import React from "react"
+import { FieldHelp } from "@/components/ui/field-help"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { useTranslation } from "react-i18next"
@@ -73,15 +74,15 @@ export function NumberInputWithUnlimited({
 
   return (
     <div className="space-y-2">
-      <div className="space-y-1">
-        <Label className="text-sm font-medium">{label}</Label>
+      <Label className="flex items-center gap-2 text-sm font-medium">
+        {label}
         {description && (
-          <p className="text-xs text-muted-foreground">
+          <FieldHelp>
             {description}
             {allowUnlimited && t("numberInput.useUnlimited")}
-          </p>
+          </FieldHelp>
         )}
-      </div>
+      </Label>
       <Input
         type="number"
         value={displayValue}

--- a/web/src/components/instances/InstanceForm.tsx
+++ b/web/src/components/instances/InstanceForm.tsx
@@ -4,6 +4,7 @@
  */
 
 import { Button } from "@/components/ui/button"
+import { FieldHelp } from "@/components/ui/field-help"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
@@ -255,13 +256,11 @@ export function InstanceForm({ instance, onSuccess, onCancel, formId }: Instance
 
         <form.Field name="tlsSkipVerify">
           {(field) => (
-            <div className="flex items-start justify-between gap-4 rounded-lg border bg-muted/40 p-4">
-              <div className="space-y-1">
-                <Label htmlFor="tls-skip-verify">{t("form.labels.skipTlsVerification")}</Label>
-                <p className="text-sm text-muted-foreground max-w-prose">
-                  {t("form.labels.skipTlsDescription")}
-                </p>
-              </div>
+            <div className="flex items-center justify-between gap-4 rounded-lg border bg-muted/40 p-4">
+              <Label htmlFor="tls-skip-verify" className="flex items-center gap-2">
+                {t("form.labels.skipTlsVerification")}
+                <FieldHelp>{t("form.labels.skipTlsDescription")}</FieldHelp>
+              </Label>
               <Switch
                 id="tls-skip-verify"
                 checked={field.state.value}
@@ -273,13 +272,11 @@ export function InstanceForm({ instance, onSuccess, onCancel, formId }: Instance
 
         <form.Field name="hasLocalFilesystemAccess">
           {(field) => (
-            <div className="flex items-start justify-between gap-4 rounded-lg border bg-muted/40 p-4">
-              <div className="space-y-1">
-                <Label htmlFor="local-filesystem-access">{t("form.labels.localFilesystemAccess")}</Label>
-                <p className="text-sm text-muted-foreground max-w-prose">
-                  {t("form.labels.localFilesystemDescription")}
-                </p>
-              </div>
+            <div className="flex items-center justify-between gap-4 rounded-lg border bg-muted/40 p-4">
+              <Label htmlFor="local-filesystem-access" className="flex items-center gap-2">
+                {t("form.labels.localFilesystemAccess")}
+                <FieldHelp>{t("form.labels.localFilesystemDescription")}</FieldHelp>
+              </Label>
               <Switch
                 id="local-filesystem-access"
                 checked={field.state.value}
@@ -289,23 +286,21 @@ export function InstanceForm({ instance, onSuccess, onCancel, formId }: Instance
           )}
         </form.Field>
 
-        <div className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="auth-type">{t("form.labels.authType")}</Label>
-            <select
-              id="auth-type"
-              value={authType}
-              onChange={(e) => setAuthType(e.target.value as InstanceAuthType)}
-              className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background"
-            >
-              <option value="none">{t("form.authType.none")}</option>
-              <option value="usernamePassword">{t("form.authType.usernamePassword")}</option>
-              <option value="apiKey">{t("form.authType.apiKey")}</option>
-            </select>
-            <p className="text-sm text-muted-foreground pr-2">
-              {t("form.labels.authTypeDescription")}
-            </p>
-          </div>
+        <div className="space-y-2">
+          <Label htmlFor="auth-type" className="flex items-center gap-2">
+            {t("form.labels.authType")}
+            <FieldHelp>{t("form.labels.authTypeDescription")}</FieldHelp>
+          </Label>
+          <select
+            id="auth-type"
+            value={authType}
+            onChange={(e) => setAuthType(e.target.value as InstanceAuthType)}
+            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background"
+          >
+            <option value="none">{t("form.authType.none")}</option>
+            <option value="usernamePassword">{t("form.authType.usernamePassword")}</option>
+            <option value="apiKey">{t("form.authType.apiKey")}</option>
+          </select>
         </div>
 
         {authType === "usernamePassword" && (
@@ -384,12 +379,10 @@ export function InstanceForm({ instance, onSuccess, onCancel, formId }: Instance
 
         <div className="space-y-4">
           <div className="flex items-center justify-between">
-            <div className="space-y-0.5">
-              <Label htmlFor="basic-auth-toggle">{t("form.labels.httpBasicAuth")}</Label>
-              <p className="text-sm text-muted-foreground">
-                {t("form.labels.httpBasicAuthDescription")}
-              </p>
-            </div>
+            <Label htmlFor="basic-auth-toggle" className="flex items-center gap-2">
+              {t("form.labels.httpBasicAuth")}
+              <FieldHelp>{t("form.labels.httpBasicAuthDescription")}</FieldHelp>
+            </Label>
             <Switch
               id="basic-auth-toggle"
               checked={showBasicAuth}

--- a/web/src/components/instances/preferences/AdvancedNetworkForm.tsx
+++ b/web/src/components/instances/preferences/AdvancedNetworkForm.tsx
@@ -249,16 +249,16 @@ export function AdvancedNetworkForm({ instanceId, onSuccess }: AdvancedNetworkFo
             <form.Field name="announce_ip">
               {(field) => (
                 <div className="space-y-2">
-                  <Label htmlFor="announce_ip">{t("preferences.advancedNetwork.announceIp")}</Label>
+                  <Label htmlFor="announce_ip" className="flex items-center gap-2">
+                    {t("preferences.advancedNetwork.announceIp")}
+                    <FieldHelp>{t("preferences.advancedNetwork.announceIpDescription")}</FieldHelp>
+                  </Label>
                   <Input
                     id="announce_ip"
                     value={field.state.value}
                     onChange={(e) => field.handleChange(e.target.value)}
                     placeholder={t("preferences.connectionSettings.autoDetect")}
                   />
-                  <p className="text-xs text-muted-foreground">
-                    {t("preferences.advancedNetwork.announceIpDescription")}
-                  </p>
                 </div>
               )}
             </form.Field>

--- a/web/src/components/instances/preferences/AdvancedNetworkForm.tsx
+++ b/web/src/components/instances/preferences/AdvancedNetworkForm.tsx
@@ -10,6 +10,7 @@ import { Label } from "@/components/ui/label"
 import { Input } from "@/components/ui/input"
 import { Switch } from "@/components/ui/switch"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { FieldHelp } from "@/components/ui/field-help"
 import { Settings, HardDrive, Zap, Ban, Radio, AlertTriangle } from "lucide-react"
 import { useInstancePreferences } from "@/hooks/useInstancePreferences"
 import { useQBittorrentFieldVisibility } from "@/hooks/useQBittorrentAppInfo"
@@ -35,7 +36,6 @@ function SwitchSetting({
   onChange: (checked: boolean) => void
 }) {
   const switchId = React.useId()
-  const descriptionId = description ? `${switchId}-desc` : undefined
 
   return (
     <label
@@ -46,14 +46,9 @@ function SwitchSetting({
         id={switchId}
         checked={checked}
         onCheckedChange={onChange}
-        aria-describedby={descriptionId}
       />
-      <div className="space-y-0.5">
-        <span className="text-sm font-medium">{label}</span>
-        {description && (
-          <p id={descriptionId} className="text-xs text-muted-foreground">{description}</p>
-        )}
-      </div>
+      <span className="text-sm font-medium">{label}</span>
+      {description && <FieldHelp>{description}</FieldHelp>}
     </label>
   )
 }
@@ -78,17 +73,14 @@ function NumberInput({
   unit?: string
 }) {
   const inputId = React.useId()
-  const descriptionId = description ? `${inputId}-desc` : undefined
 
   return (
     <div className="space-y-2">
-      <Label htmlFor={inputId} className="text-sm font-medium">
+      <Label htmlFor={inputId} className="flex items-center gap-2 text-sm font-medium">
         {label}
-        {unit && <span className="text-muted-foreground ml-1">({unit})</span>}
+        {unit && <span className="text-muted-foreground">({unit})</span>}
+        {description && <FieldHelp>{description}</FieldHelp>}
       </Label>
-      {description && (
-        <p id={descriptionId} className="text-xs text-muted-foreground">{description}</p>
-      )}
       <Input
         id={inputId}
         type="number"
@@ -100,7 +92,6 @@ function NumberInput({
           onChange(isNaN(val) ? 0 : val)
         }}
         placeholder={placeholder}
-        aria-describedby={descriptionId}
       />
     </div>
   )

--- a/web/src/components/instances/preferences/ConnectionSettingsForm.tsx
+++ b/web/src/components/instances/preferences/ConnectionSettingsForm.tsx
@@ -343,7 +343,10 @@ export function ConnectionSettingsForm({ instanceId, onSuccess }: ConnectionSett
 
                 return (
                   <div className="space-y-2">
-                    <Label className="text-sm font-medium">{t("preferences.connectionSettings.bittorrentProtocol")}</Label>
+                    <Label className="flex items-center gap-2 text-sm font-medium">
+                      {t("preferences.connectionSettings.bittorrentProtocol")}
+                      <FieldHelp>{t("preferences.connectionSettings.protocolDescription")}</FieldHelp>
+                    </Label>
                     <Select
                       value={sanitizedValue.toString()}
                       onValueChange={(value) => {
@@ -363,9 +366,6 @@ export function ConnectionSettingsForm({ instanceId, onSuccess }: ConnectionSett
                         <SelectItem value="2">{getBittorrentProtocolLabel(2)}</SelectItem>
                       </SelectContent>
                     </Select>
-                    <p className="text-xs text-muted-foreground">
-                      {t("preferences.connectionSettings.protocolDescription")}
-                    </p>
                   </div>
                 )
               }}
@@ -382,7 +382,10 @@ export function ConnectionSettingsForm({ instanceId, onSuccess }: ConnectionSett
 
                 return (
                   <div className="space-y-2">
-                    <Label className="text-sm font-medium">{t("preferences.connectionSettings.utpTcpMixedMode")}</Label>
+                    <Label className="flex items-center gap-2 text-sm font-medium">
+                      {t("preferences.connectionSettings.utpTcpMixedMode")}
+                      <FieldHelp>{t("preferences.connectionSettings.utpTcpMixedModeDescription")}</FieldHelp>
+                    </Label>
                     <Select
                       value={sanitizedValue.toString()}
                       onValueChange={(value) => {
@@ -401,9 +404,6 @@ export function ConnectionSettingsForm({ instanceId, onSuccess }: ConnectionSett
                         <SelectItem value="1">{getUtpTcpMixedModeLabel(1)}</SelectItem>
                       </SelectContent>
                     </Select>
-                    <p className="text-xs text-muted-foreground">
-                      {t("preferences.connectionSettings.utpTcpMixedModeDescription")}
-                    </p>
                   </div>
                 )
               }}
@@ -424,7 +424,10 @@ export function ConnectionSettingsForm({ instanceId, onSuccess }: ConnectionSett
               <form.Field name="current_network_interface">
                 {(field) => (
                   <div className="space-y-2">
-                    <Label htmlFor="network_interface">{t("preferences.connectionSettings.networkInterfaceReadOnly")}</Label>
+                    <Label htmlFor="network_interface" className="flex items-center gap-2">
+                      {t("preferences.connectionSettings.networkInterfaceReadOnly")}
+                      <FieldHelp>{t("preferences.connectionSettings.networkInterfaceDescription")}</FieldHelp>
+                    </Label>
                     <Input
                       id="network_interface"
                       value={field.state.value || t("preferences.connectionSettings.autoDetect")}
@@ -432,9 +435,6 @@ export function ConnectionSettingsForm({ instanceId, onSuccess }: ConnectionSett
                       className={incognitoMode ? "bg-muted blur-sm select-none" : "bg-muted"}
                       disabled
                     />
-                    <p className="text-xs text-muted-foreground">
-                      {t("preferences.connectionSettings.networkInterfaceDescription")}
-                    </p>
                   </div>
                 )}
               </form.Field>
@@ -442,7 +442,10 @@ export function ConnectionSettingsForm({ instanceId, onSuccess }: ConnectionSett
               <form.Field name="current_interface_address">
                 {(field) => (
                   <div className="space-y-2">
-                    <Label htmlFor="interface_address">{t("preferences.connectionSettings.interfaceIpAddress")}</Label>
+                    <Label htmlFor="interface_address" className="flex items-center gap-2">
+                      {t("preferences.connectionSettings.interfaceIpAddress")}
+                      <FieldHelp>{t("preferences.connectionSettings.interfaceIpAddressDescription")}</FieldHelp>
+                    </Label>
                     <Input
                       id="interface_address"
                       value={field.state.value || t("preferences.connectionSettings.autoDetect")}
@@ -450,9 +453,6 @@ export function ConnectionSettingsForm({ instanceId, onSuccess }: ConnectionSett
                       disabled
                       className={incognitoMode ? "bg-muted blur-sm select-none" : "bg-muted"}
                     />
-                    <p className="text-xs text-muted-foreground">
-                      {t("preferences.connectionSettings.interfaceIpAddressDescription")}
-                    </p>
                   </div>
                 )}
               </form.Field>
@@ -682,7 +682,10 @@ export function ConnectionSettingsForm({ instanceId, onSuccess }: ConnectionSett
             <form.Field name="ip_filter_path">
               {(field) => (
                 <div className="space-y-2">
-                  <Label htmlFor="ip_filter_path">{t("preferences.connectionSettings.ipFilterPath")}</Label>
+                  <Label htmlFor="ip_filter_path" className="flex items-center gap-2">
+                    {t("preferences.connectionSettings.ipFilterPath")}
+                    <FieldHelp>{t("preferences.connectionSettings.ipFilterPathDescription")}</FieldHelp>
+                  </Label>
                   <Input
                     id="ip_filter_path"
                     value={field.state.value}
@@ -691,9 +694,6 @@ export function ConnectionSettingsForm({ instanceId, onSuccess }: ConnectionSett
                     disabled={!form.state.values.ip_filter_enabled}
                     className={incognitoMode ? "blur-sm select-none" : ""}
                   />
-                  <p className="text-xs text-muted-foreground">
-                    {t("preferences.connectionSettings.ipFilterPathDescription")}
-                  </p>
                 </div>
               )}
             </form.Field>
@@ -712,16 +712,16 @@ export function ConnectionSettingsForm({ instanceId, onSuccess }: ConnectionSett
             <form.Field name="banned_IPs">
               {(field) => (
                 <div className="space-y-2">
-                  <Label>{t("preferences.connectionSettings.bannedIps")}</Label>
+                  <Label className="flex items-center gap-2">
+                    {t("preferences.connectionSettings.bannedIps")}
+                    <FieldHelp>{t("preferences.connectionSettings.bannedIpsDescription")}</FieldHelp>
+                  </Label>
                   <Textarea
                     value={field.state.value}
                     onChange={(e) => field.handleChange(e.target.value)}
                     placeholder={t("preferences.connectionSettings.bannedIpsPlaceholder")}
                     className={incognitoMode ? "min-h-[100px] font-mono text-sm blur-sm select-none" : "min-h-[100px] font-mono text-sm"}
                   />
-                  <p className="text-xs text-muted-foreground">
-                    {t("preferences.connectionSettings.bannedIpsDescription")}
-                  </p>
                 </div>
               )}
             </form.Field>

--- a/web/src/components/instances/preferences/ConnectionSettingsForm.tsx
+++ b/web/src/components/instances/preferences/ConnectionSettingsForm.tsx
@@ -6,6 +6,7 @@
 import { NumberInputWithUnlimited } from "@/components/forms/NumberInputWithUnlimited"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
+import { FieldHelp } from "@/components/ui/field-help"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
@@ -62,7 +63,6 @@ function SwitchSetting({
   onChange: (checked: boolean) => void
 }) {
   const switchId = React.useId()
-  const descriptionId = description ? `${switchId}-desc` : undefined
 
   return (
     <label
@@ -73,14 +73,9 @@ function SwitchSetting({
         id={switchId}
         checked={checked}
         onCheckedChange={onChange}
-        aria-describedby={descriptionId}
       />
-      <div className="space-y-0.5">
-        <span className="text-sm font-medium">{label}</span>
-        {description && (
-          <p id={descriptionId} className="text-xs text-muted-foreground">{description}</p>
-        )}
-      </div>
+      <span className="text-sm font-medium">{label}</span>
+      {description && <FieldHelp>{description}</FieldHelp>}
     </label>
   )
 }
@@ -103,14 +98,13 @@ function NumberInput({
   placeholder?: string
 }) {
   const inputId = React.useId()
-  const descriptionId = description ? `${inputId}-desc` : undefined
 
   return (
     <div className="space-y-2">
-      <Label htmlFor={inputId} className="text-sm font-medium">{label}</Label>
-      {description && (
-        <p id={descriptionId} className="text-xs text-muted-foreground">{description}</p>
-      )}
+      <Label htmlFor={inputId} className="flex items-center gap-2 text-sm font-medium">
+        {label}
+        {description && <FieldHelp>{description}</FieldHelp>}
+      </Label>
       <Input
         id={inputId}
         type="number"
@@ -122,7 +116,6 @@ function NumberInput({
           onChange(isNaN(val) ? 0 : val)
         }}
         placeholder={placeholder}
-        aria-describedby={descriptionId}
       />
     </div>
   )

--- a/web/src/components/instances/preferences/FileManagementForm.tsx
+++ b/web/src/components/instances/preferences/FileManagementForm.tsx
@@ -369,10 +369,10 @@ export function FileManagementForm({ instanceId, onSuccess }: FileManagementForm
           <form.Field name="save_path">
             {(field) => (
               <div className="space-y-2">
-                <Label className="text-sm font-medium">{t("preferences.fileManagement.defaultSavePath")}</Label>
-                <p className="text-xs text-muted-foreground">
-                  {t("preferences.fileManagement.defaultSavePathDescription")}
-                </p>
+                <Label className="flex items-center gap-2 text-sm font-medium">
+                  {t("preferences.fileManagement.defaultSavePath")}
+                  <FieldHelp>{t("preferences.fileManagement.defaultSavePathDescription")}</FieldHelp>
+                </Label>
                 <Input
                   value={field.state.value as string}
                   onChange={(e) => field.handleChange(e.target.value)}
@@ -399,10 +399,10 @@ export function FileManagementForm({ instanceId, onSuccess }: FileManagementForm
               <form.Subscribe selector={(state) => state.values.temp_path_enabled}>
                 {(tempPathEnabled) => (
                   <div className="space-y-2">
-                    <Label className="text-sm font-medium">{t("preferences.fileManagement.tempDownloadPath")}</Label>
-                    <p className="text-xs text-muted-foreground">
-                      {t("preferences.fileManagement.tempDownloadPathDescription")}
-                    </p>
+                    <Label className="flex items-center gap-2 text-sm font-medium">
+                      {t("preferences.fileManagement.tempDownloadPath")}
+                      <FieldHelp>{t("preferences.fileManagement.tempDownloadPathDescription")}</FieldHelp>
+                    </Label>
                     <Input
                       value={field.state.value as string}
                       onChange={(e) => field.handleChange(e.target.value)}
@@ -419,10 +419,10 @@ export function FileManagementForm({ instanceId, onSuccess }: FileManagementForm
           <form.Field name="torrent_content_layout">
             {(field) => (
               <div className="space-y-2">
-                <Label className="text-sm font-medium">{t("preferences.fileManagement.defaultContentLayout")}</Label>
-                <p className="text-xs text-muted-foreground">
-                  {t("preferences.fileManagement.defaultContentLayoutDescription")}
-                </p>
+                <Label className="flex items-center gap-2 text-sm font-medium">
+                  {t("preferences.fileManagement.defaultContentLayout")}
+                  <FieldHelp>{t("preferences.fileManagement.defaultContentLayoutDescription")}</FieldHelp>
+                </Label>
                 <Select
                   value={field.state.value as string}
                   onValueChange={field.handleChange}
@@ -566,7 +566,10 @@ export function FileManagementForm({ instanceId, onSuccess }: FileManagementForm
                       <form.Field name="autorun_on_torrent_added_program">
                         {(programField) => (
                           <div className="space-y-2 ml-6 pl-4 border-l-2 border-muted">
-                            <Label className="text-sm font-medium">{t("preferences.fileManagement.command")}</Label>
+                            <Label className="flex items-center gap-2 text-sm font-medium">
+                              {t("preferences.fileManagement.command")}
+                              <FieldHelp>{t("preferences.fileManagement.autorunProgramTip")}</FieldHelp>
+                            </Label>
                             <Input
                               value={programField.state.value as string}
                               onChange={(e) => programField.handleChange(e.target.value)}
@@ -574,9 +577,6 @@ export function FileManagementForm({ instanceId, onSuccess }: FileManagementForm
                               disabled={!(enabledField.state.value as boolean)}
                               className={incognitoMode ? "blur-sm select-none" : ""}
                             />
-                            <p className="text-xs text-muted-foreground">
-                              {t("preferences.fileManagement.autorunProgramTip")}
-                            </p>
                           </div>
                         )}
                       </form.Field>
@@ -608,7 +608,10 @@ export function FileManagementForm({ instanceId, onSuccess }: FileManagementForm
                     <form.Field name="autorun_program">
                       {(programField) => (
                         <div className="space-y-2 ml-6 pl-4 border-l-2 border-muted">
-                          <Label className="text-sm font-medium">{t("preferences.fileManagement.command")}</Label>
+                          <Label className="flex items-center gap-2 text-sm font-medium">
+                            {t("preferences.fileManagement.command")}
+                            <FieldHelp>{t("preferences.fileManagement.autorunProgramTip")}</FieldHelp>
+                          </Label>
                           <Input
                             value={programField.state.value as string}
                             onChange={(e) => programField.handleChange(e.target.value)}
@@ -616,9 +619,6 @@ export function FileManagementForm({ instanceId, onSuccess }: FileManagementForm
                             disabled={!(enabledField.state.value as boolean)}
                             className={incognitoMode ? "blur-sm select-none" : ""}
                           />
-                          <p className="text-xs text-muted-foreground">
-                            {t("preferences.fileManagement.autorunProgramTip")}
-                          </p>
                         </div>
                       )}
                     </form.Field>

--- a/web/src/components/instances/preferences/FileManagementForm.tsx
+++ b/web/src/components/instances/preferences/FileManagementForm.tsx
@@ -5,6 +5,7 @@
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { FieldHelp } from "@/components/ui/field-help"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import {
@@ -127,7 +128,6 @@ function SwitchSetting({
   disabled?: boolean
 }) {
   const switchId = React.useId()
-  const descriptionId = description ? `${switchId}-desc` : undefined
 
   return (
     <label
@@ -138,15 +138,10 @@ function SwitchSetting({
         id={switchId}
         checked={checked}
         onCheckedChange={onCheckedChange}
-        aria-describedby={descriptionId}
         disabled={disabled}
       />
-      <div className="space-y-0.5">
-        <span className="text-sm font-medium">{label}</span>
-        {description && (
-          <p id={descriptionId} className="text-xs text-muted-foreground">{description}</p>
-        )}
-      </div>
+      <span className="text-sm font-medium">{label}</span>
+      {description && <FieldHelp>{description}</FieldHelp>}
     </label>
   )
 }

--- a/web/src/components/instances/preferences/InstanceSettingsPanel.tsx
+++ b/web/src/components/instances/preferences/InstanceSettingsPanel.tsx
@@ -4,6 +4,7 @@
  */
 
 import { Button } from "@/components/ui/button"
+import { FieldHelp } from "@/components/ui/field-help"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
@@ -255,17 +256,14 @@ export function InstanceSettingsPanel({ instance, onSuccess }: InstanceSettingsP
                 htmlFor="tls-skip-verify"
                 className="flex items-center justify-between gap-4 rounded-lg border bg-muted/40 p-4 cursor-pointer"
               >
-                <div className="space-y-0.5">
-                  <span className="text-sm font-medium">{t("preferences.settingsPanel.labels.skipTlsVerification")}</span>
-                  <p id="tls-skip-verify-desc" className="text-xs text-muted-foreground">
-                    {t("preferences.settingsPanel.labels.skipTlsDescription")}
-                  </p>
-                </div>
+                <span className="flex items-center gap-2 text-sm font-medium">
+                  {t("preferences.settingsPanel.labels.skipTlsVerification")}
+                  <FieldHelp>{t("preferences.settingsPanel.labels.skipTlsDescription")}</FieldHelp>
+                </span>
                 <Switch
                   id="tls-skip-verify"
                   checked={field.state.value}
                   onCheckedChange={(checked) => field.handleChange(checked)}
-                  aria-describedby="tls-skip-verify-desc"
                 />
               </label>
             )}
@@ -277,17 +275,14 @@ export function InstanceSettingsPanel({ instance, onSuccess }: InstanceSettingsP
                 htmlFor="local-filesystem-access"
                 className="flex items-center justify-between gap-4 rounded-lg border bg-muted/40 p-4 cursor-pointer"
               >
-                <div className="space-y-0.5">
-                  <span className="text-sm font-medium">{t("preferences.settingsPanel.labels.localFilesystemAccess")}</span>
-                  <p id="local-filesystem-access-desc" className="text-xs text-muted-foreground">
-                    {t("preferences.settingsPanel.labels.localFilesystemDescription")}
-                  </p>
-                </div>
+                <span className="flex items-center gap-2 text-sm font-medium">
+                  {t("preferences.settingsPanel.labels.localFilesystemAccess")}
+                  <FieldHelp>{t("preferences.settingsPanel.labels.localFilesystemDescription")}</FieldHelp>
+                </span>
                 <Switch
                   id="local-filesystem-access"
                   checked={field.state.value}
                   onCheckedChange={(checked) => field.handleChange(checked)}
-                  aria-describedby="local-filesystem-access-desc"
                 />
               </label>
             )}
@@ -298,17 +293,14 @@ export function InstanceSettingsPanel({ instance, onSuccess }: InstanceSettingsP
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 items-start">
           <div className="rounded-lg border bg-muted/40 p-4 flex flex-col">
             <div className="space-y-2">
-              <div className="space-y-0.5">
-                <span className="text-sm font-medium">{t("preferences.settingsPanel.labels.qbittorrentAuth")}</span>
-                <p id="auth-type-desc" className="text-xs text-muted-foreground">
-                  {t("preferences.settingsPanel.labels.qbittorrentAuthDescription")}
-                </p>
-              </div>
+              <Label htmlFor="auth-type" className="flex items-center gap-2 text-sm font-medium">
+                {t("preferences.settingsPanel.labels.qbittorrentAuth")}
+                <FieldHelp>{t("preferences.settingsPanel.labels.qbittorrentAuthDescription")}</FieldHelp>
+              </Label>
               <select
                 id="auth-type"
                 value={authType}
                 onChange={(e) => setAuthType(e.target.value as "none" | "usernamePassword" | "apiKey")}
-                aria-describedby="auth-type-desc"
                 className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background"
               >
                 <option value="none">{t("form.authType.none")}</option>
@@ -391,17 +383,14 @@ export function InstanceSettingsPanel({ instance, onSuccess }: InstanceSettingsP
           {/* HTTP Basic Auth */}
           <div className="rounded-lg border bg-muted/40 p-4 flex flex-col">
             <label htmlFor="basic-auth-toggle" className="flex items-center justify-between cursor-pointer">
-              <div className="space-y-0.5">
-                <span className="text-sm font-medium">{t("preferences.settingsPanel.labels.httpBasicAuth")}</span>
-                <p id="basic-auth-toggle-desc" className="text-xs text-muted-foreground">
-                  {t("preferences.settingsPanel.labels.httpBasicAuthDescription")}
-                </p>
-              </div>
+              <span className="flex items-center gap-2 text-sm font-medium">
+                {t("preferences.settingsPanel.labels.httpBasicAuth")}
+                <FieldHelp>{t("preferences.settingsPanel.labels.httpBasicAuthDescription")}</FieldHelp>
+              </span>
               <Switch
                 id="basic-auth-toggle"
                 checked={showBasicAuth}
                 onCheckedChange={setShowBasicAuth}
-                aria-describedby="basic-auth-toggle-desc"
               />
             </label>
 

--- a/web/src/components/instances/preferences/NetworkDiscoveryForm.tsx
+++ b/web/src/components/instances/preferences/NetworkDiscoveryForm.tsx
@@ -217,7 +217,10 @@ export function NetworkDiscoveryForm({ instanceId, onSuccess }: NetworkDiscovery
             <form.Field name="encryption">
               {(field) => (
                 <div className="space-y-2">
-                  <Label className="text-sm font-medium">{t("preferences.networkDiscovery.protocolEncryption")}</Label>
+                  <Label className="flex items-center gap-2 text-sm font-medium">
+                    {t("preferences.networkDiscovery.protocolEncryption")}
+                    <FieldHelp>{t("preferences.networkDiscovery.encryptionDescription")}</FieldHelp>
+                  </Label>
                   <Select
                     value={field.state.value.toString()}
                     onValueChange={(value) => field.handleChange(parseInt(value))}
@@ -231,9 +234,6 @@ export function NetworkDiscoveryForm({ instanceId, onSuccess }: NetworkDiscovery
                       <SelectItem value="2">{getEncryptionLabel(2)}</SelectItem>
                     </SelectContent>
                   </Select>
-                  <p className="text-xs text-muted-foreground">
-                    {t("preferences.networkDiscovery.encryptionDescription")}
-                  </p>
                 </div>
               )}
             </form.Field>

--- a/web/src/components/instances/preferences/NetworkDiscoveryForm.tsx
+++ b/web/src/components/instances/preferences/NetworkDiscoveryForm.tsx
@@ -6,6 +6,7 @@
 import React from "react"
 import { useForm } from "@tanstack/react-form"
 import { Button } from "@/components/ui/button"
+import { FieldHelp } from "@/components/ui/field-help"
 import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
@@ -33,7 +34,6 @@ function SwitchSetting({
   onChange: (checked: boolean) => void
 }) {
   const switchId = React.useId()
-  const descriptionId = description ? `${switchId}-desc` : undefined
 
   return (
     <label
@@ -44,14 +44,9 @@ function SwitchSetting({
         id={switchId}
         checked={checked}
         onCheckedChange={onChange}
-        aria-describedby={descriptionId}
       />
-      <div className="space-y-0.5">
-        <span className="text-sm font-medium">{label}</span>
-        {description && (
-          <p id={descriptionId} className="text-xs text-muted-foreground">{description}</p>
-        )}
-      </div>
+      <span className="text-sm font-medium">{label}</span>
+      {description && <FieldHelp>{description}</FieldHelp>}
     </label>
   )
 }

--- a/web/src/components/instances/preferences/QueueManagementForm.tsx
+++ b/web/src/components/instances/preferences/QueueManagementForm.tsx
@@ -6,6 +6,7 @@
 import React from "react"
 import { useForm } from "@tanstack/react-form"
 import { Button } from "@/components/ui/button"
+import { FieldHelp } from "@/components/ui/field-help"
 import { Switch } from "@/components/ui/switch"
 import { useInstancePreferences } from "@/hooks/useInstancePreferences"
 import { useTranslation } from "react-i18next"
@@ -27,7 +28,6 @@ function SwitchSetting({
   description?: string
 }) {
   const switchId = React.useId()
-  const descriptionId = description ? `${switchId}-desc` : undefined
 
   return (
     <label
@@ -38,14 +38,9 @@ function SwitchSetting({
         id={switchId}
         checked={checked}
         onCheckedChange={onCheckedChange}
-        aria-describedby={descriptionId}
       />
-      <div className="space-y-0.5">
-        <span className="text-sm font-medium">{label}</span>
-        {description && (
-          <p id={descriptionId} className="text-xs text-muted-foreground">{description}</p>
-        )}
-      </div>
+      <span className="text-sm font-medium">{label}</span>
+      {description && <FieldHelp>{description}</FieldHelp>}
     </label>
   )
 }

--- a/web/src/components/instances/preferences/SeedingLimitsForm.tsx
+++ b/web/src/components/instances/preferences/SeedingLimitsForm.tsx
@@ -6,6 +6,7 @@
 import React from "react"
 import { useForm } from "@tanstack/react-form"
 import { Button } from "@/components/ui/button"
+import { FieldHelp } from "@/components/ui/field-help"
 import { Label } from "@/components/ui/label"
 import { Switch } from "@/components/ui/switch"
 import { useInstancePreferences } from "@/hooks/useInstancePreferences"
@@ -30,12 +31,8 @@ function SwitchSetting({
   return (
     <div className="flex items-center gap-3">
       <Switch checked={checked} onCheckedChange={onCheckedChange} />
-      <div className="space-y-0.5">
-        <Label className="text-sm font-medium">{label}</Label>
-        {description && (
-          <p className="text-xs text-muted-foreground">{description}</p>
-        )}
-      </div>
+      <Label className="text-sm font-medium">{label}</Label>
+      {description && <FieldHelp>{description}</FieldHelp>}
     </div>
   )
 }


### PR DESCRIPTION
## Description

Converts the 21 hand-written field-help paragraphs in the instance form, the instance settings panel, and the preference panes to `FieldHelp` tooltips. Every string keeps its key, so the locale files do not change. The three unlisted `FileManagementForm` sites from #2250 stay inline on purpose: a section intro, an empty state, and a version-gated status message with live values.

Based on #2290, which converts the row helpers in the same files. The four `aria-describedby` attributes go with their paragraphs; the tooltip content is wired through Radix instead. The auth select in the settings panel also gains a real `Label htmlFor`, since its old `span` never named the control.

Part of #2250

## How has this been tested?

Opened the Add Instance dialog, the settings panel, and the Connect pane against a live instance. Each icon opens its tooltip on hover with the full text. A click on the icon inside a switch label leaves the switch untouched, because label activation skips interactive descendants.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [x] eslint and tsc pass on the changed files (`make precommit`'s frontend half cannot run in a worktree)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

## AI disclosure

Yes, the whole diff. Claude Opus wrote the edits. Claude Fable 5 orchestrated, ran an over-engineering review, and checked the dialogs in a browser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Improved help text presentation across instance, connection, network, file management, and authentication settings.
  * Contextual guidance now appears directly beside relevant field labels through consistent help indicators.
  * Simplified authentication and encryption setting layouts while preserving existing controls, options, validation, and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->