### PR TITLE
fix(ui): keep landscape phones in the mobile layout

### DIFF
--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -397,7 +397,7 @@ export function Header({
   // Assigned, not returned inline: the spreadsheet ribbon strip mounts as a
   // sibling above the header without reindenting the whole header tree.
   const headerElement = (
-    <header className={cn("sticky top-0 z-50 hidden md:flex flex-wrap lg:flex-nowrap items-start lg:items-center justify-between sm:border-b bg-background pl-2 pr-4 md:pl-4 md:pr-4 lg:pl-0 lg:static py-2 lg:py-0", headerHeight)}>
+    <header className={cn("sticky top-0 z-50 hidden desk:flex flex-wrap lg:flex-nowrap items-start lg:items-center justify-between sm:border-b bg-background pl-2 pr-4 md:pl-4 md:pr-4 lg:pl-0 lg:static py-2 lg:py-0", headerHeight)}>
       <div className={cn("hidden md:flex items-center gap-2 mr-2 order-1 lg:order-none", innerHeight)}>
         {children}
         {instanceName && (hasMultipleActiveInstances || isAllInstancesRoute) ? (

--- a/web/src/components/layout/MobileFooterNav.tsx
+++ b/web/src/components/layout/MobileFooterNav.tsx
@@ -25,6 +25,7 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { isThemePremium, themes } from "@/config/themes"
 import { useMobileScroll } from "@/contexts/MobileScrollContext"
+import { useIsPhoneLandscape } from "@/hooks/useMediaQuery"
 import { useTorrentSelection } from "@/contexts/TorrentSelectionContext"
 import { useAuth } from "@/hooks/useAuth"
 import { usePersistedCompactViewState } from "@/hooks/usePersistedCompactViewState"
@@ -115,6 +116,7 @@ export function MobileFooterNav() {
   const { logout } = useAuth()
   const { isSelectionMode } = useTorrentSelection()
   const { isFooterVisible } = useMobileScroll()
+  const isPhoneLandscape = useIsPhoneLandscape()
   const { viewMode, setViewMode } = usePersistedCompactViewState("compact", MOBILE_VIEW_MODES)
   const { currentMode, currentTheme } = useThemeChange()
   const { hasPremiumAccess, isLoading, isError } = useHasPremiumAccess()
@@ -241,11 +243,12 @@ export function MobileFooterNav() {
         "fixed bottom-0 left-0 right-0 z-40 lg:hidden",
         "bg-background/80 backdrop-blur-md border-t border-border/50",
         "transition-transform duration-300",
-        !isFooterVisible && "translate-y-full"
+        "phone-land:static phone-land:order-first phone-land:w-20 phone-land:border-t-0 phone-land:border-r",
+        !isFooterVisible && "translate-y-full phone-land:translate-y-0"
       )}
-      style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
+      style={{ paddingBottom: "env(safe-area-inset-bottom)", paddingLeft: "env(safe-area-inset-left)" }}
     >
-      <div className="flex items-center justify-around h-16">
+      <div className={cn("flex items-center justify-around h-16 phone-land:h-full phone-land:flex-col phone-land:py-2")}>
         {/* Dashboard */}
         <Link
           to="/dashboard"
@@ -292,7 +295,7 @@ export function MobileFooterNav() {
                 </span>
               </button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="center" side="top" className="w-56 mb-2">
+            <DropdownMenuContent align="center" side={isPhoneLandscape ? "right" : "top"} className="w-56 mb-2">
               <DropdownMenuLabel>{t("mobileNav.qbittorrentClients")}</DropdownMenuLabel>
               <DropdownMenuSeparator />
               {activeInstances.length > 0 ? (
@@ -423,7 +426,7 @@ export function MobileFooterNav() {
               <span className="truncate">{t("mobileNav.settings")}</span>
             </button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" side="top" className="mb-2 w-56">
+          <DropdownMenuContent align="end" side={isPhoneLandscape ? "right" : "top"} className="mb-2 w-56">
             {updateInfo && (
               <>
                 <DropdownMenuItem asChild>

--- a/web/src/components/layout/MobileFooterNav.tsx
+++ b/web/src/components/layout/MobileFooterNav.tsx
@@ -246,7 +246,7 @@ export function MobileFooterNav() {
         "phone-land:static phone-land:order-first phone-land:w-20 phone-land:border-t-0 phone-land:border-r",
         !isFooterVisible && "translate-y-full phone-land:translate-y-0"
       )}
-      style={{ paddingBottom: "env(safe-area-inset-bottom)", paddingLeft: "env(safe-area-inset-left)" }}
+      style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
     >
       <div className={cn("flex items-center justify-around h-16 phone-land:h-full phone-land:flex-col phone-land:py-2")}>
         {/* Dashboard */}

--- a/web/src/components/spreadsheet/SpreadsheetRibbonTabs.tsx
+++ b/web/src/components/spreadsheet/SpreadsheetRibbonTabs.tsx
@@ -42,7 +42,7 @@ export function SpreadsheetRibbonTabs() {
   const tabs = classic ? CLASSIC_TABS : MODERN_TABS
 
   return (
-    <nav className="ss-ribbon-tabs hidden md:flex" aria-label={RIBBON_ARIA}>
+    <nav className="ss-ribbon-tabs hidden desk:flex" aria-label={RIBBON_ARIA}>
       <Link to="/settings" className="ss-ribbon-tab ss-ribbon-tab-file">{FILE_TAB}</Link>
       {tabs.map((entry) => "instance" in entry? (
         firstActiveInstanceId !== undefined && (

--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -2139,7 +2139,7 @@ export function TorrentCardsMobile({
                   <Button
                     variant="ghost"
                     size="sm"
-                    className="h-7 px-2 text-xs font-medium text-muted-foreground hover:text-foreground md:hidden"
+                    className="h-7 px-2 text-xs font-medium text-muted-foreground hover:text-foreground"
                   >
                     {t("mobileCards.sort")}: {currentSortOption.label}
                   </Button>
@@ -2162,7 +2162,7 @@ export function TorrentCardsMobile({
                 variant="ghost"
                 size="sm"
                 onClick={toggleSortOrder}
-                className="h-7 w-7 p-0 text-muted-foreground hover:text-foreground md:hidden"
+                className="h-7 w-7 p-0 text-muted-foreground hover:text-foreground"
                 aria-label={`${t("sort.label")} ${sortOrder === "desc" ? t("sort.descending") : t("sort.ascending")}`}
                 title={`${t("sort.label")} ${sortOrder === "desc" ? t("sort.descending") : t("sort.ascending")}`}
               >
@@ -2850,9 +2850,9 @@ export function TorrentCardsMobile({
           className={cn(
             "fixed left-0 right-0 z-50 lg:hidden bg-background/80 backdrop-blur-md border-t border-border/50",
             "transition-transform duration-300",
-            !isFooterVisible && "translate-y-[calc(100%+4rem+env(safe-area-inset-bottom))]"
+            "bottom-[calc(4rem+env(safe-area-inset-bottom))] phone-land:bottom-0 phone-land:left-20 phone-land:pb-[env(safe-area-inset-bottom)]",
+            !isFooterVisible && "translate-y-[calc(100%+4rem+env(safe-area-inset-bottom))] phone-land:translate-y-[calc(100%+env(safe-area-inset-bottom))]"
           )}
-          style={{ bottom: "calc(4rem + env(safe-area-inset-bottom))" }}
         >
           <div className="flex items-center justify-around h-14 px-2">
             <button
@@ -2923,16 +2923,14 @@ export function TorrentCardsMobile({
         </div>
       )}
 
-      {/* Scroll to top button - only on mobile */}
-      <div className="sm:hidden">
-        <ScrollToTopButton
-          scrollContainerRef={parentRef}
-          className={cn(
-            "right-8 z-[60]",
-            selectionBarVisible? "bottom-[calc(5rem+env(safe-area-inset-bottom))]": isFooterVisible? "bottom-[calc(8.5rem+env(safe-area-inset-bottom))]": "bottom-[calc(1.5rem+env(safe-area-inset-bottom))]"
-          )}
-        />
-      </div>
+      {/* Scroll to top button */}
+      <ScrollToTopButton
+        scrollContainerRef={parentRef}
+        className={cn(
+          "right-8 z-[60]",
+          selectionBarVisible? "bottom-[calc(5rem+env(safe-area-inset-bottom))]": isFooterVisible? "bottom-[calc(8.5rem+env(safe-area-inset-bottom))] phone-land:bottom-[calc(5rem+env(safe-area-inset-bottom))]": "bottom-[calc(1.5rem+env(safe-area-inset-bottom))]"
+        )}
+      />
     </div>
   )
 }

--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -2850,7 +2850,7 @@ export function TorrentCardsMobile({
           className={cn(
             "fixed left-0 right-0 z-50 lg:hidden bg-background/80 backdrop-blur-md border-t border-border/50",
             "transition-transform duration-300",
-            "bottom-[calc(4rem+env(safe-area-inset-bottom))] phone-land:bottom-0 phone-land:left-[calc(5rem+env(safe-area-inset-left))] phone-land:pb-[env(safe-area-inset-bottom)] phone-land:pr-[env(safe-area-inset-right)]",
+            "bottom-[calc(4rem+env(safe-area-inset-bottom))] phone-land:bottom-0 phone-land:left-[calc(5rem+env(safe-area-inset-left))] phone-land:pb-[env(safe-area-inset-bottom)]",
             !isFooterVisible && "translate-y-[calc(100%+4rem+env(safe-area-inset-bottom))] phone-land:translate-y-[calc(100%+env(safe-area-inset-bottom))]"
           )}
         >

--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -2210,10 +2210,10 @@ export function TorrentCardsMobile({
       {/* Torrent cards with virtual scrolling */}
       <div
         ref={parentRef}
-        className="flex-1 overflow-y-auto overscroll-contain transition-[padding] duration-300"
-        style={{
-          paddingBottom: selectionBarVisible? "calc(4rem + env(safe-area-inset-bottom))": isFooterVisible? "calc(8rem + env(safe-area-inset-bottom))": "env(safe-area-inset-bottom)",
-        }}
+        className={cn(
+          "flex-1 overflow-y-auto overscroll-contain transition-[padding] duration-300",
+          selectionBarVisible? "pb-[calc(4rem+env(safe-area-inset-bottom))]": isFooterVisible? "pb-[calc(8rem+env(safe-area-inset-bottom))] phone-land:pb-[calc(4rem+env(safe-area-inset-bottom))]": "pb-[env(safe-area-inset-bottom)]"
+        )}
       >
         <div
           style={{

--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -2340,13 +2340,13 @@ export function TorrentCardsMobile({
 
       {/* More actions sheet */}
       <Sheet open={showActionsSheet} onOpenChange={setShowActionsSheet}>
-        <SheetContent side="bottom" className="h-auto pb-8">
+        <SheetContent side="bottom" className="h-auto">
           <SheetHeader>
             <SheetTitle>
               {isAllSelected? t("mobileCards.actionsForAll", { count: effectiveSelectionCount }): t("mobileCards.actionsForCount", { count: effectiveSelectionCount })}
             </SheetTitle>
           </SheetHeader>
-          <div className="grid gap-2 py-4 px-4">
+          <div className="grid gap-2 pt-4 pb-8 px-4">
             {(() => {
               const { allEnabled: allForceStarted, mixed: forceStartMixed } = getToggleSelectionState(getSelectedTorrents.map(t => t.force_start), stateUnknownForSelection)
 

--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -2850,7 +2850,7 @@ export function TorrentCardsMobile({
           className={cn(
             "fixed left-0 right-0 z-50 lg:hidden bg-background/80 backdrop-blur-md border-t border-border/50",
             "transition-transform duration-300",
-            "bottom-[calc(4rem+env(safe-area-inset-bottom))] phone-land:bottom-0 phone-land:left-20 phone-land:pb-[env(safe-area-inset-bottom)]",
+            "bottom-[calc(4rem+env(safe-area-inset-bottom))] phone-land:bottom-0 phone-land:left-[calc(5rem+env(safe-area-inset-left))] phone-land:pb-[env(safe-area-inset-bottom)] phone-land:pr-[env(safe-area-inset-right)]",
             !isFooterVisible && "translate-y-[calc(100%+4rem+env(safe-area-inset-bottom))] phone-land:translate-y-[calc(100%+env(safe-area-inset-bottom))]"
           )}
         >

--- a/web/src/components/torrents/TorrentDetailsPanel.tsx
+++ b/web/src/components/torrents/TorrentDetailsPanel.tsx
@@ -875,9 +875,9 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
   return (
     <div className="h-full flex flex-col">
       <Tabs value={activeTab} onValueChange={handleTabChange} className="flex-1 flex flex-col overflow-hidden">
-        <div className="border-b flex items-center">
-          {/* phone-land: 44px targets, kept clear of the top corners iOS claims for Control/Notification Center */}
-          <TabsList className="flex-1 min-w-0 justify-start rounded-none h-8 phone-land:h-11 bg-background px-4 sm:px-2 phone-land:pl-6 flex-nowrap overflow-x-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
+        {/* phones: row sits at the bottom (thumb zone; iOS claims top-edge taps for system gestures) */}
+        <div className="border-b flex items-center max-md:order-last max-md:border-b-0 max-md:border-t phone-land:order-last phone-land:border-b-0 phone-land:border-t">
+          <TabsList className="flex-1 min-w-0 justify-start rounded-none h-8 max-md:h-11 phone-land:h-11 bg-background px-4 sm:px-2 flex-nowrap overflow-x-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
             <TabsTrigger value="general" className="text-xs shrink-0">
               {t("detailsPanel.tabs.general")}
             </TabsTrigger>
@@ -903,7 +903,7 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
             <Button
               variant="ghost"
               size="icon"
-              className="h-8 w-10 shrink-0 rounded-none phone-land:h-11 phone-land:w-14 phone-land:mr-3"
+              className="h-8 w-10 shrink-0 rounded-none max-md:h-11 max-md:w-14 phone-land:h-11 phone-land:w-14"
               onClick={onClose}
               aria-label={t("detailsPanel.closePanel")}
             >

--- a/web/src/components/torrents/TorrentDetailsPanel.tsx
+++ b/web/src/components/torrents/TorrentDetailsPanel.tsx
@@ -876,35 +876,34 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
     <div className="h-full flex flex-col">
       <Tabs value={activeTab} onValueChange={handleTabChange} className="flex-1 flex flex-col overflow-hidden">
         <div className="border-b flex items-center">
-          <div className="flex-1 overflow-x-auto scroll-smooth">
-            <TabsList className="w-full justify-start rounded-none h-8 bg-background px-4 sm:px-2 flex-nowrap overflow-x-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
-              <TabsTrigger value="general" className="text-xs shrink-0">
-                {t("detailsPanel.tabs.general")}
+          {/* phone-land: 44px targets, kept clear of the top corners iOS claims for Control/Notification Center */}
+          <TabsList className="flex-1 min-w-0 justify-start rounded-none h-8 phone-land:h-11 bg-background px-4 sm:px-2 phone-land:pl-6 flex-nowrap overflow-x-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
+            <TabsTrigger value="general" className="text-xs shrink-0">
+              {t("detailsPanel.tabs.general")}
+            </TabsTrigger>
+            <TabsTrigger value="trackers" className="text-xs shrink-0">
+              {t("detailsPanel.tabs.trackers")}
+            </TabsTrigger>
+            <TabsTrigger value="peers" className="text-xs shrink-0">
+              {t("detailsPanel.tabs.peers")}
+            </TabsTrigger>
+            {hasWebseeds && (
+              <TabsTrigger value="webseeds" className="text-xs shrink-0">
+                {t("detailsPanel.tabs.httpSources")}
               </TabsTrigger>
-              <TabsTrigger value="trackers" className="text-xs shrink-0">
-                {t("detailsPanel.tabs.trackers")}
-              </TabsTrigger>
-              <TabsTrigger value="peers" className="text-xs shrink-0">
-                {t("detailsPanel.tabs.peers")}
-              </TabsTrigger>
-              {hasWebseeds && (
-                <TabsTrigger value="webseeds" className="text-xs shrink-0">
-                  {t("detailsPanel.tabs.httpSources")}
-                </TabsTrigger>
-              )}
-              <TabsTrigger value="content" className="text-xs shrink-0">
-                {t("detailsPanel.tabs.content")}
-              </TabsTrigger>
-              <TabsTrigger value="crossseed" className="text-xs shrink-0">
-                {t("detailsPanel.tabs.crossSeed")}
-              </TabsTrigger>
-            </TabsList>
-          </div>
+            )}
+            <TabsTrigger value="content" className="text-xs shrink-0">
+              {t("detailsPanel.tabs.content")}
+            </TabsTrigger>
+            <TabsTrigger value="crossseed" className="text-xs shrink-0">
+              {t("detailsPanel.tabs.crossSeed")}
+            </TabsTrigger>
+          </TabsList>
           {onClose && (
             <Button
               variant="ghost"
               size="icon"
-              className="h-8 w-10 shrink-0 rounded-none"
+              className="h-8 w-10 shrink-0 rounded-none phone-land:h-11 phone-land:w-14 phone-land:mr-3"
               onClick={onClose}
               aria-label={t("detailsPanel.closePanel")}
             >

--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -75,13 +75,18 @@ function SheetContent({
             "inset-x-0 top-0 h-auto border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
           side === "bottom" &&
             "inset-x-0 bottom-0 h-auto border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
-          className
+          className,
+          // Safe-area insets last so call-site `p-0` cannot strip them.
+          // Sheets are fixed overlays, so body safe-area padding never applies.
+          side === "right" && "pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] pr-[env(safe-area-inset-right)]",
+          side === "left" && "pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] pl-[env(safe-area-inset-left)]",
+          side === "bottom" && "pb-[env(safe-area-inset-bottom)] pl-[env(safe-area-inset-left)] pr-[env(safe-area-inset-right)]"
         )}
         {...props}
       >
         {children}
         {!hideClose && (
-          <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none cursor-pointer">
+          <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-[max(1rem,env(safe-area-inset-top))] right-[max(1rem,env(safe-area-inset-right))] rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none cursor-pointer">
             <XIcon className="size-5" />
             <span className="sr-only">{t("actions.close")}</span>
           </SheetPrimitive.Close>

--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -78,8 +78,11 @@ function SheetContent({
           className,
           // Safe-area insets last so call-site `p-0` cannot strip them.
           // Sheets are fixed overlays, so body safe-area padding never applies.
-          side === "right" && "pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] pr-[env(safe-area-inset-right)]",
-          side === "left" && "pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] pl-[env(safe-area-inset-left)]",
+          // phone-land: iOS swallows touches in ~20px at the top edge in
+          // landscape for system gestures, and env(safe-area-inset-top) is 0
+          // there, so full-height sheets need an explicit buffer.
+          side === "right" && "pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] pr-[env(safe-area-inset-right)] phone-land:pt-5",
+          side === "left" && "pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] pl-[env(safe-area-inset-left)] phone-land:pt-5",
           side === "bottom" && "pb-[env(safe-area-inset-bottom)] pl-[env(safe-area-inset-left)] pr-[env(safe-area-inset-right)]"
         )}
         {...props}

--- a/web/src/hooks/useMediaQuery.test.ts
+++ b/web/src/hooks/useMediaQuery.test.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { readFileSync } from "node:fs"
+import { expect, it } from "vitest"
+import { PHONE_LANDSCAPE } from "./useMediaQuery"
+
+// The CSS variants in index.css and the matchMedia queries in this hook
+// must describe the same viewports, or the shell and the page content
+// disagree about which layout is active. This test pins the sync.
+it("index.css variants stay in sync with useMediaQuery", () => {
+  const css = readFileSync(new URL("../index.css", import.meta.url), "utf8")
+  expect(css).toContain(`@custom-variant phone-land (@media ${PHONE_LANDSCAPE});`)
+  expect(css).toContain(`@custom-variant desk (@media (min-width: 768px) and (not (${PHONE_LANDSCAPE})));`)
+})

--- a/web/src/hooks/useMediaQuery.test.ts
+++ b/web/src/hooks/useMediaQuery.test.ts
@@ -4,14 +4,17 @@
  */
 
 import { readFileSync } from "node:fs"
+import { join } from "node:path"
 import { expect, it } from "vitest"
 import { PHONE_LANDSCAPE } from "./useMediaQuery"
 
 // The CSS variants in index.css and the matchMedia queries in this hook
 // must describe the same viewports, or the shell and the page content
 // disagree about which layout is active. This test pins the sync.
+// import.meta.url is not a file: URL under jsdom, so resolve from cwd
+// (vitest runs with web/ as the root).
 it("index.css variants stay in sync with useMediaQuery", () => {
-  const css = readFileSync(new URL("../index.css", import.meta.url), "utf8")
+  const css = readFileSync(join(process.cwd(), "src", "index.css"), "utf8")
   expect(css).toContain(`@custom-variant phone-land (@media ${PHONE_LANDSCAPE});`)
   expect(css).toContain(`@custom-variant desk (@media (min-width: 768px) and (not (${PHONE_LANDSCAPE})));`)
 })

--- a/web/src/hooks/useMediaQuery.ts
+++ b/web/src/hooks/useMediaQuery.ts
@@ -42,7 +42,7 @@ export function useMediaQuery(query: string): boolean {
   return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 }
 
-const PHONE_LANDSCAPE = "(pointer: coarse) and (orientation: landscape) and (max-width: 1023px) and (max-height: 500px)"
+export const PHONE_LANDSCAPE = "(pointer: coarse) and (orientation: landscape) and (max-width: 1023px) and (max-height: 500px)"
 
 /**
  * Returns true when the viewport is phone-sized: narrower than the md

--- a/web/src/hooks/useMediaQuery.ts
+++ b/web/src/hooks/useMediaQuery.ts
@@ -42,9 +42,18 @@ export function useMediaQuery(query: string): boolean {
   return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 }
 
+const PHONE_LANDSCAPE = "(pointer: coarse) and (max-height: 500px)"
+
 /**
- * Returns true when viewport is mobile-sized (< 768px / md breakpoint).
+ * Returns true when the viewport is phone-sized: narrower than the md
+ * breakpoint, or a touch device in short landscape. Must stay the exact
+ * complement of the `desk` custom variant in index.css.
  */
 export function useIsMobile(): boolean {
-  return useMediaQuery("(max-width: 767px)")
+  return useMediaQuery(`(max-width: 767px), (${PHONE_LANDSCAPE})`)
+}
+
+/** Touch device in short landscape. Must match `phone-land` in index.css. */
+export function useIsPhoneLandscape(): boolean {
+  return useMediaQuery(PHONE_LANDSCAPE)
 }

--- a/web/src/hooks/useMediaQuery.ts
+++ b/web/src/hooks/useMediaQuery.ts
@@ -42,7 +42,7 @@ export function useMediaQuery(query: string): boolean {
   return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 }
 
-const PHONE_LANDSCAPE = "(pointer: coarse) and (max-height: 500px)"
+const PHONE_LANDSCAPE = "(pointer: coarse) and (orientation: landscape) and (max-width: 1023px) and (max-height: 500px)"
 
 /**
  * Returns true when the viewport is phone-sized: narrower than the md

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -249,6 +249,10 @@
     padding-top: env(safe-area-inset-top) !important;
     padding-left: env(safe-area-inset-left) !important;
     padding-right: env(safe-area-inset-right) !important;
+    /* landscape: the user picks the camera side, don't reserve the right inset */
+    @variant phone-land {
+      padding-right: 0 !important;
+    }
   }
 
   /* Apply font families from theme */

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -244,10 +244,11 @@
     @apply bg-background text-foreground;
     letter-spacing: var(--tracking-normal);
     font-family: var(--font-sans);
-    /* Handle safe areas for iOS devices (except bottom - handled by MobileFooterNav) */
-    padding-top: env(safe-area-inset-top);
-    padding-left: env(safe-area-inset-left);
-    padding-right: env(safe-area-inset-right);
+    /* Handle safe areas for iOS devices (except bottom - handled by MobileFooterNav).
+       !important: react-remove-scroll zeroes body padding while a Radix modal is open. */
+    padding-top: env(safe-area-inset-top) !important;
+    padding-left: env(safe-area-inset-left) !important;
+    padding-right: env(safe-area-inset-right) !important;
   }
 
   /* Apply font families from theme */

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -45,6 +45,16 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/*
+ * Desktop layout boundary: at least md wide, but not a touch device in
+ * short landscape (a rotated phone). Must stay the exact complement of
+ * useIsMobile() in hooks/useMediaQuery.ts.
+ */
+@custom-variant desk (@media (min-width: 768px) and (not ((pointer: coarse) and (max-height: 500px))));
+
+/* Touch device in short landscape. Must match useIsPhoneLandscape(). */
+@custom-variant phone-land (@media (pointer: coarse) and (max-height: 500px));
+
 :root {
   --background: oklch(1 0 0);
   --foreground: oklch(0.1450 0 0);

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -50,10 +50,10 @@
  * short landscape (a rotated phone). Must stay the exact complement of
  * useIsMobile() in hooks/useMediaQuery.ts.
  */
-@custom-variant desk (@media (min-width: 768px) and (not ((pointer: coarse) and (max-height: 500px))));
+@custom-variant desk (@media (min-width: 768px) and (not ((pointer: coarse) and (orientation: landscape) and (max-width: 1023px) and (max-height: 500px))));
 
 /* Touch device in short landscape. Must match useIsPhoneLandscape(). */
-@custom-variant phone-land (@media (pointer: coarse) and (max-height: 500px));
+@custom-variant phone-land (@media (pointer: coarse) and (orientation: landscape) and (max-width: 1023px) and (max-height: 500px));
 
 :root {
   --background: oklch(1 0 0);

--- a/web/src/layouts/AppLayout.tsx
+++ b/web/src/layouts/AppLayout.tsx
@@ -63,7 +63,7 @@ function AppLayoutContent() {
         <main className={cn(
           "flex-1 overflow-y-auto transition-[padding] duration-300",
           isFooterVisible ? "pb-[calc(4rem+env(safe-area-inset-bottom))]" : "pb-0",
-          "lg:pb-0"
+          "lg:pb-0 phone-land:pb-0"
         )}>
           <Outlet />
         </main>

--- a/web/src/pages/Torrents.tsx
+++ b/web/src/pages/Torrents.tsx
@@ -600,7 +600,7 @@ export function Torrents({ instanceId, instanceName, isAllInstancesView = false,
         >
           <SheetContent
             side="right"
-            className="w-full p-0 gap-0"
+            className="w-full p-0 gap-0 pl-[env(safe-area-inset-left)]"
             hideClose
           >
             <SheetHeader className="sr-only">

--- a/web/src/pages/Torrents.tsx
+++ b/web/src/pages/Torrents.tsx
@@ -421,7 +421,7 @@ export function Torrents({ instanceId, instanceName, isAllInstancesView = false,
       {/* Desktop Sidebar - slides in on tablet/desktop */}
       <div
         className={cn(
-          "hidden md:flex shrink-0 h-full overflow-hidden transition-[flex-basis,width] duration-300 ease-in-out",
+          "hidden desk:flex shrink-0 h-full overflow-hidden transition-[flex-basis,width] duration-300 ease-in-out",
           filterSidebarCollapsed && "basis-0"
         )}
         style={{ flexBasis: filterSidebarCollapsed ? 0 : sidebarWidth }}
@@ -458,7 +458,7 @@ export function Torrents({ instanceId, instanceName, isAllInstancesView = false,
       <Sheet open={mobileFilterOpen} onOpenChange={setMobileFilterOpen}>
         <SheetContent
           side="left"
-          className="p-0 w-[280px] sm:w-[320px] md:hidden flex flex-col max-h-[100dvh]"
+          className="p-0 w-[280px] sm:w-[320px] desk:hidden flex flex-col max-h-[100dvh]"
           onOpenAutoFocus={(event) => {
             event.preventDefault()
 


### PR DESCRIPTION
## Description

A phone in landscape is 812-932 px wide, so it crossed the `md` breakpoint and got the desktop table, the inline filter sidebar, and the desktop header on a ~430 px tall screen, together with the mobile footer nav. `useIsMobile()` now also matches touch devices in short landscape, and a matching `desk` Tailwind variant replaces the `md:` visibility switches on the header and the filter sidebar, so a rotated phone keeps the card UI.

Landscape also gets its own shell through a `phone-land` variant: the footer nav becomes a left icon rail and the quick-action bar moves to the bottom edge. Only one bar takes vertical space, which shows one more card row.

## How has this been tested?

Chrome device emulation at 932x430 (cards, rail, filter drawer, details sheet, rail dropdowns), 430x932 portrait unchanged, and desktop with a mouse unchanged. `make precommit`, the frontend vitest suite, and `make build` pass.

## Screenshots (for UI changes)
<img width="1982" height="966" alt="image" src="https://github.com/user-attachments/assets/5712208d-838f-4424-b6b5-0475cdfd71d5" />


## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [x] I ran `make precommit` and the tests pass locally
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved phone-landscape navigation with a vertical side footer and right-opening menus.
  * Kept torrent sorting, filtering, and scroll-to-top controls accessible in landscape orientation.
  * Refined desktop and mobile breakpoints for headers, filters, spacing, and navigation.
  * Added consistent phone-landscape detection and responsive styling.
  * Adjusted content spacing, safe-area padding, and navigation positioning for improved landscape usability.
  * Preserved portrait-mode behavior while improving layout adaptability across screen sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->