### PR TITLE
chore(github): trim pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@ Fixes # (issue)
 
 ## How has this been tested?
 
-<!--- Describe how you tested your change. --->
+<!--- Only manual or live verification that CI cannot do. Delete this section if CI covers everything. --->
 
 ## Screenshots (for UI changes)
 
@@ -17,8 +17,6 @@ Fixes # (issue)
 ## Checklist
 
 - [ ] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
-- [ ] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
-- [ ] I ran `make precommit` and the tests pass locally
 - [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL
 
 ## AI disclosure


### PR DESCRIPTION
## Description

Trim the PR template so PR bodies stay short. The testing section now asks only for manual or live verification that CI cannot do. The checklist keeps the two items that CI does not enforce: the Conventional Commits title and the dual SQLite and PostgreSQL migrations. CI already runs lint and tests, so those checklist items are gone.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pull request testing instructions to focus on manual or live verification.
  * Removed checklist items requiring contributors to review contribution guidelines and run local pre-commit checks and tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->