### PR TITLE
fix(jackett): warn when a search runs without indexer capabilities

### DIFF
--- a/internal/services/jackett/caps_rate_limit_test.go
+++ b/internal/services/jackett/caps_rate_limit_test.go
@@ -8,9 +8,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 
 	"github.com/autobrr/qui/internal/models"
 )
@@ -25,6 +29,29 @@ const bookOnlyCapsXML = `<?xml version="1.0" encoding="UTF-8"?>
     <category id="7000" name="Books"/>
   </categories>
 </caps>`
+
+const emptyCapsXML = `<?xml version="1.0" encoding="UTF-8"?>
+<caps>
+  <searching>
+    <search available="no" supportedParams="q"/>
+  </searching>
+  <categories/>
+</caps>`
+
+// countCapsWarnings counts the caps-blind warnings emitted while the test runs.
+func countCapsWarnings(t *testing.T) *atomic.Int32 {
+	t.Helper()
+
+	var count atomic.Int32
+	original := log.Logger
+	log.Logger = original.Hook(zerolog.HookFunc(func(_ *zerolog.Event, level zerolog.Level, msg string) {
+		if level >= zerolog.WarnLevel && strings.Contains(msg, "Searching without indexer capabilities") {
+			count.Add(1)
+		}
+	}))
+	t.Cleanup(func() { log.Logger = original })
+	return &count
+}
 
 func assertSingleCapsFetch(t *testing.T, requests <-chan string) {
 	t.Helper()
@@ -49,6 +76,7 @@ func TestApplyIndexerRestrictionsCapsFetchRateLimit(t *testing.T) {
 		wantRateLimited  bool
 		wantCooldown     bool
 		wantCapsCalls    int32
+		wantCapsWarnings int32
 	}{
 		{
 			name:            "caps 429 skips indexer and applies cooldown",
@@ -59,11 +87,23 @@ func TestApplyIndexerRestrictionsCapsFetchRateLimit(t *testing.T) {
 			wantCapsCalls:   1,
 		},
 		{
-			name:          "caps 500 keeps fail-open",
-			capsStatus:    http.StatusInternalServerError,
-			wantSkip:      false,
-			wantCooldown:  false,
-			wantCapsCalls: 1,
+			name:             "caps 500 keeps fail-open and warns",
+			capsStatus:       http.StatusInternalServerError,
+			wantSkip:         false,
+			wantCooldown:     false,
+			wantCapsCalls:    1,
+			wantCapsWarnings: 1,
+		},
+		{
+			// A 200 that advertises no search modes stores nothing and returns no
+			// error, so the search degrades exactly as a failed fetch does.
+			name:             "caps 200 without search modes warns",
+			capsStatus:       http.StatusOK,
+			capsBody:         emptyCapsXML,
+			wantSkip:         false,
+			wantCooldown:     false,
+			wantCapsCalls:    1,
+			wantCapsWarnings: 1,
 		},
 		{
 			name:          "healed caps without tv-search skip via caps gate without cooldown",
@@ -85,6 +125,8 @@ func TestApplyIndexerRestrictionsCapsFetchRateLimit(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			capsWarnings := countCapsWarnings(t)
+
 			var capsCalls atomic.Int32
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				capsCalls.Add(1)
@@ -127,7 +169,43 @@ func TestApplyIndexerRestrictionsCapsFetchRateLimit(t *testing.T) {
 			if got := capsCalls.Load(); got != tt.wantCapsCalls {
 				t.Fatalf("caps fetches = %d, want %d", got, tt.wantCapsCalls)
 			}
+			if got := capsWarnings.Load(); got != tt.wantCapsWarnings {
+				t.Fatalf("caps warnings = %d, want %d", got, tt.wantCapsWarnings)
+			}
 		})
+	}
+}
+
+// One indexer that cannot serve caps must not fill the log.
+func TestCapsUnavailableWarningIsSuppressedWithinCooldown(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	capsWarnings := countCapsWarnings(t)
+
+	idx := &models.TorznabIndexer{
+		ID:      92,
+		Name:    "EmptyCaps",
+		BaseURL: server.URL,
+		Backend: models.TorznabBackendProwlarr,
+		Enabled: true,
+	}
+	service := NewService(&mockTorznabIndexerStore{indexers: []*models.TorznabIndexer{idx}})
+	t.Cleanup(service.searchScheduler.Stop)
+
+	client := NewClient(server.URL, "key", nil, nil, models.TorznabBackendProwlarr, 5)
+	meta := &searchContext{searchMode: "tvsearch"}
+
+	for range 3 {
+		if skipped, _ := service.applyIndexerRestrictions(t.Context(), client, idx, "42", meta, map[string]string{"q": "some show", "season": "1"}); skipped {
+			t.Fatal("applyIndexerRestrictions skipped the indexer, want fail-open")
+		}
+	}
+
+	if got := capsWarnings.Load(); got != 1 {
+		t.Fatalf("caps warnings = %d, want 1", got)
 	}
 }
 

--- a/internal/services/jackett/service.go
+++ b/internal/services/jackett/service.go
@@ -76,6 +76,8 @@ type Service struct {
 	rateLimiterRestoreOnce sync.Once
 	persistedCooldowns     map[int]time.Time
 	persistedCooldownsMu   sync.RWMutex
+	capsWarnedAt           map[int]time.Time
+	capsWarnedAtMu         sync.Mutex
 	torrentCache           *models.TorznabTorrentCacheStore
 	searchCache            searchCacheStore
 	searchCacheTTL         time.Duration
@@ -297,6 +299,7 @@ func NewService(indexerStore IndexerStore, opts ...ServiceOption) *Service {
 		rateLimiter:        rl,
 		searchScheduler:    newSearchScheduler(rl, defaultMaxWorkers),
 		persistedCooldowns: make(map[int]time.Time),
+		capsWarnedAt:       make(map[int]time.Time),
 		searchCacheTTL:     defaultSearchCacheTTL,
 		searchCacheEnabled: true,
 		activityPublisher:  activity.NopPublisher{},
@@ -2352,6 +2355,9 @@ func (s *Service) applyIndexerRestrictions(ctx context.Context, client *Client, 
 			s.handleRateLimit(ctx, idx, cooldown, err)
 			return true, true
 		}
+		if needCaps && len(idx.Capabilities) == 0 {
+			s.warnCapsUnavailable(idx, err)
+		}
 	}
 
 	// Check capabilities first - use enhanced capability checking if we have search parameters
@@ -3297,6 +3303,30 @@ func (s *Service) isCooldownPersisted(indexerID int) bool {
 
 	_, ok := s.persistedCooldowns[indexerID]
 	return ok
+}
+
+// capsUnavailableWarnCooldown keeps one indexer that cannot serve caps from filling the log.
+const capsUnavailableWarnCooldown = time.Hour
+
+// warnCapsUnavailable reports, at most once per cooldown, that this search runs
+// caps-blind and takes the TV token fallback (#2245). err is nil when the fetch
+// succeeded but stored no capabilities.
+func (s *Service) warnCapsUnavailable(idx *models.TorznabIndexer, err error) {
+	now := time.Now()
+
+	s.capsWarnedAtMu.Lock()
+	if now.Sub(s.capsWarnedAt[idx.ID]) < capsUnavailableWarnCooldown {
+		s.capsWarnedAtMu.Unlock()
+		return
+	}
+	s.capsWarnedAt[idx.ID] = now
+	s.capsWarnedAtMu.Unlock()
+
+	log.Warn().
+		Err(err).
+		Int("indexer_id", idx.ID).
+		Str("indexer", idx.Name).
+		Msg("Searching without indexer capabilities. TV season and episode parameters fall back to a query token and can return no results. Run Sync caps on this indexer.")
 }
 
 func requiredCapabilities(meta *searchContext) []string {


### PR DESCRIPTION
## Description

A torznab caps fetch that fails without a rate limit leaves the capability list empty. qui keeps searching, which is deliberate, but a Prowlarr TV search then folds an SxxEyy token into `q` and returns nothing on indexers that match series titles instead of release names. The only signal was a Debug record, and every config file written before v1.25.0 pins `logLevel = "INFO"`, so the installed base cannot see it.

This warns once per indexer per hour when the capability list is still empty after the heal attempt. The condition is "caps still empty", not "the heal returned an error", so it also covers a fetch that succeeds but advertises no search modes and a failed capability write, which both return no error. The search sends the same parameters as before and the indexer is still not skipped.

Fixes #2245


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unavailable indexer capabilities during metadata loading.
  * Added clearer warnings when TV searches may fall back to query tokens.
  * Prevented repeated capability warnings from appearing more than once per indexer per hour.
  * Added warnings for additional rate-limit scenarios, including server errors and responses without search modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->