### PR TITLE
chore(jackett): raise torznab torrent cache TTL to 24h

### DIFF
--- a/internal/services/jackett/service.go
+++ b/internal/services/jackett/service.go
@@ -104,7 +104,7 @@ var ErrMissingIndexerIdentifier = errors.New("torznab indexer identifier is requ
 
 const (
 	defaultRateLimitCooldown = 30 * time.Minute
-	defaultTorrentCacheTTL   = 12 * time.Hour
+	defaultTorrentCacheTTL   = 24 * time.Hour
 	defaultSearchCacheTTL    = 24 * time.Hour
 	storeOperationTimeout    = 5 * time.Second
 	minSearchCacheTTL        = defaultSearchCacheTTL


### PR DESCRIPTION
## Description

Feed items that retry while a release sits in the RSS feed re-downloaded the same `.torrent` from the tracker twice a day. Raising `defaultTorrentCacheTTL` to 24h cuts that to once a day. The read-side expiry and the background cleanup share this constant, so retention and trimming move together and the cache table stays bounded by activity.

## How has this been tested?

`go test -race -count=1 ./internal/services/jackett/`, `make precommit`, and `make backend` pass locally. Measured on a live instance: the cache table held 43 rows / 2.9 MB over 15 hours, so a day of retention stays in the tens of MB even at higher grab rates.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [x] I ran `make precommit` and the tests pass locally
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Torrent payloads are now cached for up to 24 hours, reducing unnecessary refetches and improving retrieval efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->