### PR TITLE
fix(ui): show sideloaded themes in the mobile theme picker

### DIFF
--- a/web/src/components/layout/MobileFooterNav.tsx
+++ b/web/src/components/layout/MobileFooterNav.tsx
@@ -23,18 +23,20 @@ import {
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
-import { isThemePremium, themes } from "@/config/themes"
+import { getThemeById, isThemePremium, themes } from "@/config/themes"
 import { useMobileScroll } from "@/contexts/MobileScrollContext"
 import { useTorrentSelection } from "@/contexts/TorrentSelectionContext"
 import { useAuth } from "@/hooks/useAuth"
 import { usePersistedCompactViewState } from "@/hooks/usePersistedCompactViewState"
 import { useCrossSeedInstanceState } from "@/hooks/useCrossSeedInstanceState"
+import { useCustomThemes } from "@/hooks/useCustomThemes"
 import { useHasPremiumAccess } from "@/hooks/useLicense"
 import { usePersistedUnifiedInstanceFilter } from "@/hooks/usePersistedUnifiedInstanceFilter"
 import { api } from "@/lib/api"
 import { getAppVersion } from "@/lib/build-info"
 import { changeLanguage, languageNames, supportedLanguages } from "@/i18n"
 import { canSwitchToPremiumTheme } from "@/lib/license-entitlement"
+import { buildThemeCatalog } from "@/lib/theme-catalog"
 import { normalizeUnifiedInstanceIds } from "@/lib/instances"
 import { cn } from "@/lib/utils"
 import {
@@ -119,6 +121,8 @@ export function MobileFooterNav() {
   const { currentMode, currentTheme } = useThemeChange()
   const { hasPremiumAccess, isLoading, isError } = useHasPremiumAccess()
   const canSwitchPremium = canSwitchToPremiumTheme({ hasPremiumAccess, isLoading, isError })
+  const { customThemes } = useCustomThemes()
+  const themeCatalog = useMemo(() => buildThemeCatalog(themes, customThemes), [customThemes])
   const [showThemeDialog, setShowThemeDialog] = useState(false)
   const appVersion = getAppVersion()
 
@@ -207,7 +211,7 @@ export function MobileFooterNav() {
     }
 
     await setTheme(themeId)
-    const theme = themes.find(th => th.id === themeId)
+    const theme = getThemeById(themeId)
     toast.success(t("themeToggle.switchedToTheme", { theme: theme?.name || themeId }))
   }, [canSwitchPremium, isError, t])
 
@@ -226,7 +230,7 @@ export function MobileFooterNav() {
 
     await setTheme(themeId)
     await setThemeVariation(variationId)
-    const theme = themes.find(th => th.id === themeId)
+    const theme = getThemeById(themeId)
     toast.success(t("themeToggle.switchedToThemeVariation", { theme: theme?.name || themeId, variation: variationId }))
     return true
   }, [canSwitchPremium, isError, t])
