### PR TITLE
perf(sse): compress stream sessions with gzip

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -298,12 +298,14 @@ func (s *Server) Handler() (*chi.Mux, error) {
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to create HTTP compression adapter")
 	} else {
-		// SSE responses must never be compressed. The compressor's writer buffers
-		// until MinSize (delaying event flushes) and lacks Unwrap(), which prevents
-		// the stream handler from clearing the server WriteTimeout via
-		// http.NewResponseController. Bypass compression for event-stream requests
-		// (EventSource always sends Accept: text/event-stream), covering /stream and
-		// the RSS /events endpoint without coupling to specific paths.
+		// SSE responses must never go through this compressor. Its writer buffers
+		// until MinSize, so small events do not flush, and it lacks Unwrap(), which
+		// cuts the stream handler's http.NewResponseController off from the socket
+		// and silently disables the per-write deadline that evicts stalled clients.
+		// Bypass compression for event-stream requests (EventSource always sends
+		// Accept: text/event-stream), covering /stream and the RSS /events endpoint
+		// without coupling to specific paths. /api/stream compresses itself instead:
+		// see gzipSessionWriter in internal/api/sse.
 		r.Use(func(next http.Handler) http.Handler {
 			compressed := compressor(next)
 			return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/internal/api/sse/gzip_writer.go
+++ b/internal/api/sse/gzip_writer.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package sse
+
+import (
+	"compress/gzip"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// gzipLevel trades a little CPU for ~10% fewer bytes than the REST middleware's
+// level 2. The stream pays it once per init snapshot rather than per request, and
+// on a 460 KB snapshot both levels finish in about 2 ms.
+const gzipLevel = 5
+
+// gzipSessionWriter compresses an SSE session. It sits above bufferedSessionWriter
+// so the deadline path is untouched: Serve builds its http.ResponseController from
+// the raw ResponseWriter before any wrapping, and Unwrap keeps flushSession and
+// initFlushError walking down to the buffered writer.
+//
+// Flush order matters. gzip.Writer buffers, so a flush that skips the compressor
+// leaves the event sitting in the deflate window and the client sees nothing until
+// something later fills it. Flush therefore ends the deflate block first, then lets
+// the buffered writer hand the finished frame to the socket (init phase) or to the
+// drain goroutine (buffered phase) as one queued message.
+type gzipSessionWriter struct {
+	sw *bufferedSessionWriter
+	gz *gzip.Writer
+}
+
+func newGzipSessionWriter(sw *bufferedSessionWriter) *gzipSessionWriter {
+	// NewWriterLevel only errors on an invalid level, and gzipLevel is a constant.
+	gz, _ := gzip.NewWriterLevel(sw, gzipLevel)
+	return &gzipSessionWriter{sw: sw, gz: gz}
+}
+
+func (w *gzipSessionWriter) Header() http.Header { return w.sw.Header() }
+
+func (w *gzipSessionWriter) WriteHeader(code int) { w.sw.WriteHeader(code) }
+
+func (w *gzipSessionWriter) Write(p []byte) (int, error) { return w.gz.Write(p) }
+
+func (w *gzipSessionWriter) Unwrap() http.ResponseWriter { return w.sw }
+
+func (w *gzipSessionWriter) Flush() {
+	// End the deflate block before flushing the socket, or the event stays in the
+	// compressor. A flush error means the session is finished anyway: the next write
+	// fails and drops this client.
+	_ = w.gz.Flush()
+	w.sw.Flush()
+}
+
+// acceptsGzip reports whether the client asked for gzip. A gzip token with q=0 is
+// an explicit refusal, which is how a reverse proxy turns compression off, so it
+// must not be read as support.
+func acceptsGzip(header string) bool {
+	for part := range strings.SplitSeq(header, ",") {
+		token, params, _ := strings.Cut(strings.TrimSpace(part), ";")
+		if !strings.EqualFold(strings.TrimSpace(token), "gzip") {
+			continue
+		}
+		key, value, ok := strings.Cut(strings.TrimSpace(params), "=")
+		if !ok || !strings.EqualFold(strings.TrimSpace(key), "q") {
+			return true
+		}
+		q, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+		return err != nil || q > 0
+	}
+	return false
+}

--- a/internal/api/sse/manager.go
+++ b/internal/api/sse/manager.go
@@ -816,13 +816,22 @@ func (m *StreamManager) Serve(w http.ResponseWriter, r *http.Request) {
 	sw := newBufferedSessionWriter(w, rc, streamWriteTimeout, cancel)
 	defer sw.Close() // stop the drain goroutine on disconnect/return
 
+	// Compress the session when the client advertises gzip; the shared middleware
+	// cannot (see gzipSessionWriter).
+	sessionWriter := http.ResponseWriter(sw)
+	if acceptsGzip(r.Header.Get("Accept-Encoding")) {
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Add("Vary", "Accept-Encoding")
+		sessionWriter = newGzipSessionWriter(sw)
+	}
+
 	// Expose the session writer to onSession so it can switch to buffered mode
 	// after writing the init snapshot synchronously (see enableBuffering).
 	ctx = context.WithValue(ctx, sessionWriterContextKey, sw)
 	req := r.WithContext(ctx)
 
 	// ServeHTTP blocks until the client disconnects.
-	m.server.ServeHTTP(sw, req)
+	m.server.ServeHTTP(sessionWriter, req)
 }
 
 // maxQueuedMessages bounds how many flushed SSE messages a single session may

--- a/internal/api/sse/manager.go
+++ b/internal/api/sse/manager.go
@@ -819,7 +819,8 @@ func (m *StreamManager) Serve(w http.ResponseWriter, r *http.Request) {
 	// Compress the session when the client advertises gzip; the shared middleware
 	// cannot (see gzipSessionWriter).
 	sessionWriter := http.ResponseWriter(sw)
-	if acceptsGzip(r.Header.Get("Accept-Encoding")) {
+	// Values, not Get: Accept-Encoding may arrive as several field lines.
+	if acceptsGzip(strings.Join(r.Header.Values("Accept-Encoding"), ",")) {
 		w.Header().Set("Content-Encoding", "gzip")
 		w.Header().Add("Vary", "Accept-Encoding")
 		sessionWriter = newGzipSessionWriter(sw)

--- a/internal/api/sse/manager_delivery_test.go
+++ b/internal/api/sse/manager_delivery_test.go
@@ -411,11 +411,25 @@ func waitForUpdateOnBoth(t *testing.T, a, b *sseReader, timeout time.Duration, t
 func connectStream(t *testing.T, srv *httptest.Server, payload []map[string]any) (*sseReader, context.CancelFunc) {
 	t.Helper()
 
+	resp, cleanup := dialStream(t, srv, payload, "")
+	return newSSEReader(resp.Body), cleanup
+}
+
+// dialStream opens an SSE connection and returns the live response plus a cancel
+// func that closes the client (ending Serve). A non-empty acceptEncoding is sent
+// verbatim, which also stops the transport from adding its own and decoding the
+// body, so the caller sees the wire bytes.
+func dialStream(t *testing.T, srv *httptest.Server, payload []map[string]any, acceptEncoding string) (*http.Response, context.CancelFunc) {
+	t.Helper()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	reqURL := srv.URL + "/stream?streams=" + streamsQuery(t, payload)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	require.NoError(t, err)
 	req.Header.Set("Accept", "text/event-stream")
+	if acceptEncoding != "" {
+		req.Header.Set("Accept-Encoding", acceptEncoding)
+	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -429,13 +443,12 @@ func connectStream(t *testing.T, srv *httptest.Server, payload []map[string]any)
 		t.Fatalf("unexpected status %d connecting to stream: %s", resp.StatusCode, string(body))
 	}
 
-	reader := newSSEReader(resp.Body)
 	cleanup := func() {
 		cancel()
 		resp.Body.Close()
 	}
 	t.Cleanup(cleanup)
-	return reader, cleanup
+	return resp, cleanup
 }
 
 func cannedResponse() *qbittorrent.TorrentResponse {

--- a/internal/api/sse/manager_gzip_test.go
+++ b/internal/api/sse/manager_gzip_test.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2025, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package sse
+
+import (
+	"compress/gzip"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/stretchr/testify/require"
+)
+
+// connectStreamGzip opens an SSE connection that advertises gzip and returns a
+// reader over the decompressed body plus the response, so callers can assert on
+// the negotiated encoding.
+func connectStreamGzip(t *testing.T, srv *httptest.Server, payload []map[string]any) (*sseReader, *http.Response) {
+	t.Helper()
+
+	resp, _ := dialStream(t, srv, payload, "gzip")
+	zr, err := gzip.NewReader(resp.Body)
+	require.NoError(t, err, "response claimed gzip but the body is not a gzip stream")
+	return newSSEReader(zr), resp
+}
+
+// TestGzipStreamFlushesEveryEvent is the reason this change is risky. A gzip
+// writer that is not flushed per event holds bytes in the deflate buffer, so the
+// init snapshot may still arrive (it is large enough to spill on its own) while
+// every later tick sits in the compressor until the buffer fills. The visible
+// failure is "the whole table stopped updating", not a decode error, so assert a
+// second event arrives on a still-open compressed stream.
+func TestGzipStreamFlushesEveryEvent(t *testing.T) {
+	store, cleanup := newTestInstanceStore(t)
+	defer cleanup()
+
+	canned := cannedResponse()
+	provider := &fakeSyncProvider{torrentsResponse: canned}
+	manager := NewStreamManager(nil, provider, store)
+	t.Cleanup(func() { _ = manager.Shutdown(context.Background()) })
+
+	instanceID := seedActiveInstance(t, manager)
+	srv := startStreamServer(t, manager)
+
+	reader, resp := connectStreamGzip(t, srv, streamPayload(instanceID, "stream-gzip-flush"))
+	require.Equal(t, "gzip", resp.Header.Get("Content-Encoding"),
+		"a client advertising gzip should get a compressed stream")
+
+	initEvent := reader.waitForEvent(t, streamEventInit, 5*time.Second)
+	initPayload := decodeStreamPayloadData(t, initEvent.data)
+	require.Equal(t, streamEventInit, initPayload.Type)
+
+	updateEvent := reader.waitForTickTriggered(t, 5*time.Second, func() {
+		manager.HandleMainData(instanceID, &qbt.MainData{Rid: 99, FullUpdate: true})
+	})
+	updatePayload := decodeStreamPayloadData(t, updateEvent.data)
+	require.True(t, isTickEvent(updatePayload.Type), "expected a tick frame, got %q", updatePayload.Type)
+	require.Equal(t, canned.Total, updatePayload.Data.Total)
+}
+
+// TestStreamStaysPlainWithoutGzip pins the negotiated half. A reverse proxy that
+// strips or refuses gzip must still get a readable stream, byte for byte what it
+// got before compression existed.
+func TestStreamStaysPlainWithoutGzip(t *testing.T) {
+	store, cleanup := newTestInstanceStore(t)
+	defer cleanup()
+
+	provider := &fakeSyncProvider{torrentsResponse: cannedResponse()}
+	manager := NewStreamManager(nil, provider, store)
+	t.Cleanup(func() { _ = manager.Shutdown(context.Background()) })
+
+	instanceID := seedActiveInstance(t, manager)
+	srv := startStreamServer(t, manager)
+
+	// DisableCompression keeps the transport from adding its own Accept-Encoding and
+	// transparently decoding the reply, which would hide an unwanted Content-Encoding
+	// from the assertion below.
+	client := &http.Client{Transport: &http.Transport{DisableCompression: true}}
+
+	for _, encoding := range []string{"", "identity", "gzip;q=0"} {
+		t.Run("accept-encoding="+encoding, func(t *testing.T) {
+			ctx := t.Context()
+
+			reqURL := srv.URL + "/stream?streams=" + streamsQuery(t, streamPayload(instanceID, "stream-plain-"+encoding))
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+			require.NoError(t, err)
+			req.Header.Set("Accept", "text/event-stream")
+			if encoding != "" {
+				req.Header.Set("Accept-Encoding", encoding)
+			}
+
+			resp, err := client.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+			require.Empty(t, resp.Header.Get("Content-Encoding"),
+				"a client that did not ask for gzip must get an uncompressed stream")
+
+			initEvent := newSSEReader(resp.Body).waitForEvent(t, streamEventInit, 5*time.Second)
+			require.Equal(t, streamEventInit, decodeStreamPayloadData(t, initEvent.data).Type)
+		})
+	}
+}
+
+func TestAcceptsGzip(t *testing.T) {
+	tests := []struct {
+		header string
+		want   bool
+	}{
+		{"", false},
+		{"identity", false},
+		{"br, zstd", false},
+		{"gzip", true},
+		{"gzip, deflate, br, zstd", true},
+		{" GZIP ", true},
+		{"gzip;q=0.5", true},
+		{"gzip;q=0", false},
+		{"br, gzip;q=0", false},
+		{"gzipped", false},
+		{"x-gzip", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.header, func(t *testing.T) {
+			require.Equal(t, tt.want, acceptsGzip(tt.header))
+		})
+	}
+}
+
+// TestGzipSessionWriterKeepsUnwrapChain guards the silent failure. Three loops walk
+// this chain (flushSession, initFlushError, and the ResponseController Serve builds
+// from the raw writer). A wrapper without Unwrap still streams perfectly while
+// slow-client eviction and init-flush error detection quietly stop working.
+func TestGzipSessionWriterKeepsUnwrapChain(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sw := newBufferedSessionWriter(rec, http.NewResponseController(rec), streamWriteTimeout, func() {})
+	t.Cleanup(sw.Close)
+
+	gz := newGzipSessionWriter(sw)
+	require.Same(t, sw, gz.Unwrap(), "gzip writer must unwrap to the buffered session writer")
+
+	_, err := gz.Write([]byte("event: init\ndata: {}\n\n"))
+	require.NoError(t, err)
+	require.NoError(t, flushSession(gz), "flushSession must still find the writer's flush path")
+}

--- a/internal/api/sse/manager_gzip_test.go
+++ b/internal/api/sse/manager_gzip_test.go
@@ -105,6 +105,35 @@ func TestStreamStaysPlainWithoutGzip(t *testing.T) {
 	}
 }
 
+// TestGzipNegotiationReadsRepeatedHeaderLines guards the Values-not-Get call site:
+// Go keeps repeated Accept-Encoding field lines separate, so Header.Get would read
+// only "br" here and the client would silently lose compression.
+func TestGzipNegotiationReadsRepeatedHeaderLines(t *testing.T) {
+	store, cleanup := newTestInstanceStore(t)
+	defer cleanup()
+
+	provider := &fakeSyncProvider{torrentsResponse: cannedResponse()}
+	manager := NewStreamManager(nil, provider, store)
+	t.Cleanup(func() { _ = manager.Shutdown(context.Background()) })
+
+	instanceID := seedActiveInstance(t, manager)
+	srv := startStreamServer(t, manager)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet,
+		srv.URL+"/stream?streams="+streamsQuery(t, streamPayload(instanceID, "stream-two-headers")), nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Add("Accept-Encoding", "br")
+	req.Header.Add("Accept-Encoding", "gzip")
+
+	client := &http.Client{Transport: &http.Transport{DisableCompression: true}}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, "gzip", resp.Header.Get("Content-Encoding"),
+		"gzip on a second Accept-Encoding line must still be honoured")
+}
+
 func TestAcceptsGzip(t *testing.T) {
 	tests := []struct {
 		header string


### PR DESCRIPTION
## Description

`/api/stream` sends its init snapshot uncompressed. The shared `httpcompression` middleware is bypassed for `text/event-stream` requests because its writer buffers until `MinSize` and has no `Unwrap()`, which cuts the stream handler's `http.ResponseController` off from the socket and disables the per-write deadline that drops stalled clients. This adds a gzip writer in the SSE manager instead. It sits above `bufferedSessionWriter`, flushes the compressor on each event, and keeps the unwrap chain intact, so that deadline still works. It compresses only when the client sends `Accept-Encoding: gzip`, so a proxy that strips or refuses gzip gets the stream it got before.

Measured on a live instance of 5,839 torrents, first page of 300 rows: the init frame is 578 KB uncompressed, and the connection moves 611 to 650 KB in a six second window. With gzip the same window is 63 KB, close to 10 times less, and the decoded init frame is byte for byte the uncompressed one. The saving matters most on slow remote links, where the raw snapshot is most of the wait before rows appear.

Fixes #2331

## How has this been tested?

Four new tests in `internal/api/sse/manager_gzip_test.go`: a compressed stream delivers a second event after the init snapshot, a client that does not ask for gzip gets an uncompressed stream, `Accept-Encoding` parsing including `gzip;q=0`, and the writer's unwrap chain. Each one was checked against a mutant of the code it covers.

`make precommit`, `go test ./internal/api/... -race -count=1`, and `make build` all pass.

Field tested on a live instance. A request with a browser's `Accept-Encoding: gzip, deflate, br, zstd` gets `Content-Encoding: gzip` and delivers the init snapshot and the next tick in the same five second window, which is what proves the per event flush. The log shows no SSE write or flush failures and no write deadline warning.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [x] I ran `make precommit` and the tests pass locally
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added gzip compression support for Server-Sent Events (SSE) when requested by the client.
  * Compressed SSE streams flush each event promptly for timely delivery.
  * Responses now indicate compression and support proper cache variation handling.

* **Bug Fixes**
  * Preserved plain streaming when gzip is unavailable or explicitly refused.
  * Improved streaming behavior for small events by avoiding compression buffering delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->