### PR TITLE
feat(themes): store theme selection in the database

### DIFF
--- a/cmd/qui/main.go
+++ b/cmd/qui/main.go
@@ -534,6 +534,7 @@ func (app *Application) runServer() {
 	automationStore := models.NewAutomationStore(db)
 	trackerCustomizationStore := models.NewTrackerCustomizationStore(db)
 	dashboardSettingsStore := models.NewDashboardSettingsStore(db)
+	themeSettingsStore := models.NewThemeSettingsStore(db)
 	filterViewStore := models.NewFilterViewStore(db)
 	logExclusionsStore := models.NewLogExclusionsStore(db)
 
@@ -798,6 +799,7 @@ func (app *Application) runServer() {
 		AutomationService:                automationService,
 		TrackerCustomizationStore:        trackerCustomizationStore,
 		DashboardSettingsStore:           dashboardSettingsStore,
+		ThemeSettingsStore:               themeSettingsStore,
 		FilterViewStore:                  filterViewStore,
 		LogExclusionsStore:               logExclusionsStore,
 		NotificationTargetStore:          notificationTargetStore,

--- a/internal/api/handlers/themes.go
+++ b/internal/api/handlers/themes.go
@@ -5,6 +5,7 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -13,6 +14,8 @@ import (
 	"strings"
 
 	"github.com/rs/zerolog/log"
+
+	"github.com/autobrr/qui/internal/models"
 )
 
 const (
@@ -34,13 +37,21 @@ type themesDirProvider interface {
 	EnsureCustomThemesDir() (string, error)
 }
 
+// themeSettingsStore persists the selected theme.
+// Satisfied by *models.ThemeSettingsStore.
+type themeSettingsStore interface {
+	Get(ctx context.Context) (*models.ThemeSettings, error)
+	Set(ctx context.Context, ts *models.ThemeSettings) error
+}
+
 type ThemesHandler struct {
 	themesDir themesDirProvider
 	premium   premiumChecker
+	settings  themeSettingsStore
 }
 
-func NewThemesHandler(themesDir themesDirProvider, premium premiumChecker) *ThemesHandler {
-	return &ThemesHandler{themesDir: themesDir, premium: premium}
+func NewThemesHandler(themesDir themesDirProvider, premium premiumChecker, settings themeSettingsStore) *ThemesHandler {
+	return &ThemesHandler{themesDir: themesDir, premium: premium, settings: settings}
 }
 
 // CustomTheme is a single sideloaded theme file and its raw CSS contents.
@@ -135,4 +146,54 @@ func readCustomThemeCSS(path string) ([]byte, bool) {
 	}
 
 	return css, true
+}
+
+// GetThemeSettings returns the stored theme selection, or null when none is saved.
+func (h *ThemesHandler) GetThemeSettings(w http.ResponseWriter, r *http.Request) {
+	settings, err := h.settings.Get(r.Context())
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to load theme settings")
+		RespondError(w, http.StatusInternalServerError, "Failed to load theme settings")
+		return
+	}
+	RespondJSON(w, http.StatusOK, settings)
+}
+
+// UpdateThemeSettings stores the theme selection. It is premium-gated:
+// callers without an active premium-access license receive 403.
+func (h *ThemesHandler) UpdateThemeSettings(w http.ResponseWriter, r *http.Request) {
+	hasPremium, err := h.premium.HasPremiumAccess(r.Context())
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to check premium access for theme settings")
+		RespondError(w, http.StatusInternalServerError, "Failed to check premium access")
+		return
+	}
+	if !hasPremium {
+		RespondError(w, http.StatusForbidden, "Premium access required")
+		return
+	}
+
+	var settings models.ThemeSettings
+	if err := json.NewDecoder(r.Body).Decode(&settings); err != nil {
+		RespondError(w, http.StatusBadRequest, "Invalid request payload")
+		return
+	}
+	if settings.ThemeID == "" {
+		RespondError(w, http.StatusBadRequest, "themeId is required")
+		return
+	}
+	if settings.Mode == "" {
+		settings.Mode = "auto"
+	}
+	if settings.Mode != "auto" && settings.Mode != "light" && settings.Mode != "dark" {
+		RespondError(w, http.StatusBadRequest, "mode must be auto, light or dark")
+		return
+	}
+
+	if err := h.settings.Set(r.Context(), &settings); err != nil {
+		log.Error().Err(err).Msg("Failed to save theme settings")
+		RespondError(w, http.StatusInternalServerError, "Failed to save theme settings")
+		return
+	}
+	RespondJSON(w, http.StatusOK, settings)
 }

--- a/internal/api/handlers/themes_test.go
+++ b/internal/api/handlers/themes_test.go
@@ -12,9 +12,12 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/models"
 )
 
 // stubPremium controls the premium-access result for the themes handler tests.
@@ -46,7 +49,7 @@ func doListCustomThemes(t *testing.T, h *ThemesHandler) *httptest.ResponseRecord
 }
 
 func TestThemesHandler_NotPremium(t *testing.T) {
-	h := NewThemesHandler(stubThemesDir{dir: t.TempDir()}, stubPremium{ok: false})
+	h := NewThemesHandler(stubThemesDir{dir: t.TempDir()}, stubPremium{ok: false}, nil)
 	rec := doListCustomThemes(t, h)
 
 	require.Equal(t, http.StatusForbidden, rec.Code)
@@ -56,14 +59,14 @@ func TestThemesHandler_NotPremium(t *testing.T) {
 }
 
 func TestThemesHandler_PremiumCheckError(t *testing.T) {
-	h := NewThemesHandler(stubThemesDir{dir: t.TempDir()}, stubPremium{err: errors.New("boom")})
+	h := NewThemesHandler(stubThemesDir{dir: t.TempDir()}, stubPremium{err: errors.New("boom")}, nil)
 	rec := doListCustomThemes(t, h)
 	require.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
 func TestThemesHandler_EmptyDirReturnsEmptyArray(t *testing.T) {
 	dir := t.TempDir()
-	h := NewThemesHandler(stubThemesDir{dir: dir}, stubPremium{ok: true})
+	h := NewThemesHandler(stubThemesDir{dir: dir}, stubPremium{ok: true}, nil)
 	rec := doListCustomThemes(t, h)
 
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -89,7 +92,7 @@ func TestThemesHandler_ListsOnlyRegularCSSFiles(t *testing.T) {
 	require.NoError(t, os.WriteFile(outside, []byte(":root{--primary:red}"), 0o600))
 	_ = os.Symlink(outside, filepath.Join(dir, "linked.css"))
 
-	h := NewThemesHandler(stubThemesDir{dir: dir}, stubPremium{ok: true})
+	h := NewThemesHandler(stubThemesDir{dir: dir}, stubPremium{ok: true}, nil)
 	rec := doListCustomThemes(t, h)
 
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -108,7 +111,7 @@ func TestThemesHandler_SkipsOversizeFiles(t *testing.T) {
 	big := make([]byte, maxCustomThemeFileSize+1)
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "huge.css"), big, 0o600))
 
-	h := NewThemesHandler(stubThemesDir{dir: dir}, stubPremium{ok: true})
+	h := NewThemesHandler(stubThemesDir{dir: dir}, stubPremium{ok: true}, nil)
 	rec := doListCustomThemes(t, h)
 
 	var resp CustomThemesResponse
@@ -135,7 +138,7 @@ func TestThemesHandler_CapsFileCount(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(":root{}"), 0o600))
 	}
 
-	h := NewThemesHandler(stubThemesDir{dir: dir}, stubPremium{ok: true})
+	h := NewThemesHandler(stubThemesDir{dir: dir}, stubPremium{ok: true}, nil)
 	rec := doListCustomThemes(t, h)
 
 	var resp CustomThemesResponse
@@ -144,9 +147,94 @@ func TestThemesHandler_CapsFileCount(t *testing.T) {
 }
 
 func TestThemesHandler_EnsureDirErrorReturnsEmpty(t *testing.T) {
-	h := NewThemesHandler(stubThemesDir{dir: filepath.Join("non", "existent"), err: errors.New("mkdir failed")}, stubPremium{ok: true})
+	h := NewThemesHandler(stubThemesDir{dir: filepath.Join("non", "existent"), err: errors.New("mkdir failed")}, stubPremium{ok: true}, nil)
 	rec := doListCustomThemes(t, h)
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Contains(t, rec.Body.String(), `"themes":[]`)
+}
+
+// stubThemeSettings is an in-memory themeSettingsStore.
+type stubThemeSettings struct {
+	saved *models.ThemeSettings
+	err   error
+}
+
+func (s *stubThemeSettings) Get(context.Context) (*models.ThemeSettings, error) {
+	return s.saved, s.err
+}
+
+func (s *stubThemeSettings) Set(_ context.Context, ts *models.ThemeSettings) error {
+	if s.err != nil {
+		return s.err
+	}
+	s.saved = ts
+	return nil
+}
+
+func doUpdateThemeSettings(t *testing.T, h *ThemesHandler, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPut, "/api/themes/settings", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.UpdateThemeSettings(rec, req)
+	return rec
+}
+
+func TestThemeSettings_UpdateNotPremium(t *testing.T) {
+	store := &stubThemeSettings{}
+	h := NewThemesHandler(stubThemesDir{}, stubPremium{ok: false}, store)
+
+	rec := doUpdateThemeSettings(t, h, `{"themeId":"minimal"}`)
+
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.Nil(t, store.saved)
+}
+
+func TestThemeSettings_UpdateValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"missing themeId", `{"mode":"dark"}`},
+		{"bad mode", `{"themeId":"minimal","mode":"neon"}`},
+		{"bad json", `{`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &stubThemeSettings{}
+			h := NewThemesHandler(stubThemesDir{}, stubPremium{ok: true}, store)
+			rec := doUpdateThemeSettings(t, h, tt.body)
+			require.Equal(t, http.StatusBadRequest, rec.Code)
+			require.Nil(t, store.saved)
+		})
+	}
+}
+
+func TestThemeSettings_UpdateAndGet(t *testing.T) {
+	store := &stubThemeSettings{}
+	h := NewThemesHandler(stubThemesDir{}, stubPremium{ok: true}, store)
+
+	rec := doUpdateThemeSettings(t, h, `{"themeId":"minimal","variation":"blue"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, &models.ThemeSettings{ThemeID: "minimal", Mode: "auto", Variation: "blue"}, store.saved)
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/themes/settings", nil)
+	getRec := httptest.NewRecorder()
+	h.GetThemeSettings(getRec, req)
+	require.Equal(t, http.StatusOK, getRec.Code)
+
+	var got models.ThemeSettings
+	require.NoError(t, json.Unmarshal(getRec.Body.Bytes(), &got))
+	require.Equal(t, *store.saved, got)
+}
+
+func TestThemeSettings_GetEmpty(t *testing.T) {
+	h := NewThemesHandler(stubThemesDir{}, stubPremium{ok: true}, &stubThemeSettings{})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/themes/settings", nil)
+	rec := httptest.NewRecorder()
+	h.GetThemeSettings(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "null", strings.TrimSpace(rec.Body.String()))
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -79,6 +79,7 @@ type Server struct {
 	automationService                *automations.Service
 	trackerCustomizationStore        *models.TrackerCustomizationStore
 	dashboardSettingsStore           *models.DashboardSettingsStore
+	themeSettingsStore               *models.ThemeSettingsStore
 	filterViewStore                  *models.FilterViewStore
 	logExclusionsStore               *models.LogExclusionsStore
 	notificationTargetStore          *models.NotificationTargetStore
@@ -120,6 +121,7 @@ type Dependencies struct {
 	AutomationService                *automations.Service
 	TrackerCustomizationStore        *models.TrackerCustomizationStore
 	DashboardSettingsStore           *models.DashboardSettingsStore
+	ThemeSettingsStore               *models.ThemeSettingsStore
 	FilterViewStore                  *models.FilterViewStore
 	LogExclusionsStore               *models.LogExclusionsStore
 	NotificationTargetStore          *models.NotificationTargetStore
@@ -185,6 +187,7 @@ func NewServer(deps *Dependencies) *Server {
 		automationService:                deps.AutomationService,
 		trackerCustomizationStore:        deps.TrackerCustomizationStore,
 		dashboardSettingsStore:           deps.DashboardSettingsStore,
+		themeSettingsStore:               deps.ThemeSettingsStore,
 		filterViewStore:                  deps.FilterViewStore,
 		logExclusionsStore:               deps.LogExclusionsStore,
 		notificationTargetStore:          deps.NotificationTargetStore,
@@ -353,7 +356,7 @@ func (s *Server) Handler() (*chi.Mux, error) {
 	trackerIconHandler := handlers.NewTrackerIconHandler(s.trackerIconService)
 	proxyHandler := proxy.NewHandler(s.clientPool, s.clientAPIKeyStore, s.instanceStore, s.syncManager, s.reannounceCache, s.reannounceService, s.config.Config.BaseURL)
 	licenseHandler := handlers.NewLicenseHandler(s.licenseService)
-	themesHandler := handlers.NewThemesHandler(s.config, s.licenseService)
+	themesHandler := handlers.NewThemesHandler(s.config, s.licenseService, s.themeSettingsStore)
 	crossSeedHandler := handlers.NewCrossSeedHandler(
 		s.crossSeedService,
 		s.instanceCrossSeedCompletionStore,
@@ -433,6 +436,10 @@ func (s *Server) Handler() (*chi.Mux, error) {
 
 			// Sideloaded custom themes (premium-gated inside the handler)
 			r.Get("/themes/custom", themesHandler.ListCustomThemes)
+
+			// Persisted theme selection (writes premium-gated inside the handler)
+			r.Get("/themes/settings", themesHandler.GetThemeSettings)
+			r.Put("/themes/settings", themesHandler.UpdateThemeSettings)
 
 			// Jackett routes (if configured)
 			if jackettHandler != nil {

--- a/internal/database/migrations/088_add_theme_settings.sql
+++ b/internal/database/migrations/088_add_theme_settings.sql
@@ -1,0 +1,10 @@
+-- Copyright (c) 2026, s0up and the autobrr contributors.
+-- SPDX-License-Identifier: GPL-2.0-or-later
+
+CREATE TABLE IF NOT EXISTS theme_settings (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    theme_id TEXT NOT NULL,
+    mode TEXT NOT NULL DEFAULT 'auto',
+    variation TEXT NOT NULL DEFAULT '',
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/internal/database/postgres_migrations/090_add_theme_settings.sql
+++ b/internal/database/postgres_migrations/090_add_theme_settings.sql
@@ -1,0 +1,10 @@
+-- Copyright (c) 2026, s0up and the autobrr contributors.
+-- SPDX-License-Identifier: GPL-2.0-or-later
+
+CREATE TABLE IF NOT EXISTS theme_settings (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    theme_id TEXT NOT NULL,
+    mode TEXT NOT NULL DEFAULT 'auto',
+    variation TEXT NOT NULL DEFAULT '',
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/internal/models/theme_settings.go
+++ b/internal/models/theme_settings.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package models
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/autobrr/qui/internal/dbinterface"
+)
+
+// ThemeSettings is the single persisted theme selection (one row, id = 1).
+type ThemeSettings struct {
+	ThemeID   string `json:"themeId"`
+	Mode      string `json:"mode"`
+	Variation string `json:"variation,omitempty"`
+}
+
+type ThemeSettingsStore struct {
+	db dbinterface.Querier
+}
+
+func NewThemeSettingsStore(db dbinterface.Querier) *ThemeSettingsStore {
+	return &ThemeSettingsStore{db: db}
+}
+
+// Get returns the stored theme settings, or nil when none have been saved.
+func (s *ThemeSettingsStore) Get(ctx context.Context) (*ThemeSettings, error) {
+	var ts ThemeSettings
+
+	err := s.db.QueryRowContext(ctx, `
+		SELECT theme_id, mode, variation FROM theme_settings WHERE id = 1
+	`).Scan(&ts.ThemeID, &ts.Mode, &ts.Variation)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return &ts, nil
+}
+
+// Set stores the theme settings, replacing any previous selection.
+func (s *ThemeSettingsStore) Set(ctx context.Context, ts *ThemeSettings) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO theme_settings (id, theme_id, mode, variation)
+		VALUES (1, ?, ?, ?)
+		ON CONFLICT (id) DO UPDATE SET
+			theme_id = excluded.theme_id,
+			mode = excluded.mode,
+			variation = excluded.variation,
+			updated_at = CURRENT_TIMESTAMP
+	`, ts.ThemeID, ts.Mode, ts.Variation)
+	return err
+}

