### PR TITLE
docs: correct tracker customizations location and document the feature

### DIFF
--- a/documentation/docs/features/automations.md
+++ b/documentation/docs/features/automations.md
@@ -135,7 +135,7 @@ These fields use qui's current system time when the rule is evaluated. They are 
 | Tracker message | Per-tracker status message; use `nil` for an empty message (requires qBittorrent 5.1+)                       |
 | Comment         | Torrent comment field                                         |
 
-Note: if you have **Settings → Tracker Customizations** configured, the **Tracker** condition can match the display name in addition to the raw URL/domain.
+Note: if you have [Tracker Customizations](./tracker-customizations.md) configured (Dashboard → **Tracker Breakdown**), the **Tracker** condition can match the display name in addition to the raw URL/domain.
 
 #### Mode Fields
 
@@ -568,7 +568,7 @@ Options:
 
 - **Managed / Replace in Client** - `Managed` (default) applies per-torrent add/remove diffs only. `Replace in client` deletes managed tags from qBittorrent first, then reapplies to current matches.
 - **Use Tracker as Tag** - Derive tag from tracker domain
-- **Use Display Name** - Use tracker customization display name instead of raw domain
+- **Use Display Name** - Use the [tracker customization](./tracker-customizations.md) display name instead of the raw domain
 
 Behavior reference:
 
@@ -617,7 +617,7 @@ The move path is evaluated as a **Go template** for each torrent. You can use a 
 | `.Hash`                | Info hash                                                                                |
 | `.Category`            | qBittorrent category                                                                     |
 | `.IsolationFolderName` | Filesystem-safe folder name (hash or sanitized name)                                     |
-| `.Tracker`             | Tracker display name (when available from instance config), otherwise the tracker domain |
+| `.Tracker`             | Tracker display name from [Tracker Customizations](./tracker-customizations.md), otherwise the tracker domain |
 
 **Template function:**
 
@@ -631,7 +631,11 @@ The move path is evaluated as a **Go template** for each torrent. You can use a 
 - By category: `/data/{{.Category}}` → e.g. `/data/movies`
 - By name (safe for paths): `/data/{{ sanitize .Name }}`
 - By isolation folder: `/data/{{.IsolationFolderName}}`
-- By tracker: `/data/{{.Tracker}}` (when tracker display name is configured)
+- By tracker: `/data/{{.Tracker}}` (when a tracker display name is configured)
+
+:::note
+`.Tracker` only resolves to a [tracker customization](./tracker-customizations.md) display name when the rule also uses a **Tracker** condition, or a tag action with **Use Tracker as Tag** + **Use Display Name**. Otherwise it falls back to the tracker domain.
+:::
 
 ### Auto Management
 
