### PR TITLE
fix(database): resolve the sqlite→postgres import against the connection's schema

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,12 +37,7 @@ jobs:
       - name: Run tests (Postgres integration)
         env:
           QUI_TEST_POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/qui?sslmode=disable
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            go test -v -timeout 20m ./internal/database -run Postgres
-          else
-            go test -race -v -timeout 20m ./internal/database -run Postgres
-          fi
+        run: go test -race -count=1 -v -timeout 20m ./internal/database -run Postgres
 
   migration-parity:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,9 +39,9 @@ jobs:
           QUI_TEST_POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/qui?sslmode=disable
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            go test -v -timeout 20m ./internal/database -run TestOpenPostgres
+            go test -v -timeout 20m ./internal/database -run Postgres
           else
-            go test -race -v -timeout 20m ./internal/database -run TestOpenPostgres
+            go test -race -v -timeout 20m ./internal/database -run Postgres
           fi
 
   migration-parity:

--- a/internal/database/postgres_integration_test.go
+++ b/internal/database/postgres_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -41,13 +42,14 @@ func TestCleanupUnusedStringsPostgres(t *testing.T) {
 	t.Parallel()
 
 	db, ctx := openPostgresTestDB(t)
-	conn := db.Conn()
 
+	// Through the DB wrapper, not db.Conn(): the raw handle skips the ?-to-$n
+	// rebinding, so every placeholder below would reach Postgres verbatim.
 	var referencedID, orphanID int64
-	require.NoError(t, conn.QueryRowContext(ctx, "INSERT INTO string_pool (value) VALUES (?) RETURNING id", "pg_referenced").Scan(&referencedID))
-	require.NoError(t, conn.QueryRowContext(ctx, "INSERT INTO string_pool (value) VALUES (?) RETURNING id", "pg_orphan").Scan(&orphanID))
+	require.NoError(t, db.QueryRowContext(ctx, "INSERT INTO string_pool (value) VALUES (?) RETURNING id", "pg_referenced").Scan(&referencedID))
+	require.NoError(t, db.QueryRowContext(ctx, "INSERT INTO string_pool (value) VALUES (?) RETURNING id", "pg_orphan").Scan(&orphanID))
 
-	_, err := conn.ExecContext(ctx, `
+	_, err := db.ExecContext(ctx, `
 		INSERT INTO instances (name_id, host_id, username_id, password_encrypted)
 		VALUES (?, ?, ?, ?)
 	`, referencedID, referencedID, referencedID, "dummy_password")
@@ -58,9 +60,9 @@ func TestCleanupUnusedStringsPostgres(t *testing.T) {
 	require.Positive(t, deleted)
 
 	var exists bool
-	require.NoError(t, conn.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM string_pool WHERE id = ?)", referencedID).Scan(&exists))
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM string_pool WHERE id = ?)", referencedID).Scan(&exists))
 	require.True(t, exists)
-	require.NoError(t, conn.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM string_pool WHERE id = ?)", orphanID).Scan(&exists))
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM string_pool WHERE id = ?)", orphanID).Scan(&exists))
 	require.False(t, exists)
 
 	deletedAgain, err := db.CleanupUnusedStrings(ctx)
@@ -172,6 +174,9 @@ func openPostgresTestDB(t *testing.T) (*DB, context.Context) {
 	return db, ctx
 }
 
+// testSchemaSeq keeps parallel tests from claiming the same schema name.
+var testSchemaSeq atomic.Int64
+
 func openPostgresTestSchema(t *testing.T) (context.Context, string) {
 	t.Helper()
 
@@ -187,7 +192,9 @@ func openPostgresTestSchema(t *testing.T) (context.Context, string) {
 	require.NoError(t, err)
 	t.Cleanup(adminPool.Close)
 
-	schemaName := fmt.Sprintf("qui_test_%d", time.Now().UnixNano())
+	// UnixNano alone collides: the clock is coarse enough that two tests
+	// starting together get the same value, and these all run in parallel.
+	schemaName := fmt.Sprintf("qui_test_%d_%d", time.Now().UnixNano(), testSchemaSeq.Add(1))
 	_, err = adminPool.Exec(ctx, "CREATE SCHEMA "+quoteIdent(schemaName))
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/internal/database/postgres_integration_test.go
+++ b/internal/database/postgres_integration_test.go
@@ -216,3 +216,51 @@ func dsnWithSearchPath(t *testing.T, dsn string, schema string) string {
 	parsed.RawQuery = query.Encode()
 	return parsed.String()
 }
+
+// TestPostgresImportForeignKeysIgnoreOtherSchemas pins both catalog queries to
+// the active schema. A foreign key referencing another schema's same-named
+// table used to survive: regclass text output qualifies only what search_path
+// cannot reach, and stripping that qualifier turned the reference into a local
+// one. That invents an import dependency (here a cycle, which fails the order)
+// and hands the row filter a parent table that is not the one being referenced.
+func TestPostgresImportForeignKeysIgnoreOtherSchemas(t *testing.T) {
+	t.Parallel()
+
+	ctx, testDSN := openPostgresTestSchema(t)
+	pool, err := pgxpool.New(ctx, testDSN)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+
+	var activeSchema string
+	require.NoError(t, pool.QueryRow(ctx, "SELECT current_schema()").Scan(&activeSchema))
+	decoySchema := activeSchema + "_decoy"
+	_, err = pool.Exec(ctx, "CREATE SCHEMA "+quoteIdent(decoySchema))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), fmt.Sprintf("DROP SCHEMA %s CASCADE", quoteIdent(decoySchema)))
+	})
+
+	// The decoy holds a table whose name collides with one in the active schema,
+	// so a stripped qualifier lands on the local table of the same name.
+	_, err = pool.Exec(ctx, fmt.Sprintf(`
+		CREATE TABLE %s.orphan_target (id integer PRIMARY KEY);
+		CREATE TABLE orphan_target (id integer PRIMARY KEY, linker_id integer);
+		CREATE TABLE linker (id integer PRIMARY KEY, decoy_id integer REFERENCES %s.orphan_target(id));
+		ALTER TABLE orphan_target ADD CONSTRAINT orphan_target_linker_fk FOREIGN KEY (linker_id) REFERENCES linker(id);
+	`, quoteIdent(decoySchema), quoteIdent(decoySchema)))
+	require.NoError(t, err)
+
+	tx, err := pool.Begin(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tx.Rollback(context.Background()) })
+
+	// linker -> decoy.orphan_target is the cross-schema edge. Read as local it
+	// pairs with orphan_target -> linker into a cycle and the sort fails.
+	ordered, err := orderPostgresImportTables(ctx, tx, []string{"linker", "orphan_target"})
+	require.NoError(t, err)
+	require.Equal(t, []string{"linker", "orphan_target"}, ordered)
+
+	fks, err := postgresForeignKeysForTable(ctx, tx, "linker")
+	require.NoError(t, err)
+	require.Empty(t, fks, "a foreign key into another schema must not filter the copy against a local table")
+}

--- a/internal/database/sqlite_to_postgres.go
+++ b/internal/database/sqlite_to_postgres.go
@@ -140,8 +140,10 @@ func orderPostgresImportTables(ctx context.Context, tx pgx.Tx, tables []string) 
 
 	rows, err := tx.Query(ctx, `
 		SELECT conrelid::regclass::text, confrelid::regclass::text
-		FROM pg_constraint
-		WHERE contype = 'f'
+		FROM pg_constraint c
+		JOIN pg_namespace n ON n.oid = c.connamespace
+		WHERE c.contype = 'f'
+		  AND n.nspname = current_schema()
 	`)
 	if err != nil {
 		return nil, fmt.Errorf("list postgres foreign keys: %w", err)

--- a/internal/database/sqlite_to_postgres.go
+++ b/internal/database/sqlite_to_postgres.go
@@ -138,12 +138,20 @@ func orderPostgresImportTables(ctx context.Context, tx pgx.Tx, tables []string) 
 		depsByName[table] = make(map[string]struct{})
 	}
 
+	// Both ends are read as bare relnames from the catalog and both are pinned
+	// to the active schema. regclass text output only qualifies what search_path
+	// cannot reach, so a foreign key referencing another schema's same-named
+	// table would otherwise read as a local dependency and can invent a cycle.
 	rows, err := tx.Query(ctx, `
-		SELECT conrelid::regclass::text, confrelid::regclass::text
+		SELECT child.relname, parent.relname
 		FROM pg_constraint c
-		JOIN pg_namespace n ON n.oid = c.connamespace
+		JOIN pg_class child ON child.oid = c.conrelid
+		JOIN pg_namespace child_ns ON child_ns.oid = child.relnamespace
+		JOIN pg_class parent ON parent.oid = c.confrelid
+		JOIN pg_namespace parent_ns ON parent_ns.oid = parent.relnamespace
 		WHERE c.contype = 'f'
-		  AND n.nspname = current_schema()
+		  AND child_ns.nspname = current_schema()
+		  AND parent_ns.nspname = current_schema()
 	`)
 	if err != nil {
 		return nil, fmt.Errorf("list postgres foreign keys: %w", err)
@@ -152,15 +160,12 @@ func orderPostgresImportTables(ctx context.Context, tx pgx.Tx, tables []string) 
 
 	for rows.Next() {
 		var (
-			rawTable    string
-			rawRefTable string
+			table    string
+			refTable string
 		)
-		if err := rows.Scan(&rawTable, &rawRefTable); err != nil {
+		if err := rows.Scan(&table, &refTable); err != nil {
 			return nil, fmt.Errorf("scan postgres foreign key: %w", err)
 		}
-
-		table := normalizeRegclassTableName(rawTable)
-		refTable := normalizeRegclassTableName(rawRefTable)
 
 		if table == "" || refTable == "" || table == refTable {
 			continue
@@ -198,22 +203,6 @@ func orderPostgresImportTables(ctx context.Context, tx pgx.Tx, tables []string) 
 		ordered = append(ordered, meta.Name)
 	}
 	return ordered, nil
-}
-
-func normalizeRegclassTableName(value string) string {
-	if value == "" {
-		return ""
-	}
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return ""
-	}
-	if idx := strings.LastIndex(value, "."); idx >= 0 {
-		value = value[idx+1:]
-	}
-	value = strings.TrimPrefix(value, "\"")
-	value = strings.TrimSuffix(value, "\"")
-	return value
 }
 
 func validateMigrationOptions(opts SQLiteToPostgresMigrationOptions) (string, string, error) {
@@ -657,18 +646,25 @@ func postgresForeignKeysForTable(ctx context.Context, tx pgx.Tx, table string) (
 	// search_path rather than assuming the tables live in public.
 	regclassName := quoteIdent(table)
 
+	// The parent name comes back as a bare relname pinned to the active schema:
+	// it is used as a SQLite table name in the row filter below, so a foreign key
+	// referencing another schema must not be stripped down to a local-looking
+	// name and filter the copy against an unrelated table.
 	rows, err := tx.Query(ctx, `
-		SELECT confrelid::regclass::text,
+		SELECT parent.relname,
 			   ARRAY_AGG(child_col.attname ORDER BY ck.ord),
 			   ARRAY_AGG(parent_col.attname ORDER BY ck.ord)
 		FROM pg_constraint c
+		JOIN pg_class parent ON parent.oid = c.confrelid
+		JOIN pg_namespace parent_ns ON parent_ns.oid = parent.relnamespace
 		JOIN unnest(c.conkey) WITH ORDINALITY AS ck(attnum, ord) ON true
 		JOIN pg_attribute child_col ON child_col.attrelid = c.conrelid AND child_col.attnum = ck.attnum
 		JOIN unnest(c.confkey) WITH ORDINALITY AS fk(attnum, ord) ON fk.ord = ck.ord
 		JOIN pg_attribute parent_col ON parent_col.attrelid = c.confrelid AND parent_col.attnum = fk.attnum
 		WHERE c.contype = 'f'
 		  AND c.conrelid = $1::regclass
-		GROUP BY c.oid, c.confrelid
+		  AND parent_ns.nspname = current_schema()
+		GROUP BY c.oid, parent.relname
 	`, regclassName)
 	if err != nil {
 		return nil, fmt.Errorf("list postgres foreign keys for %s: %w", table, err)
@@ -678,14 +674,13 @@ func postgresForeignKeysForTable(ctx context.Context, tx pgx.Tx, table string) (
 	var fks []postgresForeignKey
 	for rows.Next() {
 		var (
-			rawParent     string
+			parentTable   string
 			childColumns  []string
 			parentColumns []string
 		)
-		if err := rows.Scan(&rawParent, &childColumns, &parentColumns); err != nil {
+		if err := rows.Scan(&parentTable, &childColumns, &parentColumns); err != nil {
 			return nil, fmt.Errorf("scan postgres foreign key for %s: %w", table, err)
 		}
-		parentTable := normalizeRegclassTableName(rawParent)
 		if parentTable == "" || parentTable == table {
 			continue
 		}

--- a/internal/database/sqlite_to_postgres.go
+++ b/internal/database/sqlite_to_postgres.go
@@ -521,7 +521,7 @@ func listPostgresTables(ctx context.Context, pool *pgxpool.Pool) (map[string]str
 	rows, err := pool.Query(ctx, `
 		SELECT table_name
 		FROM information_schema.tables
-		WHERE table_schema = 'public'
+		WHERE table_schema = current_schema()
 	`)
 	if err != nil {
 		return nil, fmt.Errorf("list postgres tables: %w", err)
@@ -585,7 +585,7 @@ func copySQLiteTableToPostgres(ctx context.Context, sqliteDB *sql.DB, tx pgx.Tx,
 	columns = filteredColumns
 	sqliteTypes = filteredTypes
 	if len(columns) == 0 {
-		return 0, nil
+		return 0, fmt.Errorf("table %s has no columns in common with its postgres counterpart", table)
 	}
 
 	fks, err := postgresForeignKeysForTable(ctx, tx, table)
@@ -651,7 +651,9 @@ type postgresForeignKey struct {
 }
 
 func postgresForeignKeysForTable(ctx context.Context, tx pgx.Tx, table string) ([]postgresForeignKey, error) {
-	regclassName := "public." + table
+	// Unqualified so the regclass cast resolves against the connection's
+	// search_path rather than assuming the tables live in public.
+	regclassName := quoteIdent(table)
 
 	rows, err := tx.Query(ctx, `
 		SELECT confrelid::regclass::text,
@@ -737,7 +739,7 @@ func postgresTableColumnSet(ctx context.Context, tx pgx.Tx, table string) (map[s
 	rows, err := tx.Query(ctx, `
 		SELECT column_name
 		FROM information_schema.columns
-		WHERE table_schema = 'public'
+		WHERE table_schema = current_schema()
 		  AND table_name = $1
 	`, table)
 	if err != nil {
@@ -837,7 +839,7 @@ func resetPostgresIdentities(ctx context.Context, tx pgx.Tx) error {
 	rows, err := tx.Query(ctx, `
 		SELECT table_name, column_name
 		FROM information_schema.columns
-		WHERE table_schema = 'public'
+		WHERE table_schema = current_schema()
 		  AND is_identity = 'YES'
 	`)
 	if err != nil {
@@ -864,7 +866,9 @@ func resetPostgresIdentities(ctx context.Context, tx pgx.Tx) error {
 	rows.Close()
 
 	for _, identity := range identityColumns {
-		fullTable := quoteIdent("public") + "." + quoteIdent(identity.table)
+		// Unqualified so pg_get_serial_sequence resolves it against the
+		// connection's search_path, same as every other statement here.
+		fullTable := quoteIdent(identity.table)
 		query := fmt.Sprintf(`
 			SELECT setval(
 				pg_get_serial_sequence($1, $2),


### PR DESCRIPTION
## Description

`MigrateSQLiteToPostgres` hardcoded `public` in every piece of schema metadata it reads — the table list, the column list, the identity columns, and the regclass cast behind the foreign-key lookup. Against a connection whose `search_path` points somewhere else, the column lookup returns nothing, every table is filtered down to zero columns, and the import commits having copied no rows at all while reporting `Applied: true` with `SQLiteRows` populated and `PostgresRows` zero across the board. The internal copy-count check cannot catch it, since copied and destination both agree on zero.

Deployments on the default search_path were never affected — `current_schema()` is `public` there — which is why nothing noticed. The only caller that is not on public is the test harness, and its tests do not run.

Second commit is why: the Postgres job filtered on `-run TestOpenPostgres`, a regex matching exactly one test, so `TestCleanupUnusedStringsPostgres` and `TestMigratedSQLiteFilesmanagerCleanupPostgres` have never run anywhere. Both failed the first time they were executed — one on the import bug above, the other driving `?` placeholders through `db.Conn()`, which is the raw handle and skips the rebinding the `DB` wrapper does. With both running in parallel, `openPostgresTestSchema` then collided on `qui_test_<UnixNano>` schema names.

Changes:

- Read schema metadata with `current_schema()`; leave regclass casts unqualified so they resolve like the import's own statements.
- A table with no columns in common with its Postgres counterpart is now an error, not a silent no-op.
- CI filters on `-run Postgres` so the job runs what the file contains.
- Test placeholders go through the `DB` wrapper; test schema names are unique per test.

Fixes #2382

## How has this been tested?

Against `postgres:16` in Docker:

- All Postgres integration tests pass, including the two that had never run.
- Six consecutive runs of the full Postgres set with no schema-name collisions.
- `go test -race -count=1 ./internal/database` green both with `QUI_TEST_POSTGRES_DSN` set and without it (SQLite-only path unchanged).
- `make precommit` clean.

Verified the failure directly before fixing it: with the old code and a per-test schema, the import reported `Applied: true` with `string_pool SQLiteRows:9 PostgresRows:0` and every other table likewise at zero.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [x] I ran `make precommit` and the tests pass locally
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

## AI disclosure

Yes. Claude Code (Opus) wrote the fix and the test changes under my direction; the bug was found by adding Postgres coverage in #1917 and following the zero-row report back to the hardcoded schema. I reviewed every line and ran the Postgres suite locally against Docker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PostgreSQL compatibility across custom schemas and search paths.
  * Corrected foreign-key handling and identity resets during database migration.
  * Cross-schema foreign-key references are now handled correctly during imports.
  * Added an error when no compatible columns are available for a table transfer.
  * Improved reliability of parallel PostgreSQL test cleanup and schema isolation.

* **Tests**
  * PostgreSQL integration tests now consistently run with race detection and without cached results.
  * Expanded coverage for database migration, schema filtering, and cleanup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->