### PR TITLE
fix(crossseed): classify a disc rip as a movie

### DIFF
--- a/internal/services/crossseed/parsing.go
+++ b/internal/services/crossseed/parsing.go
@@ -207,7 +207,9 @@ func dominantFileContent(files qbt.TorrentFiles) rls.Type {
 // rls parser, music names most of all, but file extensions are ground truth:
 // audio bytes force the music classification, and video bytes pull a music
 // parse back to tv or movie. The tv/movie split stays with the name-based
-// parse. Without files, or when neither class dominates, the name decides.
+// parse. Without files, or when neither class dominates, the name decides,
+// except for a disc layout, which classifies as a movie when the name gives
+// nothing.
 func DetermineContentTypeWithFiles(release *rls.Release, files qbt.TorrentFiles) ContentTypeInfo {
 	dominant := dominantFileContent(files)
 	if dominant == rls.Music {
@@ -223,7 +225,20 @@ func DetermineContentTypeWithFiles(release *rls.Release, files qbt.TorrentFiles)
 	if dominant == rls.Movie && release.Type == rls.Music {
 		return classifyRelease(demoteMusicToVideo(release))
 	}
-	return DetermineContentType(release)
+
+	info := DetermineContentType(release)
+	if info.ContentType == "unknown" {
+		// A disc rip holds no release name in its files (VIDEO_TS/VTS_01_1.VOB),
+		// and its folder often carries no year or resolution either, so the name
+		// alone classifies as unknown and the search goes out with no categories
+		// (#2336). The layout itself proves the content is video.
+		if isDisc, _ := isDiscLayoutTorrent(files); isDisc {
+			if movieInfo, ok := RuleContentTypeInfo("movie"); ok {
+				return movieInfo
+			}
+		}
+	}
+	return info
 }
 
 // DetermineContentType analyzes a release and returns comprehensive content type information

--- a/internal/services/crossseed/parsing_test.go
+++ b/internal/services/crossseed/parsing_test.go
@@ -470,6 +470,37 @@ func TestDetermineContentTypeWithFiles(t *testing.T) {
 			wantIsMusic: false,
 		},
 		{
+			// #2336: the file names of a disc rip say nothing, and the folder of
+			// this one has no year or resolution, so only the layout is left.
+			name:    "a disc layout classifies as a movie when the name gives nothing",
+			release: rls.Release{Type: rls.Unknown, Title: "Some Feature DVDR"},
+			files: qbt.TorrentFiles{
+				{Name: "Some Feature DVDR/VIDEO_TS/VTS_01_1.VOB", Size: 4_000_000_000},
+				{Name: "Some Feature DVDR/VIDEO_TS/VIDEO_TS.IFO", Size: 20_000},
+			},
+			wantType:    "movie",
+			wantIsMusic: false,
+		},
+		{
+			// The layout must not overrule structure the name does supply.
+			name:    "a disc layout keeps the tv structure of the name",
+			release: rls.Release{Type: rls.Unknown, Title: "Some Show", Series: 2},
+			files: qbt.TorrentFiles{
+				{Name: "Some Show S02 DVDR/VIDEO_TS/VTS_01_1.VOB", Size: 4_000_000_000},
+			},
+			wantType:    "tv",
+			wantIsMusic: false,
+		},
+		{
+			name:    "no disc layout leaves an unknown name unknown",
+			release: rls.Release{Type: rls.Unknown, Title: "Some Feature DVDR"},
+			files: qbt.TorrentFiles{
+				{Name: "Some Feature DVDR/feature.vob", Size: 4_000_000_000},
+			},
+			wantType:    "unknown",
+			wantIsMusic: false,
+		},
+		{
 			name:        "neither class dominant falls back to the name",
 			release:     rls.Release{Type: rls.Book, Title: "Test Book"},
 			files:       qbt.TorrentFiles{{Name: "Author - Book.epub", Size: 2_000_000}},


### PR DESCRIPTION
## Description

The files of a disc rip carry no release name, and a disc rip folder often has no year or resolution, so content detection classified these torrents as unknown and the search went out with no Torznab categories. A `VIDEO_TS` or `BDMV` layout is proof enough that the content is video, so the classification now falls back to movie when the name supplies nothing.

The fix sits in `DetermineContentTypeWithFiles`, next to the byte-weighted extension signal, and it only applies when the name-based classification comes out unknown. A name that does supply season structure still classifies as tv.

Fixes #2336

## How has this been tested?

Three new rows in `TestDetermineContentTypeWithFiles`: a `VIDEO_TS` rip with a nameless folder becomes a movie, a `VIDEO_TS` rip whose name carries a season stays tv, and a loose `.vob` file with no disc layout stays unknown. Without the change the first row fails.

Tested on a live instance with two `VIDEO_TS` rips whose folders carry no year. Both searches now go out as `contentType=movie` with the movie categories, where an unknown classification sent them out with no categories.

`make precommit` and `make build` pass. The set of failures in `go test -race -count=1 ./internal/services/crossseed/...` is the same before and after this change.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [x] I ran `make precommit` and the tests pass locally
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL
