### PR TITLE
docs(readme): add qBittorrent interface alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,17 @@ Contributions are welcome.
 
 See [`CONTRIBUTING.md`](.github/CONTRIBUTING.md) for the development and test workflow.
 
+## Alternatives
+
+If qui does not fit your setup, these projects offer different approaches:
+
+- [VueTorrent](https://github.com/VueTorrent/VueTorrent) is a modern, responsive alternative WebUI.
+- [iQbit](https://github.com/ntoporcov/iQbit) is a mobile-focused WebUI and PWA.
+- [Flood](https://github.com/jesec/flood) supports qBittorrent and other torrent clients.
+- [qBitController](https://github.com/Bartuzen/qBitController) is a native app for Android, iOS, Linux, macOS, and Windows.
+
+qBittorrent maintains a longer [list of community WebUIs](https://github.com/qbittorrent/qBittorrent/wiki/List-of-known-alternate-WebUIs).
+
 ## License
 
 GPL-2.0-or-later

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ If qui does not fit your setup, these projects offer different approaches:
 - [Flood](https://github.com/jesec/flood) supports qBittorrent and other torrent clients.
 - [qBitController](https://github.com/Bartuzen/qBitController) is a native app for Android, iOS, Linux, macOS, and Windows.
 
-qBittorrent maintains a longer [list of community WebUIs](https://github.com/qbittorrent/qBittorrent/wiki/List-of-known-alternate-WebUIs).
+The qBittorrent wiki includes a longer [list of community WebUIs](https://github.com/qbittorrent/qBittorrent/wiki/List-of-known-alternate-WebUIs).
 
 ## License
 


### PR DESCRIPTION
## Description

Add an Alternatives section to the README with VueTorrent, iQbit, Flood, and qBitController. It also links to qBittorrent's community WebUI list.

This gives users a direct path to other projects when qui does not fit their setup.

No issue.

## How has this been tested?

- `make precommit`
- No code tests apply to this README-only change.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [x] I ran `make precommit`. No code tests apply to this README-only change.
- [x] This change does not alter the database schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an “Alternatives” section to the README.
  * Listed VueTorrent, iQbit, Flood, qBitController, and qBittorrent’s community WebUI directory as alternative options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->