### PR TITLE
refactor(crossseed): stop tests from reaching the live gazelle trackers

### DIFF
--- a/internal/services/crossseed/gazellemusic/client.go
+++ b/internal/services/crossseed/gazellemusic/client.go
@@ -10,11 +10,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
+	"testing"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -28,8 +31,33 @@ var sharedTransport = func() *http.Transport {
 	t.MaxIdleConnsPerHost = 10
 	t.IdleConnTimeout = 90 * time.Second
 	t.ForceAttemptHTTP2 = true
+	if testing.Testing() {
+		blockLiveTrackerDials(t)
+	}
 	return t
 }()
+
+// blockLiveTrackerDials stops the test suite from reaching a real tracker.
+// The tracker APIs are rate limited per account, so a stray call from a test
+// spends the maintainer's budget on every run. Callers log a failed lookup as a
+// warning and carry on, so a returned error would keep the test green: this
+// panics instead, which no caller can swallow.
+func blockLiveTrackerDials(t *http.Transport) {
+	t.Proxy = nil // an HTTP_PROXY on the test process would route around the check below
+	dialer := &net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second}
+	// Control receives the address after DNS resolution, so a host name is
+	// already an IP here and needs no separate lookup.
+	dialer.Control = func(_, address string, _ syscall.RawConn) error {
+		if host, _, err := net.SplitHostPort(address); err == nil {
+			if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+				return nil
+			}
+		}
+		panic("gazellemusic: test tried to dial a live tracker at " + address +
+			" (give NewClient a test server baseURL, or stub the lookup)")
+	}
+	t.DialContext = dialer.DialContext
+}
 
 // sharedLimiters ensures we don't create one rate limiter per qBittorrent instance/client.
 // Rate limits are per tracker host and must be shared across the whole qui process.
@@ -160,23 +188,26 @@ func sharedLimiterForTracker(spec TrackerSpec) (*rate.Limiter, error) {
 	return actual.(*rate.Limiter), nil
 }
 
