### PR TITLE
fix(crossseed): trust disc layout for content detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,7 @@ Frontend-specific rules live in `web/AGENTS.md`. Read that file before editing `
 
 ## Commits / PRs
 
+- Keep Superpowers workflow files local and untracked; never add or commit `docs/superpowers/`.
 - Conventional commits: `feat(scope):`, `fix(scope):`, etc.
 - Keep commits focused; split backend/frontend when practical.
 - Update PR branches by merging develop into them, never rebase/force-push. PRs are squash-merged, so rebase gains nothing and force-pushes break review history and contributors' local branches.

--- a/internal/services/crossseed/parsing.go
+++ b/internal/services/crossseed/parsing.go
@@ -204,13 +204,21 @@ func dominantFileContent(files qbt.TorrentFiles) rls.Type {
 // DetermineContentTypeWithFiles classifies a release like DetermineContentType,
 // but first corrects the parsed type with the byte-weighted extension signal
 // from the torrent's files (discussion #1734). Release names often defeat the
-// rls parser, music names most of all, but file extensions are ground truth:
-// audio bytes force the music classification, and video bytes pull a music
-// parse back to tv or movie. The tv/movie split stays with the name-based
-// parse. Without files, or when neither class dominates, the name decides,
-// except for a disc layout, which classifies as a movie when the name gives
-// nothing.
+// rls parser, music names most of all. A recognized disc layout is authoritative
+// video content and preserves explicit TV structure. Otherwise, audio bytes
+// force the music classification, and video bytes pull a music parse back to tv
+// or movie. The tv/movie split stays with the name-based parse. Without files,
+// or when neither class dominates, the name decides.
 func DetermineContentTypeWithFiles(release *rls.Release, files qbt.TorrentFiles) ContentTypeInfo {
+	if isDisc, _ := isDiscLayoutTorrent(files); isDisc {
+		if isTVRelease(release) {
+			return DetermineContentType(release)
+		}
+		if movieInfo, ok := RuleContentTypeInfo("movie"); ok {
+			return movieInfo
+		}
+	}
+
 	dominant := dominantFileContent(files)
 	if dominant == rls.Music {
 		if release.Type != rls.Music && release.Type != rls.Audiobook {
@@ -226,19 +234,7 @@ func DetermineContentTypeWithFiles(release *rls.Release, files qbt.TorrentFiles)
 		return classifyRelease(demoteMusicToVideo(release))
 	}
 
-	info := DetermineContentType(release)
-	if info.ContentType == "unknown" {
-		// A disc rip holds no release name in its files (VIDEO_TS/VTS_01_1.VOB),
-		// and its folder often carries no year or resolution either, so the name
-		// alone classifies as unknown and the search goes out with no categories
-		// (#2336). The layout itself proves the content is video.
-		if isDisc, _ := isDiscLayoutTorrent(files); isDisc {
-			if movieInfo, ok := RuleContentTypeInfo("movie"); ok {
-				return movieInfo
-			}
-		}
-	}
-	return info
+	return DetermineContentType(release)
 }
 
 // DetermineContentType analyzes a release and returns comprehensive content type information

--- a/internal/services/crossseed/parsing.go
+++ b/internal/services/crossseed/parsing.go
@@ -212,7 +212,7 @@ func dominantFileContent(files qbt.TorrentFiles) rls.Type {
 func DetermineContentTypeWithFiles(release *rls.Release, files qbt.TorrentFiles) ContentTypeInfo {
 	if isDisc, _ := isDiscLayoutTorrent(files); isDisc {
 		if isTVRelease(release) {
-			return DetermineContentType(release)
+			return classifyReleaseAs(release, rls.Series)
 		}
 		if movieInfo, ok := RuleContentTypeInfo("movie"); ok {
 			return movieInfo
@@ -273,6 +273,10 @@ func RuleContentTypeInfo(contentType string) (ContentTypeInfo, bool) {
 }
 
 func classifyRelease(release *rls.Release) ContentTypeInfo {
+	return classifyReleaseAs(release, release.Type)
+}
+
+func classifyReleaseAs(release *rls.Release, releaseType rls.Type) ContentTypeInfo {
 	var info ContentTypeInfo
 
 	// Apply stacked parsing for clarity and to avoid false-positives
@@ -305,7 +309,7 @@ func classifyRelease(release *rls.Release) ContentTypeInfo {
 		return info
 	}
 
-	switch release.Type {
+	switch releaseType {
 	case rls.Movie:
 		info.ContentType = "movie"
 		info.Categories = []int{2000, 2010, 2020, 2030, 2040, 2045, 2050, 2060, 2070, 2080} // Movies
@@ -352,7 +356,7 @@ func classifyRelease(release *rls.Release) ContentTypeInfo {
 		info.Categories = []int{4000} // PC
 		info.SearchType = "search"
 		info.RequiredCaps = []string{}
-	default:
+	case rls.Unknown, rls.Education, rls.Magazine:
 		// Fallback logic based on series/episode/year detection for unknown types
 		if release.Series > 0 || release.Episode > 0 {
 			info.ContentType = "tv"

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -6671,7 +6671,11 @@ func (s *Service) selectContentDetectionRelease(torrentName string, sourceReleas
 	}
 	if isDisc, _ := isDiscLayoutTorrent(files); isDisc {
 		discRelease := *sourceRelease
-		if !isTVRelease(sourceRelease) {
+		if isTVRelease(sourceRelease) {
+			if discRelease.Type != rls.Series && discRelease.Type != rls.Episode {
+				discRelease.Type = rls.Series
+			}
+		} else {
 			discRelease.Type = rls.Movie
 		}
 		return &discRelease, false

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -6669,6 +6669,13 @@ func (s *Service) selectContentDetectionRelease(torrentName string, sourceReleas
 	if len(files) == 0 || s == nil || s.releaseCache == nil {
 		return sourceRelease, false
 	}
+	if isDisc, _ := isDiscLayoutTorrent(files); isDisc {
+		discRelease := *sourceRelease
+		if !isTVRelease(sourceRelease) {
+			discRelease.Type = rls.Movie
+		}
+		return &discRelease, false
+	}
 
 	largestFile := FindLargestFile(files)
 	if largestFile == nil {

--- a/internal/services/crossseed/source_release_inference_test.go
+++ b/internal/services/crossseed/source_release_inference_test.go
@@ -244,6 +244,8 @@ func TestSelectContentDetectionRelease_DiscLayout(t *testing.T) {
 			{Name: "Signal Voyagers S02/VIDEO_TS/VTS_01_1.VOB", Size: 1},
 			{Name: "Signal Voyagers S02/extras/misleading.mp3", Size: 10_000},
 		}
+		require.Equal(t, "tv", DetermineContentTypeWithFiles(source, files).ContentType,
+			"disc classification must normalize explicit TV metadata without relying on the selector")
 
 		contentDetectionRelease, usedFile := svc.selectContentDetectionRelease(source.Title, source, files)
 

--- a/internal/services/crossseed/source_release_inference_test.go
+++ b/internal/services/crossseed/source_release_inference_test.go
@@ -197,6 +197,55 @@ func TestSelectContentDetectionRelease_MusicNameKeepsEpisodeMarkersFromFiles(t *
 	require.Equal(t, "tv", DetermineContentTypeWithFiles(contentDetectionRelease, files).ContentType)
 }
 
+func TestSelectContentDetectionRelease_DiscLayout(t *testing.T) {
+	svc := &Service{
+		releaseCache:     NewReleaseCache(),
+		stringNormalizer: stringutils.NewDefaultNormalizer(),
+	}
+
+	const sourceName = "Space Badgers From Pluto (2011)"
+	tests := []struct {
+		name string
+		file string
+	}{
+		{
+			name: "BDMV",
+			file: sourceName + "/BDMV/STREAM/00000.m2ts",
+		},
+		{
+			name: "VIDEO_TS",
+			file: sourceName + "/VIDEO_TS/VTS_01_1.VOB",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := svc.releaseCache.Parse(sourceName)
+			require.Equal(t, rls.Music, source.Type,
+				"fixture only exercises the fix while the torrent name classifies as music")
+
+			files := qbt.TorrentFiles{{Name: tt.file, Size: 1}}
+			contentDetectionRelease, usedFile := svc.selectContentDetectionRelease(sourceName, source, files)
+
+			require.False(t, usedFile, "disc layout must bypass largest-file parsing")
+			require.Equal(t, "movie", DetermineContentType(contentDetectionRelease).ContentType)
+			require.NotSame(t, source, contentDetectionRelease, "disc classification must not mutate the cached parse")
+			require.Equal(t, rls.Music, source.Type, "disc classification must not mutate the cached parse")
+		})
+	}
+
+	t.Run("keeps explicit TV structure", func(t *testing.T) {
+		source := &rls.Release{Type: rls.Series, Title: "Signal Voyagers", Series: 2}
+		files := qbt.TorrentFiles{{Name: "Signal Voyagers S02/VIDEO_TS/VTS_01_1.VOB", Size: 1}}
+
+		contentDetectionRelease, usedFile := svc.selectContentDetectionRelease(source.Title, source, files)
+
+		require.False(t, usedFile, "disc layout must bypass largest-file parsing")
+		require.NotSame(t, source, contentDetectionRelease, "disc classification must not mutate the cached parse")
+		require.Equal(t, "tv", DetermineContentType(contentDetectionRelease).ContentType)
+	})
+}
+
 // Regression: parsing the full torrent-relative path invented a group and hard-rejected
 // byte-identical candidates with "group/site mismatch". See selectContentDetectionRelease.
 func TestSelectContentDetectionRelease_RepeatedFolderNameKeepsGroup(t *testing.T) {

--- a/internal/services/crossseed/source_release_inference_test.go
+++ b/internal/services/crossseed/source_release_inference_test.go
@@ -235,13 +235,14 @@ func TestSelectContentDetectionRelease_DiscLayout(t *testing.T) {
 	}
 
 	t.Run("keeps explicit TV structure", func(t *testing.T) {
-		source := &rls.Release{Type: rls.Series, Title: "Signal Voyagers", Series: 2}
+		source := &rls.Release{Type: rls.Music, Title: "Signal Voyagers", Series: 2}
 		files := qbt.TorrentFiles{{Name: "Signal Voyagers S02/VIDEO_TS/VTS_01_1.VOB", Size: 1}}
 
 		contentDetectionRelease, usedFile := svc.selectContentDetectionRelease(source.Title, source, files)
 
 		require.False(t, usedFile, "disc layout must bypass largest-file parsing")
 		require.NotSame(t, source, contentDetectionRelease, "disc classification must not mutate the cached parse")
+		require.Equal(t, rls.Music, source.Type, "disc classification must not mutate the cached parse")
 		require.Equal(t, "tv", DetermineContentType(contentDetectionRelease).ContentType)
 	})
 }

--- a/internal/services/crossseed/source_release_inference_test.go
+++ b/internal/services/crossseed/source_release_inference_test.go
@@ -224,11 +224,15 @@ func TestSelectContentDetectionRelease_DiscLayout(t *testing.T) {
 			require.Equal(t, rls.Music, source.Type,
 				"fixture only exercises the fix while the torrent name classifies as music")
 
-			files := qbt.TorrentFiles{{Name: tt.file, Size: 1}}
+			files := qbt.TorrentFiles{
+				{Name: tt.file, Size: 1},
+				{Name: sourceName + "/extras/misleading.mp3", Size: 10_000},
+			}
 			contentDetectionRelease, usedFile := svc.selectContentDetectionRelease(sourceName, source, files)
 
 			require.False(t, usedFile, "disc layout must bypass largest-file parsing")
-			require.Equal(t, "movie", DetermineContentType(contentDetectionRelease).ContentType)
+			require.Equal(t, "movie", DetermineContentTypeWithFiles(contentDetectionRelease, files).ContentType,
+				"dominant audio must not override the authoritative disc classification")
 			require.NotSame(t, source, contentDetectionRelease, "disc classification must not mutate the cached parse")
 			require.Equal(t, rls.Music, source.Type, "disc classification must not mutate the cached parse")
 		})
@@ -236,15 +240,43 @@ func TestSelectContentDetectionRelease_DiscLayout(t *testing.T) {
 
 	t.Run("keeps explicit TV structure", func(t *testing.T) {
 		source := &rls.Release{Type: rls.Music, Title: "Signal Voyagers", Series: 2}
-		files := qbt.TorrentFiles{{Name: "Signal Voyagers S02/VIDEO_TS/VTS_01_1.VOB", Size: 1}}
+		files := qbt.TorrentFiles{
+			{Name: "Signal Voyagers S02/VIDEO_TS/VTS_01_1.VOB", Size: 1},
+			{Name: "Signal Voyagers S02/extras/misleading.mp3", Size: 10_000},
+		}
 
 		contentDetectionRelease, usedFile := svc.selectContentDetectionRelease(source.Title, source, files)
 
 		require.False(t, usedFile, "disc layout must bypass largest-file parsing")
 		require.NotSame(t, source, contentDetectionRelease, "disc classification must not mutate the cached parse")
 		require.Equal(t, rls.Music, source.Type, "disc classification must not mutate the cached parse")
-		require.Equal(t, "tv", DetermineContentType(contentDetectionRelease).ContentType)
+		require.Equal(t, "tv", DetermineContentTypeWithFiles(contentDetectionRelease, files).ContentType,
+			"dominant audio must not override explicit TV structure")
 	})
+}
+
+func TestDiscLayoutDominantAudioKeepsTVSearchShape(t *testing.T) {
+	svc := &Service{
+		releaseCache:     NewReleaseCache(),
+		stringNormalizer: stringutils.NewDefaultNormalizer(),
+	}
+
+	const sourceName = "Signal.Voyagers.S02E03.DVDR"
+	source := &rls.Release{Type: rls.Episode, Title: "Signal Voyagers", Series: 2, Episode: 3}
+	files := qbt.TorrentFiles{
+		{Name: sourceName + "/VIDEO_TS/VTS_01_1.VOB", Size: 1},
+		{Name: sourceName + "/extras/misleading.mp3", Size: 10_000},
+	}
+
+	contentDetectionRelease, usedFile := svc.selectContentDetectionRelease(sourceName, source, files)
+	require.False(t, usedFile)
+
+	contentInfo := DetermineContentTypeWithFiles(contentDetectionRelease, files)
+	require.Equal(t, "tv", contentInfo.ContentType)
+	searchRelease := svc.selectSourceReleaseForSearch(source, contentDetectionRelease, files, contentInfo)
+	query := BuildTorznabQuery(sourceName, searchRelease, contentInfo.IsMusic)
+	require.NotNil(t, query.Episode)
+	require.Equal(t, 3, *query.Episode)
 }
 
 // Regression: parsing the full torrent-relative path invented a group and hard-rejected


### PR DESCRIPTION
## Description

Disc layouts now bypass largest-file title comparison when content detection sees a `BDMV` or `VIDEO_TS` directory. The existing disc-layout detector becomes the authoritative signal: non-TV releases classify as movies, explicit TV structure remains TV, and the cached torrent-name parse is not mutated.

This removes the recurring unrelated-file warning and prevents disc rips with weak or misleading torrent-name parses from being routed as unknown or music. Non-disc title comparison is unchanged.

Fixes #2338

## How has this been tested?

- `go test -race -count=1 ./internal/services/crossseed -run 'TestSelectContentDetectionRelease|TestDetermineContentTypeWithFiles'`
- `make precommit`
- `make build`

The full cross-seed package currently has unrelated season-pack failures locally; a representative failure reproduces on unchanged `develop`. CI remains authoritative for the complete suite.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [ ] I ran `make precommit` and the tests pass locally
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

## AI disclosure

Was any AI used in this PR? Roughly how much of the code was AI-written, and what model/tool?

Yes. OpenAI Codex assisted with most of the implementation and regression tests under human direction and review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved content classification for disc-based torrents, including BDMV and VIDEO_TS layouts.
  * Movie releases are now identified correctly without relying on largest-file analysis.
  * Existing TV and episode classifications are preserved when valid, even when large audio files are present.
  * Search results now retain accurate TV episode information for disc-based releases.

* **Tests**
  * Added regression coverage for disc-layout classification, source release preservation, and episode-aware search behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->