### PR TITLE
fix(qbittorrent): treat request timeouts as slow instances, not dead ones

### DIFF
--- a/cmd/qui/main.go
+++ b/cmd/qui/main.go
@@ -560,7 +560,7 @@ func (app *Application) runServer() {
 	}()
 
 	// Initialize qBittorrent client pool
-	clientPool, err := qbittorrent.NewClientPool(instanceStore, errorStore)
+	clientPool, err := qbittorrent.NewClientPool(instanceStore, errorStore, time.Duration(cfg.Config.QbittorrentTimeout)*time.Second)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to initialize client pool")
 	}

--- a/documentation/docs/configuration/environment.md
+++ b/documentation/docs/configuration/environment.md
@@ -82,6 +82,12 @@ QUI__DATABASE_MAX_IDLE_CONNS=5         # Postgres pool max idle connections
 QUI__DATABASE_CONN_MAX_LIFETIME=300    # Max connection lifetime in seconds
 ```
 
+## qBittorrent Connection
+
+```bash
+QUI__QBITTORRENT_TIMEOUT=60  # Optional: HTTP timeout in seconds for requests qui makes to qBittorrent instances (default: 60). Raise it for very large or slow instances.
+```
+
 ## Cross-Seed
 
 ```bash

--- a/documentation/docs/configuration/reference.md
+++ b/documentation/docs/configuration/reference.md
@@ -65,6 +65,7 @@ qui watches `config.toml` for changes. Some settings are applied immediately (fo
 | `databaseMaxOpenConns` | `QUI__DATABASE_MAX_OPEN_CONNS` | int | `25` | Postgres pool max open connections. |
 | `databaseMaxIdleConns` | `QUI__DATABASE_MAX_IDLE_CONNS` | int | `5` | Postgres pool max idle connections. |
 | `databaseConnMaxLifetime` | `QUI__DATABASE_CONN_MAX_LIFETIME` | int | `300` | Postgres connection max lifetime in seconds. |
+| `qbittorrentTimeout` | `QUI__QBITTORRENT_TIMEOUT` | int | `60` | HTTP timeout in seconds for requests qui makes to qBittorrent instances (sync, health checks). Raise it for very large or slow instances. Restart required. |
 | `checkForUpdates` | `QUI__CHECK_FOR_UPDATES` | bool | `true` | Controls update checks and UI indicators. Restart recommended. |
 | `trackerIconsFetchEnabled` | `QUI__TRACKER_ICONS_FETCH_ENABLED` | bool | `true` | Disable to prevent remote tracker favicon fetches. Applied immediately. |
 | `crossSeedRecoverErroredTorrents` | `QUI__CROSS_SEED_RECOVER_ERRORED_TORRENTS` | bool | `false` | When enabled, cross-seed automation attempts recovery (pause, recheck, resume) for errored/missingFiles torrents. Can add 25+ minutes per torrent. Restart recommended. |

--- a/internal/api/handlers/instances_test.go
+++ b/internal/api/handlers/instances_test.go
@@ -31,7 +31,7 @@ func TestGetInstanceCapabilitiesPreservesBackoffMessage(t *testing.T) {
 	instanceStore, err := models.NewInstanceStore(db, []byte("01234567890123456789012345678901"))
 	require.NoError(t, err)
 	errorStore := models.NewInstanceErrorStore(db)
-	clientPool, err := internalqbittorrent.NewClientPool(instanceStore, errorStore)
+	clientPool, err := internalqbittorrent.NewClientPool(instanceStore, errorStore, 60*time.Second)
 	require.NoError(t, err)
 	defer clientPool.Close()
 

--- a/internal/api/handlers/torrents_field_test.go
+++ b/internal/api/handlers/torrents_field_test.go
@@ -284,7 +284,7 @@ func createTorrentFieldTestHarness(t *testing.T, torrentsByInstanceName map[stri
 	require.NoError(t, err)
 
 	errorStore := models.NewInstanceErrorStore(db)
-	clientPool, err := quiqbt.NewClientPool(instanceStore, errorStore)
+	clientPool, err := quiqbt.NewClientPool(instanceStore, errorStore, 60*time.Second)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		_ = clientPool.Close()
@@ -327,7 +327,7 @@ func createStaleCrossInstanceReadHarness(t *testing.T) (*TorrentsHandler, func()
 	instanceStore, err := models.NewInstanceStore(db, []byte("01234567890123456789012345678901"))
 	require.NoError(t, err)
 	errorStore := models.NewInstanceErrorStore(db)
-	clientPool, err := quiqbt.NewClientPool(instanceStore, errorStore)
+	clientPool, err := quiqbt.NewClientPool(instanceStore, errorStore, 60*time.Second)
 	require.NoError(t, err)
 
 	instance, err := instanceStore.Create(context.Background(), "alpha", srv.URL, "user", "pass", nil, nil, false, nil)

--- a/internal/api/sse/manager.go
+++ b/internal/api/sse/manager.go
@@ -2052,7 +2052,13 @@ func (m *StreamManager) syncTimeout(instanceID int) time.Duration {
 
 	state, ok := m.syncBackoff[instanceID]
 	if !ok || !state.primed || state.attempt > 0 {
-		return syncTimeoutFull
+		// The full budget is bounded by the pool's HTTP transport timeout when
+		// the operator configured a larger one (#2037 reasoning).
+		full := syncTimeoutFull
+		if m.clientPool != nil {
+			full = max(full, m.clientPool.ClientTimeout())
+		}
+		return full
 	}
 	return syncTimeoutIncremental
 }

--- a/internal/api/sse/manager_test.go
+++ b/internal/api/sse/manager_test.go
@@ -619,6 +619,31 @@ func TestStreamManager_syncTimeout(t *testing.T) {
 	}
 }
 
+// TestStreamManager_syncTimeout_followsClientTimeout verifies the full-sync budget
+// is raised to the pool's HTTP transport timeout when the operator configured a
+// larger one, and never lowered below syncTimeoutFull (#2037 reasoning).
+func TestStreamManager_syncTimeout_followsClientTimeout(t *testing.T) {
+	tests := []struct {
+		name          string
+		clientTimeout time.Duration
+		want          time.Duration
+	}{
+		{name: "larger_transport_raises_full_budget", clientTimeout: 180 * time.Second, want: 180 * time.Second},
+		{name: "default_transport_keeps_full_budget", clientTimeout: 60 * time.Second, want: syncTimeoutFull},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pool, err := qbittorrent.NewClientPool(nil, nil, tt.clientTimeout)
+			require.NoError(t, err)
+			defer pool.Close()
+
+			manager := NewStreamManager(pool, nil, nil)
+			require.Equal(t, tt.want, manager.syncTimeout(1), "unprimed instance should get the full budget bounded by the transport")
+		})
+	}
+}
+
 func TestStreamManager_syncTimeout_concurrent(t *testing.T) {
 	// syncTimeout reads backoffState fields that markSyncSuccess/markSyncFailure
 	// mutate under m.mu. This must stay race-free; run under `go test -race`.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -122,6 +122,7 @@ func (c *AppConfig) defaults() {
 	c.viper.SetDefault("databaseMaxOpenConns", 25)
 	c.viper.SetDefault("databaseMaxIdleConns", 5)
 	c.viper.SetDefault("databaseConnMaxLifetime", 300)
+	c.viper.SetDefault("qbittorrentTimeout", 60)
 	c.viper.SetDefault("checkForUpdates", true)
 	c.viper.SetDefault("trackerIconsFetchEnabled", true)
 	c.viper.SetDefault("customThemesDir", "") // Empty means <config-dir>/themes
@@ -226,6 +227,7 @@ func (c *AppConfig) loadFromEnv() {
 	c.viper.BindEnv("databaseMaxOpenConns", envPrefix+"DATABASE_MAX_OPEN_CONNS")
 	c.viper.BindEnv("databaseMaxIdleConns", envPrefix+"DATABASE_MAX_IDLE_CONNS")
 	c.viper.BindEnv("databaseConnMaxLifetime", envPrefix+"DATABASE_CONN_MAX_LIFETIME")
+	c.viper.BindEnv("qbittorrentTimeout", envPrefix+"QBITTORRENT_TIMEOUT")
 	c.viper.BindEnv("checkForUpdates", envPrefix+"CHECK_FOR_UPDATES")
 	c.viper.BindEnv("trackerIconsFetchEnabled", envPrefix+"TRACKER_ICONS_FETCH_ENABLED")
 	c.viper.BindEnv("customThemesDir", envPrefix+"CUSTOM_THEMES_DIR")
@@ -345,6 +347,10 @@ func (c *AppConfig) hydrateConfigFromViper() {
 	c.Config.DatabaseMaxOpenConns = c.viper.GetInt("databaseMaxOpenConns")
 	c.Config.DatabaseMaxIdleConns = c.viper.GetInt("databaseMaxIdleConns")
 	c.Config.DatabaseConnMaxLifetime = c.viper.GetInt("databaseConnMaxLifetime")
+	c.Config.QbittorrentTimeout = c.viper.GetInt("qbittorrentTimeout")
+	if c.Config.QbittorrentTimeout <= 0 {
+		c.Config.QbittorrentTimeout = 60
+	}
 	c.Config.CheckForUpdates = c.viper.GetBool("checkForUpdates")
 	c.Config.TrackerIconsFetchEnabled = c.viper.GetBool("trackerIconsFetchEnabled")
 	c.Config.CustomThemesDir = c.viper.GetString("customThemesDir")
@@ -536,6 +542,12 @@ sessionSecret = "{{ .sessionSecret }}"
 #databaseMaxOpenConns = 25
 #databaseMaxIdleConns = 5
 #databaseConnMaxLifetime = 300
+
+# HTTP timeout in seconds for requests qui makes to qBittorrent instances
+# (sync, health checks, capabilities). Raise it for very large or slow
+# instances whose responses take longer than 60 seconds.
+# Default: 60
+#qbittorrentTimeout = 60
 
 # Check for new releases via api.autobrr.com
 # Default: true

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -41,6 +41,7 @@ type Config struct {
 	DatabaseMaxOpenConns     int    `toml:"databaseMaxOpenConns" mapstructure:"databaseMaxOpenConns"`
 	DatabaseMaxIdleConns     int    `toml:"databaseMaxIdleConns" mapstructure:"databaseMaxIdleConns"`
 	DatabaseConnMaxLifetime  int    `toml:"databaseConnMaxLifetime" mapstructure:"databaseConnMaxLifetime"`
+	QbittorrentTimeout       int    `toml:"qbittorrentTimeout" mapstructure:"qbittorrentTimeout"`
 	CheckForUpdates          bool   `toml:"checkForUpdates" mapstructure:"checkForUpdates"`
 	PprofEnabled             bool   `toml:"pprofEnabled" mapstructure:"pprofEnabled"`
 	PprofAddr                string `toml:"pprofAddr" mapstructure:"pprofAddr"`

--- a/internal/qbittorrent/client.go
+++ b/internal/qbittorrent/client.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"math"
 	"net/url"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -17,6 +18,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/autobrr/autobrr/pkg/ttlcache"
 	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/avast/retry-go"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 )
@@ -320,19 +322,29 @@ func isContextStopped(err error) bool {
 	return strings.Contains(msg, "context canceled")
 }
 
-// isDeadlineExpired recognizes request timeouts even after retry wrappers flatten the sentinel.
+// isDeadlineExpired recognizes request timeouts even after wrappers flatten the sentinel.
 // A deadline is ambiguous: usually a saturated instance working through its
 // queue, but it can also be a dial that never completed (a blackholed host).
-// The two are indistinguishable here: go-qbt's retry wrapper drops the error
-// chain, and a caller deadline firing before the 30s dial timeout yields the
-// same "context deadline exceeded" text either way. We deliberately classify
-// both as slow: stale data with a staleness badge beats backoff and 502s.
+// A caller deadline firing before the 30s dial timeout yields the same
+// "context deadline exceeded" text either way. We deliberately classify both
+// as slow: stale data with a staleness badge beats backoff and 502s.
 // Hard failures (refused, DNS, EOF, a bare "dial tcp: i/o timeout") are
 // unambiguous evidence of a dead instance and stay unmatched here.
 func isDeadlineExpired(err error) bool {
 	if err == nil {
 		return false
 	}
+
+	var retryErr retry.Error
+	if errors.As(err, &retryErr) {
+		for _, r := range slices.Backward(retryErr) {
+			if r != nil {
+				err = r
+				break
+			}
+		}
+	}
+
 	if errors.Is(err, context.DeadlineExceeded) {
 		return true
 	}

--- a/internal/qbittorrent/client.go
+++ b/internal/qbittorrent/client.go
@@ -272,7 +272,7 @@ func (c *Client) IsHealthy() bool {
 }
 
 // handleSyncManagerError records qBittorrent sync failures while ignoring explicit caller cancellation.
-// Deadline expiry keeps the client healthy: a saturated instance answering slowly is not down,
+// Deadline expiry keeps the client healthy: it is treated as slow by design (see isDeadlineExpired),
 // and flipping it unhealthy sends every caller into the probe/backoff path (502 storms).
 // The error is still dispatched so the SSE loop backs off and escalates to the full sync budget.
 func (c *Client) handleSyncManagerError(err error) {
@@ -321,10 +321,14 @@ func isContextStopped(err error) bool {
 }
 
 // isDeadlineExpired recognizes request timeouts even after retry wrappers flatten the sentinel.
-// A deadline expiring against qBittorrent means the instance is slow, not down:
-// the connection was accepted and the server is working through its queue.
-// Hard failures (refused, DNS, EOF, dial i/o timeout) are the evidence of a
-// dead instance and deliberately stay unmatched here.
+// A deadline is ambiguous: usually a saturated instance working through its
+// queue, but it can also be a dial that never completed (a blackholed host).
+// The two are indistinguishable here: go-qbt's retry wrapper drops the error
+// chain, and a caller deadline firing before the 30s dial timeout yields the
+// same "context deadline exceeded" text either way. We deliberately classify
+// both as slow: stale data with a staleness badge beats backoff and 502s.
+// Hard failures (refused, DNS, EOF, a bare "dial tcp: i/o timeout") are
+// unambiguous evidence of a dead instance and stay unmatched here.
 func isDeadlineExpired(err error) bool {
 	if err == nil {
 		return false

--- a/internal/qbittorrent/client.go
+++ b/internal/qbittorrent/client.go
@@ -128,7 +128,12 @@ type Client struct {
 	activeTaskMu         sync.Mutex
 }
 
-func NewClientWithTimeout(instanceID int, instanceHost, username, password, apiKey string, basicUsername, basicPassword *string, tlsSkipVerify bool, timeout time.Duration) (*Client, error) {
+// NewClientWithTimeout builds a pooled client. loginTimeout bounds only the
+// initial login and capability fetch; transportTimeout becomes the HTTP client
+// timeout for every request the client ever makes. Keeping them separate stops
+// a short creation budget (e.g. the 3s login warm) from being baked into the
+// transport for the life of the client.
+func NewClientWithTimeout(instanceID int, instanceHost, username, password, apiKey string, basicUsername, basicPassword *string, tlsSkipVerify bool, loginTimeout, transportTimeout time.Duration) (*Client, error) {
 	// Strip credentials embedded in the host URL (user:pass@host) so they never
 	// reach go-qbt request URLs, whose error strings get logged verbatim all
 	// over qui. They move to basic auth, which is what URL userinfo means.
@@ -139,7 +144,7 @@ func NewClientWithTimeout(instanceID int, instanceHost, username, password, apiK
 		Username:      username,
 		Password:      password,
 		APIKey:        apiKey,
-		Timeout:       int(timeout.Seconds()),
+		Timeout:       int(transportTimeout.Seconds()),
 		TLSSkipVerify: tlsSkipVerify,
 	}
 
@@ -155,7 +160,7 @@ func NewClientWithTimeout(instanceID int, instanceHost, username, password, apiK
 
 	qbtClient := qbt.NewClient(cfg)
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), loginTimeout)
 	defer cancel()
 
 	if err := qbtClient.LoginCtx(ctx); err != nil {
@@ -267,8 +272,9 @@ func (c *Client) IsHealthy() bool {
 }
 
 // handleSyncManagerError records qBittorrent sync failures while ignoring explicit caller cancellation.
-// Deadline expiry is treated as a real sync failure so stream error handling can
-// mark cached health stale instead of preserving a stale healthy state.
+// Deadline expiry keeps the client healthy: a saturated instance answering slowly is not down,
+// and flipping it unhealthy sends every caller into the probe/backoff path (502 storms).
+// The error is still dispatched so the SSE loop backs off and escalates to the full sync budget.
 func (c *Client) handleSyncManagerError(err error) {
 	if err == nil {
 		return
@@ -279,6 +285,16 @@ func (c *Client) handleSyncManagerError(err error) {
 			Err(err).
 			Int("instanceID", c.instanceID).
 			Msg("Sync manager context stopped, keeping client health unchanged")
+		return
+	}
+
+	if isDeadlineExpired(err) {
+		log.Debug().
+			Err(err).
+			Int("instanceID", c.instanceID).
+			Msg("Sync timed out against a slow instance, keeping client health unchanged")
+
+		c.dispatchSyncError(err)
 		return
 	}
 
@@ -302,6 +318,24 @@ func isContextStopped(err error) bool {
 
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "context canceled")
+}
+
+// isDeadlineExpired recognizes request timeouts even after retry wrappers flatten the sentinel.
+// A deadline expiring against qBittorrent means the instance is slow, not down:
+// the connection was accepted and the server is working through its queue.
+// Hard failures (refused, DNS, EOF, dial i/o timeout) are the evidence of a
+// dead instance and deliberately stay unmatched here.
+func isDeadlineExpired(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "context deadline exceeded") ||
+		strings.Contains(msg, "client.timeout exceeded")
 }
 
 func (c *Client) SupportsTorrentCreation() bool {
@@ -537,7 +571,10 @@ func (c *Client) HealthCheck(ctx context.Context) error {
 	}
 
 	if err := c.RefreshCapabilities(ctx); err != nil {
-		c.updateHealthStatus(false)
+		// Slow, not down: a timed-out probe keeps the current health state.
+		if !isDeadlineExpired(err) {
+			c.updateHealthStatus(false)
+		}
 		return errors.Wrap(err, "health check failed")
 	}
 

--- a/internal/qbittorrent/client_test.go
+++ b/internal/qbittorrent/client_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/avast/retry-go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -602,6 +603,8 @@ func TestIsDeadlineExpired(t *testing.T) {
 		{name: "nil", err: nil, want: false},
 		{name: "deadline sentinel", err: fmt.Errorf("could not get main data: %w", context.DeadlineExceeded), want: true},
 		{name: "flattened retry text", err: errors.New("All attempts fail: #1: Get \"http://gluetun:8080/api/v2/app/webapiVersion\": context deadline exceeded"), want: true},
+		{name: "mixed retry ending in hard failure", err: retry.Error{context.DeadlineExceeded, errors.New("connection refused")}, want: false},
+		{name: "mixed retry ending in deadline", err: retry.Error{errors.New("connection refused"), context.DeadlineExceeded}, want: true},
 		{name: "net/http client timeout", err: errors.New("Get \"http://x\": net/http: request canceled (Client.Timeout exceeded while awaiting headers)"), want: true},
 		{name: "cancellation", err: context.Canceled, want: false},
 		{name: "connection refused", err: errors.New("dial tcp 127.0.0.1:1: connect: connection refused"), want: false},

--- a/internal/qbittorrent/client_test.go
+++ b/internal/qbittorrent/client_test.go
@@ -275,7 +275,7 @@ func TestNewClientWithTimeoutRejectsLoginCookiesWithoutVerifiedSessionMarker(t *
 	}))
 	defer srv.Close()
 
-	client, err := NewClientWithTimeout(1, srv.URL, "user", "pass", "", nil, nil, true, time.Second)
+	client, err := NewClientWithTimeout(1, srv.URL, "user", "pass", "", nil, nil, true, time.Second, 60*time.Second)
 
 	require.Error(t, err)
 	require.Nil(t, client)
@@ -307,11 +307,42 @@ func TestNewClientWithTimeoutToleratesSlowCapabilitiesFetch(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client, err := NewClientWithTimeout(1, srv.URL, "user", "pass", "", nil, nil, true, time.Second)
+	client, err := NewClientWithTimeout(1, srv.URL, "user", "pass", "", nil, nil, true, time.Second, 60*time.Second)
 
 	require.NoError(t, err, "transient capability fetch failures must not block client creation")
 	require.NotNil(t, client)
 	require.False(t, client.IsHealthy(), "client should start unhealthy until a capability refresh succeeds")
+}
+
+// TestNewClientWithTimeoutTransportIndependentOfLoginBudget verifies that a short
+// creation budget (e.g. the 3s login warm) is not baked into the HTTP transport
+// timeout for the life of the client.
+func TestNewClientWithTimeoutTransportIndependentOfLoginBudget(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			http.SetCookie(w, &http.Cookie{
+				Name:     "SID",
+				Value:    "quick-login",
+				Secure:   true,
+				HttpOnly: true,
+				SameSite: http.SameSiteStrictMode,
+			})
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/app/webapiVersion":
+			_, _ = w.Write([]byte("2.16.0"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client, err := NewClientWithTimeout(1, srv.URL, "user", "pass", "", nil, nil, true, 3*time.Second, 60*time.Second)
+
+	require.NoError(t, err)
+	require.Equal(t, 60*time.Second, client.GetHTTPClient().Timeout, "transport timeout must come from the pool, not the creation budget")
 }
 
 func TestTruncateWebAPIVersion(t *testing.T) {
@@ -519,7 +550,7 @@ func TestClientHandleSyncManagerErrorIgnoresContextStopped(t *testing.T) {
 	}
 }
 
-func TestClientHandleSyncManagerErrorMarksUnhealthyForDeadline(t *testing.T) {
+func TestClientHandleSyncManagerErrorKeepsHealthyForDeadline(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -550,11 +581,76 @@ func TestClientHandleSyncManagerErrorMarksUnhealthyForDeadline(t *testing.T) {
 
 			client.handleSyncManagerError(tc.err)
 
-			require.False(t, client.IsHealthy())
-			require.Nil(t, client.GetCachedServerState())
+			// Slow, not down: health and cached state survive, but the error
+			// still dispatches so the SSE loop backs off and escalates its
+			// sync budget.
+			require.True(t, client.IsHealthy())
+			require.NotNil(t, client.GetCachedServerState())
 			require.Len(t, sink.getSyncErrorCalls(), 1)
 		})
 	}
+}
+
+func TestIsDeadlineExpired(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "deadline sentinel", err: fmt.Errorf("could not get main data: %w", context.DeadlineExceeded), want: true},
+		{name: "flattened retry text", err: errors.New("All attempts fail: #1: Get \"http://gluetun:8080/api/v2/app/webapiVersion\": context deadline exceeded"), want: true},
+		{name: "net/http client timeout", err: errors.New("Get \"http://x\": net/http: request canceled (Client.Timeout exceeded while awaiting headers)"), want: true},
+		{name: "cancellation", err: context.Canceled, want: false},
+		{name: "connection refused", err: errors.New("dial tcp 127.0.0.1:1: connect: connection refused"), want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, isDeadlineExpired(tc.err))
+		})
+	}
+}
+
+// TestClientHealthCheckKeepsHealthOnDeadline verifies that a probe timing out against a
+// responding-but-saturated instance does not demote health.
+func TestClientHealthCheckKeepsHealthOnDeadline(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	client := &Client{Client: qbt.NewClient(qbt.Config{Host: srv.URL, Timeout: 60}), instanceID: 42, isHealthy: true}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := client.HealthCheck(ctx)
+	require.Error(t, err)
+	require.True(t, client.IsHealthy(), "a timed-out probe must not demote a healthy client")
+}
+
+// TestClientHealthCheckMarksUnhealthyOnHardFailure pins that connection-level failures
+// still demote health immediately (#2096: dead instances must go red fast).
+func TestClientHealthCheckMarksUnhealthyOnHardFailure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	srv.Close()
+
+	client := &Client{Client: qbt.NewClient(qbt.Config{Host: srv.URL, Timeout: 60}), instanceID: 42, isHealthy: true}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := client.HealthCheck(ctx)
+	require.Error(t, err)
+	require.False(t, client.IsHealthy(), "a hard connection failure must demote the client")
 }
 
 func TestClientHandleSyncManagerErrorMarksUnhealthyForRealError(t *testing.T) {

--- a/internal/qbittorrent/pool.go
+++ b/internal/qbittorrent/pool.go
@@ -340,11 +340,11 @@ func (cp *ClientPool) GetClientWithTimeout(ctx context.Context, instanceID int, 
 
 		if err := client.HealthCheck(ctx); err != nil {
 			// A caller-cancelled probe (client disconnect / shutdown) is not
-			// evidence the instance is down, and a deadline means the instance is
-			// slow, not down — the server accepted the connection and is working
-			// through its queue. Only hard failures (refused, DNS, EOF, auth)
-			// record a failure and advance backoff. Both helpers match even after
-			// go-qbt's retry wrapper flattens the sentinel into a string.
+			// evidence the instance is down, and a deadline is treated as slow
+			// by design (ambiguous, see isDeadlineExpired). Only hard failures
+			// (refused, DNS, EOF, auth) record a failure and advance backoff.
+			// Both helpers match even after go-qbt's retry wrapper flattens the
+			// sentinel into a string.
 			if !isContextStopped(err) && !isDeadlineExpired(err) {
 				cp.trackFailure(instanceID, err)
 			}

--- a/internal/qbittorrent/pool.go
+++ b/internal/qbittorrent/pool.go
@@ -149,11 +149,14 @@ type ClientPool struct {
 	syncEventSinkSeq  uint64
 	completionHandler TorrentCompletionHandler
 	addedHandler      TorrentAddedHandler
-	syncManager       *SyncManager // Reference for starting background tasks
+	syncManager       *SyncManager  // Reference for starting background tasks
+	clientTimeout     time.Duration // HTTP transport timeout for every pooled client
 }
 
-// NewClientPool creates a new client pool
-func NewClientPool(instanceStore *models.InstanceStore, errorStore *models.InstanceErrorStore) (*ClientPool, error) {
+// NewClientPool creates a new client pool. clientTimeout is the HTTP transport
+// timeout applied to every client it creates, independent of any caller's
+// creation budget.
+func NewClientPool(instanceStore *models.InstanceStore, errorStore *models.InstanceErrorStore, clientTimeout time.Duration) (*ClientPool, error) {
 	// Create cache with 30 second TTL since torrent data changes frequently
 	cache := ttlcache.New(ttlcache.Options[string, *TorrentResponse]{}.
 		SetDefaultTTL(30 * time.Second))
@@ -163,6 +166,7 @@ func NewClientPool(instanceStore *models.InstanceStore, errorStore *models.Insta
 		instanceStore:     instanceStore,
 		errorStore:        errorStore,
 		cache:             cache,
+		clientTimeout:     clientTimeout,
 		creationLocks:     make(map[int]*sync.Mutex),
 		healthTicker:      time.NewTicker(healthCheckInterval),
 		stopHealth:        make(chan struct{}),
@@ -336,11 +340,12 @@ func (cp *ClientPool) GetClientWithTimeout(ctx context.Context, instanceID int, 
 
 		if err := client.HealthCheck(ctx); err != nil {
 			// A caller-cancelled probe (client disconnect / shutdown) is not
-			// evidence the instance is down, so don't record a failure or back it
-			// off. A deadline (unreachable / too slow) is a real failure and still
-			// tracks. isContextStopped matches even after go-qbt's retry wrapper
-			// flattens the cancellation sentinel into a string.
-			if !isContextStopped(err) {
+			// evidence the instance is down, and a deadline means the instance is
+			// slow, not down — the server accepted the connection and is working
+			// through its queue. Only hard failures (refused, DNS, EOF, auth)
+			// record a failure and advance backoff. Both helpers match even after
+			// go-qbt's retry wrapper flattens the sentinel into a string.
+			if !isContextStopped(err) && !isDeadlineExpired(err) {
 				cp.trackFailure(instanceID, err)
 			}
 			return nil, errors.Wrap(err, "client healthcheck failed")
@@ -424,8 +429,9 @@ func (cp *ClientPool) createClientWithTimeout(ctx context.Context, instanceID in
 		basicPassword = &decryptedBasicPassword
 	}
 
-	// Create new client with custom timeout
-	client, err := NewClientWithTimeout(instanceID, instance.Host, instance.Username, password, apiKey, instance.BasicUsername, basicPassword, instance.TLSSkipVerify, timeout)
+	// The caller's timeout bounds only login/creation; the transport timeout is
+	// pool-wide so a short creation budget never sticks to the client.
+	client, err := NewClientWithTimeout(instanceID, instance.Host, instance.Username, password, apiKey, instance.BasicUsername, basicPassword, instance.TLSSkipVerify, timeout, cp.clientTimeout)
 	if err != nil {
 		cp.trackFailure(instanceID, err)
 		return nil, fmt.Errorf("failed to create client: %w", err)
@@ -560,6 +566,13 @@ func (cp *ClientPool) performHealthChecks() {
 			defer cancel()
 
 			if err := client.HealthCheck(ctx); err != nil {
+				if isDeadlineExpired(err) {
+					// Slow, not down: no backoff, and debug level to keep a
+					// saturated instance from producing a warn every cycle.
+					log.Debug().Err(err).Int("instanceID", instanceID).Msg("Health check timed out against slow instance")
+					return
+				}
+
 				log.Warn().Err(err).Int("instanceID", instanceID).Msg("Health check failed")
 
 				// Track failure and apply backoff
@@ -577,6 +590,11 @@ func (cp *ClientPool) performHealthChecks() {
 // GetCache returns the cache instance for external use
 func (cp *ClientPool) GetCache() *ttlcache.Cache[string, *TorrentResponse] {
 	return cp.cache
+}
+
+// ClientTimeout returns the HTTP transport timeout applied to pooled clients.
+func (cp *ClientPool) ClientTimeout() time.Duration {
+	return cp.clientTimeout
 }
 
 // GetErrorStore returns the error store instance for external use

--- a/internal/qbittorrent/pool_test.go
+++ b/internal/qbittorrent/pool_test.go
@@ -31,7 +31,7 @@ func setupTestPool(t *testing.T) *ClientPool {
 	require.NoError(t, err, "Failed to create instance store")
 
 	errorStore := models.NewInstanceErrorStore(db)
-	pool, err := NewClientPool(instanceStore, errorStore)
+	pool, err := NewClientPool(instanceStore, errorStore, 60*time.Second)
 	require.NoError(t, err, "Failed to create client pool")
 	return pool
 }
@@ -216,12 +216,11 @@ func TestClientPool_GetClientWithTimeout_UnhealthyInBackoffFastFails(t *testing.
 // TestClientPool_GetClientWithTimeout_ConcurrentUnhealthyProbesBackoffOnce verifies that
 // a burst of concurrent callers against one unhealthy, not-yet-backed-off instance records
 // a single failure (advances backoff once), not once per caller (adversarial review of #2096).
+// The instance is dead (connection refused): a hard failure, so it must back off.
 func TestClientPool_GetClientWithTimeout_ConcurrentUnhealthyProbesBackoffOnce(t *testing.T) {
-	// Blocking endpoint so the probes overlap in time instead of failing instantly.
-	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		<-r.Context().Done()
-	}))
-	defer srv.Close()
+	// Closed listener: probes fail fast with a hard connection error.
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	srv.Close()
 
 	pool := setupTestPool(t)
 	defer pool.Close()
@@ -235,7 +234,7 @@ func TestClientPool_GetClientWithTimeout_ConcurrentUnhealthyProbesBackoffOnce(t 
 	var wg sync.WaitGroup
 	for range callers {
 		wg.Go(func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 			_, _ = pool.GetClientWithTimeout(ctx, instanceID, 60*time.Second)
 		})
@@ -248,6 +247,41 @@ func TestClientPool_GetClientWithTimeout_ConcurrentUnhealthyProbesBackoffOnce(t 
 
 	require.NotNil(t, info, "one failure should have been recorded")
 	assert.Equal(t, 1, info.attempts, "concurrent probes must advance the backoff exactly once, not once per caller")
+	assert.True(t, pool.isInBackoff(instanceID), "a dead instance must go into backoff (#2096)")
+}
+
+// TestClientPool_GetClientWithTimeout_SlowProbeDoesNotBackoff verifies that a probe that
+// times out against a responding-but-saturated instance does NOT record a failure or back
+// the instance off: slow is not down, and backing off a working instance turns one slow
+// request into an outage for every caller.
+func TestClientPool_GetClientWithTimeout_SlowProbeDoesNotBackoff(t *testing.T) {
+	// Blocking endpoint: the connection is accepted but the response never comes,
+	// so the probe fails with a deadline, the signature of a saturated instance.
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	pool := setupTestPool(t)
+	defer pool.Close()
+
+	const instanceID = 1
+	pool.mu.Lock()
+	pool.clients[instanceID] = &Client{Client: qbt.NewClient(qbt.Config{Host: srv.URL, Timeout: 60}), instanceID: instanceID}
+	pool.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	client, err := pool.GetClientWithTimeout(ctx, instanceID, 60*time.Second)
+	require.Error(t, err)
+	require.Nil(t, client)
+
+	assert.False(t, pool.isInBackoff(instanceID), "a timed-out probe must not put the instance in backoff")
+	pool.mu.RLock()
+	_, tracked := pool.failureTracker[instanceID]
+	pool.mu.RUnlock()
+	assert.False(t, tracked, "a timed-out probe must not record an instance failure")
 }
 
 // TestClientPool_GetClientWithTimeout_CancelledProbeDoesNotBackoff verifies that a probe


### PR DESCRIPTION
## Description

Since #2097, a health probe that times out puts the instance in backoff, and every concurrent caller gets an instant error. On a large instance (15k torrents) where requests take 30 to 150 seconds, this causes constant red/green flapping, 502s on proxied requests, and failed cross-seed runs with `health check already in progress`. A timeout now means slow, not down: it no longer marks the client unhealthy or advances backoff. Hard failures (connection refused, DNS, EOF) still turn the instance red immediately, so the #2096 fix stays intact.

Two related fixes: the HTTP transport timeout no longer inherits the caller's creation budget (the 3-second login warm could bake a 3-second transport timeout into a pooled client forever), and a new `QUI__QBITTORRENT_TIMEOUT` (seconds, default 60) raises the transport ceiling for instances whose responses take longer; the SSE full-sync budget follows it.

## How has this been tested?

Ran the built binary with `QUI__QBITTORRENT_TIMEOUT=180` and confirmed a clean start. The person who originally reported the issue tested the PR build on their 15k-torrent instance with the default timeout and reported no further instability during testing.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable qBittorrent request timeout, defaulting to 60 seconds.
  * Full synchronization timeouts now accommodate longer qBittorrent requests.

* **Bug Fixes**
  * Temporary timeouts no longer incorrectly mark instances as unhealthy or trigger backoff.
  * Health checks now better distinguish temporary timeouts, cancellations, and connection failures.
  * Improved timeout detection for requests that are retried.

* **Documentation**
  * Documented the timeout setting, environment variable, default value, units, and restart requirement.
  * Clarified metrics basic authentication credential formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