@@ -657,92 +661,85 @@ export function MobileFooterNav() {
             <div>
               <div className="text-sm font-medium mb-2">{t("themeToggle.theme")}</div>
               <div className="space-y-1">
-                {themes
-                  .sort((a, b) => {
-                    const aIsPremium = isThemePremium(a.id)
-                    const bIsPremium = isThemePremium(b.id)
-                    if (aIsPremium === bIsPremium) return 0
-                    return aIsPremium ? 1 : -1
-                  })
-                  .map((theme) => {
-                    const isPremium = isThemePremium(theme.id)
-                    const isLocked = isPremium && !hasPremiumAccess
-                    const colors = getThemeColors(theme)
-                    const currentVariation = getThemeVariation(theme.id)
+                {themeCatalog.map((theme) => {
+                  const isPremium = isThemePremium(theme.id)
+                  const isLocked = isPremium && !hasPremiumAccess
+                  const colors = getThemeColors(theme)
+                  const currentVariation = getThemeVariation(theme.id)
 
-                    return (
-                      <button
-                        key={theme.id}
-                        onClick={() => {
-                          if (!isLocked) {
-                            handleThemeSelect(theme.id)
-                            setShowThemeDialog(false)
-                          }
-                        }}
-                        disabled={isLocked}
-                        className={cn(
-                          "w-full flex items-center gap-3 px-3 py-2 rounded-md transition-colors",
-                          currentTheme.id === theme.id ? "bg-accent" : "hover:bg-accent/50",
-                          isLocked && "opacity-60 cursor-not-allowed"
-                        )}
-                      >
-                        <div className="flex-1">
-                          <div className="flex items-center gap-3">
-                            <div
-                              className="h-4 w-4 rounded-full ring-1 ring-black/10 dark:ring-white/10 flex-shrink-0"
-                              style={{
-                                backgroundColor: colors.primary,
-                                backgroundImage: "none",
-                                background: colors.primary + " !important",
-                              }}
-                            />
-                            <div className="flex items-center gap-2 flex-1 min-w-0">
-                              <span className="truncate">{theme.name}</span>
-                              {isPremium && (
-                                <span className="text-[10px] px-1.5 py-0.5 rounded bg-secondary text-secondary-foreground font-medium flex-shrink-0">
-                                  {t("themeToggle.premium")}
-                                </span>
-                              )}
+                  return (
+                    <button
+                      key={theme.id}
+                      onClick={() => {
+                        if (!isLocked) {
+                          handleThemeSelect(theme.id)
+                          setShowThemeDialog(false)
+                        }
+                      }}
+                      disabled={isLocked}
+                      className={cn(
+                        "w-full flex items-center gap-3 px-3 py-2 rounded-md transition-colors",
+                        currentTheme.id === theme.id ? "bg-accent" : "hover:bg-accent/50",
+                        isLocked && "opacity-60 cursor-not-allowed"
+                      )}
+                    >
+                      <div className="flex-1">
+                        <div className="flex items-center gap-3">
+                          <div
+                            className="h-4 w-4 rounded-full ring-1 ring-black/10 dark:ring-white/10 flex-shrink-0"
+                            style={{
+                              backgroundColor: colors.primary,
+                              backgroundImage: "none",
+                              background: colors.primary + " !important",
+                            }}
+                          />
+                          <div className="flex items-center gap-2 flex-1 min-w-0">
+                            <span className="truncate">{theme.name}</span>
+                            {isPremium && (
+                              <span className="text-[10px] px-1.5 py-0.5 rounded bg-secondary text-secondary-foreground font-medium flex-shrink-0">
+                                {t("themeToggle.premium")}
+                              </span>
+                            )}
+                          </div>
+                        </div>
+
+                        {/* Variation pills */}
+                        {colors.variations && colors.variations.length > 0 && (
+                          <div className="flex items-center gap-2 pl-1.5 mt-2">
+                            <CornerDownRight className="h-4 w-4 text-muted-foreground" />
+                            <div className="flex gap-2">
+                              {colors.variations.map((variation) => {
+                                const isSelected = currentVariation === variation.id
+                                return (
+                                  <div
+                                    key={variation.id}
+                                    onClick={async (e) => {
+                                      e.stopPropagation()
+                                      const success = await handleVariationSelect(theme.id, variation.id)
+                                      if (success) {
+                                        setShowThemeDialog(false)
+                                      }
+                                    }}
+                                    className={cn(
+                                      "w-8 h-8 rounded-full transition-all cursor-pointer",
+                                      isSelected? "ring-2 ring-black dark:ring-white": "ring-1 ring-black/10 dark:ring-white/10"
+                                    )}
+                                    style={{
+                                      backgroundColor: variation.color,
+                                      backgroundImage: "none",
+                                      background: variation.color + " !important",
+                                    }}
+                                  />
+                                )
+                              })}
                             </div>
                           </div>
-
-                          {/* Variation pills */}
-                          {colors.variations && colors.variations.length > 0 && (
-                            <div className="flex items-center gap-2 pl-1.5 mt-2">
-                              <CornerDownRight className="h-4 w-4 text-muted-foreground" />
-                              <div className="flex gap-2">
-                                {colors.variations.map((variation) => {
-                                  const isSelected = currentVariation === variation.id
-                                  return (
-                                    <div
-                                      key={variation.id}
-                                      onClick={async (e) => {
-                                        e.stopPropagation()
-                                        const success = await handleVariationSelect(theme.id, variation.id)
-                                        if (success) {
-                                          setShowThemeDialog(false)
-                                        }
-                                      }}
-                                      className={cn(
-                                        "w-8 h-8 rounded-full transition-all cursor-pointer",
-                                        isSelected? "ring-2 ring-black dark:ring-white": "ring-1 ring-black/10 dark:ring-white/10"
-                                      )}
-                                      style={{
-                                        backgroundColor: variation.color,
-                                        backgroundImage: "none",
-                                        background: variation.color + " !important",
-                                      }}
-                                    />
-                                  )
-                                })}
-                              </div>
-                            </div>
-                          )}
-                        </div>
-                        {currentTheme.id === theme.id && <Check className="h-4 w-4 flex-shrink-0 self-center" />}
-                      </button>
-                    )
-                  })}
+                        )}
+                      </div>
+                      {currentTheme.id === theme.id && <Check className="h-4 w-4 flex-shrink-0 self-center" />}
+                    </button>
+                  )
+                })}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Description

Sideloaded (custom) themes showed up in the desktop theme picker but not in the mobile one.

`ThemeToggle` and the settings `ThemeSelector` both build their list with `buildThemeCatalog(themes, customThemes)`, while the mobile appearance dialog in `MobileFooterNav` mapped over the built-in `themes` array directly, so custom themes were never rendered there.

- Use the same `buildThemeCatalog(themes, customThemes)` list in `MobileFooterNav` (this also drops the in-place `themes.sort()` that mutated the shared array — the catalog already orders free → premium → custom).
- Resolve the theme name for the switch toast via `getThemeById` so a custom theme shows its name instead of its `custom:` id.

## How has this been tested?

- `pnpm exec eslint src/components/layout/MobileFooterNav.tsx` — clean
- `pnpm exec tsc -b` — clean
- `pnpm exec vitest run src/components` — 16 files / 63 tests passing

Not verified against a live instance with sideloaded theme files; the change reuses the exact catalog the desktop picker already renders from.

## Screenshots (for UI changes)

None — the dialog layout is unchanged, only the list contents.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [x] I ran the frontend lint/typecheck/tests locally (frontend-only change; full `make precommit` not run)
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL — N/A

## AI disclosure

Yes — written by Claude Code (Claude Opus 5) from a one-line bug report; the entire diff is AI-written and human-reviewed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5tpQJNo1xqGW1HGURqda5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Theme selection in the mobile footer now supports custom themes.
  * Custom themes appear alongside available built-in themes in the theme picker.

* **Bug Fixes**
  * Improved theme and variation selection so custom and built-in themes are resolved consistently.
  * Preserved theme indicators, premium labels, variations, and selection states in the updated picker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->