### PR TITLE
fix(orphanscan): compare paths case-insensitively

### DIFF
--- a/internal/services/orphanscan/delete.go
+++ b/internal/services/orphanscan/delete.go
@@ -27,6 +27,12 @@ const (
 // withinScanRoot checks that target is an absolute path strictly below scanRoot.
 // Comparison is case-folded, because the scan root and the target can carry
 // different casing of the same directory on a case-insensitive filesystem.
+//
+// The fold cannot let a delete escape the scan: target is always a path that a
+// walk of one of the run's scan roots produced, so a match that needs the fold
+// means the file sits under a different spelling of a root that was walked, not
+// under a directory nobody scanned. Only the fence is spelled differently; the
+// path handed to os.Remove is target itself.
 func withinScanRoot(scanRoot, target string) error {
 	if !filepath.IsAbs(target) {
 		return fmt.Errorf("refusing non-absolute path: %s", target)

--- a/internal/services/orphanscan/delete.go
+++ b/internal/services/orphanscan/delete.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 )
 
 // ErrInUse indicates a deletion target contains files currently in use by torrents.
@@ -25,24 +24,32 @@ const (
 	deleteDispositionSkippedIgnored
 )
 
+// withinScanRoot checks that target is an absolute path strictly below scanRoot.
+// Comparison is case-folded, because the scan root and the target can carry
+// different casing of the same directory on a case-insensitive filesystem.
+func withinScanRoot(scanRoot, target string) error {
+	if !filepath.IsAbs(target) {
+		return fmt.Errorf("refusing non-absolute path: %s", target)
+	}
+
+	normRoot := normalizePath(scanRoot)
+	normTarget := normalizePath(target)
+
+	if normTarget == normRoot {
+		return fmt.Errorf("refusing to delete scan root: %s", scanRoot)
+	}
+	if !isPathUnderNormalized(normTarget, normRoot) {
+		return fmt.Errorf("path escapes scan root: %s", target)
+	}
+	return nil
+}
+
 // safeDeleteFile removes a single file with safety checks.
 // Re-checks TorrentFileMap before deletion to handle torrents added since scan.
 // Never removes directories.
 func safeDeleteFile(scanRoot, target string, tfm *TorrentFileMap) (deleteDisposition, error) {
-	// Must be absolute
-	if !filepath.IsAbs(target) {
-		return 0, fmt.Errorf("refusing non-absolute path: %s", target)
-	}
-
-	// Must not be the scan root itself
-	if filepath.Clean(target) == filepath.Clean(scanRoot) {
-		return 0, fmt.Errorf("refusing to delete scan root: %s", scanRoot)
-	}
-
-	// Must be within scan root (no path traversal)
-	rel, err := filepath.Rel(scanRoot, target)
-	if err != nil || strings.HasPrefix(rel, "..") {
-		return 0, fmt.Errorf("path escapes scan root: %s", target)
+	if err := withinScanRoot(scanRoot, target); err != nil {
+		return 0, err
 	}
 
 	// Re-check: torrent may have been added since scan (skip)
@@ -69,21 +76,6 @@ func safeDeleteFile(scanRoot, target string, tfm *TorrentFileMap) (deleteDisposi
 		return 0, err
 	}
 	return deleteDispositionDeleted, nil
-}
-
-// validateDeleteTarget checks that target is a valid deletion candidate.
-func validateDeleteTarget(scanRoot, target string) error {
-	if !filepath.IsAbs(target) {
-		return fmt.Errorf("refusing non-absolute path: %s", target)
-	}
-	if filepath.Clean(target) == filepath.Clean(scanRoot) {
-		return fmt.Errorf("refusing to delete scan root: %s", scanRoot)
-	}
-	rel, err := filepath.Rel(scanRoot, target)
-	if err != nil || strings.HasPrefix(rel, "..") {
-		return fmt.Errorf("path escapes scan root: %s", target)
-	}
-	return nil
 }
 
 // checkDirContainsInUseFile walks a directory and returns ErrInUse if any file is in the TorrentFileMap.
@@ -120,7 +112,7 @@ func checkFileInUse(path string, tfm *TorrentFileMap) error {
 // the directory is currently referenced by TorrentFileMap or protected by ignorePaths.
 // Symlinks are never followed.
 func safeDeleteTarget(scanRoot, target string, tfm *TorrentFileMap, ignorePaths []string) (deleteDisposition, error) {
-	if err := validateDeleteTarget(scanRoot, target); err != nil {
+	if err := withinScanRoot(scanRoot, target); err != nil {
 		return 0, err
 	}
 	if len(ignorePaths) > 0 && isPathProtectedByIgnorePaths(target, ignorePaths) {
@@ -176,24 +168,12 @@ func safeDeleteDirectory(target string, tfm *TorrentFileMap) (deleteDisposition,
 
 // safeDeleteEmptyDir removes a directory only if empty. Never recursive.
 func safeDeleteEmptyDir(scanRoot, target string) error {
-	// Must be absolute
-	if !filepath.IsAbs(target) {
-		return fmt.Errorf("refusing non-absolute path: %s", target)
-	}
-
-	// Must not be the scan root itself
-	if filepath.Clean(target) == filepath.Clean(scanRoot) {
-		return fmt.Errorf("refusing to delete scan root: %s", scanRoot)
-	}
-
-	// Must be within scan root (no path traversal)
-	rel, err := filepath.Rel(scanRoot, target)
-	if err != nil || strings.HasPrefix(rel, "..") {
-		return fmt.Errorf("path escapes scan root: %s", target)
+	if err := withinScanRoot(scanRoot, target); err != nil {
+		return err
 	}
 
 	// os.Remove on a directory only succeeds if it's empty
-	err = os.Remove(target)
+	err := os.Remove(target)
 	if os.IsNotExist(err) {
 		return nil // Already gone
 	}
@@ -207,10 +187,10 @@ func collectCandidateDirsForCleanup(files []string, scanRoots []string, ignorePa
 		if scanRoot == "" {
 			continue
 		}
-		scanRoot = filepath.Clean(scanRoot)
+		normScanRoot := normalizePath(scanRoot)
 
 		dir := filepath.Clean(filepath.Dir(filePath))
-		for dir != scanRoot {
+		for normalizePath(dir) != normScanRoot {
 			if dir == "." || dir == string(filepath.Separator) {
 				break
 			}

--- a/internal/services/orphanscan/delete_test.go
+++ b/internal/services/orphanscan/delete_test.go
@@ -598,3 +598,127 @@ func TestOrphanScan_RecoverStuckRuns_MarksDeletingFailedImmediately(t *testing.T
 		t.Fatalf("expected pending run unchanged, got %q", pendingRun.Status)
 	}
 }
+
+// A case-insensitive filesystem can hand the deletion flow a target spelled
+// differently from the file map entry and from the scan root it was found under.
+// Neither may lead to deleting an owned file. See issue #2314.
+func TestSafeDeleteTarget_CaseDifferentOwnedFileIsSkipped(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	trackerDir := filepath.Join(root, "trackername")
+	if err := os.MkdirAll(trackerDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	target := filepath.Join(trackerDir, "Show.S01E01.mkv")
+	if err := os.WriteFile(target, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	// Owned under the other casing of the same directory.
+	tfm := NewTorrentFileMap()
+	tfm.Add(filepath.Join(root, "TrackerName", "Show.S01E01.mkv"))
+
+	disp, err := safeDeleteTarget(root, target, tfm, nil)
+	if err != nil {
+		t.Fatalf("safeDeleteTarget file: %v", err)
+	}
+	if disp != deleteDispositionSkippedInUse {
+		t.Fatalf("expected skipped-in-use disposition, got %v", disp)
+	}
+	if _, err := os.Stat(target); err != nil {
+		t.Fatalf("expected owned file to remain, stat err=%v", err)
+	}
+
+	// Same guard when the target is the directory (recursive delete path).
+	disp, err = safeDeleteTarget(root, trackerDir, tfm, nil)
+	if err != nil {
+		t.Fatalf("safeDeleteTarget dir: %v", err)
+	}
+	if disp != deleteDispositionSkippedInUse {
+		t.Fatalf("expected skipped-in-use disposition for directory, got %v", disp)
+	}
+	if _, err := os.Stat(target); err != nil {
+		t.Fatalf("expected owned file to survive directory delete, stat err=%v", err)
+	}
+}
+
+func TestWithinScanRoot_CaseDifferentScanRootDoesNotEscape(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	root := filepath.Join(base, "cross-seed", "TrackerName")
+	target := filepath.Join(base, "cross-seed", "trackername", "Show.S01E01.mkv")
+
+	if err := withinScanRoot(root, target); err != nil {
+		t.Fatalf("expected target inside scan root, got %v", err)
+	}
+	if err := withinScanRoot(root, strings.ToLower(root)); err == nil ||
+		!strings.Contains(err.Error(), "refusing to delete scan root") {
+		t.Fatalf("expected refusal to delete the scan root itself, got %v", err)
+	}
+	outside := filepath.Join(base, "cross-seed", "other", "movie.mkv")
+	if err := withinScanRoot(root, outside); err == nil ||
+		!strings.Contains(err.Error(), "escapes scan root") {
+		t.Fatalf("expected escape error for %q, got %v", outside, err)
+	}
+}
+
+// safeDeleteTarget routes symlinks to safeDeleteSymlink, whose in-use re-check
+// folds case like every other one.
+func TestSafeDeleteSymlink_CaseDifferentOwnedLinkIsSkipped(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	payload := filepath.Join(root, "payload.mkv")
+	if err := os.WriteFile(payload, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	link := filepath.Join(root, "Linked.mkv")
+	if err := os.Symlink(payload, link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	tfm := NewTorrentFileMap()
+	tfm.Add(filepath.Join(root, "linked.mkv"))
+
+	disp, err := safeDeleteTarget(root, link, tfm, nil)
+	if err != nil {
+		t.Fatalf("safeDeleteTarget symlink: %v", err)
+	}
+	if disp != deleteDispositionSkippedInUse {
+		t.Fatalf("expected skipped-in-use disposition, got %v", disp)
+	}
+	if _, err := os.Lstat(link); err != nil {
+		t.Fatalf("expected symlink to remain, lstat err=%v", err)
+	}
+
+	// Not owned: the link goes, under its real (unfolded) name.
+	disp, err = safeDeleteTarget(root, link, NewTorrentFileMap(), nil)
+	if err != nil {
+		t.Fatalf("safeDeleteTarget symlink: %v", err)
+	}
+	if disp != deleteDispositionDeleted {
+		t.Fatalf("expected deleted disposition, got %v", disp)
+	}
+	if _, err := os.Lstat(link); !os.IsNotExist(err) {
+		t.Fatalf("expected symlink removed, lstat err=%v", err)
+	}
+}
+
+// The empty-directory cleanup walks up from a deleted file to its scan root,
+// which can be spelled differently on a case-insensitive filesystem.
+func TestCollectCandidateDirsForCleanup_CaseDifferentScanRoot(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	scanRoot := filepath.Join(base, "TrackerName")
+	deleted := filepath.Join(base, "trackername", "Show.S01", "Show.S01E01.mkv")
+
+	got := collectCandidateDirsForCleanup([]string{deleted}, []string{scanRoot}, nil)
+
+	want := []string{filepath.Join(base, "trackername", "Show.S01")}
+	if len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("expected candidate dirs %v, got %v", want, got)
+	}
+}

--- a/internal/services/orphanscan/filemap.go
+++ b/internal/services/orphanscan/filemap.go
@@ -5,15 +5,12 @@ package orphanscan
 
 import (
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"unicode/utf8"
 
 	"golang.org/x/text/unicode/norm"
 )
-
-const goosWindows = "windows"
 
 // TorrentFileMap is a thread-safe set of file paths belonging to torrents.
 type TorrentFileMap struct {
@@ -100,19 +97,16 @@ func (m *TorrentFileMap) MergeFrom(other *TorrentFileMap) int {
 	return added
 }
 
-// normalizePath cleans and normalizes a path for consistent comparison.
+// cleanPath cleans a path without changing its casing.
 // Uses filepath.Clean (OS-specific separators) and NFC unicode normalization to
 // avoid mismatches between canonically-equivalent strings (e.g. composed vs
 // decomposed forms on some platforms).
 // Tradeoff: canonically-equivalent names collapse to one key, so byte-distinct
 // NFC/NFD twins on normalization-sensitive filesystems are treated as one path.
-// On Windows, we also case-fold to lower to match filesystem semantics and
-// avoid false orphans from drive-letter/path casing differences.
-func normalizePath(path string) string {
+// Use this when the result is shown to the user or stored; use normalizePath
+// when the result is only compared against another path.
+func cleanPath(path string) string {
 	p := filepath.Clean(path)
-	if runtime.GOOS == goosWindows {
-		p = strings.ToLower(p)
-	}
 	// On Unix, paths can contain arbitrary bytes (not always valid UTF-8).
 	// Avoid normalizing invalid UTF-8 to prevent replacing bytes with U+FFFD.
 	if !utf8.ValidString(p) {
@@ -122,6 +116,30 @@ func normalizePath(path string) string {
 		p = norm.NFC.String(p)
 	}
 	return p
+}
+
+// normalizePath cleans a path and case-folds it for consistent comparison.
+//
+// Case-folding is unconditional because runtime.GOOS cannot answer whether the
+// scanned filesystem is case-insensitive: macOS APFS and Windows volumes are
+// case-insensitive by default, and Docker bind-mounts them into a Linux
+// container, where qBittorrent can report two save paths that differ only by
+// case for one physical directory.
+//
+// ponytail: an orphan whose path differs from an owned file only by case is no
+// longer detected on a genuinely case-sensitive filesystem. That direction is
+// safe (a missed orphan, never a deleted owned file). Upgrade path if it is
+// ever reported: keep a folded secondary index and confirm hits with
+// os.SameFile.
+//
+// The result is for comparison only. It must never reach an os.* call or the
+// database, because on a case-sensitive filesystem it can name a different file.
+func normalizePath(path string) string {
+	p := cleanPath(path)
+	if !utf8.ValidString(p) {
+		return p
+	}
+	return cleanPath(strings.ToLower(p))
 }
 
 // canonicalizeHash matches SyncManager's internal hash normalization.

--- a/internal/services/orphanscan/filemap.go
+++ b/internal/services/orphanscan/filemap.go
@@ -126,20 +126,24 @@ func cleanPath(path string) string {
 // container, where qBittorrent can report two save paths that differ only by
 // case for one physical directory.
 //
-// ponytail: an orphan whose path differs from an owned file only by case is no
-// longer detected on a genuinely case-sensitive filesystem. That direction is
-// safe (a missed orphan, never a deleted owned file). Upgrade path if it is
-// ever reported: keep a folded secondary index and confirm hits with
-// os.SameFile.
+// Invalid UTF-8 is folded too. strings.ToLower and encoding/json replace a bad
+// byte the same way, so the fold is what lets a name read from disk match the
+// same name after a round trip through the qBittorrent API. Do not add a
+// utf8.ValidString guard here: an owned file whose name carries a non-UTF-8
+// byte is then reported as an orphan and deleted.
+//
+// ToLower can turn an NFC string into a non-NFC one (H + U+0331 becomes U+1E96),
+// so the folded result is cleaned again.
+//
+// ponytail: names that differ only by case, or only in which invalid bytes they
+// carry, collapse to one key. That direction is safe (a missed orphan, never a
+// deleted owned file). Upgrade path if it is ever reported: keep a folded
+// secondary index and confirm hits with os.SameFile.
 //
 // The result is for comparison only. It must never reach an os.* call or the
 // database, because on a case-sensitive filesystem it can name a different file.
 func normalizePath(path string) string {
-	p := cleanPath(path)
-	if !utf8.ValidString(p) {
-		return p
-	}
-	return cleanPath(strings.ToLower(p))
+	return cleanPath(strings.ToLower(cleanPath(path)))
 }
 
 // canonicalizeHash matches SyncManager's internal hash normalization.

--- a/internal/services/orphanscan/filemap_test.go
+++ b/internal/services/orphanscan/filemap_test.go
@@ -5,7 +5,6 @@ package orphanscan
 
 import (
 	"path/filepath"
-	"runtime"
 	"testing"
 	"unicode/utf8"
 )
@@ -63,9 +62,6 @@ func TestNormalizePath_UnicodeCanonicalEquivalence(t *testing.T) {
 
 func TestNormalizePath_InvalidUTF8Preserved(t *testing.T) {
 	t.Parallel()
-	if runtime.GOOS == goosWindows {
-		t.Skip("windows path handling lower-cases before UTF-8 check")
-	}
 
 	// On Unix, filenames are arbitrary bytes; ensure we don't replace invalid
 	// sequences with U+FFFD during normalization.
@@ -82,17 +78,17 @@ func TestNormalizePath_InvalidUTF8Preserved(t *testing.T) {
 	}
 }
 
-func TestNormalizePath_WindowsCaseInsensitive(t *testing.T) {
+// Case-insensitive filesystems (APFS, NTFS, exFAT, SMB, and Docker bind mounts
+// of them) let qBittorrent report two spellings of one directory. Comparison
+// must fold on every OS, not only on Windows.
+func TestNormalizePath_CaseInsensitive(t *testing.T) {
 	t.Parallel()
 
-	if runtime.GOOS != goosWindows {
-		t.Skip("windows-only path normalization")
-	}
-
-	p1 := normalizePath(`L:\movies\Code.8.2019.1080p.AMZN.WEB-DL.DDP5.1.H.264-NTG.mkv`)
-	p2 := normalizePath(`l:\MOVIES\Code.8.2019.1080p.AMZN.WEB-DL.DDP5.1.H.264-NTG.mkv`)
+	sep := string(filepath.Separator)
+	p1 := normalizePath(filepath.Join(sep, "downloads", "cross-seed", "TrackerName", "Show.S01E01.mkv"))
+	p2 := normalizePath(filepath.Join(sep, "downloads", "cross-seed", "trackername", "show.s01e01.mkv"))
 	if p1 != p2 {
-		t.Fatalf("expected normalized paths equal on windows:\n  %q\n  %q", p1, p2)
+		t.Fatalf("expected normalized paths equal:\n  %q\n  %q", p1, p2)
 	}
 
 	m := NewTorrentFileMap()
@@ -102,15 +98,12 @@ func TestNormalizePath_WindowsCaseInsensitive(t *testing.T) {
 	}
 }
 
-func TestFindScanRoot_WindowsCaseInsensitive(t *testing.T) {
+func TestFindScanRoot_CaseInsensitive(t *testing.T) {
 	t.Parallel()
 
-	if runtime.GOOS != goosWindows {
-		t.Skip("windows-only path matching")
-	}
-
-	root := `l:\movies`
-	path := `L:\movies\Code.8.2019.1080p.AMZN.WEB-DL.DDP5.1.H.264-NTG.mkv`
+	sep := string(filepath.Separator)
+	root := filepath.Join(sep, "downloads", "cross-seed", "trackername")
+	path := filepath.Join(sep, "downloads", "cross-seed", "TrackerName", "Show.S01E01.mkv")
 
 	got := findScanRoot(path, []string{root})
 	if got != root {

--- a/internal/services/orphanscan/filemap_test.go
+++ b/internal/services/orphanscan/filemap_test.go
@@ -4,6 +4,7 @@
 package orphanscan
 
 import (
+	"encoding/json"
 	"path/filepath"
 	"testing"
 	"unicode/utf8"
@@ -60,11 +61,11 @@ func TestNormalizePath_UnicodeCanonicalEquivalence(t *testing.T) {
 	}
 }
 
-func TestNormalizePath_InvalidUTF8Preserved(t *testing.T) {
+func TestCleanPath_InvalidUTF8Preserved(t *testing.T) {
 	t.Parallel()
 
-	// On Unix, filenames are arbitrary bytes; ensure we don't replace invalid
-	// sequences with U+FFFD during normalization.
+	// On Unix, filenames are arbitrary bytes. cleanPath is the form that is
+	// stored in settings and shown to the user, so it must keep them verbatim.
 	bad := string([]byte{0xff, 0xfe})
 	if utf8.ValidString(bad) {
 		t.Fatalf("expected test string to be invalid UTF-8")
@@ -72,9 +73,44 @@ func TestNormalizePath_InvalidUTF8Preserved(t *testing.T) {
 
 	p := filepath.Join("downloads", bad, "file.mkv")
 	want := filepath.Clean(p)
-	got := normalizePath(p)
+	got := cleanPath(p)
 	if got != want {
 		t.Fatalf("expected invalid UTF-8 path preserved:\n  %q\n  %q", got, want)
+	}
+}
+
+// Imported content (cp1252, FAT, old rips) can carry bytes that are not valid
+// UTF-8. The walker reads those bytes from disk verbatim, but the same name
+// arrives from the qBittorrent API with each bad byte replaced by U+FFFD.
+// Comparison must coerce both sides the same way, or an owned file is reported
+// as an orphan and deleted.
+func TestNormalizePath_InvalidUTF8MatchesAPIForm(t *testing.T) {
+	t.Parallel()
+
+	onDisk := filepath.Join("downloads", "Keep", "mo"+string([]byte{0xff})+"vie.mkv")
+	if utf8.ValidString(onDisk) {
+		t.Fatalf("expected on-disk name to be invalid UTF-8")
+	}
+
+	encoded, err := json.Marshal(onDisk)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var viaAPI string
+	if err := json.Unmarshal(encoded, &viaAPI); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !utf8.ValidString(viaAPI) {
+		t.Fatalf("expected API form to be valid UTF-8")
+	}
+
+	// Add normalizes internally; Has takes the already-normalized form, exactly as
+	// the walker does for each path it reads off disk.
+	m := NewTorrentFileMap()
+	m.Add(viaAPI)
+	if !m.Has(normalizePath(onDisk)) {
+		t.Fatalf("owned file must match its API spelling:\n  disk %q -> %q\n  api  %q -> %q",
+			onDisk, normalizePath(onDisk), viaAPI, normalizePath(viaAPI))
 	}
 }
 

--- a/internal/services/orphanscan/service.go
+++ b/internal/services/orphanscan/service.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"math/rand"
 	"os"
 	"path"
@@ -1159,6 +1160,45 @@ func filterScanRootsCoveredBySkippedRoots(scanRoots, skippedRoots []string) []st
 	return filtered
 }
 
+// dedupeCaseVariantRoots drops a scan root when an earlier root differs from it
+// only by case AND both name the same directory on disk, which is what a
+// case-insensitive filesystem gives us when qBittorrent reports two spellings of
+// one save path (issue #2314). Without the os.SameFile confirmation this would
+// silently stop scanning a second, genuinely different directory on a
+// case-sensitive filesystem.
+// Roots are compared in the given order; the first spelling wins.
+//
+// os.Lstat, never os.Stat: a symlink that differs from its target only by case
+// would look like the same directory through os.Stat, and dropping the real
+// directory in favour of the symlink would scan nothing at all, because
+// filepath.WalkDir does not follow a symlinked root.
+func dedupeCaseVariantRoots(roots []string) []string {
+	if len(roots) < 2 {
+		return roots
+	}
+
+	kept := make([]string, 0, len(roots))
+	seen := make(map[string]fs.FileInfo, len(roots))
+	for _, root := range roots {
+		norm := normalizePath(root)
+		info, err := os.Lstat(root)
+		if err != nil {
+			info = nil
+		}
+
+		if prev, ok := seen[norm]; ok && prev != nil && info != nil && os.SameFile(prev, info) {
+			log.Debug().Str("root", root).Msg("orphanscan: dropped scan root that is the same directory as an earlier root")
+			continue
+		}
+
+		kept = append(kept, root)
+		if _, ok := seen[norm]; !ok {
+			seen[norm] = info
+		}
+	}
+	return kept
+}
+
 func addAbsoluteScanRoot(scanRoots map[string]struct{}, root string) {
 	root = filepath.Clean(root)
 	if root == "" || !filepath.IsAbs(root) {
@@ -1285,7 +1325,7 @@ func buildFileMapFromTorrents(torrents []qbt.Torrent, filesByHash map[string]qbt
 	}
 
 	skippedRootList := sortedRoots(skippedRoots)
-	scanRootList := filterScanRootsCoveredBySkippedRoots(sortedRoots(scanRoots), skippedRootList)
+	scanRootList := dedupeCaseVariantRoots(filterScanRootsCoveredBySkippedRoots(sortedRoots(scanRoots), skippedRootList))
 
 	return &buildFileMapResult{
 		fileMap:      tfm,

--- a/internal/services/orphanscan/service.go
+++ b/internal/services/orphanscan/service.go
@@ -1181,10 +1181,7 @@ func dedupeCaseVariantRoots(roots []string) []string {
 	seen := make(map[string]fs.FileInfo, len(roots))
 	for _, root := range roots {
 		norm := normalizePath(root)
-		info, err := os.Lstat(root)
-		if err != nil {
-			info = nil
-		}
+		info, _ := os.Lstat(root) // nil FileInfo on error
 
 		if prev, ok := seen[norm]; ok && prev != nil && info != nil && os.SameFile(prev, info) {
 			log.Debug().Str("root", root).Msg("orphanscan: dropped scan root that is the same directory as an earlier root")

--- a/internal/services/orphanscan/settling_test.go
+++ b/internal/services/orphanscan/settling_test.go
@@ -4,7 +4,9 @@
 package orphanscan
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -288,4 +290,64 @@ func TestBuildFileMapFromTorrents_FlatMultiFileDivergentContentPathUsesContentRo
 	assert.Contains(t, result.scanRoots, filepath.Clean(categoryRoot))
 	assert.Contains(t, result.scanRoots, filepath.Clean(contentRoot))
 	assert.NotContains(t, result.scanRoots, filepath.Dir(categoryRoot))
+}
+
+// Two torrents whose save paths differ only by case name the same physical
+// directory on a case-insensitive filesystem, so both spellings must resolve to
+// the same owned files. See issue #2314.
+func TestBuildFileMapFromTorrents_SavePathsDifferingOnlyByCase(t *testing.T) {
+	t.Parallel()
+
+	categoryRoot := filepath.Join(t.TempDir(), "cross-seed")
+	upper := filepath.Join(categoryRoot, "TrackerName")
+	lower := filepath.Join(categoryRoot, "trackername")
+
+	result, err := buildFileMapFromTorrents(
+		[]qbt.Torrent{
+			{Hash: "upper", SavePath: upper, ContentPath: filepath.Join(upper, "Show.S01"), State: qbt.TorrentStatePausedUp},
+			{Hash: "lower", SavePath: lower, ContentPath: filepath.Join(lower, "Movie.2024"), State: qbt.TorrentStatePausedUp},
+		},
+		map[string]qbt.TorrentFiles{
+			"upper": {{Name: "Show.S01/Show.S01E01.mkv", Size: 1000}},
+			"lower": {{Name: "Movie.2024/Movie.2024.mkv", Size: 2000}},
+		},
+	)
+	require.NoError(t, err)
+
+	// Each file must be found under either spelling of its directory.
+	assert.True(t, result.fileMap.Has(normalizePath(filepath.Join(lower, "Show.S01", "Show.S01E01.mkv"))))
+	assert.True(t, result.fileMap.Has(normalizePath(filepath.Join(upper, "Movie.2024", "Movie.2024.mkv"))))
+}
+
+func TestDedupeCaseVariantRoots(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	upper := filepath.Join(base, "TrackerName")
+	require.NoError(t, os.MkdirAll(upper, 0o755))
+	lower := filepath.Join(base, "trackername")
+
+	if _, err := os.Lstat(lower); err == nil {
+		// Case-insensitive filesystem: one directory, two spellings, walk once.
+		assert.Equal(t, []string{upper}, dedupeCaseVariantRoots([]string{upper, lower}))
+		return
+	}
+
+	// Case-sensitive filesystem: nothing may be dropped, because every spelling
+	// is a directory of its own.
+	require.NoError(t, os.MkdirAll(lower, 0o755))
+	missing := filepath.Join(base, "Gone")
+	roots := []string{upper, lower, missing, strings.ToLower(missing)}
+	assert.Equal(t, roots, dedupeCaseVariantRoots(roots))
+
+	// A symlink whose name is a case variant of its target must not evict the
+	// target: filepath.WalkDir does not follow a symlinked scan root, so the
+	// tree would stop being scanned.
+	linked := filepath.Join(base, "Linked")
+	require.NoError(t, os.MkdirAll(linked, 0o755))
+	link := filepath.Join(base, "linked")
+	if err := os.Symlink(linked, link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	assert.Equal(t, []string{link, linked}, dedupeCaseVariantRoots([]string{link, linked}))
 }

--- a/internal/services/orphanscan/walker.go
+++ b/internal/services/orphanscan/walker.go
@@ -273,13 +273,15 @@ func (w *scanWalker) mergeSuppressedUnitsIntoDiscUnits() {
 		return
 	}
 
+	// Do not fold: two real sibling directories that differ only by case would
+	// merge into one on a case-sensitive filesystem.
 	discRoots := make(map[string]string, len(w.discUnitPaths))
 	for du := range w.discUnitPaths {
-		discRoots[normalizePath(du)] = du
+		discRoots[cleanPath(du)] = du
 	}
 
 	for unit, entry := range w.orphanUnits {
-		discUnitPath, ok := containingDiscUnit(normalizePath(unit), discRoots)
+		discUnitPath, ok := containingDiscUnit(cleanPath(unit), discRoots)
 		if !ok {
 			continue
 		}
@@ -397,7 +399,9 @@ func discUnitFromParentMarker(
 	unitCache map[string]discUnitDecision,
 	ignorePaths []string,
 ) (unitPath string, ok bool) {
-	key := normalizePath(candidateAbs) + "|" + markerUpper
+	// Do not fold: the cached decision holds the first caller's absolute path, so
+	// two case-variant sibling directories would share one entry.
+	key := cleanPath(candidateAbs) + "|" + markerUpper
 	if unitCache != nil {
 		if decision, ok := unitCache[key]; ok {
 			if decision.disableGrouping {

--- a/internal/services/orphanscan/walker.go
+++ b/internal/services/orphanscan/walker.go
@@ -549,7 +549,7 @@ func discParentIsSafeDiscRoot(parentAbs, marker string, tfm *TorrentFileMap) boo
 
 // isIgnoredPath checks if path matches any ignore prefix with boundary safety.
 // Ensures /data/foo doesn't match /data/foobar (requires separator after prefix).
-// Uses normalizePath for consistent comparison across platforms (handles Windows casing).
+// Uses normalizePath for consistent comparison across platforms.
 func isIgnoredPath(path string, ignorePaths []string) bool {
 	normPath := normalizePath(path)
 	for _, prefix := range ignorePaths {
@@ -644,7 +644,9 @@ func isPathProtectedByIgnorePaths(path string, ignorePaths []string) bool {
 }
 
 // NormalizeIgnorePaths validates and normalizes ignore paths.
-// All paths must be absolute. Uses normalizePath for consistency (Windows casing).
+// All paths must be absolute. The result is stored in settings and shown in the
+// UI, so it keeps the casing the user typed; matching case-folds on both sides
+// (see isIgnoredPath).
 func NormalizeIgnorePaths(paths []string) ([]string, error) {
 	result := make([]string, 0, len(paths))
 	for _, p := range paths {
@@ -652,7 +654,7 @@ func NormalizeIgnorePaths(paths []string) ([]string, error) {
 		if !filepath.IsAbs(cleaned) {
 			return nil, fmt.Errorf("ignore path must be absolute: %s", p)
 		}
-		result = append(result, normalizePath(cleaned))
+		result = append(result, cleanPath(cleaned))
 	}
 	return result, nil
 }

--- a/internal/services/orphanscan/walker_test.go
+++ b/internal/services/orphanscan/walker_test.go
@@ -716,3 +716,46 @@ func TestNormalizeIgnorePaths_KeepsUserCasing(t *testing.T) {
 		t.Fatalf("expected %q to be ignored by %q", other, got[0])
 	}
 }
+
+// An ignore path protects a directory the user typed. A file below it whose name
+// carries a non-UTF-8 byte must still be protected: the prefix is folded for
+// comparison, so the file path has to fold the same way or the protection
+// silently does nothing and the file is deleted.
+func TestIsIgnoredPath_InvalidUTF8UnderMixedCaseDir(t *testing.T) {
+	t.Parallel()
+
+	sep := string(filepath.Separator)
+	ignore := filepath.Join(sep, "data", "downloads", "Keep")
+	file := filepath.Join(ignore, "mo"+string([]byte{0xff})+"vie.mkv")
+
+	if !isIgnoredPath(file, []string{ignore}) {
+		t.Fatalf("expected file under ignored directory to be protected: %q", file)
+	}
+}
+
+// Two sibling disc directories that differ only by case are two real directories
+// on a case-sensitive filesystem. The decision cache must keep them apart, or the
+// second directory's files are attributed to the first, and deleting the first
+// takes files the second one's scan never approved.
+func TestDiscUnitFromParentMarker_CaseVariantSiblingsDoNotShareCache(t *testing.T) {
+	t.Parallel()
+
+	sep := string(filepath.Separator)
+	upper := filepath.Join(sep, "rips", "Pack")
+	lower := filepath.Join(sep, "rips", "pack")
+	cache := make(map[string]discUnitDecision)
+
+	unitFor := func(dir string) string {
+		unit, ok := discUnitFromParentMarker(
+			filepath.Join(dir, "BDMV", "STREAM", "a.m2ts"),
+			dir, filepath.Join(dir, "BDMV"), "BDMV", nil, cache, nil)
+		if !ok {
+			t.Fatalf("expected a disc unit for %q", dir)
+		}
+		return unit
+	}
+
+	if u, l := unitFor(upper), unitFor(lower); u == l {
+		t.Fatalf("distinct disc directories must not share a unit path: %q", u)
+	}
+}

--- a/internal/services/orphanscan/walker_test.go
+++ b/internal/services/orphanscan/walker_test.go
@@ -664,3 +664,55 @@ func TestWalkScanRoot_UnicodeCanonicalEquivalenceDoesNotFalseOrphan(t *testing.T
 		t.Fatalf("expected no orphans for canonical-equivalent unicode paths, got %d: %v", len(orphans), orphans)
 	}
 }
+
+// On a case-insensitive filesystem qBittorrent can report two save paths that
+// differ only by case for one physical directory. The walker sees one spelling
+// on disk; the owned-file map holds the other. See issue #2314.
+func TestWalkScanRoot_CaseDifferenceDoesNotFalseOrphan(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	trackerDir := filepath.Join(root, "TrackerName")
+	if err := os.MkdirAll(trackerDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	onDisk := filepath.Join(trackerDir, "Show.S01E01.mkv")
+	if err := os.WriteFile(onDisk, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	old := time.Now().Add(-2 * time.Hour)
+	_ = os.Chtimes(onDisk, old, old)
+
+	// qBittorrent reports the same file under the other casing of the same dir.
+	tfm := NewTorrentFileMap()
+	tfm.Add(filepath.Join(root, "trackername", "Show.S01E01.mkv"))
+
+	orphans, _, err := walkScanRoot(context.Background(), root, tfm, nil, 0, 100)
+	if err != nil {
+		t.Fatalf("walkScanRoot: %v", err)
+	}
+	if len(orphans) != 0 {
+		t.Fatalf("expected no orphans for case-different owned path, got %d: %v", len(orphans), orphans)
+	}
+}
+
+func TestNormalizeIgnorePaths_KeepsUserCasing(t *testing.T) {
+	t.Parallel()
+
+	typed := filepath.Join(t.TempDir(), "downloads", "Keep", "Archive")
+
+	got, err := NormalizeIgnorePaths([]string{typed})
+	if err != nil {
+		t.Fatalf("NormalizeIgnorePaths: %v", err)
+	}
+	if len(got) != 1 || got[0] != typed {
+		t.Fatalf("expected ignore path stored verbatim %q, got %v", typed, got)
+	}
+
+	// Matching still folds, so the differently-cased on-disk path stays protected.
+	other := filepath.Join(strings.ToLower(typed), "movie.mkv")
+	if !isIgnoredPath(other, got) {
+		t.Fatalf("expected %q to be ignored by %q", other, got[0])
+	}
+}


### PR DESCRIPTION
## Description

qBittorrent can report two save paths that differ only by letter case for one physical directory when the filesystem is case-insensitive, which is the default on macOS APFS and on Windows, and applies to a Docker bind mount of either. The orphan scanner compared paths byte for byte unless `GOOS` was `windows`, so files owned through one spelling were reported as orphans while the scanner walked the other, and the deletion re-check used the same comparison. `normalizePath` now folds case on every OS, because `GOOS` cannot answer this question: the container is Linux while the mounted filesystem is not.

Folding at that one point changes three other places. Ignore paths keep the casing the user typed, because `NormalizeIgnorePaths` output is stored in settings and shown in the UI, so a new `cleanPath` does the cleaning without the fold. The three copied containment checks in the deletion flow become one folded `withinScanRoot`, because `findScanRoot` can now return a scan root spelled differently from the file below it, which made `filepath.Rel` refuse every deletion. A scan root is dropped when an earlier root is the same directory, confirmed with `os.Lstat` and `os.SameFile`; `os.Lstat` and not `os.Stat`, because a symlink whose name is a case variant of its target looks like the same directory through `os.Stat`, and dropping the real directory for the symlink would scan nothing at all. This supersedes draft PR #1967, whose correction runs only when `os.Lstat` fails, and on a case-insensitive mount `os.Lstat` succeeds for the wrong spelling; that PR fixes a different problem, casing drift on a case-sensitive filesystem, and does not conflict with this one.

Fixes #2314

## How has this been tested?

`go test -race -count=1 ./internal/services/orphanscan/...`, `make precommit` and `make build` all pass.

Each new test was checked against the unfixed code. Reverting the fold turns eight tests red, including a walker test that reproduces the report: an owned file registered under one spelling while the directory on disk carries the other. Reverting `os.Lstat` to `os.Stat` in the root dedupe, and reverting the folded compare in the empty-directory cleanup, each turn their own guard red.

The package test binary was also cross-compiled for Windows and run under wine, which resolves paths case-insensitively. All tests pass there.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [x] I ran `make precommit` and the tests pass locally
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved orphan scanning on case-insensitive filesystems to prevent valid files, directories, and symlinks from being incorrectly identified as orphans.
  * Enhanced deletion safeguards to prevent scan roots or paths outside the scan area from being removed.
  * Fixed cleanup handling for paths that differ only by letter casing.
  * Improved discovery when torrent save paths use different capitalization.
  * Ignore paths now preserve the casing entered by users while matching reliably regardless of case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->