### PR TITLE
feat(settings): add client_settings key-value store and API

### DIFF
--- a/cmd/qui/main.go
+++ b/cmd/qui/main.go
@@ -537,6 +537,7 @@ func (app *Application) runServer() {
 	automationStore := models.NewAutomationStore(db)
 	trackerCustomizationStore := models.NewTrackerCustomizationStore(db)
 	dashboardSettingsStore := models.NewDashboardSettingsStore(db)
+	clientSettingsStore := models.NewClientSettingsStore(db)
 	themeSettingsStore := models.NewThemeSettingsStore(db)
 	filterViewStore := models.NewFilterViewStore(db)
 	logExclusionsStore := models.NewLogExclusionsStore(db)
@@ -803,6 +804,7 @@ func (app *Application) runServer() {
 		AutomationService:                automationService,
 		TrackerCustomizationStore:        trackerCustomizationStore,
 		DashboardSettingsStore:           dashboardSettingsStore,
+		ClientSettingsStore:              clientSettingsStore,
 		ThemeSettingsStore:               themeSettingsStore,
 		FilterViewStore:                  filterViewStore,
 		LogExclusionsStore:               logExclusionsStore,

--- a/internal/api/handlers/client_settings.go
+++ b/internal/api/handlers/client_settings.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/services/activity"
+)
+
+// maxClientSettingsBodySize caps one PUT payload.
+const maxClientSettingsBodySize = 1 << 20 // 1 MiB
+
+type ClientSettingsHandler struct {
+	store *models.ClientSettingsStore
+	// activity signals stored-settings changes so open tabs refetch instead
+	// of polling.
+	activity activity.Publisher
+}
+
+func NewClientSettingsHandler(store *models.ClientSettingsStore, publisher activity.Publisher) *ClientSettingsHandler {
+	return &ClientSettingsHandler{store: store, activity: publisher}
+}
+
+// GetClientSettings returns every stored setting as a key-value map.
+func (h *ClientSettingsHandler) GetClientSettings(w http.ResponseWriter, r *http.Request) {
+	settings, err := h.store.GetAll(r.Context())
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to load client settings")
+		RespondError(w, http.StatusInternalServerError, "Failed to load client settings")
+		return
+	}
+	RespondJSON(w, http.StatusOK, settings)
+}
+
+// UpdateClientSettings upserts the submitted settings. The payload is a
+// partial map; keys not present stay untouched.
+func (h *ClientSettingsHandler) UpdateClientSettings(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxClientSettingsBodySize)
+
+	var settings map[string]string
+	if err := json.NewDecoder(r.Body).Decode(&settings); err != nil {
+		RespondError(w, http.StatusBadRequest, "Invalid request payload")
+		return
+	}
+	if len(settings) == 0 {
+		RespondError(w, http.StatusBadRequest, "No settings provided")
+		return
+	}
+	for key := range settings {
+		if key == "" {
+			RespondError(w, http.StatusBadRequest, "Invalid setting key")
+			return
+		}
+	}
+
+	if err := h.store.SetMany(r.Context(), settings); err != nil {
+		log.Error().Err(err).Msg("Failed to save client settings")
+		RespondError(w, http.StatusInternalServerError, "Failed to save client settings")
+		return
+	}
+	h.activity.Publish(activity.Event{Kind: activity.KindClientSettings})
+	RespondJSON(w, http.StatusOK, settings)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -79,6 +79,7 @@ type Server struct {
 	automationService                *automations.Service
 	trackerCustomizationStore        *models.TrackerCustomizationStore
 	dashboardSettingsStore           *models.DashboardSettingsStore
+	clientSettingsStore              *models.ClientSettingsStore
 	themeSettingsStore               *models.ThemeSettingsStore
 	filterViewStore                  *models.FilterViewStore
 	logExclusionsStore               *models.LogExclusionsStore
@@ -122,6 +123,7 @@ type Dependencies struct {
 	AutomationService                *automations.Service
 	TrackerCustomizationStore        *models.TrackerCustomizationStore
 	DashboardSettingsStore           *models.DashboardSettingsStore
+	ClientSettingsStore              *models.ClientSettingsStore
 	ThemeSettingsStore               *models.ThemeSettingsStore
 	FilterViewStore                  *models.FilterViewStore
 	LogExclusionsStore               *models.LogExclusionsStore
@@ -188,6 +190,7 @@ func NewServer(deps *Dependencies) *Server {
 		automationService:                deps.AutomationService,
 		trackerCustomizationStore:        deps.TrackerCustomizationStore,
 		dashboardSettingsStore:           deps.DashboardSettingsStore,
+		clientSettingsStore:              deps.ClientSettingsStore,
 		themeSettingsStore:               deps.ThemeSettingsStore,
 		filterViewStore:                  deps.FilterViewStore,
 		logExclusionsStore:               deps.LogExclusionsStore,
@@ -379,6 +382,7 @@ func (s *Server) Handler() (*chi.Mux, error) {
 	rssHandler := handlers.NewRSSHandler(s.syncManager)
 	rssSSEHandler := handlers.NewRSSSSEHandler(s.syncManager)
 	dashboardSettingsHandler := handlers.NewDashboardSettingsHandler(s.dashboardSettingsStore)
+	clientSettingsHandler := handlers.NewClientSettingsHandler(s.clientSettingsStore, s.activityHub)
 	filterViewHandler := handlers.NewFilterViewHandler(s.filterViewStore)
 	logExclusionsHandler := handlers.NewLogExclusionsHandler(s.logExclusionsStore)
 	logsHandler := handlers.NewLogsHandler(s.config)
@@ -451,6 +455,10 @@ func (s *Server) Handler() (*chi.Mux, error) {
 
 			// Persisted theme selection (reads are public above)
 			r.Put("/themes/settings", themesHandler.UpdateThemeSettings)
+
+			// Persisted frontend user settings (opaque key-value map)
+			r.Get("/client-settings", clientSettingsHandler.GetClientSettings)
+			r.Put("/client-settings", clientSettingsHandler.UpdateClientSettings)
 
 			// Jackett routes (if configured)
 			if jackettHandler != nil {

--- a/internal/database/migrations/090_add_client_settings.sql
+++ b/internal/database/migrations/090_add_client_settings.sql
@@ -1,0 +1,8 @@
+-- Copyright (c) 2026, s0up and the autobrr contributors.
+-- SPDX-License-Identifier: GPL-2.0-or-later
+
+CREATE TABLE IF NOT EXISTS client_settings (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/internal/database/postgres_migrations/092_add_client_settings.sql
+++ b/internal/database/postgres_migrations/092_add_client_settings.sql
@@ -1,0 +1,8 @@
+-- Copyright (c) 2026, s0up and the autobrr contributors.
+-- SPDX-License-Identifier: GPL-2.0-or-later
+
+CREATE TABLE IF NOT EXISTS client_settings (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/internal/models/client_settings.go
+++ b/internal/models/client_settings.go
@@ -39,10 +39,17 @@ func (s *ClientSettingsStore) GetAll(ctx context.Context) (map[string]string, er
 	return settings, rows.Err()
 }
 
-// SetMany upserts the given settings, leaving keys not in the map untouched.
+// SetMany upserts the given settings atomically, leaving keys not in the map
+// untouched.
 func (s *ClientSettingsStore) SetMany(ctx context.Context, settings map[string]string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
 	for key, value := range settings {
-		_, err := s.db.ExecContext(ctx, `
+		_, err := tx.ExecContext(ctx, `
 			INSERT INTO client_settings (key, value)
 			VALUES (?, ?)
 			ON CONFLICT (key) DO UPDATE SET
@@ -53,5 +60,5 @@ func (s *ClientSettingsStore) SetMany(ctx context.Context, settings map[string]s
 			return err
 		}
 	}
-	return nil
+	return tx.Commit()
 }

--- a/internal/models/client_settings.go
+++ b/internal/models/client_settings.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package models
+
+import (
+	"context"
+
+	"github.com/autobrr/qui/internal/dbinterface"
+)
+
+// ClientSettingsStore persists frontend user settings as an opaque key-value
+// map. Values are raw strings the backend never parses; the frontend owns the
+// encoding of every key.
+type ClientSettingsStore struct {
+	db dbinterface.Querier
+}
+
+func NewClientSettingsStore(db dbinterface.Querier) *ClientSettingsStore {
+	return &ClientSettingsStore{db: db}
+}
+
+// GetAll returns every stored setting. An empty map means nothing is stored.
+func (s *ClientSettingsStore) GetAll(ctx context.Context) (map[string]string, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT key, value FROM client_settings`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	settings := make(map[string]string)
+	for rows.Next() {
+		var key, value string
+		if err := rows.Scan(&key, &value); err != nil {
+			return nil, err
+		}
+		settings[key] = value
+	}
+	return settings, rows.Err()
+}
+
+// SetMany upserts the given settings, leaving keys not in the map untouched.
+func (s *ClientSettingsStore) SetMany(ctx context.Context, settings map[string]string) error {
+	for key, value := range settings {
+		_, err := s.db.ExecContext(ctx, `
+			INSERT INTO client_settings (key, value)
+			VALUES (?, ?)
+			ON CONFLICT (key) DO UPDATE SET
+				value = excluded.value,
+				updated_at = CURRENT_TIMESTAMP
+		`, key, value)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/models/client_settings_test.go
+++ b/internal/models/client_settings_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package models_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/testutil/testdb"
+)
+
+func TestClientSettingsStore_GetAllEmpty(t *testing.T) {
+	store := models.NewClientSettingsStore(testdb.NewMigratedSQLite(t, "client-settings"))
+
+	settings, err := store.GetAll(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, settings)
+}
+
+func TestClientSettingsStore_SetManyAndOverwrite(t *testing.T) {
+	store := models.NewClientSettingsStore(testdb.NewMigratedSQLite(t, "client-settings"))
+	ctx := context.Background()
+
+	require.NoError(t, store.SetMany(ctx, map[string]string{
+		"qui-speed-units":       `"bits"`,
+		"qui-column-sorting:1":  `[{"id":"name","desc":false}]`,
+		"qui-torrent-view-mode": "compact",
+	}))
+
+	settings, err := store.GetAll(ctx)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{
+		"qui-speed-units":       `"bits"`,
+		"qui-column-sorting:1":  `[{"id":"name","desc":false}]`,
+		"qui-torrent-view-mode": "compact",
+	}, settings)
+
+	// Partial update overwrites one key and leaves the others untouched.
+	require.NoError(t, store.SetMany(ctx, map[string]string{
+		"qui-speed-units": `"bytes"`,
+	}))
+
+	settings, err = store.GetAll(ctx)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{
+		"qui-speed-units":       `"bytes"`,
+		"qui-column-sorting:1":  `[{"id":"name","desc":false}]`,
+		"qui-torrent-view-mode": "compact",
+	}, settings)
+}

--- a/internal/services/activity/activity.go
+++ b/internal/services/activity/activity.go
@@ -36,6 +36,7 @@ const (
 	KindSearchHistory      Kind = "search.history"
 	KindTrackerIcons       Kind = "tracker.icons"
 	KindThemeSettings      Kind = "theme.settings"
+	KindClientSettings     Kind = "client.settings"
 )
 
 // Event is a small, JSON-serializable signal that some qui-owned state changed.

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -3187,6 +3187,50 @@ paths:
         '500':
           description: Failed to save theme settings
 
+  /api/client-settings:
+    get:
+      tags:
+        - Client Settings
+      summary: Get stored client settings
+      description: Get every stored frontend user setting as a key-value map of raw strings. The backend does not parse values.
+      responses:
+        '200':
+          description: All stored client settings
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+        '500':
+          description: Failed to load client settings
+    put:
+      tags:
+        - Client Settings
+      summary: Store client settings
+      description: Upsert the submitted settings. The payload is a partial key-value map; keys not present stay untouched.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: string
+      responses:
+        '200':
+          description: Settings stored; echoes the submitted map
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+        '400':
+          description: Invalid payload, empty map, empty key, or body over 1 MiB
+        '500':
+          description: Failed to save client settings
+
   /api/torrents/export:
     post:
       tags:


### PR DESCRIPTION
## Description

Adds a `client_settings` key-value table and `GET`/`PUT /api/client-settings` so frontend user settings (column layout, filters, view prefs) can persist in the database instead of browser localStorage. Values are opaque strings the backend never parses; a PUT is a partial upsert and publishes a `client.settings` activity event so open tabs refetch. Backend half of #2406, frontend follows in separate PRs.

Part of #2406

## How has this been tested?

Ran the built binary against a fresh database and exercised the endpoints with curl: empty GET returns `{}`, PUT upserts, a partial PUT leaves other keys untouched, empty map and empty key get 400, unauthenticated requests get 401.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added authenticated API endpoints to retrieve and update client settings.
  - Supports partial updates while preserving settings that are not included.
  - Client settings are persisted across sessions.
  - Changes are recorded in the activity feed.
  - Added validation for invalid or oversized requests.

- **Documentation**
  - Added API documentation for retrieving and updating client settings.

- **Bug Fixes**
  - Improved handling of settings persistence and update errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->