### PR TITLE
perf(torrents): trim magnet_uri from the torrent list payload

### DIFF
--- a/internal/api/handlers/torrents.go
+++ b/internal/api/handlers/torrents.go
@@ -424,7 +424,7 @@ func (h *TorrentsHandler) GetTorrentField(w http.ResponseWriter, r *http.Request
 					continue
 				}
 
-				value := torrentFieldValue(req.Field, torrent.Name, torrent.Hash, torrent.InfohashV1, torrent.InfohashV2, torrent.SavePath, torrent.Tags, torrent.MagnetURI)
+				value := torrentFieldValue(req.Field, torrent.Name, torrent.Hash, torrent.InfohashV1, torrent.InfohashV2, torrent.SavePath, torrent.Tags, torrent.Torrent.MagnetURI)
 				if shouldIncludeTorrentFieldValue(req.Field, value) {
 					values = append(values, value)
 					resolvedCount++
@@ -482,7 +482,7 @@ func (h *TorrentsHandler) GetTorrentField(w http.ResponseWriter, r *http.Request
 				continue
 			}
 
-			value := torrentFieldValue(req.Field, torrent.Name, torrent.Hash, torrent.InfohashV1, torrent.InfohashV2, torrent.SavePath, torrent.Tags, torrent.MagnetURI)
+			value := torrentFieldValue(req.Field, torrent.Name, torrent.Hash, torrent.InfohashV1, torrent.InfohashV2, torrent.SavePath, torrent.Tags, torrent.Torrent.MagnetURI)
 			if shouldIncludeTorrentFieldValue(req.Field, value) {
 				values = append(values, value)
 			}

--- a/internal/api/handlers/torrents.go
+++ b/internal/api/handlers/torrents.go
@@ -459,12 +459,13 @@ func (h *TorrentsHandler) GetTorrentField(w http.ResponseWriter, r *http.Request
 			RespondError(w, http.StatusInternalServerError, "Failed to get torrent field")
 			return
 		}
-		if response.PartialResults && req.Field == "tags" {
-			log.Error().
-				Int("instanceID", instanceID).
+		// A truncated value list behind a 200 reads as complete, so partial aggregates fail for every field.
+		if response.PartialResults {
+			log.Warn().
 				Str("field", req.Field).
-				Msg("Cross-instance torrent field returned partial results for tag baseline")
-			RespondError(w, http.StatusServiceUnavailable, "Failed to resolve the full tag baseline")
+				Ints("instanceIDs", req.InstanceIDs).
+				Msg("Cross-instance torrent field returned partial results")
+			RespondError(w, http.StatusServiceUnavailable, "Unable to resolve all scoped instances for torrent field request")
 			return
 		}
 

--- a/internal/api/handlers/torrents_field_test.go
+++ b/internal/api/handlers/torrents_field_test.go
@@ -115,6 +115,74 @@ func TestGetTorrentField_MagnetURIReturnsSelectedLinks(t *testing.T) {
 	}, response.Values)
 }
 
