### PR TITLE
fix(crossseed): log repeated size-mismatch rejections at trace

### DIFF
--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -43,6 +43,7 @@ import (
 	"github.com/moistari/rls"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/sync/singleflight"
 
@@ -356,6 +357,10 @@ type Service struct {
 	asyncFilteringCache *ttlcache.Cache[string, *AsyncIndexerFilteringState]
 	indexerDomainCache  *ttlcache.Cache[string, string]
 	stringNormalizer    *stringutils.Normalizer[string, string]
+
+	// sizeMismatchWarned tracks (source hash, matched hash) pairs whose
+	// size-mismatch rejection already logged at warn; repeats drop to trace.
+	sizeMismatchWarned sync.Map
 
 	automationStore          *models.CrossSeedStore
 	blocklistStore           *models.CrossSeedBlocklistStore
@@ -3791,6 +3796,16 @@ func (s *Service) executeAutomationRun(ctx context.Context, run *models.CrossSee
 	return run, runErr
 }
 
+// sizeMismatchLogLevel returns warn for the first size-mismatch rejection of a
+// (source, matched) pair and trace for repeats: RSS retries the same doomed
+// pair every run until it leaves the feed. In-memory and unbounded on purpose.
+func (s *Service) sizeMismatchLogLevel(sourceHash, matchedHash string) zerolog.Level {
+	if _, seen := s.sizeMismatchWarned.LoadOrStore(sourceHash+"|"+matchedHash, struct{}{}); seen {
+		return zerolog.TraceLevel
+	}
+	return zerolog.WarnLevel
+}
+
 func isSkippedCrossSeedResultStatus(status string) bool {
 	switch status {
 	case "no_match", "skipped", "rejected", "blocked", "requires_hardlink_reflink", "below_threshold", "skipped_recheck", "skipped_unsafe_pieces", contentPrefilterRejectedContentStatus:
@@ -5176,7 +5191,7 @@ func (s *Service) processCrossSeedCandidate(
 		if hasMismatch, fileSizeMismatches := hasContentFileSizeMismatch(sourceFiles, candidateFiles, s.stringNormalizer); hasMismatch {
 			result.Status = "rejected"
 			result.Message = "Content file sizes do not match - possible corruption or different release"
-			log.Warn().
+			log.WithLevel(s.sizeMismatchLogLevel(torrentHash, matchedTorrent.Hash)).
 				Int("instanceID", candidate.InstanceID).
 				Str("instanceName", candidate.InstanceName).
 				Str("torrentHash", torrentHash).

--- a/internal/services/crossseed/size_mismatch_log_test.go
+++ b/internal/services/crossseed/size_mismatch_log_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package crossseed
+
+import (
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSizeMismatchLogLevel(t *testing.T) {
+	t.Parallel()
+
+	s := &Service{}
+
+	require.Equal(t, zerolog.WarnLevel, s.sizeMismatchLogLevel("src-a", "match-1"), "first rejection of a pair warns")
+	require.Equal(t, zerolog.TraceLevel, s.sizeMismatchLogLevel("src-a", "match-1"), "repeat of the same pair drops to trace")
+	require.Equal(t, zerolog.TraceLevel, s.sizeMismatchLogLevel("src-a", "match-1"), "further repeats stay trace")
+
+	require.Equal(t, zerolog.WarnLevel, s.sizeMismatchLogLevel("src-a", "match-2"), "same source against another local copy warns")
+	require.Equal(t, zerolog.WarnLevel, s.sizeMismatchLogLevel("src-b", "match-1"), "different source against the same local copy warns")
+}


### PR DESCRIPTION
## Description

RSS automation retries a size-mismatched feed item every run until it leaves the feed, and each attempt logged the same warn-level "possible data corruption" message. The retries are wanted, the matched local copy can change between runs, so only the log level changes: the first rejection of a (source, matched) pair keeps the warn, repeats drop to trace.

## How has this been tested?

New `TestSizeMismatchLogLevel` covers first-warn, repeat-trace, and per-pair isolation, written and run red before the fix. `go test -race -count=1 ./internal/services/crossseed/`, `make precommit`, and `make build` pass locally. Observed on a live instance: 14 identical warns in 24 hours for one stuck feed item.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [x] I ran `make precommit` and the tests pass locally
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced repetitive warning logs for repeated torrent size-mismatch rejections.
  * The first occurrence is highlighted as a warning, while identical subsequent occurrences are recorded at a lower detail level.

* **Tests**
  * Added coverage to verify logging behavior for repeated and distinct source/match pairs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->