--- a/internal/models/theme_settings_test.go
+++ b/internal/models/theme_settings_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package models_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/testutil/testdb"
+)
+
+func TestThemeSettingsStore_GetEmpty(t *testing.T) {
+	store := models.NewThemeSettingsStore(testdb.NewMigratedSQLite(t, "theme-settings"))
+
+	settings, err := store.Get(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, settings)
+}
+
+func TestThemeSettingsStore_SetAndOverwrite(t *testing.T) {
+	store := models.NewThemeSettingsStore(testdb.NewMigratedSQLite(t, "theme-settings"))
+	ctx := context.Background()
+
+	require.NoError(t, store.Set(ctx, &models.ThemeSettings{ThemeID: "minimal", Mode: "dark", Variation: "blue"}))
+
+	settings, err := store.Get(ctx)
+	require.NoError(t, err)
+	require.Equal(t, &models.ThemeSettings{ThemeID: "minimal", Mode: "dark", Variation: "blue"}, settings)
+
+	// Overwrite: the single row is replaced, variation cleared.
+	require.NoError(t, store.Set(ctx, &models.ThemeSettings{ThemeID: "catppuccin", Mode: "auto"}))
+
+	settings, err = store.Get(ctx)
+	require.NoError(t, err)
+	require.Equal(t, &models.ThemeSettings{ThemeID: "catppuccin", Mode: "auto"}, settings)
+}

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -3103,6 +3103,47 @@ paths:
         '500':
           description: Failed to check premium access or read the custom themes directory
 