+// TestGetTorrentField_MagnetURIExplicitHashes pins magnet values through the
+// explicit-hash field path. List payloads no longer carry magnet_uri (issue
+// #2328), so this endpoint is the only source for the copy-magnet action.
+func TestGetTorrentField_MagnetURIExplicitHashes(t *testing.T) {
+	t.Parallel()
+
+	instanceStore, syncManager, instanceIDs := createTorrentFieldTestHarness(t, map[string][]qbt.Torrent{
+		"alpha": {
+			{Name: "Alpha", Hash: "aaa", MagnetURI: "magnet:?xt=urn:btih:aaa"},
+			{Name: "Beta", Hash: "bbb", MagnetURI: "magnet:?xt=urn:btih:bbb"},
+			{Name: "Gamma", Hash: "ccc", MagnetURI: "magnet:?xt=urn:btih:ccc"},
+		},
+	})
+
+	handler := NewTorrentsHandler(syncManager, nil, instanceStore)
+	req := newTorrentFieldRequest(t, instanceIDs["alpha"], map[string]any{
+		"field":  "magnet_uri",
+		"hashes": []string{"aaa", "ccc"},
+	})
+
+	rec := httptest.NewRecorder()
+	handler.GetTorrentField(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var response quiqbt.TorrentFieldResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+	require.ElementsMatch(t, []string{
+		"magnet:?xt=urn:btih:aaa",
+		"magnet:?xt=urn:btih:ccc",
+	}, response.Values)
+}
+
+// TestGetTorrentField_MagnetURICrossInstanceFilterScope pins magnet values
+// through the cross-instance filter-scope field path, the third MagnetURI
+// read site (issue #2328).
+func TestGetTorrentField_MagnetURICrossInstanceFilterScope(t *testing.T) {
+	t.Parallel()
+
+	instanceStore, syncManager, instanceIDs := createTorrentFieldTestHarness(t, map[string][]qbt.Torrent{
+		"alpha": {
+			{Name: "Alpha", Hash: "aaa", MagnetURI: "magnet:?xt=urn:btih:aaa"},
+		},
+		"beta": {
+			{Name: "Beta", Hash: "bbb", MagnetURI: "magnet:?xt=urn:btih:bbb"},
+			{Name: "Gamma", Hash: "ccc"},
+		},
+	})
+
+	handler := NewTorrentsHandler(syncManager, nil, instanceStore)
+	req := newTorrentFieldRequest(t, allInstancesID, map[string]any{
+		"field":       "magnet_uri",
+		"instanceIds": []int{instanceIDs["alpha"], instanceIDs["beta"]},
+	})
+
+	rec := httptest.NewRecorder()
+	handler.GetTorrentField(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	var response quiqbt.TorrentFieldResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+	require.ElementsMatch(t, []string{
+		"magnet:?xt=urn:btih:aaa",
+		"magnet:?xt=urn:btih:bbb",
+	}, response.Values)
+}
+
 func TestListCrossInstanceTorrentsSkipsFreshData(t *testing.T) {
 	handler, release := createStaleCrossInstanceReadHarness(t)
 	defer release()

--- a/internal/api/handlers/torrents_field_test.go
+++ b/internal/api/handlers/torrents_field_test.go
@@ -183,6 +183,35 @@ func TestGetTorrentField_MagnetURICrossInstanceFilterScope(t *testing.T) {
 	}, response.Values)
 }
 
+// TestGetTorrentField_CrossInstancePartialResultsRejected pins the filter-scope
+// partial guard for non-tags fields: a truncated magnet list behind a 200 would
+// read as complete, so a failed instance must fail the whole request.
+func TestGetTorrentField_CrossInstancePartialResultsRejected(t *testing.T) {
+	t.Parallel()
+
+	instanceStore, syncManager, instanceIDs := createTorrentFieldTestHarness(t, map[string][]qbt.Torrent{
+		"alpha": {
+			{Name: "Alpha", Hash: "aaa", MagnetURI: "magnet:?xt=urn:btih:aaa"},
+		},
+	})
+
+	// A second instance with no pool client and an unreachable address: its
+	// per-instance fetch errors, which marks the cross-instance aggregate partial.
+	broken, err := instanceStore.Create(context.Background(), "beta", "http://127.0.0.1:1", "user", "pass", nil, nil, false, nil)
+	require.NoError(t, err)
+
+	handler := NewTorrentsHandler(syncManager, nil, instanceStore)
+	req := newTorrentFieldRequest(t, allInstancesID, map[string]any{
+		"field":       "magnet_uri",
+		"instanceIds": []int{instanceIDs["alpha"], broken.ID},
+	})
+
+	rec := httptest.NewRecorder()
+	handler.GetTorrentField(rec, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code, rec.Body.String())
+}
+
 func TestListCrossInstanceTorrentsSkipsFreshData(t *testing.T) {
 	handler, release := createStaleCrossInstanceReadHarness(t)
 	defer release()

--- a/internal/api/sse/delta.go
+++ b/internal/api/sse/delta.go
@@ -196,8 +196,7 @@ func computeRowDelta[T any](rows []T, keyOf func(T) string, fpOf func(*fpBuf, T)
 // prefix so adjacent fields cannot alias ("ab"+"c" vs "a"+"bc").
 type fpBuf []byte
 
-// fpBufSize covers a typical row (fixed fields plus name and paths); a row with a
-// long magnet URI takes one extra grow.
+// fpBufSize covers a typical row (fixed fields plus name and paths).
 const fpBufSize = 1024
 
 func (b *fpBuf) i64(v int64)   { *b = binary.LittleEndian.AppendUint64(*b, uint64(v)) }
@@ -220,7 +219,10 @@ func (b *fpBuf) bit(v bool) {
 // almost as large as a full snapshot (the root cause of the stream saturating an
 // HTTP/2 connection). The excluded fields still ride along with their current value
 // whenever a row is sent for a real change; they are just not on their own a reason
-// to resend a row. TestTorrentFingerprintCoversEveryField pins this partition, so a
+// to resend a row. MagnetURI is also left out, for a different reason: TorrentView
+// shadows it out of the serialized payload entirely (issue #2328), so a magnet-only
+// change has nothing to update and must not resend a row.
+// TestTorrentFingerprintCoversEveryField pins this partition, so a
 // go-qbittorrent bump that adds a field fails until the field is categorized here.
 func (b *fpBuf) torrent(t *qbt.Torrent) {
 	if t == nil {
@@ -246,7 +248,6 @@ func (b *fpBuf) torrent(t *qbt.Torrent) {
 	b.str(t.InfohashV1)
 	b.str(t.InfohashV2)
 	b.bit(t.Private)
-	b.str(t.MagnetURI)
 	b.f64(t.MaxRatio)
 	b.i64(t.MaxSeedingTime)
 	b.i64(t.MaxInactiveSeedingTime)

--- a/internal/api/sse/fingerprint_test.go
+++ b/internal/api/sse/fingerprint_test.go
@@ -32,6 +32,13 @@ var volatileTorrentFields = map[string]bool{
 	"NumSeeds":      true,
 }
 
+// payloadOmittedTorrentFields are skipped for a different reason than jitter:
+// TorrentView shadows them out of the serialized payload (issue #2328), so a
+// change to one has nothing to update client-side and must not resend a row.
+var payloadOmittedTorrentFields = map[string]bool{
+	"MagnetURI": true,
+}
+
 // setSampleValue writes a non-zero value of the field's kind so a hashed field
 // must move the fingerprint. New field kinds in go-qbittorrent fail loudly here.
 func setSampleValue(t *testing.T, f reflect.Value) {
@@ -60,9 +67,9 @@ func setSampleValue(t *testing.T, f reflect.Value) {
 }
 
 // TestTorrentFingerprintCoversEveryField proves the fingerprint reacts to every
-// non-volatile qbt.Torrent field and ignores every volatile one. When a
-// go-qbittorrent bump adds a field, this fails until the field is added to
-// fpBuf.torrent or to volatileTorrentFields.
+// hashed qbt.Torrent field and ignores every volatile or payload-omitted one.
+// When a go-qbittorrent bump adds a field, this fails until the field is added
+// to fpBuf.torrent, volatileTorrentFields, or payloadOmittedTorrentFields.
 func TestTorrentFingerprintCoversEveryField(t *testing.T) {
 	base := singleRowFingerprint(new(fpBuf), qbittorrent.TorrentView{Torrent: &qbt.Torrent{}})
 	typ := reflect.TypeFor[qbt.Torrent]()
@@ -71,12 +78,27 @@ func TestTorrentFingerprintCoversEveryField(t *testing.T) {
 		var mutated qbt.Torrent
 		setSampleValue(t, reflect.ValueOf(&mutated).Elem().Field(i))
 		fp := singleRowFingerprint(new(fpBuf), qbittorrent.TorrentView{Torrent: &mutated})
-		if volatileTorrentFields[field.Name] {
+		switch {
+		case volatileTorrentFields[field.Name]:
 			require.Equal(t, base, fp, "volatile field %s must not affect the fingerprint", field.Name)
-		} else {
-			require.NotEqual(t, base, fp, "field %s must change the fingerprint; add it to fpBuf.torrent or volatileTorrentFields", field.Name)
+		case payloadOmittedTorrentFields[field.Name]:
+			require.Equal(t, base, fp, "payload-omitted field %s must not affect the fingerprint", field.Name)
+		default:
+			require.NotEqual(t, base, fp, "field %s must change the fingerprint; add it to fpBuf.torrent, volatileTorrentFields, or payloadOmittedTorrentFields", field.Name)
 		}
 	}
+}
+
+// TestMagnetOnlyChangeDoesNotResendRow pins the payload-omitted rule end to end:
+// magnet_uri no longer serializes in list/SSE rows, so a magnet-only change must
+// not flag the row as changed.
+func TestMagnetOnlyChangeDoesNotResendRow(t *testing.T) {
+	before := []qbittorrent.TorrentView{{Torrent: &qbt.Torrent{Hash: "aaa", Name: "Alpha"}}}
+	after := []qbittorrent.TorrentView{{Torrent: &qbt.Torrent{Hash: "aaa", Name: "Alpha", MagnetURI: "magnet:?xt=urn:btih:aaa"}}}
+
+	_, _, baseFP := computeRowDelta(before, singleRowKey, singleRowFingerprint, nil)
+	_, changed, _ := computeRowDelta(after, singleRowKey, singleRowFingerprint, baseFP)
+	require.Empty(t, changed, "magnet-only change must not resend the row")
 }
 
 // assertEveryFieldHashed proves fp reacts to every field of T: a fingerprint

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -187,6 +187,12 @@ const (
 // Uses pointer embedding to avoid unnecessary copies of the large qbt.Torrent struct.
 type TorrentView struct {
 	*qbt.Torrent
+	// MagnetURI shadows the promoted qbt.Torrent field so magnet_uri never
+	// reaches list/SSE JSON (issue #2328: 13% of the list payload, only the
+	// copy-magnet action reads it, and that fetches on demand). *struct{}
+	// instead of string so any promoted read fails to compile instead of
+	// silently returning ""; readers must go through .Torrent.MagnetURI.
+	MagnetURI     *struct{}     `json:"magnet_uri,omitempty"`
 	TrackerHealth TrackerHealth `json:"tracker_health,omitempty"`
 }
 
@@ -1911,7 +1917,7 @@ func (sm *SyncManager) GetTorrentField(
 		case "tags":
 			v = t.Tags
 		case "magnet_uri":
-			v = strings.TrimSpace(t.MagnetURI)
+			v = strings.TrimSpace(t.Torrent.MagnetURI)
 		}
 		if field == "tags" || v != "" {
 			values = append(values, v)

--- a/internal/qbittorrent/torrent_view_json_test.go
+++ b/internal/qbittorrent/torrent_view_json_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package qbittorrent
+
+import (
+	"encoding/json"
+	"testing"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTorrentViewJSONOmitsMagnetURI pins the shadow field on TorrentView: the
+// embedded qbt.Torrent.MagnetURI must never serialize in list/SSE rows (issue
+// #2328), while the rest of the row stays intact. Marshaling the cross-instance
+// view exercises TorrentView through its deepest embedding, covering both row
+// types in one pass.
+func TestTorrentViewJSONOmitsMagnetURI(t *testing.T) {
+	t.Parallel()
+
+	torrent := &qbt.Torrent{
+		Hash:      "aaa",
+		Name:      "Alpha",
+		MagnetURI: "magnet:?xt=urn:btih:aaa",
+	}
+
+	data, err := json.Marshal(CrossInstanceTorrentView{
+		TorrentView: &TorrentView{Torrent: torrent},
+		InstanceID:  1,
+	})
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.NotContains(t, decoded, "magnet_uri")
+	require.Equal(t, "aaa", decoded["hash"])
+	require.Equal(t, "Alpha", decoded["name"])
+}

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -1746,12 +1746,13 @@ paths:
               properties:
                 field:
                   type: string
-                  description: The torrent field to retrieve. When set to `tags`, the 200 response `values` array contains one raw comma-separated tag string per matching torrent, and empty strings represent untagged torrents.
+                  description: The torrent field to retrieve. When set to `tags`, the 200 response `values` array contains one raw comma-separated tag string per matching torrent, and empty strings represent untagged torrents. `magnet_uri` is only available here; torrent list responses omit it.
                   enum:
                     - name
                     - hash
                     - full_path
                     - tags
+                    - magnet_uri
                 sort:
                   type: string
                   description: Sort field. Defaults to added_on.

--- a/web/src/components/torrents/TorrentContextMenu.tsx
+++ b/web/src/components/torrents/TorrentContextMenu.tsx
@@ -19,7 +19,7 @@ import { TORRENT_ACTIONS } from "@/hooks/useTorrentActions"
 import { api } from "@/lib/api"
 import { getLinuxIsoName, getLinuxSavePath, useIncognitoMode } from "@/lib/incognito"
 import { buildTorrentActionTargets } from "@/lib/torrent-action-targets"
-import type { TorrentFieldName } from "@/lib/torrent-field-request"
+import type { TorrentFieldName, TorrentFieldSelection } from "@/lib/torrent-field-request"
 import { getToggleSelectionState, getTorrentDisplayHash } from "@/lib/torrent-utils"
 import { copyTextToClipboard } from "@/lib/utils"
 import type { Category, ExternalProgram, InstanceCapabilities, Torrent, TorrentFilters } from "@/types"
@@ -89,7 +89,7 @@ export interface TorrentContextMenuProps {
   onFilterChange?: (filters: TorrentFilters) => void
   onFetchTorrentField?: (
     field: TorrentFieldName,
-    selection?: { hashes: string[]; targets: Array<{ instanceId: number; hash: string }> }
+    selection?: TorrentFieldSelection
   ) => Promise<string[]>
 }
 

--- a/web/src/components/torrents/TorrentContextMenu.tsx
+++ b/web/src/components/torrents/TorrentContextMenu.tsx
@@ -19,6 +19,7 @@ import { TORRENT_ACTIONS } from "@/hooks/useTorrentActions"
 import { api } from "@/lib/api"
 import { getLinuxIsoName, getLinuxSavePath, useIncognitoMode } from "@/lib/incognito"
 import { buildTorrentActionTargets } from "@/lib/torrent-action-targets"
+import type { TorrentFieldName } from "@/lib/torrent-field-request"
 import { getToggleSelectionState, getTorrentDisplayHash } from "@/lib/torrent-utils"
 import { copyTextToClipboard } from "@/lib/utils"
 import type { Category, ExternalProgram, InstanceCapabilities, Torrent, TorrentFilters } from "@/types"
@@ -86,7 +87,10 @@ export interface TorrentContextMenuProps {
   onCrossSeedSearch?: (torrent: Torrent) => void
   isCrossSeedSearching?: boolean
   onFilterChange?: (filters: TorrentFilters) => void
-  onFetchAllField?: (field: "name" | "hash" | "full_path" | "magnet_uri") => Promise<string[]>
+  onFetchTorrentField?: (
+    field: TorrentFieldName,
+    selection?: { hashes: string[]; targets: Array<{ instanceId: number; hash: string }> }
+  ) => Promise<string[]>
 }
 
 export const TorrentContextMenu = memo(function TorrentContextMenu({
@@ -122,7 +126,7 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
   onCrossSeedSearch,
   isCrossSeedSearching = false,
   onFilterChange,
-  onFetchAllField,
+  onFetchTorrentField,
 }: TorrentContextMenuProps) {
   const { t } = useTranslation("torrents")
   const [incognitoMode] = useIncognitoMode()
@@ -193,16 +197,16 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
 
   const handleCopyNames = useCallback(async () => {
     // Select all fetch from backend
-    if (isAllSelected && onFetchAllField && torrents.length < effectiveSelectionCount) {
+    if (isAllSelected && onFetchTorrentField && torrents.length < effectiveSelectionCount) {
       try {
         if (incognitoMode) {
           // In incognito mode, fetch hashes and transform client-side
-          const hashes = await onFetchAllField("hash")
+          const hashes = await onFetchTorrentField("hash")
           const values = hashes.map(h => getLinuxIsoName(h)).filter(Boolean)
           if (values.length === 0) { toast.error(t("contextMenu.toast.nameNotAvailable")); return }
           void copyToClipboard(values.join("\n"), "name", values.length)
         } else {
-          const values = await onFetchAllField("name")
+          const values = await onFetchTorrentField("name")
           if (values.length === 0) { toast.error(t("contextMenu.toast.nameNotAvailable")); return }
           void copyToClipboard(values.join("\n"), "name", values.length)
         }
@@ -224,12 +228,12 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
     }
 
     void copyToClipboard(values.join("\n"), "name", values.length)
-  }, [copyToClipboard, incognitoMode, torrents, isAllSelected, effectiveSelectionCount, onFetchAllField, t])
+  }, [copyToClipboard, incognitoMode, torrents, isAllSelected, effectiveSelectionCount, onFetchTorrentField, t])
 
   const handleCopyHashes = useCallback(async () => {
-    if (isAllSelected && onFetchAllField && torrents.length < effectiveSelectionCount) {
+    if (isAllSelected && onFetchTorrentField && torrents.length < effectiveSelectionCount) {
       try {
-        const values = await onFetchAllField("hash")
+        const values = await onFetchTorrentField("hash")
         if (values.length === 0) { toast.error(t("contextMenu.toast.hashNotAvailable")); return }
         void copyToClipboard(values.join("\n"), "hash", values.length)
       } catch (error) {
@@ -249,21 +253,21 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
       return
     }
     void copyToClipboard(values.join("\n"), "hash", values.length)
-  }, [copyToClipboard, torrents, isAllSelected, effectiveSelectionCount, onFetchAllField, t])
+  }, [copyToClipboard, torrents, isAllSelected, effectiveSelectionCount, onFetchTorrentField, t])
 
   const handleCopyFullPaths = useCallback(async () => {
-    if (isAllSelected && onFetchAllField && torrents.length < effectiveSelectionCount) {
+    if (isAllSelected && onFetchTorrentField && torrents.length < effectiveSelectionCount) {
       try {
         if (incognitoMode) {
           // In incognito mode, fetch hashes and construct fake paths
-          const hashes = await onFetchAllField("hash")
+          const hashes = await onFetchTorrentField("hash")
           const values = hashes
             .map(h => `${getLinuxSavePath(h)}/${getLinuxIsoName(h)}`)
             .filter(Boolean)
           if (values.length === 0) { toast.error(t("contextMenu.toast.fullPathNotAvailable")); return }
           void copyToClipboard(values.join("\n"), "full path", values.length)
         } else {
-          const values = await onFetchAllField("full_path")
+          const values = await onFetchTorrentField("full_path")
           if (values.length === 0) { toast.error(t("contextMenu.toast.fullPathNotAvailable")); return }
           void copyToClipboard(values.join("\n"), "full path", values.length)
         }
@@ -292,32 +296,32 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
     }
 
     void copyToClipboard(values.join("\n"), "full path", values.length)
-  }, [copyToClipboard, incognitoMode, torrents, isAllSelected, effectiveSelectionCount, onFetchAllField, t])
+  }, [copyToClipboard, incognitoMode, torrents, isAllSelected, effectiveSelectionCount, onFetchTorrentField, t])
 
   const handleCopyMagnetLinks = useCallback(async () => {
-    if (isAllSelected && onFetchAllField && torrents.length < effectiveSelectionCount) {
-      try {
-        const values = await onFetchAllField("magnet_uri")
-        if (values.length === 0) { toast.error(t("contextMenu.toast.magnetNotAvailable")); return }
-        void copyToClipboard(values.join("\n"), "magnet link", values.length)
-      } catch (error) {
-        console.error("Failed to fetch torrent magnet links:", error)
-        toast.error(t("contextMenu.toast.failedToFetchMagnets"))
-      }
-      return
-    }
-
-    const values = torrents
-      .map(t => (t.magnet_uri ?? "").trim())
-      .filter(Boolean)
-
-    if (values.length === 0) {
+    // List rows no longer carry magnet_uri (issue #2328); every copy fetches on
+    // demand. Select-all resolves by filter scope, otherwise by explicit selection.
+    if (!onFetchTorrentField) {
       toast.error(t("contextMenu.toast.magnetNotAvailable"))
       return
     }
 
-    void copyToClipboard(values.join("\n"), "magnet link", values.length)
-  }, [copyToClipboard, torrents, isAllSelected, effectiveSelectionCount, onFetchAllField, t])
+    try {
+      const useFilterScope = isAllSelected && torrents.length < effectiveSelectionCount
+      const values = await onFetchTorrentField(
+        "magnet_uri",
+        useFilterScope ? undefined : { hashes, targets: actionTargets }
+      )
+      if (values.length === 0) {
+        toast.error(t("contextMenu.toast.magnetNotAvailable"))
+        return
+      }
+      void copyToClipboard(values.join("\n"), "magnet link", values.length)
+    } catch (error) {
+      console.error("Failed to fetch torrent magnet links:", error)
+      toast.error(t("contextMenu.toast.failedToFetchMagnets"))
+    }
+  }, [copyToClipboard, torrents, hashes, actionTargets, isAllSelected, effectiveSelectionCount, onFetchTorrentField, t])
 
   const handleExport = useCallback(() => {
     if (!onExport) {

--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -77,6 +77,7 @@ import { resolveFooterSpeeds } from "@/lib/scoped-speeds"
 import { formatSpeedWithUnit, useSpeedUnits } from "@/lib/speedUnits"
 import { useSpreadsheetDisguise } from "@/lib/spreadsheet-disguise"
 import { resolveStreamFallbackStatus } from "@/lib/stream-status"
+import { buildTorrentFieldRequest, type TorrentFieldName, type TorrentFieldScope, type TorrentFieldSelection } from "@/lib/torrent-field-request"
 import { cn } from "@/lib/utils"
 import type {
   Category,
@@ -443,7 +444,7 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
   const isAllInstancesView = instanceId <= 0
 
   // Memoized so the `?? []` fallback cannot mint a fresh array per render:
-  // these feed fetchAllTorrentField, whose identity anchors the shared row
+  // these feed fetchTorrentField, whose identity anchors the shared row
   // menu bundle.
   const effectiveIncludedCategories = useMemo(
     () => filters?.expandedCategories ?? filters?.categories ?? [],
@@ -981,9 +982,15 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
     filters,
   })
 
-  // Callback for context menu to fetch field for matching torrents
-  const fetchAllTorrentField = useCallback(async (field: "name" | "hash" | "full_path" | "magnet_uri"): Promise<string[]> => {
-    const response = await api.getTorrentField(instanceId, field, {
+  // Callback for context menu to fetch field values on demand: explicit
+  // selection when given, otherwise the active filter scope (select-all).
+  const fetchTorrentField = useCallback(async (
+    field: TorrentFieldName,
+    selection?: TorrentFieldSelection
+  ): Promise<string[]> => {
+    const scope: TorrentFieldScope = {
+      isCrossInstance: isCrossInstanceEndpoint ?? false,
+      instanceIds,
       sort: activeSortField,
       order: activeSortOrder,
       search: effectiveSearch,
@@ -1001,9 +1008,9 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
         expr: combinedFiltersExpr || undefined,
       },
       excludeHashes: selectAllExcludeHashes,
-      excludeTargets: isCrossInstanceEndpoint ? selectAllExcludedTargets : undefined,
-      instanceIds: isCrossInstanceEndpoint ? instanceIds : undefined,
-    })
+      excludeTargets: selectAllExcludedTargets,
+    }
+    const response = await api.getTorrentField(instanceId, field, buildTorrentFieldRequest(scope, selection))
     return response.values
   }, [instanceId, filters, effectiveIncludedCategories, effectiveExcludedCategories, combinedFiltersExpr, activeSortField, activeSortOrder, effectiveSearch, selectAllExcludeHashes, isCrossInstanceEndpoint, selectAllExcludedTargets, instanceIds])
 
@@ -1315,8 +1322,8 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
     onCrossSeedSearch,
     isCrossSeedSearching,
     onFilterChange,
-    onFetchAllField: fetchAllTorrentField,
-  }), [instanceId, isReadOnly, isAllSelected, selectedHashes, selectedTorrents, effectiveSelectionCount, onTorrentSelect, runAction, prepareDeleteAction, prepareTagsAction, prepareCommentAction, prepareCategoryAction, prepareCreateCategoryAction, prepareShareLimitAction, prepareSpeedLimitAction, prepareLocationAction, prepareRenameTorrentAction, prepareRecheckAction, prepareReannounceAction, prepareTmmAction, availableCategories, handleSetCategoryDirect, isPending, handleExportWrapper, isExportingTorrent, capabilities, allowSubcategories, canCrossSeedSearch, onCrossSeedSearch, isCrossSeedSearching, onFilterChange, fetchAllTorrentField])
+    onFetchTorrentField: fetchTorrentField,
+  }), [instanceId, isReadOnly, isAllSelected, selectedHashes, selectedTorrents, effectiveSelectionCount, onTorrentSelect, runAction, prepareDeleteAction, prepareTagsAction, prepareCommentAction, prepareCategoryAction, prepareCreateCategoryAction, prepareShareLimitAction, prepareSpeedLimitAction, prepareLocationAction, prepareRenameTorrentAction, prepareRecheckAction, prepareReannounceAction, prepareTmmAction, availableCategories, handleSetCategoryDirect, isPending, handleExportWrapper, isExportingTorrent, capabilities, allowSubcategories, canCrossSeedSearch, onCrossSeedSearch, isCrossSeedSearching, onFilterChange, fetchTorrentField])
 
   const showCompactCheckbox = table.getColumn("select")?.getIsVisible() !== false
   const compactRowProps = useMemo<CompactRowSharedProps>(() => ({

--- a/web/src/lib/__tests__/cross-seed-utils.test.tsx
+++ b/web/src/lib/__tests__/cross-seed-utils.test.tsx
@@ -234,7 +234,6 @@ describe("toCompatibleMatch", () => {
     const result = toCompatibleMatch(makeMatch())
     expect(result.added_on).toBe(0)
     expect(result.ratio).toBe(0)
-    expect(result.magnet_uri).toBe("")
   })
 })
 

--- a/web/src/lib/cross-seed-utils.ts
+++ b/web/src/lib/cross-seed-utils.ts
@@ -172,7 +172,6 @@ export function toCompatibleMatch(m: LocalCrossSeedMatch): CrossSeedTorrent {
     amount_left: 0,
     completed: 0,
     last_activity: 0,
-    magnet_uri: "",
     availability: 0,
     dl_limit: 0,
     download_path: "",

--- a/web/src/lib/torrent-field-request.test.ts
+++ b/web/src/lib/torrent-field-request.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { describe, expect, it } from "vitest"
+
+import { buildTorrentFieldRequest, type TorrentFieldScope } from "./torrent-field-request"
+
+const filters = {
+  status: ["downloading"],
+  excludeStatus: [],
+  categories: ["tv"],
+  excludeCategories: [],
+  tags: [],
+  excludeTags: [],
+  trackers: [],
+  excludeTrackers: [],
+}
+
+const singleInstanceScope: TorrentFieldScope = {
+  isCrossInstance: false,
+  sort: "name",
+  order: "asc",
+  search: "iso",
+  filters,
+  excludeHashes: ["ddd"],
+  excludeTargets: [{ instanceId: 1, hash: "ddd" }],
+}
+
+const crossInstanceScope: TorrentFieldScope = {
+  ...singleInstanceScope,
+  isCrossInstance: true,
+  instanceIds: [1, 2],
+}
+
+const selection = {
+  hashes: ["aaa", "bbb"],
+  targets: [
+    { instanceId: 1, hash: "aaa" },
+    { instanceId: 2, hash: "bbb" },
+  ],
+}
+
+describe("buildTorrentFieldRequest", () => {
+  it("resolves a single-instance selection by hashes, not filter scope", () => {
+    expect(buildTorrentFieldRequest(singleInstanceScope, selection)).toEqual({
+      hashes: ["aaa", "bbb"],
+    })
+  })
+
+  it("resolves a cross-instance selection by instance/hash targets", () => {
+    expect(buildTorrentFieldRequest(crossInstanceScope, selection)).toEqual({
+      targets: selection.targets,
+      instanceIds: [1, 2],
+    })
+  })
+
+  it("resolves select-all by the active filter scope with exclusions", () => {
+    expect(buildTorrentFieldRequest(crossInstanceScope)).toEqual({
+      sort: "name",
+      order: "asc",
+      search: "iso",
+      filters,
+      excludeHashes: ["ddd"],
+      excludeTargets: [{ instanceId: 1, hash: "ddd" }],
+      instanceIds: [1, 2],
+    })
+  })
+
+  it("drops cross-instance-only params from a single-instance filter scope", () => {
+    expect(buildTorrentFieldRequest(singleInstanceScope)).toEqual({
+      sort: "name",
+      order: "asc",
+      search: "iso",
+      filters,
+      excludeHashes: ["ddd"],
+      excludeTargets: undefined,
+      instanceIds: undefined,
+    })
+  })
+})

--- a/web/src/lib/torrent-field-request.ts
+++ b/web/src/lib/torrent-field-request.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import type { TorrentFilters } from "@/types"
+
+import type { TorrentActionTarget } from "./torrent-action-targets"
+
+// Fields the context menu copies on demand. The /torrents/field endpoint also
+// accepts "tags" (bulk tag baselines); api.ts keeps that wider union.
+export type TorrentFieldName = "name" | "hash" | "full_path" | "magnet_uri"
+
+export interface TorrentFieldScope {
+  isCrossInstance: boolean
+  instanceIds?: number[]
+  sort?: string
+  order?: "asc" | "desc"
+  search?: string
+  filters?: TorrentFilters
+  excludeHashes?: string[]
+  excludeTargets?: TorrentActionTarget[]
+}
+
+export interface TorrentFieldSelection {
+  hashes: string[]
+  targets: TorrentActionTarget[]
+}
+
+// Builds the /torrents/field request body. An explicit selection resolves by
+// hash on a single instance and by instance/hash targets on the unified view;
+// without a selection the request carries the active filter scope (select-all).
+export function buildTorrentFieldRequest(scope: TorrentFieldScope, selection?: TorrentFieldSelection) {
+  const { isCrossInstance, ...rest } = scope
+  if (selection) {
+    return isCrossInstance
+      ? { targets: selection.targets, instanceIds: scope.instanceIds }
+      : { hashes: selection.hashes }
+  }
+
+  return isCrossInstance ? rest : { ...rest, excludeTargets: undefined, instanceIds: undefined }
+}

--- a/web/src/test/mockTorrent.ts
+++ b/web/src/test/mockTorrent.ts
@@ -36,7 +36,6 @@ export function makeTorrent(overrides: Partial<Torrent> = {}): Torrent {
     popularity: 0,
     private: false,
     last_activity: 0,
-    magnet_uri: "",
     max_ratio: 0,
     max_seeding_time: 0,
     name: "test-torrent",

--- a/web/src/types/torrents.ts
+++ b/web/src/types/torrents.ts
@@ -109,7 +109,6 @@ export interface Torrent {
   popularity: number
   private: boolean
   last_activity: number
-  magnet_uri: string
   max_ratio: number
   max_seeding_time: number
   max_inactive_seeding_time?: number


### PR DESCRIPTION
## Description

`magnet_uri` was 13% of the torrent list payload (74 kB of a 582 kB 300-row page) and rode every SSE tick, but only the copy magnet action reads it. `TorrentView` now shadows the field out of serialized rows, and copy magnet fetches values on demand through the existing field endpoint. The qBittorrent-compat proxy serializes the raw torrent and keeps the field.

The shadow is a `*struct{}`, so a promoted read fails to compile instead of silently returning an empty string. The three real readers go through `.Torrent.MagnetURI`, and the SSE fingerprint no longer hashes the field, so a magnet-only change does not resend a row. Also fixes a pre-existing gap QA surfaced on this PR: the cross-instance field endpoint now returns 503 on partial results for every field instead of only for the tag baseline, so a copy during an instance outage fails instead of silently returning a truncated list.

Fixes #2328

## How has this been tested?

New tests pin the missing key on serialized rows, magnet values through all three field endpoint paths, the partial-results rejection, no row resend on a magnet-only change, and the frontend request routing for explicit selection vs select-all. Targeted Go and vitest suites, `make test-openapi`, and `make build` pass.

Field-tested on a live instance with the `pr-2360` image. A 300-row page dropped from 618,782 to 542,198 bytes (-12.4%) on one instance and from 564,106 to 487,326 bytes (-13.6%) on another. No `magnet_uri` key in any REST row or in a 572 kB SSE init capture. Copy magnet by explicit hashes returned 3/3 links, select-all returned 5,837, all valid. No error log lines after the switch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added magnet-link retrieval through torrent field requests for filtered, selected, and cross-instance views.
  * Added magnet-link copying from the torrent context menu with improved selection and error handling.
  * Documented `magnet_uri` as a supported torrent field.

* **Bug Fixes**
  * Magnet links are no longer included in list or live-update payloads.
  * Magnet-only changes no longer trigger unnecessary live row updates.
  * Partial cross-instance field results now return an appropriate service-unavailable response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->