### PR TITLE
fix(crossseed): parse the file name instead of its whole path

### DIFF
--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -6675,7 +6675,11 @@ func (s *Service) selectContentDetectionRelease(torrentName string, sourceReleas
 		return sourceRelease, false
 	}
 
-	largestRelease := s.releaseCache.Parse(largestFile.Name)
+	// qBittorrent file names are torrent-relative paths, and anime folders repeat the
+	// release name inside themselves, so parsing the full path makes rls read the title
+	// twice and invent a Group ("Azure Compass" -> "Compass"). Folder-only fields are
+	// backfilled from the torrent-name parse below.
+	largestRelease := s.releaseCache.Parse(path.Base(largestFile.Name))
 	largestRelease = enrichReleaseFromTorrent(largestRelease, sourceRelease)
 	if largestRelease.Type == rls.Unknown {
 		return sourceRelease, false

--- a/internal/services/crossseed/source_release_inference_test.go
+++ b/internal/services/crossseed/source_release_inference_test.go
@@ -197,6 +197,37 @@ func TestSelectContentDetectionRelease_MusicNameKeepsEpisodeMarkersFromFiles(t *
 	require.Equal(t, "tv", DetermineContentTypeWithFiles(contentDetectionRelease, files).ContentType)
 }
 
+// Regression: parsing the full torrent-relative path invented a group and hard-rejected
+// byte-identical candidates with "group/site mismatch". See selectContentDetectionRelease.
+func TestSelectContentDetectionRelease_RepeatedFolderNameKeepsGroup(t *testing.T) {
+	svc := &Service{
+		releaseCache:     NewReleaseCache(),
+		stringNormalizer: stringutils.NewDefaultNormalizer(),
+	}
+
+	const sourceName = "[FanSubs] Azure Compass - 1168 (1080p) [0A043BA1]"
+	const sourceSize = 1414363469
+	files := qbt.TorrentFiles{{Name: sourceName + "/" + sourceName + ".mkv", Size: sourceSize}}
+
+	source := svc.releaseCache.Parse(sourceName)
+	contentDetectionRelease, _ := svc.selectContentDetectionRelease(sourceName, source, files)
+	require.Empty(t, contentDetectionRelease.Group, "repeated folder name must not invent a group")
+
+	contentInfo := DetermineContentTypeWithFiles(contentDetectionRelease, files)
+	searchRelease := svc.selectSourceReleaseForSearch(source, contentDetectionRelease, files, contentInfo)
+
+	const candidateName = sourceName + ".mkv"
+	ok, reason := svc.validateExactSizeSearchIdentity(searchCandidateInput{
+		SourceRelease:    searchRelease,
+		CandidateRelease: svc.releaseCache.Parse(candidateName),
+		SourceName:       sourceName,
+		CandidateName:    candidateName,
+		SourceSize:       sourceSize,
+		CandidateSize:    sourceSize,
+	})
+	require.True(t, ok, "byte-identical candidate rejected: %s", reason)
+}
+
 func TestSelectSourceReleaseForSearch_SeasonPackKeepsTorrentIdentity(t *testing.T) {
 	svc := &Service{
 		releaseCache:     NewReleaseCache(),
@@ -207,15 +238,16 @@ func TestSelectSourceReleaseForSearch_SeasonPackKeepsTorrentIdentity(t *testing.
 	source := svc.releaseCache.Parse(sourceName)
 	require.NotNil(t, source)
 
+	// File names must share the torrent title or content detection discards them as unrelated.
 	files := qbt.TorrentFiles{
 		{
 			Name: "Silver.Gear.Labyrinth.S02.720p.CR.WEB-DL.AAC2.0.H.264-ALPHA/" +
-				"[ALPHA] Aoi Gear no Meiro Tansaku S2 - 01 (720p) [11111111].mkv",
+				"[BETA] Silver Gear Labyrinth S2 - 01 (720p) [11111111].mkv",
 			Size: 1,
 		},
 		{
 			Name: "Silver.Gear.Labyrinth.S02.720p.CR.WEB-DL.AAC2.0.H.264-ALPHA/" +
-				"[ALPHA] Aoi Gear no Meiro Tansaku S2 - 02 (720p) [22222222].mkv",
+				"[BETA] Silver Gear Labyrinth S2 - 02 (720p) [22222222].mkv",
 			Size: 2,
 		},
 	}
@@ -232,7 +264,7 @@ func TestSelectSourceReleaseForSearch_SeasonPackKeepsTorrentIdentity(t *testing.
 	require.Equal(t, source.Group, searchRelease.Group)
 	require.Equal(t, source.Site, searchRelease.Site)
 	require.Equal(t, source.Sum, searchRelease.Sum)
-	require.NotEqual(t, contentDetectionRelease.Group, searchRelease.Group)
+	require.NotEqual(t, contentDetectionRelease.Site, searchRelease.Site)
 	require.NotEqual(t, contentDetectionRelease.Sum, searchRelease.Sum)
 
 	candidate := svc.releaseCache.Parse("Silver.Gear.Labyrinth.S02.720p.CR.WEB-DL.AAC2.0.H.264-ALPHA")

--- a/internal/services/crossseed/source_release_inference_test.go
+++ b/internal/services/crossseed/source_release_inference_test.go
@@ -210,7 +210,8 @@ func TestSelectContentDetectionRelease_RepeatedFolderNameKeepsGroup(t *testing.T
 	files := qbt.TorrentFiles{{Name: sourceName + "/" + sourceName + ".mkv", Size: sourceSize}}
 
 	source := svc.releaseCache.Parse(sourceName)
-	contentDetectionRelease, _ := svc.selectContentDetectionRelease(sourceName, source, files)
+	contentDetectionRelease, usedFile := svc.selectContentDetectionRelease(sourceName, source, files)
+	require.True(t, usedFile, "must use the file: a sourceRelease fallback also has an empty group")
 	require.Empty(t, contentDetectionRelease.Group, "repeated folder name must not invent a group")
 
 	contentInfo := DetermineContentTypeWithFiles(contentDetectionRelease, files)


### PR DESCRIPTION
## Description

qBittorrent reports torrent file names as torrent-relative paths, and an anime torrent usually repeats its release name in the file it holds. Content detection gave that full path to `rls`, which read the title two times and made a group from the second word of it (`[FanSubs] Azure Compass - 1168 (1080p) [0A043BA1]` gave the group `Compass`). `enrichReleaseFromTorrent` only fills empty fields, so the wrong group stayed. It then did not agree with the group of the candidate, and each result with the same byte size was rejected with `group/site mismatch`.

The result was that these torrents could not cross-seed at all. This change parses the base name. The folder holds no field that the parse of the torrent name does not already supply.

## How has this been tested?

`TestSelectContentDetectionRelease_RepeatedFolderNameKeepsGroup` is new. It builds the file list of an anime torrent, and it makes sure that content detection uses the file, invents no group, and accepts a candidate with the same byte size. Without the change it fails with `Should be empty, but was Compass`.

`TestSelectSourceReleaseForSearch_SeasonPackKeepsTorrentIdentity` needed a new fixture. Its file names used a different title from the folder, which content detection now correctly discards, so all three of its `NotEqual` assertions became true for the wrong reason. The file names now share the title of the torrent, and `Site` and `Sum` are the two fields that keep the assertions meaningful. A mutation of `mergeSeasonPackSearchStructure` to copy from the inferred release still makes the test fail.

Tested on a live instance against a Torznab indexer. Before the change, searches for this kind of torrent reported four candidates with the same byte size and rejected all four. After the change, the same torrent, the same indexer and the same search reported four candidates, rejected one, and returned three matches. Nine more searches of this kind gave the same result.

`make precommit` and `make build` pass. The set of failures in `go test -race -count=1 ./internal/services/crossseed/...` is the same before and after this change.

## Known effect on other content

The change was measured against the file lists of 4562 real torrents. 574 of them get a different result from content detection:

- 0 torrents lose their season or episode structure.
- 43 torrents change content type from `movie` to `unknown`. All of them are disc rips, where the largest file is `VIDEO_TS/VTS_01_1.VOB`. That name gives no title, so the file no longer agrees with the folder and content detection falls back to the torrent name, which a disc rip folder does not supply either. Before the change the folder half of the path supplied it.
- 531 torrents only change which release content detection reads. The search is the same.

The disc rip case is a known loss and is not fixed here.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [x] I ran `make precommit` and the tests pass locally
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL
