### PR TITLE
perf(web): migrate torrent tables to TanStack Table v9

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -55,7 +55,7 @@
     "@tanstack/react-form": "^1.33.2",
     "@tanstack/react-query": "^5.101.4",
     "@tanstack/react-router": "^1.170.18",
-    "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-table": "^9.1.2",
     "@tanstack/react-virtual": "^3.14.9",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -89,8 +89,8 @@ importers:
         specifier: ^1.170.18
         version: 1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/react-table':
-        specifier: ^8.21.3
-        version: 8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: ^9.1.2
+        version: 9.1.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/react-virtual':
         specifier: ^3.14.9
         version: 3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1919,12 +1919,11 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@tanstack/react-table@8.21.3':
-    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
-    engines: {node: '>=12'}
+  '@tanstack/react-table@9.1.2':
+    resolution: {integrity: sha512-YQPZFJ1nIi/bjjwsPZVouABgahDcl7Gdm33CdTStUJBn0DjEVJ2uhSTVmIoWt9MVKdQziXGAsXipSzy949Hygg==}
+    engines: {node: '>=20'}
     peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
+      react: '>=18'
 
   '@tanstack/react-virtual@3.14.9':
     resolution: {integrity: sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==}
@@ -1955,9 +1954,9 @@ packages:
   '@tanstack/store@0.9.3':
     resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
 
-  '@tanstack/table-core@8.21.3':
-    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
-    engines: {node: '>=12'}
+  '@tanstack/table-core@9.1.2':
+    resolution: {integrity: sha512-ONpWQeass1sfg80CWF1NSwQ8r3GiqxA2lT/EdqIcrDEPZ0Z+0mM94eQoFYLPN0Kztzj8TQVb2+PrSZSItqA61g==}
+    engines: {node: '>=20'}
 
   '@tanstack/virtual-core@3.17.7':
     resolution: {integrity: sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==}
@@ -6299,11 +6298,13 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
       use-sync-external-store: 1.6.0(react@19.2.8)
 
-  '@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@tanstack/react-table@9.1.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@tanstack/table-core': 8.21.3
+      '@tanstack/react-store': 0.11.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tanstack/table-core': 9.1.2
       react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
+    transitivePeerDependencies:
+      - react-dom
 
   '@tanstack/react-virtual@3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
@@ -6356,7 +6357,9 @@ snapshots:
 
   '@tanstack/store@0.9.3': {}
 
-  '@tanstack/table-core@8.21.3': {}
+  '@tanstack/table-core@9.1.2':
+    dependencies:
+      '@tanstack/store': 0.11.0
 
   '@tanstack/virtual-core@3.17.7': {}
 

--- a/web/src/components/torrents/DraggableTableHeader.tsx
+++ b/web/src/components/torrents/DraggableTableHeader.tsx
@@ -4,14 +4,14 @@
  */
 
 import { getColumnType, type ColumnFilter } from "@/lib/column-filter-utils"
-import type { Torrent } from "@/types"
 import { useSortable } from "@dnd-kit/sortable"
 import { CSS } from "@dnd-kit/utilities"
-import { flexRender, type Header } from "@tanstack/react-table"
+import { flexRender } from "@tanstack/react-table"
 import { ChevronDown, ChevronUp } from "lucide-react"
 import { ColumnFilterPopover } from "./ColumnFilterPopover"
 import { useMediaQuery } from "@/hooks/useMediaQuery"
 import type { ViewMode } from "@/hooks/usePersistedCompactViewState"
+import type { TorrentTableHeader } from "./tanstackTableFeatures"
 
 {/* Auto-fit width for column headers on double-click*/}
 const TORRENT_ROW_CELL_MEASURE = "data-torrent-column-measure"
