### PR TITLE
fix(crossseed): omit categories from ID-driven searches

### DIFF
--- a/internal/services/jackett/models.go
+++ b/internal/services/jackett/models.go
@@ -42,7 +42,7 @@ type TorznabSearchRequest struct {
 	IndexerIDs []int `json:"indexer_ids,omitempty"`
 	// CacheMode controls cache behaviour (""=default, "bypass" = skip cache)
 	CacheMode string `json:"cache_mode,omitempty"`
-	// OmitQueryForIDs when true, omits the q parameter if IDs are present (for cross-seed ID-driven searches)
+	// OmitQueryForIDs when true, omits the q and cat parameters if IDs are present (for cross-seed ID-driven searches)
 	OmitQueryForIDs bool `json:"-"`
 	// SkipHistory prevents recording this search in the history buffer. It does NOT
 	// gate cache persistence; that concern is governed separately by SkipCachePersist.

--- a/internal/services/jackett/models.go
+++ b/internal/services/jackett/models.go
@@ -42,7 +42,9 @@ type TorznabSearchRequest struct {
 	IndexerIDs []int `json:"indexer_ids,omitempty"`
 	// CacheMode controls cache behaviour (""=default, "bypass" = skip cache)
 	CacheMode string `json:"cache_mode,omitempty"`
-	// OmitQueryForIDs when true, omits the q and cat parameters if IDs are present (for cross-seed ID-driven searches)
+	// OmitQueryForIDs when true, omits q from a movie or TV search that carries IDs, and
+	// omits cat from every indexer that keeps a usable ID (for cross-seed ID-driven
+	// searches). An indexer that falls back to the title query keeps its category.
 	OmitQueryForIDs bool `json:"-"`
 	// SkipHistory prevents recording this search in the history buffer. It does NOT
 	// gate cache persistence; that concern is governed separately by SkipCachePersist.

--- a/internal/services/jackett/service.go
+++ b/internal/services/jackett/service.go
@@ -2446,47 +2446,40 @@ func (s *Service) applyIndexerRestrictions(ctx context.Context, client *Client, 
 		}
 	}
 
-	// If no categories requested, continue with search
-	if len(requested) == 0 {
-		return false, false
-	}
+	// Map the requested categories onto this indexer. Nothing to map means the params
+	// keep the categories they were built with; the capability handling below still runs.
+	if len(requested) > 0 && len(idx.Categories) > 0 {
+		mappedCategories := s.MapCategoriesToIndexerCapabilities(ctx, idx, requested)
 
-	// If indexer has no categories stored, continue (will use requested categories as-is)
-	if len(idx.Categories) == 0 {
-		return false, false
-	}
+		// Filter mapped categories through indexer's supported categories
+		filtered, ok := filterCategoriesForIndexer(idx.Categories, mappedCategories)
+		if !ok {
+			log.Debug().
+				Int("indexer_id", idx.ID).
+				Str("indexer", idx.Name).
+				Ints("requested_categories", requested).
+				Ints("mapped_categories", mappedCategories).
+				Msg("Skipping torznab indexer due to unsupported categories")
+			return true, false
+		}
 
-	// Map requested categories to what this indexer actually supports
-	mappedCategories := s.MapCategoriesToIndexerCapabilities(ctx, idx, requested)
+		// Update the params with the filtered categories
+		params["cat"] = formatCategoryList(filtered)
 
-	// Filter mapped categories through indexer's supported categories
-	filtered, ok := filterCategoriesForIndexer(idx.Categories, mappedCategories)
-	if !ok {
 		log.Debug().
 			Int("indexer_id", idx.ID).
 			Str("indexer", idx.Name).
 			Ints("requested_categories", requested).
 			Ints("mapped_categories", mappedCategories).
-			Msg("Skipping torznab indexer due to unsupported categories")
-		return true, false
+			Ints("filtered_categories", filtered).
+			Msg("Applied category mapping and filtering for indexer")
 	}
-
-	// Update the params with the filtered categories
-	params["cat"] = formatCategoryList(filtered)
-
-	log.Debug().
-		Int("indexer_id", idx.ID).
-		Str("indexer", idx.Name).
-		Ints("requested_categories", requested).
-		Ints("mapped_categories", mappedCategories).
-		Ints("filtered_categories", filtered).
-		Msg("Applied category mapping and filtering for indexer")
 
 	// Handle conditional parameter addition based on indexer capabilities
 	s.applyCapabilitySpecificParams(idx, meta, params)
 
-	// Drop the category filter again for an ID-driven search, but only while this
-	// indexer still has an ID to search by. applyCapabilitySpecificParams above prunes
+	// Drop the category filter for an ID-driven search, but only while this indexer
+	// still has an ID to search by. applyCapabilitySpecificParams above prunes
 	// unsupported IDs and restores the title query; that fallback keeps its category.
 	if meta != nil && meta.omitCategoriesForIDs && hasTorznabIDParams(params) {
 		delete(params, "cat")
@@ -3048,17 +3041,16 @@ func (s *Service) buildSearchParams(req *TorznabSearchRequest, searchMode string
 		params.Set("limit", strconv.Itoa(req.Limit))
 	}
 
-	// Omit the q and cat parameters when doing an ID-driven search (for cross-seed).
-	// This lets the IDs drive matching. A category filter would hide a release the ID
-	// matches but the tracker files outside the mapped category.
+	// Omit q parameter when doing ID-driven search (for cross-seed) so the IDs drive
+	// matching. applyIndexerRestrictions drops cat per-indexer, keeping it for any
+	// indexer that has to fall back to the title search.
 	if req.OmitQueryForIDs {
 		hasIDs := req.IMDbID != "" || req.TVDbID != "" || req.TMDbID > 0 || req.TVMazeID > 0
 		if hasIDs && (mode == "movie" || mode == "tvsearch") {
 			params.Del("q")
-			params.Del("cat")
 			log.Debug().
 				Str("search_mode", mode).
-				Msg("Omitting q and cat parameters for ID-driven search")
+				Msg("Omitting q parameter for ID-driven search")
 		}
 	}
 

--- a/internal/services/jackett/service.go
+++ b/internal/services/jackett/service.go
@@ -160,6 +160,11 @@ type searchContext struct {
 	releaseName   string // Original full release name for debugging/history
 	skipHistory   bool   // Skip recording this search in history buffer
 	originalQuery string // Original query for fallback when ID params are pruned per-indexer
+
+	// omitCategoriesForIDs is set when buildSearchParams dropped the query for an
+	// ID-driven movie or TV search. The category filter is dropped with it, but only
+	// for indexers that keep at least one usable ID.
+	omitCategoriesForIDs bool
 }
 
 type searchPriorityKey struct{}
@@ -679,6 +684,8 @@ func (s *Service) performSearch(ctx context.Context, req *TorznabSearchRequest, 
 		releaseName:   req.ReleaseName,
 		skipHistory:   req.SkipHistory,
 		originalQuery: req.Query,
+
+		omitCategoriesForIDs: req.OmitQueryForIDs && !params.Has("q"),
 	}, RateLimitPriorityInteractive)
 
 	cacheEnabled := s.shouldUseSearchCache()
@@ -2478,6 +2485,13 @@ func (s *Service) applyIndexerRestrictions(ctx context.Context, client *Client, 
 	// Handle conditional parameter addition based on indexer capabilities
 	s.applyCapabilitySpecificParams(idx, meta, params)
 
+	// Drop the category filter again for an ID-driven search, but only while this
+	// indexer still has an ID to search by. applyCapabilitySpecificParams above prunes
+	// unsupported IDs and restores the title query; that fallback keeps its category.
+	if meta != nil && meta.omitCategoriesForIDs && hasTorznabIDParams(params) {
+		delete(params, "cat")
+	}
+
 	// Debug log parameters after capability/category restrictions. Backend-specific
 	// query workarounds may still run after this returns.
 	log.Debug().
@@ -3034,15 +3048,17 @@ func (s *Service) buildSearchParams(req *TorznabSearchRequest, searchMode string
 		params.Set("limit", strconv.Itoa(req.Limit))
 	}
 
-	// Omit q parameter when doing ID-driven search (for cross-seed)
-	// This lets IDs drive matching instead of query string
+	// Omit the q and cat parameters when doing an ID-driven search (for cross-seed).
+	// This lets the IDs drive matching. A category filter would hide a release the ID
+	// matches but the tracker files outside the mapped category.
 	if req.OmitQueryForIDs {
 		hasIDs := req.IMDbID != "" || req.TVDbID != "" || req.TMDbID > 0 || req.TVMazeID > 0
 		if hasIDs && (mode == "movie" || mode == "tvsearch") {
 			params.Del("q")
+			params.Del("cat")
 			log.Debug().
 				Str("search_mode", mode).
-				Msg("Omitting q parameter for ID-driven search")
+				Msg("Omitting q and cat parameters for ID-driven search")
 		}
 	}
 

--- a/internal/services/jackett/service_test.go
+++ b/internal/services/jackett/service_test.go
@@ -3453,3 +3453,167 @@ func TestSearchIndexersWithSchedulerDedupExcludedFromFailureThreshold(t *testing
 		t.Fatal("first RSS search never completed after release")
 	}
 }
+
+// TestSearchIDDrivenMovieCategoryBehavior pins the outbound Torznab request for an
+// ID-driven movie search. An indexer that can search by IMDb ID must receive the ID
+// alone, without a query or a category filter that could hide a correctly matching
+// release stored outside the mapped category. An indexer without that capability
+// falls back to the title search and keeps its mapped category.
+func TestSearchIDDrivenMovieCategoryBehavior(t *testing.T) {
+	tests := []struct {
+		name         string
+		capabilities []string
+		wantQuery    string
+		wantCategory string
+		wantIMDbID   string
+	}{
+		{
+			name:         "supported ID omits query and category",
+			capabilities: []string{"movie-search", "movie-search-imdbid"},
+			wantIMDbID:   "1234567",
+		},
+		{
+			name:         "unsupported ID restores title and category",
+			capabilities: []string{"movie-search"},
+			wantQuery:    "Synthetic Documentary",
+			wantCategory: "2000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outboundCh := make(chan url.Values, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				select {
+				case outboundCh <- r.URL.Query():
+				default:
+				}
+				w.Header().Set("Content-Type", "application/rss+xml")
+				if _, writeErr := w.Write([]byte(`<rss version="2.0"><channel><title>Test</title></channel></rss>`)); writeErr != nil {
+					t.Errorf("write RSS response: %v", writeErr)
+				}
+			}))
+			defer server.Close()
+
+			indexer := &models.TorznabIndexer{
+				ID:             1,
+				Name:           "Synthetic Prowlarr Indexer",
+				BaseURL:        server.URL,
+				Backend:        models.TorznabBackendProwlarr,
+				IndexerID:      "7",
+				Enabled:        true,
+				TimeoutSeconds: 5,
+				Capabilities:   tt.capabilities,
+				Categories: []models.TorznabIndexerCategory{
+					{CategoryID: CategoryMovies},
+				},
+			}
+			service := NewService(&mockTorznabIndexerStore{indexers: []*models.TorznabIndexer{indexer}})
+
+			done := make(chan error, 1)
+			req := &TorznabSearchRequest{
+				Query:           "Synthetic Documentary",
+				Categories:      []int{CategoryMovies},
+				IMDbID:          "tt1234567",
+				OmitQueryForIDs: true,
+				IndexerIDs:      []int{1},
+				OnAllComplete: func(_ *SearchResponse, err error) {
+					done <- err
+				},
+			}
+
+			if err := service.Search(context.Background(), req); err != nil {
+				t.Fatalf("Search() error = %v", err)
+			}
+
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Fatalf("search completed with error: %v", err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("timed out waiting for search to complete")
+			}
+
+			var outbound url.Values
+			select {
+			case outbound = <-outboundCh:
+			case <-time.After(time.Second):
+				t.Fatal("timed out waiting for the outbound request")
+			}
+
+			if got := outbound.Get("t"); got != "movie" {
+				t.Fatalf("t = %q, want movie", got)
+			}
+			if got := outbound.Get("q"); got != tt.wantQuery {
+				t.Fatalf("q = %q, want %q", got, tt.wantQuery)
+			}
+			if got := outbound.Get("cat"); got != tt.wantCategory {
+				t.Fatalf("cat = %q, want %q", got, tt.wantCategory)
+			}
+			if got := outbound.Get("imdbid"); got != tt.wantIMDbID {
+				t.Fatalf("imdbid = %q, want %q", got, tt.wantIMDbID)
+			}
+		})
+	}
+}
+
+// TestApplyIndexerRestrictionsKeepsContentTypeRouting locks the capability gate that
+// keeps a search on indexers of the correct content type. Omitting categories from an
+// ID-driven request must not let a TV or music search reach a movie-only indexer.
+func TestApplyIndexerRestrictionsKeepsContentTypeRouting(t *testing.T) {
+	tests := []struct {
+		name         string
+		searchMode   string
+		capabilities []string
+		params       map[string]string
+		wantSkip     bool
+	}{
+		{
+			name:         "TV rejects movie-only indexer",
+			searchMode:   "tvsearch",
+			capabilities: []string{"movie-search", "movie-search-imdbid"},
+			params:       map[string]string{"tvdbid": "123456"},
+			wantSkip:     true,
+		},
+		{
+			name:         "TV accepts TV indexer",
+			searchMode:   "tvsearch",
+			capabilities: []string{"tv-search", "tv-search-tvdbid"},
+			params:       map[string]string{"tvdbid": "123456"},
+		},
+		{
+			name:         "music rejects movie-only indexer",
+			searchMode:   "music",
+			capabilities: []string{"movie-search"},
+			params:       map[string]string{"q": "Synthetic Artist Synthetic Album", "artist": "Synthetic Artist", "album": "Synthetic Album"},
+			wantSkip:     true,
+		},
+		{
+			name:         "music accepts music indexer",
+			searchMode:   "music",
+			capabilities: []string{"music-search"},
+			params:       map[string]string{"q": "Synthetic Artist Synthetic Album", "artist": "Synthetic Artist", "album": "Synthetic Album"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := NewService(&mockTorznabIndexerStore{})
+			indexer := &models.TorznabIndexer{
+				ID:           1,
+				Name:         "Synthetic Indexer",
+				Capabilities: tt.capabilities,
+			}
+			meta := &searchContext{searchMode: tt.searchMode}
+
+			skip, rateLimited := service.applyIndexerRestrictions(context.Background(), nil, indexer, "", meta, maps.Clone(tt.params))
+			if skip != tt.wantSkip {
+				t.Fatalf("skip = %v, want %v", skip, tt.wantSkip)
+			}
+			if rateLimited {
+				t.Fatalf("rateLimited = true, want false")
+			}
+		})
+	}
+}