+  /api/themes/settings:
+    get:
+      tags:
+        - Themes
+      summary: Get stored theme selection
+      description: Get the theme selection stored in the database. Returns null when no selection is stored.
+      responses:
+        '200':
+          description: Stored theme selection, or null when none is stored
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ThemeSettings'
+                nullable: true
+        '500':
+          description: Failed to load theme settings
+    put:
+      tags:
+        - Themes
+      summary: Store theme selection
+      description: Store the theme selection in the database. Requires premium access.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ThemeSettings'
+      responses:
+        '200':
+          description: Theme selection stored
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ThemeSettings'
+        '400':
+          description: Invalid payload, missing themeId, or invalid mode
+        '403':
+          description: Premium access required
+        '500':
+          description: Failed to check premium access or save theme settings
+
   /api/torrents/export:
     post:
       tags:
@@ -5744,6 +5785,20 @@ components:
       description: Directory scan run ID
 
   schemas:
+    ThemeSettings:
+      type: object
+      required:
+        - themeId
+      properties:
+        themeId:
+          type: string
+        mode:
+          type: string
+          enum: [auto, light, dark]
+          default: auto
+        variation:
+          type: string
+
     User:
       type: object
       properties:

--- a/web/src/components/themes/CustomThemesLoader.tsx
+++ b/web/src/components/themes/CustomThemesLoader.tsx
@@ -4,12 +4,15 @@
  */
 
 import { useCustomThemes } from "@/hooks/useCustomThemes"
+import { useThemeSettingsSync } from "@/hooks/useThemeSettingsSync"
 
 /**
  * Mounts the custom-themes loader app-wide (for authenticated users) so a stored
  * custom theme is registered and applied even when the theme picker isn't open.
+ * Also keeps the theme selection synced with the server for premium users.
  */
 export function CustomThemesLoader(): null {
   useCustomThemes()
+  useThemeSettingsSync()
   return null
 }

