### PR TITLE
fix(backups): apply restore category and tags on add only

### DIFF
--- a/internal/backups/restore_execute.go
+++ b/internal/backups/restore_execute.go
@@ -287,6 +287,8 @@ func (s *Service) applyTorrentPlan(ctx context.Context, plan *RestorePlan, appli
 		if len(spec.Manifest.Tags) > 0 {
 			options["tags"] = strings.Join(spec.Manifest.Tags, ",")
 		}
+		// Category and tags ride on the add. A post-add SetCategory raced the
+		// sync cache and failed for a torrent qB had accepted (#2259).
 
 		// Pin the captured per-torrent save path so torrents whose on-disk
 		// location diverges from their category (cross-seed hardlinks, manual
@@ -315,20 +317,6 @@ func (s *Service) applyTorrentPlan(ctx context.Context, plan *RestorePlan, appli
 		}
 		if pinned {
 			pinnedSavePaths++
-		}
-
-		desiredCategory := normalizeCategory(spec.Manifest.Category)
-		if desiredCategory != "" {
-			if err := s.torrentWriter.SetCategory(ctx, instanceID, []string{spec.Manifest.Hash}, desiredCategory); err != nil {
-				appendRestoreError(errs, "set_category", spec.Manifest.Hash, err)
-			}
-		}
-
-		if len(spec.Manifest.Tags) > 0 {
-			tagPayload := strings.Join(spec.Manifest.Tags, ",")
-			if err := s.torrentWriter.SetTags(ctx, instanceID, []string{spec.Manifest.Hash}, tagPayload); err != nil {
-				appendRestoreError(errs, "set_tags", spec.Manifest.Hash, err)
-			}
 		}
 
 		applied.Torrents.Added = append(applied.Torrents.Added, spec.Manifest.Hash)

--- a/internal/backups/restore_execute_test.go
+++ b/internal/backups/restore_execute_test.go
@@ -21,6 +21,7 @@ import (
 type captureTorrentWriter struct {
 	stubBackupSyncManager
 	addOptions []map[string]string
+	postAdd    []string
 }
 
 func (w *captureTorrentWriter) AddTorrent(_ context.Context, _ int, _ []byte, options map[string]string) (*qbt.TorrentAddResponse, error) {
@@ -30,8 +31,15 @@ func (w *captureTorrentWriter) AddTorrent(_ context.Context, _ int, _ []byte, op
 	return nil, nil
 }
 
-func (w *captureTorrentWriter) SetCategory(context.Context, int, []string, string) error { return nil }
-func (w *captureTorrentWriter) SetTags(context.Context, int, []string, string) error     { return nil }
+func (w *captureTorrentWriter) SetCategory(_ context.Context, _ int, hashes []string, _ string) error {
+	w.postAdd = append(w.postAdd, hashes...)
+	return nil
+}
+
+func (w *captureTorrentWriter) SetTags(_ context.Context, _ int, hashes []string, _ string) error {
+	w.postAdd = append(w.postAdd, hashes...)
+	return nil
+}
 func (w *captureTorrentWriter) ResumeWhenComplete(int, []string, qbittorrent.ResumeWhenCompleteOptions) {
 }
 func (w *captureTorrentWriter) BulkAction(context.Context, int, []string, string) error { return nil }
@@ -66,6 +74,9 @@ func runRestoreAdd(t *testing.T, manifest ManifestItem) (map[string]string, []st
 	require.NoError(t, err)
 	require.Empty(t, errs)
 	require.Len(t, writer.addOptions, 1)
+	// Metadata rides on the add options; a post-add mutation raced the sync
+	// cache and failed for a torrent qBittorrent had accepted (#2259).
+	require.Empty(t, writer.postAdd, "added torrents must not get post-add category/tag calls")
 
 	return writer.addOptions[0], warnings
 }
@@ -94,8 +105,11 @@ func TestApplyTorrentPlanUsesCategoryPlacementWhenNoSavePath(t *testing.T) {
 		Hash:     "deadbeef",
 		Name:     "Ordinary Torrent",
 		Category: &category,
+		Tags:     []string{"tag-a", "tag-b"},
 	})
 
+	require.Equal(t, "movies", options["category"], "add must carry the category")
+	require.Equal(t, "tag-a,tag-b", options["tags"], "add must carry the tags")
 	require.Equal(t, "true", options["autoTMM"], "category-managed torrents must request qB category placement")
 	_, hasSavePath := options["savepath"]
 	require.False(t, hasSavePath, "category-managed torrents must not pin a redundant save path")


### PR DESCRIPTION
## Description

Restore sends `category` and `tags` in the `AddTorrent` options. It then called `SetCategory` and `SetTags` for the same hash. `SetCategory` first looks for that hash in the sync cache. A restore that qBittorrent accepted can therefore report `set_category: no valid torrents found to set category`. This change removes both calls after the add, because the add already applies the values.

A retry with a limit is not sufficient. go-qbt collapses concurrent syncs into one request. The forced sync inside `SetCategory` can therefore return maindata that qBittorrent sent before the add. In one test the torrent was present for 150 ms and the check still failed.

Fixes #2259

## How has this been tested?

I reproduced the reported error against qBittorrent 5.2.2 in Docker. With background syncs, 5 of 10 adds failed. A proxy that delays only the maindata response makes the failure deterministic. qBittorrent applies the category, the tags, the save path, and Auto TMM from the add options alone.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [x] I ran `make precommit` and the tests pass locally
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored torrents now receive their categories and tags during creation, improving consistency and avoiding follow-up update failures.
  * Restore operations no longer report errors from separate category or tag updates after a torrent is added.

* **Tests**
  * Enhanced restore coverage to verify that categories and tags are applied correctly during torrent creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->