--- a/internal/services/jackett/service_test.go
+++ b/internal/services/jackett/service_test.go
@@ -3463,6 +3463,7 @@ func TestSearchIDDrivenMovieCategoryBehavior(t *testing.T) {
 	tests := []struct {
 		name         string
 		capabilities []string
+		noStoredCats bool
 		wantQuery    string
 		wantCategory string
 		wantIMDbID   string
@@ -3478,14 +3479,31 @@ func TestSearchIDDrivenMovieCategoryBehavior(t *testing.T) {
 			wantQuery:    "Synthetic Documentary",
 			wantCategory: "2000",
 		},
+		{
+			name:         "unsupported ID falls back without stored categories",
+			capabilities: []string{"movie-search"},
+			noStoredCats: true,
+			wantQuery:    "Synthetic Documentary",
+			wantCategory: "2000",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			outboundCh := make(chan url.Values, 1)
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				query := r.URL.Query()
+				if query.Get("t") == "caps" {
+					// An indexer with no stored categories triggers a caps fetch first.
+					// Answer without categories so it stays category-blind.
+					w.Header().Set("Content-Type", "application/xml")
+					if _, writeErr := w.Write([]byte(`<caps><categories/></caps>`)); writeErr != nil {
+						t.Errorf("write caps response: %v", writeErr)
+					}
+					return
+				}
 				select {
-				case outboundCh <- r.URL.Query():
+				case outboundCh <- query:
 				default:
 				}
 				w.Header().Set("Content-Type", "application/rss+xml")
@@ -3507,6 +3525,9 @@ func TestSearchIDDrivenMovieCategoryBehavior(t *testing.T) {
 				Categories: []models.TorznabIndexerCategory{
 					{CategoryID: CategoryMovies},
 				},
+			}
+			if tt.noStoredCats {
+				indexer.Categories = nil
 			}
 			service := NewService(&mockTorznabIndexerStore{indexers: []*models.TorznabIndexer{indexer}})
 


### PR DESCRIPTION
## Description

Cross-seed and dir-scan searches that have an IMDb, TMDb, TVDb, or TVMaze ID already omit the `q` parameter so the ID drives the match. They still sent `cat`, so a release the ID matches was dropped when the tracker filed it outside the mapped category. A documentary in a Documentary category was invisible to a `cat=2000` movie search. The category is now omitted too, but only for indexers that keep a usable ID: an indexer that cannot search by the supplied ID falls back to the title search and keeps its category filter.

The second commit fixes a related fault found in review. `applyIndexerRestrictions` returned early when an indexer had no stored categories, which skipped the capability step. An indexer that supports none of the supplied IDs got neither the pruned IDs nor the restored title query, so it received a search with no query at all. This is not new, it fails the same way before this branch, but the category change made that path worse. The two early returns are now one guarded block, so the capability step always runs.

Content-type routing is unchanged. TV searches still require `tv-search`, movie searches still require `movie-search`, and music is untouched.

## How has this been tested?

A user ran this build against a live setup and confirmed the fix works: the ID-driven searches now find the releases that the category filter used to hide.

The new tests drive the real service through a fake Prowlarr HTTP endpoint and assert the query string that goes on the wire, which is where the bug was.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved searches using IMDb or other supported IDs by sending only the relevant ID when possible.
  * Restored title and category filters for indexers that cannot search by ID.
  * Improved category handling for indexers with and without available category mappings.
  * Fixed content-type routing so movie, TV, and music searches are sent only to compatible indexers.
* **Tests**
  * Added coverage for ID-based searches, category fallbacks, and content-type filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