--- a/web/src/hooks/useThemeSettingsSync.test.tsx
+++ b/web/src/hooks/useThemeSettingsSync.test.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { renderHook, act, cleanup } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { ReactNode } from "react"
+import { useThemeSettingsSync } from "./useThemeSettingsSync"
+
+const { mockApi, mockPremium } = vi.hoisted(() => ({
+  mockApi: {
+    getThemeSettings: vi.fn(() => Promise.resolve(undefined)),
+    updateThemeSettings: vi.fn(() => Promise.resolve({ themeId: "minimal", mode: "dark" })),
+  },
+  mockPremium: { hasPremiumAccess: true, isLoading: false, isError: false },
+}))
+
+vi.mock("@/lib/api", () => ({ api: mockApi }))
+vi.mock("@/hooks/useLicense", () => ({ useHasPremiumAccess: () => mockPremium }))
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}
+
+function dispatchThemeChange(detail: object) {
+  act(() => {
+    window.dispatchEvent(new CustomEvent("themechange", { detail }))
+  })
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+  mockPremium.hasPremiumAccess = true
+})
+
+describe("useThemeSettingsSync", () => {
+  it("pushes local theme changes to the server", () => {
+    renderHook(() => useThemeSettingsSync(), { wrapper })
+
+    dispatchThemeChange({ theme: { id: "minimal" }, mode: "dark", isSystemChange: false, variant: "blue" })
+
+    expect(mockApi.updateThemeSettings).toHaveBeenCalledExactlyOnceWith({
+      themeId: "minimal",
+      mode: "dark",
+      variation: "blue",
+    })
+  })
+
+  it("skips system-driven changes and duplicate payloads", () => {
+    renderHook(() => useThemeSettingsSync(), { wrapper })
+
+    dispatchThemeChange({ theme: { id: "minimal" }, mode: "auto", isSystemChange: true })
+    expect(mockApi.updateThemeSettings).not.toHaveBeenCalled()
+
+    dispatchThemeChange({ theme: { id: "minimal" }, mode: "dark", isSystemChange: false })
+    dispatchThemeChange({ theme: { id: "minimal" }, mode: "dark", isSystemChange: false })
+    expect(mockApi.updateThemeSettings).toHaveBeenCalledTimes(1)
+  })
+
+  it("does nothing without premium access", () => {
+    mockPremium.hasPremiumAccess = false
+    renderHook(() => useThemeSettingsSync(), { wrapper })
+
+    dispatchThemeChange({ theme: { id: "minimal" }, mode: "dark", isSystemChange: false })
+
+    expect(mockApi.getThemeSettings).not.toHaveBeenCalled()
+    expect(mockApi.updateThemeSettings).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/hooks/useThemeSettingsSync.ts
+++ b/web/src/hooks/useThemeSettingsSync.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { useEffect, useRef } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { api } from "@/lib/api"
+import { useHasPremiumAccess } from "@/hooks/useLicense"
+import { getThemeById } from "@/config/themes"
+import { setTheme } from "@/utils/theme"
+import type { ThemeSettings } from "@/types"
+
+/**
+ * Syncs the theme selection with the server (premium-gated). On load the
+ * stored server selection is applied; afterwards every local theme change is
+ * pushed to the server. localStorage stays as the instant-boot cache.
+ */
+export function useThemeSettingsSync(): void {
+  const { hasPremiumAccess } = useHasPremiumAccess()
+  // Last payload synced with the server, to avoid echoing an applied server
+  // value straight back as a PUT.
+  const lastSynced = useRef<string | null>(null)
+
+  const { data } = useQuery({
+    queryKey: ["theme-settings"],
+    queryFn: () => api.getThemeSettings(),
+    enabled: hasPremiumAccess,
+    staleTime: Infinity,
+    retry: false,
+  })
+
+  // Pull: apply the stored server selection.
+  useEffect(() => {
+    if (!data?.themeId) return
+    lastSynced.current = JSON.stringify(data)
+    // Skip unknown ids (e.g. a custom theme not registered yet) so we never
+    // downgrade the local selection to the default theme.
+    if (!getThemeById(data.themeId)) return
+    void setTheme(data.themeId, data.mode, data.variation)
+  }, [data])
+
+  // Push: store local theme changes on the server.
+  useEffect(() => {
+    if (!hasPremiumAccess) return
+
+    const handleThemeChange = (event: Event) => {
+      const { theme, mode, isSystemChange, variant } = (event as CustomEvent).detail
+      if (isSystemChange) return
+      const payload: ThemeSettings = { themeId: theme.id, mode, ...(variant ? { variation: variant } : {}) }
+      const serialized = JSON.stringify(payload)
+      if (serialized === lastSynced.current) return
+      lastSynced.current = serialized
+      api.updateThemeSettings(payload).catch(() => {
+        lastSynced.current = null
+      })
+    }
+
+    window.addEventListener("themechange", handleThemeChange)
+    return () => window.removeEventListener("themechange", handleThemeChange)
+  }, [hasPremiumAccess])
+}

--- a/web/src/hooks/useThemeSettingsSync.ts
+++ b/web/src/hooks/useThemeSettingsSync.ts
@@ -26,7 +26,8 @@ export function useThemeSettingsSync(): void {
     queryKey: ["theme-settings"],
     queryFn: () => api.getThemeSettings(),
     enabled: hasPremiumAccess,
-    staleTime: Infinity,
+    // Poll so an API-side theme change repaints open tabs; pauses while the tab is hidden.
+    refetchInterval: 5_000,
     retry: false,
   })
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -122,6 +122,7 @@ import type {
   TrackerCustomization,
   TrackerCustomizationInput,
   TransferInfo,
+  ThemeSettings,
   User,
   WarningResponse,
   WebSeed
@@ -2044,6 +2045,18 @@ class ApiClient {
     themes: Array<{ id: string; filename: string; css: string }>
   }> {
     return this.request("/themes/custom")
+  }
+
+  // Theme settings (theme selection stored in the database; writes premium-gated server-side)
+  async getThemeSettings(): Promise<ThemeSettings | null> {
+    return this.request<ThemeSettings | null>("/themes/settings")
+  }
+
+  async updateThemeSettings(data: ThemeSettings): Promise<ThemeSettings> {
+    return this.request<ThemeSettings>("/themes/settings", {
+      method: "PUT",
+      body: JSON.stringify(data),
+    })
   }
 
   // Preferences endpoints

--- a/web/src/types/app.ts
+++ b/web/src/types/app.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
+import type { ThemeMode } from "@/utils/theme"
+
 export interface ApplicationDatabaseInfo {
   engine: string
   target: string
@@ -289,4 +291,10 @@ export interface QBittorrentAppInfo {
 
 export interface QBittorrentProcessInfo {
   launchTime: number
+}
+
+export interface ThemeSettings {
+  themeId: string
+  mode: ThemeMode
+  variation?: string
 }


### PR DESCRIPTION
## Description

Stores the selected theme, mode, and variation in the database and exposes them at `GET`/`PUT /api/themes/settings`, so the selection follows the server instead of one browser. Writes require premium access. The frontend applies the stored selection on load and pushes local theme changes; localStorage stays as the instant-boot cache.

## How has this been tested?

New store, handler, and hook tests. `make precommit`, `make test-openapi`, targeted Go tests with `-race -count=1`, and `make build` all pass.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [x] I ran `make precommit` and the tests pass locally
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Premium users can save and synchronize theme selections across sessions, devices, and open tabs.
  * Added light, dark, and automatic modes with optional theme variations.
  * Saved settings apply automatically when the app loads, while local changes sync to the server.
  * Added API support for retrieving and updating theme settings.

* **Bug Fixes**
  * Prevented redundant updates and ignored system-driven theme changes during synchronization.

* **Documentation**
  * Documented the theme settings API and supported values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->