### PR TITLE
chore: bump golangci-lint to v2.13.0 and apply go fix for Go 1.27

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -99,5 +99,5 @@ jobs:
       - name: Lint backend
         uses: golangci/golangci-lint-action@v9.3.0
         with:
-          version: v2.11.1
+          version: v2.13.0
           only-new-issues: true

--- a/internal/api/handlers/instances.go
+++ b/internal/api/handlers/instances.go
@@ -162,18 +162,16 @@ type transferInfoResponse struct {
 // endpoint clients poll every few seconds.
 func newTransferInfoResponse(state *qbt.ServerState) transferInfoResponse {
 	return transferInfoResponse{
-		TransferInfo: qbt.TransferInfo{
-			ConnectionStatus: qbt.ConnectionStatus(state.ConnectionStatus),
-			DHTNodes:         state.DhtNodes,
-			DlInfoData:       state.DlInfoData,
-			DlInfoSpeed:      state.DlInfoSpeed,
-			DlRateLimit:      state.DlRateLimit,
-			UpInfoData:       state.UpInfoData,
-			UpInfoSpeed:      state.UpInfoSpeed,
-			UpRateLimit:      state.UpRateLimit,
-		},
-		AlltimeDl: &state.AlltimeDl,
-		AlltimeUl: &state.AlltimeUl,
+		ConnectionStatus: qbt.ConnectionStatus(state.ConnectionStatus),
+		DHTNodes:         state.DhtNodes,
+		DlInfoData:       state.DlInfoData,
+		DlInfoSpeed:      state.DlInfoSpeed,
+		DlRateLimit:      state.DlRateLimit,
+		UpInfoData:       state.UpInfoData,
+		UpInfoSpeed:      state.UpInfoSpeed,
+		UpRateLimit:      state.UpRateLimit,
+		AlltimeDl:        &state.AlltimeDl,
+		AlltimeUl:        &state.AlltimeUl,
 	}
 }
 
@@ -319,9 +317,8 @@ func (h *InstancesHandler) buildInstanceResponse(ctx context.Context, instance *
 		ConnectionStatus:         connectionStatus,
 		SortOrder:                instance.SortOrder,
 		IsActive:                 instance.IsActive,
-	}
 
-	response.ReannounceSettings = h.getReannounceSettingsPayload(ctx, instance.ID)
+		ReannounceSettings: h.getReannounceSettingsPayload(ctx, instance.ID)}
 
 	// Fetch recent errors for disconnected instances
 	if instance.IsActive && !healthy {

--- a/internal/api/handlers/instances_transfer_info_test.go
+++ b/internal/api/handlers/instances_transfer_info_test.go
@@ -54,7 +54,7 @@ func TestTransferInfoResponseFromServerState(t *testing.T) {
 // and let the client keep the value it already has.
 func TestTransferInfoResponseFallbackOmitsAlltimeTotals(t *testing.T) {
 	payload, err := json.Marshal(transferInfoResponse{
-		TransferInfo: qbt.TransferInfo{ConnectionStatus: "connected", DlInfoSpeed: 42},
+		ConnectionStatus: "connected", DlInfoSpeed: 42,
 	})
 	require.NoError(t, err)
 

--- a/internal/backups/service_export_test.go
+++ b/internal/backups/service_export_test.go
@@ -369,8 +369,8 @@ func TestExecuteBackupRunsExportsConcurrently(t *testing.T) {
 		})
 	}
 	stub := &rendezvousExportStub{
-		concurrentExportStub: concurrentExportStub{torrents: torrents},
-		ready:                make(chan struct{}),
+		torrents: torrents,
+		ready:    make(chan struct{}),
 	}
 	svc, instanceID := newExportTestService(t, stub)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -162,8 +162,7 @@ func (c *AppConfig) loadFromPath(configDirOrPath string) error {
 	c.viper.SetConfigFile(configPath)
 
 	if err := c.viper.ReadInConfig(); err != nil {
-		var notFound viper.ConfigFileNotFoundError
-		if !errors.As(err, &notFound) {
+		if _, ok := errors.AsType[viper.ConfigFileNotFoundError](err); !ok {
 			return fmt.Errorf("failed to read config: %w", err)
 		}
 		if writeErr := c.writeDefaultConfig(configPath); writeErr != nil {
@@ -182,8 +181,7 @@ func (c *AppConfig) loadFromStandardLocations() error {
 	c.viper.AddConfigPath(GetDefaultConfigDir())
 
 	if err := c.viper.ReadInConfig(); err != nil {
-		var notFound viper.ConfigFileNotFoundError
-		if !errors.As(err, &notFound) {
+		if _, ok := errors.AsType[viper.ConfigFileNotFoundError](err); !ok {
 			return fmt.Errorf("failed to read config: %w", err)
 		}
 		defaultConfigPath := filepath.Join(GetDefaultConfigDir(), "config.toml")
@@ -730,24 +728,24 @@ func setLogLevel(level string) {
 
 func baseLogWriter(version string) io.Writer {
 	if isDevBuild(version) {
-		writer := zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339}
-		writer.PartsOrder = []string{zerolog.TimestampFieldName, zerolog.LevelFieldName, zerolog.MessageFieldName}
-		writer.FormatTimestamp = func(i any) string {
-			if i == nil {
-				return ""
-			}
-			return fmt.Sprint(i)
-		}
-		writer.FormatMessage = func(i any) string {
-			if i == nil {
-				return ""
-			}
-			msg := strings.TrimSpace(fmt.Sprint(i))
-			if msg == "" {
-				return ""
-			}
-			return msg
-		}
+		writer := zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339,
+			PartsOrder: []string{zerolog.TimestampFieldName, zerolog.LevelFieldName, zerolog.MessageFieldName},
+			FormatTimestamp: func(i any) string {
+				if i == nil {
+					return ""
+				}
+				return fmt.Sprint(i)
+			},
+			FormatMessage: func(i any) string {
+				if i == nil {
+					return ""
+				}
+				msg := strings.TrimSpace(fmt.Sprint(i))
+				if msg == "" {
+					return ""
+				}
+				return msg
+			}}
 		return writer
 	}
 	return os.Stderr

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -462,9 +462,9 @@ func TestApplyDynamicChangesRejectsInvalidAuthDisabledReload(t *testing.T) {
 		logManager: NewLogManager("test"),
 	}
 
-	var listenerCalls int32
+	var listenerCalls atomic.Int32
 	cfg.RegisterReloadListener(func(_ *domain.Config) {
-		atomic.AddInt32(&listenerCalls, 1)
+		listenerCalls.Add(1)
 	})
 
 	previousAuth := authReloadSettings{
@@ -481,7 +481,7 @@ func TestApplyDynamicChangesRejectsInvalidAuthDisabledReload(t *testing.T) {
 	assert.True(t, cfg.Config.IAcknowledgeThisIsABadIdea)
 	assert.Equal(t, []string{"127.0.0.1/32"}, cfg.Config.AuthDisabledAllowedCIDRs)
 	assert.False(t, cfg.Config.OIDCEnabled)
-	assert.Equal(t, int32(0), atomic.LoadInt32(&listenerCalls))
+	assert.Equal(t, int32(0), listenerCalls.Load())
 	assert.Equal(t, zerolog.WarnLevel, zerolog.GlobalLevel())
 	require.NoError(t, cfg.Config.ValidateAuthDisabledConfig())
 }
@@ -503,9 +503,9 @@ func TestApplyDynamicChangesNotifiesOnValidAuthDisabledReload(t *testing.T) {
 		logManager: NewLogManager("test"),
 	}
 
-	var listenerCalls int32
+	var listenerCalls atomic.Int32
 	cfg.RegisterReloadListener(func(conf *domain.Config) {
-		atomic.AddInt32(&listenerCalls, 1)
+		listenerCalls.Add(1)
 		assert.True(t, conf.IsAuthDisabled())
 		assert.Equal(t, []string{"10.0.0.0/8"}, conf.AuthDisabledAllowedCIDRs)
 	})
@@ -520,7 +520,7 @@ func TestApplyDynamicChangesNotifiesOnValidAuthDisabledReload(t *testing.T) {
 	cfg.applyDynamicChanges(previousAuth)
 
 	assert.Equal(t, "test", cfg.Config.Version)
-	assert.Equal(t, int32(1), atomic.LoadInt32(&listenerCalls))
+	assert.Equal(t, int32(1), listenerCalls.Load())
 	assert.Equal(t, zerolog.ErrorLevel, zerolog.GlobalLevel())
 }
 
@@ -540,9 +540,9 @@ func TestApplyDynamicChangesRejectsInvalidCORSReload(t *testing.T) {
 		logManager: NewLogManager("test"),
 	}
 
-	var listenerCalls int32
+	var listenerCalls atomic.Int32
 	cfg.RegisterReloadListener(func(conf *domain.Config) {
-		atomic.AddInt32(&listenerCalls, 1)
+		listenerCalls.Add(1)
 		assert.Equal(t, []string{"https://good.example"}, conf.CORSAllowedOrigins)
 	})
 
@@ -554,7 +554,7 @@ func TestApplyDynamicChangesRejectsInvalidCORSReload(t *testing.T) {
 	cfg.applyDynamicChanges(previous)
 
 	assert.Equal(t, []string{"https://good.example"}, cfg.Config.CORSAllowedOrigins)
-	assert.Equal(t, int32(1), atomic.LoadInt32(&listenerCalls))
+	assert.Equal(t, int32(1), listenerCalls.Load())
 }
 
 func TestApplyDynamicChangesRejectsInvalidAuthDisabledReloadAlsoRestoresCORS(t *testing.T) {
@@ -575,9 +575,9 @@ func TestApplyDynamicChangesRejectsInvalidAuthDisabledReloadAlsoRestoresCORS(t *
 		logManager: NewLogManager("test"),
 	}
 
-	var listenerCalls int32
+	var listenerCalls atomic.Int32
 	cfg.RegisterReloadListener(func(_ *domain.Config) {
-		atomic.AddInt32(&listenerCalls, 1)
+		listenerCalls.Add(1)
 	})
 
 	previous := authReloadSettings{
@@ -595,7 +595,7 @@ func TestApplyDynamicChangesRejectsInvalidAuthDisabledReloadAlsoRestoresCORS(t *
 	assert.Nil(t, cfg.Config.AuthDisabledAllowedCIDRs)
 	assert.False(t, cfg.Config.OIDCEnabled)
 	assert.Equal(t, []string{"https://good.example"}, cfg.Config.CORSAllowedOrigins)
-	assert.Equal(t, int32(0), atomic.LoadInt32(&listenerCalls))
+	assert.Equal(t, int32(0), listenerCalls.Load())
 }
 
 func TestHydrateConfigFromViperSplitsStringSlices(t *testing.T) {

--- a/internal/fsops/local/local.go
+++ b/internal/fsops/local/local.go
@@ -124,8 +124,8 @@ func (b *Backend) WalkDir(ctx context.Context, root string, opts fsops.WalkOptio
 				}
 			}
 
-			entry := fsops.WalkEntry{}
-			entry.Path = path
+			entry := fsops.WalkEntry{
+				Path: path}
 
 			rel, err := filepath.Rel(root, path)
 			if err == nil {
@@ -179,8 +179,8 @@ func (b *Backend) WalkDir(ctx context.Context, root string, opts fsops.WalkOptio
 		// where the callback propagates walkErr. Context cancellation is not
 		// an error — the caller initiated it.
 		if walkErr != nil && ctx.Err() == nil {
-			entry := fsops.WalkEntry{Err: walkErr}
-			entry.Path = root
+			entry := fsops.WalkEntry{Err: walkErr,
+				Path: root}
 			select {
 			case ch <- entry:
 			case <-ctx.Done():

--- a/internal/models/sql_errors.go
+++ b/internal/models/sql_errors.go
@@ -16,13 +16,11 @@ func isUniqueConstraintError(err error) bool {
 		return false
 	}
 
-	var sqlErr *sqlite.Error
-	if errors.As(err, &sqlErr) {
+	if sqlErr, ok := errors.AsType[*sqlite.Error](err); ok {
 		return sqlErr.Code() == sqlitelib.SQLITE_CONSTRAINT_UNIQUE
 	}
 
-	var pgErr *pgconn.PgError
-	if errors.As(err, &pgErr) {
+	if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
 		return pgErr.Code == "23505"
 	}
 
@@ -34,13 +32,11 @@ func isCheckConstraintError(err error) bool {
 		return false
 	}
 
-	var sqlErr *sqlite.Error
-	if errors.As(err, &sqlErr) {
+	if sqlErr, ok := errors.AsType[*sqlite.Error](err); ok {
 		return sqlErr.Code() == sqlitelib.SQLITE_CONSTRAINT_CHECK
 	}
 
-	var pgErr *pgconn.PgError
-	if errors.As(err, &pgErr) {
+	if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
 		return pgErr.Code == "23514"
 	}
 
@@ -52,13 +48,11 @@ func isForeignKeyConstraintError(err error) bool {
 		return false
 	}
 
-	var sqlErr *sqlite.Error
-	if errors.As(err, &sqlErr) {
+	if sqlErr, ok := errors.AsType[*sqlite.Error](err); ok {
 		return sqlErr.Code() == sqlitelib.SQLITE_CONSTRAINT_FOREIGNKEY
 	}
 
-	var pgErr *pgconn.PgError
-	if errors.As(err, &pgErr) {
+	if pgErr, ok := errors.AsType[*pgconn.PgError](err); ok {
 		return pgErr.Code == "23503"
 	}
 

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -1671,8 +1671,7 @@ func (h *Handler) handleTorrentMediaInfo(w http.ResponseWriter, r *http.Request)
 
 	instance, prefs, err := validateProxyMediainfoRequest(ctx, h.instanceStore, h.syncManager, instanceID)
 	if err != nil {
-		var reqErr *proxyMediaInfoRequestError
-		if errors.As(err, &reqErr) {
+		if reqErr, ok := errors.AsType[*proxyMediaInfoRequestError](err); ok {
 			writeJSONError(w, reqErr.status, reqErr.message)
 			return
 		}
@@ -1684,8 +1683,7 @@ func (h *Handler) handleTorrentMediaInfo(w http.ResponseWriter, r *http.Request)
 
 	contentPath, resolvedPath, err := resolveProxyContentPathCandidates(r, prefs, contentPathCandidatesFromPreferences)
 	if err != nil {
-		var reqErr *proxyMediaInfoRequestError
-		if errors.As(err, &reqErr) {
+		if reqErr, ok := errors.AsType[*proxyMediaInfoRequestError](err); ok {
 			writeJSONError(w, reqErr.status, reqErr.message)
 			return
 		}
@@ -1707,8 +1705,7 @@ func (h *Handler) handleTorrentMediaInfo(w http.ResponseWriter, r *http.Request)
 
 	summaryTxt, rawJSON, err := analyzeMediaFile(resolvedPath, contentPath, instanceID)
 	if err != nil {
-		var reqErr *proxyMediaInfoRequestError
-		if errors.As(err, &reqErr) {
+		if reqErr, ok := errors.AsType[*proxyMediaInfoRequestError](err); ok {
 			writeJSONError(w, reqErr.status, reqErr.message)
 			return
 		}
@@ -1718,8 +1715,7 @@ func (h *Handler) handleTorrentMediaInfo(w http.ResponseWriter, r *http.Request)
 	}
 
 	if err = writeProxyMediaInfoResponse(w, contentPath, summaryTxt, rawJSON); err != nil {
-		var writeErr *proxyMediaInfoResponseWriteError
-		if errors.As(err, &writeErr) {
+		if writeErr, ok := errors.AsType[*proxyMediaInfoResponseWriteError](err); ok {
 			if writeErr.encodeErr != nil {
 				log.Error().Err(writeErr.encodeErr).Int("instanceId", instanceID).Str("contentPath", contentPath).Msg("Failed to encode proxy mediainfo response")
 			}

--- a/internal/proxy/retry_transport.go
+++ b/internal/proxy/retry_transport.go
@@ -278,8 +278,7 @@ func isRetryableError(err error) bool {
 	}
 
 	// Check for URL errors first - unwrap and check underlying error
-	var urlErr *url.Error
-	if errors.As(err, &urlErr) {
+	if urlErr, ok := errors.AsType[*url.Error](err); ok {
 		return isRetryableError(urlErr.Err)
 	}
 
@@ -296,8 +295,7 @@ func isRetryableError(err error) bool {
 func isRetryableNetError(err error) bool {
 	// Check OpError first - dial errors (including dial timeouts) are retryable
 	// since they indicate transient connection issues, not slow server responses
-	var opErr *net.OpError
-	if errors.As(err, &opErr) {
+	if opErr, ok := errors.AsType[*net.OpError](err); ok {
 		if opErr.Op == "dial" {
 			return true
 		}

--- a/internal/proxy/retry_transport_test.go
+++ b/internal/proxy/retry_transport_test.go
@@ -828,10 +828,8 @@ func TestRetryTransport_ClosesIdleConnectionsMultipleTimes(t *testing.T) {
 
 func TestRetryTransport_DoesNotCloseOnNonRetryableError(t *testing.T) {
 	mock := &mockTransportWithIdleClose{
-		mockRoundTripper: mockRoundTripper{
-			err:        errors.New("some non-retryable error"),
-			maxAttempt: 10,
-		},
+		err:        errors.New("some non-retryable error"),
+		maxAttempt: 10,
 	}
 
 	transport := NewRetryTransport(mock)

--- a/internal/services/crossseed/search_run_partial_failure_test.go
+++ b/internal/services/crossseed/search_run_partial_failure_test.go
@@ -161,25 +161,23 @@ func TestSearchRunLoop_OneFailedCandidateDoesNotFailWholeRun(t *testing.T) {
 	require.NoError(t, err)
 
 	svc, state := newSearchRunLoopFixture(t, "crossseed-runloop-partial-failure", &hashFilteringSyncManager{
-		gazelleSkipHashSyncManager: gazelleSkipHashSyncManager{
-			torrents: []qbt.Torrent{brokenTorrent, sourceTorrent},
-			filesByHash: map[string]qbt.TorrentFiles{
-				sourceHashNorm: sourceFiles,
-				strings.ToLower(cachedCandidate.Hash): {
-					{Name: "During - LMK (2024 WF)/01 - Durante - Track.flac", Size: 123},
-				},
+		torrents: []qbt.Torrent{brokenTorrent, sourceTorrent},
+		filesByHash: map[string]qbt.TorrentFiles{
+			sourceHashNorm: sourceFiles,
+			strings.ToLower(cachedCandidate.Hash): {
+				{Name: "During - LMK (2024 WF)/01 - Durante - Track.flac", Size: 123},
 			},
-			cachedInstanceTorrents: []internalqb.CrossInstanceTorrentView{
-				{
-					TorrentView: &internalqb.TorrentView{
-						Torrent: &cachedCandidate,
-					},
-					InstanceID:   1,
-					InstanceName: "Local Node",
-				},
-			},
-			exportedTorrent: torrentBytes,
 		},
+		cachedInstanceTorrents: []internalqb.CrossInstanceTorrentView{
+			{
+				TorrentView: &internalqb.TorrentView{
+					Torrent: &cachedCandidate,
+				},
+				InstanceID:   1,
+				InstanceName: "Local Node",
+			},
+		},
+		exportedTorrent: torrentBytes,
 	})
 
 	runSearchLoopToCompletion(t, svc, state)
@@ -229,9 +227,7 @@ func TestSearchRunLoop_AllCandidatesFailedMarksRunFailed(t *testing.T) {
 	}
 
 	svc, state := newSearchRunLoopFixture(t, "crossseed-runloop-total-failure", &hashFilteringSyncManager{
-		gazelleSkipHashSyncManager: gazelleSkipHashSyncManager{
-			torrents: []qbt.Torrent{brokenTorrent},
-		},
+		torrents: []qbt.Torrent{brokenTorrent},
 	})
 
 	runSearchLoopToCompletion(t, svc, state)

--- a/internal/services/crossseed/search_torznab_failure_gazelle_test.go
+++ b/internal/services/crossseed/search_torznab_failure_gazelle_test.go
@@ -106,13 +106,11 @@ func newTorznabGazelleFixture(t *testing.T, dbName, trackerURL string) (*Service
 			},
 		}}}),
 		syncManager: &hashFilteringSyncManager{
-			gazelleSkipHashSyncManager: gazelleSkipHashSyncManager{
-				torrents: []qbt.Torrent{sourceTorrent},
-				filesByHash: map[string]qbt.TorrentFiles{
-					strings.ToLower(torznabGazelleSourceHash): sourceFiles,
-				},
-				exportedTorrent: torrentBytes,
+			torrents: []qbt.Torrent{sourceTorrent},
+			filesByHash: map[string]qbt.TorrentFiles{
+				strings.ToLower(torznabGazelleSourceHash): sourceFiles,
 			},
+			exportedTorrent: torrentBytes,
 		},
 		releaseCache:     NewReleaseCache(),
 		stringNormalizer: stringutils.NewDefaultNormalizer(),

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -2779,8 +2779,7 @@ func completionRetryDelay(err error) (time.Duration, bool) {
 		return 0, false
 	}
 
-	var waitErr *jackett.RateLimitWaitError
-	if errors.As(err, &waitErr) {
+	if waitErr, ok := errors.AsType[*jackett.RateLimitWaitError](err); ok {
 		if waitErr.Wait > 0 {
 			return waitErr.Wait, true
 		}
@@ -15403,8 +15402,7 @@ func (s *Service) processReflinkMode(
 	// Materialize only after the coverage and plan gates so clearly invalid
 	// partial matches are skipped before probing filesystem capabilities.
 	created, err := s.materializeReflink(selectedBaseDir, plan)
-	var unsupportedErr *reflinkUnsupportedError
-	if errors.As(err, &unsupportedErr) {
+	if unsupportedErr, ok := errors.AsType[*reflinkUnsupportedError](err); ok {
 		log.Warn().
 			Str("reason", unsupportedErr.reason).
 			Str("baseDir", selectedBaseDir).

--- a/internal/services/crossseed/service_local_matches_reflink_test.go
+++ b/internal/services/crossseed/service_local_matches_reflink_test.go
@@ -474,10 +474,10 @@ func TestFindLocalMatches_ReflinkVerificationErrorPolicy(t *testing.T) {
 	}
 	candidate := *hardlinkTestCandidate(candidateDir)
 	syncManager := &reflinkFindLocalMatchesSyncManager{
-		localMatchSyncManager: localMatchSyncManager{files: map[string]qbt.TorrentFiles{
+		files: map[string]qbt.TorrentFiles{
 			normalizeHash(hlSourceHash):    files,
 			normalizeHash(hlCandidateHash): files,
-		}},
+		},
 		source:    source,
 		candidate: candidate,
 	}

--- a/internal/services/jackett/scheduler_test.go
+++ b/internal/services/jackett/scheduler_test.go
@@ -106,7 +106,7 @@ func TestSearchScheduler_PriorityOrdering(t *testing.T) {
 
 	var executedTasks []RateLimitPriority
 	var execMu sync.Mutex
-	var completed int32
+	var completed atomic.Int32
 	done := make(chan struct{})
 
 	exec := func(_ context.Context, _ []*models.TorznabIndexer, _ url.Values, meta *searchContext) ([]Result, []int, error) {
@@ -123,7 +123,7 @@ func TestSearchScheduler_PriorityOrdering(t *testing.T) {
 	indexer2 := &models.TorznabIndexer{ID: 2, Name: "indexer2"}
 
 	callback := func(jobID uint64) {
-		if atomic.AddInt32(&completed, 1) == 2 {
+		if completed.Add(1) == 2 {
 			close(done)
 		}
 	}
@@ -167,25 +167,24 @@ func TestSearchScheduler_WorkerPoolLimit(t *testing.T) {
 	s := newSearchScheduler(rl, 2) // Only 2 workers
 	defer s.Stop()
 
-	var maxConcurrent int32
-	var currentConcurrent int32
-	var completed int32
+	var maxConcurrent atomic.Int32
+	var currentConcurrent atomic.Int32
+	var completed atomic.Int32
 	done := make(chan struct{})
 
 	exec := func(_ context.Context, _ []*models.TorznabIndexer, _ url.Values, _ *searchContext) ([]Result, []int, error) {
-		current := atomic.AddInt32(&currentConcurrent, 1)
+		current := currentConcurrent.Add(1)
 		for {
-			max := atomic.LoadInt32(&maxConcurrent)
-			if current > max {
-				if atomic.CompareAndSwapInt32(&maxConcurrent, max, current) {
-					break
-				}
-			} else {
+			peak := maxConcurrent.Load()
+			if current <= peak {
+				break
+			}
+			if maxConcurrent.CompareAndSwap(peak, current) {
 				break
 			}
 		}
 		time.Sleep(50 * time.Millisecond)
-		atomic.AddInt32(&currentConcurrent, -1)
+		currentConcurrent.Add(-1)
 		return []Result{{Title: "test"}}, []int{1}, nil
 	}
 
@@ -197,7 +196,7 @@ func TestSearchScheduler_WorkerPoolLimit(t *testing.T) {
 			ExecFn:   exec,
 			Callbacks: JobCallbacks{
 				OnJobDone: func(jobID uint64) {
-					if atomic.AddInt32(&completed, 1) == 5 {
+					if completed.Add(1) == 5 {
 						close(done)
 					}
 				},
@@ -209,7 +208,7 @@ func TestSearchScheduler_WorkerPoolLimit(t *testing.T) {
 	<-done
 
 	// Max concurrent should be limited to 2 (worker pool size)
-	assert.LessOrEqual(t, atomic.LoadInt32(&maxConcurrent), int32(2))
+	assert.LessOrEqual(t, maxConcurrent.Load(), int32(2))
 }
 
 func TestSearchScheduler_ContextCancellation(t *testing.T) {
@@ -261,7 +260,7 @@ func TestSearchScheduler_WorkerPanicRecovery(t *testing.T) {
 	s := newSearchScheduler(nil, 10)
 	defer s.Stop()
 
-	var completed int32
+	var completed atomic.Int32
 	done := make(chan struct{})
 
 	// Exec that panics for indexer 1, succeeds for indexer 2
@@ -283,7 +282,7 @@ func TestSearchScheduler_WorkerPanicRecovery(t *testing.T) {
 			OnComplete: func(_ uint64, _ *models.TorznabIndexer, _ []Result, _ []int, err error) {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), "scheduler worker panic")
-				if atomic.AddInt32(&completed, 1) == 2 {
+				if completed.Add(1) == 2 {
 					close(done)
 				}
 			},
@@ -299,7 +298,7 @@ func TestSearchScheduler_WorkerPanicRecovery(t *testing.T) {
 			OnComplete: func(_ uint64, _ *models.TorznabIndexer, results []Result, _ []int, err error) {
 				assert.NoError(t, err)
 				assert.Len(t, results, 1)
-				if atomic.AddInt32(&completed, 1) == 2 {
+				if completed.Add(1) == 2 {
 					close(done)
 				}
 			},
@@ -382,7 +381,7 @@ func TestSearchScheduler_RSSDeduplication(t *testing.T) {
 	defer s.Stop()
 
 	var executions atomic.Int32
-	var completed int32
+	var completed atomic.Int32
 	done := make(chan struct{})
 
 	exec := func(ctx context.Context, indexers []*models.TorznabIndexer, params url.Values, meta *searchContext) ([]Result, []int, error) {
@@ -395,7 +394,7 @@ func TestSearchScheduler_RSSDeduplication(t *testing.T) {
 	rssMeta := &searchContext{rateLimit: &RateLimitOptions{Priority: RateLimitPriorityRSS}}
 
 	callback := func(jobID uint64) {
-		if atomic.AddInt32(&completed, 1) == 2 {
+		if completed.Add(1) == 2 {
 			close(done)
 		}
 	}
@@ -554,7 +553,7 @@ func TestSearchScheduler_ConcurrentSubmissions(t *testing.T) {
 	defer s.Stop()
 
 	var executions atomic.Int32
-	var completed int32
+	var completed atomic.Int32
 	done := make(chan struct{})
 
 	exec := func(ctx context.Context, indexers []*models.TorznabIndexer, params url.Values, meta *searchContext) ([]Result, []int, error) {
@@ -578,7 +577,7 @@ func TestSearchScheduler_ConcurrentSubmissions(t *testing.T) {
 					ExecFn:   exec,
 					Callbacks: JobCallbacks{
 						OnJobDone: func(jobID uint64) {
-							if atomic.AddInt32(&completed, 1) == numGoroutines*tasksPerGoroutine {
+							if completed.Add(1) == numGoroutines*tasksPerGoroutine {
 								close(done)
 							}
 						},
@@ -746,10 +745,10 @@ func TestSearchScheduler_RateLimitIntervalStartsAfterCompletion(t *testing.T) {
 	defer s.Stop()
 
 	indexer := &models.TorznabIndexer{ID: 1, Name: "test-indexer"}
-	var calls int32
+	var calls atomic.Int32
 
 	exec := func(ctx context.Context, indexers []*models.TorznabIndexer, params url.Values, meta *searchContext) ([]Result, []int, error) {
-		if atomic.AddInt32(&calls, 1) == 1 {
+		if calls.Add(1) == 1 {
 			time.Sleep(100 * time.Millisecond)
 		}
 		return []Result{{Title: "test"}}, []int{1}, nil

--- a/internal/services/jackett/service.go
+++ b/internal/services/jackett/service.go
@@ -1178,8 +1178,7 @@ func isRetryableDownloadError(err error) bool {
 		return false
 	}
 
-	var dlErr *DownloadError
-	if errors.As(err, &dlErr) {
+	if dlErr, ok := errors.AsType[*DownloadError](err); ok {
 		return dlErr.StatusCode >= 500 && dlErr.StatusCode < 600
 	}
 
@@ -1876,8 +1875,7 @@ func (s *Service) MapCategoriesToIndexerCapabilities(ctx context.Context, indexe
 }
 
 func asRateLimitWaitError(err error) (*RateLimitWaitError, bool) {
-	var waitErr *RateLimitWaitError
-	if errors.As(err, &waitErr) {
+	if waitErr, ok := errors.AsType[*RateLimitWaitError](err); ok {
 		return waitErr, true
 	}
 	return nil, false

--- a/internal/services/notifications/notifiarr_api_test.go
+++ b/internal/services/notifications/notifiarr_api_test.go
@@ -28,7 +28,7 @@ func TestValidateNotifiarrAPIKeyValid(t *testing.T) {
 	t.Parallel()
 
 	var (
-		hits int32
+		hits atomic.Int32
 		ch   = make(chan struct {
 			key  string
 			path string
@@ -36,7 +36,7 @@ func TestValidateNotifiarrAPIKeyValid(t *testing.T) {
 	)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&hits, 1)
+		hits.Add(1)
 		ch <- struct {
 			key  string
 			path string
@@ -53,7 +53,7 @@ func TestValidateNotifiarrAPIKeyValid(t *testing.T) {
 
 	err := ValidateNotifiarrAPIKey(context.Background(), rawURL)
 	require.NoError(t, err)
-	require.Equal(t, int32(1), atomic.LoadInt32(&hits))
+	require.Equal(t, int32(1), hits.Load())
 	select {
 	case got := <-ch:
 		require.Equal(t, "abc123", got.key)

--- a/internal/services/notifications/service.go
+++ b/internal/services/notifications/service.go
@@ -100,7 +100,7 @@ func ValidateURL(rawURL string) error {
 		_, err := parseNotifiarrAPIConfig(rawURL)
 		return err
 	}
-	_, err := router.New(nil, rawURL)
+	_, err := router.NewWithOptions(nil, types.SenderOptions{}, rawURL)
 	return err
 }
 
@@ -207,7 +207,7 @@ func (s *Service) send(ctx context.Context, target *models.NotificationTarget, e
 }
 
 func (s *Service) sendDefault(rawURL, title, message string) error {
-	sender, err := router.New(nil, rawURL)
+	sender, err := router.NewWithOptions(nil, types.SenderOptions{}, rawURL)
 	if err != nil {
 		return err
 	}
@@ -257,7 +257,7 @@ func (s *Service) sendDiscord(rawURL string, event Event, title, message string)
 }
 
 func (s *Service) sendNotifiarr(rawURL string, _ Event, title, message string) error {
-	sender, err := router.New(nil, rawURL)
+	sender, err := router.NewWithOptions(nil, types.SenderOptions{}, rawURL)
 	if err != nil {
 		return err
 	}

--- a/pkg/debounce/debounce_test.go
+++ b/pkg/debounce/debounce_test.go
@@ -163,13 +163,13 @@ func TestDebouncer_MultipleSequences(t *testing.T) {
 	d := New(50 * time.Millisecond)
 	defer d.Stop()
 
-	var executed int64
+	var executed atomic.Int64
 
 	// First sequence
 	firstDone := make(chan bool, 1)
 	for range 3 {
 		d.Do(func() {
-			atomic.AddInt64(&executed, 1)
+			executed.Add(1)
 			firstDone <- true
 		})
 		time.Sleep(10 * time.Millisecond)
@@ -178,7 +178,7 @@ func TestDebouncer_MultipleSequences(t *testing.T) {
 	// Wait for first sequence execution
 	select {
 	case <-firstDone:
-		firstCount := atomic.LoadInt64(&executed)
+		firstCount := executed.Load()
 		if firstCount != 1 {
 			t.Errorf("Expected 1 execution in first sequence, got %d", firstCount)
 		}
@@ -190,7 +190,7 @@ func TestDebouncer_MultipleSequences(t *testing.T) {
 	secondDone := make(chan bool, 1)
 	for range 2 {
 		d.Do(func() {
-			atomic.AddInt64(&executed, 1)
+			executed.Add(1)
 			secondDone <- true
 		})
 		time.Sleep(10 * time.Millisecond)
@@ -199,7 +199,7 @@ func TestDebouncer_MultipleSequences(t *testing.T) {
 	// Wait for second sequence execution
 	select {
 	case <-secondDone:
-		totalCount := atomic.LoadInt64(&executed)
+		totalCount := executed.Load()
 		if totalCount != 2 {
 			t.Errorf("Expected 2 total executions, got %d", totalCount)
 		}

--- a/pkg/redact/redact.go
+++ b/pkg/redact/redact.go
@@ -129,8 +129,7 @@ func URLError(err error) error {
 		return nil
 	}
 
-	var urlErr *url.Error
-	if errors.As(err, &urlErr) {
+	if urlErr, ok := errors.AsType[*url.Error](err); ok {
 		// Clone the error with redacted URL
 		return &url.Error{
 			Op:  urlErr.Op,


### PR DESCRIPTION
## Description

Finishes the Go 1.27 move from #2369 so CI stops blocking PRs that did not cause the problem. Details and sizing in #2380.

Two commits:

1. **`golangci-lint` pin `v2.11.1` → `v2.13.0`.** v2.13.0 shipped 2026-08-19 built against Go 1.27 and analyzes this module — that was the release #2369 was waiting for.
2. **`go fix ./...`.** Go 1.27 permits promoted fields in composite literals and prefers the `atomic.Int32` value types over `atomic.AddInt32(&x, 1)`, so its fixer rewrites code that was idiomatic under 1.26. Nothing ran it when the toolchain moved, leaving 20 files drifting: 20 files, +120/−150.

Why it blocks anything: the `Check gofix drift on changed Go files` step inspects only packages a PR touches, so develop never checks itself, while any PR touching one of those 20 files fails on drift it did not introduce (currently #1915 and #1917, on `internal/api/handlers` and `internal/services/crossseed`). That step also runs before `Lint backend` with no `continue-on-error`, so golangci-lint has been **skipped** on every PR since the bump rather than merely deferred.

### Two spots the fixer could not do itself

- `service_local_matches_reflink_test.go`: `go fix` mangles a nested map literal inside an embedded struct field — it drops both the field key and the map type and leaves entries that do not parse. Written out by hand. Re-running `go fix ./...` on a clean tree reproduces the breakage, so it is worth knowing before anyone reruns the sweep.
- `scheduler_test.go`: rewriting the atomics moved a pre-existing local named `max` onto a changed line, where revive reports it as shadowing the builtin. Renamed to `peak`.

### Not in this PR

The 711 issues golangci-lint reports repo-wide once it can run again. `only-new-issues: true` keeps them off the gate — verified that #1915 reports 0 issues under `--new-from-merge-base=develop` with v2.13.0 — so they are debt to burn down deliberately, not a blocker. Breakdown in #2380.

## How has this been tested?

- `go fix -diff ./...` — clean
- `go test -race -count=1 ./internal/... ./pkg/...` — 46 packages, all pass
- `make precommit` (with golangci-lint v2.13.0) and `make build` — clean
- `go vet ./...` — only the pre-existing `lostcancel` in `internal/api/handlers/jackett.go:792`, untouched here

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [x] I ran `make precommit` and the tests pass locally
- [x] This change does not modify the database schema

## AI disclosure

Yes. Claude ran the fixer and the checks, hand-repaired the two spots it could not do itself, and drafted this description. The rewrites themselves are `go fix` output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend linting to a newer validation tool version.
  * Modernized internal error handling and concurrency utilities without changing behavior.

* **Bug Fixes**
  * Preserved transfer information, instance settings, proxy retry handling, database constraint detection, and notification validation behavior.

* **Tests**
  * Updated test fixtures and synchronization checks to maintain existing coverage and assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->