### PR TITLE
fix(ui): show unknown for unavailable disk space

### DIFF
--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -1832,7 +1832,7 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
                       </span>
                     </Button>
                   </div>
-                  {effectiveServerState && (
+                  {effectiveServerState?.free_space_on_disk !== undefined && (
                     <div className="flex items-center gap-2 pr-2 border-r last:border-r-0 last:pr-0">
                       <Tooltip>
                         <TooltipTrigger asChild>

--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -32,7 +32,7 @@ import { useTorrentExporter } from "@/hooks/useTorrentExporter"
 import { TORRENT_STREAM_POLL_INTERVAL_SECONDS, useTorrentsList } from "@/hooks/useTorrentsList"
 import { getBackendSortField } from "@/lib/torrent-table/backend-sort-field"
 import { resolveTrackerHealthSupport } from "@/lib/tracker-health-support"
-import { formatBytes } from "@/lib/utils"
+import { formatBytes, formatBytesOrFallback } from "@/lib/utils"
 import {
   getCoreRowModel,
   getFilteredRowModel,
@@ -1832,13 +1832,13 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
                       </span>
                     </Button>
                   </div>
-                  {effectiveServerState?.free_space_on_disk !== undefined && (
+                  {effectiveServerState && (
                     <div className="flex items-center gap-2 pr-2 border-r last:border-r-0 last:pr-0">
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <span className="flex items-center h-6 px-2 text-xs text-muted-foreground">
                             <HardDrive  aria-hidden="true" className="h-3 w-3 mr-1"/>
-                            <span className="ml-auto font-medium truncate">{formatBytes(effectiveServerState.free_space_on_disk)}</span>
+                            <span className="ml-auto font-medium truncate">{formatBytesOrFallback(effectiveServerState.free_space_on_disk, t("common:status.unknown"))}</span>
                           </span>
                         </TooltipTrigger>
                         <TooltipContent>{t("statusBar.freeSpace")}</TooltipContent>

--- a/web/src/lib/__tests__/utils.test.ts
+++ b/web/src/lib/__tests__/utils.test.ts
@@ -53,14 +53,8 @@ describe("joinPath", () => {
 })
 
 describe("formatBytesOrFallback", () => {
-  it.each([
-    { value: undefined, label: "missing" },
-    { value: Number.NaN, label: "NaN" },
-    { value: Number.POSITIVE_INFINITY, label: "positive infinity" },
-    { value: Number.NEGATIVE_INFINITY, label: "negative infinity" },
-    { value: -1, label: "negative" },
-  ])("returns the fallback for an unavailable $label byte value", ({ value }) => {
-    expect(formatBytesOrFallback(value, "Unknown")).toBe("Unknown")
+  it("returns the fallback for a negative byte value", () => {
+    expect(formatBytesOrFallback(-1, "Unknown")).toBe("Unknown")
   })
 
   it.each([

--- a/web/src/lib/__tests__/utils.test.ts
+++ b/web/src/lib/__tests__/utils.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { joinPath, parseTrackerDomains } from "@/lib/utils"
+import { formatBytesOrFallback, joinPath, parseTrackerDomains } from "@/lib/utils"
 import type { Automation } from "@/types"
 import { describe, expect, it } from "vitest"
 
@@ -49,5 +49,24 @@ describe("joinPath", () => {
 
   it("returns the relative path unchanged when the base is empty", () => {
     expect(joinPath("", "Movie/file.mkv")).toBe("Movie/file.mkv")
+  })
+})
+
+describe("formatBytesOrFallback", () => {
+  it.each([
+    { value: undefined, label: "missing" },
+    { value: Number.NaN, label: "NaN" },
+    { value: Number.POSITIVE_INFINITY, label: "positive infinity" },
+    { value: Number.NEGATIVE_INFINITY, label: "negative infinity" },
+    { value: -1, label: "negative" },
+  ])("returns the fallback for an unavailable $label byte value", ({ value }) => {
+    expect(formatBytesOrFallback(value, "Unknown")).toBe("Unknown")
+  })
+
+  it.each([
+    [0, "0 B"],
+    [1024, "1 KiB"],
+  ])("formats the available byte value %s", (value, expected) => {
+    expect(formatBytesOrFallback(value, "Unknown")).toBe(expected)
   })
 })

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -20,8 +20,8 @@ export function formatBytes(bytes: number): string {
   return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`
 }
 
-export function formatBytesOrFallback(bytes: number | undefined, fallback: string): string {
-  if (bytes === undefined || !Number.isFinite(bytes) || bytes < 0) return fallback
+export function formatBytesOrFallback(bytes: number, fallback: string): string {
+  if (bytes < 0) return fallback
 
   return formatBytes(bytes)
 }

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -20,6 +20,12 @@ export function formatBytes(bytes: number): string {
   return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`
 }
 
+export function formatBytesOrFallback(bytes: number | undefined, fallback: string): string {
+  if (bytes === undefined || !Number.isFinite(bytes) || bytes < 0) return fallback
+
+  return formatBytes(bytes)
+}
+
 /**
  * Get the appropriate color for a torrent ratio based on predefined thresholds
  * @param ratio - The ratio value (uploaded/downloaded)

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1140,7 +1140,7 @@ function InstanceCard({
                 </div>
               </div>
 
-              {serverState && (
+              {serverState?.free_space_on_disk !== undefined && (
                 <div className="flex items-center gap-2 text-xs mt-1 sm:mt-2">
                   <HardDrive className="h-3 w-3 text-muted-foreground flex-shrink-0" />
                   <span className="text-muted-foreground">{t("instanceCard.freeSpace")}</span>

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -65,7 +65,7 @@ import {
   resolveDashboardTorrentCounts,
   shouldUseDashboardStatsFallback
 } from "@/lib/dashboard-stream"
-import { copyTextToClipboard, formatBytes, formatDuration, getRatioColor } from "@/lib/utils"
+import { copyTextToClipboard, formatBytes, formatBytesOrFallback, formatDuration, getRatioColor } from "@/lib/utils"
 import type {
   CacheMetadata,
   DashboardSettings,
@@ -1140,11 +1140,11 @@ function InstanceCard({
                 </div>
               </div>
 
-              {serverState?.free_space_on_disk !== undefined && (
+              {serverState && (
                 <div className="flex items-center gap-2 text-xs mt-1 sm:mt-2">
                   <HardDrive className="h-3 w-3 text-muted-foreground flex-shrink-0" />
                   <span className="text-muted-foreground">{t("instanceCard.freeSpace")}</span>
-                  <span className="ml-auto font-medium truncate">{formatBytes(serverState.free_space_on_disk)}</span>
+                  <span className="ml-auto font-medium truncate">{formatBytesOrFallback(serverState.free_space_on_disk, t("common:status.unknown"))}</span>
                 </div>
               )}
 


### PR DESCRIPTION
## Description

qBittorrent uses `-1` for `free_space_on_disk` when it cannot read storage information for the default save path. qui passed that sentinel to `formatBytes`, which produced `NaN undefined`.

This change shows the localized `Unknown` label for negative free-space values on the Dashboard and torrent table footer. Omitted fields keep their existing behavior, while zero and positive values keep the existing byte format. Utility tests cover the qBittorrent sentinel and valid-value boundaries.

## How has this been tested?

- `make precommit`
- `make test-frontend` (972 tests)
- `make build`

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [x] I ran `make precommit` and the tests pass locally
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disk-space information now remains visible when server data is available, even if the value is missing or invalid.
  * Unavailable disk-space values display a localized “unknown” label instead of leaving the section blank.
  * Valid disk-space values continue to use the standard formatted display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->