### PR TITLE
fix(reflinktree): track root before support probe

### DIFF
--- a/pkg/reflinktree/reflink.go
+++ b/pkg/reflinktree/reflink.go
@@ -40,12 +40,6 @@ func Create(plan *hardlinktree.TreePlan) (*hardlinktree.Created, error) {
 		return nil, errors.New("plan has no files")
 	}
 
-	// Check reflink support before creating any files
-	supported, reason := SupportsReflink(plan.RootDir)
-	if !supported {
-		return nil, fmt.Errorf("%w: %s", ErrReflinkUnsupported, reason)
-	}
-
 	// Track created items for rollback
 	created := &hardlinktree.Created{}
 
@@ -63,6 +57,13 @@ func Create(plan *hardlinktree.TreePlan) (*hardlinktree.Created, error) {
 	created.Dirs = append(created.Dirs, rootDirs...)
 	if err != nil {
 		return nil, rollbackOnError(fmt.Errorf("create root directory %s: %w", plan.RootDir, err))
+	}
+
+	// Check reflink support after tracking the root directory. SupportsReflink
+	// creates the directory, which would otherwise hide it from rollback.
+	supported, reason := SupportsReflink(plan.RootDir)
+	if !supported {
+		return nil, rollbackOnError(fmt.Errorf("%w: %s", ErrReflinkUnsupported, reason))
 	}
 
 	// Process each file in the plan


### PR DESCRIPTION
## Description

Track a newly created reflink tree root before probing filesystem support, so the rollback handle owns and removes it. Previously, `SupportsReflink` created the root before `MkdirAllTracked` ran, causing rollback to leave the empty root behind.

Addresses [discussion #2340](https://github.com/autobrr/qui/discussions/2340).

## How has this been tested?

- `env TMPDIR=/var/tmp go test -race -count=3 -run '^TestRollback$' -v ./pkg/reflinktree`
- `env TMPDIR=/var/tmp go test -race -count=1 -v ./pkg/reflinktree ./pkg/hardlinktree`
- `make precommit`
- `make build`

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [x] I ran `make precommit` and the tests pass locally
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

## AI disclosure

Was any AI used in this PR? Roughly how much of the code was AI-written, and what model/tool?

Yes. Codex diagnosed the root cause and authored the one-file fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup when reflink support checks fail during root directory creation.
  * Prevented partially created directories from being left behind after an unsuccessful setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->