### PR TITLE
chore(build): bump Go to 1.27

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,7 +22,7 @@ This guide helps you get started developing qui.
 Make sure you have the following dependencies installed before setting up your developer environment:
 
 - [Git](https://git-scm.com/)
-- [Go](https://golang.org/dl/) 1.26 or later (see [go.mod](../go.mod#L3) for exact version)
+- [Go](https://golang.org/dl/) 1.27 or later (see [go.mod](../go.mod#L3) for exact version)
 - [Node.js](https://nodejs.org) (we usually use the latest Node LTS version - for further information see `@types/node` major version in [package.json](../web/package.json))
 - [pnpm](https://pnpm.io/installation)
 - [prek](https://github.com/prefix-dev/prek) (optional, for pre-commit hooks)

--- a/distrib/docker/Dockerfile
+++ b/distrib/docker/Dockerfile
@@ -18,7 +18,7 @@ RUN pnpm run build
 
 # Go build stage
 # Use BUILDPLATFORM to build on native architecture (fast)
-FROM --platform=$BUILDPLATFORM golang:1.26-alpine3.22 AS go-builder
+FROM --platform=$BUILDPLATFORM golang:1.27-alpine3.23 AS go-builder
 
 # Install build dependencies
 RUN apk add --no-cache git

--- a/distrib/docker/ci.Dockerfile
+++ b/distrib/docker/ci.Dockerfile
@@ -2,7 +2,7 @@
 
 # Build stage for Go binary
 # Use BUILDPLATFORM to build on native architecture (fast)
-FROM --platform=$BUILDPLATFORM golang:1.26-alpine3.22 AS go-builder
+FROM --platform=$BUILDPLATFORM golang:1.27-alpine3.23 AS go-builder
 
 # Install build dependencies
 RUN apk add --no-cache git make

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/autobrr/qui
 
-go 1.26.0
+go 1.27.0
 
 require (
 	github.com/CAFxX/httpcompression v0.0.9
@@ -26,6 +26,7 @@ require (
 	github.com/lithammer/fuzzysearch v1.1.8
 	github.com/mat/besticon/v3 v3.22.0
 	github.com/moistari/rls v0.6.0
+	github.com/nicholas-fedor/shoutrrr v0.16.3
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.24.1
 	github.com/rs/cors v1.11.1
@@ -43,22 +44,11 @@ require (
 	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
 	golang.org/x/text v0.40.0
+	golang.org/x/time v0.15.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.55.0
 )
-
-require (
-	github.com/eclipse/paho.golang v0.23.0 // indirect
-	github.com/google/go-github/v86 v86.0.0 // indirect
-	github.com/gorilla/websocket v1.5.3 // indirect
-	github.com/jackc/pgpassfile v1.0.0 // indirect
-	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/puddle/v2 v2.2.2 // indirect
-	github.com/rogpeppe/go-internal v1.14.1 // indirect
-)
-
-replace github.com/moistari/rls => github.com/autobrr/rls v0.8.1
 
 require (
 	code.gitea.io/sdk/gitea v0.23.2 // indirect
@@ -68,26 +58,32 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/davidmz/go-pageant v1.0.2 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/eclipse/paho.golang v0.23.0 // indirect
 	github.com/go-fed/httpsig v1.1.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
+	github.com/google/go-github/v86 v86.0.0 // indirect
 	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
+	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.15 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/nicholas-fedor/shoutrrr v0.16.3
 	github.com/pelletier/go-toml/v2 v2.4.3 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.1 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
@@ -96,9 +92,10 @@ require (
 	gitlab.com/gitlab-org/api/client-go v1.46.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a // indirect
-	golang.org/x/time v0.15.0
 	google.golang.org/protobuf v1.36.11 // indirect
 	modernc.org/libc v1.74.1 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
 )
+
+replace github.com/moistari/rls => github.com/autobrr/rls v0.8.1


### PR DESCRIPTION
## Description

Bump the module and contributor requirement from Go 1.26 to Go 1.27.

Go 1.27 `go mod tidy` also consolidates the duplicate `require` blocks. Dependency versions do not change.

The GitHub workflows already use `go-version-file: go.mod`, so they need no Go version edits.

### Waiting for

- ~~Docker Official Images to publish a stable Go 1.27 Alpine image.~~ Done: `golang:1.27-alpine3.23` is live, and both Dockerfiles now use it.
- A golangci-lint release that can analyze Go 1.27 export data. The pinned v2.11.1 binary rejects the Go 1.27 module, and rebuilding v2.11.1 with Go 1.27 still fails during type analysis.

Fixes # N/A

## How has this been tested?

- `GOTOOLCHAIN=go1.27.0 go mod tidy`
- `GOTOOLCHAIN=go1.27.0 make build`
- Confirmed the previous CI Docker build stopped at `go mod download` because its Go 1.26 image set `GOTOOLCHAIN=local`; both Dockerfiles now use `golang:1.27-alpine3.23`.
- `make precommit` reaches golangci-lint, then fails on the known Go 1.27 compatibility blocker above.
- The full Go test suite is deferred to CI.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [ ] I ran `make precommit` and the tests pass locally
- [x] This change does not modify the database schema

## AI disclosure

Yes. Codex prepared the version bump, checked the upstream tool availability, ran the local validation, and drafted this pull request. No application code was generated.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the supported Go version to 1.27.
  * Updated build environments to use the latest Go 1.27 and Alpine 3.23 images.

* **Documentation**
  * Revised contribution guidance to reflect the updated minimum Go version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->