### PR TITLE
fix(qbittorrent): read the tracker mapping before publishing it

### DIFF
--- a/internal/api/sse/fingerprint_test.go
+++ b/internal/api/sse/fingerprint_test.go
@@ -48,6 +48,12 @@ func setSampleValue(t *testing.T, f reflect.Value) {
 		f.SetBool(true)
 	case reflect.Slice:
 		f.Set(reflect.Append(f, reflect.New(f.Type().Elem()).Elem()))
+	case reflect.Map:
+		// One entry with a zero value: fpSortedMap hashes the length and key, so
+		// the entry alone must move the fingerprint.
+		m := reflect.MakeMap(f.Type())
+		m.SetMapIndex(reflect.ValueOf("x"), reflect.New(f.Type().Elem()).Elem())
+		f.Set(m)
 	default:
 		t.Fatalf("field kind %s not handled; extend setSampleValue", f.Kind())
 	}
@@ -73,19 +79,46 @@ func TestTorrentFingerprintCoversEveryField(t *testing.T) {
 	}
 }
 
+// assertEveryFieldHashed proves fp reacts to every field of T: a fingerprint
+// with no coverage guard fails silently, because the delta stream drops a field
+// whose hash holds and no periodic keyframe corrects the client.
+func assertEveryFieldHashed[T any](t *testing.T, hint string, fp func(T) uint64) {
+	var zero T
+	base := fp(zero)
+	typ := reflect.TypeFor[T]()
+	for i := 0; i < typ.NumField(); i++ {
+		var mutated T
+		setSampleValue(t, reflect.ValueOf(&mutated).Elem().Field(i))
+		require.NotEqual(t, base, fp(mutated), "%s.%s must change the fingerprint; %s", typ.Name(), typ.Field(i).Name, hint)
+	}
+}
+
 // TestTrackerFingerprintCoversEveryField does the same for the per-tracker rows
 // inside Torrent.Trackers.
 func TestTrackerFingerprintCoversEveryField(t *testing.T) {
-	row := func(tr qbt.TorrentTracker) uint64 {
+	assertEveryFieldHashed(t, "add it to the Trackers loop in fpBuf.torrent", func(tr qbt.TorrentTracker) uint64 {
 		return singleRowFingerprint(new(fpBuf), qbittorrent.TorrentView{Torrent: &qbt.Torrent{Trackers: []qbt.TorrentTracker{tr}}})
-	}
-	base := row(qbt.TorrentTracker{})
-	typ := reflect.TypeFor[qbt.TorrentTracker]()
-	for i := 0; i < typ.NumField(); i++ {
-		var mutated qbt.TorrentTracker
-		setSampleValue(t, reflect.ValueOf(&mutated).Elem().Field(i))
-		require.NotEqual(t, base, row(mutated), "tracker field %s must change the fingerprint; add it to the Trackers loop in fpBuf.torrent", typ.Field(i).Name)
-	}
+	})
+}
+
+// TestCountsFingerprintCoversEveryField proves the counts fingerprint reacts to
+// every TorrentCounts field, the way the row fingerprint is already guarded.
+func TestCountsFingerprintCoversEveryField(t *testing.T) {
+	assertEveryFieldHashed(t, "add it to countsFingerprint", func(c qbittorrent.TorrentCounts) uint64 {
+		return countsFingerprint(&c)
+	})
+}
+
+// TestTrackerTransferStatsFingerprintCoversEveryField does the same for the
+// per-domain transfer stats nested inside TorrentCounts.TrackerTransfers. The
+// map sample in the counts test only proves the map key is hashed, not the
+// struct fields of its values.
+func TestTrackerTransferStatsFingerprintCoversEveryField(t *testing.T) {
+	assertEveryFieldHashed(t, "add it to countsFingerprint's TrackerTransfers loop", func(s qbittorrent.TrackerTransferStats) uint64 {
+		return countsFingerprint(&qbittorrent.TorrentCounts{
+			TrackerTransfers: map[string]qbittorrent.TrackerTransferStats{"x": s},
+		})
+	})
 }
 
 func BenchmarkSingleRowFingerprint(b *testing.B) {

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -335,6 +335,13 @@ type ValidatedTrackerMapping struct {
 	DomainToHashes map[string]map[string]struct{} // domain -> set of hashes
 	UpdatedAt      time.Time
 	FallbackOnly   bool
+
+	// domainSnapshot memoizes the DomainToHashes copy that
+	// getAuthoritativeDomainToHashes hands to counts passes, with the mapping
+	// generation it was copied from. Guarded by validatedTrackerMu; shared
+	// read-only between callers of the same generation.
+	domainSnapshot    map[string]map[string]struct{}
+	domainSnapshotGen uint64
 }
 
 // TrackerCustomizationLister provides access to tracker customizations for sorting.
@@ -717,11 +724,12 @@ func (sm *SyncManager) applyTrackerHealthRefreshResult(instanceID int, torrents,
 	sm.trackerHealthCache[instanceID] = counts
 	sm.trackerHealthMu.Unlock()
 
-	sm.setValidatedTrackerMappingWithMetrics(instanceID, mapping, len(torrents), started, "hydrated")
-
 	// Queue icon fetches for discovered tracker domains. We do this here (in the
 	// background refresh) so icons get fetched even when API requests use the
-	// validated mapping path (which doesn't walk MainData.Trackers).
+	// validated mapping path (which doesn't walk MainData.Trackers). Read the
+	// mapping before publishing it: once stored, concurrent tracker edits mutate
+	// these maps under validatedTrackerMu, and an unlocked iteration here would
+	// race them (concurrent map read and write is a runtime fatal).
 	for domain := range mapping.DomainToHashes {
 		trackericons.QueueFetch(domain, "")
 	}
@@ -738,6 +746,8 @@ func (sm *SyncManager) applyTrackerHealthRefreshResult(instanceID int, torrents,
 		Int("totalTorrents", len(torrents)).
 		Dur("elapsed", elapsed).
 		Msg("Refreshed tracker health counts and validated tracker mapping")
+
+	sm.setValidatedTrackerMappingWithMetrics(instanceID, mapping, len(torrents), started, "hydrated")
 	return true
 }
 
@@ -882,24 +892,39 @@ func (sm *SyncManager) getAuthoritativeTrackerMapping(instanceID int) *Validated
 
 // getAuthoritativeDomainToHashes returns a copy of the domain to hash sets of the
 // hydrated tracker mapping, without the HashToDomains half that counts never read.
+// The copy is memoized per mapping generation: counts recompute on every sync
+// tick while mapping writes are rare, so without the memo each tick rebuilt a
+// library-sized map only to read it once. Callers must treat it as read-only.
+//
+// The write lock, not the read lock, so the generation cannot move under the
+// copy (every generation bump happens under this lock) and the snapshot can be
+// stored in the same critical section. The copy this serializes is exactly the
+// once-per-generation work the memo makes rare.
 //
 // A nil result means there is no authoritative mapping and the caller must fall
 // back to MainData. A non-nil empty map means the mapping is authoritative and has
 // no domains, which is not the same thing.
 func (sm *SyncManager) getAuthoritativeDomainToHashes(instanceID int) map[string]map[string]struct{} {
-	sm.validatedTrackerMu.RLock()
-	defer sm.validatedTrackerMu.RUnlock()
+	sm.validatedTrackerMu.Lock()
+	defer sm.validatedTrackerMu.Unlock()
 
 	original := sm.validatedTrackerMapping[instanceID]
 	if original == nil || original.FallbackOnly {
 		return nil
 	}
 
-	// Deep copy to prevent data races when caller iterates over the maps
+	gen := sm.trackerMappingGen.Load()
+	if original.domainSnapshot != nil && original.domainSnapshotGen == gen {
+		return original.domainSnapshot
+	}
+
+	// Deep copy so callers can iterate without holding the lock.
 	domainToHashes := make(map[string]map[string]struct{}, len(original.DomainToHashes))
 	for domain, hashes := range original.DomainToHashes {
 		domainToHashes[domain] = maps.Clone(hashes)
 	}
+	original.domainSnapshot = domainToHashes
+	original.domainSnapshotGen = gen
 	return domainToHashes
 }
 

--- a/internal/qbittorrent/sync_manager_test.go
+++ b/internal/qbittorrent/sync_manager_test.go
@@ -11,6 +11,7 @@ import (
 	"maps"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"slices"
 	"strings"
 	"sync"
@@ -3011,4 +3012,30 @@ func TestEmptyAuthoritativeMappingDoesNotFallBackToMainData(t *testing.T) {
 
 	require.Empty(t, counts.Trackers)
 	require.Empty(t, counts.TrackerTransfers)
+}
+
+// TestGetAuthoritativeDomainToHashesMemoizesPerGeneration pins the per-generation
+// memo: counts recompute every sync tick, so without it each tick deep-copied a
+// library-sized map that no mapping write had touched.
+func TestGetAuthoritativeDomainToHashesMemoizesPerGeneration(t *testing.T) {
+	sm := NewSyncManager(nil, nil)
+	sm.setValidatedTrackerMapping(1, &ValidatedTrackerMapping{
+		HashToDomains:  map[string]map[string]struct{}{"h1": {"tracker.example.invalid": {}}},
+		DomainToHashes: map[string]map[string]struct{}{"tracker.example.invalid": {"h1": {}}},
+	})
+
+	first := sm.getAuthoritativeDomainToHashes(1)
+	require.Contains(t, first["tracker.example.invalid"], "h1")
+
+	second := sm.getAuthoritativeDomainToHashes(1)
+	require.Equal(t, reflect.ValueOf(first).Pointer(), reflect.ValueOf(second).Pointer(),
+		"the same generation must share one snapshot instead of re-copying")
+
+	// A mapping write bumps the generation, so the memo must not serve the old copy.
+	sm.removeHashFromTrackerMapping(1, "h1", "tracker.example.invalid")
+	third := sm.getAuthoritativeDomainToHashes(1)
+	require.NotEqual(t, reflect.ValueOf(first).Pointer(), reflect.ValueOf(third).Pointer(),
+		"a mapping write must invalidate the snapshot")
+	require.NotContains(t, third, "tracker.example.invalid",
+		"the fresh snapshot must reflect the removal")
 }


### PR DESCRIPTION
## Description

The tracker health refresh read the mapping's maps after it published them, while tracker edits mutate the same maps under the lock. A concurrent map read and write is a runtime fatal, so a refresh that finished during an edit could crash the process. The refresh now reads the mapping before it publishes.

It also memoizes the `DomainToHashes` copy per mapping generation, because each sync tick deep-copied a library-sized map that it read once, and adds coverage guard tests so a future `TorrentCounts` field cannot silently fall out of the SSE counts dedup.

## How has this been tested?

`make precommit`, `go test -race -count=1` for `internal/qbittorrent` and `internal/api/sse`, and each new test was proven to fail against the unfixed code.

Field-tested on a live 5-instance deployment: sidebar tracker counts matched the filtered list totals for all 26 domains on a 5.6k-torrent instance, and a 60-second allocation profile with an active stream showed the per-tick domain map copy gone (`getAuthoritativeDomainToHashes` absent from the profile).

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [x] I ran `make precommit` and the tests pass locally
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL
