### PR TITLE
docs: link the community themes repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ qui is developed and maintained by volunteers. Your support helps us continue im
 
 Purchase premium themes directly from Settings → Themes in your qui instance. Your license key is delivered instantly after checkout.
 If you donate with crypto, verify your transaction at [crypto.getqui.com](https://crypto.getqui.com/) to receive a 100% discount code for premium themes.
+A license also unlocks custom themes, which you can write yourself or take from [qui-community-themes](https://github.com/autobrr/qui-community-themes).
 
 ### Donations
 

--- a/documentation/docs/features/custom-themes.md
+++ b/documentation/docs/features/custom-themes.md
@@ -30,6 +30,10 @@ environment variable (see the [configuration reference](../configuration/referen
 Each theme is a single, self-contained `.css` file placed directly in that
 directory (subdirectories and symlinks are ignored).
 
+Ready-made themes live in
+[qui-community-themes](https://github.com/autobrr/qui-community-themes), which
+also takes submissions.
+
 ## Authoring a theme
 
 A theme file has an optional metadata comment header followed by a `:root`

--- a/documentation/docs/intro.md
+++ b/documentation/docs/intro.md
@@ -13,7 +13,7 @@ A web interface for qBittorrent. Manage multiple qBittorrent instances from a si
 - **Single Binary**: No dependencies, just download and run
 - **Multi-Instance Support**: Manage all your qBittorrent instances from one place
 - **Large Collections**: Handles thousands of torrents efficiently
-- **Themeable**: Multiple built-in color themes, plus sideloadable [custom themes](./features/custom-themes.md) (premium)
+- **Themeable**: Multiple built-in color themes, plus sideloadable [custom themes](./features/custom-themes.md) (premium), with a shared collection in [qui-community-themes](https://github.com/autobrr/qui-community-themes)
 - **Base URL Support**: Serve from a subdirectory (e.g., `/qui/`) for reverse proxy setups
 - **OIDC Single Sign-On**: Authenticate through your OpenID Connect provider
 - **External Programs**: Launch custom scripts from the torrent context menu

--- a/documentation/docs/support.md
+++ b/documentation/docs/support.md
@@ -15,6 +15,7 @@ qui is developed and maintained by volunteers. Your support helps us continue im
 Purchase premium themes directly from Settings → Themes in your qui instance. Your license key is delivered instantly after checkout.
 If you donate with crypto, verify your transaction at [crypto.getqui.com](https://crypto.getqui.com/) to receive a 100% discount code for premium themes.
 To manage activations or move a license to a new server, see [License Management](./licenses.md).
+A license also unlocks [custom themes](./features/custom-themes.md), which you can write yourself or take from [qui-community-themes](https://github.com/autobrr/qui-community-themes).
 
 ## Donations
 


### PR DESCRIPTION
## Description

Links [qui-community-themes](https://github.com/autobrr/qui-community-themes) from the README, the docs intro, the support page, and the custom themes page, so users can find community-made themes without being told about the repo on Discord.

Fixes # (issue)

## How has this been tested?

Docs and README only, no code changes. Links checked by hand.

## Screenshots (for UI changes)

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [ ] I ran `make precommit` and the tests pass locally
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that premium theme licenses include access to custom themes.
  * Added links to the community themes collection.
  * Documented that community members can submit themes for inclusion.
  * Updated theme feature and support documentation with these details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->