-func NewClient(serverURL, apiKey string) (*Client, error) {
-	parsed, err := url.Parse(serverURL)
-	if err != nil {
-		return nil, fmt.Errorf("invalid server URL: %w", err)
-	}
-	host := parsed.Host
+// NewClient builds a client for one of the KnownTrackers. trackerHost is the
+// tracker's identity: it selects the rate limit and the source flag. baseURL is
+// the address to talk to, and is empty outside tests, where it means the
+// tracker's own site.
+func NewClient(trackerHost, baseURL, apiKey string) (*Client, error) {
+	host := strings.ToLower(strings.TrimSpace(trackerHost))
 	spec, ok := KnownTrackers[host]
 	if !ok {
-		return nil, fmt.Errorf("unsupported gazelle host: %s", host)
+		return nil, fmt.Errorf("unsupported gazelle host: %s", trackerHost)
 	}
 	limiter, err := sharedLimiterForTracker(spec)
 	if err != nil {
 		return nil, err
 	}
+	if strings.TrimSpace(baseURL) == "" {
+		baseURL = "https://" + host
+	}
 
 	return &Client{
-		baseURL: serverURL,
+		baseURL: baseURL,
 		apiKey:  apiKey,
 		httpClient: &http.Client{
 			Timeout:   30 * time.Second,

--- a/internal/services/crossseed/gazellemusic/client_test.go
+++ b/internal/services/crossseed/gazellemusic/client_test.go
@@ -1,13 +1,18 @@
 package gazellemusic
 
-import "testing"
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
 
 func TestNewClient_SharesLimiterPerHost(t *testing.T) {
-	c1, err := NewClient("https://redacted.sh", "key1")
+	c1, err := NewClient("redacted.sh", "", "key1")
 	if err != nil {
 		t.Fatalf("NewClient 1: %v", err)
 	}
-	c2, err := NewClient("https://redacted.sh", "key2")
+	c2, err := NewClient("redacted.sh", "", "key2")
 	if err != nil {
 		t.Fatalf("NewClient 2: %v", err)
 	}
@@ -18,11 +23,11 @@ func TestNewClient_SharesLimiterPerHost(t *testing.T) {
 }
 
 func TestNewClient_DifferentHostsHaveDifferentLimiters(t *testing.T) {
-	red, err := NewClient("https://redacted.sh", "key1")
+	red, err := NewClient("redacted.sh", "", "key1")
 	if err != nil {
 		t.Fatalf("NewClient red: %v", err)
 	}
-	ops, err := NewClient("https://orpheus.network", "key2")
+	ops, err := NewClient("orpheus.network", "", "key2")
 	if err != nil {
 		t.Fatalf("NewClient ops: %v", err)
 	}
@@ -30,4 +35,58 @@ func TestNewClient_DifferentHostsHaveDifferentLimiters(t *testing.T) {
 	if red.limiter == ops.limiter {
 		t.Fatalf("expected different limiter instances across hosts")
 	}
+}
+
+func TestNewClient_DefaultsToTrackerSite(t *testing.T) {
+	c, err := NewClient("redacted.sh", "", "key")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	if c.baseURL != "https://redacted.sh" {
+		t.Fatalf("expected the tracker site as the default, got %q", c.baseURL)
+	}
+}
+
+// TestClientTalksToATestServer is the positive half of the dial guard: a client
+// pointed at a loopback server must still work, over the guarded transport.
+func TestClientTalksToATestServer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"status":"success","response":{"group":{"id":3,"name":"Album"},"torrent":{"id":7,"size":123}}}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient("orpheus.network", server.URL, "key")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if client.SourceFlag() != "OPS" {
+		t.Fatalf("expected the tracker identity to drive the source flag, got %q", client.SourceFlag())
+	}
+
+	result, err := client.SearchByHash(context.Background(), "abc")
+	if err != nil {
+		t.Fatalf("SearchByHash: %v", err)
+	}
+	if result == nil || result.TorrentID != 7 {
+		t.Fatalf("expected the test server's torrent, got %+v", result)
+	}
+}
+
+// TestDialGuardPanicsOnLiveTracker is the negative half. Calling the shared
+// transport's dialer directly keeps the panic on this goroutine, so it can be
+// recovered. Through an http.Client it lands on the transport's own dial
+// goroutine and takes the whole run down, which is the point: callers log a
+// failed lookup and carry on, so a returned error would keep the test green
+// while the request went out.
+func TestDialGuardPanicsOnLiveTracker(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected the dial guard to panic on a non-loopback address")
+		}
+	}()
+
+	// 192.0.2.1 is TEST-NET-1 (RFC 5737), reserved for documentation. The guard
+	// fires before connect, so nothing leaves the machine either way.
+	_, _ = sharedTransport.DialContext(t.Context(), "tcp", "192.0.2.1:9")
 }

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -8125,12 +8125,12 @@ func (s *Service) buildGazelleClientSet(ctx context.Context, settings *models.Cr
 		out := &gazelleClientSet{byHost: make(map[string]*gazellemusic.Client, 2)}
 		if settings != nil {
 			if key := strings.TrimSpace(settings.RedactedAPIKey); key != "" && !domain.IsRedactedString(key) {
-				if c, err := gazellemusic.NewClient("https://redacted.sh", key); err == nil {
+				if c, err := gazellemusic.NewClient("redacted.sh", "", key); err == nil {
 					out.byHost["redacted.sh"] = c
 				}
 			}
 			if key := strings.TrimSpace(settings.OrpheusAPIKey); key != "" && !domain.IsRedactedString(key) {
-				if c, err := gazellemusic.NewClient("https://orpheus.network", key); err == nil {
+				if c, err := gazellemusic.NewClient("orpheus.network", "", key); err == nil {
 					out.byHost["orpheus.network"] = c
 				}
 			}
@@ -8152,7 +8152,7 @@ func (s *Service) buildGazelleClientSet(ctx context.Context, settings *models.Cr
 		if !ok || strings.TrimSpace(key) == "" {
 			continue
 		}
-		client, err := gazellemusic.NewClient("https://"+strings.TrimSpace(host), key)
+		client, err := gazellemusic.NewClient(host, "", key)
 		if err != nil {
 			log.Warn().Err(err).Str("host", host).Msg("[CROSSSEED-GAZELLE] Failed to initialize client")
 			continue

--- a/internal/services/crossseed/service_search_test.go
+++ b/internal/services/crossseed/service_search_test.go
@@ -2360,21 +2360,10 @@ func TestSearchRunLoop_FilteredIndexersDoesNotSleepWithoutRemoteRequest(t *testi
 }
 
 // gazelleTestServer stands in for the real Gazelle APIs so tests never send
-// requests to the live trackers. Registering its host is what lets NewClient
-// accept a loopback base URL: it rejects hosts outside KnownTrackers.
-var gazelleTestServer = func() *httptest.Server {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "unexpected gazelle API call: "+r.URL.Path, http.StatusNotImplemented)
-	}))
-	host := server.Listener.Addr().String()
-	gazellemusic.KnownTrackers[host] = gazellemusic.TrackerSpec{
-		Host:       host,
-		RateLimit:  1000,
-		RatePeriod: 1,
-		SourceFlag: "OPS",
-	}
-	return server
-}()
+// requests to the live trackers.
+var gazelleTestServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "unexpected gazelle API call: "+r.URL.Path, http.StatusNotImplemented)
+}))
 
 // stubGazelleMatchLookup keeps a test off the real tracker APIs when it builds a
 // client through buildGazelleClientSet, which always points at the live hosts.
