### PR TITLE
test(crossseed): stop the suite from calling the real trackers

### DIFF
--- a/internal/services/crossseed/search_run_partial_failure_test.go
+++ b/internal/services/crossseed/search_run_partial_failure_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/autobrr/qui/internal/models"
 	internalqb "github.com/autobrr/qui/internal/qbittorrent"
-	"github.com/autobrr/qui/internal/services/crossseed/gazellemusic"
 	"github.com/autobrr/qui/internal/testutil/testdb"
 )
 
@@ -66,13 +65,7 @@ func newSearchRunLoopFixture(t *testing.T, dbName string, syncManager *hashFilte
 	clients, err := gazelleClientsForTest()
 	require.NoError(t, err)
 
-	prevFindMatch := findGazelleMatch
-	findGazelleMatch = func(_ context.Context, _ *gazellemusic.Client, _ []byte, _ map[string]int64, _ int64) (*gazellemusic.Match, error) {
-		return nil, nil
-	}
-	t.Cleanup(func() {
-		findGazelleMatch = prevFindMatch
-	})
+	stubGazelleMatchLookup(t)
 
 	run, err := store.CreateSearchRun(ctx, &models.CrossSeedSearchRun{
 		InstanceID:      instance.ID,

--- a/internal/services/crossseed/service_completion_gazelle_test.go
+++ b/internal/services/crossseed/service_completion_gazelle_test.go
@@ -173,7 +173,8 @@ func (m *completionGazelleSyncMock) CreateCategory(context.Context, int, string,
 }
 
 func TestHandleTorrentCompletion_AllowsGazelleWhenJackettMissing(t *testing.T) {
-	t.Parallel()
+	// Not parallel: the test stubs the package-level findGazelleMatch.
+	stubGazelleMatchLookup(t)
 
 	db, err := sql.Open("sqlite", "file:completion_gazelle_guard?mode=memory&cache=shared")
 	if err != nil {
@@ -246,7 +247,8 @@ func TestHandleTorrentCompletion_AllowsGazelleWhenJackettMissing(t *testing.T) {
 }
 
 func TestExecuteCompletionSearch_GazelleSourceSkipsTorznab(t *testing.T) {
-	t.Parallel()
+	// Not parallel: the test stubs the package-level findGazelleMatch.
+	stubGazelleMatchLookup(t)
 
 	db := testdb.NewMigratedSQLite(t, "completion-gazelle-search")
 

--- a/internal/services/crossseed/service_search_test.go
+++ b/internal/services/crossseed/service_search_test.go
@@ -6,6 +6,8 @@ package crossseed
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"sync/atomic"
@@ -1542,6 +1544,9 @@ func TestSearchTorrentMatches_GazelleTargetHashSkipReturnsNoBackendWithoutTorzna
 	sourceHash := "223759985c562a644428312c8cd3585d04686847"
 	sourceHashNorm := strings.ToLower(sourceHash)
 
+	// Stub keeps a broken skip from reaching the live tracker.
+	stubGazelleMatchLookup(t)
+
 	svc := &Service{
 		instanceStore:    instanceStore,
 		automationStore:  store,
@@ -1691,6 +1696,9 @@ func TestSearchTorrentMatches_DisableTorznabAllowsGazellePrefilterOnlySkip(t *te
 		Size:     123,
 		Tracker:  "https://orpheus.network/announce",
 	}
+
+	// Stub keeps a broken skip from reaching the live tracker.
+	stubGazelleMatchLookup(t)
 
 	svc := &Service{
 		instanceStore:    instanceStore,
@@ -2351,8 +2359,41 @@ func TestSearchRunLoop_FilteredIndexersDoesNotSleepWithoutRemoteRequest(t *testi
 	require.False(t, found)
 }
 
+// gazelleTestServer stands in for the real Gazelle APIs so tests never send
+// requests to the live trackers. Registering its host is what lets NewClient
+// accept a loopback base URL: it rejects hosts outside KnownTrackers.
+var gazelleTestServer = func() *httptest.Server {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unexpected gazelle API call: "+r.URL.Path, http.StatusNotImplemented)
+	}))
+	host := server.Listener.Addr().String()
+	gazellemusic.KnownTrackers[host] = gazellemusic.TrackerSpec{
+		Host:       host,
+		RateLimit:  1000,
+		RatePeriod: 1,
+		SourceFlag: "OPS",
+	}
+	return server
+}()
+
+// stubGazelleMatchLookup keeps a test off the real tracker APIs when it builds a
+// client through buildGazelleClientSet, which always points at the live hosts.
+// Callers must not be parallel: findGazelleMatch is a package variable.
+func stubGazelleMatchLookup(t *testing.T) {
+	t.Helper()
+	prevFindMatch := findGazelleMatch
+	findGazelleMatch = func(context.Context, *gazellemusic.Client, []byte, map[string]int64, int64) (*gazellemusic.Match, error) {
+		return nil, nil
+	}
+	t.Cleanup(func() {
+		findGazelleMatch = prevFindMatch
+	})
+}
+
+// gazelleClientsForTest returns a client set keyed by the real OPS host, because
+// host matching uses that key, but the client itself talks to the test server.
 func gazelleClientsForTest() (*gazelleClientSet, error) {
-	client, err := gazellemusic.NewClient("https://orpheus.network", "ops-key")
+	client, err := gazellemusic.NewClient(gazelleTestServer.URL, "ops-key")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

Two tests in the cross-seed completion path built a Gazelle client from settings and ran the match lookup against it, so every run of `go test ./internal/services/crossseed/` sent requests to the live OPS API with a fake key. Both tests passed either way, because the request error is swallowed by a warning.

The shared client helper now points at a test server instead of the real host, and the two tests that build a client through `buildGazelleClientSet` stub the match lookup. Two more tests stop one step short of a request only because of their fixture data, so they get the same stub to keep a fixture change from turning them into live requests.

## How has this been tested?

Measured with a local proxy that logs connection targets and forwards nothing. On develop the package makes two connections to the live OPS host; with this change it makes none, for the package and its subpackages under `-race`. The set of failing tests is unchanged.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [x] I ran `make precommit` and the tests pass locally
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved cross-seeding service test reliability by replacing live tracker requests with controlled test responses.
  - Standardized Gazelle match lookup stubbing across test scenarios.
  - Prevented test interference by running related completion tests sequentially.
  - Added coverage for tracker interactions using an isolated HTTP test server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->