@@ -722,7 +726,7 @@ The save path field supports Go templates, the same as the [Move action](#move-p
 | `.Hash`                | Info hash                                                                                |
 | `.Category`            | qBittorrent category (on source instance)                                                |
 | `.IsolationFolderName` | Filesystem-safe folder name (hash or sanitized name)                                     |
-| `.Tracker`             | Tracker display name (when available from instance config), otherwise the tracker domain |
+| `.Tracker`             | Tracker display name from [Tracker Customizations](./tracker-customizations.md), otherwise the tracker domain |
 
 | Function   | Description                                                                 |
 | ---------- | --------------------------------------------------------------------------- |

--- a/documentation/docs/features/automations.md
+++ b/documentation/docs/features/automations.md
@@ -634,7 +634,7 @@ The move path is evaluated as a **Go template** for each torrent. You can use a 
 - By tracker: `/data/{{.Tracker}}` (when a tracker display name is configured)
 
 :::note
-`.Tracker` only resolves to a [tracker customization](./tracker-customizations.md) display name when the rule also uses a **Tracker** condition, or a tag action with **Use Tracker as Tag** + **Use Display Name**. Otherwise it falls back to the tracker domain.
+For `.Tracker` to use your [tracker customization](./tracker-customizations.md) display name, the rule also needs a **Tracker** condition, or a tag action with **Use Tracker as Tag** and **Use Display Name** enabled. Without one of those, `.Tracker` falls back to the tracker domain and your folders are named after the domain instead.
 :::
 
 ### Auto Management

--- a/documentation/docs/features/cross-seed/link-directories.md
+++ b/documentation/docs/features/cross-seed/link-directories.md
@@ -37,7 +37,7 @@ qui supports three presets:
 
 For `by-tracker`, qui resolves the folder name using the same fallback chain as cross-seed statistics:
 
-1. **Tracker customization display name** (Settings → Tracker Customizations)
+1. **Tracker customization display name** ([Tracker Customizations](../tracker-customizations.md), on the Dashboard under **Tracker Breakdown**)
 2. Indexer name (from Prowlarr/Jackett)
 3. Raw announce domain
 

--- a/documentation/docs/features/tracker-customizations.md
+++ b/documentation/docs/features/tracker-customizations.md
@@ -31,7 +31,9 @@ Trackers that announce on several domains can be combined into a single entry:
 2. Click the link icon on one of the selected rows (**Merge selected trackers into this group**).
 3. Enter the **Display Name** for the merged entry and save.
 
-In the merge dialog you can untick individual domains so they are not counted in Dashboard statistics. Use this when the same torrents are reachable through more than one domain and would otherwise be counted twice.
+In the merge dialog, the first domain is the **Primary** one and always counts toward Dashboard statistics. Every other domain in the group starts excluded — tick its checkbox to add its stats to the group total.
+
+This is deliberate: when the same torrents are reachable through more than one domain of the same tracker, including all of them would count those torrents twice. Only tick a secondary domain when it carries torrents the primary domain does not.
 
 To add another domain to an existing group later, select the domain and click the link icon on the group's row.
 
@@ -58,10 +60,10 @@ The **Tracker Breakdown** header has import and export buttons.
 }
 ```
 
-`includedInStats` is optional; when omitted, every domain in the entry counts toward Dashboard statistics.
+`includedInStats` is optional and lists the **secondary** domains that count toward Dashboard statistics. The primary domain (`domains[0]`) is always counted and does not need to be listed. When `includedInStats` is omitted, only the primary domain counts.
 
 ## Where Display Names Are Used
 
 - **Dashboard** statistics and tracker breakdown.
-- **[Automations](./automations.md)**: the `Tracker` condition matches the display name in addition to the raw URL/domain, tag actions can tag by display name via **Use Display Name**, and the `.Tracker` template variable resolves to it.
+- **[Automations](./automations.md)**: the `Tracker` condition matches the display name in addition to the raw URL/domain, tag actions can tag by display name via **Use Display Name**, and the `.Tracker` template variable resolves to it (only when the rule also uses a **Tracker** condition or a **Use Tracker as Tag** + **Use Display Name** tag action; otherwise `.Tracker` falls back to the raw domain).
 - **[Cross-seed link directories](./cross-seed/link-directories.md)**: the `by-tracker` preset uses the display name for folder names.

--- a/documentation/docs/features/tracker-customizations.md
+++ b/documentation/docs/features/tracker-customizations.md
@@ -1,0 +1,67 @@
+---
+sidebar_position: 8
+title: Tracker Customizations
+description: Give trackers friendly display names and merge multiple announce domains into one entry.
+---
+
+# Tracker Customizations
+
+qui identifies trackers by their announce domain (`tracker.example.com`). A tracker customization maps one or more domains to a friendly display name (`MyTracker`), which qui then uses in place of the raw domain.
+
+Customizations are global — they apply to every instance, not per instance.
+
+## Where to Find It
+
+Tracker customizations live on the **Dashboard**, in the **Tracker Breakdown** section. There is no Settings page for them.
+
+Expand **Tracker Breakdown** to see the table of trackers; the rename, merge, edit, and delete actions are the row actions in that table.
+
+## Rename a Tracker
+
+1. Open the **Dashboard** and expand **Tracker Breakdown**.
+2. Hover the tracker row (on mobile, tap the row to open its drawer).
+3. Click the pencil icon (**Rename**).
+4. Enter a **Display Name** and save.
+
+## Merge Trackers
+
+Trackers that announce on several domains can be combined into a single entry:
+
+1. Tick the checkbox on each tracker row you want to combine.
+2. Click the link icon on one of the selected rows (**Merge selected trackers into this group**).
+3. Enter the **Display Name** for the merged entry and save.
+
+In the merge dialog you can untick individual domains so they are not counted in Dashboard statistics. Use this when the same torrents are reachable through more than one domain and would otherwise be counted twice.
+
+To add another domain to an existing group later, select the domain and click the link icon on the group's row.
+
+## Edit or Delete
+
+Rows that already have a customization show a pencil (**Edit**) and a trash icon (**Delete**) on hover. Deleting a customization reverts those trackers to their raw domains.
+
+## Import and Export
+
+The **Tracker Breakdown** header has import and export buttons.
+
+**Export** copies all customizations to the clipboard as JSON. **Import** accepts the same JSON and reports new entries, conflicts, and unchanged entries before applying; for each conflict you choose **Skip** or **Overwrite**.
+
+```json
+{
+  "comment": "qui tracker customizations for Dashboard",
+  "trackerCustomizations": [
+    {
+      "displayName": "MyTracker",
+      "domains": ["tracker.example.com", "tracker2.example.com"],
+      "includedInStats": ["tracker.example.com"]
+    }
+  ]
+}
+```
+
+`includedInStats` is optional; when omitted, every domain in the entry counts toward Dashboard statistics.
+
+## Where Display Names Are Used
+
+- **Dashboard** statistics and tracker breakdown.
+- **[Automations](./automations.md)**: the `Tracker` condition matches the display name in addition to the raw URL/domain, tag actions can tag by display name via **Use Display Name**, and the `.Tracker` template variable resolves to it.
+- **[Cross-seed link directories](./cross-seed/link-directories.md)**: the `by-tracker` preset uses the display name for folder names.

--- a/documentation/docs/features/tracker-customizations.md
+++ b/documentation/docs/features/tracker-customizations.md
@@ -8,7 +8,7 @@ description: Give trackers friendly display names and merge multiple announce do
 
 qui identifies trackers by their announce domain (`tracker.example.com`). A tracker customization maps one or more domains to a friendly display name (`MyTracker`), which qui then uses in place of the raw domain.
 
-Customizations are global — they apply to every instance, not per instance.
+Display names apply across all your instances — you only set them up once.
 
 ## Where to Find It
 
@@ -31,9 +31,9 @@ Trackers that announce on several domains can be combined into a single entry:
 2. Click the link icon on one of the selected rows (**Merge selected trackers into this group**).
 3. Enter the **Display Name** for the merged entry and save.
 
-In the merge dialog, the first domain is the **Primary** one and always counts toward Dashboard statistics. Every other domain in the group starts excluded — tick its checkbox to add its stats to the group total.
+The merge dialog marks the first domain **Primary**. Its torrents always count toward the group's Dashboard statistics. The other domains start unticked and do not count until you tick them.
 
-This is deliberate: when the same torrents are reachable through more than one domain of the same tracker, including all of them would count those torrents twice. Only tick a secondary domain when it carries torrents the primary domain does not.
+That default avoids double-counting. Trackers often announce the same torrents on several domains, so counting every domain would count those torrents twice and inflate your upload and ratio figures. Tick a domain only if it holds torrents the primary one doesn't.
 
 To add another domain to an existing group later, select the domain and click the link icon on the group's row.
 
@@ -54,16 +54,16 @@ The **Tracker Breakdown** header has import and export buttons.
     {
       "displayName": "MyTracker",
       "domains": ["tracker.example.com", "tracker2.example.com"],
-      "includedInStats": ["tracker.example.com"]
+      "includedInStats": ["tracker2.example.com"]
     }
   ]
 }
 ```
 
