### PR TITLE
perf(sse): hash delta fingerprints without a JSON encode

### DIFF
--- a/internal/api/sse/delta.go
+++ b/internal/api/sse/delta.go
@@ -4,9 +4,9 @@
 package sse
 
 import (
-	"encoding/json"
-	"hash"
+	"encoding/binary"
 	"hash/fnv"
+	"math"
 	"slices"
 	"strconv"
 
@@ -143,60 +143,125 @@ func computeRowDelta[T any](rows []T, keyOf func(T) string, fpOf func(T) uint64,
 	return order, changedIdx, newFP
 }
 
-// maskVolatile zeroes the per-second counters and swarm/peer-count jitter that change
-// on an otherwise-idle torrent every tick. They are excluded from change detection
-// only: on a mostly-idle instance these are the sole fields that move each tick, so
-// hashing them would flag nearly every row as changed and make each "delta" almost
-// as large as a full snapshot (the root cause of the stream saturating an HTTP/2
-// connection). The excluded fields still ride along with their current value whenever
-// a row is sent for a real change (speed, progress, state, ratio, ...); they are just
-// not on their own a reason to resend a row.
-func maskVolatile(t *qbt.Torrent) qbt.Torrent {
-	masked := *t
-	masked.Reannounce = 0
-	masked.TimeActive = 0
-	masked.SeedingTime = 0
-	masked.ETA = 0
-	masked.LastActivity = 0
-	masked.SeenComplete = 0
-	masked.Popularity = 0
-	masked.Availability = 0
-	masked.NumComplete = 0
-	masked.NumIncomplete = 0
-	masked.NumLeechs = 0
-	masked.NumSeeds = 0
-	return masked
+// fpBuf accumulates a row's change-relevant fields as flat bytes so the row is
+// hashed with a single FNV write instead of a JSON encode. Strings carry a length
+// prefix so adjacent fields cannot alias ("ab"+"c" vs "a"+"bc").
+type fpBuf []byte
+
+// fpBufSize covers a typical row (fixed fields plus name and paths); a row with a
+// long magnet URI takes one extra grow.
+const fpBufSize = 1024
+
+func (b *fpBuf) i64(v int64)   { *b = binary.LittleEndian.AppendUint64(*b, uint64(v)) }
+func (b *fpBuf) f64(v float64) { *b = binary.LittleEndian.AppendUint64(*b, math.Float64bits(v)) }
+func (b *fpBuf) str(s string)  { b.i64(int64(len(s))); *b = append(*b, s...) }
+func (b *fpBuf) bit(v bool) {
+	if v {
+		*b = append(*b, 1)
+	} else {
+		*b = append(*b, 0)
+	}
 }
 
-func writeTorrentFingerprint(h hash.Hash64, t *qbt.Torrent) {
+// torrent appends every change-relevant torrent field. The per-second counters and
+// swarm/peer-count jitter that move on an otherwise-idle torrent every tick
+// (Reannounce, TimeActive, SeedingTime, ETA, LastActivity, SeenComplete, Popularity,
+// Availability, NumComplete, NumIncomplete, NumLeechs, NumSeeds) are deliberately
+// left out: on a mostly-idle instance they are the sole fields that change each tick,
+// so including them would flag nearly every row as changed and make each "delta"
+// almost as large as a full snapshot (the root cause of the stream saturating an
+// HTTP/2 connection). The excluded fields still ride along with their current value
+// whenever a row is sent for a real change; they are just not on their own a reason
+// to resend a row. TestTorrentFingerprintCoversEveryField pins this partition, so a
+// go-qbittorrent bump that adds a field fails until the field is categorized here.
+func (b *fpBuf) torrent(t *qbt.Torrent) {
 	if t == nil {
 		return
 	}
-	masked := maskVolatile(t)
-	if encoded, err := json.Marshal(&masked); err == nil {
-		_, _ = h.Write(encoded)
+	b.i64(t.AddedOn)
+	b.i64(t.AmountLeft)
+	b.bit(t.AutoManaged)
+	b.str(t.Category)
+	b.str(t.Comment)
+	b.i64(t.Completed)
+	b.i64(t.CompletionOn)
+	b.str(t.CreatedBy)
+	b.str(t.ContentPath)
+	b.i64(t.DlLimit)
+	b.i64(t.DlSpeed)
+	b.str(t.DownloadPath)
+	b.i64(t.Downloaded)
+	b.i64(t.DownloadedSession)
+	b.bit(t.FirstLastPiecePrio)
+	b.bit(t.ForceStart)
+	b.str(t.Hash)
+	b.str(t.InfohashV1)
+	b.str(t.InfohashV2)
+	b.bit(t.Private)
+	b.str(t.MagnetURI)
+	b.f64(t.MaxRatio)
+	b.i64(t.MaxSeedingTime)
+	b.i64(t.MaxInactiveSeedingTime)
+	b.str(t.Name)
+	b.i64(t.Priority)
+	b.f64(t.Progress)
+	b.f64(t.Ratio)
+	b.f64(t.RatioLimit)
+	b.str(t.SavePath)
+	b.i64(t.SeedingTimeLimit)
+	b.i64(t.InactiveSeedingTimeLimit)
+	b.str(t.ShareLimitAction)
+	b.str(t.ShareLimitsMode)
+	b.bit(t.SequentialDownload)
+	b.i64(t.Size)
+	b.str(string(t.State))
+	b.bit(t.SuperSeeding)
+	b.str(t.Tags)
+	b.i64(t.TotalSize)
+	b.str(t.Tracker)
+	b.i64(t.TrackersCount)
+	b.i64(t.UpLimit)
+	b.i64(t.Uploaded)
+	b.i64(t.UploadedSession)
+	b.i64(t.UpSpeed)
+	b.i64(int64(len(t.Trackers)))
+	for i := range t.Trackers {
+		tr := &t.Trackers[i]
+		b.str(tr.Url)
+		b.i64(int64(tr.Status))
+		b.i64(int64(tr.NumPeers))
+		b.i64(int64(tr.NumSeeds))
+		b.i64(int64(tr.NumLeechers))
+		b.i64(int64(tr.NumDownloaded))
+		b.str(tr.Message)
 	}
+}
+
+func (b fpBuf) sum() uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write(b)
+	return h.Sum64()
 }
 
 // singleRowFingerprint hashes a single-instance row's change-relevant content.
 func singleRowFingerprint(tv qbittorrent.TorrentView) uint64 {
-	h := fnv.New64a()
-	writeTorrentFingerprint(h, tv.Torrent)
-	_, _ = h.Write([]byte(tv.TrackerHealth))
-	return h.Sum64()
+	b := make(fpBuf, 0, fpBufSize)
+	b.torrent(tv.Torrent)
+	b.str(string(tv.TrackerHealth))
+	return b.sum()
 }
 
 // crossRowFingerprint hashes a cross-instance row's change-relevant content,
 // including its instance identity (the same torrent on two instances is two rows).
 func crossRowFingerprint(c qbittorrent.CrossInstanceTorrentView) uint64 {
-	h := fnv.New64a()
+	b := make(fpBuf, 0, fpBufSize)
 	if c.TorrentView != nil {
-		writeTorrentFingerprint(h, c.Torrent)
-		_, _ = h.Write([]byte(c.TrackerHealth))
+		b.torrent(c.Torrent)
+		b.str(string(c.TrackerHealth))
 	}
-	_, _ = h.Write([]byte(strconv.Itoa(c.InstanceID)))
-	_, _ = h.Write([]byte(c.InstanceName))
-	return h.Sum64()
+	b.i64(int64(c.InstanceID))
+	b.str(c.InstanceName)
+	return b.sum()
 }
 
 // subsetRows returns the rows at the given indices, preserving order.

--- a/internal/api/sse/fingerprint_test.go
+++ b/internal/api/sse/fingerprint_test.go
@@ -4,6 +4,7 @@
 package sse
 
 import (
+	"math"
 	"reflect"
 	"testing"
 
@@ -114,4 +115,12 @@ func BenchmarkSingleRowFingerprint(b *testing.B) {
 	for b.Loop() {
 		singleRowFingerprint(row)
 	}
+}
+
+// TestFingerprintDistinguishesNaNRows guards the fix for the old JSON path,
+// where a NaN ratio made json.Marshal fail and every such row hashed as empty.
+func TestFingerprintDistinguishesNaNRows(t *testing.T) {
+	a := singleRowFingerprint(qbittorrent.TorrentView{Torrent: &qbt.Torrent{Name: "A", Ratio: math.NaN()}})
+	b := singleRowFingerprint(qbittorrent.TorrentView{Torrent: &qbt.Torrent{Name: "B", Ratio: math.NaN()}})
+	require.NotEqual(t, a, b)
 }

--- a/internal/api/sse/fingerprint_test.go
+++ b/internal/api/sse/fingerprint_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package sse
+
+import (
+	"reflect"
+	"testing"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/qbittorrent"
+)
+
+// volatileTorrentFields are the per-tick jitter fields fpBuf.torrent deliberately
+// skips. Keep this set in sync with the skip list documented on that method.
+var volatileTorrentFields = map[string]bool{
+	"Reannounce":    true,
+	"TimeActive":    true,
+	"SeedingTime":   true,
+	"ETA":           true,
+	"LastActivity":  true,
+	"SeenComplete":  true,
+	"Popularity":    true,
+	"Availability":  true,
+	"NumComplete":   true,
+	"NumIncomplete": true,
+	"NumLeechs":     true,
+	"NumSeeds":      true,
+}
+
+// setSampleValue writes a non-zero value of the field's kind so a hashed field
+// must move the fingerprint. New field kinds in go-qbittorrent fail loudly here.
+func setSampleValue(t *testing.T, f reflect.Value) {
+	t.Helper()
+	//exhaustive:ignore -- default fails loudly on any kind not yet used by qbt.Torrent
+	switch f.Kind() {
+	case reflect.String:
+		f.SetString("x")
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		f.SetInt(1)
+	case reflect.Float32, reflect.Float64:
+		f.SetFloat(1)
+	case reflect.Bool:
+		f.SetBool(true)
+	case reflect.Slice:
+		f.Set(reflect.Append(f, reflect.New(f.Type().Elem()).Elem()))
+	default:
+		t.Fatalf("field kind %s not handled; extend setSampleValue", f.Kind())
+	}
+}
+
+// TestTorrentFingerprintCoversEveryField proves the fingerprint reacts to every
+// non-volatile qbt.Torrent field and ignores every volatile one. When a
+// go-qbittorrent bump adds a field, this fails until the field is added to
+// fpBuf.torrent or to volatileTorrentFields.
+func TestTorrentFingerprintCoversEveryField(t *testing.T) {
+	base := singleRowFingerprint(qbittorrent.TorrentView{Torrent: &qbt.Torrent{}})
+	typ := reflect.TypeFor[qbt.Torrent]()
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		var mutated qbt.Torrent
+		setSampleValue(t, reflect.ValueOf(&mutated).Elem().Field(i))
+		fp := singleRowFingerprint(qbittorrent.TorrentView{Torrent: &mutated})
+		if volatileTorrentFields[field.Name] {
+			require.Equal(t, base, fp, "volatile field %s must not affect the fingerprint", field.Name)
+		} else {
+			require.NotEqual(t, base, fp, "field %s must change the fingerprint; add it to fpBuf.torrent or volatileTorrentFields", field.Name)
+		}
+	}
+}
+
+// TestTrackerFingerprintCoversEveryField does the same for the per-tracker rows
+// inside Torrent.Trackers.
+func TestTrackerFingerprintCoversEveryField(t *testing.T) {
+	row := func(tr qbt.TorrentTracker) uint64 {
+		return singleRowFingerprint(qbittorrent.TorrentView{Torrent: &qbt.Torrent{Trackers: []qbt.TorrentTracker{tr}}})
+	}
+	base := row(qbt.TorrentTracker{})
+	typ := reflect.TypeFor[qbt.TorrentTracker]()
+	for i := 0; i < typ.NumField(); i++ {
+		var mutated qbt.TorrentTracker
+		setSampleValue(t, reflect.ValueOf(&mutated).Elem().Field(i))
+		require.NotEqual(t, base, row(mutated), "tracker field %s must change the fingerprint; add it to the Trackers loop in fpBuf.torrent", typ.Field(i).Name)
+	}
+}
+
+func BenchmarkSingleRowFingerprint(b *testing.B) {
+	row := qbittorrent.TorrentView{
+		Torrent: &qbt.Torrent{
+			AddedOn:     1700000000,
+			Category:    "tv-sonarr",
+			ContentPath: "/data/torrents/tv/Some.Show.S01.1080p.WEB-DL.DDP5.1.H.264-GRP",
+			SavePath:    "/data/torrents/tv",
+			DlSpeed:     1234567,
+			UpSpeed:     7654321,
+			Downloaded:  123456789012,
+			Uploaded:    98765432101,
+			Hash:        "0123456789abcdef0123456789abcdef01234567",
+			InfohashV1:  "0123456789abcdef0123456789abcdef01234567",
+			Name:        "Some.Show.S01.1080p.WEB-DL.DDP5.1.H.264-GRP",
+			Progress:    0.75,
+			Ratio:       1.234,
+			Size:        56712345678,
+			State:       qbt.TorrentStateUploading,
+			Tags:        "cross-seed, keep",
+			Tracker:     "https://tracker.example.invalid/announce",
+			TotalSize:   56712345678,
+		},
+		TrackerHealth: "ok",
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		singleRowFingerprint(row)
+	}
+}


### PR DESCRIPTION
## Description

The SSE delta path computes a change fingerprint for every torrent row on every tick. It copied the row, encoded the copy as JSON, and hashed the JSON. The fingerprint now appends the change-relevant fields to one flat buffer and hashes that buffer with the same FNV hash. The volatile fields stay excluded, so change detection does not change. Per row: 3046 ns and 3 allocations before, 776 ns and 1 allocation after. This also closes a silent gap: a NaN ratio made `json.Marshal` fail, and the old code then hashed the row as empty, invisible to change detection.

Follow-up to the "deliberately left alone" list in #2319.

## How has this been tested?

A reflection test sets each `qbt.Torrent` field and each `TorrentTracker` field, then makes sure that the fingerprint changes, or stays the same for the 12 volatile fields. A go-qbittorrent update that adds a field fails this test until the field is categorized. Three hand-made mutants (a removed field, an added volatile field, a removed tracker sub-field) all made the test fail. `make precommit`, `go test -race -count=1 ./internal/api/sse/`, and `make build` pass.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [x] I ran `make precommit` and the tests pass locally
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved real-time torrent and tracker update detection.
  * Prevented volatile counters and swarm metrics from causing unnecessary updates.
  * Preserved accurate change detection for tracker health and instance information.
  * Ensured rows with unavailable ratio values remain distinguishable.

* **Tests**
  * Added comprehensive coverage for relevant torrent and tracker changes.
  * Added performance benchmarking for update fingerprint generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->