### PR TITLE
feat(crossseed): collapse video search matching to size and group

### DIFF
--- a/internal/services/crossseed/alt_pass_usable_test.go
+++ b/internal/services/crossseed/alt_pass_usable_test.go
@@ -24,7 +24,7 @@ func TestSearchResultUsable(t *testing.T) {
 	const (
 		webripDotted  = "Law.and.Order.Special.Victims.Unit.S05.1080p.AMZN.WEBRip.DD2.0.x264-NTb"
 		webdlDotted   = "Law.and.Order.Special.Victims.Unit.S05.1080p.AMZN.WEB-DL.DD+2.0.x264-NTb"
-		otherShow     = "Law.and.Order.Organized.Crime.S05.1080p.AMZN.WEB-DL.DD+2.0.x264-NTb"
+		otherGroup    = "Law.and.Order.Organized.Crime.S05.1080p.AMZN.WEB-DL.DD+2.0.x264-XYZ"
 		episodeDotted = "Law.and.Order.Special.Victims.Unit.S05E03.1080p.AMZN.WEB-DL.DD+2.0.x264-NTb"
 		size          = int64(115_682_424_111)
 	)
@@ -64,16 +64,22 @@ func TestSearchResultUsable(t *testing.T) {
 			want: false,
 		},
 		{
-			name:       "different show is not usable (indexer stays eligible for re-query)",
-			sourceName: webripDotted, candidateName: otherShow,
+			// Video no longer gates on title, only size and group: a same-size,
+			// different-group result is what stays unusable (indexer stays
+			// eligible for re-query), not a merely different title.
+			name:       "different group is not usable (indexer stays eligible for re-query)",
+			sourceName: webripDotted, candidateName: otherGroup,
 			sourceSize: size, candidateSize: size, tolerance: 5,
 			want: false,
 		},
 		{
-			name:       "title rescue does not stop safer re-query passes",
+			// Title no longer gates video, so there is no separate "rescue" tier
+			// of weaker confidence for a title mismatch: same size and group is
+			// usable outright, same as an exact title match.
+			name:       "different title with matching size and group is usable",
 			sourceName: webdlDotted, candidateName: "Different.Title.S05.1080p.AMZN.WEB-DL.DD+2.0.x264-NTb",
 			sourceSize: size, candidateSize: size, tolerance: 5,
-			want: false,
+			want: true,
 		},
 		{
 			// findIndividualEpisodes makes a season-pack source match an individual
@@ -87,15 +93,16 @@ func TestSearchResultUsable(t *testing.T) {
 			want:                   true,
 		},
 		{
-			// Reverse pairing: a season-pack candidate against a single-episode source
-			// is a forbidden cross-seed even under findIndividualEpisodes. Sizes are
-			// equal (within tolerance) and the show/season match, so the ONLY thing
-			// that makes this not usable is the season-pack-from-episode rejection.
-			name:       "season pack candidate against episode source is rejected (pairing rule)",
+			// Reverse pairing: a season-pack candidate against a single-episode
+			// source. The video path no longer runs the season-pack-from-episode
+			// pairing rule at search time (Task 1); sizes are equal here so the
+			// size gate does not catch it either, so search now calls it usable.
+			// Apply's file validation is the backstop that still rejects the pair.
+			name:       "season pack candidate against episode source is usable at search time (pairing rule moved to apply)",
 			sourceName: episodeDotted, candidateName: webdlDotted,
 			sourceSize: size, candidateSize: size, tolerance: 5,
 			findIndividualEpisodes: true,
-			want:                   false,
+			want:                   true,
 		},
 	}
 
@@ -157,7 +164,10 @@ func TestShouldRunTitleFallbackForRescueOnly(t *testing.T) {
 
 	require.True(t, service.shouldRunTitleFallback(nil, &source, sourceName, size, nil, 5, false, false))
 	require.False(t, service.shouldRunTitleFallback([]jackett.SearchResult{rescue}, &source, sourceName, size, nil, 5, false, false))
-	require.True(t, service.shouldRunTitleFallback([]jackett.SearchResult{rescue}, &source, sourceName, size, nil, 5, false, true))
+	// Title no longer gates video: a retitled same-group, same-size result is a
+	// direct size-group accept, not a weaker "rescue" tier, so it already
+	// counts as a usable result and no fallback pass is needed.
+	require.False(t, service.shouldRunTitleFallback([]jackett.SearchResult{rescue}, &source, sourceName, size, nil, 5, false, true))
 	require.False(t, service.shouldRunTitleFallback([]jackett.SearchResult{junk}, &source, sourceName, size, nil, 5, false, true))
 	require.False(t, service.shouldRunTitleFallback([]jackett.SearchResult{rescue, normal}, &source, sourceName, size, nil, 5, false, true))
 }

--- a/internal/services/crossseed/alt_pass_usable_test.go
+++ b/internal/services/crossseed/alt_pass_usable_test.go
@@ -15,9 +15,9 @@ import (
 
 // TestSearchResultUsable covers the per-result usability decision that drives the
 // alternate connector pass's indexer scoping: a result is usable only when it
-// would survive the match loop's release/size filtering. Junk hits (different
-// show, or a relabel outside tolerance, or a size mismatch) are NOT usable, so
-// their indexer stays eligible for the alternate-spelling re-query.
+// would survive the match loop's video gates (size tolerance, then group
+// agreement). Junk hits (different group, or a size mismatch) are NOT usable,
+// so their indexer stays eligible for the alternate-spelling re-query.
 func TestSearchResultUsable(t *testing.T) {
 	s := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
 

--- a/internal/services/crossseed/search_candidate_match.go
+++ b/internal/services/crossseed/search_candidate_match.go
@@ -133,13 +133,40 @@ func (s *Service) classifySearchCandidate(input searchCandidateInput) searchCand
 	return decision
 }
 
-// groupIdentitiesConflict reports whether source and candidate both carry a
-// group/site identity and those identities differ. A missing identity on
-// either side is absence of evidence, not a conflict.
+// groupIdentitiesConflict reports whether source and candidate both carry
+// group/site evidence with no agreement between them. Each side contributes
+// its normalized Group and Site as a set, and any overlap counts as
+// agreement: bracket-anime names put the fansub group in Site while rls can
+// invent a Group from a stray trailing tag ("[Batch]"), so requiring a
+// single collapsed identity to match rejects torrents that visibly agree on
+// the real group. A side with no evidence at all never conflicts.
 func groupIdentitiesConflict(s *Service, source, candidate *rls.Release) bool {
-	sourceIdentity := normalizedGroupSiteIdentity(s, source)
-	candidateIdentity := normalizedGroupSiteIdentity(s, candidate)
-	return sourceIdentity != "" && candidateIdentity != "" && sourceIdentity != candidateIdentity
+	sourceIdentities := normalizedGroupSiteIdentities(s, source)
+	candidateIdentities := normalizedGroupSiteIdentities(s, candidate)
+	if len(sourceIdentities) == 0 || len(candidateIdentities) == 0 {
+		return false
+	}
+	for _, identity := range sourceIdentities {
+		if slices.Contains(candidateIdentities, identity) {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizedGroupSiteIdentities(s *Service, release *rls.Release) []string {
+	if release == nil {
+		return nil
+	}
+	normalizer := normalizerForService(s)
+	identities := make([]string, 0, 2)
+	if group := normalizer.Normalize(release.Group); group != "" {
+		identities = append(identities, group)
+	}
+	if site := normalizer.Normalize(release.Site); site != "" {
+		identities = append(identities, site)
+	}
+	return identities
 }
 
 // classifySearchCandidateLegacy is the pre-size-group cascade: strict release
@@ -391,14 +418,10 @@ func exactSizeRelaxedDifferenceForReason(input searchCandidateInput, mismatchRea
 }
 
 func normalizedGroupSiteIdentity(s *Service, release *rls.Release) string {
-	if release == nil {
-		return ""
+	if identities := normalizedGroupSiteIdentities(s, release); len(identities) > 0 {
+		return identities[0]
 	}
-	normalizer := normalizerForService(s)
-	if group := normalizer.Normalize(release.Group); group != "" {
-		return group
-	}
-	return normalizer.Normalize(release.Site)
+	return ""
 }
 
 func softMetadataDifferences(source, candidate *rls.Release) []string {

--- a/internal/services/crossseed/search_candidate_match.go
+++ b/internal/services/crossseed/search_candidate_match.go
@@ -23,6 +23,9 @@ const (
 	// replaced only the soft release-attribute checks rejected by strict matching.
 	searchCandidateClassExactSizeFallback searchCandidateClass = "exact-size-fallback"
 	searchCandidateClassTitleRescue       searchCandidateClass = "title-rescue"
+	// searchCandidateClassSizeGroup means the video path admitted the candidate
+	// on size tolerance plus group/site identity alone; see classifySearchCandidate.
+	searchCandidateClassSizeGroup searchCandidateClass = "size-group"
 )
 
 // searchSizeEvidence describes size evidence available before a candidate
@@ -77,13 +80,68 @@ const (
 )
 
 // classifySearchCandidate applies the shared search-only admission rules.
-// Exact-size fallback requires positive byte-for-byte size equality plus strict
-// title, TV structure, resolution, group/site, checksum, artist, and date
-// identity. It may relax descriptive attributes such as source, collection,
-// HDR, codec, or bit depth. Apply later uses the private decision class only to
-// skip its duplicate release prefilter; normal torrent-file validation remains
-// authoritative.
+// Music keeps the full legacy cascade (strict / web-source relabel / title
+// rescue / exact-size fallback): its release names are unreliable enough that
+// the extra identity checks earn their keep. Video collapses to two gates:
+// size tolerance, then group/site identity enforced only when both sides
+// carry one. Title, season/episode, resolution, and checksum no longer gate
+// video — WEB-DL/remux bytes are the same stream regardless of release-name
+// noise, and group is the one name field that still tells same-source apart
+// from re-encoded-elsewhere. Apply later uses the private decision class only
+// to skip its duplicate release prefilter; normal torrent-file validation
+// remains authoritative.
 func (s *Service) classifySearchCandidate(input searchCandidateInput) searchCandidateDecision {
+	if DetermineContentType(input.SourceRelease).IsMusic {
+		return s.classifySearchCandidateLegacy(input)
+	}
+
+	decision := searchCandidateDecision{
+		Class:        searchCandidateClassRejected,
+		SizeEvidence: classifySearchSizeEvidence(input.SourceSize, input.CandidateSize),
+	}
+
+	// Episode-from-pack searches compare an episode against a pack total; the
+	// size gate cannot apply. Apply's file validation decides.
+	ignoreSizeCheck := input.FindIndividualEpisodes &&
+		isTVSeasonPack(input.SourceRelease) && isTVEpisode(input.CandidateRelease)
+
+	if !ignoreSizeCheck && !s.isSizeWithinTolerance(input.SourceSize, input.CandidateSize, input.TolerancePercent) {
+		decision.RejectReason = "size mismatch"
+		decision.SizeRejected = true
+		return decision
+	}
+
+	// The one identity gate. WEB-DLs and remuxes from different groups are the
+	// same untouched stream, so sizes collide across groups; group is the only
+	// name field that encodes that. Enforced only when both sides carry one: a
+	// missing group is absence of evidence, and recheck decides at apply.
+	sourceIdentity := normalizedGroupSiteIdentity(s, input.SourceRelease)
+	candidateIdentity := normalizedGroupSiteIdentity(s, input.CandidateRelease)
+	if sourceIdentity != "" && candidateIdentity != "" && sourceIdentity != candidateIdentity {
+		decision.RejectReason = "group mismatch"
+		return decision
+	}
+
+	decision.Accepted = true
+	decision.Class = searchCandidateClassSizeGroup
+	decision.SourceTitles = slices.Clone(input.SourceTitles)
+	decision.Score, decision.MatchReason = evaluateReleaseMatch(input.SourceRelease, input.CandidateRelease)
+	if decision.Score <= 0 {
+		decision.Score = 1
+	}
+	if decision.SizeEvidence.matches() {
+		decision.Score += sizeEvidenceStrictScoreBonus
+		decision.MatchReason = decision.SizeEvidence.matchReason() + "; size+group; " + decision.MatchReason
+	} else {
+		decision.MatchReason = "size+group; " + decision.MatchReason
+	}
+	return decision
+}
+
+// classifySearchCandidateLegacy is the pre-size-group cascade: strict release
+// match, web-source relabel, title rescue, then exact-size fallback with hard
+// identity gates. Music routes here; see classifySearchCandidate.
+func (s *Service) classifySearchCandidateLegacy(input searchCandidateInput) searchCandidateDecision {
 	decision := searchCandidateDecision{
 		Class:        searchCandidateClassRejected,
 		SizeEvidence: classifySearchSizeEvidence(input.SourceSize, input.CandidateSize),

--- a/internal/services/crossseed/search_candidate_match.go
+++ b/internal/services/crossseed/search_candidate_match.go
@@ -115,9 +115,7 @@ func (s *Service) classifySearchCandidate(input searchCandidateInput) searchCand
 	// same untouched stream, so sizes collide across groups; group is the only
 	// name field that encodes that. Enforced only when both sides carry one: a
 	// missing group is absence of evidence, and recheck decides at apply.
-	sourceIdentity := normalizedGroupSiteIdentity(s, input.SourceRelease)
-	candidateIdentity := normalizedGroupSiteIdentity(s, input.CandidateRelease)
-	if sourceIdentity != "" && candidateIdentity != "" && sourceIdentity != candidateIdentity {
+	if groupIdentitiesConflict(s, input.SourceRelease, input.CandidateRelease) {
 		decision.RejectReason = "group mismatch"
 		return decision
 	}
@@ -126,16 +124,22 @@ func (s *Service) classifySearchCandidate(input searchCandidateInput) searchCand
 	decision.Class = searchCandidateClassSizeGroup
 	decision.SourceTitles = slices.Clone(input.SourceTitles)
 	decision.Score, decision.MatchReason = evaluateReleaseMatch(input.SourceRelease, input.CandidateRelease)
-	if decision.Score <= 0 {
-		decision.Score = 1
-	}
+	decision.Score = max(decision.Score, 1)
+	decision.MatchReason = "size+group; " + decision.MatchReason
 	if decision.SizeEvidence.matches() {
 		decision.Score += sizeEvidenceStrictScoreBonus
-		decision.MatchReason = decision.SizeEvidence.matchReason() + "; size+group; " + decision.MatchReason
-	} else {
-		decision.MatchReason = "size+group; " + decision.MatchReason
+		decision.MatchReason = decision.SizeEvidence.matchReason() + "; " + decision.MatchReason
 	}
 	return decision
+}
+
+// groupIdentitiesConflict reports whether source and candidate both carry a
+// group/site identity and those identities differ. A missing identity on
+// either side is absence of evidence, not a conflict.
+func groupIdentitiesConflict(s *Service, source, candidate *rls.Release) bool {
+	sourceIdentity := normalizedGroupSiteIdentity(s, source)
+	candidateIdentity := normalizedGroupSiteIdentity(s, candidate)
+	return sourceIdentity != "" && candidateIdentity != "" && sourceIdentity != candidateIdentity
 }
 
 // classifySearchCandidateLegacy is the pre-size-group cascade: strict release

--- a/internal/services/crossseed/search_candidate_match_test.go
+++ b/internal/services/crossseed/search_candidate_match_test.go
@@ -1615,3 +1615,25 @@ func TestARRAliasSurvivesSearchToManualAndAutomatedApply(t *testing.T) {
 		require.Equal(t, QueryDegradedARRLookupFailed, errResponse.QueryDegraded)
 	})
 }
+
+func TestClassifySearchCandidate_MusicKeepsLegacyGates(t *testing.T) {
+	svc := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
+
+	src := rls.ParseString("Azure Ensemble - Compass Songs (2019) [FLAC]")
+	cand := rls.ParseString("Different Artist - Other Album (2019) [FLAC]")
+
+	decision := svc.classifySearchCandidate(searchCandidateInput{
+		SourceRelease:    &src,
+		CandidateRelease: &cand,
+		SourceName:       "Azure Ensemble - Compass Songs (2019) [FLAC]",
+		CandidateName:    "Different Artist - Other Album (2019) [FLAC]",
+		SourceSize:       400_000_000,
+		CandidateSize:    400_000_000,
+		TolerancePercent: 5,
+	})
+
+	// Same size, but music routes through the legacy cascade, which rejects
+	// on identity. If this starts passing size+group, the routing broke.
+	require.False(t, decision.Accepted)
+	require.NotEqual(t, searchCandidateClassSizeGroup, decision.Class)
+}

--- a/internal/services/crossseed/search_candidate_match_test.go
+++ b/internal/services/crossseed/search_candidate_match_test.go
@@ -1351,6 +1351,71 @@ func TestFindCandidatesExactSizeFallbackIsScopedAndContinuesToFileValidation(t *
 	require.Empty(t, incompatibleResponse.Candidates, "fallback must not bypass file-level release validation")
 }
 
+// TestFindCandidatesSizeGroupHonorsGroupGate exercises the apply-side
+// search-origin prefilter's size-group case (Task 3): a search-origin
+// pairing whose release match fails on season alone (the AB season-stamp
+// bug: existing torrent mislabeled S02, target is S01) must still survive
+// when the class is size-group and the group identity agrees, and must
+// still drop when the groups differ. File-level validation (the S01E01 file
+// under the existing torrent) stays authoritative below this gate.
+func TestFindCandidatesSizeGroupHonorsGroupGate(t *testing.T) {
+	const (
+		instanceID   = 1
+		targetName   = "[KIRI] Azure Compass S01 [Blu-ray][MKV][h264][1080p Remux][FLAC 2.0][Dual Audio][Softsubs (KIRI)]"
+		existingHash = "existing"
+		torrentSize  = int64(71_052_546_722)
+	)
+	instance := &models.Instance{ID: instanceID, Name: "main"}
+
+	newService := func(existingName string) *Service {
+		existing := qbt.Torrent{Hash: existingHash, Name: existingName, Size: torrentSize, Progress: 1}
+		files := map[string]qbt.TorrentFiles{
+			existingHash: {
+				{Name: "Azure.Compass.S01E01.1080p.BluRay.REMUX.AVC.DUAL.FLAC2.0-KIRI.mkv", Size: torrentSize},
+			},
+		}
+		return &Service{
+			instanceStore:    &fakeInstanceStore{instances: map[int]*models.Instance{instanceID: instance}},
+			syncManager:      newFakeSyncManager(instance, []qbt.Torrent{existing}, files),
+			releaseCache:     NewReleaseCache(),
+			stringNormalizer: stringutils.NewDefaultNormalizer(),
+		}
+	}
+	sizeGroupRequest := &FindCandidatesRequest{
+		TorrentName:            targetName,
+		TargetInstanceIDs:      []int{instanceID},
+		SearchDecisionClass:    searchCandidateClassSizeGroup,
+		SearchSourceInstanceID: instanceID,
+		SearchSourceHash:       existingHash,
+	}
+
+	// Same group: the season-stamp mismatch survives the prefilter because
+	// normalizedGroupSiteIdentity agrees on both sides.
+	sameGroupName := "Azure.Compass.S02.1080p.BluRay.REMUX.AVC.DUAL.FLAC2.0-KIRI"
+	sameGroupService := newService(sameGroupName)
+
+	direct, err := sameGroupService.FindCandidates(context.Background(), &FindCandidatesRequest{
+		TorrentName:       targetName,
+		TargetInstanceIDs: []int{instanceID},
+	})
+	require.NoError(t, err)
+	require.Empty(t, direct.Candidates, "direct requests must retain strict release matching")
+
+	sameGroupResponse, err := sameGroupService.FindCandidates(context.Background(), sizeGroupRequest)
+	require.NoError(t, err)
+	require.Len(t, sameGroupResponse.Candidates, 1)
+	require.Len(t, sameGroupResponse.Candidates[0].Torrents, 1)
+	require.Equal(t, existingHash, sameGroupResponse.Candidates[0].Torrents[0].Hash)
+
+	// Different group: the same season mismatch must not survive.
+	differentGroupName := "Azure.Compass.S02.1080p.BluRay.REMUX.AVC.DUAL.FLAC2.0-OTHERGRP"
+	differentGroupService := newService(differentGroupName)
+
+	differentGroupResponse, err := differentGroupService.FindCandidates(context.Background(), sizeGroupRequest)
+	require.NoError(t, err)
+	require.Empty(t, differentGroupResponse.Candidates, "size-group class must still enforce the group gate")
+}
+
 func TestFindCandidatesScopesSearchSourceAliasesToSourceTorrent(t *testing.T) {
 	const (
 		instanceID    = 1

--- a/internal/services/crossseed/search_candidate_match_test.go
+++ b/internal/services/crossseed/search_candidate_match_test.go
@@ -1220,6 +1220,137 @@ func TestTitleRescueSkipRecheckStopsBeforeFileLoading(t *testing.T) {
 	require.Equal(t, skippedRecheckMessage, result.Message)
 }
 
+// Calls classifySearchCandidateLegacy directly; the rest of the test exercises
+// FindCandidates apply-side scoping (SearchRelaxedDifferences must be
+// search-recorded, not just present, and file-level validation must still
+// reject an incompatible pack), which Task 1 never touched and which is still
+// live for the classes that carry those fields. See the comment on
+// TestClassifySearchCandidateExactSizeFallback.
+func TestFindCandidatesExactSizeFallbackIsScopedAndContinuesToFileValidation(t *testing.T) {
+	const (
+		instanceID    = 1
+		torrentSize   = int64(94_329_473_840)
+		targetName    = "Example.Show.2024.S01.2160p.ATVP.WEB-DL.DV.HDR10+.H.265-NTb"
+		existingName  = "Example.Show.2024.S01.2160p.ATV.WEB-DL.DV.HDR.H.265-NTb"
+		existingHash  = "existing"
+		unrelatedHash = "unrelated"
+	)
+	instance := &models.Instance{ID: instanceID, Name: "main"}
+	existing := qbt.Torrent{
+		Hash: existingHash,
+		Name: existingName,
+		// Search already established exact size. Apply must not replace that
+		// evidence with a new comparison against downloaded metainfo.
+		Size:     torrentSize + 1,
+		Progress: 1,
+	}
+	unrelated := existing
+	unrelated.Hash = unrelatedHash
+	files := map[string]qbt.TorrentFiles{
+		existingHash: {
+			{
+				Name: "Example.Show.2024.S01E01.2160p.ATV.WEB-DL.DV.HDR.H.265-NTb.mkv",
+				Size: torrentSize,
+			},
+		},
+		unrelatedHash: {
+			{
+				Name: "Example.Show.2024.S01E01.2160p.ATV.WEB-DL.DV.HDR.H.265-NTb.mkv",
+				Size: torrentSize,
+			},
+		},
+	}
+	service := &Service{
+		instanceStore:    &fakeInstanceStore{instances: map[int]*models.Instance{instanceID: instance}},
+		syncManager:      newFakeSyncManager(instance, []qbt.Torrent{existing, unrelated}, files),
+		releaseCache:     NewReleaseCache(),
+		stringNormalizer: stringutils.NewDefaultNormalizer(),
+	}
+	sourceRelease := rls.ParseString(existingName)
+	targetRelease := rls.ParseString(targetName)
+	decision := service.classifySearchCandidateLegacy(searchCandidateInput{
+		SourceRelease:    &sourceRelease,
+		CandidateRelease: &targetRelease,
+		SourceName:       existingName,
+		CandidateName:    targetName,
+		SourceSize:       torrentSize,
+		CandidateSize:    torrentSize,
+		TolerancePercent: 5,
+	})
+	require.True(t, decision.Accepted)
+	require.Equal(t, searchCandidateClassExactSizeFallback, decision.Class)
+	require.Equal(t, "hdr mismatch", decision.StrictMismatchReason)
+	require.ElementsMatch(t, []string{"collection", "hdr"}, decision.RelaxedDifferences)
+
+	fallbackRequest := func() *FindCandidatesRequest {
+		return &FindCandidatesRequest{
+			TorrentName:                targetName,
+			TargetInstanceIDs:          []int{instanceID},
+			SearchDecisionClass:        decision.Class,
+			SearchSourceInstanceID:     instanceID,
+			SearchSourceHash:           existingHash,
+			SearchStrictMismatchReason: decision.StrictMismatchReason,
+			SearchRelaxedDifferences:   append([]string(nil), decision.RelaxedDifferences...),
+		}
+	}
+
+	directResponse, err := service.FindCandidates(context.Background(), &FindCandidatesRequest{
+		TorrentName:       targetName,
+		TargetInstanceIDs: []int{instanceID},
+	})
+	require.NoError(t, err)
+	require.Empty(t, directResponse.Candidates, "direct requests must retain strict release matching")
+
+	fallbackResponse, err := service.FindCandidates(context.Background(), fallbackRequest())
+	require.NoError(t, err)
+	require.Len(t, fallbackResponse.Candidates, 1)
+	require.Len(t, fallbackResponse.Candidates[0].Torrents, 1)
+	require.Equal(t, existingHash, fallbackResponse.Candidates[0].Torrents[0].Hash)
+	require.NotEmpty(t, fallbackResponse.Candidates[0].MatchType)
+
+	unrecordedDifferenceRequest := fallbackRequest()
+	// The live strict mismatch for this pair is "hdr"; recording only an
+	// unrelated relaxation must keep the apply stage strict.
+	unrecordedDifferenceRequest.SearchRelaxedDifferences = []string{"collection"}
+	unrecordedDifferenceResponse, err := service.FindCandidates(context.Background(), unrecordedDifferenceRequest)
+	require.NoError(t, err)
+	require.Empty(t, unrecordedDifferenceResponse.Candidates, "fallback must retain the search-recorded relaxation")
+
+	for name, hardMismatchTitle := range map[string]string{
+		"title":      "Different.Show.2024.S01.2160p.ATVP.WEB-DL.DV.HDR10+.H.265-NTb",
+		"season":     "Example.Show.2024.S02.2160p.ATVP.WEB-DL.DV.HDR10+.H.265-NTb",
+		"episode":    "Example.Show.2024.S01E02.2160p.ATVP.WEB-DL.DV.HDR10+.H.265-NTb",
+		"resolution": "Example.Show.2024.S01.1080p.ATVP.WEB-DL.DV.HDR10+.H.265-NTb",
+		"group":      "Example.Show.2024.S01.2160p.ATVP.WEB-DL.DV.HDR10+.H.265-FLUX",
+	} {
+		t.Run("retains strict "+name, func(t *testing.T) {
+			request := fallbackRequest()
+			request.TorrentName = hardMismatchTitle
+			response, findErr := service.FindCandidates(context.Background(), request)
+			require.NoError(t, findErr)
+			require.Empty(t, response.Candidates)
+		})
+	}
+
+	incompatibleFiles := map[string]qbt.TorrentFiles{
+		existingHash: {
+			{
+				Name: "Example.Show.2024.S02E01.2160p.ATV.WEB-DL.DV.HDR.H.265-NTb.mkv",
+				Size: torrentSize,
+			},
+		},
+	}
+	incompatibleService := &Service{
+		instanceStore:    &fakeInstanceStore{instances: map[int]*models.Instance{instanceID: instance}},
+		syncManager:      newFakeSyncManager(instance, []qbt.Torrent{existing}, incompatibleFiles),
+		releaseCache:     NewReleaseCache(),
+		stringNormalizer: stringutils.NewDefaultNormalizer(),
+	}
+	incompatibleResponse, err := incompatibleService.FindCandidates(context.Background(), fallbackRequest())
+	require.NoError(t, err)
+	require.Empty(t, incompatibleResponse.Candidates, "fallback must not bypass file-level release validation")
+}
+
 func TestFindCandidatesScopesSearchSourceAliasesToSourceTorrent(t *testing.T) {
 	const (
 		instanceID    = 1

--- a/internal/services/crossseed/search_candidate_match_test.go
+++ b/internal/services/crossseed/search_candidate_match_test.go
@@ -275,8 +275,6 @@ func TestClassifySearchCandidateExactSizeFallback(t *testing.T) {
 	require.Contains(t, decision.MatchReason, "relaxed collection")
 }
 
-// Calls classifySearchCandidateLegacy directly; see the comment on
-// TestClassifySearchCandidateExactSizeFallback.
 func TestClassifySearchCandidateRejectsNonExactSizeFallback(t *testing.T) {
 	service := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
 	const (
@@ -303,9 +301,6 @@ func TestClassifySearchCandidateRejectsNonExactSizeFallback(t *testing.T) {
 	require.Equal(t, searchSizeEvidenceNone, decision.SizeEvidence)
 }
 
-// Calls classifySearchCandidateLegacy directly; title rescue no longer exists
-// on the video path (title never gates video), but the cascade still runs for
-// music. See the comment on TestClassifySearchCandidateExactSizeFallback.
 func TestClassifySearchCandidateTitleRescue(t *testing.T) {
 	service := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
 	const (
@@ -351,8 +346,6 @@ func TestClassifySearchCandidateTitleRescue(t *testing.T) {
 // Field case: the user's own movie re-uploaded as a bare .mkv, byte-identical,
 // listing retitled with a "cdn-" prefix and the -GROUP tag dropped. The rescue
 // probe must tolerate the absent group; the strict matcher must not.
-// Calls classifySearchCandidateLegacy directly; see the comment on
-// TestClassifySearchCandidateExactSizeFallback.
 func TestClassifySearchCandidateTitleRescueToleratesBareFileCandidate(t *testing.T) {
 	service := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
 	const (
@@ -508,8 +501,6 @@ func TestSearchCandidateARRSourceTitlesSurviveResultCache(t *testing.T) {
 	require.Empty(t, rejected.SourceTitles)
 }
 
-// Calls classifySearchCandidateLegacy directly; see the comment on
-// TestClassifySearchCandidateExactSizeFallback.
 func TestClassifySearchCandidateExactSizePreconditions(t *testing.T) {
 	service := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
 	sourceName := "Example.Show.S01.2160p.ATV.WEB-DL.HDR.H.265-NTb"
@@ -547,10 +538,6 @@ func TestClassifySearchCandidateExactSizePreconditions(t *testing.T) {
 	}
 }
 
-// Calls classifySearchCandidateLegacy directly; the per-field identity gates
-// (title/season/resolution/checksum) it pins are gone from the video path,
-// which now checks only size and group. See the comment on
-// TestClassifySearchCandidateExactSizeFallback.
 func TestClassifySearchCandidateExactSizeHardIdentity(t *testing.T) {
 	service := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
 	const size = int64(94_329_473_840)
@@ -595,9 +582,6 @@ func TestClassifySearchCandidateExactSizeHardIdentity(t *testing.T) {
 	}
 }
 
-// Calls classifySearchCandidateLegacy directly; date identity is no longer
-// checked on the video path. See the comment on
-// TestClassifySearchCandidateExactSizeFallback.
 func TestClassifySearchCandidateExactSizeDateIdentity(t *testing.T) {
 	service := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
 	const size = int64(94_329_473_840)
@@ -669,11 +653,6 @@ func TestClassifySearchCandidateExactSizeDateIdentity(t *testing.T) {
 	}
 }
 
-// Calls classifySearchCandidateLegacy directly; episode/season-pack pairing
-// and content-type identity are no longer checked on the video path (a
-// season-pack candidate against an episode source now fails only if size or
-// group disagrees; apply's file validation catches what search no longer
-// does). See the comment on TestClassifySearchCandidateExactSizeFallback.
 func TestClassifySearchCandidateExactSizeTVAndContentIdentity(t *testing.T) {
 	service := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
 	const size = int64(94_329_473_840)
@@ -1220,12 +1199,10 @@ func TestTitleRescueSkipRecheckStopsBeforeFileLoading(t *testing.T) {
 	require.Equal(t, skippedRecheckMessage, result.Message)
 }
 
-// Calls classifySearchCandidateLegacy directly; the rest of the test exercises
-// FindCandidates apply-side scoping (SearchRelaxedDifferences must be
-// search-recorded, not just present, and file-level validation must still
+// Exercises FindCandidates apply-side scoping (SearchRelaxedDifferences must
+// be search-recorded, not just present, and file-level validation must still
 // reject an incompatible pack), which Task 1 never touched and which is still
-// live for the classes that carry those fields. See the comment on
-// TestClassifySearchCandidateExactSizeFallback.
+// live for the classes that carry those fields.
 func TestFindCandidatesExactSizeFallbackIsScopedAndContinuesToFileValidation(t *testing.T) {
 	const (
 		instanceID    = 1
@@ -1351,13 +1328,8 @@ func TestFindCandidatesExactSizeFallbackIsScopedAndContinuesToFileValidation(t *
 	require.Empty(t, incompatibleResponse.Candidates, "fallback must not bypass file-level release validation")
 }
 
-// TestFindCandidatesSizeGroupHonorsGroupGate exercises the apply-side
-// search-origin prefilter's size-group case (Task 3): a search-origin
-// pairing whose release match fails on season alone (the AB season-stamp
-// bug: existing torrent mislabeled S02, target is S01) must still survive
-// when the class is size-group and the group identity agrees, and must
-// still drop when the groups differ. File-level validation (the S01E01 file
-// under the existing torrent) stays authoritative below this gate.
+// The size-group class must honor the group gate at apply; file validation
+// stays authoritative.
 func TestFindCandidatesSizeGroupHonorsGroupGate(t *testing.T) {
 	const (
 		instanceID   = 1

--- a/internal/services/crossseed/search_candidate_match_test.go
+++ b/internal/services/crossseed/search_candidate_match_test.go
@@ -27,6 +27,107 @@ import (
 	"github.com/autobrr/qui/pkg/stringutils"
 )
 
+// TestClassifySearchCandidate_SizeGroup pins the video classifier to size
+// tolerance plus group/site identity, replacing the old strict/relabel/rescue
+// cascade for non-music sources (title, season, episode, and resolution no
+// longer gate a match; a missing group on either side is absence of evidence,
+// not a rejection).
+func TestClassifySearchCandidate_SizeGroup(t *testing.T) {
+	svc := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
+
+	parse := func(name string) *rls.Release {
+		r := rls.ParseString(name)
+		return &r
+	}
+
+	tests := []struct {
+		name          string
+		source        string
+		candidate     string
+		sourceSize    int64
+		candidateSize int64
+		wantAccepted  bool
+		wantReason    string
+	}{
+		{
+			// The AB season-stamp bug: byte-identical, same group, wrong season label.
+			name:          "season label mismatch accepted on exact size and same group",
+			source:        "Azure.Compass.S02.1080p.BluRay.REMUX.AVC.DUAL.FLAC2.0-KIRI",
+			candidate:     "[KIRI] Azure Compass S01 [Blu-ray][MKV][h264][1080p Remux][FLAC 2.0][Dual Audio][Softsubs (KIRI)]",
+			sourceSize:    71_052_546_722,
+			candidateSize: 71_052_546_722,
+			wantAccepted:  true,
+		},
+		{
+			// The absolute-numbering bug: same group, renumbered episode.
+			name:          "episode renumbering accepted on exact size and same group",
+			source:        "[FanSubs] Azure Compass - 171 (1080p) [0A043BA1]",
+			candidate:     "Azure Compass S00E23 1080p CR WEB-DL AAC 2.0 H.264-FanSubs",
+			sourceSize:    1_424_466_789,
+			candidateSize: 1_424_466_789,
+			wantAccepted:  true,
+		},
+		{
+			// The scary WEB-DL case: same bytes, different group. Must stay dead.
+			name:          "same size different group rejected",
+			source:        "Azure.Compass.2024.1080p.AMZN.WEB-DL.DDP5.1.H.264-KIRI",
+			candidate:     "Azure.Compass.2024.1080p.AMZN.WEB-DL.DDP5.1.H.264-OTHERGRP",
+			sourceSize:    4_581_505_024,
+			candidateSize: 4_581_505_024,
+			wantAccepted:  false,
+			wantReason:    "group mismatch",
+		},
+		{
+			// Absence of evidence passes to recheck.
+			name:          "missing group on one side accepted",
+			source:        "AZURE_COMPASS_DISC",
+			candidate:     "Azure.Compass.2024.NTSC.DVD5-KIRI",
+			sourceSize:    4_581_505_024,
+			candidateSize: 4_581_505_024,
+			wantAccepted:  true,
+		},
+		{
+			name:          "size outside tolerance rejected",
+			source:        "Azure.Compass.2024.1080p.BluRay.x264-KIRI",
+			candidate:     "Azure.Compass.2024.1080p.BluRay.x264-KIRI",
+			sourceSize:    10_000_000_000,
+			candidateSize: 4_000_000_000,
+			wantAccepted:  false,
+			wantReason:    "size mismatch",
+		},
+		{
+			// Title no longer gates video.
+			name:          "different title accepted on exact size and same group",
+			source:        "Sora.no.Azure.Compass.S01.1080p.BluRay.x264-KIRI",
+			candidate:     "Azure.Compass.First.Voyage.S01.1080p.BluRay.x264-KIRI",
+			sourceSize:    20_000_000_000,
+			candidateSize: 20_000_000_000,
+			wantAccepted:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			decision := svc.classifySearchCandidate(searchCandidateInput{
+				SourceRelease:    parse(tt.source),
+				CandidateRelease: parse(tt.candidate),
+				SourceName:       tt.source,
+				CandidateName:    tt.candidate,
+				SourceSize:       tt.sourceSize,
+				CandidateSize:    tt.candidateSize,
+				TolerancePercent: 5,
+			})
+			require.Equal(t, tt.wantAccepted, decision.Accepted)
+			if tt.wantReason != "" {
+				require.Equal(t, tt.wantReason, decision.RejectReason)
+			}
+			if tt.wantAccepted {
+				require.Equal(t, searchCandidateClassSizeGroup, decision.Class)
+			}
+		})
+	}
+}
+
 func TestFindCandidatesSearchSourceUsesFileDerivedTVStructure(t *testing.T) {
 	// Bracket-anime pack names carry no season token, so the raw name parses as
 	// non-TV. Search matched these via file-derived TV structure; the apply
@@ -135,6 +236,10 @@ func TestFindCandidatesSearchSourceUsesFileDerivedTVStructure(t *testing.T) {
 	})
 }
 
+// Calls classifySearchCandidateLegacy directly: video no longer reaches the
+// exact-size-fallback cascade (Task 1 collapses it to size+group), but the
+// cascade itself is unchanged and still runs for music, so this test now
+// exercises it directly instead of through the routing wrapper.
 func TestClassifySearchCandidateExactSizeFallback(t *testing.T) {
 	service := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
 	const (
@@ -151,7 +256,7 @@ func TestClassifySearchCandidateExactSizeFallback(t *testing.T) {
 	require.False(t, strict)
 	require.NotEmpty(t, strictReason)
 
-	decision := service.classifySearchCandidate(searchCandidateInput{
+	decision := service.classifySearchCandidateLegacy(searchCandidateInput{
 		SourceRelease:    &source,
 		CandidateRelease: &candidate,
 		SourceName:       sourceName,
@@ -170,6 +275,8 @@ func TestClassifySearchCandidateExactSizeFallback(t *testing.T) {
 	require.Contains(t, decision.MatchReason, "relaxed collection")
 }
 
+// Calls classifySearchCandidateLegacy directly; see the comment on
+// TestClassifySearchCandidateExactSizeFallback.
 func TestClassifySearchCandidateRejectsNonExactSizeFallback(t *testing.T) {
 	service := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
 	const (
@@ -181,7 +288,7 @@ func TestClassifySearchCandidateRejectsNonExactSizeFallback(t *testing.T) {
 	source := rls.ParseString(sourceName)
 	candidate := rls.ParseString(candidateName)
 
-	decision := service.classifySearchCandidate(searchCandidateInput{
+	decision := service.classifySearchCandidateLegacy(searchCandidateInput{
 		SourceRelease:    &source,
 		CandidateRelease: &candidate,
 		SourceName:       sourceName,
@@ -196,6 +303,9 @@ func TestClassifySearchCandidateRejectsNonExactSizeFallback(t *testing.T) {
 	require.Equal(t, searchSizeEvidenceNone, decision.SizeEvidence)
 }
 
+// Calls classifySearchCandidateLegacy directly; title rescue no longer exists
+// on the video path (title never gates video), but the cascade still runs for
+// music. See the comment on TestClassifySearchCandidateExactSizeFallback.
 func TestClassifySearchCandidateTitleRescue(t *testing.T) {
 	service := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
 	const (
@@ -216,24 +326,24 @@ func TestClassifySearchCandidateTitleRescue(t *testing.T) {
 		RescueTitleMismatches: true,
 	}
 
-	decision := service.classifySearchCandidate(input)
+	decision := service.classifySearchCandidateLegacy(input)
 	require.True(t, decision.Accepted)
 	require.Equal(t, searchCandidateClassTitleRescue, decision.Class)
 	require.Equal(t, "title mismatch", decision.StrictMismatchReason)
 	require.Equal(t, "Title rescue · full check required", decision.MatchReason)
 
 	input.RescueTitleMismatches = false
-	require.False(t, service.classifySearchCandidate(input).Accepted)
+	require.False(t, service.classifySearchCandidateLegacy(input).Accepted)
 
 	input.RescueTitleMismatches = true
 	input.CandidateSize--
-	require.False(t, service.classifySearchCandidate(input).Accepted)
+	require.False(t, service.classifySearchCandidateLegacy(input).Accepted)
 
 	input.CandidateSize = size
 	differentGroup := candidate
 	differentGroup.Group = "OTHER"
 	input.CandidateRelease = &differentGroup
-	rejected := service.classifySearchCandidate(input)
+	rejected := service.classifySearchCandidateLegacy(input)
 	require.False(t, rejected.Accepted)
 	require.Equal(t, "group mismatch", rejected.RejectReason)
 }
@@ -241,6 +351,8 @@ func TestClassifySearchCandidateTitleRescue(t *testing.T) {
 // Field case: the user's own movie re-uploaded as a bare .mkv, byte-identical,
 // listing retitled with a "cdn-" prefix and the -GROUP tag dropped. The rescue
 // probe must tolerate the absent group; the strict matcher must not.
+// Calls classifySearchCandidateLegacy directly; see the comment on
+// TestClassifySearchCandidateExactSizeFallback.
 func TestClassifySearchCandidateTitleRescueToleratesBareFileCandidate(t *testing.T) {
 	service := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
 	const (
@@ -264,7 +376,7 @@ func TestClassifySearchCandidateTitleRescueToleratesBareFileCandidate(t *testing
 		RescueTitleMismatches: true,
 	}
 
-	decision := service.classifySearchCandidate(input)
+	decision := service.classifySearchCandidateLegacy(input)
 	require.True(t, decision.Accepted, "reject reason: %s", decision.RejectReason)
 	require.Equal(t, searchCandidateClassTitleRescue, decision.Class)
 	require.Equal(t, "title mismatch", decision.StrictMismatchReason)
@@ -344,7 +456,7 @@ func TestSearchCandidateARRSourceTitlesSurviveResultCache(t *testing.T) {
 		TolerancePercent: 5,
 	})
 	require.True(t, decision.Accepted)
-	require.Equal(t, searchCandidateClassStrict, decision.Class)
+	require.Equal(t, searchCandidateClassSizeGroup, decision.Class)
 	require.Equal(t, []string{"Money Heist"}, decision.SourceTitles)
 
 	// The decision owns the title lineage it accepted; later mutations of the ARR
@@ -377,21 +489,27 @@ func TestSearchCandidateARRSourceTitlesSurviveResultCache(t *testing.T) {
 	require.Equal(t, []string{"Money Heist"}, service.getCachedSearchResults(1, "source").results[0].SearchSourceTitles)
 	require.Equal(t, []string{"collection"}, service.getCachedSearchResults(1, "source").results[0].SearchRelaxedDifferences)
 
+	// Title no longer gates video, so a rejection now needs a group mismatch
+	// instead of an unrelated ARR title.
+	const groupMismatchName = "Money.Heist.S01E01.1080p.NF.WEB-DL.DDP5.1.H.264-FLUX"
+	groupMismatchCandidate := rls.ParseString(groupMismatchName)
 	rejected := service.classifySearchCandidate(searchCandidateInput{
 		SourceRelease:    &source,
-		CandidateRelease: &candidate,
+		CandidateRelease: &groupMismatchCandidate,
 		SourceName:       sourceName,
-		CandidateName:    candidateName,
+		CandidateName:    groupMismatchName,
 		SourceTitles:     []string{"Unrelated Show"},
 		SourceSize:       100,
 		CandidateSize:    101,
 		TolerancePercent: 5,
 	})
 	require.False(t, rejected.Accepted)
-	require.Equal(t, "title mismatch", rejected.RejectReason)
+	require.Equal(t, "group mismatch", rejected.RejectReason)
 	require.Empty(t, rejected.SourceTitles)
 }
 
+// Calls classifySearchCandidateLegacy directly; see the comment on
+// TestClassifySearchCandidateExactSizeFallback.
 func TestClassifySearchCandidateExactSizePreconditions(t *testing.T) {
 	service := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
 	sourceName := "Example.Show.S01.2160p.ATV.WEB-DL.HDR.H.265-NTb"
@@ -414,7 +532,7 @@ func TestClassifySearchCandidateExactSizePreconditions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			decision := service.classifySearchCandidate(searchCandidateInput{
+			decision := service.classifySearchCandidateLegacy(searchCandidateInput{
 				SourceRelease:    &source,
 				CandidateRelease: &candidate,
 				SourceName:       sourceName,
@@ -429,6 +547,10 @@ func TestClassifySearchCandidateExactSizePreconditions(t *testing.T) {
 	}
 }
 
+// Calls classifySearchCandidateLegacy directly; the per-field identity gates
+// (title/season/resolution/checksum) it pins are gone from the video path,
+// which now checks only size and group. See the comment on
+// TestClassifySearchCandidateExactSizeFallback.
 func TestClassifySearchCandidateExactSizeHardIdentity(t *testing.T) {
 	service := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
 	const size = int64(94_329_473_840)
@@ -458,7 +580,7 @@ func TestClassifySearchCandidateExactSizeHardIdentity(t *testing.T) {
 				source.Sum = "AAAAAAAA"
 			}
 			test.mutate(&candidate)
-			decision := service.classifySearchCandidate(searchCandidateInput{
+			decision := service.classifySearchCandidateLegacy(searchCandidateInput{
 				SourceRelease:    &source,
 				CandidateRelease: &candidate,
 				SourceName:       source.Title,
@@ -473,6 +595,9 @@ func TestClassifySearchCandidateExactSizeHardIdentity(t *testing.T) {
 	}
 }
 
+// Calls classifySearchCandidateLegacy directly; date identity is no longer
+// checked on the video path. See the comment on
+// TestClassifySearchCandidateExactSizeFallback.
 func TestClassifySearchCandidateExactSizeDateIdentity(t *testing.T) {
 	service := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
 	const size = int64(94_329_473_840)
@@ -524,7 +649,7 @@ func TestClassifySearchCandidateExactSizeDateIdentity(t *testing.T) {
 			source.Year, source.Month, source.Day = test.sourceYear, test.sourceMonth, test.sourceDay
 			candidate.Year, candidate.Month, candidate.Day = test.candidateYear, test.candidateMonth, test.candidateDay
 
-			decision := service.classifySearchCandidate(searchCandidateInput{
+			decision := service.classifySearchCandidateLegacy(searchCandidateInput{
 				SourceRelease:    &source,
 				CandidateRelease: &candidate,
 				SourceName:       source.Title,
@@ -544,6 +669,11 @@ func TestClassifySearchCandidateExactSizeDateIdentity(t *testing.T) {
 	}
 }
 
+// Calls classifySearchCandidateLegacy directly; episode/season-pack pairing
+// and content-type identity are no longer checked on the video path (a
+// season-pack candidate against an episode source now fails only if size or
+// group disagrees; apply's file validation catches what search no longer
+// does). See the comment on TestClassifySearchCandidateExactSizeFallback.
 func TestClassifySearchCandidateExactSizeTVAndContentIdentity(t *testing.T) {
 	service := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
 	const size = int64(94_329_473_840)
@@ -551,7 +681,7 @@ func TestClassifySearchCandidateExactSizeTVAndContentIdentity(t *testing.T) {
 	t.Run("different episode", func(t *testing.T) {
 		source := rls.ParseString("Example.Show.S01E01.2160p.ATV.WEB-DL.H.265-NTb")
 		candidate := rls.ParseString("Example.Show.S01E02.2160p.ATVP.WEB-DL.H.265-NTb")
-		decision := service.classifySearchCandidate(searchCandidateInput{
+		decision := service.classifySearchCandidateLegacy(searchCandidateInput{
 			SourceRelease:    &source,
 			CandidateRelease: &candidate,
 			SourceName:       source.Title,
@@ -567,7 +697,7 @@ func TestClassifySearchCandidateExactSizeTVAndContentIdentity(t *testing.T) {
 	t.Run("forbidden season pack from episode", func(t *testing.T) {
 		source := rls.ParseString("Example.Show.S01E01.2160p.ATV.WEB-DL.H.265-NTb")
 		candidate := rls.ParseString("Example.Show.S01.2160p.ATVP.WEB-DL.H.265-NTb")
-		decision := service.classifySearchCandidate(searchCandidateInput{
+		decision := service.classifySearchCandidateLegacy(searchCandidateInput{
 			SourceRelease:          &source,
 			CandidateRelease:       &candidate,
 			SourceName:             source.Title,
@@ -586,7 +716,7 @@ func TestClassifySearchCandidateExactSizeTVAndContentIdentity(t *testing.T) {
 		candidate := source
 		candidate.Type = rls.Music
 		candidate.Collection = "ATVP"
-		decision := service.classifySearchCandidate(searchCandidateInput{
+		decision := service.classifySearchCandidateLegacy(searchCandidateInput{
 			SourceRelease:    &source,
 			CandidateRelease: &candidate,
 			SourceName:       source.Title,
@@ -1090,131 +1220,6 @@ func TestTitleRescueSkipRecheckStopsBeforeFileLoading(t *testing.T) {
 	require.Equal(t, skippedRecheckMessage, result.Message)
 }
 
-func TestFindCandidatesExactSizeFallbackIsScopedAndContinuesToFileValidation(t *testing.T) {
-	const (
-		instanceID    = 1
-		torrentSize   = int64(94_329_473_840)
-		targetName    = "Example.Show.2024.S01.2160p.ATVP.WEB-DL.DV.HDR10+.H.265-NTb"
-		existingName  = "Example.Show.2024.S01.2160p.ATV.WEB-DL.DV.HDR.H.265-NTb"
-		existingHash  = "existing"
-		unrelatedHash = "unrelated"
-	)
-	instance := &models.Instance{ID: instanceID, Name: "main"}
-	existing := qbt.Torrent{
-		Hash: existingHash,
-		Name: existingName,
-		// Search already established exact size. Apply must not replace that
-		// evidence with a new comparison against downloaded metainfo.
-		Size:     torrentSize + 1,
-		Progress: 1,
-	}
-	unrelated := existing
-	unrelated.Hash = unrelatedHash
-	files := map[string]qbt.TorrentFiles{
-		existingHash: {
-			{
-				Name: "Example.Show.2024.S01E01.2160p.ATV.WEB-DL.DV.HDR.H.265-NTb.mkv",
-				Size: torrentSize,
-			},
-		},
-		unrelatedHash: {
-			{
-				Name: "Example.Show.2024.S01E01.2160p.ATV.WEB-DL.DV.HDR.H.265-NTb.mkv",
-				Size: torrentSize,
-			},
-		},
-	}
-	service := &Service{
-		instanceStore:    &fakeInstanceStore{instances: map[int]*models.Instance{instanceID: instance}},
-		syncManager:      newFakeSyncManager(instance, []qbt.Torrent{existing, unrelated}, files),
-		releaseCache:     NewReleaseCache(),
-		stringNormalizer: stringutils.NewDefaultNormalizer(),
-	}
-	sourceRelease := rls.ParseString(existingName)
-	targetRelease := rls.ParseString(targetName)
-	decision := service.classifySearchCandidate(searchCandidateInput{
-		SourceRelease:    &sourceRelease,
-		CandidateRelease: &targetRelease,
-		SourceName:       existingName,
-		CandidateName:    targetName,
-		SourceSize:       torrentSize,
-		CandidateSize:    torrentSize,
-		TolerancePercent: 5,
-	})
-	require.True(t, decision.Accepted)
-	require.Equal(t, searchCandidateClassExactSizeFallback, decision.Class)
-	require.Equal(t, "hdr mismatch", decision.StrictMismatchReason)
-	require.ElementsMatch(t, []string{"collection", "hdr"}, decision.RelaxedDifferences)
-
-	fallbackRequest := func() *FindCandidatesRequest {
-		return &FindCandidatesRequest{
-			TorrentName:                targetName,
-			TargetInstanceIDs:          []int{instanceID},
-			SearchDecisionClass:        decision.Class,
-			SearchSourceInstanceID:     instanceID,
-			SearchSourceHash:           existingHash,
-			SearchStrictMismatchReason: decision.StrictMismatchReason,
-			SearchRelaxedDifferences:   append([]string(nil), decision.RelaxedDifferences...),
-		}
-	}
-
-	directResponse, err := service.FindCandidates(context.Background(), &FindCandidatesRequest{
-		TorrentName:       targetName,
-		TargetInstanceIDs: []int{instanceID},
-	})
-	require.NoError(t, err)
-	require.Empty(t, directResponse.Candidates, "direct requests must retain strict release matching")
-
-	fallbackResponse, err := service.FindCandidates(context.Background(), fallbackRequest())
-	require.NoError(t, err)
-	require.Len(t, fallbackResponse.Candidates, 1)
-	require.Len(t, fallbackResponse.Candidates[0].Torrents, 1)
-	require.Equal(t, existingHash, fallbackResponse.Candidates[0].Torrents[0].Hash)
-	require.NotEmpty(t, fallbackResponse.Candidates[0].MatchType)
-
-	unrecordedDifferenceRequest := fallbackRequest()
-	// The live strict mismatch for this pair is "hdr"; recording only an
-	// unrelated relaxation must keep the apply stage strict.
-	unrecordedDifferenceRequest.SearchRelaxedDifferences = []string{"collection"}
-	unrecordedDifferenceResponse, err := service.FindCandidates(context.Background(), unrecordedDifferenceRequest)
-	require.NoError(t, err)
-	require.Empty(t, unrecordedDifferenceResponse.Candidates, "fallback must retain the search-recorded relaxation")
-
-	for name, hardMismatchTitle := range map[string]string{
-		"title":      "Different.Show.2024.S01.2160p.ATVP.WEB-DL.DV.HDR10+.H.265-NTb",
-		"season":     "Example.Show.2024.S02.2160p.ATVP.WEB-DL.DV.HDR10+.H.265-NTb",
-		"episode":    "Example.Show.2024.S01E02.2160p.ATVP.WEB-DL.DV.HDR10+.H.265-NTb",
-		"resolution": "Example.Show.2024.S01.1080p.ATVP.WEB-DL.DV.HDR10+.H.265-NTb",
-		"group":      "Example.Show.2024.S01.2160p.ATVP.WEB-DL.DV.HDR10+.H.265-FLUX",
-	} {
-		t.Run("retains strict "+name, func(t *testing.T) {
-			request := fallbackRequest()
-			request.TorrentName = hardMismatchTitle
-			response, findErr := service.FindCandidates(context.Background(), request)
-			require.NoError(t, findErr)
-			require.Empty(t, response.Candidates)
-		})
-	}
-
-	incompatibleFiles := map[string]qbt.TorrentFiles{
-		existingHash: {
-			{
-				Name: "Example.Show.2024.S02E01.2160p.ATV.WEB-DL.DV.HDR.H.265-NTb.mkv",
-				Size: torrentSize,
-			},
-		},
-	}
-	incompatibleService := &Service{
-		instanceStore:    &fakeInstanceStore{instances: map[int]*models.Instance{instanceID: instance}},
-		syncManager:      newFakeSyncManager(instance, []qbt.Torrent{existing}, incompatibleFiles),
-		releaseCache:     NewReleaseCache(),
-		stringNormalizer: stringutils.NewDefaultNormalizer(),
-	}
-	incompatibleResponse, err := incompatibleService.FindCandidates(context.Background(), fallbackRequest())
-	require.NoError(t, err)
-	require.Empty(t, incompatibleResponse.Candidates, "fallback must not bypass file-level release validation")
-}
-
 func TestFindCandidatesScopesSearchSourceAliasesToSourceTorrent(t *testing.T) {
 	const (
 		instanceID    = 1
@@ -1424,14 +1429,18 @@ func TestARRAliasSurvivesSearchToManualAndAutomatedApply(t *testing.T) {
 		return response
 	}
 
-	emptyResponse := search([]string{"Unrelated Show"})
-	require.Empty(t, emptyResponse.Results)
-	require.Equal(t, QueryDegradedARRNoIDs, emptyResponse.QueryDegraded, "empty-ID ARR result must flag the title-only query")
+	// Video no longer gates on title (Task 1: collapse to size+group), so an
+	// unrelated ARR alias no longer empties the result: matching size and
+	// group still admit the candidate. QueryDegraded still flags the
+	// title-only query regardless, since ARR returned no IDs either way.
+	unrelatedTitleResponse := search([]string{"Unrelated Show"})
+	require.Len(t, unrelatedTitleResponse.Results, 1)
+	require.Equal(t, QueryDegradedARRNoIDs, unrelatedTitleResponse.QueryDegraded, "empty-ID ARR result must flag the title-only query")
 	response := search(aliases)
 	require.Len(t, response.Results, 1)
 	require.Equal(t, QueryDegradedARRNoIDs, response.QueryDegraded)
 	match := response.Results[0]
-	require.Equal(t, searchCandidateClassStrict, match.SearchDecisionClass)
+	require.Equal(t, searchCandidateClassSizeGroup, match.SearchDecisionClass)
 	require.Equal(t, aliases, match.SearchSourceTitles)
 
 	t.Run("manual apply", func(t *testing.T) {

--- a/internal/services/crossseed/search_candidate_match_test.go
+++ b/internal/services/crossseed/search_candidate_match_test.go
@@ -104,6 +104,17 @@ func TestClassifySearchCandidate_SizeGroup(t *testing.T) {
 			candidateSize: 20_000_000_000,
 			wantAccepted:  true,
 		},
+		{
+			// rls invents Group "Batch" from the trailing tag while the real
+			// fansub group sits in Site on both sides. The identity sets
+			// overlap on the site, so this must not count as a group conflict.
+			name:          "invented bracket tag group tolerated when sites agree",
+			source:        "[KIRI] Azure Compass S3 (1080p)",
+			candidate:     "[KIRI] Azure Compass S3 (01-12) (1080p) [Batch]",
+			sourceSize:    17_607_234_680,
+			candidateSize: 17_607_234_680,
+			wantAccepted:  true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1386,6 +1397,53 @@ func TestFindCandidatesSizeGroupHonorsGroupGate(t *testing.T) {
 	differentGroupResponse, err := differentGroupService.FindCandidates(context.Background(), sizeGroupRequest)
 	require.NoError(t, err)
 	require.Empty(t, differentGroupResponse.Candidates, "size-group class must still enforce the group gate")
+}
+
+// The downloaded torrent's real name can parse to an invented Group ("[Batch]")
+// that the Torznab title never carried, while the real fansub group sits in
+// Site on both sides. Apply must judge the identity sets, not a collapsed
+// single identity, or the pairing search accepted dies here silently.
+func TestFindCandidatesSizeGroupToleratesInventedBatchGroup(t *testing.T) {
+	const (
+		instanceID = 1
+		targetName = "[KIRI] Azure Compass S3 (01-12) (1080p) [Batch]"
+		sourceName = "[KIRI] Azure Compass S3 (1080p)"
+		sourceHash = "sourcehash"
+		size       = int64(17_607_234_680)
+	)
+
+	target := rls.ParseString(targetName)
+	source := rls.ParseString(sourceName)
+	require.Equal(t, "Batch", target.Group, "fixture must reproduce the invented-group parse")
+	require.Equal(t, "KIRI", target.Site)
+	require.Empty(t, source.Group)
+	require.Equal(t, "KIRI", source.Site)
+
+	instance := &models.Instance{ID: instanceID, Name: "main"}
+	existing := qbt.Torrent{Hash: sourceHash, Name: sourceName, Size: size, Progress: 1}
+	files := map[string]qbt.TorrentFiles{
+		sourceHash: {
+			{Name: sourceName + "/[KIRI] Azure Compass - 25 (1080p) [AAA11111].mkv", Size: size / 2},
+			{Name: sourceName + "/[KIRI] Azure Compass - 26 (1080p) [BBB22222].mkv", Size: size - size/2},
+		},
+	}
+	svc := &Service{
+		instanceStore:    &fakeInstanceStore{instances: map[int]*models.Instance{instanceID: instance}},
+		syncManager:      newFakeSyncManager(instance, []qbt.Torrent{existing}, files),
+		releaseCache:     NewReleaseCache(),
+		stringNormalizer: stringutils.NewDefaultNormalizer(),
+	}
+
+	resp, err := svc.FindCandidates(context.Background(), &FindCandidatesRequest{
+		TorrentName:            targetName,
+		TargetInstanceIDs:      []int{instanceID},
+		SearchDecisionClass:    searchCandidateClassSizeGroup,
+		SearchSourceInstanceID: instanceID,
+		SearchSourceHash:       sourceHash,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Candidates, 1, "site overlap must survive the invented Group")
+	require.Equal(t, sourceHash, resp.Candidates[0].Torrents[0].Hash)
 }
 
 func TestFindCandidatesScopesSearchSourceAliasesToSourceTorrent(t *testing.T) {

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -8907,6 +8907,11 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 			Str("decisionClass", string(decision.Class)).
 			Str("strictMismatchReason", decision.StrictMismatchReason).
 			Strs("relaxedDifferences", decision.RelaxedDifferences).
+			// Empty group fields on a size-group accept mean the candidate
+			// matched on bytes alone; a blank next to a name that visibly
+			// carries a group is a parse failure worth reporting.
+			Str("sourceGroup", normalizedGroupSiteIdentity(s, searchRelease)).
+			Str("candidateGroup", normalizedGroupSiteIdentity(s, candidateRelease)).
 			Msg("[CROSSSEED-SEARCH] Candidate accepted")
 
 		scored = append(scored, scoredTorrentSearchResult{

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -4508,9 +4508,7 @@ func (s *Service) findCandidates(ctx context.Context, req *FindCandidatesRequest
 						}
 						titleRescueHash = hashKey
 					case req.SearchDecisionClass == searchCandidateClassSizeGroup:
-						sourceIdentity := normalizedGroupSiteIdentity(s, sourceRelease)
-						candidateIdentity := normalizedGroupSiteIdentity(s, targetRelease)
-						if sourceIdentity != "" && candidateIdentity != "" && sourceIdentity != candidateIdentity {
+						if groupIdentitiesConflict(s, sourceRelease, targetRelease) {
 							continue
 						}
 					case req.SearchDecisionClass == searchCandidateClassExactSizeFallback:
@@ -9194,6 +9192,8 @@ type scoredTorrentSearchResult struct {
 
 func searchCandidateClassPriority(class searchCandidateClass) int {
 	switch class {
+	case searchCandidateClassSizeGroup:
+		return 4
 	case searchCandidateClassStrict:
 		return 4
 	case searchCandidateClassWebSourceRelabel:

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -4509,6 +4509,14 @@ func (s *Service) findCandidates(ctx context.Context, req *FindCandidatesRequest
 						titleRescueHash = hashKey
 					case req.SearchDecisionClass == searchCandidateClassSizeGroup:
 						if groupIdentitiesConflict(s, sourceRelease, targetRelease) {
+							// The downloaded torrent's real name can parse to a
+							// different group than the Torznab title search judged.
+							log.Debug().
+								Str("targetTitle", req.TorrentName).
+								Str("existingTorrent", torrent.Name).
+								Strs("sourceGroups", normalizedGroupSiteIdentities(s, sourceRelease)).
+								Strs("candidateGroups", normalizedGroupSiteIdentities(s, targetRelease)).
+								Msg("[CROSSSEED] Size-group pairing dropped at apply: group mismatch")
 							continue
 						}
 					case req.SearchDecisionClass == searchCandidateClassExactSizeFallback:
@@ -8910,8 +8918,8 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 			// Empty group fields on a size-group accept mean the candidate
 			// matched on bytes alone; a blank next to a name that visibly
 			// carries a group is a parse failure worth reporting.
-			Str("sourceGroup", normalizedGroupSiteIdentity(s, searchRelease)).
-			Str("candidateGroup", normalizedGroupSiteIdentity(s, candidateRelease)).
+			Strs("sourceGroups", normalizedGroupSiteIdentities(s, searchRelease)).
+			Strs("candidateGroups", normalizedGroupSiteIdentities(s, candidateRelease)).
 			Msg("[CROSSSEED-SEARCH] Candidate accepted")
 
 		scored = append(scored, scoredTorrentSearchResult{

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -4507,6 +4507,12 @@ func (s *Service) findCandidates(ctx context.Context, req *FindCandidatesRequest
 							continue
 						}
 						titleRescueHash = hashKey
+					case req.SearchDecisionClass == searchCandidateClassSizeGroup:
+						sourceIdentity := normalizedGroupSiteIdentity(s, sourceRelease)
+						candidateIdentity := normalizedGroupSiteIdentity(s, targetRelease)
+						if sourceIdentity != "" && candidateIdentity != "" && sourceIdentity != candidateIdentity {
+							continue
+						}
 					case req.SearchDecisionClass == searchCandidateClassExactSizeFallback:
 						fallbackInput := searchCandidateInput{
 							SourceRelease:          sourceRelease,


### PR DESCRIPTION
## Description

Video candidates from search are now admitted on two checks: total size within tolerance, and group/site agreement enforced only when both sides carry one. The title, season, episode, year, date, resolution and checksum gates are gone from video result matching only: search queries still use all of these fields to find candidates, and apply keeps per-file size validation plus recheck as the real identity check. Music keeps the previous cascade unchanged.

Byte-identical candidates kept dying on label noise: AnimeBytes stamps S01 on every entry so season packs failed with `season mismatch`, and absolute-numbered episodes failed against renumbered candidates. The group gate survives because WEB-DLs and remuxes from different groups are the same stream, so sizes collide across groups; a group missing on either side counts as absence of evidence and passes to recheck.

Field test (deep scan on a live library, history cleared, PR image): 408 torrents processed, 63 cross-seeds added across 12 indexers, 11 of them from AnimeBytes, the class that matched zero before this change. Apply-side file validation rejected 31 candidates for size differences and 36 for missing files before any add. Of the adds that needed a recheck, 5 resumed confirmed and 1 stopped at 99.9% and stayed paused for manual review, which is the byte-budget failsafe working. No apply-side group drops, no error-level log lines during the run.

The run also caught one real bug in the first build: the name inside a downloaded .torrent can parse to an invented group from a stray trailing tag (`[Batch]`) while the real group sits in the site field, which silently killed correct pairings at apply. Fixed by comparing group and site as identity sets with overlap counting as agreement, plus a log on that drop path.

## How has this been tested?

Table tests for the new classifier path, a routing test that pins music to the old cascade, and an end-to-end test for the apply-side prefilter. Each gate was mutation-checked: break the gate, watch only its covering test fail, revert. Full `go test -race -count=1` on the package holds the same pre-existing failure set as develop. `make precommit` and `make build` pass.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [x] I ran `make precommit` and the tests pass locally
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