-`includedInStats` is optional and lists the **secondary** domains that count toward Dashboard statistics. The primary domain (`domains[0]`) is always counted and does not need to be listed. When `includedInStats` is omitted, only the primary domain counts.
+The first entry in `domains` is the primary one and always counts toward Dashboard statistics. `includedInStats` is optional and lists any of the other domains you also want counted; leave it out and only the primary domain counts.
 
 ## Where Display Names Are Used
 
 - **Dashboard** statistics and tracker breakdown.
-- **[Automations](./automations.md)**: the `Tracker` condition matches the display name in addition to the raw URL/domain, tag actions can tag by display name via **Use Display Name**, and the `.Tracker` template variable resolves to it (only when the rule also uses a **Tracker** condition or a **Use Tracker as Tag** + **Use Display Name** tag action; otherwise `.Tracker` falls back to the raw domain).
+- **[Automations](./automations.md)**: the **Tracker** condition matches your display name as well as the raw URL or domain, tag actions can tag torrents with it, and move paths can use it via `{{.Tracker}}`.
 - **[Cross-seed link directories](./cross-seed/link-directories.md)**: the `by-tracker` preset uses the display name for folder names.


### PR DESCRIPTION
## Description

The docs told users to configure tracker friendly names under **Settings → Tracker Customizations**, which does not exist. The feature actually lives on the **Dashboard**, in the **Tracker Breakdown** section.

