### PR TITLE
feat(crossseed): let file extensions correct the search category

### DIFF
--- a/internal/services/crossseed/parsing.go
+++ b/internal/services/crossseed/parsing.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"path"
 	"regexp"
 	"strings"
 
@@ -143,9 +144,94 @@ func detectRIAJMediaType(title string) string {
 	return ""
 }
 
+// audioFileExtensions lists the extensions of standalone audio content for the
+// byte-weighted signal in DetermineContentTypeWithFiles. It is deliberately a
+// separate list from gazellePlausibleExtensions: that one encodes what RED/OPS
+// host, this one encodes what is audio.
+var audioFileExtensions = map[string]bool{
+	".flac": true,
+	".mp3":  true,
+	".m4a":  true,
+	".m4b":  true,
+	".aac":  true,
+	".ac3":  true,
+	".dts":  true,
+	".ogg":  true,
+	".opus": true,
+	".wav":  true,
+	".aiff": true,
+	".dsf":  true,
+	".dff":  true,
+	".dsd":  true,
+	".wma":  true,
+	".ape":  true,
+	".alac": true,
+	".wv":   true,
+	".mka":  true,
+	".tta":  true,
+	".aob":  true,
+}
+
+// dominantFileContent reports which class of content holds the majority of a
+// torrent's bytes: rls.Music for audio, rls.Movie for video, or rls.Unknown
+// when neither dominates. It weighs total bytes per class instead of picking
+// the largest file, because booklet scans and cover art outweigh individual
+// tracks in many music releases.
+//
+// ponytail: videoExtensions is the season-pack list and misses .vob, .mpg,
+// .webm, and .m4v; those torrents fall through to name-based classification.
+// Widen the list if field reports show it.
+func dominantFileContent(files qbt.TorrentFiles) rls.Type {
+	var audioBytes, videoBytes, totalBytes int64
+	for _, file := range files {
+		ext := strings.ToLower(path.Ext(file.Name))
+		if audioFileExtensions[ext] {
+			audioBytes += file.Size
+		} else if _, ok := videoExtensions[ext]; ok {
+			videoBytes += file.Size
+		}
+		totalBytes += file.Size
+	}
+	switch {
+	case audioBytes > 0 && audioBytes >= totalBytes-audioBytes:
+		return rls.Music
+	case videoBytes > 0 && videoBytes >= totalBytes-videoBytes:
+		return rls.Movie
+	}
+	return rls.Unknown
+}
+
+// DetermineContentTypeWithFiles classifies a release like DetermineContentType,
+// but first corrects the parsed type with the byte-weighted extension signal
+// from the torrent's files (discussion #1734). Release names often defeat the
+// rls parser, music names most of all, but file extensions are ground truth:
+// audio bytes force the music classification, and video bytes pull a music
+// parse back to tv or movie. The tv/movie split stays with the name-based
+// parse. Without files, or when neither class dominates, the name decides.
+func DetermineContentTypeWithFiles(release *rls.Release, files qbt.TorrentFiles) ContentTypeInfo {
+	dominant := dominantFileContent(files)
+	if dominant == rls.Music {
+		if release.Type != rls.Music && release.Type != rls.Audiobook {
+			adjusted := *release
+			adjusted.Type = rls.Music
+			release = &adjusted
+		}
+		// Skip the music-to-video name rescue: the bytes are audio, so a
+		// video-looking token in the name must not flip the type back.
+		return classifyRelease(release)
+	}
+	if dominant == rls.Movie && release.Type == rls.Music {
+		return classifyRelease(demoteMusicToVideo(release))
+	}
+	return DetermineContentType(release)
+}
+
 // DetermineContentType analyzes a release and returns comprehensive content type information
 func DetermineContentType(release *rls.Release) ContentTypeInfo {
-	release = normalizeReleaseTypeForContent(release)
+	return classifyRelease(normalizeReleaseTypeForContent(release))
+}
+
+func classifyRelease(release *rls.Release) ContentTypeInfo {
 	var info ContentTypeInfo
 
 	// Apply stacked parsing for clarity and to avoid false-positives
@@ -307,21 +393,24 @@ func DetermineContentType(release *rls.Release) ContentTypeInfo {
 // misclassifications (e.g. video torrents parsed as music because of dash-separated
 // folder names such as BDMV/STREAM paths).
 func normalizeReleaseTypeForContent(release *rls.Release) *rls.Release {
+	if release.Type == rls.Music && looksLikeVideoRelease(release) {
+		return demoteMusicToVideo(release)
+	}
+
 	normalized := *release
-	if normalized.Type != rls.Music {
-		return &normalized
-	}
-
-	if looksLikeVideoRelease(&normalized) {
-		// Preserve episode metadata when present so TV content keeps season info.
-		if normalized.Series > 0 || normalized.Episode > 0 {
-			normalized.Type = rls.Episode
-		} else {
-			normalized.Type = rls.Movie
-		}
-	}
-
 	return &normalized
+}
+
+// demoteMusicToVideo returns a copy of a music-typed release retyped as video.
+// Episode metadata is preserved when present so TV content keeps season info.
+func demoteMusicToVideo(release *rls.Release) *rls.Release {
+	demoted := *release
+	if demoted.Series > 0 || demoted.Episode > 0 {
+		demoted.Type = rls.Episode
+	} else {
+		demoted.Type = rls.Movie
+	}
+	return &demoted
 }
 
 func looksLikeVideoRelease(release *rls.Release) bool {

--- a/internal/services/crossseed/parsing_test.go
+++ b/internal/services/crossseed/parsing_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	qbt "github.com/autobrr/go-qbittorrent"
 	"github.com/autobrr/go-torrent/metainfo"
 	"github.com/moistari/rls"
 	"github.com/stretchr/testify/assert"
@@ -320,6 +321,172 @@ func TestDetermineContentType(t *testing.T) {
 			assert.Equal(t, tt.wantSearch, result.SearchType)
 			assert.Equal(t, tt.wantCaps, result.RequiredCaps)
 			assert.Equal(t, tt.wantIsMusic, result.IsMusic)
+		})
+	}
+}
+
+// TestDetermineContentTypeWithFiles covers discussion #1734: file extensions
+// are ground truth for the audio/video split, so a byte-weighted extension
+// signal overrides the name-based type when the two disagree.
+func TestDetermineContentTypeWithFiles(t *testing.T) {
+	audioFiles := qbt.TorrentFiles{
+		{Name: "Artist - Album (2019) [FLAC]/01 - Track.flac", Size: 40_000_000},
+		{Name: "Artist - Album (2019) [FLAC]/cover.jpg", Size: 900_000},
+	}
+	videoFiles := qbt.TorrentFiles{
+		{Name: "Release/release.mkv", Size: 8_000_000_000},
+		{Name: "Release/release.nfo", Size: 4_000},
+	}
+
+	tests := []struct {
+		name        string
+		release     rls.Release
+		files       qbt.TorrentFiles
+		wantType    string
+		wantIsMusic bool
+	}{
+		{
+			name:        "audio files force music over a tv parse",
+			release:     rls.Release{Type: rls.Episode, Title: "Test Album", Series: 1, Episode: 1},
+			files:       audioFiles,
+			wantType:    "music",
+			wantIsMusic: true,
+		},
+		{
+			name:        "audio files force music over a movie parse",
+			release:     rls.Release{Type: rls.Movie, Title: "Test Album", Year: 2019},
+			files:       audioFiles,
+			wantType:    "music",
+			wantIsMusic: true,
+		},
+		{
+			name:        "audio files force music over an unknown parse",
+			release:     rls.Release{Type: rls.Unknown, Title: "weird_name_2019"},
+			files:       audioFiles,
+			wantType:    "music",
+			wantIsMusic: true,
+		},
+		{
+			// The music-to-video name rescue must not undo the file signal:
+			// a music parse with a video-looking token stays music when the
+			// bytes are audio.
+			name:        "audio files beat video tokens in the name",
+			release:     rls.Release{Type: rls.Music, Title: "Test Album", Resolution: "1080p"},
+			files:       audioFiles,
+			wantType:    "music",
+			wantIsMusic: true,
+		},
+		{
+			name:        "video files rewrite a music parse with episode metadata to tv",
+			release:     rls.Release{Type: rls.Music, Title: "Test Show", Series: 2, Episode: 3},
+			files:       videoFiles,
+			wantType:    "tv",
+			wantIsMusic: false,
+		},
+		{
+			name:        "video files rewrite a music parse without episode metadata to movie",
+			release:     rls.Release{Type: rls.Music, Title: "Test Title"},
+			files:       videoFiles,
+			wantType:    "movie",
+			wantIsMusic: false,
+		},
+		{
+			name:        "video files keep a movie parse unchanged",
+			release:     rls.Release{Type: rls.Movie, Title: "Test Movie", Year: 2019},
+			files:       videoFiles,
+			wantType:    "movie",
+			wantIsMusic: false,
+		},
+		{
+			name:        "audio files keep a music parse music",
+			release:     rls.Release{Type: rls.Music, Artist: "Test Artist", Title: "Test Album"},
+			files:       audioFiles,
+			wantType:    "music",
+			wantIsMusic: true,
+		},
+		{
+			name:        "audio files keep an audiobook parse audiobook",
+			release:     rls.Release{Type: rls.Audiobook, Title: "Test Audiobook"},
+			files:       qbt.TorrentFiles{{Name: "Author - Book/book.m4b", Size: 300_000_000}},
+			wantType:    "audiobook",
+			wantIsMusic: true,
+		},
+		{
+			name:    "video bytes dominate a movie with a soundtrack folder",
+			release: rls.Release{Type: rls.Music, Title: "Test Title"},
+			files: qbt.TorrentFiles{
+				{Name: "Movie/movie.mkv", Size: 8_000_000_000},
+				{Name: "Movie/Soundtrack/01 - theme.mp3", Size: 9_000_000},
+			},
+			wantType:    "movie",
+			wantIsMusic: false,
+		},
+		{
+			// Booklet scans outweigh individual tracks in many lossy releases;
+			// the signal weighs total bytes per class, not the largest file.
+			name:    "audio bytes dominate an album with booklet scans",
+			release: rls.Release{Type: rls.Unknown, Title: "Test Album"},
+			files: qbt.TorrentFiles{
+				{Name: "Album/01.mp3", Size: 9_000_000},
+				{Name: "Album/02.mp3", Size: 9_000_000},
+				{Name: "Album/Scans/booklet.tif", Size: 12_000_000},
+			},
+			wantType:    "music",
+			wantIsMusic: true,
+		},
+		{
+			// Ties go to the content class, mirroring the RED/OPS gate.
+			name:    "audio wins an exact byte tie",
+			release: rls.Release{Type: rls.Unknown, Title: "Test Album"},
+			files: qbt.TorrentFiles{
+				{Name: "Album/01.flac", Size: 10_000_000},
+				{Name: "Album/booklet.pdf", Size: 10_000_000},
+			},
+			wantType:    "music",
+			wantIsMusic: true,
+		},
+		{
+			name:    "video wins an exact byte tie",
+			release: rls.Release{Type: rls.Music, Title: "Test Title"},
+			files: qbt.TorrentFiles{
+				{Name: "Release/release.mkv", Size: 10_000_000},
+				{Name: "Release/cover.jpg", Size: 10_000_000},
+			},
+			wantType:    "movie",
+			wantIsMusic: false,
+		},
+		{
+			name:        "uppercase audio extension still counts",
+			release:     rls.Release{Type: rls.Episode, Title: "Test Album", Series: 1},
+			files:       qbt.TorrentFiles{{Name: "Album/01 - Track.FLAC", Size: 40_000_000}},
+			wantType:    "music",
+			wantIsMusic: true,
+		},
+		{
+			name:        "no files falls back to the name-based rescue",
+			release:     rls.Release{Type: rls.Music, Title: "Test Title", Resolution: "1080p"},
+			files:       qbt.TorrentFiles{},
+			wantType:    "movie",
+			wantIsMusic: false,
+		},
+		{
+			name:        "neither class dominant falls back to the name",
+			release:     rls.Release{Type: rls.Book, Title: "Test Book"},
+			files:       qbt.TorrentFiles{{Name: "Author - Book.epub", Size: 2_000_000}},
+			wantType:    "book",
+			wantIsMusic: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := DetermineContentTypeWithFiles(&tt.release, tt.files)
+
+			assert.Equal(t, tt.wantType, result.ContentType)
+			assert.Equal(t, tt.wantIsMusic, result.IsMusic)
+			if tt.wantIsMusic {
+				assert.Equal(t, []int{3000}, result.Categories)
+			}
 		})
 	}
 }

--- a/internal/services/crossseed/search_music_query_test.go
+++ b/internal/services/crossseed/search_music_query_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package crossseed
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/moistari/rls"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/services/jackett"
+	"github.com/autobrr/qui/internal/testutil/testdb"
+	"github.com/autobrr/qui/pkg/stringutils"
+)
+
+const musicQuerySourceHash = "5f2b1c4d3e6a7089bacd1122334455667788990a"
+
+// Regression: the file-extension signal forces the music content type on releases whose
+// name parses as tv, because a numeric album title reads as a season or an episode. The
+// Torznab request must then be music-shaped too: the album title has to survive into the
+// query, and the season or episode the name parse invented must not reach the indexer.
+func TestSearchTorrentMatches_ForcedMusicBuildsMusicQuery(t *testing.T) {
+	tests := []struct {
+		name        string
+		sourceName  string
+		wantInQuery string
+	}{
+		{
+			name:        "numeric album title parses as an episode",
+			sourceName:  "Sable Wren - 9 (2025) [WEB FLAC]",
+			wantInQuery: "9",
+		},
+		{
+			name:        "album title parses as a series",
+			sourceName:  "Sable Wren - Season 2 (2024) WEB FLAC",
+			wantInQuery: "Season 2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var mu sync.Mutex
+			var params []url.Values
+
+			tracker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Query().Get("t") != "caps" {
+					mu.Lock()
+					params = append(params, r.URL.Query())
+					mu.Unlock()
+				}
+				w.Header().Set("Content-Type", "application/xml")
+				_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"><channel></channel></rss>`))
+			}))
+			t.Cleanup(tracker.Close)
+
+			sourceTorrent := qbt.Torrent{
+				Hash:     musicQuerySourceHash,
+				Name:     tt.sourceName,
+				Progress: 1.0,
+				Size:     100,
+				Tracker:  "https://example.invalid/announce",
+			}
+			sourceFiles := qbt.TorrentFiles{
+				{Name: tt.sourceName + "/01. Opening Track.flac", Size: 100},
+			}
+
+			ctx := context.Background()
+			db := testdb.NewMigratedSQLite(t, "crossseed-forced-music-query")
+			instanceStore, err := models.NewInstanceStore(db, []byte("01234567890123456789012345678901"))
+			require.NoError(t, err)
+			instance, err := instanceStore.Create(ctx, "Test", "http://localhost:8080", "user", "pass", nil, nil, false, nil)
+			require.NoError(t, err)
+
+			svc := &Service{
+				instanceStore: instanceStore,
+				jackettService: jackett.NewService(&gettableIndexerStore{failingEnabledIndexerStore{indexers: []*models.TorznabIndexer{
+					{
+						ID:           1,
+						Name:         "Generic Indexer",
+						Enabled:      true,
+						BaseURL:      tracker.URL,
+						Backend:      models.TorznabBackendNative,
+						Capabilities: []string{"search", "music-search", "audio-search"},
+						Categories:   []models.TorznabIndexerCategory{{IndexerID: 1, CategoryID: 3000, CategoryName: "Audio"}},
+					},
+				}}}),
+				syncManager: &gazelleSkipHashSyncManager{
+					torrents: []qbt.Torrent{sourceTorrent},
+					filesByHash: map[string]qbt.TorrentFiles{
+						strings.ToLower(musicQuerySourceHash): sourceFiles,
+					},
+				},
+				releaseCache:     NewReleaseCache(),
+				stringNormalizer: stringutils.NewDefaultNormalizer(),
+			}
+
+			sourceRelease := svc.releaseCache.Parse(tt.sourceName)
+			require.True(t, sourceRelease.Series > 0 || sourceRelease.Episode > 0,
+				"fixture only exercises the fix while the name parses with TV structure")
+			contentDetectionRelease, _ := svc.selectContentDetectionRelease(tt.sourceName, sourceRelease, sourceFiles)
+			require.NotEqual(t, rls.Music, contentDetectionRelease.Type,
+				"fixture only exercises the fix while the detection release is not already music")
+			require.Equal(t, "music", DetermineContentTypeWithFiles(contentDetectionRelease, sourceFiles).ContentType,
+				"fixture must be forced to music by the file signal")
+
+			// nil gazelle clients: this source is not a gazelle tracker, and a client set here
+			// would send the fixture out to the real RED/OPS hosts.
+			_, _, _, err = svc.searchTorrentMatches(ctx, instance.ID, musicQuerySourceHash, TorrentSearchOptions{IndexerIDs: []int{1}}, nil)
+			require.NoError(t, err)
+
+			mu.Lock()
+			defer mu.Unlock()
+			require.NotEmpty(t, params, "indexer was never queried")
+			for _, p := range params {
+				require.Contains(t, p.Get("q"), tt.wantInQuery,
+					"album title must survive into the query, not just the artist")
+				require.Empty(t, p.Get("season"), "music search must not carry a season")
+				require.Empty(t, p.Get("ep"), "music search must not carry an episode")
+			}
+		})
+	}
+}

--- a/internal/services/crossseed/search_query.go
+++ b/internal/services/crossseed/search_query.go
@@ -35,7 +35,15 @@ func BuildTorznabQuery(name string, release *rls.Release, isMusic bool) SearchQu
 	if isMusic && baseQuery != "" && release.Artist != "" {
 		baseQuery = release.Artist + " " + baseQuery
 	}
-	return buildSafeSearchQuery(name, release, baseQuery)
+	query := buildSafeSearchQuery(name, release, baseQuery)
+	if isMusic {
+		// Torznab audio searches carry no season or episode. A numeric album title
+		// parses as an episode number ("9" reads as episode 9), which would send
+		// ep=9 to the indexer and drop every result.
+		query.Season = nil
+		query.Episode = nil
+	}
+	return query
 }
 
 // buildSafeSearchQuery constructs a conservative Torznab query for TV/anime when parsing is weak.

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -7004,7 +7004,7 @@ func (s *Service) AnalyzeTorrentForSearchAsync(ctx context.Context, instanceID i
 	contentDetectionRelease, _ := s.selectContentDetectionRelease(sourceTorrent.Name, sourceRelease, sourceFiles)
 
 	// Use unified content type detection
-	contentInfo := DetermineContentType(contentDetectionRelease)
+	contentInfo := DetermineContentTypeWithFiles(contentDetectionRelease, sourceFiles)
 
 	// Detect disc layout
 	isDiscLayout, discMarker := isDiscLayoutTorrent(sourceFiles)
@@ -8206,7 +8206,7 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 	contentDetectionRelease, _ := s.selectContentDetectionRelease(sourceTorrent.Name, sourceRelease, sourceFiles)
 
 	// Use unified content type detection with expanded categories for search
-	contentInfo := DetermineContentType(contentDetectionRelease)
+	contentInfo := DetermineContentTypeWithFiles(contentDetectionRelease, sourceFiles)
 	searchRelease := s.selectSourceReleaseForSearch(sourceRelease, contentDetectionRelease, sourceFiles, contentInfo)
 	// Keep contentInfo as the Torznab category decision; searchRelease is selected from it
 	// so later release matching follows the same search mode.

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -6698,7 +6698,9 @@ func (s *Service) selectContentDetectionRelease(torrentName string, sourceReleas
 	// Special case: file has explicit episode markers → trust it for TV detection
 	// Handles season packs where torrent name has year but files have episode numbers
 	// Only apply when titles match (to avoid unrelated files in wrong folders)
-	if contentMismatch && !titleMismatch && fileContent.ContentType == "tv" && sourceContent.ContentType == "movie" {
+	// Music too: series folders like "Show (2006)" parse as music and lose the markers.
+	if contentMismatch && !titleMismatch && fileContent.ContentType == "tv" &&
+		(sourceContent.ContentType == "movie" || sourceContent.ContentType == "music") {
 		if largestRelease.Episode > 0 || largestRelease.Series > 0 {
 			log.Debug().
 				Str("torrentName", torrentName).

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -8293,8 +8293,10 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 	query := strings.TrimSpace(opts.Query)
 	var seasonPtr, episodePtr *int
 	queryRelease := searchRelease
-	if contentInfo.IsMusic && contentDetectionRelease.Type == rls.Music {
-		// For music, create a proper music release object by parsing the torrent name as music
+	if contentInfo.ContentType == "music" {
+		// Keyed on the content type, not the parsed type: the file-extension signal forces music
+		// on releases whose name parsed as tv or movie, and those need the artist/album re-parse
+		// too. Audiobooks are excluded here only; they still take the music query shaping below.
 		queryRelease = ParseMusicReleaseFromTorrentName(sourceRelease, sourceTorrent.Name)
 	}
 	if query == "" {
@@ -8553,7 +8555,7 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 		}
 
 		// Add season/episode info for TV content only if not already set by safe query
-		if searchRelease.Series > 0 && searchReq.Season == nil {
+		if !contentInfo.IsMusic && searchRelease.Series > 0 && searchReq.Season == nil {
 			season := searchRelease.Series
 			searchReq.Season = &season
 
@@ -8568,37 +8570,28 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 			searchReq.Year = searchRelease.Year
 		}
 
-		// Use the appropriate release object for logging based on content type
-		var logRelease rls.Release
-		if contentInfo.IsMusic && contentDetectionRelease.Type == rls.Music {
-			// For music, create a proper music release object by parsing the torrent name as music
-			logRelease = *ParseMusicReleaseFromTorrentName(sourceRelease, sourceTorrent.Name)
-		} else {
-			logRelease = *searchRelease
-		}
-
 		logEvent := log.Debug().
 			Str("torrentName", sourceTorrent.Name).
 			Str("contentType", contentInfo.ContentType).
 			Ints("categories", contentInfo.Categories).
-			Int("year", logRelease.Year)
+			Int("year", queryRelease.Year)
 
 		// Show different metadata based on content type
 		if !contentInfo.IsMusic {
 			// For TV/Movies, show series/episode data
 			logEvent = logEvent.
-				Str("releaseType", logRelease.Type.String()).
-				Int("series", logRelease.Series).
-				Int("episode", logRelease.Episode)
+				Str("releaseType", queryRelease.Type.String()).
+				Int("series", queryRelease.Series).
+				Int("episode", queryRelease.Episode)
 		} else {
 			// For music, show music-specific metadata
 			logEvent = logEvent.
 				Str("releaseType", "music").
-				Str("artist", logRelease.Artist).
-				Str("title", logRelease.Title).
-				Str("disc", logRelease.Disc).
-				Str("source", logRelease.Source).
-				Str("group", logRelease.Group)
+				Str("artist", queryRelease.Artist).
+				Str("title", queryRelease.Title).
+				Str("disc", queryRelease.Disc).
+				Str("source", queryRelease.Source).
+				Str("group", queryRelease.Group)
 		}
 
 		logEvent.Msg("[CROSSSEED-SEARCH] Applied RLS-based content type filtering")

--- a/internal/services/crossseed/source_release_inference.go
+++ b/internal/services/crossseed/source_release_inference.go
@@ -98,7 +98,7 @@ func (s *Service) deriveTVReleaseFromFiles(name string, parsed *rls.Release, fil
 	}
 
 	contentDetectionRelease, _ := s.selectContentDetectionRelease(name, parsed, files)
-	contentInfo := DetermineContentType(contentDetectionRelease)
+	contentInfo := DetermineContentTypeWithFiles(contentDetectionRelease, files)
 	derived := s.selectSourceReleaseForSearch(parsed, contentDetectionRelease, files, contentInfo)
 	if !isTVRelease(derived) {
 		return nil

--- a/internal/services/crossseed/source_release_inference_test.go
+++ b/internal/services/crossseed/source_release_inference_test.go
@@ -176,6 +176,27 @@ func TestSelectSourceReleaseForSearch_UsesTVDetectionReleaseForTVCategories(t *t
 	require.Equal(t, 37, *query.Episode)
 }
 
+func TestSelectContentDetectionRelease_MusicNameKeepsEpisodeMarkersFromFiles(t *testing.T) {
+	svc := &Service{
+		releaseCache:     NewReleaseCache(),
+		stringNormalizer: stringutils.NewDefaultNormalizer(),
+	}
+
+	sourceName := "Space Badgers From Pluto (2011)"
+	source := svc.releaseCache.Parse(sourceName)
+	require.NotNil(t, source)
+	require.Equal(t, "music", DetermineContentType(source).ContentType,
+		"fixture only exercises the fix while the torrent name classifies as music")
+
+	files := qbt.TorrentFiles{
+		{Name: sourceName + "/Space Badgers from Pluto (2011) - 101 - The Journey Starts [abc123].avi", Size: 1},
+	}
+
+	contentDetectionRelease, usedFile := svc.selectContentDetectionRelease(sourceName, source, files)
+	require.True(t, usedFile, "episode markers in the files must win over a music name parse")
+	require.Equal(t, "tv", DetermineContentTypeWithFiles(contentDetectionRelease, files).ContentType)
+}
+
 func TestSelectSourceReleaseForSearch_SeasonPackKeepsTorrentIdentity(t *testing.T) {
 	svc := &Service{
 		releaseCache:     NewReleaseCache(),


### PR DESCRIPTION
## Description

Cross-seed sometimes searches music releases as TV, Movie, or Unknown because only the release name is parsed, and music names often defeat the parser (discussion #1734). This adds a byte-weighted file-extension signal, generalized from the RED/OPS content gate: audio-dominant bytes force the music category, and video-dominant bytes pull a music parse back to tv or movie. The tv/movie split stays with the name-based parse. A follow-up PR adds manual qBittorrent-category rules for the cases no automatic detection can get right.

Forcing the category is not enough on its own, so two follow-on fixes are included. The Torznab request now follows the content type instead of the name parse, because a forced-music release was searching the artist alone with the album title dropped. Audio searches also no longer carry a season or an episode, which a numeric album title used to produce. Separately, episode markers found in file names now survive a name that parses as music, so a series folder named like `Show Name (2006)` is searched as tv instead of movie.

Link: #1734

## How has this been tested?

Table-driven unit tests for the new signal, including byte ties, booklet-scan weighting, and uppercase extensions. The query fixes have end-to-end tests that assert the outgoing Torznab parameters.

Field-tested against a live instance with about 6300 torrents across a music library and a TV/movie library. Replaying the full library through the classifier showed 170 torrents change category, all of them corrections. Manual searches confirmed the classification, the query, and the indexer selection in the logs.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [x] I ran `make precommit` and the tests pass locally
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved content detection by analyzing torrent file extensions alongside release names.
  * More accurately distinguishes music, video, TV, movies, and audiobooks, including mixed-content and uppercase file extensions.
  * Episode markers in files can now correctly identify TV content even when the release name suggests music.

* **Bug Fixes**
  * Reduced incorrect content classifications during torrent searches and analysis.
  * Prevented album titles containing numbers from being treated as TV episode or season numbers in music searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->