### PR TITLE
fix(arr): keep live positive ID-cache rows over concurrent negative writes

### DIFF
--- a/internal/models/arr_id_cache.go
+++ b/internal/models/arr_id_cache.go
@@ -127,11 +127,15 @@ func (s *ArrIDCacheStore) Set(ctx context.Context, titleHash, contentType string
 }
 
 // SetWithTitles creates or updates a cache entry with known ARR title aliases.
+// A negative write never replaces a live positive row: concurrent lookups of the
+// same title can race, and a slower no-ID result must not hide freshly resolved
+// IDs for the negative TTL (#2300). Positive writes always win.
 func (s *ArrIDCacheStore) SetWithTitles(ctx context.Context, titleHash, contentType string, arrInstanceID *int, ids *ExternalIDs, titles []string, isNegative bool, ttl time.Duration) error {
 	// Store expires_at in UTC so the bound-UTC comparisons in Get/CleanupExpired/
 	// CountValid are timezone-independent. Without .UTC() the value carries the
 	// process-local offset and the cache silently misses in non-UTC zones (#1961).
-	expiresAt := time.Now().Add(ttl).UTC()
+	now := time.Now().UTC()
+	expiresAt := now.Add(ttl)
 
 	// Prepare nullable values
 	var imdbID, titlesJSON *string
@@ -173,9 +177,12 @@ func (s *ArrIDCacheStore) SetWithTitles(ctx context.Context, titleHash, contentT
 			is_negative = excluded.is_negative,
 			cached_at = CURRENT_TIMESTAMP,
 			expires_at = excluded.expires_at
+		WHERE excluded.is_negative = 0
+			OR arr_id_cache.is_negative = 1
+			OR arr_id_cache.expires_at <= ?
 	`
 
-	_, err := s.db.ExecContext(ctx, query, titleHash, contentType, arrInstanceID, imdbID, tmdbID, tvdbID, tvmazeID, titlesJSON, BoolToSQLite(isNegative), expiresAt)
+	_, err := s.db.ExecContext(ctx, query, titleHash, contentType, arrInstanceID, imdbID, tmdbID, tvdbID, tvmazeID, titlesJSON, BoolToSQLite(isNegative), expiresAt, now)
 	if err != nil {
 		return fmt.Errorf("failed to set arr id cache entry: %w", err)
 	}

--- a/internal/models/arr_id_cache_test.go
+++ b/internal/models/arr_id_cache_test.go
@@ -106,3 +106,66 @@ func TestArrIDCacheStore_GetReturnsNegativeEntryInNonUTCTimezone(t *testing.T) {
 	require.True(t, entry.IsNegative)
 	require.True(t, entry.ExternalIDs.IsEmpty())
 }
+
+// TestArrIDCacheStore_NegativeWriteDoesNotClobberLivePositive is the #2300 guard:
+// concurrent lookups of the same title can race, and the slower one may resolve
+// nothing. Its negative write must not replace freshly cached IDs, or every
+// search for that title goes ID-less until the negative TTL expires.
+func TestArrIDCacheStore_NegativeWriteDoesNotClobberLivePositive(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := testdb.NewMigratedSQLite(t, "arr-id-cache-negative-clobber")
+	store := models.NewArrIDCacheStore(db)
+	ids := &models.ExternalIDs{IMDbID: "tt1234567", TMDbID: 42}
+
+	t.Run("negative loses to live positive", func(t *testing.T) {
+		require.NoError(t, store.Set(ctx, "race", "movie", nil, ids, false, time.Hour))
+		require.NoError(t, store.Set(ctx, "race", "movie", nil, nil, true, time.Hour))
+
+		entry, err := store.Get(ctx, "race", "movie")
+		require.NoError(t, err)
+		require.False(t, entry.IsNegative)
+		require.Equal(t, *ids, entry.ExternalIDs)
+	})
+
+	t.Run("positive replaces negative", func(t *testing.T) {
+		require.NoError(t, store.Set(ctx, "neg-first", "movie", nil, nil, true, time.Hour))
+		require.NoError(t, store.Set(ctx, "neg-first", "movie", nil, ids, false, time.Hour))
+
+		entry, err := store.Get(ctx, "neg-first", "movie")
+		require.NoError(t, err)
+		require.False(t, entry.IsNegative)
+		require.Equal(t, *ids, entry.ExternalIDs)
+	})
+
+	t.Run("positive refreshes positive", func(t *testing.T) {
+		newer := &models.ExternalIDs{IMDbID: "tt7654321", TMDbID: 7}
+		require.NoError(t, store.Set(ctx, "refresh", "movie", nil, ids, false, time.Hour))
+		require.NoError(t, store.Set(ctx, "refresh", "movie", nil, newer, false, time.Hour))
+
+		entry, err := store.Get(ctx, "refresh", "movie")
+		require.NoError(t, err)
+		require.Equal(t, *newer, entry.ExternalIDs)
+	})
+
+	t.Run("negative replaces expired positive", func(t *testing.T) {
+		require.NoError(t, store.Set(ctx, "expired", "movie", nil, ids, false, -time.Minute))
+		require.NoError(t, store.Set(ctx, "expired", "movie", nil, nil, true, time.Hour))
+
+		// Get filters expired rows, so read the row state via CountValid semantics:
+		// the negative entry must be the live one.
+		entry, err := store.Get(ctx, "expired", "movie")
+		require.NoError(t, err)
+		require.True(t, entry.IsNegative)
+	})
+
+	t.Run("negative refreshes negative", func(t *testing.T) {
+		require.NoError(t, store.Set(ctx, "neg-refresh", "movie", nil, nil, true, time.Minute))
+		require.NoError(t, store.Set(ctx, "neg-refresh", "movie", nil, nil, true, time.Hour))
+
+		entry, err := store.Get(ctx, "neg-refresh", "movie")
+		require.NoError(t, err)
+		require.True(t, entry.IsNegative)
+	})
+}

--- a/internal/models/postgres_bool_args_test.go
+++ b/internal/models/postgres_bool_args_test.go
@@ -293,7 +293,8 @@ func TestArrIDCacheSetUsesIntegerNegativeArg(t *testing.T) {
 	store := NewArrIDCacheStore(q)
 	err := store.Set(context.Background(), "title-hash", "movie", nil, nil, false, time.Hour)
 	require.NoError(t, err)
-	require.Len(t, insertArgs, 10)
+	// 10 insert columns plus the now bound in the upsert's expired-row check (#2300).
+	require.Len(t, insertArgs, 11)
 
 	isNegativeArg, ok := insertArgs[8].(int)
 	require.Truef(t, ok, "expected int arg for is_negative, got %T", insertArgs[8])


### PR DESCRIPTION
## Description

The `arr_id_cache` upsert was last-writer-wins across every column, including `is_negative`. Two concurrent `LookupExternalIDs` calls for the same title can both miss the cache; if one resolves IDs and the slower one resolves nothing, the late negative write replaced the freshly cached positive row — every later search then took the negative entry as authoritative and skipped ARR for the full negative TTL, silently hiding a valid match.

The upsert now carries a guard: a write only replaces the existing row when the incoming row is positive, or the existing row is negative or expired. Net effect: positive writes always win, negative writes can only refresh negatives or reclaim expired rows. No schema change; the shared query stays portable across SQLite and Postgres (`is_negative` is INTEGER in both, and the extra `now` comparison uses a bound UTC value like the other expiry comparisons from #1961).

Closes #2300

## Testing

- New store-level regression table (`TestArrIDCacheStore_NegativeWriteDoesNotClobberLivePositive`): negative-after-positive keeps the positive row; positive-after-negative wins; positive refreshes positive; negative replaces an expired positive; negative refreshes negative.
- `TestArrIDCacheSetUsesIntegerNegativeArg` updated for the extra bound argument.
- `go test -race -count=1 ./internal/models/ ./internal/services/arr/`, `make precommit`, `make build`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented temporary negative cache results from overwriting valid, unexpired positive results.
  * Ensured expired cache entries can be replaced and refreshed correctly.
* **Tests**
  * Added coverage for cache overwrite, refresh, and expiration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->