### PR TITLE
feat(torrents): archive large exports

### DIFF
--- a/internal/api/handlers/torrents.go
+++ b/internal/api/handlers/torrents.go
@@ -58,6 +58,7 @@ type TorrentsHandler struct {
 	torrentAdder      torrentAdder
 	torrentDownloader torrentDownloader
 	contentResolver   torrentContentResolver
+	archiveExporter   torrentArchiveExporter
 }
 
 // truncateExpr truncates long filter expressions for cleaner logging

--- a/internal/api/handlers/torrents_export_archive.go
+++ b/internal/api/handlers/torrents_export_archive.go
@@ -1,0 +1,170 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package handlers
+
+import (
+	"archive/zip"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/autobrr/qui/pkg/pathutil"
+	"github.com/autobrr/qui/pkg/torrentname"
+)
+
+type torrentArchiveExporter interface {
+	ExportTorrent(ctx context.Context, instanceID int, hash string) ([]byte, string, string, error)
+}
+
+type torrentArchiveTarget struct {
+	InstanceID   int    `json:"instanceId"`
+	InstanceName string `json:"instanceName"`
+	Hash         string `json:"hash"`
+	Category     string `json:"category"`
+	Filename     string `json:"filename,omitempty"`
+}
+
+type torrentArchiveRequest struct {
+	Targets []torrentArchiveTarget `json:"targets"`
+}
+
+func (h *TorrentsHandler) ExportTorrentArchive(w http.ResponseWriter, r *http.Request) {
+	var request torrentArchiveRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil || len(request.Targets) == 0 {
+		RespondError(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+
+	for i := range request.Targets {
+		request.Targets[i].Hash = strings.TrimSpace(request.Targets[i].Hash)
+		if request.Targets[i].InstanceID <= 0 || request.Targets[i].Hash == "" {
+			RespondError(w, http.StatusBadRequest, "Each target requires a valid instance ID and torrent hash")
+			return
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/zip")
+	w.Header().Set("Content-Disposition", `attachment; filename="qui-torrents.zip"`)
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+
+	exporter := h.archiveExporter
+	if exporter == nil {
+		exporter = h.syncManager
+	}
+	if err := writeTorrentArchive(r.Context(), w, request.Targets, exporter); err != nil {
+		log.Error().Err(err).Msg("Failed to write torrent export archive")
+	}
+}
+
+func writeTorrentArchive(ctx context.Context, output io.Writer, targets []torrentArchiveTarget, exporter torrentArchiveExporter) (err error) {
+	archive := zip.NewWriter(output)
+	defer func() {
+		err = errors.Join(err, archive.Close())
+	}()
+
+	multipleInstances := hasMultipleArchiveInstances(targets)
+	failures := make([]string, 0)
+	usedNames := make(map[string]struct{}, len(targets))
+
+	for _, target := range targets {
+		data, suggestedName, trackerDomain, exportErr := exporter.ExportTorrent(ctx, target.InstanceID, target.Hash)
+		if exportErr != nil {
+			failures = append(failures, fmt.Sprintf("%s/%s (%s): %v", archiveInstanceName(target), archiveCategoryPath(target.Category), target.Hash, exportErr))
+			continue
+		}
+
+		filename := torrentname.SanitizeExportFilename(suggestedName, target.Hash, trackerDomain, target.Hash)
+		if target.Filename != "" {
+			filename = torrentname.SanitizeExportFilename(target.Filename, target.Hash, "", "")
+		}
+		entryName := path.Join(archiveCategoryPath(target.Category), filename)
+		if multipleInstances {
+			entryName = path.Join(archiveInstanceName(target), entryName)
+		}
+		entryName = uniqueArchiveName(entryName, usedNames)
+		entry, createErr := archive.Create(entryName)
+		if createErr != nil {
+			return createErr
+		}
+		if _, writeErr := entry.Write(data); writeErr != nil {
+			return writeErr
+		}
+	}
+
+	if len(failures) > 0 {
+		entry, createErr := archive.Create("export-errors.txt")
+		if createErr != nil {
+			return createErr
+		}
+		if _, writeErr := io.WriteString(entry, strings.Join(failures, "\n")+"\n"); writeErr != nil {
+			return writeErr
+		}
+	}
+
+	return nil
+}
+
+func hasMultipleArchiveInstances(targets []torrentArchiveTarget) bool {
+	if len(targets) < 2 {
+		return false
+	}
+
+	first := targets[0].InstanceID
+	for _, target := range targets[1:] {
+		if target.InstanceID != first {
+			return true
+		}
+	}
+	return false
+}
+
+func archiveInstanceName(target torrentArchiveTarget) string {
+	name := strings.TrimSpace(target.InstanceName)
+	if name == "" {
+		name = "Instance " + strconv.Itoa(target.InstanceID)
+	}
+	return pathutil.SanitizePathSegment(name)
+}
+
+func archiveCategoryPath(category string) string {
+	parts := strings.FieldsFunc(category, func(r rune) bool {
+		return r == '/' || r == '\\'
+	})
+	if len(parts) == 0 {
+		return "Uncategorized"
+	}
+
+	for i := range parts {
+		parts[i] = pathutil.SanitizePathSegment(strings.TrimSpace(parts[i]))
+	}
+	return path.Join(parts...)
+}
+
+func uniqueArchiveName(name string, used map[string]struct{}) string {
+	key := strings.ToLower(name)
+	if _, exists := used[key]; !exists {
+		used[key] = struct{}{}
+		return name
+	}
+
+	extension := path.Ext(name)
+	base := strings.TrimSuffix(name, extension)
+	for suffix := 2; ; suffix++ {
+		candidate := fmt.Sprintf("%s (%d)%s", base, suffix, extension)
+		candidateKey := strings.ToLower(candidate)
+		if _, exists := used[candidateKey]; !exists {
+			used[candidateKey] = struct{}{}
+			return candidate
+		}
+	}
+}

--- a/internal/api/handlers/torrents_export_archive_test.go
+++ b/internal/api/handlers/torrents_export_archive_test.go
@@ -1,0 +1,208 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package handlers
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type archiveExportResult struct {
+	data          []byte
+	suggestedName string
+	trackerDomain string
+	err           error
+}
+
+type archiveExporterFake map[string]archiveExportResult
+
+func (f archiveExporterFake) ExportTorrent(_ context.Context, instanceID int, hash string) ([]byte, string, string, error) {
+	result := f[archiveFakeKey(instanceID, hash)]
+	return result.data, result.suggestedName, result.trackerDomain, result.err
+}
+
+func TestWriteTorrentArchiveGroupsByInstanceAndCategory(t *testing.T) {
+	t.Parallel()
+
+	targets := []torrentArchiveTarget{
+		{InstanceID: 1, InstanceName: "Home", Hash: "aaaaa11111", Category: "Movies/HD"},
+		{InstanceID: 2, InstanceName: "Seedbox", Hash: "bbbbb22222"},
+	}
+	exporter := archiveExporterFake{
+		archiveFakeKey(1, "aaaaa11111"): {data: []byte("alpha"), suggestedName: "Alpha"},
+		archiveFakeKey(2, "bbbbb22222"): {data: []byte("beta"), suggestedName: "Beta"},
+	}
+
+	var output bytes.Buffer
+	require.NoError(t, writeTorrentArchive(context.Background(), &output, targets, exporter))
+
+	reader, err := zip.NewReader(bytes.NewReader(output.Bytes()), int64(output.Len()))
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"Home/Movies/HD/Alpha - aaaaa.torrent",
+		"Seedbox/Uncategorized/Beta - bbbbb.torrent",
+	}, zipEntryNames(reader.File))
+	require.Equal(t, "alpha", readZipEntry(t, reader.File[0]))
+	require.Equal(t, "beta", readZipEntry(t, reader.File[1]))
+}
+
+func TestWriteTorrentArchiveIncludesPartialFailures(t *testing.T) {
+	t.Parallel()
+
+	targets := []torrentArchiveTarget{
+		{InstanceID: 1, InstanceName: "Home", Hash: "aaaaa11111", Category: "Movies"},
+		{InstanceID: 1, InstanceName: "Home", Hash: "bbbbb22222", Category: "TV"},
+	}
+	exporter := archiveExporterFake{
+		archiveFakeKey(1, "aaaaa11111"): {data: []byte("alpha"), suggestedName: "Alpha"},
+		archiveFakeKey(1, "bbbbb22222"): {err: errors.New("export unavailable")},
+	}
+
+	var output bytes.Buffer
+	require.NoError(t, writeTorrentArchive(context.Background(), &output, targets, exporter))
+
+	reader, err := zip.NewReader(bytes.NewReader(output.Bytes()), int64(output.Len()))
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"Movies/Alpha - aaaaa.torrent",
+		"export-errors.txt",
+	}, zipEntryNames(reader.File))
+	require.Equal(t, "Home/TV (bbbbb22222): export unavailable\n", readZipEntry(t, reader.File[1]))
+}
+
+func TestWriteTorrentArchiveReturnsErrorReportWhenAllExportsFail(t *testing.T) {
+	t.Parallel()
+
+	targets := []torrentArchiveTarget{{InstanceID: 1, Hash: "aaaaa11111"}}
+	exporter := archiveExporterFake{
+		archiveFakeKey(1, "aaaaa11111"): {err: errors.New("export unavailable")},
+	}
+
+	var output bytes.Buffer
+	require.NoError(t, writeTorrentArchive(context.Background(), &output, targets, exporter))
+
+	reader, err := zip.NewReader(bytes.NewReader(output.Bytes()), int64(output.Len()))
+	require.NoError(t, err)
+	require.Equal(t, []string{"export-errors.txt"}, zipEntryNames(reader.File))
+}
+
+func TestWriteTorrentArchiveDeduplicatesFilenamesWithinCategory(t *testing.T) {
+	t.Parallel()
+
+	targets := []torrentArchiveTarget{
+		{InstanceID: 1, Hash: "zzzzz", Category: "Movies"},
+		{InstanceID: 1, Hash: "yyyyy", Category: "Movies"},
+	}
+	exporter := archiveExporterFake{
+		archiveFakeKey(1, "zzzzz"): {data: []byte("first"), suggestedName: "Same"},
+		archiveFakeKey(1, "yyyyy"): {data: []byte("second"), suggestedName: "same"},
+	}
+
+	var output bytes.Buffer
+	require.NoError(t, writeTorrentArchive(context.Background(), &output, targets, exporter))
+
+	reader, err := zip.NewReader(bytes.NewReader(output.Bytes()), int64(output.Len()))
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"Movies/Same.torrent",
+		"Movies/same (2).torrent",
+	}, zipEntryNames(reader.File))
+}
+
+func TestWriteTorrentArchiveSanitizesFolderPaths(t *testing.T) {
+	t.Parallel()
+
+	targets := []torrentArchiveTarget{
+		{InstanceID: 1, InstanceName: "../Home", Hash: "aaaaa11111", Category: "../Movies\\4K"},
+		{InstanceID: 2, InstanceName: "Other", Hash: "bbbbb22222", Category: "TV"},
+	}
+	exporter := archiveExporterFake{
+		archiveFakeKey(1, "aaaaa11111"): {data: []byte("alpha"), suggestedName: "Alpha"},
+		archiveFakeKey(2, "bbbbb22222"): {data: []byte("beta"), suggestedName: "Beta"},
+	}
+
+	var output bytes.Buffer
+	require.NoError(t, writeTorrentArchive(context.Background(), &output, targets, exporter))
+
+	reader, err := zip.NewReader(bytes.NewReader(output.Bytes()), int64(output.Len()))
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"..Home/_/Movies/4K/Alpha - aaaaa.torrent",
+		"Other/TV/Beta - bbbbb.torrent",
+	}, zipEntryNames(reader.File))
+}
+
+func TestWriteTorrentArchiveUsesRequestedFilename(t *testing.T) {
+	t.Parallel()
+
+	targets := []torrentArchiveTarget{
+		{InstanceID: 1, Hash: "aaaaa11111", Category: "Movies", Filename: "ubuntu.iso.torrent"},
+	}
+	exporter := archiveExporterFake{
+		archiveFakeKey(1, "aaaaa11111"): {data: []byte("alpha"), suggestedName: "Secret Movie"},
+	}
+
+	var output bytes.Buffer
+	require.NoError(t, writeTorrentArchive(context.Background(), &output, targets, exporter))
+
+	reader, err := zip.NewReader(bytes.NewReader(output.Bytes()), int64(output.Len()))
+	require.NoError(t, err)
+	require.Equal(t, []string{"Movies/ubuntu.iso.torrent"}, zipEntryNames(reader.File))
+}
+
+func TestExportTorrentArchiveStreamsZip(t *testing.T) {
+	t.Parallel()
+
+	handler := &TorrentsHandler{archiveExporter: archiveExporterFake{
+		archiveFakeKey(1, "aaaaa11111"): {data: []byte("alpha"), suggestedName: "Alpha"},
+	}}
+	request := httptest.NewRequest(http.MethodPost, "/api/torrents/export", strings.NewReader(`{
+		"targets": [{"instanceId": 1, "instanceName": "Home", "hash": "aaaaa11111", "category": "Movies"}]
+	}`))
+	response := httptest.NewRecorder()
+
+	handler.ExportTorrentArchive(response, request)
+
+	require.Equal(t, http.StatusOK, response.Code)
+	require.Equal(t, "application/zip", response.Header().Get("Content-Type"))
+	require.Equal(t, `attachment; filename="qui-torrents.zip"`, response.Header().Get("Content-Disposition"))
+
+	reader, err := zip.NewReader(bytes.NewReader(response.Body.Bytes()), int64(response.Body.Len()))
+	require.NoError(t, err)
+	require.Equal(t, []string{"Movies/Alpha - aaaaa.torrent"}, zipEntryNames(reader.File))
+}
+
+func archiveFakeKey(instanceID int, hash string) string {
+	return strconv.Itoa(instanceID) + ":" + hash
+}
+
+func zipEntryNames(files []*zip.File) []string {
+	names := make([]string, len(files))
+	for i, file := range files {
+		names[i] = file.Name
+	}
+	return names
+}
+
+func readZipEntry(t *testing.T, file *zip.File) string {
+	t.Helper()
+
+	reader, err := file.Open()
+	require.NoError(t, err)
+	defer reader.Close()
+
+	data, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	return string(data)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -686,6 +686,7 @@ func (s *Server) Handler() (*chi.Mux, error) {
 			// Global torrent operations (cross-instance)
 			r.Route("/torrents", func(r chi.Router) {
 				r.Get("/cross-instance", torrentsHandler.ListCrossInstanceTorrents)
+				r.Post("/export", torrentsHandler.ExportTorrentArchive)
 			})
 		})
 	})

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -3103,6 +3103,57 @@ paths:
         '500':
           description: Failed to check premium access or read the custom themes directory
 