@@ -55,7 +55,7 @@ function measureTorrentColumnFitWidth(gridRoot: HTMLElement, columnId: string): 
 {/* Auto-fit width for column headers on double-click end*/}
 
 interface DraggableTableHeaderProps {
-  header: Header<Torrent, unknown>
+  header: TorrentTableHeader
   columnFilters?: ColumnFilter[]
   viewMode?: ViewMode
   onFilterChange?: (columnId: string, filter: ColumnFilter | null) => void

--- a/web/src/components/torrents/TorrentTableColumns.tsx
+++ b/web/src/components/torrents/TorrentTableColumns.tsx
@@ -31,7 +31,8 @@ import {
 import { resolveTrackerIconSrc } from "@/lib/tracker-icons"
 import { cn, formatBytes, formatDuration, getRatioColor } from "@/lib/utils"
 import type { AppPreferences, CrossInstanceTorrent, Torrent } from "@/types"
-import type { CellContext, ColumnDef, HeaderContext } from "@tanstack/react-table"
+import type { CellContext, HeaderContext, RowSelectionState } from "@tanstack/react-table"
+import type { TorrentTableColumnDef, TorrentTableFeatures } from "./tanstackTableFeatures"
 import {
   AlertCircle,
   ArrowDownAZ,
@@ -432,7 +433,7 @@ export const createColumns = (
   trackerCustomizationLookup?: TrackerCustomizationLookup,
   includeSelectionColumn: boolean = true,
   t?: TFunction
-): ColumnDef<Torrent>[] => {
+): TorrentTableColumnDef[] => {
   // Badge padding classes based on view mode
   const badgePadding = viewMode === "dense" ? "px-1.5 py-0" : ""
   const instanceLabel = t?.("tableColumns.instance") ?? "Instance"
@@ -443,7 +444,7 @@ export const createColumns = (
   const statusIconLabel = t?.("tableColumns.statusIcon") ?? "Status Icon"
   const trackerIconLabel = t?.("tableColumns.trackerIcon") ?? "Tracker Icon"
 
-  const instanceColumn: ColumnDef<Torrent> = {
+  const instanceColumn: TorrentTableColumnDef = {
     id: "instance",
     accessorKey: "instanceName",
     header: instanceLabel,
@@ -463,7 +464,7 @@ export const createColumns = (
   return [
     ...(includeSelectionColumn ? [{
       id: "select",
-      header: ({ table }: HeaderContext<Torrent, unknown>) => (
+      header: ({ table }: HeaderContext<TorrentTableFeatures, Torrent, unknown>) => (
         <div className="flex items-center justify-center p-1 -m-1">
           <Checkbox
             checked={selectionEnhancers?.customSelectAll?.isIndeterminate ? "indeterminate" : selectionEnhancers?.customSelectAll?.isAllSelected || false}
@@ -480,7 +481,7 @@ export const createColumns = (
           />
         </div>
       ),
-      cell: ({ row, table }: CellContext<Torrent, unknown>) => {
+      cell: ({ row, table }: CellContext<TorrentTableFeatures, Torrent, unknown>) => {
         const torrent = row.original
         const hash = torrent.hash
         const selectionIdentity = selectionEnhancers?.getSelectionIdentity?.(torrent) ?? hash
@@ -525,12 +526,16 @@ export const createColumns = (
                       }
                     }
                   } else {
-                    table.setRowSelection((prev: Record<string, boolean>) => {
-                      const next: Record<string, boolean> = { ...prev }
+                    table.setRowSelection((prev: RowSelectionState) => {
+                      const next: RowSelectionState = { ...prev }
                       for (let i = start; i <= end; i++) {
                         const r = allRows[i]
                         if (r) {
-                          next[r.id] = !!checked
+                          if (checked) {
+                            next[r.id] = true
+                          } else {
+                            delete next[r.id]
+                          }
                         }
                       }
                       return next
@@ -662,7 +667,7 @@ export const createColumns = (
       meta: {
         headerString: statusIconLabel,
       },
-      sortingFn: (rowA, rowB) => compareTrackerAwareStatus(rowA.original, rowB.original, supportsTrackerHealth, t),
+      sortFn: (rowA, rowB) => compareTrackerAwareStatus(rowA.original, rowB.original, supportsTrackerHealth, t),
       cell: ({ row }) => {
         const torrent = row.original
         const StatusIcon = getStatusIcon(torrent.state, torrent.tracker_health ?? null, supportsTrackerHealth)
@@ -687,7 +692,7 @@ export const createColumns = (
     {
       accessorKey: "state",
       header: t?.("tableColumns.status") ?? "Status",
-      sortingFn: (rowA, rowB) => compareTrackerAwareStatus(rowA.original, rowB.original, supportsTrackerHealth, t),
+      sortFn: (rowA, rowB) => compareTrackerAwareStatus(rowA.original, rowB.original, supportsTrackerHealth, t),
       cell: ({ row }) => {
         const torrent = row.original
         const state = torrent.state
@@ -785,7 +790,7 @@ export const createColumns = (
           </span>
         )
       },
-      sortingFn: (rowA, rowB) => {
+      sortFn: (rowA, rowB) => {
         const ratioA = incognitoMode ? getLinuxRatio(rowA.original.hash) : rowA.original.ratio
         const ratioB = incognitoMode ? getLinuxRatio(rowB.original.hash) : rowB.original.ratio
 

--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -1025,13 +1025,13 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
     backendLoadMore,
   })
 
-  // Memoize minTableWidth to avoid recalculation on every row render
+  // Keyed on the state that changes widths, not on the per-render `table` object.
   const minTableWidth = useMemo(() => {
     return table.getVisibleLeafColumns().reduce((width, col) => {
       return width + col.getSize()
     }, 0)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [table, columnVisibility])
+  }, [columnVisibility, columnSizing])
 
   const { clearFiltersAtomically } = useFilterLifecycle({
     virtualizer,
@@ -1169,6 +1169,8 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
   // reading current state at click time. Assigned during render, same pattern
   // as leafColumnIdsRef above.
   const rowInteraction = {
+    // v9's useTable returns a new table object every render; read it here, never from a dep array.
+    table,
     isReadOnly,
     isAllSelected,
     selectedRowIds,
@@ -1198,7 +1200,7 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
     }
 
     const selectionIdentity = s.getSelectionIdentity(torrent)
-    const allRows = table.getRowModel().rows
+    const allRows = s.table.getRowModel().rows
     const currentIndex = allRows.findIndex(r => r.id === row.id)
 
     // Handle shift-click for range selection - EXACTLY like checkbox
@@ -1263,7 +1265,7 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
       lastSelectedIndexRef.current = currentIndex
     }
     s.onTorrentSelect?.(torrent)
-  }, [table, lastSelectedIndexRef])
+  }, [lastSelectedIndexRef])
 
   const handleRowContextMenu = useCallback((row: TorrentRow, isRowSelected: boolean) => {
     const s = rowInteractionRef.current

--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -33,17 +33,12 @@ import { TORRENT_STREAM_POLL_INTERVAL_SECONDS, useTorrentsList } from "@/hooks/u
 import { getBackendSortField } from "@/lib/torrent-table/backend-sort-field"
 import { resolveTrackerHealthSupport } from "@/lib/tracker-health-support"
 import { formatBytes, formatBytesOrFallback } from "@/lib/utils"
-import {
-  getCoreRowModel,
-  getFilteredRowModel,
-  getSortedRowModel,
-  useReactTable,
-  type Row
-} from "@tanstack/react-table"
+import { useTable } from "@tanstack/react-table"
 import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 import { createPortal } from "react-dom"
 import { useTranslation } from "react-i18next"
 import { InstancePreferencesDialog } from "../instances/preferences/InstancePreferencesDialog"
+import { torrentTableFeatures, type TorrentRow } from "./tanstackTableFeatures"
 import { type TableViewMode } from "./TorrentTableColumns"
 import { type TorrentSortOptionValue } from "./torrentSortOptions"
 
@@ -783,16 +778,14 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
     sortedTorrents,
   })
 
-  const table = useReactTable({
+  const table = useTable({
+    features: torrentTableFeatures,
     data: sortedTorrents,
     columns,
-    getCoreRowModel: getCoreRowModel(),
     // For cross-seed filtering, enable client-side sorting and filtering
     // For regular filtering, backend handles sorting and column filters
     manualSorting: !isCrossSeedFiltering,
-    getSortedRowModel: isCrossSeedFiltering ? getSortedRowModel() : undefined,
     manualFiltering: !isCrossSeedFiltering,
-    getFilteredRowModel: isCrossSeedFiltering ? getFilteredRowModel() : undefined,
     // Prefer stable torrent hash for row identity while keeping duplicates unique
     getRowId: (row: Torrent, index: number) => {
       const baseIdentity = row.hash ?? row.infohash_v1 ?? row.infohash_v2
@@ -839,9 +832,6 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
     // Enable column resizing
     enableColumnResizing: true,
     columnResizeMode: "onChange" as const,
-    // Prevent automatic state resets during data updates
-    autoResetPageIndex: false,
-    autoResetExpanded: false,
   })
 
   // Keep the leaf-column accessor current for useColumnDnd (drag reads it lazily).
@@ -1193,7 +1183,7 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
   const rowInteractionRef = useRef(rowInteraction)
   rowInteractionRef.current = rowInteraction
 
-  const handleRowClick = useCallback((e: React.MouseEvent, row: Row<Torrent>, isSelected: boolean, isRowSelected: boolean) => {
+  const handleRowClick = useCallback((e: React.MouseEvent, row: TorrentRow, isSelected: boolean, isRowSelected: boolean) => {
     const s = rowInteractionRef.current
     // Don't select when clicking checkbox or its wrapper
     const target = e.target as HTMLElement
@@ -1275,7 +1265,7 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
     s.onTorrentSelect?.(torrent)
   }, [table, lastSelectedIndexRef])
 
-  const handleRowContextMenu = useCallback((row: Row<Torrent>, isRowSelected: boolean) => {
+  const handleRowContextMenu = useCallback((row: TorrentRow, isRowSelected: boolean) => {
     const s = rowInteractionRef.current
     if (s.isReadOnly) {
       return

--- a/web/src/components/torrents/details/CrossSeedTable.tsx
+++ b/web/src/components/torrents/details/CrossSeedTable.tsx
@@ -21,11 +21,10 @@ import type { Instance } from "@/types"
 import {
   createColumnHelper,
   flexRender,
-  getCoreRowModel,
-  getSortedRowModel,
-  useReactTable,
+  useTable,
   type SortingState
 } from "@tanstack/react-table"
+import { sortableDetailsTableFeatures } from "../tanstackTableFeatures"
 import type { TFunction } from "i18next"
 import { Copy, Loader2, Trash2 } from "lucide-react"
 import { memo, useMemo, useState } from "react"
@@ -46,7 +45,7 @@ interface CrossSeedTableProps {
   onNavigateToTorrent?: (instanceId: number, torrentHash: string) => void
 }
 
-const columnHelper = createColumnHelper<CrossSeedTorrent>()
+const columnHelper = createColumnHelper<typeof sortableDetailsTableFeatures, CrossSeedTorrent>()
 
 function getStatusInfo(match: CrossSeedTorrent, t: TFunction): { label: string; variant: "default" | "secondary" | "destructive" | "outline"; className: string } {
   const trackerHealth = match.tracker_health ?? null
@@ -140,7 +139,7 @@ export const CrossSeedTable = memo(function CrossSeedTable({
     return map
   }, [trackerCustomizations])
 
-  const columns = useMemo(() => [
+  const columns = useMemo(() => columnHelper.columns([
     columnHelper.display({
       id: "select",
       header: () => null,
@@ -320,15 +319,14 @@ export const CrossSeedTable = memo(function CrossSeedTable({
       },
       size: 130,
     }),
-  ], [incognitoMode, selectedTorrents, onToggleSelection, trackerDisplayNames, trackerIcons, instanceById, t])
+  ]), [incognitoMode, selectedTorrents, onToggleSelection, trackerDisplayNames, trackerIcons, instanceById, t])
 
-  const table = useReactTable({
+  const table = useTable({
+    features: sortableDetailsTableFeatures,
     data: matches,
     columns,
     state: { sorting },
     onSortingChange: setSorting,
-    getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
   })
 
   if (loading && matches.length === 0) {
@@ -443,7 +441,7 @@ export const CrossSeedTable = memo(function CrossSeedTable({
                     }
                   }}
                 >
-                  {row.getVisibleCells().map((cell) => (
+                  {row.getAllCells().map((cell) => (
                     <td
                       key={cell.id}
                       className="px-2 py-1.5"

--- a/web/src/components/torrents/details/PeersTable.tsx
+++ b/web/src/components/torrents/details/PeersTable.tsx
@@ -14,12 +14,11 @@ import type { SortedPeer, TorrentPeer } from "@/types"
 import {
   createColumnHelper,
   flexRender,
-  getCoreRowModel,
-  getSortedRowModel,
-  type SortingFn,
+  type SortFn,
   type SortingState,
-  useReactTable
+  useTable
 } from "@tanstack/react-table"
+import { sortableDetailsTableFeatures } from "../tanstackTableFeatures"
 import { SortIcon } from "@/components/ui/sort-icon"
 import { Ban, Copy, Loader2 } from "lucide-react"
 import { memo, useMemo, useState } from "react"
@@ -35,10 +34,10 @@ interface PeersTableProps {
   onBanPeer?: (peer: TorrentPeer) => void
 }
 
-const columnHelper = createColumnHelper<SortedPeer>()
+const columnHelper = createColumnHelper<typeof sortableDetailsTableFeatures, SortedPeer>()
 
 // Sorting function that pushes 0/null/undefined values to the bottom
-const zeroLastSortingFn: SortingFn<SortedPeer> = (rowA, rowB, columnId) => {
+const zeroLastSortingFn: SortFn<typeof sortableDetailsTableFeatures, SortedPeer> = (rowA, rowB, columnId) => {
   const a = (rowA.getValue(columnId) as number | undefined | null) ?? 0
   const b = (rowB.getValue(columnId) as number | undefined | null) ?? 0
   if (a === 0 && b !== 0) return 1
@@ -57,7 +56,7 @@ export const PeersTable = memo(function PeersTable({
   const { t } = useTranslation("torrents")
   const [sorting, setSorting] = useState<SortingState>([{ id: "progress", desc: true }])
 
-  const columns = useMemo(() => [
+  const columns = useMemo(() => columnHelper.columns([
     columnHelper.accessor("country_code", {
       header: "",
       cell: (info) => {
@@ -124,7 +123,7 @@ export const PeersTable = memo(function PeersTable({
       ),
       size: 90,
       sortUndefined: "last",
-      sortingFn: zeroLastSortingFn,
+      sortFn: zeroLastSortingFn,
     }),
     columnHelper.accessor("up_speed", {
       header: t("peersTable.upSpeed"),
@@ -135,7 +134,7 @@ export const PeersTable = memo(function PeersTable({
       ),
       size: 90,
       sortUndefined: "last",
-      sortingFn: zeroLastSortingFn,
+      sortFn: zeroLastSortingFn,
     }),
     columnHelper.accessor("downloaded", {
       header: t("peersTable.downloaded"),
@@ -146,7 +145,7 @@ export const PeersTable = memo(function PeersTable({
       ),
       size: 90,
       sortUndefined: "last",
-      sortingFn: zeroLastSortingFn,
+      sortFn: zeroLastSortingFn,
     }),
     columnHelper.accessor("uploaded", {
       header: t("peersTable.uploaded"),
@@ -157,7 +156,7 @@ export const PeersTable = memo(function PeersTable({
       ),
       size: 90,
       sortUndefined: "last",
-      sortingFn: zeroLastSortingFn,
+      sortFn: zeroLastSortingFn,
     }),
     ...(showFlags ? [
       columnHelper.accessor("flags", {
@@ -188,17 +187,16 @@ export const PeersTable = memo(function PeersTable({
         size: 60,
       }),
     ] : []),
-  ], [speedUnit, showFlags, incognitoMode, t])
+  ]), [speedUnit, showFlags, incognitoMode, t])
 
   const data = useMemo(() => peers || [], [peers])
 
-  const table = useReactTable({
+  const table = useTable({
+    features: sortableDetailsTableFeatures,
     data,
     columns,
     state: { sorting },
     onSortingChange: setSorting,
-    getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
   })
 
   const handleCopyIp = (peer: SortedPeer) => {
@@ -256,7 +254,7 @@ export const PeersTable = memo(function PeersTable({
               <ContextMenu key={row.id}>
                 <ContextMenuTrigger asChild>
                   <tr className="border-b border-border/50 hover:bg-muted/30 cursor-default">
-                    {row.getVisibleCells().map((cell) => (
+                    {row.getAllCells().map((cell) => (
                       <td
                         key={cell.id}
                         className="px-2 py-1.5"

--- a/web/src/components/torrents/details/TrackersTable.tsx
+++ b/web/src/components/torrents/details/TrackersTable.tsx
@@ -14,11 +14,10 @@ import type { TorrentTracker } from "@/types"
 import {
   createColumnHelper,
   flexRender,
-  getCoreRowModel,
-  getSortedRowModel,
   type SortingState,
-  useReactTable
+  useTable
 } from "@tanstack/react-table"
+import { sortableDetailsTableFeatures } from "../tanstackTableFeatures"
 import { SortIcon } from "@/components/ui/sort-icon"
 import { Loader2 } from "lucide-react"
 import { memo, useMemo, useState } from "react"
@@ -33,7 +32,7 @@ interface TrackersTableProps {
   supportsTrackerEditing?: boolean
 }
 
-const columnHelper = createColumnHelper<TorrentTracker>()
+const columnHelper = createColumnHelper<typeof sortableDetailsTableFeatures, TorrentTracker>()
 
 function getColumnStyle(meta: unknown, size?: number) {
   const columnMeta = meta as { fullWidth?: boolean }
@@ -58,13 +57,13 @@ export const TrackersTable = memo(function TrackersTable({
   const [sorting, setSorting] = useState<SortingState>([{ id: "status", desc: false }])
   const { data: trackerIcons } = useTrackerIcons()
 
-  const columns = useMemo(() => [
+  const columns = useMemo(() => columnHelper.columns([
     columnHelper.accessor("status", {
       header: t("trackersTable.status"),
       cell: (info) => getTrackerStatusBadge(info.getValue(), true),
       size: 90,
       // Custom sort: disabled (0) always at bottom
-      sortingFn: (rowA, rowB) => {
+      sortFn: (rowA, rowB) => {
         const a = rowA.original.status
         const b = rowB.original.status
         if (a === 0 && b !== 0) return 1
@@ -151,17 +150,16 @@ export const TrackersTable = memo(function TrackersTable({
       cell: (info) => <span className="tabular-nums">{info.getValue()}</span>,
       size: 60,
     }),
-  ], [incognitoMode, t, trackerIcons])
+  ]), [incognitoMode, t, trackerIcons])
 
   const data = useMemo(() => trackers || [], [trackers])
 
-  const table = useReactTable({
+  const table = useTable({
+    features: sortableDetailsTableFeatures,
     data,
     columns,
     state: { sorting },
     onSortingChange: setSorting,
-    getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
   })
 
   if (loading && !trackers) {
@@ -220,7 +218,7 @@ export const TrackersTable = memo(function TrackersTable({
                   supportsTrackerEditing={supportsTrackerEditing}
                 >
                   <tr className="border-b border-border/50 hover:bg-muted/30">
-                    {row.getVisibleCells().map((cell) => (
+                    {row.getAllCells().map((cell) => (
                       <td
                         key={cell.id}
                         className="px-3 py-2"

--- a/web/src/components/torrents/details/WebSeedsTable.tsx
+++ b/web/src/components/torrents/details/WebSeedsTable.tsx
@@ -12,8 +12,8 @@ import type { WebSeed } from "@/types"
 import {
   createColumnHelper,
   flexRender,
-  getCoreRowModel,
-  useReactTable
+  tableFeatures,
+  useTable
 } from "@tanstack/react-table"
 import { Copy, Loader2, Search, X } from "lucide-react"
 import { memo, useMemo, useState } from "react"
@@ -26,7 +26,8 @@ interface WebSeedsTableProps {
   incognitoMode: boolean
 }
 
-const columnHelper = createColumnHelper<WebSeed>()
+const webSeedTableFeatures = tableFeatures({})
+const columnHelper = createColumnHelper<typeof webSeedTableFeatures, WebSeed>()
 
 export const WebSeedsTable = memo(function WebSeedsTable({
   webseeds,
@@ -36,7 +37,7 @@ export const WebSeedsTable = memo(function WebSeedsTable({
   const { t } = useTranslation("torrents")
   const [searchQuery, setSearchQuery] = useState("")
 
-  const columns = useMemo(() => [
+  const columns = useMemo(() => columnHelper.columns([
     columnHelper.accessor("url", {
       header: t("webSeedsTable.url"),
       cell: (info) => {
@@ -60,7 +61,7 @@ export const WebSeedsTable = memo(function WebSeedsTable({
         )
       },
     }),
-  ], [incognitoMode, t])
+  ]), [incognitoMode, t])
 
   const filteredData = useMemo(() => {
     const data = webseeds || []
@@ -69,10 +70,10 @@ export const WebSeedsTable = memo(function WebSeedsTable({
     return data.filter((ws) => ws.url.toLowerCase().includes(query))
   }, [webseeds, searchQuery])
 
-  const table = useReactTable({
+  const table = useTable({
+    features: webSeedTableFeatures,
     data: filteredData,
     columns,
-    getCoreRowModel: getCoreRowModel(),
   })
 
   const handleCopyUrl = (webseed: WebSeed) => {
@@ -146,7 +147,7 @@ export const WebSeedsTable = memo(function WebSeedsTable({
                 <ContextMenu key={row.id}>
                   <ContextMenuTrigger asChild>
                     <tr className="border-b border-border/50 hover:bg-muted/30 cursor-default">
-                      {row.getVisibleCells().map((cell) => (
+                      {row.getAllCells().map((cell) => (
                         <td key={cell.id} className="px-2 py-1.5">
                           {flexRender(cell.column.columnDef.cell, cell.getContext())}
                         </td>

--- a/web/src/components/torrents/table/TableColumnHeader.tsx
+++ b/web/src/components/torrents/table/TableColumnHeader.tsx
@@ -6,16 +6,15 @@
 import type { ColumnDnd } from "@/hooks/torrent-table/useColumnDnd"
 import type { ViewMode } from "@/hooks/usePersistedCompactViewState"
 import type { ColumnFilter } from "@/lib/column-filter-utils"
-import type { Torrent } from "@/types"
 import { closestCenter, DndContext } from "@dnd-kit/core"
 import { restrictToHorizontalAxis } from "@dnd-kit/modifiers"
 import { horizontalListSortingStrategy, SortableContext } from "@dnd-kit/sortable"
-import type { Table } from "@tanstack/react-table"
 import type { Dispatch, SetStateAction } from "react"
 import { DraggableTableHeader } from "../DraggableTableHeader"
+import type { TorrentTable } from "../tanstackTableFeatures"
 
 export interface TableColumnHeaderProps {
-  table: Table<Torrent>
+  table: TorrentTable
   sensors: ColumnDnd["sensors"]
   onDragEnd: ColumnDnd["onDragEnd"]
   columnFilters: ColumnFilter[]

--- a/web/src/components/torrents/table/TorrentTableRow.tsx
+++ b/web/src/components/torrents/table/TorrentTableRow.tsx
@@ -10,15 +10,14 @@ import { cn } from "@/lib/utils"
 import type { Torrent } from "@/types"
 import {
   flexRender,
-  type ColumnDef,
   type ColumnOrderState,
   type ColumnSizingState,
-  type Row,
-  type VisibilityState
+  type ColumnVisibilityState
 } from "@tanstack/react-table"
 import { memo } from "react"
 import { TorrentContextMenu, type TorrentContextMenuProps } from "../TorrentContextMenu"
 import type { TableViewMode } from "../TorrentTableColumns"
+import type { TorrentRow, TorrentTableColumnDef } from "../tanstackTableFeatures"
 import { CompactRow } from "./CompactRow"
 
 // Everything the per-row context menu needs except the row-specific fields.
@@ -39,7 +38,7 @@ export interface CompactRowSharedProps {
 }
 
 export interface TorrentTableRowProps {
-  row: Row<Torrent>
+  row: TorrentRow
   virtualIndex: number
   virtualStart: number
   virtualSize: number
@@ -52,14 +51,14 @@ export interface TorrentTableRowProps {
   // Comparison tokens: cells read column config lazily through `row`, so these
   // exist only to invalidate the memo when table-level display state changes
   // (column set, resize, visibility, order).
-  columns: ColumnDef<Torrent>[]
+  columns: TorrentTableColumnDef[]
   columnSizing: ColumnSizingState
-  columnVisibility: VisibilityState
+  columnVisibility: ColumnVisibilityState
   columnOrder: ColumnOrderState
   menu: TorrentRowMenuProps
   compact: CompactRowSharedProps
-  onRowClick: (event: React.MouseEvent, row: Row<Torrent>, isSelected: boolean, isRowSelected: boolean) => void
-  onRowContextMenu: (row: Row<Torrent>, isRowSelected: boolean) => void
+  onRowClick: (event: React.MouseEvent, row: TorrentRow, isSelected: boolean, isRowSelected: boolean) => void
+  onRowContextMenu: (row: TorrentRow, isRowSelected: boolean) => void
 }
 
 // TanStack Table rebuilds the Row wrapper whenever the data array changes, so

--- a/web/src/components/torrents/table/__tests__/TableColumnHeader.test.tsx
+++ b/web/src/components/torrents/table/__tests__/TableColumnHeader.test.tsx
@@ -4,9 +4,8 @@
  */
 
 import { TableColumnHeader, type TableColumnHeaderProps } from "@/components/torrents/table/TableColumnHeader"
+import type { TorrentTable } from "@/components/torrents/tanstackTableFeatures"
 import type { ColumnFilter } from "@/lib/column-filter-utils"
-import type { Table } from "@tanstack/react-table"
-import type { Torrent } from "@/types"
 import { cleanup, render } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -20,13 +19,13 @@ vi.mock("@/components/torrents/DraggableTableHeader", () => ({
   },
 }))
 
-function fakeTable(columnIds: string[]): Table<Torrent> {
+function fakeTable(columnIds: string[]): TorrentTable {
   return {
     getHeaderGroups: () => [{
       id: "hg-0",
       headers: columnIds.map(id => ({ id: `h-${id}`, column: { id } })),
     }],
-  } as unknown as Table<Torrent>
+  } as unknown as TorrentTable
 }
 
 function filter(columnId: string, value: string): ColumnFilter {

--- a/web/src/components/torrents/table/__tests__/TorrentTableRow.test.tsx
+++ b/web/src/components/torrents/table/__tests__/TorrentTableRow.test.tsx
@@ -4,13 +4,13 @@
  */
 
 import { makeTorrent } from "@/test/mockTorrent"
+import type { TorrentRow } from "@/components/torrents/tanstackTableFeatures"
 import type { Torrent } from "@/types"
-import type { Row } from "@tanstack/react-table"
 import { describe, expect, it } from "vitest"
 import { torrentTableRowPropsAreEqual, type TorrentTableRowProps } from "../TorrentTableRow"
 
-function makeRow(torrent: Torrent, id = torrent.hash): Row<Torrent> {
-  return { id, original: torrent } as Row<Torrent>
+function makeRow(torrent: Torrent, id = torrent.hash): TorrentRow {
+  return { id, original: torrent } as TorrentRow
 }
 
 function makeProps(overrides: Partial<TorrentTableRowProps> = {}): TorrentTableRowProps {

--- a/web/src/components/torrents/tanstackTableFeatures.ts
+++ b/web/src/components/torrents/tanstackTableFeatures.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import {
+  columnFilteringFeature,
+  columnOrderingFeature,
+  columnResizingFeature,
+  columnSizingFeature,
+  columnVisibilityFeature,
+  createFilteredRowModel,
+  createSortedRowModel,
+  filterFn_arrIncludes,
+  filterFn_equals,
+  filterFn_inDateRange,
+  filterFn_inNumberRange,
+  filterFn_includesString,
+  filterFn_weakEquals,
+  globalFilteringFeature,
+  rowSelectionFeature,
+  rowSortingFeature,
+  sortFn_alphanumeric,
+  sortFn_text,
+  tableFeatures,
+  type ColumnDef,
+  type Header,
+  type Row,
+  type Table
+} from "@tanstack/react-table"
+import type { Torrent } from "@/types"
+
+const sortFns = {
+  alphanumeric: sortFn_alphanumeric,
+  text: sortFn_text,
+}
+
+export const sortableDetailsTableFeatures = tableFeatures({
+  columnSizingFeature,
+  rowSortingFeature,
+  sortedRowModel: createSortedRowModel(),
+  sortFns,
+})
+
+export const torrentTableFeatures = tableFeatures({
+  columnFilteringFeature,
+  globalFilteringFeature,
+  columnOrderingFeature,
+  columnSizingFeature,
+  columnResizingFeature,
+  columnVisibilityFeature,
+  rowSelectionFeature,
+  rowSortingFeature,
+  filteredRowModel: createFilteredRowModel(),
+  sortedRowModel: createSortedRowModel(),
+  filterFns: {
+    arrIncludes: filterFn_arrIncludes,
+    equals: filterFn_equals,
+    inDateRange: filterFn_inDateRange,
+    inNumberRange: filterFn_inNumberRange,
+    includesString: filterFn_includesString,
+    weakEquals: filterFn_weakEquals,
+  },
+  sortFns,
+})
+
+export type TorrentTableFeatures = typeof torrentTableFeatures
+export type TorrentTable = Table<TorrentTableFeatures, Torrent>
+export type TorrentRow = Row<TorrentTableFeatures, Torrent>
+export type TorrentTableColumnDef = ColumnDef<TorrentTableFeatures, Torrent, unknown>
+export type TorrentTableHeader = Header<TorrentTableFeatures, Torrent, unknown>

--- a/web/src/hooks/torrent-table/__tests__/useCompactViewSort.test.ts
+++ b/web/src/hooks/torrent-table/__tests__/useCompactViewSort.test.ts
@@ -31,7 +31,7 @@ function render(overrides: Partial<UseCompactViewSortParams> = {}) {
     setLastUserAction: vi.fn(),
     ...overrides,
   }
-  return { params, ...renderHook(() => useCompactViewSort(params)) }
+  return { params, ...renderHook((p: UseCompactViewSortParams) => useCompactViewSort(p), { initialProps: params }) }
 }
 
 describe("useCompactViewSort", () => {
@@ -80,5 +80,14 @@ describe("useCompactViewSort", () => {
     const { params, result } = render({ activeSortField: "name", activeSortOrder: "desc" })
     act(() => result.current.handleCompactSortOrderToggle())
     expect(params.setSorting).toHaveBeenCalledWith([{ id: "name", desc: false }])
+  })
+
+  it("keeps stable identities when the table object changes between renders", () => {
+    const { params, result, rerender } = render()
+    const first = result.current
+    rerender({ ...params, table: fakeTable(COLUMNS) })
+    expect(result.current.compactSortOptions).toBe(first.compactSortOptions)
+    expect(result.current.currentCompactSortLabel).toBe(first.currentCompactSortLabel)
+    expect(result.current.handleCompactSortOrderToggle).toBe(first.handleCompactSortOrderToggle)
   })
 })

--- a/web/src/hooks/torrent-table/__tests__/useCompactViewSort.test.ts
+++ b/web/src/hooks/torrent-table/__tests__/useCompactViewSort.test.ts
@@ -4,15 +4,14 @@
  */
 
 import { type UseCompactViewSortParams, useCompactViewSort } from "@/hooks/torrent-table/useCompactViewSort"
-import type { Torrent } from "@/types"
-import type { Table } from "@tanstack/react-table"
+import type { TorrentTable } from "@/components/torrents/tanstackTableFeatures"
 import { act, renderHook } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 
 type FakeColumn = { id: string; columnDef: { meta?: { headerString?: string }; header?: unknown } }
 
-function fakeTable(columns: FakeColumn[]): Table<Torrent> {
-  return { getAllLeafColumns: () => columns } as unknown as Table<Torrent>
+function fakeTable(columns: FakeColumn[]): TorrentTable {
+  return { getAllLeafColumns: () => columns } as unknown as TorrentTable
 }
 
 const COLUMNS: FakeColumn[] = [

--- a/web/src/hooks/torrent-table/__tests__/useTorrentTableArrowNavigation.test.ts
+++ b/web/src/hooks/torrent-table/__tests__/useTorrentTableArrowNavigation.test.ts
@@ -7,8 +7,8 @@ import {
   useTorrentTableArrowNavigation,
   type UseTorrentTableArrowNavigationParams
 } from "@/hooks/torrent-table/useTorrentTableArrowNavigation"
+import type { TorrentRow } from "@/components/torrents/tanstackTableFeatures"
 import type { Torrent } from "@/types"
-import type { Row } from "@tanstack/react-table"
 import type { Virtualizer } from "@tanstack/react-virtual"
 import { act, cleanup, renderHook } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
@@ -16,11 +16,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 const scrollToIndex = vi.fn()
 const virtualizer = { scrollToIndex } as unknown as Virtualizer<HTMLDivElement, Element>
 
-function makeRows(n: number): Row<Torrent>[] {
+function makeRows(n: number): TorrentRow[] {
   return Array.from({ length: n }, (_, i) => ({
     id: `hash${i}`,
     original: { hash: `hash${i}`, name: `torrent ${i}` } as Torrent,
-  })) as unknown as Row<Torrent>[]
+  })) as unknown as TorrentRow[]
 }
 
 function baseProps(over: Partial<UseTorrentTableArrowNavigationParams> = {}): UseTorrentTableArrowNavigationParams {

--- a/web/src/hooks/torrent-table/__tests__/useTorrentTableVirtualization.test.ts
+++ b/web/src/hooks/torrent-table/__tests__/useTorrentTableVirtualization.test.ts
@@ -4,8 +4,7 @@
  */
 
 import { useTorrentTableVirtualization, type UseTorrentTableVirtualizationParams } from "@/hooks/torrent-table/useTorrentTableVirtualization"
-import type { Torrent } from "@/types"
-import type { Row } from "@tanstack/react-table"
+import type { TorrentRow } from "@/components/torrents/tanstackTableFeatures"
 import { act, renderHook } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -23,8 +22,8 @@ const { virtualizerMock } = vi.hoisted(() => ({
 vi.mock("@tanstack/react-virtual", () => ({ useVirtualizer: () => virtualizerMock }))
 vi.mock("@/hooks/useKeyboardNavigation", () => ({ useKeyboardNavigation: () => {} }))
 
-function makeRows(n: number): Row<Torrent>[] {
-  return Array.from({ length: n }, (_, i) => ({ id: `r${i}` })) as unknown as Row<Torrent>[]
+function makeRows(n: number): TorrentRow[] {
+  return Array.from({ length: n }, (_, i) => ({ id: `r${i}` })) as unknown as TorrentRow[]
 }
 
 function baseProps(over: Partial<UseTorrentTableVirtualizationParams> = {}): UseTorrentTableVirtualizationParams {

--- a/web/src/hooks/torrent-table/useCompactViewSort.ts
+++ b/web/src/hooks/torrent-table/useCompactViewSort.ts
@@ -5,14 +5,14 @@
 
 import { TORRENT_SORT_OPTIONS, type TorrentSortOptionValue, getDefaultSortOrder } from "@/components/torrents/torrentSortOptions"
 import { getBackendSortField } from "@/lib/torrent-table/backend-sort-field"
-import type { Torrent } from "@/types"
-import type { ColumnOrderState, Table, VisibilityState } from "@tanstack/react-table"
+import type { ColumnOrderState, ColumnVisibilityState } from "@tanstack/react-table"
 import { useCallback, useMemo } from "react"
+import type { TorrentTable } from "@/components/torrents/tanstackTableFeatures"
 
 export interface UseCompactViewSortParams {
-  table: Table<Torrent>
+  table: TorrentTable
   // Included so the derived options/label recompute when columns change.
-  columnVisibility: VisibilityState
+  columnVisibility: ColumnVisibilityState
   columnOrder: ColumnOrderState
   activeSortField: string
   activeSortOrder: "asc" | "desc"

--- a/web/src/hooks/torrent-table/useCompactViewSort.ts
+++ b/web/src/hooks/torrent-table/useCompactViewSort.ts
@@ -6,7 +6,7 @@
 import { TORRENT_SORT_OPTIONS, type TorrentSortOptionValue, getDefaultSortOrder } from "@/components/torrents/torrentSortOptions"
 import { getBackendSortField } from "@/lib/torrent-table/backend-sort-field"
 import type { ColumnOrderState, ColumnVisibilityState } from "@tanstack/react-table"
-import { useCallback, useMemo } from "react"
+import { useCallback, useMemo, useRef } from "react"
 import type { TorrentTable } from "@/components/torrents/tanstackTableFeatures"
 
 export interface UseCompactViewSortParams {
@@ -33,8 +33,13 @@ export function useCompactViewSort({
   setSorting,
   setLastUserAction,
 }: UseCompactViewSortParams) {
+  // v9's useTable returns a new table object every render; read it through a
+  // latest-ref so the memos and callbacks below keep stable identities.
+  const tableRef = useRef(table)
+  tableRef.current = table
+
   const resolveSortColumnId = useCallback((field: string): string => {
-    const columns = table.getAllLeafColumns()
+    const columns = tableRef.current.getAllLeafColumns()
     const directMatch = columns.find(column => column.id === field)
     if (directMatch) {
       return directMatch.id
@@ -46,11 +51,11 @@ export function useCompactViewSort({
     }
 
     return field
-    // Reads table.getAllLeafColumns() at call time, so it only depends on `table`.
-  }, [table])
+    // Reads the table at call time through tableRef, so it needs no deps.
+  }, [])
 
   const compactSortOptions = useMemo(() => {
-    const columns = table.getAllLeafColumns()
+    const columns = tableRef.current.getAllLeafColumns()
     const availableFields = new Set<string>()
 
     for (const column of columns) {
@@ -60,7 +65,7 @@ export function useCompactViewSort({
 
     return TORRENT_SORT_OPTIONS.filter(option => availableFields.has(option.value))
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [table, columnVisibility, columnOrder])
+  }, [columnVisibility, columnOrder])
 
   const currentCompactSortLabel = useMemo(() => {
     const directOption = compactSortOptions.find(option => option.value === activeSortField)
@@ -68,7 +73,7 @@ export function useCompactViewSort({
       return directOption.label
     }
 
-    const columns = table.getAllLeafColumns()
+    const columns = tableRef.current.getAllLeafColumns()
     const directColumn = columns.find(column => column.id === activeSortField)
     if (directColumn) {
       const meta = directColumn.columnDef.meta as { headerString?: string } | undefined
@@ -95,7 +100,7 @@ export function useCompactViewSort({
 
     return activeSortField
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [compactSortOptions, activeSortField, table, columnVisibility, columnOrder])
+  }, [compactSortOptions, activeSortField, columnVisibility, columnOrder])
 
   const handleCompactSortFieldChange = useCallback((value: TorrentSortOptionValue) => {
     if (activeSortField === value) {

--- a/web/src/hooks/torrent-table/useTorrentSelection.ts
+++ b/web/src/hooks/torrent-table/useTorrentSelection.ts
@@ -4,6 +4,7 @@
  */
 
 import type { CrossInstanceTorrent, Torrent } from "@/types"
+import type { RowSelectionState } from "@tanstack/react-table"
 import { type Dispatch, type RefObject, type SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 // Minimal structural shape of a TanStack row that the selection logic reads.
@@ -28,8 +29,8 @@ export interface UseTorrentSelectionParams {
 }
 
 export interface TorrentSelection {
-  rowSelection: Record<string, boolean>
-  setRowSelection: Dispatch<SetStateAction<Record<string, boolean>>>
+  rowSelection: RowSelectionState
+  setRowSelection: Dispatch<SetStateAction<RowSelectionState>>
   isAllSelected: boolean
   setIsAllSelected: Dispatch<SetStateAction<boolean>>
   excludedFromSelectAll: Set<string>
@@ -61,7 +62,7 @@ export function useTorrentSelection({
   onResetSelection,
   getVisibleRows,
 }: UseTorrentSelectionParams): TorrentSelection {
-  const [rowSelection, setRowSelection] = useState<Record<string, boolean>>({})
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({})
   const [isAllSelected, setIsAllSelected] = useState(false)
   const [excludedFromSelectAll, setExcludedFromSelectAll] = useState<Set<string>>(new Set())
 
@@ -201,10 +202,15 @@ export function useTorrentSelection({
     } else {
       // Regular selection mode - use table's built-in selection with correct row ID
       const keyToUse = rowId || selectionIdentity // Use rowId if provided, fallback for backward compatibility
-      setRowSelection(prev => ({
-        ...prev,
-        [keyToUse]: checked,
-      }))
+      setRowSelection(prev => {
+        if (checked) {
+          return { ...prev, [keyToUse]: true }
+        }
+
+        const next = { ...prev }
+        delete next[keyToUse]
+        return next
+      })
     }
   }, [isAllSelected, setRowSelection, isReadOnly])
 

--- a/web/src/hooks/torrent-table/useTorrentTableArrowNavigation.ts
+++ b/web/src/hooks/torrent-table/useTorrentTableArrowNavigation.ts
@@ -4,7 +4,8 @@
  */
 
 import type { Torrent } from "@/types"
-import type { Row } from "@tanstack/react-table"
+import type { TorrentRow } from "@/components/torrents/tanstackTableFeatures"
+import type { RowSelectionState } from "@tanstack/react-table"
 import type { Virtualizer } from "@tanstack/react-virtual"
 import { useEffect, type Dispatch, type RefObject, type SetStateAction } from "react"
 
@@ -12,7 +13,7 @@ import { useEffect, type Dispatch, type RefObject, type SetStateAction } from "r
 const LOAD_MORE_THRESHOLD = 50
 
 export interface UseTorrentTableArrowNavigationParams {
-  rows: Row<Torrent>[]
+  rows: TorrentRow[]
   virtualizer: Virtualizer<HTMLDivElement, Element>
   /** Virtualized row count (progressive window), which can trail rows.length. */
   safeLoadedRows: number
@@ -22,7 +23,7 @@ export interface UseTorrentTableArrowNavigationParams {
   selectedRowIds: string[]
   lastSelectedIndexRef: RefObject<number | null>
   getSelectionIdentity: (torrent: Torrent) => string
-  setRowSelection: Dispatch<SetStateAction<Record<string, boolean>>>
+  setRowSelection: Dispatch<SetStateAction<RowSelectionState>>
   setIsAllSelected: Dispatch<SetStateAction<boolean>>
   setExcludedFromSelectAll: Dispatch<SetStateAction<Set<string>>>
   onTorrentSelect?: (torrent: Torrent | null) => void

--- a/web/src/hooks/torrent-table/useTorrentTableColumns.ts
+++ b/web/src/hooks/torrent-table/useTorrentTableColumns.ts
@@ -4,10 +4,10 @@
  */
 
 import { createColumns, type TableViewMode } from "@/components/torrents/TorrentTableColumns"
+import type { TorrentTableColumnDef } from "@/components/torrents/tanstackTableFeatures"
 import type { SpeedUnit } from "@/lib/speedUnits"
 import type { TrackerCustomizationLookup } from "@/lib/tracker-customizations"
 import type { AppPreferences, Torrent } from "@/types"
-import type { ColumnDef } from "@tanstack/react-table"
 import type { TFunction } from "i18next"
 import { type RefObject, useMemo } from "react"
 
@@ -40,7 +40,7 @@ export interface UseTorrentTableColumnsParams {
 }
 
 export interface TorrentTableColumns {
-  columns: ColumnDef<Torrent>[]
+  columns: TorrentTableColumnDef[]
   torrentIdentityCounts: Map<string, number>
 }
 

--- a/web/src/hooks/torrent-table/useTorrentTableHotkeys.ts
+++ b/web/src/hooks/torrent-table/useTorrentTableHotkeys.ts
@@ -4,13 +4,14 @@
  */
 
 import type { Torrent } from "@/types"
+import type { RowSelectionState } from "@tanstack/react-table"
 import { type Dispatch, type RefObject, type SetStateAction, useCallback, useMemo } from "react"
 
 export interface UseTorrentTableHotkeysParams {
   sortedTorrents: Torrent[]
   setIsAllSelected: Dispatch<SetStateAction<boolean>>
   setExcludedFromSelectAll: Dispatch<SetStateAction<Set<string>>>
-  setRowSelection: Dispatch<SetStateAction<Record<string, boolean>>>
+  setRowSelection: Dispatch<SetStateAction<RowSelectionState>>
   lastSelectedIndexRef: RefObject<number | null>
 }
 

--- a/web/src/hooks/torrent-table/useTorrentTableVirtualization.ts
+++ b/web/src/hooks/torrent-table/useTorrentTableVirtualization.ts
@@ -6,14 +6,13 @@
 import { useKeyboardNavigation } from "@/hooks/useKeyboardNavigation"
 import type { ViewMode } from "@/hooks/usePersistedCompactViewState"
 import { viewModeRowHeight } from "@/lib/torrent-table/row-height"
-import type { Torrent } from "@/types"
-import type { Row } from "@tanstack/react-table"
+import type { TorrentRow } from "@/components/torrents/tanstackTableFeatures"
 import { useVirtualizer, type VirtualItem, type Virtualizer } from "@tanstack/react-virtual"
 import { useCallback, useEffect, useMemo, useRef, useState, type Dispatch, type RefObject, type SetStateAction } from "react"
 
 export interface UseTorrentTableVirtualizationParams {
   /** The table's current row model rows (by value — this hook runs after the table). */
-  rows: Row<Torrent>[]
+  rows: TorrentRow[]
   desktopViewMode: ViewMode
   /** Full filtered dataset length (drives overscan + the progressive target), NOT rows.length. */
   sortedTorrentsLength: number

--- a/web/src/hooks/usePersistedColumnVisibility.ts
+++ b/web/src/hooks/usePersistedColumnVisibility.ts
@@ -3,24 +3,24 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import type { VisibilityState } from "@tanstack/react-table"
+import type { ColumnVisibilityState } from "@tanstack/react-table"
 import { useEffect, useState } from "react"
 
 export function usePersistedColumnVisibility(
-  defaultVisibility: VisibilityState = {},
+  defaultVisibility: ColumnVisibilityState = {},
   instanceKey?: string | number
 ) {
   const baseStorageKey = "qui-column-visibility"
   const hasInstanceKey = instanceKey !== undefined && instanceKey !== null
   const storageKey = hasInstanceKey ? `${baseStorageKey}:${instanceKey}` : baseStorageKey
 
-  const loadVisibility = (): VisibilityState => {
+  const loadVisibility = (): ColumnVisibilityState => {
     try {
       const stored = localStorage.getItem(storageKey)
       if (stored) {
         const parsed = JSON.parse(stored)
         if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-          return parsed as VisibilityState
+          return parsed as ColumnVisibilityState
         }
       }
     } catch (error) {
@@ -30,7 +30,7 @@ export function usePersistedColumnVisibility(
     return { ...defaultVisibility }
   }
 
-  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>(() => loadVisibility())
+  const [columnVisibility, setColumnVisibility] = useState<ColumnVisibilityState>(() => loadVisibility())
 
   useEffect(() => {
     if (!hasInstanceKey) {


### PR DESCRIPTION
## Description

Upgrade `@tanstack/react-table` from v8.21.3 to v9.1.2 and migrate qui's five torrent table implementations to the Store-backed v9 API.

- replace `useReactTable` with `useTable`
- register only the sorting, filtering, selection, ordering, visibility, and sizing features each table uses
- avoid `stockFeatures` and `useLegacyTable` so unused functionality remains tree-shakeable
- preserve server-side sorting/filtering and cross-seed client-side row models
- migrate v9 feature generics, sorting APIs, visibility state, and sparse row-selection state

Initial Chrome field test with 5,868 torrents:

- progressive load: 100.9s -> 79.9s (20.9% faster)
- final used JS heap: 611MB -> 525MB (14.0% lower)
- final total JS heap: 650MB -> 581MB (10.5% lower)
- total JavaScript bundle: +3.9kB gzip

The v9 backend cache was warmer, so the timing is a promising field signal rather than an isolated repeatable benchmark. The test only loaded and scrolled the table; it performed no torrent actions.

Follow-up 891e6191: a performance review found that v9's `useTable` returns a new table object on every render, where v8 returned one stable object. The row click handler listed it in a dependency array, so the handler got a new identity each render and defeated the `TorrentTableRow` memo, re-rendering every visible row on every data tick. The handler now reads the table through the existing latest-ref bundle, and the width and compact-sort memos key on the state they derive from. Live A/B on a 5,880-torrent instance, 60 seconds idle: worst frame 150ms to 83ms, accumulated frame jank down 18%, steady per-tick cost unchanged.

No linked issue.

## How has this been tested?

- `pnpm install --frozen-lockfile`
- `make test-frontend` (998 tests passed)
- `pnpm lint` (0 errors; 53 existing warnings)
- `make build`
- connected Chrome smoke test with 5,868 torrents and no console errors
- independent read-only code review found no implementation defects
- follow-up: 165 torrent-table tests, tsc, and eslint pass; a new regression test fails on the unfixed hook and passes with the fix
- follow-up: 60-second idle frame sampling against the live instance, before and after deploy

`make precommit` ran formatting and then stopped because `golangci-lint` is not installed in the local environment. No Go files are changed; frontend lint and the production build pass.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [ ] I ran `make precommit` and the tests pass locally
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

## AI disclosure

Yes. Codex wrote most of the migration under maintainer direction. Claude found and wrote the follow-up render-identity fix (891e6191) after a multi-agent performance review. The result was type-checked, tested, built, field-tested, and independently reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent sorting, filtering, resizing, column visibility, and row selection across torrent and detail tables.
  * Improved table rendering consistency in torrent details and web seed views.

* **Bug Fixes**
  * Deselected rows are now removed cleanly from selection state.
  * Updated sorting behavior for status, ratio, and detail-table columns.

* **Refactor**
  * Upgraded the table library and standardized table interactions across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
