### PR TITLE
docs: move macOS Container install to the docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,19 +34,6 @@ docker run -d \
   ghcr.io/autobrr/qui:latest
 ```
 
-### macOS Container
-First, install Container from the official source: https://github.com/apple/container/releases
-Second, create the /config and /downloads folders where you would like them.
-Third, run the command below:
-
-```bash
-container run -d \
-  -p 7476:7476 \
-  -v $(pwd)/config:/config \
-  -v $(pwd)/downloads:/downloads \
-  ghcr.io/autobrr/qui:latest
-```
-
 ## Features
 
 - **Single Binary**: No dependencies, just download and run

--- a/documentation/docs/getting-started/docker.md
+++ b/documentation/docs/getting-started/docker.md
@@ -36,6 +36,17 @@ docker run -d \
   ghcr.io/autobrr/qui:latest
 ```
 
+## macOS Container
+
+On macOS, [Apple Container](https://github.com/apple/container/releases) runs the same image. Create the host folders first, then use `container` in place of `docker`:
+
+```bash
+container run -d \
+  -p 7476:7476 \
+  -v $(pwd)/config:/config \
+  ghcr.io/autobrr/qui:latest
+```
+
 ## Local Filesystem Access
 
 <LocalFilesystemDocker />


### PR DESCRIPTION
## Description

Moves the macOS Apple Container install steps out of the README and into the Docker page on the docs site, next to the standalone `docker run` example it mirrors.

Fixes # (issue)

## How has this been tested?

Docs only. No code paths touched.

## Screenshots (for UI changes)

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [ ] I ran `make precommit` and the tests pass locally
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Quick Start guide to streamline the macOS setup instructions.
  * Added dedicated macOS container setup guidance, including host-folder preparation and an example command for running Qui with Apple Container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->