### PR TITLE
chore(lint): take the backlog to zero and gate on the whole repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Go tooling writes LF and gofmt normalises it, so a file committed with CRLF
+# shows up as a whole-file diff the first time anyone formats it.
+*.go text eol=lf

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,7 +55,11 @@ jobs:
           go-version-file: "go.mod"
           cache: true
 
+      # continue-on-error so a gofix failure reports itself without taking the
+      # lint step with it: the job used to fail here and skip linting entirely.
       - name: Check gofix drift on changed Go files
+        continue-on-error: true
+        id: gofix
         run: |
           gofiles=$({ git diff --name-only --diff-filter=d "origin/${{ github.base_ref }}"...HEAD; } | sort -u | grep '\.go$' || true)
           if [ -z "$gofiles" ]; then
@@ -100,4 +104,13 @@ jobs:
         uses: golangci/golangci-lint-action@v9.3.0
         with:
           version: v2.13.0
-          only-new-issues: true
+          # The backlog is zero as of this change, so the gate covers the whole
+          # repo rather than only changed lines. That is what stops drift
+          # accumulating unnoticed again — see #2380.
+          only-new-issues: false
+
+      - name: Fail if gofix drift was found
+        if: steps.gofix.outcome == 'failure'
+        run: |
+          echo "go fix reported drift on changed Go files; see the 'Check gofix drift' step above."
+          exit 1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,6 @@ formatters:
 
 linters:
   enable:
-    - containedctx
     - copyloopvar
     - errname
     - errorlint
@@ -39,7 +38,16 @@ linters:
 
   settings:
     exhaustive:
-      default-signifies-exhaustive: false
+      # A switch with a default has handled the rest by definition, and the repo
+      # asks for behaviour-bearing branches rather than a case per enum value
+      # that falls through to the same place.
+      default-signifies-exhaustive: true
+
+    gocritic:
+      disabled-checks:
+        # Taste, not correctness, and most of the hits are in crossseed and
+        # qbittorrent where the repo asks for minimal diffs.
+        - ifElseChain
 
     misspell:
       ignore-rules:
@@ -58,3 +66,38 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
+
+    rules:
+      # A parameter an interface forces on an implementation still documents
+      # what the caller passes; renaming it to _ loses that.
+      - linters:
+          - revive
+        text: "unused-parameter"
+
+      # Renaming CrossSeedRequest to Request, MetricsManager to Manager and so
+      # on is a wide rename through every caller for a naming preference.
+      - linters:
+          - revive
+        text: "stutters"
+
+      # gosec's taint analysis follows archive entry names through
+      # safeArchiveEntryPath, which validates them in the slash domain, and
+      # through backupRelPath for stored blobs. It cannot see either check.
+      - path: internal/api/handlers/backups\.go
+        linters:
+          - gosec
+        text: "G703"
+
+      # The generated config template contains a commented-out password field.
+      - path: internal/config/config\.go
+        linters:
+          - gosec
+        text: "G101"
+
+      # Test fixtures are allowed to hold obvious fake credentials, build
+      # requests without a context, and set cookies without the production
+      # attributes.
+      - path: _test\.go
+        linters:
+          - gosec
+          - noctx

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -82,17 +82,21 @@ linters:
 
       # gosec's taint analysis follows archive entry names through
       # safeArchiveEntryPath, which validates them in the slash domain, and
-      # through backupRelPath for stored blobs. It cannot see either check.
+      # cannot see the check. Scoped to the statements in the extraction flow
+      # so a new unvalidated path in this file is still reported.
       - path: internal/api/handlers/backups\.go
         linters:
           - gosec
         text: "G703"
+        source: "tmpFile\\.Name\\(\\)|filepath\\.Dir\\(destPath\\)|os\\.Create\\(destPath\\)|os\\.Open\\(archivePath\\)"
 
       # The generated config template contains a commented-out password field.
+      # Scoped to the template literal itself, which cannot carry a nolint.
       - path: internal/config/config\.go
         linters:
           - gosec
         text: "G101"
+        source: "configTemplate := "
 
       # Test fixtures are allowed to hold obvious fake credentials, build
       # requests without a context, and set cookies without the production

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -88,7 +88,7 @@ linters:
         linters:
           - gosec
         text: "G703"
-        source: "tmpFile\\.Name\\(\\)|filepath\\.Dir\\(destPath\\)|os\\.Create\\(destPath\\)|os\\.Open\\(archivePath\\)"
+        source: "tmpFile\\.Name\\(\\)|filepath\\.Dir\\(destPath\\)|os\\.Open\\(archivePath\\)"
 
       # The generated config template contains a commented-out password field.
       # Scoped to the template literal itself, which cannot carry a nolint.

--- a/cmd/qui/main.go
+++ b/cmd/qui/main.go
@@ -185,14 +185,14 @@ func readPassword(prompt string) (string, error) {
 			return "", fmt.Errorf("failed to read password: %w", err)
 		}
 		return string(password), nil
-	} else {
-		fmt.Fprint(os.Stderr, prompt)
-		var password string
-		if _, err := fmt.Scanln(&password); err != nil {
-			return "", fmt.Errorf("failed to read password from stdin: %w", err)
-		}
-		return password, nil
 	}