Closes #2363

Changes:

- **New page** `documentation/docs/features/tracker-customizations.md` — where the feature actually lives, how to rename and merge trackers, edit/delete, import/export (with the real export JSON shape and `includedInStats`), and where display names get used.
- **`features/automations.md`**
  - Replaced the stale `Settings → Tracker Customizations` path with a link to the new page.
  - Fixed the `.Tracker` template variable description in both tables — it said "when available from instance config", but `resolveMovePath` calls `selectTrackerTag(..., useDisplayName: true, ...)`, so the value comes from tracker customizations.
  - Added a note about a gotcha found while verifying that: `service.go:2209` only loads the display-name map when a rule uses a **Tracker** condition or a **Use Tracker as Tag** + **Use Display Name** tag action. A rule that only uses `{{.Tracker}}` in a move/export path silently falls back to the raw domain. Documented as current behavior; this looks like an unintended gap and may be worth a separate issue.
- **`features/cross-seed/link-directories.md`** — same stale path in the `by-tracker` fallback chain, now linked to the new page.

## How has this been tested?

`pnpm build` in `documentation/` passes. The config sets `onBrokenLinks: "throw"`, so the new cross-page links are verified to resolve.

The documented UI flow was verified against `web/src/pages/Dashboard.tsx` (rename/merge/edit/delete row actions, import/export buttons, the mobile drawer) and `internal/models/tracker_customization.go` (customizations are global, not per-instance).

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [ ] I ran `make precommit` and the tests pass locally — not applicable, docs-only change with no Go or frontend source touched; `pnpm build` in `documentation/` was run instead
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL — n/a, no schema changes

## AI disclosure

Yes. The documentation was written by Claude Code, which read the Dashboard component and the automations service to verify the actual UI flow and the `.Tracker` resolution behavior before writing. Reviewed by a human before opening.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQsU2fuWTLS2mzis2x5pjm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for managing global tracker customizations, including renaming, merging, editing, deleting, and importing or exporting settings.
  * Documented optional inclusion of tracker customizations in statistics.
  * Clarified how tracker display names appear in Automations, Dashboard statistics, and cross-seed link directories.
  * Updated references to direct readers to the dedicated Tracker Customizations documentation and Dashboard location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->