+  /api/torrents/export:
+    post:
+      tags:
+        - Torrents
+      summary: Export torrents as a ZIP archive
+      description: |
+        Download selected .torrent files in one ZIP. Files are grouped by category and,
+        when multiple instances are selected, by instance. Failed exports are listed in
+        export-errors.txt while successful exports remain available.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - targets
+              properties:
+                targets:
+                  type: array
+                  minItems: 1
+                  items:
+                    type: object
+                    required:
+                      - instanceId
+                      - hash
+                    properties:
+                      instanceId:
+                        type: integer
+                        minimum: 1
+                      instanceName:
+                        type: string
+                      hash:
+                        type: string
+                        minLength: 1
+                      category:
+                        type: string
+                      filename:
+                        type: string
+                        description: Optional safe display filename, used by incognito exports.
+      responses:
+        '200':
+          description: ZIP archive containing exported torrents and any partial-failure report
+          content:
+            application/zip:
+              schema:
+                type: string
+                format: binary
+        '400':
+          description: Invalid request
+
   /api/torrents/cross-instance:
     get:
       tags:

--- a/web/src/hooks/useTorrentExporter.test.tsx
+++ b/web/src/hooks/useTorrentExporter.test.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { act, renderHook, waitFor } from "@testing-library/react"
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 vi.mock("@/lib/api", () => ({
@@ -77,6 +77,8 @@ afterEach(() => {
   vi.unstubAllGlobals()
   vi.clearAllMocks()
 })
+
+afterEach(cleanup)
 
 function setupHook(incognitoMode = false) {
   return renderHook(() =>

--- a/web/src/hooks/useTorrentExporter.test.tsx
+++ b/web/src/hooks/useTorrentExporter.test.tsx
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 vi.mock("@/lib/api", () => ({
   api: {
     exportTorrent: vi.fn(),
+    exportTorrentsArchive: vi.fn(),
     getTorrents: vi.fn(),
   },
 }))
@@ -30,6 +31,7 @@ vi.mock("react-i18next", () => ({
 
 vi.mock("@/lib/incognito", () => ({
   getLinuxIsoName: vi.fn((hash: string) => `linux-${hash}.iso`),
+  getLinuxCategory: vi.fn((hash: string) => `linux-category-${hash}`),
 }))
 
 import { api } from "@/lib/api"
@@ -116,6 +118,79 @@ describe("useTorrentExporter", () => {
   })
 
   describe("explicit selection (isAllSelected=false)", () => {
+    it("downloads one category-grouped archive when more than 10 torrents are selected", async () => {
+      mockedApi.exportTorrentsArchive.mockResolvedValue(makeExportResult("qui-torrents.zip"))
+      const torrents = Array.from({ length: 11 }, (_, index) => ({
+        ...makeTorrent({ hash: `hash-${index}`, category: index < 6 ? "Movies" : "TV" }),
+        instanceId: 8,
+        instanceName: "Seedbox",
+      }))
+
+      const { result } = setupHook()
+      await act(async () => {
+        await result.current.exportTorrents({
+          hashes: torrents.map(torrent => torrent.hash),
+          torrents,
+          isAllSelected: false,
+          totalSelected: torrents.length,
+        })
+      })
+
+      expect(mockedApi.exportTorrentsArchive).toHaveBeenCalledOnce()
+      expect(mockedApi.exportTorrentsArchive).toHaveBeenCalledWith(torrents.map(torrent => ({
+        instanceId: 8,
+        instanceName: "Seedbox",
+        hash: torrent.hash,
+        category: torrent.category,
+      })))
+      expect(mockedApi.exportTorrent).not.toHaveBeenCalled()
+      expect(clickedDownloads).toEqual(["qui-torrents.zip"])
+      expect(mockedToast.success).toHaveBeenCalledWith("creationTasks.toast.downloadStarted")
+    })
+
+    it("keeps individual downloads for exactly 10 torrents", async () => {
+      mockedApi.exportTorrent.mockResolvedValue(makeExportResult("file.torrent"))
+      const torrents = Array.from({ length: 10 }, (_, index) =>
+        makeTorrent({ hash: `hash-${index}` }))
+
+      const { result } = setupHook()
+      await act(async () => {
+        await result.current.exportTorrents({
+          hashes: torrents.map(torrent => torrent.hash),
+          torrents,
+          isAllSelected: false,
+          totalSelected: torrents.length,
+        })
+      })
+
+      expect(mockedApi.exportTorrent).toHaveBeenCalledTimes(10)
+      expect(mockedApi.exportTorrentsArchive).not.toHaveBeenCalled()
+    })
+
+    it("disguises archive filenames and categories in incognito mode", async () => {
+      mockedApi.exportTorrentsArchive.mockResolvedValue(makeExportResult("qui-torrents.zip"))
+      const torrents = Array.from({ length: 11 }, (_, index) =>
+        makeTorrent({ hash: `hash-${index}`, category: "Secret" }))
+
+      const { result } = setupHook(true)
+      await act(async () => {
+        await result.current.exportTorrents({
+          hashes: torrents.map(torrent => torrent.hash),
+          torrents,
+          isAllSelected: false,
+          totalSelected: torrents.length,
+        })
+      })
+
+      expect(mockedApi.exportTorrentsArchive).toHaveBeenCalledWith(torrents.map(torrent => ({
+        instanceId: INSTANCE_ID,
+        instanceName: "",
+        hash: torrent.hash,
+        category: `linux-category-${torrent.hash}`,
+        filename: `linux-${torrent.hash}.torrent`,
+      })))
+    })
+
     it("dedupes torrents in hash order, exports each, downloads per blob, and toasts plural", async () => {
       mockedApi.exportTorrent.mockResolvedValue(makeExportResult("file.torrent"))
 
@@ -406,7 +481,7 @@ describe("useTorrentExporter", () => {
       mockedApi.getTorrents
         .mockResolvedValueOnce({ torrents: fullPage } as never)
         .mockResolvedValueOnce({ torrents: [], hasMore: false } as never)
-      mockedApi.exportTorrent.mockResolvedValue(makeExportResult("p.torrent"))
+      mockedApi.exportTorrentsArchive.mockResolvedValue(makeExportResult("qui-torrents.zip"))
 
       const { result } = setupHook()
       await act(async () => {
@@ -420,10 +495,10 @@ describe("useTorrentExporter", () => {
       })
 
       expect(mockedApi.getTorrents).toHaveBeenCalledTimes(2)
-      // 300 in first page minus the one excluded = 299 exported.
-      expect(mockedApi.exportTorrent).toHaveBeenCalledTimes(299)
-      const exported = mockedApi.exportTorrent.mock.calls.map((c) => c[1])
-      expect(exported).not.toContain("excluded")
+      expect(mockedApi.exportTorrentsArchive).toHaveBeenCalledOnce()
+      const exported = mockedApi.exportTorrentsArchive.mock.calls[0][0]
+      expect(exported).toHaveLength(299)
+      expect(exported.map(target => target.hash)).not.toContain("excluded")
     })
 
     it("emits noTorrentsFoundToExport when the all-selected fetch returns nothing", async () => {

--- a/web/src/hooks/useTorrentExporter.test.tsx
+++ b/web/src/hooks/useTorrentExporter.test.tsx
@@ -19,6 +19,7 @@ vi.mock("sonner", () => ({
     success: vi.fn(),
     error: vi.fn(),
     info: vi.fn(),
+    loading: vi.fn(() => "archive-toast"),
   },
 }))
 
@@ -118,6 +119,36 @@ describe("useTorrentExporter", () => {
   })
 
   describe("explicit selection (isAllSelected=false)", () => {
+    it("shows a loading toast while the archive request is pending", async () => {
+      let resolveArchive!: (value: ReturnType<typeof makeExportResult>) => void
+      mockedApi.exportTorrentsArchive.mockReturnValue(new Promise((resolve) => {
+        resolveArchive = resolve
+      }))
+      const torrents = Array.from({ length: 11 }, (_, index) =>
+        makeTorrent({ hash: `hash-${index}` }))
+
+      const { result } = setupHook()
+      let pending: Promise<void>
+      act(() => {
+        pending = result.current.exportTorrents({
+          hashes: torrents.map(torrent => torrent.hash),
+          torrents,
+          isAllSelected: false,
+          totalSelected: torrents.length,
+        })
+      })
+
+      await waitFor(() => expect(mockedToast.loading).toHaveBeenCalledWith(
+        "contextMenu.exportTorrents/11"
+      ))
+      expect(clickedDownloads).toHaveLength(0)
+
+      await act(async () => {
+        resolveArchive(makeExportResult("qui-torrents.zip"))
+        await pending
+      })
+    })
+
     it("downloads one category-grouped archive when more than 10 torrents are selected", async () => {
       mockedApi.exportTorrentsArchive.mockResolvedValue(makeExportResult("qui-torrents.zip"))
       const torrents = Array.from({ length: 11 }, (_, index) => ({
@@ -145,7 +176,10 @@ describe("useTorrentExporter", () => {
       })))
       expect(mockedApi.exportTorrent).not.toHaveBeenCalled()
       expect(clickedDownloads).toEqual(["qui-torrents.zip"])
-      expect(mockedToast.success).toHaveBeenCalledWith("creationTasks.toast.downloadStarted")
+      expect(mockedToast.success).toHaveBeenCalledWith(
+        "creationTasks.toast.downloadStarted",
+        { id: "archive-toast" }
+      )
     })
 
     it("keeps individual downloads for exactly 10 torrents", async () => {
@@ -522,6 +556,27 @@ describe("useTorrentExporter", () => {
   })
 
   describe("error paths", () => {
+    it("replaces the archive loading toast when the request fails", async () => {
+      mockedApi.exportTorrentsArchive.mockRejectedValue(new Error("archive failed"))
+      const torrents = Array.from({ length: 11 }, (_, index) =>
+        makeTorrent({ hash: `hash-${index}` }))
+
+      const { result } = setupHook()
+      await act(async () => {
+        await result.current.exportTorrents({
+          hashes: torrents.map(torrent => torrent.hash),
+          torrents,
+          isAllSelected: false,
+          totalSelected: torrents.length,
+        })
+      })
+
+      expect(mockedToast.error).toHaveBeenCalledWith(
+        "archive failed",
+        { id: "archive-toast" }
+      )
+    })
+
     it("toasts error.message, resets isExporting, and triggers no download when exportTorrent rejects", async () => {
       mockedApi.exportTorrent.mockRejectedValue(new Error("export failed"))
 

--- a/web/src/hooks/useTorrentExporter.ts
+++ b/web/src/hooks/useTorrentExporter.ts
@@ -5,7 +5,7 @@
 
 import { useCallback, useState } from "react"
 import { api } from "@/lib/api"
-import { getLinuxIsoName } from "@/lib/incognito"
+import { getLinuxCategory, getLinuxIsoName } from "@/lib/incognito"
 import { isAllInstancesScope } from "@/lib/instances"
 import { getTorrentTargetInstanceId, type TorrentActionTarget } from "@/lib/torrent-action-targets"
 import type { Torrent, TorrentFilters } from "@/types"
@@ -30,6 +30,8 @@ interface ExportSelection {
   sortField?: string
   sortOrder?: "asc" | "desc"
 }
+
+const TORRENT_ARCHIVE_THRESHOLD = 10
 
 export function useTorrentExporter({ instanceId, incognitoMode }: UseTorrentExporterOptions) {
   const { t } = useTranslation("torrents")
@@ -83,15 +85,34 @@ export function useTorrentExporter({ instanceId, incognitoMode }: UseTorrentExpo
         return
       }
 
+      targets = targets.filter(torrent => {
+        const targetInstanceId = getTorrentTargetInstanceId(torrent, instanceId)
+        return !excludeSet.has(torrent.hash) && !excludeTargetSet.has(targetKey(targetInstanceId, torrent.hash))
+      })
+
+      if (targets.length === 0) {
+        toast.info(t("contextMenu.toast.noTorrentsExported"))
+        return
+      }
+
+      if (targets.length > TORRENT_ARCHIVE_THRESHOLD) {
+        const { blob, filename } = await api.exportTorrentsArchive(targets.map(torrent => ({
+          instanceId: getTorrentTargetInstanceId(torrent, instanceId),
+          instanceName: (torrent as Torrent & { instanceName?: string }).instanceName ?? "",
+          hash: torrent.hash,
+          category: incognitoMode ? getLinuxCategory(torrent.hash) : torrent.category,
+          ...(incognitoMode && { filename: buildDownloadName(torrent.hash, torrent.hash, true) }),
+        })))
+        triggerBrowserDownload(blob, filename || "qui-torrents.zip")
+        toast.success(t("creationTasks.toast.downloadStarted"))
+        return
+      }
+
       const filenameCounts = new Map<string, number>()
       let exportedCount = 0
 
       for (const torrent of targets) {
         const targetInstanceId = getTorrentTargetInstanceId(torrent, instanceId)
-        if (excludeSet.has(torrent.hash) || excludeTargetSet.has(targetKey(targetInstanceId, torrent.hash))) {
-          continue
-        }
-
         const { blob, filename } = await api.exportTorrent(targetInstanceId, torrent.hash)
         const fallbackName = filename || torrent.name || torrent.hash
         const downloadName = buildDownloadName(torrent.hash, fallbackName, incognitoMode)

--- a/web/src/hooks/useTorrentExporter.ts
+++ b/web/src/hooks/useTorrentExporter.ts
@@ -61,6 +61,7 @@ export function useTorrentExporter({ instanceId, incognitoMode }: UseTorrentExpo
     }
 
     setIsExporting(true)
+    let archiveToastId: string | number | undefined
 
     try {
       let targets: Torrent[]
@@ -96,6 +97,7 @@ export function useTorrentExporter({ instanceId, incognitoMode }: UseTorrentExpo
       }
 
       if (targets.length > TORRENT_ARCHIVE_THRESHOLD) {
+        archiveToastId = toast.loading(t("contextMenu.exportTorrents", { count: targets.length }))
         const { blob, filename } = await api.exportTorrentsArchive(targets.map(torrent => ({
           instanceId: getTorrentTargetInstanceId(torrent, instanceId),
           instanceName: (torrent as Torrent & { instanceName?: string }).instanceName ?? "",
@@ -104,7 +106,7 @@ export function useTorrentExporter({ instanceId, incognitoMode }: UseTorrentExpo
           ...(incognitoMode && { filename: buildDownloadName(torrent.hash, torrent.hash, true) }),
         })))
         triggerBrowserDownload(blob, filename || "qui-torrents.zip")
-        toast.success(t("creationTasks.toast.downloadStarted"))
+        toast.success(t("creationTasks.toast.downloadStarted"), { id: archiveToastId })
         return
       }
 
@@ -129,7 +131,11 @@ export function useTorrentExporter({ instanceId, incognitoMode }: UseTorrentExpo
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : t("contextMenu.toast.exportFailed")
-      toast.error(message)
+      if (archiveToastId === undefined) {
+        toast.error(message)
+      } else {
+        toast.error(message, { id: archiveToastId })
+      }
     } finally {
       setIsExporting(false)
     }

--- a/web/src/lib/__tests__/api.export.test.ts
+++ b/web/src/lib/__tests__/api.export.test.ts
@@ -55,6 +55,35 @@ describe("api.exportTorrent — request serialization", () => {
   })
 })
 
+describe("api.exportTorrentsArchive", () => {
+  it("posts archive targets and returns the ZIP filename", async () => {
+    let captured: Request | undefined
+    const targets = [{
+      instanceId: 7,
+      instanceName: "Home",
+      hash: "deadbeef",
+      category: "Movies",
+    }]
+
+    server.use(
+      http.post("*/api/torrents/export", ({ request }) => {
+        captured = request.clone()
+        return new HttpResponse("zipdata", {
+          status: 200,
+          headers: { "Content-Disposition": "attachment; filename=qui-torrents.zip" },
+        })
+      })
+    )
+
+    const result = await api.exportTorrentsArchive(targets)
+
+    expect(captured?.method).toBe("POST")
+    expect(await captured?.json()).toEqual({ targets })
+    expect(await result.blob.text()).toBe("zipdata")
+    expect(result.filename).toBe("qui-torrents.zip")
+  })
+})
+
 describe("api.exportTorrent — response parsing", () => {
   it("returns a Blob and the filename parsed from a quoted content-disposition", async () => {
     server.use(

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1664,6 +1664,31 @@ class ApiClient {
     return { blob, filename }
   }
 
+  async exportTorrentsArchive(targets: Array<{
+    instanceId: number
+    instanceName: string
+    hash: string
+    category: string
+    filename?: string
+  }>): Promise<{ blob: Blob; filename: string | null }> {
+    const response = await ssoSafeFetch(`${API_BASE}/torrents/export`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ targets }),
+    })
+
+    if (!response.ok) {
+      const { message } = await this.extractErrorData(response)
+      this.handleAuthError(response.status, "/torrents/export", message)
+      throw new Error(message)
+    }
+
+    return {
+      blob: await response.blob(),
+      filename: parseContentDispositionFilename(response.headers.get("content-disposition")),
+    }
+  }
+
   async getTorrentPeers(instanceId: number, hash: string): Promise<SortedPeersResponse> {
     return this.request<SortedPeersResponse>(`/instances/${instanceId}/torrents/${hash}/peers`)
   }


### PR DESCRIPTION
## Description

- Bundle exports of more than 10 torrents into one ZIP to avoid browser multi-download limits.
- Group files by qBittorrent category and, for cross-instance exports, by instance.
- Keep successful exports when individual torrents fail and include details in `export-errors.txt`.
- Preserve individual downloads for 10 or fewer torrents and disguise archive names in incognito mode.

## How has this been tested?

- `go test -race -count=1 ./internal/api/handlers`
- `pnpm --dir web exec vitest run src/hooks/useTorrentExporter.test.tsx src/hooks/useTorrentExporter.test.ts src/lib/__tests__/api.export.test.ts`
- `make test-openapi`
- Frontend and backend production builds
- Independent code review

`make precommit` completed formatting and Go fixes, but its lint step could not run because `golangci-lint` is not installed in the environment.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [ ] I ran `make precommit` and the tests pass locally
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

## AI disclosure

Yes. Most of the implementation and tests were written with OpenAI Codex under maintainer direction, then reviewed and verified locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bulk torrent export as a downloadable ZIP archive.
  * Archives organize files by instance and category, sanitize paths, preserve requested filenames, and prevent duplicates.
  * Export failures are collected in an error report while successful exports continue.
  * Larger selections are automatically bundled; smaller selections continue using individual downloads.
* **Documentation**
  * Documented the torrent archive export endpoint and request options.
* **Bug Fixes**
  * Improved handling of filtered and incognito torrent selections during export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->