@@ -2393,7 +2382,7 @@ func stubGazelleMatchLookup(t *testing.T) {
 // gazelleClientsForTest returns a client set keyed by the real OPS host, because
 // host matching uses that key, but the client itself talks to the test server.
 func gazelleClientsForTest() (*gazelleClientSet, error) {
-	client, err := gazellemusic.NewClient(gazelleTestServer.URL, "ops-key")
+	client, err := gazellemusic.NewClient("orpheus.network", gazelleTestServer.URL, "ops-key")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

Two tests called the live OPS API on every run of the package until #2309. Neither test named a host: they built a `Service`, the `Service` built its clients against the hardcoded tracker URLs, and the request error was logged as a warning and dropped. The tests stayed green. This adds a dial guard that makes the same mistake loud. Under `go test`, the gazelle transport refuses to dial any address other than loopback, and panics. A returned error would land in that same warning path and keep the test green.

`NewClient` now takes the tracker identity and the base URL as separate arguments. The identity still selects the rate limit and the source flag. The URL is now plain data, so a test can point a client at a test server. This removes the write into the production `KnownTrackers` map from the test helper, and the copy of the OPS source flag that came with it. The guard covers the gazelle transport only, so the wider class in #2310 stays open. The shared rate limiter is unchanged: if a test ever makes more than one real request through a client, it shares the real OPS bucket of one request every two seconds.

Fixes #2310

## How has this been tested?

`make precommit` and `make build` pass.

`go test -race -count=1 ./internal/services/crossseed/...` gives the same failure set as `develop` without this change. The 24 season pack and link mode failures are pre-existing and unrelated.

The guard has a test in both directions. A client pointed at a loopback test server still works, and a dial to a non-loopback address panics. I disabled the guard to confirm that the second test fails without it.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [x] I ran `make precommit` and the tests pass locally
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracker connection handling by separating tracker identity from the request destination.
  * Added safer test protections to prevent accidental connections to live tracker addresses.
  * Improved defaulting to secure HTTPS tracker URLs when no base URL is provided.
  * Enhanced validation for tracker-specific configuration and local test server routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->