### PR TITLE
chore(deps): bump go-mediainfo to v0.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/alexedwards/scs/v2 v2.9.0
 	github.com/andybalholm/brotli v1.2.2
 	github.com/autobrr/autobrr v1.82.1
-	github.com/autobrr/go-mediainfo v0.7.1-0.20260822130955-5266bc82c5aa
+	github.com/autobrr/go-mediainfo v0.8.0
 	github.com/autobrr/go-qbittorrent v1.17.1-0.20260815045428-fe3b4cb79f3e
 	github.com/autobrr/go-torrent v1.1.1-0.20260811091921-e2224c4f4e34
 	github.com/avast/retry-go v3.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -17,10 +17,8 @@ github.com/andybalholm/brotli v1.2.2 h1:HzTuoo2ErYQqf5qvcJInB8uvqSVxRttzkFexPWtn
 github.com/andybalholm/brotli v1.2.2/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/autobrr/autobrr v1.82.1 h1:r05Hoq2Tmvoji52pLQiuWyqj2YvxTQakpg2/cd9ZxGg=
 github.com/autobrr/autobrr v1.82.1/go.mod h1:OE4k6MRIIvHKJ2Ja113dPudF/8RnMJiJW6bXvbw4eOg=
-github.com/autobrr/go-mediainfo v0.7.0 h1:AnyDZC7merAVNfY9qu28/xjt/HZq8/28gqn+NbA/J8A=
-github.com/autobrr/go-mediainfo v0.7.0/go.mod h1:P3LGxIPznO2TLKV/e58YgN0/ozP5pLCAncFzsdxMDcY=
-github.com/autobrr/go-mediainfo v0.7.1-0.20260822130955-5266bc82c5aa h1:szYwRic8q52BCeZKlrLrVXsiDOPuyL9/s14ZsceATYk=
-github.com/autobrr/go-mediainfo v0.7.1-0.20260822130955-5266bc82c5aa/go.mod h1:P3LGxIPznO2TLKV/e58YgN0/ozP5pLCAncFzsdxMDcY=
+github.com/autobrr/go-mediainfo v0.8.0 h1:XzsjHvBOlGx2BnwYCqwCOIJsmrFy4BJb0jgoB2qKuR0=
+github.com/autobrr/go-mediainfo v0.8.0/go.mod h1:P3LGxIPznO2TLKV/e58YgN0/ozP5pLCAncFzsdxMDcY=
 github.com/autobrr/go-qbittorrent v1.17.1-0.20260815045428-fe3b4cb79f3e h1:bzRlD5PdJ+edMyjI3bjpcfUlZSNtJDoSZwZq3Zg8+HM=
 github.com/autobrr/go-qbittorrent v1.17.1-0.20260815045428-fe3b4cb79f3e/go.mod h1:9ujARiuSKZf8+NtApflTB69Wsptsp0Qk1mSVVC0tGzM=
 github.com/autobrr/go-torrent v1.1.1-0.20260811091921-e2224c4f4e34 h1:ubxfEt1oWe2B3otV6mhHiONaeO7ydAJaveOsQyPiIz0=


### PR DESCRIPTION
## Description

Bumps `github.com/autobrr/go-mediainfo` from a pinned pseudo-version to the tagged v0.8.0 release, which includes the context-aware file analysis the pin pointed at.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the media information dependency to version 0.8.0 for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->