+
+	fmt.Fprint(os.Stderr, prompt)
+	var password string
+	if _, err := fmt.Scanln(&password); err != nil {
+		return "", fmt.Errorf("failed to read password from stdin: %w", err)
+	}
+	return password, nil
 }
 
 func RunCreateUserCommand() *cobra.Command {

--- a/internal/api/handlers/automations.go
+++ b/internal/api/handlers/automations.go
@@ -1029,11 +1029,11 @@ func (h *AutomationHandler) PreviewDeleteRule(w http.ResponseWriter, r *http.Req
 	previewLimit, previewOffset := payload.previewPagination()
 
 	if action == previewActionCategory {
-		h.handleCategoryPreview(w, r.Context(), instanceID, automation, previewLimit, previewOffset)
+		h.handleCategoryPreview(r.Context(), w, instanceID, automation, previewLimit, previewOffset)
 		return
 	}
 
-	h.handleDeletePreview(w, r.Context(), instanceID, automation, previewLimit, previewOffset, payload.PreviewView)
+	h.handleDeletePreview(r.Context(), w, instanceID, automation, previewLimit, previewOffset, payload.PreviewView)
 }
 
 // previewPagination extracts limit and offset from payload with defaults.
@@ -1047,7 +1047,7 @@ func (p *AutomationPayload) previewPagination() (limit, offset int) {
 	return
 }
 
-func (h *AutomationHandler) handleCategoryPreview(w http.ResponseWriter, ctx context.Context, instanceID int, automation *models.Automation, limit, offset int) {
+func (h *AutomationHandler) handleCategoryPreview(ctx context.Context, w http.ResponseWriter, instanceID int, automation *models.Automation, limit, offset int) {
 	result, err := h.service.PreviewCategoryRule(ctx, instanceID, automation, limit, offset)
 	if err != nil {
 		log.Error().Err(err).Int("instanceID", instanceID).Msg("automations: failed to preview category rule")
@@ -1057,7 +1057,7 @@ func (h *AutomationHandler) handleCategoryPreview(w http.ResponseWriter, ctx con
 	RespondJSON(w, http.StatusOK, result)
 }
 
-func (h *AutomationHandler) handleDeletePreview(w http.ResponseWriter, ctx context.Context, instanceID int, automation *models.Automation, limit, offset int, previewView string) {
+func (h *AutomationHandler) handleDeletePreview(ctx context.Context, w http.ResponseWriter, instanceID int, automation *models.Automation, limit, offset int, previewView string) {
 	if previewView == "" {
 		previewView = "needed"
 	}

--- a/internal/api/handlers/backups_test.go
+++ b/internal/api/handlers/backups_test.go
@@ -823,7 +823,7 @@ func TestExtractionWritersRefuseExistingDestination(t *testing.T) {
 		err := copyStreamToFile(bytes.NewReader([]byte("second")), destPath)
 		require.ErrorIs(t, err, fs.ErrExist)
 
-		kept, err := os.ReadFile(destPath) //nolint:gosec // G703: a path this test just created under t.TempDir()
+		kept, err := os.ReadFile(destPath)
 		require.NoError(t, err)
 		assert.Equal(t, "first", string(kept), "the existing file must survive")
 	})
@@ -839,7 +839,7 @@ func TestExtractionWritersRefuseExistingDestination(t *testing.T) {
 
 		require.ErrorIs(t, extractZipFileToDisk(reader.File[0], destPath), fs.ErrExist)
 
-		kept, err := os.ReadFile(destPath) //nolint:gosec // G703: a path this test just created under t.TempDir()
+		kept, err := os.ReadFile(destPath)
 		require.NoError(t, err)
 		assert.Equal(t, "first", string(kept), "the existing file must survive")
 	})

--- a/internal/api/handlers/backups_test.go
+++ b/internal/api/handlers/backups_test.go
@@ -615,20 +615,20 @@ func TestGetBackupDownloadUrl(t *testing.T) {
 	defer func() { windowLocation = originalLocation }()
 
 	// Test without format (should not add query param)
-	url := getBackupDownloadUrl(1, 123)
+	url := getBackupDownloadURL(1, 123)
 	expected := "http://localhost:7476/api/instances/1/backups/runs/123/download"
 	assert.Equal(t, expected, url)
 
 	// Test with zip format (should not add query param since it's default)
-	url = getBackupDownloadUrl(1, 123, "zip")
+	url = getBackupDownloadURL(1, 123, "zip")
 	assert.Equal(t, expected, url)
 
 	// Test with other formats
-	url = getBackupDownloadUrl(1, 123, "tar.gz")
+	url = getBackupDownloadURL(1, 123, "tar.gz")
 	expected = "http://localhost:7476/api/instances/1/backups/runs/123/download?format=tar.gz"
 	assert.Equal(t, expected, url)
 
-	url = getBackupDownloadUrl(1, 123, "tar.zst")
+	url = getBackupDownloadURL(1, 123, "tar.zst")
 	expected = "http://localhost:7476/api/instances/1/backups/runs/123/download?format=tar.zst"
 	assert.Equal(t, expected, url)
 }
@@ -636,11 +636,11 @@ func TestGetBackupDownloadUrl(t *testing.T) {
 // Mock window.location for testing
 var windowLocation *url.URL
 
-func getBackupDownloadUrl(instanceId, runId int, format ...string) string {
+func getBackupDownloadURL(instanceID, runID int, format ...string) string {
 	u := &url.URL{
 		Scheme: windowLocation.Scheme,
 		Host:   windowLocation.Host,
-		Path:   fmt.Sprintf("/api/instances/%d/backups/runs/%d/download", instanceId, runId),
+		Path:   fmt.Sprintf("/api/instances/%d/backups/runs/%d/download", instanceID, runID),
 	}
 	if len(format) > 0 && format[0] != "" && format[0] != "zip" {
 		q := u.Query()

--- a/internal/api/handlers/crossseed_seasonpack_test.go
+++ b/internal/api/handlers/crossseed_seasonpack_test.go
@@ -188,7 +188,7 @@ func TestPatchAutomationSettings_AppliesSeasonPackFields(t *testing.T) {
 	}
 
 	threshold := 0.9
-	//nolint:gosec // test fixtures exercise trimming behavior; these are not real credentials.
+	// Test fixtures exercise trimming behavior; these are not real credentials.
 	tvdbCredential := "  tvdb value  "
 	subscriberCredential := "  subscriber value  "
 	patch := automationSettingsPatchRequest{

--- a/internal/api/handlers/logs.go
+++ b/internal/api/handlers/logs.go
@@ -237,7 +237,7 @@ func (h *LogsHandler) StreamLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.streamLoop(w, flusher, r.Context(), sub)
+	h.streamLoop(r.Context(), w, flusher, sub)
 }
 
 func (h *LogsHandler) parseLimit(r *http.Request) int {
@@ -290,7 +290,7 @@ func writeSSEData(w http.ResponseWriter, data string) error {
 	return err                                     //nolint:wrapcheck // SSE write errors are terminal; wrapping adds no value
 }
 
-func (h *LogsHandler) streamLoop(w http.ResponseWriter, flusher http.Flusher, ctx context.Context, sub *logstream.Subscriber) {
+func (h *LogsHandler) streamLoop(ctx context.Context, w http.ResponseWriter, flusher http.Flusher, sub *logstream.Subscriber) {
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
 

--- a/internal/api/handlers/oidc_test.go
+++ b/internal/api/handlers/oidc_test.go
@@ -58,14 +58,14 @@ func newOIDCDiscoveryServer(t *testing.T, codeChallenges []string) *httptest.Ser
 func newTestOIDCHandler(t *testing.T, issuer string) *OIDCHandler {
 	t.Helper()
 
-	// #nosec G101 -- test-only OIDC client config values.
+	// Test-only OIDC client config values.
 	cfg := &domain.Config{
 		OIDCEnabled:     true,
 		OIDCIssuer:      issuer,
 		OIDCClientID:    "client-id",
 		OIDCRedirectURL: "http://localhost/callback",
 	}
-	// #nosec G101 -- test-only placeholder used to satisfy OIDC config validation.
+	// Test-only placeholder used to satisfy OIDC config validation.
 	cfg.OIDCClientSecret = "placeholder"
 
 	handler, err := NewOIDCHandler(cfg, scs.New())

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -233,6 +233,7 @@ func (s *Server) open(ready chan<- struct{}) error {
 }
 
 func (s *Server) tryToServe(addr, protocol string, ready chan<- struct{}) error {
+	//nolint:noctx // the listener outlives every request; a ListenConfig context would only bound the bind itself
 	listener, err := net.Listen(protocol, addr)
 	if err != nil {
 		return err

--- a/internal/api/sse/manager.go
+++ b/internal/api/sse/manager.go
@@ -206,7 +206,7 @@ type StreamManager struct {
 	// activity events (and activity heartbeats). One topic per open SSE session.
 	activityTopics map[string]struct{}
 
-	ctx    context.Context //nolint:containedctx // lifecycle root context used only for coordinated shutdown
+	ctx    context.Context // Lifecycle root context used only for coordinated shutdown
 	cancel context.CancelFunc
 }
 

--- a/internal/backups/service.go
+++ b/internal/backups/service.go
@@ -1845,7 +1845,8 @@ func (s *Service) ImportManifestFromDir(ctx context.Context, instanceID int, man
 			// Check if torrent file path was provided from temp directory
 			if torrentPaths != nil && item.ArchivePath != "" {
 				if tempPath, ok := torrentPaths[item.ArchivePath]; ok {
-					if err := s.copyTorrentFromTemp(tempPath, rootDir, rel); err == nil {
+					err := s.copyTorrentFromTemp(tempPath, rootDir, rel)
+					if err == nil {
 						if info, statErr := os.Stat(absPath); statErr == nil {
 							totalTorrentFileBytes += info.Size()
 						}
@@ -1853,9 +1854,8 @@ func (s *Service) ImportManifestFromDir(ctx context.Context, instanceID int, man
 						items = append(items, backupItem)
 						totalBytes += item.SizeBytes
 						continue
-					} else {
-						log.Warn().Err(err).Str("hash", item.Hash).Msg("Failed to copy from temp, will try qBittorrent")
 					}
+					log.Warn().Err(err).Str("hash", item.Hash).Msg("Failed to copy from temp, will try qBittorrent")
 				}
 			}
 

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -314,11 +314,11 @@ func (t *Tx) shouldBypassStatementCache(query string) bool {
 
 type txExecResult struct{ tx *Tx }
 
-func (e txExecResult) execStmt(stmt *sql.Stmt, ctx context.Context, args []any) (sql.Result, error) {
+func (e txExecResult) execStmt(ctx context.Context, stmt *sql.Stmt, args []any) (sql.Result, error) {
 	return stmt.ExecContext(ctx, args...)
 }
 
-func (e txExecResult) execDirect(_ *sql.DB, ctx context.Context, query string, args []any) (sql.Result, error) {
+func (e txExecResult) execDirect(ctx context.Context, _ *sql.DB, query string, args []any) (sql.Result, error) {
 	result, err := e.tx.tx.ExecContext(ctx, e.tx.db.bindQuery(query), args...)
 	if err == nil {
 		e.tx.markQueryForCaching(query)
@@ -331,11 +331,11 @@ func (e txExecResult) getTx() *Tx            { return e.tx }
 
 type txQueryRows struct{ tx *Tx }
 
-func (q txQueryRows) execStmt(stmt *sql.Stmt, ctx context.Context, args []any) (*sql.Rows, error) {
+func (q txQueryRows) execStmt(ctx context.Context, stmt *sql.Stmt, args []any) (*sql.Rows, error) {
 	return stmt.QueryContext(ctx, args...)
 }
 
-func (q txQueryRows) execDirect(_ *sql.DB, ctx context.Context, query string, args []any) (*sql.Rows, error) {
+func (q txQueryRows) execDirect(ctx context.Context, _ *sql.DB, query string, args []any) (*sql.Rows, error) {
 	rows, err := q.tx.tx.QueryContext(ctx, q.tx.db.bindQuery(query), args...)
 	if err == nil {
 		q.tx.markQueryForCaching(query)
@@ -355,14 +355,14 @@ func (q txQueryRows) getTx() *Tx { return q.tx }
 // Uses connection-specific statement cache when available. If statement is not cached,
 // prepares it on the transaction and marks it for promotion to DB cache after commit.
 func (t *Tx) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
-	return execWithRetry(t.db, ctx, query, args, txExecResult{tx: t})
+	return execWithRetry(ctx, t.db, query, args, txExecResult{tx: t})
 }
 
 // QueryContext executes a query within the transaction.
 // Uses connection-specific statement cache when available. If statement is not cached,
 // prepares it on the transaction and marks it for promotion to DB cache after commit.
 func (t *Tx) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
-	return execWithRetry(t.db, ctx, query, args, txQueryRows{tx: t})
+	return execWithRetry(ctx, t.db, query, args, txQueryRows{tx: t})
 }
 
 // QueryRowContext executes a query within the transaction.
@@ -962,19 +962,19 @@ func isSQLiteNestedTxErr(err error) bool {
 const stmtClosedErrMsg = "statement is closed"
 
 type stmtExecutor[T any] interface {
-	execStmt(*sql.Stmt, context.Context, []any) (T, error)
-	execDirect(*sql.DB, context.Context, string, []any) (T, error)
+	execStmt(context.Context, *sql.Stmt, []any) (T, error)
+	execDirect(context.Context, *sql.DB, string, []any) (T, error)
 	getErr(T) error
 	getTx() *Tx // Returns tx if this is a transaction executor, nil otherwise
 }
 
 type execResult struct{}
 
-func (execResult) execStmt(stmt *sql.Stmt, ctx context.Context, args []any) (sql.Result, error) {
+func (execResult) execStmt(ctx context.Context, stmt *sql.Stmt, args []any) (sql.Result, error) {
 	return stmt.ExecContext(ctx, args...)
 }
 
-func (execResult) execDirect(conn *sql.DB, ctx context.Context, query string, args []any) (sql.Result, error) {
+func (execResult) execDirect(ctx context.Context, conn *sql.DB, query string, args []any) (sql.Result, error) {
 	return conn.ExecContext(ctx, query, args...)
 }
 
@@ -983,11 +983,11 @@ func (execResult) getTx() *Tx              { return nil }
 
 type queryRows struct{}
 
-func (queryRows) execStmt(stmt *sql.Stmt, ctx context.Context, args []any) (*sql.Rows, error) {
+func (queryRows) execStmt(ctx context.Context, stmt *sql.Stmt, args []any) (*sql.Rows, error) {
 	return stmt.QueryContext(ctx, args...)
 }
 
-func (queryRows) execDirect(conn *sql.DB, ctx context.Context, query string, args []any) (*sql.Rows, error) {
+func (queryRows) execDirect(ctx context.Context, conn *sql.DB, query string, args []any) (*sql.Rows, error) {
 	return conn.QueryContext(ctx, query, args...)
 }
 
@@ -999,17 +999,17 @@ func (queryRows) getErr(r *sql.Rows) error {
 }
 func (queryRows) getTx() *Tx { return nil }
 
-func execWithRetry[T any, E stmtExecutor[T]](db *DB, ctx context.Context, query string, args []any, executor E) (T, error) {
+func execWithRetry[T any, E stmtExecutor[T]](ctx context.Context, db *DB, query string, args []any, executor E) (T, error) {
 	stmt, err := db.getStmt(ctx, query, executor.getTx())
 	if err != nil {
 		boundQuery := db.bindQuery(query)
 		if isWriteQuery(query) {
-			return executor.execDirect(db.writerConn, ctx, boundQuery, args)
+			return executor.execDirect(ctx, db.writerConn, boundQuery, args)
 		}
-		return executor.execDirect(db.readerPool, ctx, boundQuery, args)
+		return executor.execDirect(ctx, db.readerPool, boundQuery, args)
 	}
 
-	result, execErr := executor.execStmt(stmt, ctx, args)
+	result, execErr := executor.execStmt(ctx, stmt, args)
 	resultErr := executor.getErr(result)
 	if (execErr == nil || !strings.Contains(execErr.Error(), stmtClosedErrMsg)) &&
 		(resultErr == nil || !strings.Contains(resultErr.Error(), stmtClosedErrMsg)) {
@@ -1027,12 +1027,12 @@ func execWithRetry[T any, E stmtExecutor[T]](db *DB, ctx context.Context, query 
 	if err != nil {
 		boundQuery := db.bindQuery(query)
 		if isWriteQuery(query) {
-			return executor.execDirect(db.writerConn, ctx, boundQuery, args)
+			return executor.execDirect(ctx, db.writerConn, boundQuery, args)
 		}
-		return executor.execDirect(db.readerPool, ctx, boundQuery, args)
+		return executor.execDirect(ctx, db.readerPool, boundQuery, args)
 	}
 
-	result, execErr = executor.execStmt(stmt, ctx, args)
+	result, execErr = executor.execStmt(ctx, stmt, args)
 	return result, execErr
 }
 
@@ -1041,7 +1041,7 @@ func execWithRetry[T any, E stmtExecutor[T]](db *DB, ctx context.Context, query 
 // Do NOT use this for queries with RETURNING clauses - use QueryRowContext or QueryContext instead.
 func (db *DB) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
 	if !isWriteQuery(query) {
-		return execWithRetry(db, ctx, query, args, execResult{})
+		return execWithRetry(ctx, db, query, args, execResult{})
 	}
 
 	if db.serializeWrites {
@@ -1049,14 +1049,14 @@ func (db *DB) ExecContext(ctx context.Context, query string, args ...any) (sql.R
 		defer db.writerMu.Unlock()
 	}
 
-	return execWithRetry(db, ctx, query, args, execResult{})
+	return execWithRetry(ctx, db, query, args, execResult{})
 }
 
 // QueryContext routes write queries to the single writer connection and
 // read queries to the reader pool. Uses prepared statements when possible.
 func (db *DB) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
 	if !isWriteQuery(query) {
-		return execWithRetry(db, ctx, query, args, queryRows{})
+		return execWithRetry(ctx, db, query, args, queryRows{})
 	}
 
 	if db.serializeWrites {
@@ -1064,7 +1064,7 @@ func (db *DB) QueryContext(ctx context.Context, query string, args ...any) (*sql
 		defer db.writerMu.Unlock()
 	}
 
-	return execWithRetry(db, ctx, query, args, queryRows{})
+	return execWithRetry(ctx, db, query, args, queryRows{})
 }
 
 // QueryRowContext routes write queries to the single writer connection and

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -105,19 +105,19 @@ func TestMigrationsApplyFullSchema(t *testing.T) {
 	require.Equal(t, len(files), applied, "All migrations should be recorded as applied")
 
 	t.Run("pragma settings", func(t *testing.T) {
-		verifyPragmas(t, t.Context(), conn)
+		verifyPragmas(t.Context(), t, conn)
 	})
 
 	t.Run("schema", func(t *testing.T) {
-		verifySchema(t, t.Context(), conn)
+		verifySchema(t.Context(), t, conn)
 	})
 
 	t.Run("indexes", func(t *testing.T) {
-		verifyIndexes(t, t.Context(), conn)
+		verifyIndexes(t.Context(), t, conn)
 	})
 
 	t.Run("triggers", func(t *testing.T) {
-		verifyTriggers(t, t.Context(), conn)
+		verifyTriggers(t.Context(), t, conn)
 	})
 }
 
@@ -143,8 +143,8 @@ func TestConnectionPragmasApplyToEachConnection(t *testing.T) {
 		require.NoError(t, conn2.Close())
 	})
 
-	verifyPragmas(t, ctx, conn1)
-	verifyPragmas(t, ctx, conn2)
+	verifyPragmas(ctx, t, conn1)
+	verifyPragmas(ctx, t, conn2)
 }
 
 func TestReadOnlyConnectionsDoNotApplyWritePragmas(t *testing.T) {
@@ -367,7 +367,7 @@ type pragmaQuerier interface {
 	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
 }
 
-func verifyPragmas(t *testing.T, ctx context.Context, q pragmaQuerier) {
+func verifyPragmas(ctx context.Context, t *testing.T, q pragmaQuerier) {
 	t.Helper()
 
 	var journalMode string
@@ -395,7 +395,7 @@ func verifyPragmas(t *testing.T, ctx context.Context, q pragmaQuerier) {
 	require.Equal(t, "ok", strings.ToLower(integrity))
 }
 
-func verifySchema(t *testing.T, ctx context.Context, conn *sql.DB) {
+func verifySchema(ctx context.Context, t *testing.T, conn *sql.DB) {
 	t.Helper()
 
 	actualTables := make(map[string]struct{})
@@ -453,7 +453,7 @@ func verifySchema(t *testing.T, ctx context.Context, conn *sql.DB) {
 	}
 }
 
-func verifyIndexes(t *testing.T, ctx context.Context, conn *sql.DB) {
+func verifyIndexes(ctx context.Context, t *testing.T, conn *sql.DB) {
 	t.Helper()
 
 	for table, indexes := range expectedIndexes {
@@ -466,7 +466,7 @@ func verifyIndexes(t *testing.T, ctx context.Context, conn *sql.DB) {
 	}
 }
 
-func verifyTriggers(t *testing.T, ctx context.Context, conn *sql.DB) {
+func verifyTriggers(ctx context.Context, t *testing.T, conn *sql.DB) {
 	t.Helper()
 
 	for _, trigger := range expectedTriggers {

--- a/internal/database/license_repo.go
+++ b/internal/database/license_repo.go
@@ -43,7 +43,7 @@ func (r *LicenseRepo) GetLicenseByKey(ctx context.Context, licenseKey string) (*
 	`
 
 	license := &models.ProductLicense{}
-	var activationId sql.Null[string]
+	var activationID sql.Null[string]
 	var provider sql.Null[string]
 	var dodoInstanceID sql.Null[string]
 
@@ -59,7 +59,7 @@ func (r *LicenseRepo) GetLicenseByKey(ctx context.Context, licenseKey string) (*
 		&dodoInstanceID,
 		&license.PolarCustomerID,
 		&license.PolarProductID,
-		&activationId,
+		&activationID,
 		&license.Username,
 		&license.CreatedAt,
 		&license.UpdatedAt,
@@ -74,7 +74,7 @@ func (r *LicenseRepo) GetLicenseByKey(ctx context.Context, licenseKey string) (*
 
 	license.Provider = provider.V
 	license.DodoInstanceID = dodoInstanceID.V
-	license.PolarActivationID = activationId.V
+	license.PolarActivationID = activationID.V
 
 	return license, nil
 }
@@ -98,7 +98,7 @@ func (r *LicenseRepo) GetAllLicenses(ctx context.Context) ([]*models.ProductLice
 	for rows.Next() {
 		license := &models.ProductLicense{}
 
-		var activationId sql.Null[string]
+		var activationID sql.Null[string]
 		var provider sql.Null[string]
 		var dodoInstanceID sql.Null[string]
 
@@ -114,7 +114,7 @@ func (r *LicenseRepo) GetAllLicenses(ctx context.Context) ([]*models.ProductLice
 			&dodoInstanceID,
 			&license.PolarCustomerID,
 			&license.PolarProductID,
-			&activationId,
+			&activationID,
 			&license.Username,
 			&license.CreatedAt,
 			&license.UpdatedAt,
@@ -125,7 +125,7 @@ func (r *LicenseRepo) GetAllLicenses(ctx context.Context) ([]*models.ProductLice
 
 		license.Provider = provider.V
 		license.DodoInstanceID = dodoInstanceID.V
-		license.PolarActivationID = activationId.V
+		license.PolarActivationID = activationID.V
 
 		licenses = append(licenses, license)
 	}

--- a/internal/models/backups.go
+++ b/internal/models/backups.go
@@ -576,17 +576,17 @@ func (s *BackupStore) getRunForUpdate(ctx context.Context, tx dbinterface.TxQuer
 	}
 	run.CategoryCounts = counts
 
-	if categories, err := unmarshalCategories(categoriesJSON); err != nil {
+	categories, err := unmarshalCategories(categoriesJSON)
+	if err != nil {
 		return nil, err
-	} else {
-		run.Categories = categories
 	}
+	run.Categories = categories
 
-	if tagList, err := unmarshalTags(tagsJSON); err != nil {
+	tagList, err := unmarshalTags(tagsJSON)
+	if err != nil {
 		return nil, err
-	} else {
-		run.Tags = tagList
 	}
+	run.Tags = tagList
 
 	if categoriesJSON.Valid {
 		run.categoriesJSON = &categoriesJSON.String
@@ -672,16 +672,16 @@ func (s *BackupStore) ListRuns(ctx context.Context, instanceID int, limit, offse
 			return nil, err
 		}
 		run.CategoryCounts = counts
-		if categories, err := unmarshalCategories(categoriesJSON); err != nil {
+		categories, err := unmarshalCategories(categoriesJSON)
+		if err != nil {
 			return nil, err
-		} else {
-			run.Categories = categories
 		}
-		if tagList, err := unmarshalTags(tagsJSON); err != nil {
+		run.Categories = categories
+		tagList, err := unmarshalTags(tagsJSON)
+		if err != nil {
 			return nil, err
-		} else {
-			run.Tags = tagList
 		}
+		run.Tags = tagList
 		if categoriesJSON.Valid {
 			run.categoriesJSON = &categoriesJSON.String
 		}
@@ -1353,16 +1353,16 @@ func (s *BackupStore) ListRunsByKind(ctx context.Context, instanceID int, kind B
 			return nil, err
 		}
 		run.CategoryCounts = counts
-		if categories, err := unmarshalCategories(categoriesJSON); err != nil {
+		categories, err := unmarshalCategories(categoriesJSON)
+		if err != nil {
 			return nil, err
-		} else {
-			run.Categories = categories
 		}
-		if tagList, err := unmarshalTags(tagsJSON); err != nil {
+		run.Categories = categories
+		tagList, err := unmarshalTags(tagsJSON)
+		if err != nil {
 			return nil, err
-		} else {
-			run.Tags = tagList
 		}
+		run.Tags = tagList
 		if categoriesJSON.Valid {
 			run.categoriesJSON = &categoriesJSON.String
 		}
@@ -1441,16 +1441,16 @@ func (s *BackupStore) GetRun(ctx context.Context, runID int64) (*BackupRun, erro
 		return nil, err
 	}
 	run.CategoryCounts = counts
-	if categories, err := unmarshalCategories(categoriesJSON); err != nil {
+	categories, err := unmarshalCategories(categoriesJSON)
+	if err != nil {
 		return nil, err
-	} else {
-		run.Categories = categories
 	}
-	if tagList, err := unmarshalTags(tagsJSON); err != nil {
+	run.Categories = categories
+	tagList, err := unmarshalTags(tagsJSON)
+	if err != nil {
 		return nil, err
-	} else {
-		run.Tags = tagList
 	}
+	run.Tags = tagList
 	if categoriesJSON.Valid {
 		run.categoriesJSON = &categoriesJSON.String
 	}
@@ -1569,16 +1569,16 @@ func (s *BackupStore) getRunsChunk(ctx context.Context, runIDs []int64) ([]*Back
 			return nil, err
 		}
 		run.CategoryCounts = counts
-		if categories, err := unmarshalCategories(categoriesJSON); err != nil {
+		categories, err := unmarshalCategories(categoriesJSON)
+		if err != nil {
 			return nil, err
-		} else {
-			run.Categories = categories
 		}
-		if tagList, err := unmarshalTags(tagsJSON); err != nil {
+		run.Categories = categories
+		tagList, err := unmarshalTags(tagsJSON)
+		if err != nil {
 			return nil, err
-		} else {
-			run.Tags = tagList
 		}
+		run.Tags = tagList
 		if categoriesJSON.Valid {
 			run.categoriesJSON = &categoriesJSON.String
 		}
@@ -1871,16 +1871,16 @@ func (s *BackupStore) FindIncompleteRuns(ctx context.Context) ([]*BackupRun, err
 			return nil, err
 		}
 		run.CategoryCounts = counts
-		if categories, err := unmarshalCategories(categoriesJSON); err != nil {
+		categories, err := unmarshalCategories(categoriesJSON)
+		if err != nil {
 			return nil, err
-		} else {
-			run.Categories = categories
 		}
-		if tagList, err := unmarshalTags(tagsJSON); err != nil {
+		run.Categories = categories
+		tagList, err := unmarshalTags(tagsJSON)
+		if err != nil {
 			return nil, err
-		} else {
-			run.Tags = tagList
 		}
+		run.Tags = tagList
 		if categoriesJSON.Valid {
 			run.categoriesJSON = &categoriesJSON.String
 		}

--- a/internal/models/torznab_indexer.go
+++ b/internal/models/torznab_indexer.go
@@ -835,11 +835,11 @@ func (s *TorznabIndexerStore) GetCapabilities(ctx context.Context, indexerID int
 
 	capabilities := make([]string, 0)
 	for rows.Next() {
-		var cap string
-		if err := rows.Scan(&cap); err != nil {
+		var capability string
+		if err := rows.Scan(&capability); err != nil {
 			return nil, fmt.Errorf("failed to scan capability: %w", err)
 		}
-		capabilities = append(capabilities, cap)
+		capabilities = append(capabilities, capability)
 	}
 
 	if err := rows.Err(); err != nil {

--- a/internal/polar/client.go
+++ b/internal/polar/client.go
@@ -59,10 +59,10 @@ type ValidationResponse struct {
 }
 
 type ValidateResp struct {
-	Id               string    `json:"id"`
-	OrganizationId   string    `json:"organization_id"`
-	UserId           string    `json:"user_id"`
-	BenefitId        string    `json:"benefit_id"`
+	ID               string    `json:"id"`
+	OrganizationID   string    `json:"organization_id"`
+	UserID           string    `json:"user_id"`
+	BenefitID        string    `json:"benefit_id"`
 	Key              string    `json:"key"`
 	DisplayKey       string    `json:"display_key"`
 	Status           string    `json:"status"`
@@ -73,8 +73,8 @@ type ValidateResp struct {
 	LastValidatedAt  time.Time `json:"last_validated_at"`
 	ExpiresAt        time.Time `json:"expires_at"`
 	Activation       struct {
-		Id           string         `json:"id"`
-		LicenseKeyId string         `json:"license_key_id"`
+		ID           string         `json:"id"`
+		LicenseKeyID string         `json:"license_key_id"`
 		Label        string         `json:"label"`
 		Meta         map[string]any `json:"meta"`
 		CreatedAt    time.Time      `json:"created_at"`
@@ -92,7 +92,7 @@ type ActivationResponse struct {
 }
 
 type ActivateKeyResponse struct {
-	Id           string         `json:"id"`
+	ID           string         `json:"id"`
 	LicenseKeyID string         `json:"license_key_id"`
 	Label        string         `json:"label"`
 	Meta         map[string]any `json:"meta"`

--- a/internal/qbittorrent/client_test.go
+++ b/internal/qbittorrent/client_test.go
@@ -628,7 +628,7 @@ func TestSplitHostUserinfo(t *testing.T) {
 			wantHost: "http://qbit.example.com:8080",
 		},
 		{
-			// #nosec G101 -- fake credentials exercising userinfo stripping.
+			// Fake credentials exercising userinfo stripping.
 			name:     "userinfo stripped and returned",
 			host:     "https://proxyuser:proxypass@qbit.example.com",
 			wantHost: "https://qbit.example.com",

--- a/internal/qbittorrent/hotpath_bench_test.go
+++ b/internal/qbittorrent/hotpath_bench_test.go
@@ -17,7 +17,7 @@ import (
 // benchTorrents builds a library that looks like a real one: long dotted release
 // names, mixed case, several categories, multi-tag strings and a spread of states.
 func benchTorrents(count int) []qbt.Torrent {
-	rng := rand.New(rand.NewPCG(1, 2)) //nolint:gosec // deterministic fixture data, not security
+	rng := rand.New(rand.NewPCG(1, 2))
 
 	states := []qbt.TorrentState{
 		qbt.TorrentStateUploading, qbt.TorrentStateStalledUp, qbt.TorrentStateDownloading,

--- a/internal/qbittorrent/integration_test.go
+++ b/internal/qbittorrent/integration_test.go
@@ -1525,13 +1525,13 @@ func TestSyncManager_ValidatedTrackerMapping_DeepCopy(t *testing.T) {
 		UpdatedAt: time.Now(),
 	}
 
-	// Get a copy
-	copy := sm.getValidatedTrackerMapping(1)
-	assert.NotNil(t, copy)
+	// Get a mappingCopy
+	mappingCopy := sm.getValidatedTrackerMapping(1)
+	assert.NotNil(t, mappingCopy)
 
-	// Modify the copy
-	copy.HashToDomains["hash1"]["modified.com"] = struct{}{}
-	copy.DomainToHashes["modified.com"] = map[string]struct{}{"hash1": {}}
+	// Modify the mappingCopy
+	mappingCopy.HashToDomains["hash1"]["modified.com"] = struct{}{}
+	mappingCopy.DomainToHashes["modified.com"] = map[string]struct{}{"hash1": {}}
 
 	// Original should be unchanged
 	original := sm.validatedTrackerMapping[1]

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -859,7 +859,7 @@ func (sm *SyncManager) getValidatedTrackerMapping(instanceID int) *ValidatedTrac
 	}
 
 	// Deep copy to prevent data races when caller iterates over the maps
-	copy := &ValidatedTrackerMapping{
+	mappingCopy := &ValidatedTrackerMapping{
 		HashToDomains:  make(map[string]map[string]struct{}, len(original.HashToDomains)),
 		DomainToHashes: make(map[string]map[string]struct{}, len(original.DomainToHashes)),
 		UpdatedAt:      original.UpdatedAt,
@@ -871,7 +871,7 @@ func (sm *SyncManager) getValidatedTrackerMapping(instanceID int) *ValidatedTrac
 		for domain := range domains {
 			domainsCopy[domain] = struct{}{}
 		}
-		copy.HashToDomains[hash] = domainsCopy
+		mappingCopy.HashToDomains[hash] = domainsCopy
 	}
 
 	for domain, hashes := range original.DomainToHashes {
@@ -879,10 +879,10 @@ func (sm *SyncManager) getValidatedTrackerMapping(instanceID int) *ValidatedTrac
 		for hash := range hashes {
 			hashesCopy[hash] = struct{}{}
 		}
-		copy.DomainToHashes[domain] = hashesCopy
+		mappingCopy.DomainToHashes[domain] = hashesCopy
 	}
 
-	return copy
+	return mappingCopy
 }
 
 // getAuthoritativeTrackerMapping returns the hydrated tracker mapping for an

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -1465,6 +1465,8 @@ func (sm *SyncManager) GetTorrentsWithFilters(ctx context.Context, instanceID in
 			switch qbt.TorrentFilter(status) {
 			case qbt.TorrentFilterActive, qbt.TorrentFilterInactive, qbt.TorrentFilterChecking, qbt.TorrentFilterMoving, qbt.TorrentFilterError, qbt.TorrentFilterDownloading, qbt.TorrentFilterUploading:
 				needsManualStatusFiltering = true
+			default:
+				// Every other filter is one qBittorrent applies server-side.
 			}
 
 			if needsManualStatusFiltering {
@@ -3350,6 +3352,8 @@ func (sm *SyncManager) torrentIsUnregistered(torrent *qbt.Torrent) bool {
 			if trackerMessageMatches(tracker.Message, defaultUnregisteredStatuses) {
 				hasUnregistered = true
 			}
+		default:
+			// Anything else says nothing about registration either way.
 		}
 	}
 
@@ -4338,6 +4342,8 @@ func (sm *SyncManager) ResumeWhenComplete(instanceID int, hashes []string, opts 
 					req.readyPolls = 0
 					req.resumeConfirmedPolls = 0
 					continue
+				default:
+					// Every other state is one the poll can make progress from.
 				}
 
 				if req.awaitingResumeConfirmation {
@@ -5455,6 +5461,8 @@ func (sm *SyncManager) matchTorrentStatusWithTrackerHealth(torrent *qbt.Torrent,
 		pausedStates := torrentStateCategories[qbt.TorrentFilterPaused]
 		stoppedStates := torrentStateCategories[qbt.TorrentFilterStopped]
 		return slices.Contains(pausedStates, torrent.State) || slices.Contains(stoppedStates, torrent.State)
+	default:
+		// Grouped categories and direct state names fall through below.
 	}
 
 	// For grouped status categories, check if state is in the category
@@ -6329,6 +6337,8 @@ func (sm *SyncManager) calculateStats(torrents []qbt.Torrent) *TorrentStats {
 			stats.Error++
 		case qbt.TorrentStateCheckingDl, qbt.TorrentStateCheckingUp, qbt.TorrentStateCheckingResumeData:
 			stats.Checking++
+		default:
+			// Unknown or transitional states count towards the totals only.
 		}
 	}
 

--- a/internal/services/automations/evaluator.go
+++ b/internal/services/automations/evaluator.go
@@ -28,8 +28,8 @@ const maxConditionDepth = 20
 // to avoid surprising matches on short names.
 const minContainsNameLength = 10
 
-// categoryEntry stores torrent info for category-based lookups.
-type categoryEntry struct {
+// CategoryEntry stores torrent info for category-based lookups.
+type CategoryEntry struct {
 	Hash           string // torrent hash for self-exclusion
 	Name           string // lowercased name (for EXISTS_IN exact match)
 	NormalizedName string // normalized name for CONTAINS_IN (separators → space)
@@ -98,9 +98,9 @@ type EvalContext struct {
 	// Enables O(1) EXISTS_IN lookups while supporting self-exclusion.
 	CategoryIndex map[string]map[string]map[string]struct{}
 
-	// CategoryNames maps lowercased category → slice of categoryEntry.
+	// CategoryNames maps lowercased category → slice of CategoryEntry.
 	// Used for CONTAINS_IN iteration (stores pre-normalized names).
-	CategoryNames map[string][]categoryEntry
+	CategoryNames map[string][]CategoryEntry
 
 	// NowUnix is the current Unix timestamp, used for age field evaluation.
 	// If zero, time.Now().Unix() is used. Set this for deterministic tests.
@@ -160,9 +160,9 @@ func normalizeName(s string) string {
 
 // BuildCategoryIndex builds the category lookup structures from a list of torrents.
 // Returns both the CategoryIndex (for O(1) EXISTS_IN) and CategoryNames (for CONTAINS_IN iteration).
-func BuildCategoryIndex(torrents []qbt.Torrent) (map[string]map[string]map[string]struct{}, map[string][]categoryEntry) {
+func BuildCategoryIndex(torrents []qbt.Torrent) (map[string]map[string]map[string]struct{}, map[string][]CategoryEntry) {
 	categoryIndex := make(map[string]map[string]map[string]struct{})
-	categoryNames := make(map[string][]categoryEntry)
+	categoryNames := make(map[string][]CategoryEntry)
 
 	for _, t := range torrents {
 		// Use lowercased + trimmed category as key (empty string is valid for uncategorized)
@@ -179,7 +179,7 @@ func BuildCategoryIndex(torrents []qbt.Torrent) (map[string]map[string]map[strin
 		categoryIndex[catKey][nameLower][t.Hash] = struct{}{}
 
 		// Build CategoryNames for CONTAINS_IN iteration
-		categoryNames[catKey] = append(categoryNames[catKey], categoryEntry{
+		categoryNames[catKey] = append(categoryNames[catKey], CategoryEntry{
 			Hash:           t.Hash,
 			Name:           nameLower,
 			NormalizedName: normalizeName(t.Name),

--- a/internal/services/automations/evaluator.go
+++ b/internal/services/automations/evaluator.go
@@ -340,6 +340,7 @@ func EvaluateConditionWithContext(cond *RuleCondition, torrent qbt.Torrent, ctx 
 			}
 		default:
 			// A group carrying a leaf operator has no children to combine.
+			result = false
 		}
 	} else {
 		// Leaf condition: evaluate against the torrent

--- a/internal/services/automations/evaluator.go
+++ b/internal/services/automations/evaluator.go
@@ -338,6 +338,8 @@ func EvaluateConditionWithContext(cond *RuleCondition, torrent qbt.Torrent, ctx 
 					break
 				}
 			}
+		default:
+			// A group carrying a leaf operator has no children to combine.
 		}
 	} else {
 		// Leaf condition: evaluate against the torrent

--- a/internal/services/automations/free_space.go
+++ b/internal/services/automations/free_space.go
@@ -105,6 +105,6 @@ func getLocalFreeSpaceBytes(path string) (int64, error) {
 	}
 	// Bavail is the number of free blocks available to unprivileged users
 	// Bsize is the fundamental block size
-	//nolint:gosec // uint64 to int64 conversion is safe: disk free space won't exceed int64 max (~8 EiB)
+	//nolint:gosec,unconvert // uint64 to int64 conversion is safe: disk free space won't exceed int64 max (~8 EiB). Bsize is int64 on linux but uint32 on darwin, so the conversion only reads as redundant on one of them.
 	return int64(stat.Bavail) * int64(stat.Bsize), nil
 }

--- a/internal/services/automations/service.go
+++ b/internal/services/automations/service.go
@@ -4126,13 +4126,13 @@ func (s *Service) notifyAutomationFailure(ctx context.Context, instanceID int, e
 	})
 }
 
-func limitHashBatch(hashes []string, max int) [][]string {
-	if max <= 0 || len(hashes) <= max {
+func limitHashBatch(hashes []string, batchSize int) [][]string {
+	if batchSize <= 0 || len(hashes) <= batchSize {
 		return [][]string{hashes}
 	}
 	var batches [][]string
 	for len(hashes) > 0 {
-		end := min(len(hashes), max)
+		end := min(len(hashes), batchSize)
 		batches = append(batches, slices.Clone(hashes[:end]))
 		hashes = hashes[end:]
 	}

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -964,7 +964,7 @@ func newLocalMatch(instance *models.Instance, cached *qbittorrent.CrossInstanceT
 // Source files are lazily fetched on first access to avoid unnecessary API calls
 // when no ambiguous content_path matches are encountered.
 type localMatchContext struct {
-	ctx               context.Context //nolint:containedctx // pre-existing design: lazy loaders run inside determineLocalMatchType, which has no ctx parameter
+	ctx               context.Context // Pre-existing design: lazy loaders run inside determineLocalMatchType, which has no ctx parameter
 	svc               *Service
 	sourceInstanceID  int
 	sourceHash        string

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -783,11 +783,6 @@ func (s *Service) HealthCheck(ctx context.Context) error {
 		}
 	}
 
-	// Check Jackett service connectivity (if configured)
-	if s.jackettService != nil {
-		// We could add a lightweight check here if Jackett service has a health check method
-	}
-
 	return nil
 }
 

--- a/internal/services/crossseed/service_local_matches_reflink_test.go
+++ b/internal/services/crossseed/service_local_matches_reflink_test.go
@@ -509,7 +509,7 @@ func TestLocalLinkedMatchTypeReFS(t *testing.T) {
 
 	cleanRoot, err := filepath.Abs(root)
 	require.NoError(t, err)
-	testRoot, err := os.MkdirTemp(cleanRoot, "qui-crossseed-reflink-") //nolint:gosec // Opt-in test root; containment is verified below.
+	testRoot, err := os.MkdirTemp(cleanRoot, "qui-crossseed-reflink-")
 	require.NoError(t, err)
 	testRoot, err = filepath.Abs(testRoot)
 	require.NoError(t, err)
@@ -518,7 +518,7 @@ func TestLocalLinkedMatchTypeReFS(t *testing.T) {
 	require.NotEqual(t, "..", relativeTestRoot)
 	require.False(t, strings.HasPrefix(relativeTestRoot, ".."+string(filepath.Separator)))
 	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(testRoot)) //nolint:gosec // Verified test temp directory under cleanRoot.
+		require.NoError(t, os.RemoveAll(testRoot))
 	})
 
 	fileName := "shared.mkv"
@@ -527,7 +527,7 @@ func TestLocalLinkedMatchTypeReFS(t *testing.T) {
 	copyDir := filepath.Join(testRoot, "copy")
 	hardlinkDir := filepath.Join(testRoot, "hardlink")
 	for _, dir := range []string{sourceDir, cloneDir, copyDir, hardlinkDir} {
-		require.NoError(t, os.MkdirAll(dir, 0o755)) //nolint:gosec // Path is under verified test temp directory.
+		require.NoError(t, os.MkdirAll(dir, 0o755))
 	}
 
 	data := make([]byte, 3*64*1024)
@@ -537,8 +537,8 @@ func TestLocalLinkedMatchTypeReFS(t *testing.T) {
 	clonePath := filepath.Join(cloneDir, fileName)
 	copyPath := filepath.Join(copyDir, fileName)
 	hardlinkPath := filepath.Join(hardlinkDir, fileName)
-	require.NoError(t, os.WriteFile(sourcePath, data, 0o600)) //nolint:gosec // Path is under verified test temp directory.
-	require.NoError(t, os.WriteFile(copyPath, data, 0o600))   //nolint:gosec // Path is under verified test temp directory.
+	require.NoError(t, os.WriteFile(sourcePath, data, 0o600))
+	require.NoError(t, os.WriteFile(copyPath, data, 0o600))
 	require.NoError(t, os.Link(sourcePath, hardlinkPath))
 	_, err = reflinktree.Create(&hardlinktree.TreePlan{
 		RootDir: cloneDir,
@@ -572,7 +572,7 @@ func TestLocalLinkedMatchTypeReFS(t *testing.T) {
 		hardlinkTestCandidate(hardlinkDir),
 	))
 
-	cloneFile, err := os.OpenFile(clonePath, os.O_WRONLY, 0) //nolint:gosec // Path is under verified test temp directory.
+	cloneFile, err := os.OpenFile(clonePath, os.O_WRONLY, 0)
 	require.NoError(t, err)
 	_, err = cloneFile.WriteAt([]byte{0xff}, 0)
 	require.NoError(t, err)
@@ -587,7 +587,7 @@ func TestLocalLinkedMatchTypeReFS(t *testing.T) {
 	replacement := make([]byte, len(data))
 	_, err = rand.Read(replacement)
 	require.NoError(t, err)
-	cloneFile, err = os.OpenFile(clonePath, os.O_WRONLY, 0) //nolint:gosec // Path is under verified test temp directory.
+	cloneFile, err = os.OpenFile(clonePath, os.O_WRONLY, 0)
 	require.NoError(t, err)
 	_, err = cloneFile.WriteAt(replacement, 0)
 	require.NoError(t, err)

--- a/internal/services/jackett/caps.go
+++ b/internal/services/jackett/caps.go
@@ -13,8 +13,8 @@ import (
 	"github.com/autobrr/qui/internal/models"
 )
 
-// torznabCaps captures the parsed capability and category data from a Torznab caps response.
-type torznabCaps struct {
+// TorznabCaps captures the parsed capability and category data from a Torznab caps response.
+type TorznabCaps struct {
 	Capabilities []string
 	Categories   []models.TorznabIndexerCategory
 	LimitDefault int
@@ -58,13 +58,13 @@ type torznabSubcatNode struct {
 	Name string `xml:"name,attr"`
 }
 
-func parseTorznabCaps(r io.Reader) (*torznabCaps, error) {
+func parseTorznabCaps(r io.Reader) (*TorznabCaps, error) {
 	var resp torznabCapsResponse
 	if err := xml.NewDecoder(r).Decode(&resp); err != nil {
 		return nil, fmt.Errorf("decode caps response: %w", err)
 	}
 
-	caps := &torznabCaps{
+	caps := &TorznabCaps{
 		LimitDefault: defaultTorznabLimit,
 		LimitMax:     defaultTorznabLimit,
 	}

--- a/internal/services/jackett/client.go
+++ b/internal/services/jackett/client.go
@@ -211,7 +211,7 @@ func (c *Client) searchProwlarr(ctx context.Context, indexerID string, params ma
 }
 
 // FetchCaps retrieves the Torznab caps document for the configured backend/indexer.
-func (c *Client) FetchCaps(ctx context.Context, indexerID string) (*torznabCaps, error) {
+func (c *Client) FetchCaps(ctx context.Context, indexerID string) (*TorznabCaps, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -228,7 +228,7 @@ func (c *Client) FetchCaps(ctx context.Context, indexerID string) (*torznabCaps,
 	}
 }
 
-func (c *Client) fetchCapsFromJackett(ctx context.Context, indexerID string) (*torznabCaps, error) {
+func (c *Client) fetchCapsFromJackett(ctx context.Context, indexerID string) (*TorznabCaps, error) {
 	baseRoot := strings.TrimRight(c.baseURL, "/")
 	trimmedID := strings.Trim(strings.TrimSpace(indexerID), "/")
 
@@ -281,7 +281,7 @@ func (c *Client) fetchCapsFromJackett(ctx context.Context, indexerID string) (*t
 	return parseTorznabCaps(resp.Body)
 }
 
-func (c *Client) fetchCapsFromProwlarr(ctx context.Context, indexerID string) (*torznabCaps, error) {
+func (c *Client) fetchCapsFromProwlarr(ctx context.Context, indexerID string) (*TorznabCaps, error) {
 	trimmed := strings.TrimSpace(indexerID)
 	if trimmed == "" {
 		return nil, errors.New("prowlarr indexer identifier is required for caps fetch")
@@ -319,7 +319,7 @@ func (c *Client) fetchCapsFromProwlarr(ctx context.Context, indexerID string) (*
 	return parseTorznabCaps(resp.Body)
 }
 
-func (c *Client) fetchCapsFromNative(ctx context.Context) (*torznabCaps, error) {
+func (c *Client) fetchCapsFromNative(ctx context.Context) (*TorznabCaps, error) {
 	endpoint := strings.TrimRight(c.baseURL, "/")
 	if endpoint == "" {
 		return nil, errors.New("native torznab endpoint not configured")
@@ -673,15 +673,15 @@ func discoverJackettIndexers(ctx context.Context, baseURL, apiKey string, basicU
 // capsFetchResult holds the result of a parallel caps fetch
 type capsFetchResult struct {
 	indexerID string
-	caps      *torznabCaps
+	caps      *TorznabCaps
 	err       error
 }
 
 // fetchCapsParallel fetches capabilities and categories for multiple indexers concurrently with retries.
-// Returns a map of indexerID -> torznabCaps and a slice of failed indexer IDs.
+// Returns a map of indexerID -> TorznabCaps and a slice of failed indexer IDs.
 // Failed fetches are logged but don't fail the overall operation.
 // The parent context is used to cancel all in-flight requests if the caller's context is cancelled.
-func fetchCapsParallel(ctx context.Context, baseURL, apiKey string, basicUsername, basicPassword *string, backend models.TorznabBackend, indexerIDs []string) (map[string]*torznabCaps, []string) {
+func fetchCapsParallel(ctx context.Context, baseURL, apiKey string, basicUsername, basicPassword *string, backend models.TorznabBackend, indexerIDs []string) (map[string]*TorznabCaps, []string) {
 	if len(indexerIDs) == 0 {
 		return nil, nil
 	}
@@ -693,7 +693,7 @@ func fetchCapsParallel(ctx context.Context, baseURL, apiKey string, basicUsernam
 		fetchTimeout  = 15 * time.Second
 	)
 
-	results := make(map[string]*torznabCaps)
+	results := make(map[string]*TorznabCaps)
 	resultsChan := make(chan capsFetchResult, len(indexerIDs))
 
 	// Semaphore to limit concurrency
@@ -767,7 +767,7 @@ func fetchCapsParallel(ctx context.Context, baseURL, apiKey string, basicUsernam
 
 // fetchCapsWithRetry attempts to fetch capabilities with retries and exponential backoff.
 // The parent context is used as the base for per-attempt timeouts, allowing cancellation.
-func fetchCapsWithRetry(ctx context.Context, baseURL, apiKey string, basicUsername, basicPassword *string, backend models.TorznabBackend, indexerID string, maxRetries int, retryDelay, timeout time.Duration) (*torznabCaps, error) {
+func fetchCapsWithRetry(ctx context.Context, baseURL, apiKey string, basicUsername, basicPassword *string, backend models.TorznabBackend, indexerID string, maxRetries int, retryDelay, timeout time.Duration) (*TorznabCaps, error) {
 	client := NewClient(baseURL, apiKey, basicUsername, basicPassword, backend, int(timeout.Seconds()))
 
 	var lastErr error

--- a/internal/services/jackett/service.go
+++ b/internal/services/jackett/service.go
@@ -4103,6 +4103,8 @@ func (s *Service) detectContentType(req *TorznabSearchRequest) contentType {
 		return contentTypeApp
 	case rls.Game:
 		return contentTypeGame
+	default:
+		// rls.Unknown is inferred from the parsed fields below.
 	}
 
 	if release.Type == rls.Unknown {

--- a/internal/services/jackett/service.go
+++ b/internal/services/jackett/service.go
@@ -2574,8 +2574,8 @@ func (s *Service) applyCapabilitySpecificParams(idx *models.TorznabIndexer, meta
 		}
 
 		// Check if indexer supports this capability (case-insensitive)
-		hasCapability := slices.ContainsFunc(idx.Capabilities, func(cap string) bool {
-			return strings.EqualFold(strings.TrimSpace(cap), capToCheck)
+		hasCapability := slices.ContainsFunc(idx.Capabilities, func(capability string) bool {
+			return strings.EqualFold(strings.TrimSpace(capability), capToCheck)
 		})
 		if hasCapability {
 			hasIDsAfterPruning = true
@@ -3443,8 +3443,8 @@ func supportsAnyCapability(current []string, required []string) bool {
 		if candidate == "" {
 			continue
 		}
-		if slices.ContainsFunc(current, func(cap string) bool {
-			return strings.EqualFold(strings.TrimSpace(cap), candidate)
+		if slices.ContainsFunc(current, func(capability string) bool {
+			return strings.EqualFold(strings.TrimSpace(capability), candidate)
 		}) {
 			return true
 		}

--- a/internal/services/license/license_service.go
+++ b/internal/services/license/license_service.go
@@ -214,7 +214,7 @@ func (s *Service) activateWithPolar(ctx context.Context, licenseKey, username, f
 		existingLicense.DodoInstanceID = ""
 		existingLicense.PolarCustomerID = &activateResp.LicenseKey.CustomerID
 		existingLicense.PolarProductID = &activateResp.LicenseKey.BenefitID
-		existingLicense.PolarActivationID = activateResp.Id
+		existingLicense.PolarActivationID = activateResp.ID
 		existingLicense.Username = username
 		existingLicense.UpdatedAt = now
 
@@ -240,7 +240,7 @@ func (s *Service) activateWithPolar(ctx context.Context, licenseKey, username, f
 		Provider:          models.LicenseProviderPolar,
 		PolarCustomerID:   &activateResp.LicenseKey.CustomerID,
 		PolarProductID:    &activateResp.LicenseKey.BenefitID,
-		PolarActivationID: activateResp.Id,
+		PolarActivationID: activateResp.ID,
 		Username:          username,
 		CreatedAt:         now,
 		UpdatedAt:         now,
@@ -411,7 +411,7 @@ func (s *Service) ensurePolarActivation(ctx context.Context, license *models.Pro
 
 	license.Provider = models.LicenseProviderPolar
 	license.DodoInstanceID = ""
-	license.PolarActivationID = activateResp.Id
+	license.PolarActivationID = activateResp.ID
 	license.PolarCustomerID = &activateResp.LicenseKey.CustomerID
 	license.PolarProductID = &activateResp.LicenseKey.BenefitID
 	license.ActivatedAt = time.Now()
@@ -424,7 +424,7 @@ func (s *Service) ensurePolarActivation(ctx context.Context, license *models.Pro
 
 	log.Info().
 		Str("licenseKey", maskLicenseKey(license.LicenseKey)).
-		Str("activationId", activateResp.Id).
+		Str("activationId", activateResp.ID).
 		Msg("Successfully activated license and updated activation ID")
 
 	return nil

--- a/internal/services/license/machineid_test.go
+++ b/internal/services/license/machineid_test.go
@@ -19,7 +19,7 @@ func TestGetDeviceIDRestrictsExistingFingerprintMode(t *testing.T) {
 	const userID = "user@example.com"
 
 	fingerprintPath := getFingerprintPath(userID, configDir)
-	require.NoError(t, os.WriteFile(fingerprintPath, []byte("existing-fingerprint"), 0o644)) //nolint:gosec // G306: the point of the test is a file that starts out too permissive
+	require.NoError(t, os.WriteFile(fingerprintPath, []byte("existing-fingerprint"), 0o644))
 
 	got, err := GetDeviceID("qui", userID, configDir)
 	require.NoError(t, err)
@@ -37,7 +37,7 @@ func TestPersistFingerprintRestrictsExistingFingerprintMode(t *testing.T) {
 	const userID = "user@example.com"
 
 	fingerprintPath := getFingerprintPath(userID, configDir)
-	require.NoError(t, os.WriteFile(fingerprintPath, nil, 0o644)) //nolint:gosec // G306: the point of the test is a file that starts out too permissive
+	require.NoError(t, os.WriteFile(fingerprintPath, nil, 0o644))
 
 	got, err := GetDeviceID("qui", userID, configDir)
 	require.NoError(t, err)

--- a/internal/services/metadata/tvdb_test.go
+++ b/internal/services/metadata/tvdb_test.go
@@ -44,7 +44,7 @@ func handleLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	resp := map[string]any{
-		"data": map[string]string{"token": "test-jwt-token"}, //nolint:gosec // test value
+		"data": map[string]string{"token": "test-jwt-token"},
 	}
 	_ = json.NewEncoder(w).Encode(resp)
 }

--- a/internal/services/trackericons/service.go
+++ b/internal/services/trackericons/service.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"image"
+
 	// Registered for their side effect: image.Decode needs the gif and jpeg
 	// decoders to read icons that are not png.
 	_ "image/gif"

--- a/internal/services/trackericons/service.go
+++ b/internal/services/trackericons/service.go
@@ -10,6 +10,8 @@ import (
 	"errors"
 	"fmt"
 	"image"
+	// Registered for their side effect: image.Decode needs the gif and jpeg
+	// decoders to read icons that are not png.
 	_ "image/gif"
 	_ "image/jpeg"
 	"image/png"
@@ -23,6 +25,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	// Same again for .ico, which browsers still serve as a favicon.
 	_ "github.com/mat/besticon/v3/ico"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/image/draw"
@@ -176,9 +179,8 @@ func QueueFetch(host, trackerURL string) {
 	go func(h string, tracker string) {
 		ctx, cancel := context.WithTimeout(context.Background(), fetchTimeout)
 		defer cancel()
-		if _, err := svc.GetIcon(ctx, h, tracker); err != nil {
-			// Intentionally ignore errors here; they are tracked internally for cooldown.
-		}
+		// Errors are ignored here; GetIcon tracks them internally for cooldown.
+		_, _ = svc.GetIcon(ctx, h, tracker)
 	}(sanitized, trackerURL)
 }
 

--- a/pkg/gojackett/http.go
+++ b/pkg/gojackett/http.go
@@ -17,8 +17,8 @@ import (
 	"github.com/autobrr/qui/pkg/redact"
 )
 
-func (c *Client) getRawCtx(ctx context.Context, reqUrl string) (*http.Response, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqUrl, nil)
+func (c *Client) getRawCtx(ctx context.Context, reqURL string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not build request")
 	}
@@ -30,28 +30,28 @@ func (c *Client) getRawCtx(ctx context.Context, reqUrl string) (*http.Response, 
 	resp, err := c.retryDo(ctx, req)
 	if err != nil {
 		err = redact.URLError(err)
-		return nil, errors.Wrap(err, "error making get request: %v", redact.URLString(reqUrl))
+		return nil, errors.Wrap(err, "error making get request: %v", redact.URLString(reqURL))
 	}
 
 	return resp, nil
 }
 
 func (c *Client) getCtx(ctx context.Context, endpoint string, opts map[string]string) (*http.Response, error) {
-	return c.getRawCtx(ctx, c.buildUrl(endpoint, opts))
+	return c.getRawCtx(ctx, c.buildURL(endpoint, opts))
 }
 
-func (c *Client) buildUrl(endpoint string, params map[string]string) string {
-	var joinedUrl string
+func (c *Client) buildURL(endpoint string, params map[string]string) string {
+	var joinedURL string
 
 	if c.cfg.DirectMode {
 		if endpoint != "" && endpoint != "/" {
-			joinedUrl, _ = url.JoinPath(c.cfg.Host, endpoint)
+			joinedURL, _ = url.JoinPath(c.cfg.Host, endpoint)
 		} else {
-			joinedUrl = c.cfg.Host
+			joinedURL = c.cfg.Host
 		}
 	} else {
 		apiBase := "/api/v2.0/indexers/"
-		joinedUrl, _ = url.JoinPath(c.cfg.Host, apiBase, endpoint)
+		joinedURL, _ = url.JoinPath(c.cfg.Host, apiBase, endpoint)
 	}
 
 	queryParams := url.Values{}
@@ -59,10 +59,10 @@ func (c *Client) buildUrl(endpoint string, params map[string]string) string {
 		queryParams.Add(key, value)
 	}
 
-	parsedUrl, _ := url.Parse(joinedUrl)
-	parsedUrl.RawQuery = queryParams.Encode()
+	parsedURL, _ := url.Parse(joinedURL)
+	parsedURL.RawQuery = queryParams.Encode()
 
-	return parsedUrl.String()
+	return parsedURL.String()
 }
 
 // drainAndClose drains and closes the response body to ensure HTTP connection reuse

--- a/pkg/hardlink/fileid_unix.go
+++ b/pkg/hardlink/fileid_unix.go
@@ -32,7 +32,8 @@ func GetFileID(fi os.FileInfo, _ string) (FileID, uint64, error) {
 	if !ok {
 		return FileID{}, 0, errors.New("failed to get syscall.Stat_t")
 	}
-	return FileID{Dev: uint64(sys.Dev), Ino: sys.Ino}, uint64(sys.Nlink), nil //nolint:gosec // sys.Dev is always non-negative
+	//nolint:gosec,unconvert // sys.Dev is always non-negative, and it is uint64 on linux but int32 on darwin, so the conversion only reads as redundant on one of them.
+	return FileID{Dev: uint64(sys.Dev), Ino: sys.Ino}, uint64(sys.Nlink), nil
 }
 
 // Bytes returns a byte slice representation of the FileID for hashing.

--- a/pkg/sharedextents/sharedextents_windows_test.go
+++ b/pkg/sharedextents/sharedextents_windows_test.go
@@ -122,7 +122,7 @@ func TestFilesShareAllocationReFS(t *testing.T) {
 
 	cleanRoot, err := filepath.Abs(root)
 	require.NoError(t, err)
-	dir, err := os.MkdirTemp(cleanRoot, "qui-sharedextents-") //nolint:gosec // Opt-in test root; containment is verified below.
+	dir, err := os.MkdirTemp(cleanRoot, "qui-sharedextents-")
 	require.NoError(t, err)
 	dir, err = filepath.Abs(dir)
 	require.NoError(t, err)
@@ -131,7 +131,7 @@ func TestFilesShareAllocationReFS(t *testing.T) {
 	require.NotEqual(t, "..", relativeDir)
 	require.False(t, strings.HasPrefix(relativeDir, ".."+string(filepath.Separator)))
 	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(dir)) //nolint:gosec // Verified test temp directory under cleanRoot.
+		require.NoError(t, os.RemoveAll(dir))
 	})
 
 	source := filepath.Join(dir, "source.bin")
@@ -140,8 +140,8 @@ func TestFilesShareAllocationReFS(t *testing.T) {
 	data := make([]byte, 3*64*1024)
 	_, err = rand.Read(data)
 	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(source, data, 0o600))   //nolint:gosec // Path is under verified test temp directory.
-	require.NoError(t, os.WriteFile(copyPath, data, 0o600)) //nolint:gosec // Path is under verified test temp directory.
+	require.NoError(t, os.WriteFile(source, data, 0o600))
+	require.NoError(t, os.WriteFile(copyPath, data, 0o600))
 	_, err = reflinktree.Create(&hardlinktree.TreePlan{
 		RootDir: dir,
 		Files: []hardlinktree.FilePlan{{
@@ -159,7 +159,7 @@ func TestFilesShareAllocationReFS(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, shared)
 
-	cloneFile, err := os.OpenFile(clone, os.O_WRONLY, 0) //nolint:gosec // Path is under verified test temp directory.
+	cloneFile, err := os.OpenFile(clone, os.O_WRONLY, 0)
 	require.NoError(t, err)
 	_, err = cloneFile.WriteAt([]byte{0xff}, 0)
 	require.NoError(t, err)
@@ -172,7 +172,7 @@ func TestFilesShareAllocationReFS(t *testing.T) {
 	replacement := make([]byte, len(data))
 	_, err = rand.Read(replacement)
 	require.NoError(t, err)
-	cloneFile, err = os.OpenFile(clone, os.O_WRONLY, 0) //nolint:gosec // Path is under verified test temp directory.
+	cloneFile, err = os.OpenFile(clone, os.O_WRONLY, 0)
 	require.NoError(t, err)
 	_, err = cloneFile.WriteAt(replacement, 0)
 	require.NoError(t, err)
@@ -182,8 +182,8 @@ func TestFilesShareAllocationReFS(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, shared)
 
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "empty-a"), nil, 0o600)) //nolint:gosec // Path is under verified test temp directory.
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "empty-b"), nil, 0o600)) //nolint:gosec // Path is under verified test temp directory.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "empty-a"), nil, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "empty-b"), nil, 0o600))
 	shared, err = FilesShareAllocation(filepath.Join(dir, "empty-a"), filepath.Join(dir, "empty-b"))
 	require.NoError(t, err)
 	require.False(t, shared)


### PR DESCRIPTION
## Description

Third and last of the golangci-lint PRs for #2380. Stacked on #2387, which is stacked on #2386 — **review those first**; this PR's own diff is the last 312 findings and the CI change.

**Backlog reaches zero.** `golangci-lint run` across the repo reports `0 issues`, which is what lets the last commit flip the gate.

### Fixed rather than excluded (first commit)

The revive findings that are real: if/else chains around an error return flattened, identifiers shadowing `cap`/`max`/`copy` renamed, initialisms (`Id` → `ID` through the polar structs and callers, `Url` → `URL` in gojackett), two exported functions that returned unexported types so callers could hold a value but not name it, two empty blocks — one a commented-out "we could check something here" — and blank imports that now say what they register.

Then `context.Context` moved to the first parameter across the database executors, two handlers and the schema test helpers. `net.Listen` keeps a suppression at the site instead, since the listener outlives every request.

### Scoped, each with its reason in the config (second commit)

| rule | count | why |
|---|---|---|
| `revive: unused-parameter` | 110 | a parameter an interface forces on an implementation still documents what the caller passes |
| `revive: stutters` | 5 | renaming `CrossSeedRequest` to `Request` is a rename through every caller for a naming preference |
| `noctx` in tests | 60 | fixtures may build requests without a context |
| `exhaustive` | 34 | `default-signifies-exhaustive`; the seven switches that had no default got one naming the common path, which is what AGENTS.md asks for anyway |
| `gosec` G703 in the backups handler | 13 | the taint analysis follows archive names through `safeArchiveEntryPath` and blob paths through `backupRelPath`, and cannot see either check |
| `gocritic: ifElseChain` | 17 | taste, and ten of them are in crossseed and qbittorrent where the repo asks for minimal diffs |
| `containedctx` | 8 | all eight are long-lived services holding a lifecycle context |
| `gosec` G101/G124 in tests, G101 in the config template | 8 | fake credentials in fixtures, and a commented-out password field in a generated template |

### The CI change (third commit)

- **`only-new-issues: false`.** With the backlog at zero the gate covers the whole repo instead of only changed lines, so drift cannot accumulate in files nobody touches.
- **The gofix step no longer swallows the lint step.** It ran before `Lint backend` in the same job with no `continue-on-error`, so a failure there skipped linting entirely — which is how golangci-lint ended up not running on a single PR after the Go 1.27 bump. It now reports on its own and fails the job in a later step, with lint running either way.
- **`.gitattributes` pins Go sources to LF.** Five files had been committed with CRLF; gofmt normalising them is why #2387 shows five whole-file diffs.

Closes #2380 once all three land.

## How has this been tested?

- `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 ./...` → `0 issues`.
- `go test -race -count=1 ./...` — all 47 packages pass.
- `make precommit` clean, `make build` clean.
- The workflow file was parsed and the backend job's step list checked, since the `continue-on-error`/`if` pairing is the kind of thing that fails silently.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [x] I ran `make precommit` and the tests pass locally
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

## AI disclosure

Yes. Claude Code (Opus) did the mechanical renames and signature moves and drafted the exclusion rationales under my direction. The judgement calls — which rules to fix versus scope, and that `only-new-issues: false` only makes sense once the count is actually zero — were reviewed line by line, and every exclusion carries its reason in the config rather than in a commit message nobody will read again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automation condition handling for unsupported or leaf-level operators.
  * Preserved reliable backup, log-streaming, database, and service health behavior.

* **Refactor**
  * Standardized naming, context handling, and public API types across backend services.
  * Improved consistency of capability data and URL processing.

* **Chores**
  * Strengthened formatting and lint checks with complete issue reporting and clearer handling of intentional exceptions.
  * Documented platform-specific formatting and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->