### PR TITLE
feat(settings): sync localStorage user settings to the database

### DIFF
--- a/web/src/components/themes/BuiltinThemesLoader.tsx
+++ b/web/src/components/themes/BuiltinThemesLoader.tsx
@@ -4,15 +4,18 @@
  */
 
 import { useBuiltinThemes } from "@/hooks/useBuiltinThemes"
+import { useClientSettingsSync } from "@/hooks/useClientSettingsSync"
 import { useThemeSettingsSync } from "@/hooks/useThemeSettingsSync"
 
 /**
  * Mounts the built-in theme query and the server theme-settings sync app-wide,
  * above auth, so the login page paints the selected theme too. Registration
- * happens in the queryFn.
+ * happens in the queryFn. The client-settings sync rides along; its query is
+ * auth-gated and idles on the login page.
  */
 export function BuiltinThemesLoader(): null {
   useBuiltinThemes()
   useThemeSettingsSync()
+  useClientSettingsSync()
   return null
 }

--- a/web/src/hooks/useClientSettingsSync.ts
+++ b/web/src/hooks/useClientSettingsSync.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { useEffect } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { api } from "@/lib/api"
+import { useActivityStream } from "@/contexts/SyncStreamContext"
+import { useIsAuthed } from "@/hooks/useIsAuthed"
+import { applyServerSettings, readRaw, seedAndMarkReady } from "@/lib/client-settings"
+import { changeLanguage, supportedLanguages, type AppLanguage } from "@/i18n"
+
+/**
+ * Syncs DB-backed client settings with the server. On load the server
+ * snapshot is applied to localStorage (the instant-boot cache), keys the
+ * server does not know yet are seeded up from localStorage, and the debounced
+ * push queue opens. A "client.settings" activity event invalidates the query
+ * so other open tabs and browsers pull changes.
+ */
+export function useClientSettingsSync(): void {
+  const isAuthed = useIsAuthed()
+
+  useActivityStream(isAuthed)
+
+  const { data } = useQuery({
+    queryKey: ["client-settings"],
+    queryFn: () => api.getClientSettings(),
+    enabled: isAuthed,
+  })
+
+  useEffect(() => {
+    if (!data) return
+    const changed = applyServerSettings(data)
+    // i18n boots from localStorage before React mounts; a language applied
+    // from the server needs the imperative switch too.
+    if (changed.includes("qui.language")) {
+      const language = readRaw("qui.language")
+      if (language && supportedLanguages.includes(language as AppLanguage)) {
+        void changeLanguage(language as AppLanguage)
+      }
+    }
+    seedAndMarkReady(data)
+  }, [data])
+}

--- a/web/src/hooks/useIsAuthed.ts
+++ b/web/src/hooks/useIsAuthed.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { useQuery } from "@tanstack/react-query"
+import { api } from "@/lib/api"
+
+/**
+ * Observes the cached auth state without fetching (enabled: false); useAuth
+ * owns the fetch. Sync hooks gate their auth-only work on this so nothing
+ * runs on the login/setup pages.
+ */
+export function useIsAuthed(): boolean {
+  const { data: user } = useQuery({
+    queryKey: ["auth", "user"],
+    queryFn: () => api.checkAuth(),
+    enabled: false,
+  })
+  return Boolean(user)
+}

--- a/web/src/hooks/usePersistedCrossSeedBlocklist.ts
+++ b/web/src/hooks/usePersistedCrossSeedBlocklist.ts
@@ -3,50 +3,20 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useCallback, useEffect, useState } from "react"
+import { useState, type Dispatch, type SetStateAction } from "react"
+
+import { parseJsonBoolean, useClientSetting } from "@/lib/client-settings"
 
 export function usePersistedCrossSeedBlocklist(instanceId: number, defaultValue: boolean = false) {
-  const readStoredPreference = useCallback(() => {
-    if (instanceId <= 0) return undefined
-
-    try {
-      const storageKey = `qui-cross-seed-blocklist-${instanceId}`
-      const existingPreference = localStorage.getItem(storageKey)
-      if (existingPreference) {
-        const parsedPreference = JSON.parse(existingPreference)
-        if (typeof parsedPreference === "boolean") {
-          return parsedPreference
-        }
-      }
-    } catch (error) {
-      console.error("Failed to read cross-seed blocklist preference from localStorage:", error)
-    }
-
-    return undefined
-  }, [instanceId])
-
-  const [blockCrossSeeds, setBlockCrossSeeds] = useState<boolean>(() => readStoredPreference() ?? defaultValue)
-
-  useEffect(() => {
-    const storedPreference = readStoredPreference()
-    if (typeof storedPreference === "boolean") {
-      setBlockCrossSeeds(storedPreference)
-      return
-    }
-
-    setBlockCrossSeeds(defaultValue)
-  }, [defaultValue, readStoredPreference])
-
-  useEffect(() => {
-    if (instanceId <= 0) return
-
-    try {
-      const storageKey = `qui-cross-seed-blocklist-${instanceId}`
-      localStorage.setItem(storageKey, JSON.stringify(blockCrossSeeds))
-    } catch (error) {
-      console.error("Failed to save cross-seed blocklist preference to localStorage:", error)
-    }
-  }, [blockCrossSeeds, instanceId])
+  const persisted = useClientSetting<boolean>(`qui-cross-seed-blocklist-${instanceId}`, {
+    defaultValue,
+    parse: parseJsonBoolean,
+  })
+  // Non-positive ids (the all-instances view passes -1) never persisted this
+  // choice; keep it session-local there.
+  const local = useState<boolean>(defaultValue)
+  const blockCrossSeeds = instanceId > 0 ? persisted[0] : local[0]
+  const setBlockCrossSeeds: Dispatch<SetStateAction<boolean>> = instanceId > 0 ? persisted[1] : local[1]
 
   return {
     blockCrossSeeds,

--- a/web/src/hooks/usePersistedDateTimePreferences.ts
+++ b/web/src/hooks/usePersistedDateTimePreferences.ts
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useState, useEffect } from "react"
+import { useCallback } from "react"
+
+import { useClientSetting } from "@/lib/client-settings"
 
 export interface DateTimePreferences {
   timezone: string
@@ -17,67 +19,23 @@ const DEFAULT_PREFERENCES: DateTimePreferences = {
   dateFormat: "iso",
 }
 
+const parseDateTimePreferences = (raw: string): DateTimePreferences => ({
+  ...DEFAULT_PREFERENCES,
+  ...JSON.parse(raw),
+})
+
 export function usePersistedDateTimePreferences() {
-  const storageKey = "qui-datetime-preferences"
-
-  // Initialize state from localStorage or default values
-  const [preferences, setPreferencesState] = useState<DateTimePreferences>(() => {
-    try {
-      const stored = localStorage.getItem(storageKey)
-      if (stored) {
-        const parsed = JSON.parse(stored)
-        return {
-          ...DEFAULT_PREFERENCES,
-          ...parsed,
-        }
-      }
-    } catch (error) {
-      console.error("Failed to load date/time preferences from localStorage:", error)
-    }
-
-    return DEFAULT_PREFERENCES
+  const [preferences, setStored] = useClientSetting<DateTimePreferences>("qui-datetime-preferences", {
+    defaultValue: DEFAULT_PREFERENCES,
+    parse: parseDateTimePreferences,
   })
 
-  // Persist to localStorage whenever preferences change
-  useEffect(() => {
-    try {
-      localStorage.setItem(storageKey, JSON.stringify(preferences))
-    } catch (error) {
-      console.error("Failed to save date/time preferences to localStorage:", error)
-    }
-  }, [preferences])
-
-  // Listen for cross-component updates via CustomEvent within the same tab
-  useEffect(() => {
-    const handleEvent = (e: Event) => {
-      const custom = e as CustomEvent<{ preferences: DateTimePreferences }>
-      if (custom.detail?.preferences) {
-        setPreferencesState(custom.detail.preferences)
-      }
-    }
-
-    window.addEventListener(storageKey, handleEvent as EventListener)
-    return () => window.removeEventListener(storageKey, handleEvent as EventListener)
-  }, [])
-
-  // Update preferences function
-  const setPreferences = (newPreferences: Partial<DateTimePreferences>) => {
-    setPreferencesState((prev) => {
-      const updated = { ...prev, ...newPreferences }
-
-      try {
-        localStorage.setItem(storageKey, JSON.stringify(updated))
-      } catch (error) {
-        console.error("Failed to save date/time preferences to localStorage:", error)
-      }
-
-      // Notify other components via CustomEvent
-      const evt = new CustomEvent(storageKey, { detail: { preferences: updated } })
-      window.dispatchEvent(evt)
-
-      return updated
-    })
-  }
+  const setPreferences = useCallback(
+    (newPreferences: Partial<DateTimePreferences>) => {
+      setStored((prev) => ({ ...prev, ...newPreferences }))
+    },
+    [setStored]
+  )
 
   return {
     preferences,

--- a/web/src/hooks/usePersistedDeleteFiles.ts
+++ b/web/src/hooks/usePersistedDeleteFiles.ts
@@ -3,82 +3,55 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useState, type SetStateAction } from "react"
+
+import { parseJsonBoolean, readRaw, useClientSetting, writeRaw } from "@/lib/client-settings"
+
+const PREF_KEY = "qui-delete-files-default"
+const LOCK_KEY = "qui-delete-files-lock"
 
 export function usePersistedDeleteFiles(defaultValue: boolean = false) {
-  const storageKey = "qui-delete-files-default"
-  const lockKey = "qui-delete-files-lock"
+  const [storedValue, setStoredValue] = useClientSetting<boolean>(PREF_KEY, {
+    defaultValue,
+    parse: parseJsonBoolean,
+  })
+  const [lockRaw, setLockRaw] = useClientSetting<string>(LOCK_KEY, {
+    defaultValue: "",
+    parse: String,
+    serialize: String,
+  })
+  // Unlocked means "don't remember": the choice lives only in this component
+  // instance, like the old useState did.
+  const [localValue, setLocalValue] = useState<boolean>(defaultValue)
 
-  const readStoredPreference = () => {
-    try {
-      const existingPreference = localStorage.getItem(storageKey)
-      if (existingPreference) {
-        const parsedPreference = JSON.parse(existingPreference)
-        if (typeof parsedPreference === "boolean") {
-          return parsedPreference
-        }
+  // Legacy state (pre-lock-key) stored only the preference; its presence
+  // implied the lock. "" is the cleared sentinel.
+  const isLocked = lockRaw !== "" ? lockRaw === "true" : (readRaw(PREF_KEY) ?? "") !== ""
+
+  const deleteFiles = isLocked ? storedValue : localValue
+
+  const setDeleteFiles = useCallback(
+    (value: SetStateAction<boolean>) => {
+      if (isLocked) {
+        setStoredValue(value)
+      } else {
+        setLocalValue(value)
       }
-    } catch (error) {
-      console.error("Failed to read delete files preference from localStorage:", error)
-    }
-
-    return undefined
-  }
-
-  const readStoredLock = () => {
-    try {
-      const storedLock = localStorage.getItem(lockKey)
-      if (storedLock) {
-        return JSON.parse(storedLock) === true
-      }
-
-      const preference = readStoredPreference()
-      return typeof preference === "boolean"
-    } catch (error) {
-      console.error("Failed to read delete files lock state from localStorage:", error)
-    }
-
-    return false
-  }
-
-  const [isLocked, setIsLocked] = useState<boolean>(() => readStoredLock())
-
-  // Initialize state from localStorage or default value
-  const [deleteFiles, setDeleteFiles] = useState<boolean>(() => readStoredPreference() ?? defaultValue)
-
-  // Persist the lock state and clear stored values when unlocking
-  useEffect(() => {
-    if (isLocked) {
-      try {
-        localStorage.setItem(lockKey, JSON.stringify(true))
-      } catch (error) {
-        console.error("Failed to update delete files lock state in localStorage:", error)
-      }
-      return
-    }
-
-    try {
-      localStorage.removeItem(lockKey)
-      localStorage.removeItem(storageKey)
-    } catch (error) {
-      console.error("Failed to clear delete files preference from localStorage:", error)
-    }
-  }, [isLocked, lockKey, storageKey])
-
-  // Persist changes to the preference only when locked
-  useEffect(() => {
-    if (!isLocked) return
-
-    try {
-      localStorage.setItem(storageKey, JSON.stringify(deleteFiles))
-    } catch (error) {
-      console.error("Failed to save delete files preference to localStorage:", error)
-    }
-  }, [deleteFiles, isLocked, storageKey])
+    },
+    [isLocked, setStoredValue]
+  )
 
   const toggleLock = useCallback(() => {
-    setIsLocked(prev => !prev)
-  }, [])
+    if (isLocked) {
+      // Keep the current choice visible, stop remembering it.
+      setLocalValue(storedValue)
+      setLockRaw("false")
+      writeRaw(PREF_KEY, "")
+    } else {
+      setStoredValue(localValue)
+      setLockRaw("true")
+    }
+  }, [isLocked, storedValue, localValue, setStoredValue, setLockRaw])
 
   return {
     deleteFiles,

--- a/web/src/hooks/usePersistedStartPaused.ts
+++ b/web/src/hooks/usePersistedStartPaused.ts
@@ -3,41 +3,19 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useState, useEffect } from "react"
+import { parseJsonBoolean, useClientSetting } from "@/lib/client-settings"
 
 /**
- * Hook to persist the "Start Torrents Paused" preference per instance in localStorage
+ * Persists the "Start Torrents Paused" preference per instance.
  *
  * NOTE: This is a workaround for qBittorrent's API limitation where the start_paused_enabled
  * preference cannot be set via app/setPreferences (it gets rejected/ignored). Instead of
- * relying on qBittorrent's global preference, we store this setting in localStorage and
+ * relying on qBittorrent's global preference, we store this setting ourselves and
  * apply it when adding torrents.
  */
 export function usePersistedStartPaused(instanceId: number, defaultValue: boolean = false) {
-  const storageKey = `qui-start-paused-instance-${instanceId}`
-
-  // Initialize state from localStorage or default value
-  const [startPaused, setStartPaused] = useState<boolean>(() => {
-    try {
-      const stored = localStorage.getItem(storageKey)
-      if (stored !== null) {
-        return JSON.parse(stored)
-      }
-    } catch (error) {
-      console.error("Failed to load start paused preference from localStorage:", error)
-    }
-
-    return defaultValue
+  return useClientSetting<boolean>(`qui-start-paused-instance-${instanceId}`, {
+    defaultValue,
+    parse: parseJsonBoolean,
   })
-
-  // Persist to localStorage whenever state changes
-  useEffect(() => {
-    try {
-      localStorage.setItem(storageKey, JSON.stringify(startPaused))
-    } catch (error) {
-      console.error("Failed to save start paused preference to localStorage:", error)
-    }
-  }, [startPaused, storageKey])
-
-  return [startPaused, setStartPaused] as const
 }

--- a/web/src/hooks/usePersistedTitleBarSpeeds.ts
+++ b/web/src/hooks/usePersistedTitleBarSpeeds.ts
@@ -3,34 +3,10 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useEffect, useState } from "react"
+import { parseJsonBoolean, useClientSetting } from "@/lib/client-settings"
 
 const STORAGE_KEY = "qui-titlebar-speeds-enabled"
 
 export function usePersistedTitleBarSpeeds(defaultValue: boolean = false) {
-  const [isEnabled, setIsEnabled] = useState<boolean>(() => {
-    try {
-      const stored = localStorage.getItem(STORAGE_KEY)
-      if (stored !== null) {
-        const parsed = JSON.parse(stored)
-        if (typeof parsed === "boolean") {
-          return parsed
-        }
-      }
-    } catch (error) {
-      console.error("Failed to load title bar speed preference from localStorage:", error)
-    }
-
-    return defaultValue
-  })
-
-  useEffect(() => {
-    try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(isEnabled))
-    } catch (error) {
-      console.error("Failed to save title bar speed preference to localStorage:", error)
-    }
-  }, [isEnabled])
-
-  return [isEnabled, setIsEnabled] as const
+  return useClientSetting<boolean>(STORAGE_KEY, { defaultValue, parse: parseJsonBoolean })
 }

--- a/web/src/hooks/useThemeSettingsSync.ts
+++ b/web/src/hooks/useThemeSettingsSync.ts
@@ -8,6 +8,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { api } from "@/lib/api"
 import { useActivityStream } from "@/contexts/SyncStreamContext"
 import { useBuiltinThemes } from "@/hooks/useBuiltinThemes"
+import { useIsAuthed } from "@/hooks/useIsAuthed"
 import { getStoredVariation } from "@/hooks/usePersistedThemeVariation"
 import { getThemeById } from "@/config/themes"
 import { setTheme } from "@/utils/theme"
@@ -25,15 +26,9 @@ export function useThemeSettingsSync(): void {
   // value straight back as a PUT.
   const lastSynced = useRef<string | null>(null)
 
-  // Observe the cached auth state without fetching (enabled: false); useAuth
-  // owns the fetch. Pre-auth the activity stream would 401 and retry forever,
-  // so registration must wait for a user.
-  const { data: user } = useQuery({
-    queryKey: ["auth", "user"],
-    queryFn: () => api.checkAuth(),
-    enabled: false,
-  })
-  const isAuthed = Boolean(user)
+  // Pre-auth the activity stream would 401 and retry forever, so
+  // registration must wait for a user.
+  const isAuthed = useIsAuthed()
 
   // Authed tabs hear about API-side theme changes over the activity SSE
   // channel ("theme.settings" invalidates ["theme-settings"]); the login/setup

--- a/web/src/i18n/index.ts
+++ b/web/src/i18n/index.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
+import { writeRaw } from "@/lib/client-settings"
 import { spreadsheetPostProcessor } from "@/lib/spreadsheet-disguise"
 import i18n, { type ResourceKey, type ResourceLanguage } from "i18next"
 import { initReactI18next } from "react-i18next"
@@ -98,11 +99,8 @@ function getStoredLanguage(): AppLanguage | null {
 }
 
 function persistLanguage(lng: AppLanguage) {
-  try {
-    localStorage.setItem(LANGUAGE_STORAGE_KEY, lng)
-  } catch (error) {
-    console.error("Failed to save language preference to localStorage:", error)
-  }
+  // writeRaw caches locally and queues the server push (issue #2406).
+  writeRaw(LANGUAGE_STORAGE_KEY, lng)
 }
 
 // Monotonic token so that rapid language switches can't apply out of order: a slow

--- a/web/src/lib/__tests__/activity-invalidation.test.ts
+++ b/web/src/lib/__tests__/activity-invalidation.test.ts
@@ -29,6 +29,7 @@ const ALL_KINDS_MAP = {
   "search.history": true,
   "tracker.icons": true,
   "theme.settings": true,
+  "client.settings": true,
 } satisfies Record<ActivityEvent["kind"], true>
 
 const ALL_KINDS = Object.keys(ALL_KINDS_MAP) as ActivityEvent["kind"][]

--- a/web/src/lib/__tests__/client-settings.test.ts
+++ b/web/src/lib/__tests__/client-settings.test.ts
@@ -107,6 +107,43 @@ describe("push queue", () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
+  // REGRESSION (itoqa on #2409/#2410): pending cleared before the PUT resolved,
+  // so a server apply during the in-flight window clobbered the newer value.
+  it("keeps in-flight keys guarded against a concurrent server apply", async () => {
+    let resolvePut: (value: unknown) => void = () => {}
+    fetchMock.mockReturnValueOnce(new Promise((resolve) => { resolvePut = resolve }))
+    seedAndMarkReady({})
+    writeRaw("qui-test-bool", "true")
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    // PUT is in flight; a stale snapshot must not overwrite the newer value.
+    const changed = applyServerSettings({ "qui-test-bool": "false" })
+    expect(changed).toEqual([])
+    expect(localStorage.getItem("qui-test-bool")).toBe("true")
+
+    resolvePut({ ok: true, status: 200 })
+    await vi.runAllTimersAsync()
+    expect(localStorage.getItem("qui-test-bool")).toBe("true")
+  })
+
+  it("flushes a value written while a PUT for the same key is in flight", async () => {
+    let resolvePut: (value: unknown) => void = () => {}
+    fetchMock.mockReturnValueOnce(new Promise((resolve) => { resolvePut = resolve }))
+    seedAndMarkReady({})
+    writeRaw("qui-test-bool", "true")
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    // Newer write lands mid-flight; it must survive the first PUT's cleanup.
+    writeRaw("qui-test-bool", "false")
+    resolvePut({ ok: true, status: 200 })
+    await vi.runAllTimersAsync()
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({ "qui-test-bool": "false" })
+  })
+
   it("requeues a failed batch for the next flush", async () => {
     fetchMock.mockResolvedValueOnce({ ok: false, status: 500 })
     seedAndMarkReady({})

--- a/web/src/lib/__tests__/client-settings.test.ts
+++ b/web/src/lib/__tests__/client-settings.test.ts
@@ -107,8 +107,8 @@ describe("push queue", () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  // REGRESSION (itoqa on #2409/#2410): pending cleared before the PUT resolved,
-  // so a server apply during the in-flight window clobbered the newer value.
+  // REGRESSION: pending was cleared before the PUT resolved, so a server
+  // apply during the in-flight window clobbered the newer value.
   it("keeps in-flight keys guarded against a concurrent server apply", async () => {
     let resolvePut: (value: unknown) => void = () => {}
     fetchMock.mockReturnValueOnce(new Promise((resolve) => { resolvePut = resolve }))

--- a/web/src/lib/__tests__/client-settings.test.ts
+++ b/web/src/lib/__tests__/client-settings.test.ts
@@ -107,6 +107,20 @@ describe("push queue", () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
+  // REGRESSION: only visibilitychange flushed the queue, and a same-tab
+  // reload does not fire it, so a write inside the debounce window was lost
+  // and the stale server snapshot reverted it at next boot.
+  it("flushes pending writes on pagehide without waiting for the debounce", () => {
+    seedAndMarkReady({})
+    writeRaw("qui-test-bool", "true")
+    expect(fetchMock).not.toHaveBeenCalled()
+
+    window.dispatchEvent(new Event("pagehide"))
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({ "qui-test-bool": "true" })
+  })
+
   // REGRESSION: pending was cleared before the PUT resolved, so a server
   // apply during the in-flight window clobbered the newer value.
   it("keeps in-flight keys guarded against a concurrent server apply", async () => {

--- a/web/src/lib/__tests__/client-settings.test.ts
+++ b/web/src/lib/__tests__/client-settings.test.ts
@@ -202,6 +202,40 @@ describe("push queue", () => {
   })
 })
 
+describe("outbox persistence", () => {
+  it("replays a write whose unload flush never reached the server", async () => {
+    // A pagehide keepalive PUT can die in flight (Chrome drops keepalive
+    // fetches from service-worker-controlled pages on unload), so an instant
+    // reload after a write must recover from the persisted outbox.
+    seedAndMarkReady({})
+    writeRaw("qui-test-bool", "true")
+
+    // Page dies before the debounced flush is acked; next boot, stale server.
+    _resetClientSettingsForTests()
+    fetchMock.mockClear()
+
+    applyServerSettings({ "qui-test-bool": "false" })
+    expect(localStorage.getItem("qui-test-bool")).toBe("true")
+
+    seedAndMarkReady({ "qui-test-bool": "false" })
+    await vi.runAllTimersAsync()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({ "qui-test-bool": "true" })
+  })
+
+  it("an acked write leaves no outbox entry to replay", async () => {
+    seedAndMarkReady({})
+    writeRaw("qui-test-bool", "true")
+    await vi.runAllTimersAsync()
+
+    _resetClientSettingsForTests()
+
+    const changed = applyServerSettings({ "qui-test-bool": "false" })
+    expect(changed).toEqual(["qui-test-bool"])
+    expect(localStorage.getItem("qui-test-bool")).toBe("false")
+  })
+})
+
 describe("applyServerSettings", () => {
   it("writes changed keys, reports them, and notifies live hooks", () => {
     const { result } = renderHook(() => useClientSetting("qui-test-bool", boolSetting))

--- a/web/src/lib/__tests__/client-settings.test.ts
+++ b/web/src/lib/__tests__/client-settings.test.ts
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { act, cleanup, renderHook } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  _resetClientSettingsForTests,
+  applyServerSettings,
+  parseJsonBoolean,
+  seedAndMarkReady,
+  useClientSetting,
+  writeRaw
+} from "@/lib/client-settings"
+
+const fetchMock = vi.fn()
+
+beforeEach(() => {
+  localStorage.clear()
+  _resetClientSettingsForTests()
+  fetchMock.mockReset()
+  fetchMock.mockResolvedValue({ ok: true, status: 200 })
+  vi.stubGlobal("fetch", fetchMock)
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+const boolSetting = { defaultValue: false, parse: parseJsonBoolean }
+
+describe("useClientSetting", () => {
+  it("returns the default when nothing is stored or the raw value is invalid", () => {
+    const { result } = renderHook(() => useClientSetting("qui-test-bool", boolSetting))
+    expect(result.current[0]).toBe(false)
+
+    localStorage.setItem("qui-test-bool", "garbage")
+    const second = renderHook(() => useClientSetting("qui-test-bool", boolSetting))
+    expect(second.result.current[0]).toBe(false)
+  })
+
+  it("persists writes and keeps a second hook instance in sync", () => {
+    const hookA = renderHook(() => useClientSetting("qui-test-bool", boolSetting))
+    const hookB = renderHook(() => useClientSetting("qui-test-bool", boolSetting))
+
+    act(() => hookA.result.current[1](true))
+
+    expect(localStorage.getItem("qui-test-bool")).toBe("true")
+    expect(hookB.result.current[0]).toBe(true)
+  })
+
+  it("supports functional updates", () => {
+    const { result } = renderHook(() => useClientSetting("qui-test-bool", boolSetting))
+
+    act(() => result.current[1]((prev) => !prev))
+
+    expect(result.current[0]).toBe(true)
+  })
+
+  it("re-reads on a cross-tab storage event", () => {
+    const { result } = renderHook(() => useClientSetting("qui-test-bool", boolSetting))
+
+    localStorage.setItem("qui-test-bool", "true")
+    act(() => {
+      window.dispatchEvent(new Event("storage"))
+    })
+
+    expect(result.current[0]).toBe(true)
+  })
+})
+
+describe("push queue", () => {
+  it("sends nothing before the first successful GET opens the gate", () => {
+    writeRaw("qui-test-bool", "true")
+    vi.advanceTimersByTime(5_000)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("coalesces rapid writes into one debounced PUT with the last value per key", async () => {
+    seedAndMarkReady({})
+    writeRaw("qui-test-bool", "true")
+    writeRaw("qui-test-other", "1")
+    writeRaw("qui-test-bool", "false")
+
+    await vi.runAllTimersAsync()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(String(url)).toContain("/client-settings")
+    expect(init.method).toBe("PUT")
+    expect(JSON.parse(init.body)).toEqual({ "qui-test-bool": "false", "qui-test-other": "1" })
+  })
+
+  it("skips the push when the value is unchanged", async () => {
+    localStorage.setItem("qui-test-bool", "true")
+    seedAndMarkReady({ "qui-test-bool": "true" })
+    writeRaw("qui-test-bool", "true")
+
+    await vi.runAllTimersAsync()
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("requeues a failed batch for the next flush", async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 500 })
+    seedAndMarkReady({})
+    writeRaw("qui-test-bool", "true")
+    await vi.runAllTimersAsync()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    // The next write flushes the failed key again alongside the new one.
+    writeRaw("qui-test-other", "1")
+    await vi.runAllTimersAsync()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({
+      "qui-test-bool": "true",
+      "qui-test-other": "1",
+    })
+  })
+})
+
+describe("applyServerSettings", () => {
+  it("writes changed keys, reports them, and notifies live hooks", () => {
+    const { result } = renderHook(() => useClientSetting("qui-test-bool", boolSetting))
+
+    let changed: string[] = []
+    act(() => {
+      changed = applyServerSettings({ "qui-test-bool": "true", "qui-test-other": "1" })
+    })
+
+    expect(changed.sort()).toEqual(["qui-test-bool", "qui-test-other"])
+    expect(result.current[0]).toBe(true)
+    expect(localStorage.getItem("qui-test-other")).toBe("1")
+  })
+
+  it("never clobbers a pending local write (echo guard)", () => {
+    writeRaw("qui-test-bool", "true")
+
+    const changed = applyServerSettings({ "qui-test-bool": "false" })
+
+    expect(changed).toEqual([])
+    expect(localStorage.getItem("qui-test-bool")).toBe("true")
+  })
+})
+
+describe("seedAndMarkReady", () => {
+  it("pushes synced keys the server does not know, and only those", async () => {
+    localStorage.setItem("qui-speed-units", "bits")
+    localStorage.setItem("qui-incognito-mode", "true")
+    localStorage.setItem("theme-cache", "{}") // not a synced key
+
+    seedAndMarkReady({ "qui-incognito-mode": "true" })
+    await vi.runAllTimersAsync()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({ "qui-speed-units": "bits" })
+  })
+})

--- a/web/src/lib/__tests__/client-settings.test.ts
+++ b/web/src/lib/__tests__/client-settings.test.ts
@@ -144,6 +144,32 @@ describe("push queue", () => {
     expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({ "qui-test-bool": "false" })
   })
 
+  // REGRESSION: a flush whose timer fired during an in-flight PUT was
+  // swallowed; if that PUT then failed, the newer write stalled until the
+  // next write or tab-hide.
+  it("replays a flush swallowed during a failed in-flight PUT", async () => {
+    let rejectPut: (reason: unknown) => void = () => {}
+    fetchMock.mockReturnValueOnce(new Promise((_resolve, reject) => { rejectPut = reject }))
+    seedAndMarkReady({})
+    writeRaw("qui-test-bool", "true")
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    // New write mid-flight; its timer fires while the PUT is still pending.
+    writeRaw("qui-test-other", "1")
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    rejectPut(new Error("network down"))
+    await vi.runAllTimersAsync()
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({
+      "qui-test-bool": "true",
+      "qui-test-other": "1",
+    })
+  })
+
   it("requeues a failed batch for the next flush", async () => {
     fetchMock.mockResolvedValueOnce({ ok: false, status: 500 })
     seedAndMarkReady({})

--- a/web/src/lib/__tests__/speedUnits.test.ts
+++ b/web/src/lib/__tests__/speedUnits.test.ts
@@ -101,13 +101,13 @@ describe("useSpeedUnits listener cleanup", () => {
     unmount()
 
     expect(removeSpy).toHaveBeenCalledWith("storage", expect.any(Function))
-    expect(removeSpy).toHaveBeenCalledWith("speed-units-changed", expect.any(Function))
+    expect(removeSpy).toHaveBeenCalledWith("qui-client-setting-changed", expect.any(Function))
 
     // After unmount, external events must not throw or update the stale state.
     localStorage.setItem(STORAGE_KEY, "bits")
     expect(() => {
       window.dispatchEvent(new Event("storage"))
-      window.dispatchEvent(new Event("speed-units-changed"))
+      window.dispatchEvent(new CustomEvent("qui-client-setting-changed", { detail: { key: STORAGE_KEY } }))
     }).not.toThrow()
     expect(last()).toBe("bytes")
   })

--- a/web/src/lib/__tests__/speedUnits.test.ts
+++ b/web/src/lib/__tests__/speedUnits.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { act, renderHook } from "@testing-library/react"
+import { act, cleanup, renderHook } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { formatSpeedWithUnit, useSpeedUnits } from "@/lib/speedUnits"
 
@@ -14,6 +14,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  cleanup()
   vi.restoreAllMocks()
 })
 

--- a/web/src/lib/activity-invalidation.ts
+++ b/web/src/lib/activity-invalidation.ts
@@ -42,6 +42,8 @@ export function activityQueryKeys(event: ActivityEvent): QueryKey[] {
       return [["tracker-icons"]]
     case "theme.settings":
       return [["theme-settings"]]
+    case "client.settings":
+      return [["client-settings"]]
     default:
       return []
   }
@@ -77,6 +79,7 @@ export const ACTIVITY_FEATURE_PREFIXES: QueryKey[] = [
   ["searchHistory"],
   ["tracker-icons"],
   ["theme-settings"],
+  ["client-settings"],
 ]
 
 /**

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2065,6 +2065,12 @@ class ApiClient {
     })
   }
 
+  // Client settings (frontend user settings stored in the database as opaque key-value pairs;
+  // writes go through the debounced push queue in lib/client-settings.ts, not this client)
+  async getClientSettings(): Promise<Record<string, string>> {
+    return this.request<Record<string, string>>("/client-settings")
+  }
+
   // Preferences endpoints
   async getInstancePreferences(instanceId: number): Promise<AppPreferences> {
     return this.request<AppPreferences>(`/instances/${instanceId}/preferences`)

--- a/web/src/lib/client-settings.ts
+++ b/web/src/lib/client-settings.ts
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { useCallback, useMemo, useRef, useSyncExternalStore } from "react"
+import { getApiBaseUrl } from "@/lib/base-url"
+
+/**
+ * DB-backed client settings (issue #2406).
+ *
+ * localStorage stays as the instant-boot cache; the server's client_settings
+ * table is the source of truth. Every write goes to localStorage immediately
+ * and is queued for a debounced bulk PUT. useClientSettingsSync pulls the
+ * server state, applies it locally, seeds missing keys from localStorage and
+ * opens the push gate.
+ *
+ * Values are raw strings end to end; each setting keeps the exact encoding it
+ * always had in localStorage, and the backend never parses them. A cleared
+ * setting stores "" instead of removing the key, so "absent on the server"
+ * always means "never synced".
+ */
+
+const CHANGE_EVENT = "qui-client-setting-changed"
+const FLUSH_DELAY_MS = 800
+
+// Keys synced to the server. Grown as hooks convert; keys not listed here
+// (theme boot caches, dismissed banners, sessionStorage) stay local-only.
+const SYNCED_KEYS = new Set<string>([
+  "qui-delete-files-default",
+  "qui-delete-files-lock",
+  "qui-speed-units",
+  "qui-incognito-mode",
+  "qui-datetime-preferences",
+  "qui-titlebar-speeds-enabled",
+  "qui.language",
+])
+const SYNCED_PREFIXES = [
+  "qui-start-paused-instance-",
+  "qui-cross-seed-blocklist-",
+]
+
+function isSyncedKey(key: string): boolean {
+  return SYNCED_KEYS.has(key) || SYNCED_PREFIXES.some((prefix) => key.startsWith(prefix))
+}
+
+export function readRaw(key: string): string | null {
+  try {
+    return localStorage.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+function writeLocal(key: string, raw: string): boolean {
+  try {
+    localStorage.setItem(key, raw)
+  } catch (error) {
+    console.error("Failed to write client setting to localStorage:", error)
+    return false
+  }
+  window.dispatchEvent(new CustomEvent(CHANGE_EVENT, { detail: { key } }))
+  return true
+}
+
+/**
+ * Store a setting locally and queue it for the server. No-op when the value
+ * is unchanged, which also breaks server-apply echo loops.
+ */
+export function writeRaw(key: string, raw: string): void {
+  if (readRaw(key) === raw) return
+  if (writeLocal(key, raw)) enqueuePush(key, raw)
+}
+
+// --- push queue ---
+
+const pending = new Map<string, string>()
+let flushTimer: ReturnType<typeof setTimeout> | null = null
+// Opens after the first successful GET, so nothing fires while logged out.
+let syncReady = false
+
+function enqueuePush(key: string, raw: string): void {
+  pending.set(key, raw)
+  scheduleFlush()
+}
+
+function scheduleFlush(): void {
+  if (!syncReady || pending.size === 0) return
+  if (flushTimer !== null) clearTimeout(flushTimer)
+  flushTimer = setTimeout(() => {
+    flushTimer = null
+    void flushPending()
+  }, FLUSH_DELAY_MS)
+}
+
+async function flushPending(): Promise<void> {
+  if (!syncReady || pending.size === 0) return
+  const batch = Object.fromEntries(pending)
+  pending.clear()
+  try {
+    // Plain fetch instead of the api client: keepalive lets the tab-hidden
+    // flush finish, and this module must stay import-light (i18n boots on it).
+    const response = await fetch(`${getApiBaseUrl()}/client-settings`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(batch),
+      keepalive: true,
+    })
+    if (!response.ok) throw new Error(`HTTP ${response.status}`)
+  } catch (error) {
+    console.error("Failed to push client settings:", error)
+    // Requeue for the next flush; a newer write for the same key wins.
+    for (const [key, raw] of Object.entries(batch)) {
+      if (!pending.has(key)) pending.set(key, raw)
+    }
+  }
+}
+
+if (typeof document !== "undefined") {
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState !== "hidden") return
+    if (flushTimer !== null) {
+      clearTimeout(flushTimer)
+      flushTimer = null
+    }
+    void flushPending()
+  })
+}
+
+// --- server sync (called by useClientSettingsSync) ---
+
+/**
+ * Apply a server snapshot to localStorage. Keys with a pending local push and
+ * keys already equal are skipped. Returns the keys that changed.
+ */
+export function applyServerSettings(settings: Record<string, string>): string[] {
+  const changed: string[] = []
+  for (const [key, raw] of Object.entries(settings)) {
+    if (pending.has(key)) continue
+    if (readRaw(key) === raw) continue
+    if (writeLocal(key, raw)) changed.push(key)
+  }
+  return changed
+}
+
+/**
+ * Queue every synced localStorage key the server does not know yet, then open
+ * the push gate. Idempotent: after one push the server has the key.
+ */
+export function seedAndMarkReady(serverSettings: Record<string, string>): void {
+  try {
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i)
+      if (!key || !isSyncedKey(key) || key in serverSettings || pending.has(key)) continue
+      const raw = localStorage.getItem(key)
+      if (raw !== null) pending.set(key, raw)
+    }
+  } catch (error) {
+    console.error("Failed to scan localStorage for client settings seed:", error)
+  }
+  syncReady = true
+  scheduleFlush()
+}
+
+// Test-only: reset module state between vitest cases.
+export function _resetClientSettingsForTests(): void {
+  pending.clear()
+  if (flushTimer !== null) clearTimeout(flushTimer)
+  flushTimer = null
+  syncReady = false
+}
+
+// --- React hook ---
+
+/** JSON-parse a raw value, accepting only a real boolean. */
+export function parseJsonBoolean(raw: string): boolean {
+  const parsed = JSON.parse(raw)
+  if (typeof parsed !== "boolean") throw new Error("not a boolean")
+  return parsed
+}
+
+interface ClientSettingOptions<T> {
+  defaultValue: T
+  /** Raw string to value; throw to fall back to defaultValue. Pass a stable function. */
+  parse: (raw: string) => T
+  /** Value to raw string; defaults to JSON.stringify. Pass a stable function. */
+  serialize?: (value: T) => string
+}
+
+/**
+ * One DB-backed setting as React state. All hook instances for a key stay in
+ * sync in the same tab (change event) and across tabs (storage event); writes
+ * persist to localStorage and queue a debounced server push.
+ */
+export function useClientSetting<T>(
+  key: string,
+  { defaultValue, parse, serialize = (value) => JSON.stringify(value) }: ClientSettingOptions<T>
+): [T, (value: T | ((prev: T) => T)) => void] {
+  const subscribe = useCallback(
+    (callback: () => void) => {
+      // A storage event without a key is localStorage.clear() (or a test's
+      // bare Event); re-read for those too.
+      const onStorage = (e: StorageEvent) => {
+        if (e.key == null || e.key === key) callback()
+      }
+      const onChange = (e: Event) => {
+        if ((e as CustomEvent<{ key?: string }>).detail?.key === key) callback()
+      }
+      window.addEventListener("storage", onStorage)
+      window.addEventListener(CHANGE_EVENT, onChange)
+      return () => {
+        window.removeEventListener("storage", onStorage)
+        window.removeEventListener(CHANGE_EVENT, onChange)
+      }
+    },
+    [key]
+  )
+
+  const raw = useSyncExternalStore(subscribe, () => readRaw(key))
+
+  const value = useMemo(() => {
+    // "" is the cleared sentinel (settings never remove their key).
+    if (raw == null || raw === "") return defaultValue
+    try {
+      return parse(raw)
+    } catch {
+      return defaultValue
+    }
+  }, [raw, parse, defaultValue])
+
+  const valueRef = useRef(value)
+  valueRef.current = value
+
+  const set = useCallback(
+    (next: T | ((prev: T) => T)) => {
+      const resolved = typeof next === "function" ? (next as (prev: T) => T)(valueRef.current) : next
+      writeRaw(key, serialize(resolved))
+    },
+    [key, serialize]
+  )
+
+  return [value, set]
+}

--- a/web/src/lib/client-settings.ts
+++ b/web/src/lib/client-settings.ts
@@ -94,9 +94,16 @@ function scheduleFlush(): void {
 }
 
 let flushInFlight = false
+// A timer or tab-hide flush that fired while a PUT was in flight; replayed
+// once the PUT settles so the write it carried is not stalled.
+let flushRequestedInFlight = false
 
 async function flushPending(): Promise<void> {
-  if (flushInFlight || !syncReady || pending.size === 0) return
+  if (flushInFlight) {
+    flushRequestedInFlight = true
+    return
+  }
+  if (!syncReady || pending.size === 0) return
   // Keys stay in pending while the PUT is in flight so a concurrent server
   // apply cannot clobber the newer local value (the echo guard checks
   // pending). On failure they simply stay queued for the next flush.
@@ -112,15 +119,19 @@ async function flushPending(): Promise<void> {
       keepalive: true,
     })
     if (!response.ok) throw new Error(`HTTP ${response.status}`)
-    // Drop what this PUT delivered.
+    // Drop what this PUT delivered. Entries replaced mid-flight stay queued;
+    // their own scheduleFlush timer (or the replay below) picks them up.
     for (const [key, raw] of Object.entries(batch)) {
       if (pending.get(key) === raw) pending.delete(key)
     }
-    scheduleFlush()
   } catch (error) {
     console.error("Failed to push client settings:", error)
   } finally {
     flushInFlight = false
+    if (flushRequestedInFlight) {
+      flushRequestedInFlight = false
+      scheduleFlush()
+    }
   }
 }
 
@@ -176,6 +187,7 @@ export function _resetClientSettingsForTests(): void {
   if (flushTimer !== null) clearTimeout(flushTimer)
   flushTimer = null
   flushInFlight = false
+  flushRequestedInFlight = false
   syncReady = false
 }
 

--- a/web/src/lib/client-settings.ts
+++ b/web/src/lib/client-settings.ts
@@ -79,8 +79,45 @@ let flushTimer: ReturnType<typeof setTimeout> | null = null
 // Opens after the first successful GET, so nothing fires while logged out.
 let syncReady = false
 
+// Durable outbox: the dirty key list mirrored to localStorage. The pagehide
+// keepalive PUT is not reliable (Chrome drops keepalive fetches from
+// service-worker-controlled pages on unload), so unacked writes must survive
+// the page. The next boot loads them back into pending, which both blocks the
+// stale server snapshot from reverting them and replays their push. Only keys
+// are stored; the values already live in localStorage under those keys.
+// ponytail: single outbox key is last-writer-wins across tabs, so one tab's
+// crash can drop another tab's unacked key; read-merge-write if that bites.
+const OUTBOX_KEY = "qui-client-settings-outbox"
+
+function persistPending(): void {
+  try {
+    if (pending.size === 0) localStorage.removeItem(OUTBOX_KEY)
+    else localStorage.setItem(OUTBOX_KEY, JSON.stringify([...pending.keys()]))
+  } catch {
+    // Best effort; losing the outbox only reopens the unload race.
+  }
+}
+
+function loadPersistedPending(): void {
+  try {
+    const raw = localStorage.getItem(OUTBOX_KEY)
+    if (!raw) return
+    for (const key of JSON.parse(raw) as string[]) {
+      // A key gone from localStorage has no value to replay; "" would push
+      // the cleared sentinel, so skip it.
+      const value = readRaw(key)
+      if (value !== null) pending.set(key, value)
+    }
+  } catch {
+    // Corrupt outbox: drop it, the values themselves are still in localStorage.
+  }
+}
+
+loadPersistedPending()
+
 function enqueuePush(key: string, raw: string): void {
   pending.set(key, raw)
+  persistPending()
   scheduleFlush()
 }
 
@@ -124,6 +161,7 @@ async function flushPending(): Promise<void> {
     for (const [key, raw] of Object.entries(batch)) {
       if (pending.get(key) === raw) pending.delete(key)
     }
+    persistPending()
   } catch (error) {
     console.error("Failed to push client settings:", error)
   } finally {
@@ -189,7 +227,8 @@ export function seedAndMarkReady(serverSettings: Record<string, string>): void {
   scheduleFlush()
 }
 
-// Test-only: reset module state between vitest cases.
+// Test-only: reset module state between vitest cases. Mirrors a fresh page
+// boot: in-memory state resets, then the persisted outbox loads back in.
 export function _resetClientSettingsForTests(): void {
   pending.clear()
   if (flushTimer !== null) clearTimeout(flushTimer)
@@ -197,6 +236,7 @@ export function _resetClientSettingsForTests(): void {
   flushInFlight = false
   flushRequestedInFlight = false
   syncReady = false
+  loadPersistedPending()
 }
 
 // --- React hook ---

--- a/web/src/lib/client-settings.ts
+++ b/web/src/lib/client-settings.ts
@@ -93,10 +93,15 @@ function scheduleFlush(): void {
   }, FLUSH_DELAY_MS)
 }
 
+let flushInFlight = false
+
 async function flushPending(): Promise<void> {
-  if (!syncReady || pending.size === 0) return
+  if (flushInFlight || !syncReady || pending.size === 0) return
+  // Keys stay in pending while the PUT is in flight so a concurrent server
+  // apply cannot clobber the newer local value (the echo guard checks
+  // pending). On failure they simply stay queued for the next flush.
   const batch = Object.fromEntries(pending)
-  pending.clear()
+  flushInFlight = true
   try {
     // Plain fetch instead of the api client: keepalive lets the tab-hidden
     // flush finish, and this module must stay import-light (i18n boots on it).
@@ -107,12 +112,15 @@ async function flushPending(): Promise<void> {
       keepalive: true,
     })
     if (!response.ok) throw new Error(`HTTP ${response.status}`)
+    // Drop what this PUT delivered.
+    for (const [key, raw] of Object.entries(batch)) {
+      if (pending.get(key) === raw) pending.delete(key)
+    }
+    scheduleFlush()
   } catch (error) {
     console.error("Failed to push client settings:", error)
-    // Requeue for the next flush; a newer write for the same key wins.
-    for (const [key, raw] of Object.entries(batch)) {
-      if (!pending.has(key)) pending.set(key, raw)
-    }
+  } finally {
+    flushInFlight = false
   }
 }
 
@@ -167,6 +175,7 @@ export function _resetClientSettingsForTests(): void {
   pending.clear()
   if (flushTimer !== null) clearTimeout(flushTimer)
   flushTimer = null
+  flushInFlight = false
   syncReady = false
 }
 

--- a/web/src/lib/client-settings.ts
+++ b/web/src/lib/client-settings.ts
@@ -135,15 +135,23 @@ async function flushPending(): Promise<void> {
   }
 }
 
+function flushNow(): void {
+  if (flushTimer !== null) {
+    clearTimeout(flushTimer)
+    flushTimer = null
+  }
+  void flushPending()
+}
+
 if (typeof document !== "undefined") {
   document.addEventListener("visibilitychange", () => {
-    if (document.visibilityState !== "hidden") return
-    if (flushTimer !== null) {
-      clearTimeout(flushTimer)
-      flushTimer = null
-    }
-    void flushPending()
+    if (document.visibilityState === "hidden") flushNow()
   })
+  // Chrome does not fire visibilitychange on a same-tab reload or navigation,
+  // so a write inside the debounce window would die with the page and the
+  // stale server snapshot would revert it at next boot. keepalive lets the
+  // PUT outlive the page.
+  window.addEventListener("pagehide", flushNow)
 }
 
 // --- server sync (called by useClientSettingsSync) ---

--- a/web/src/lib/incognito.ts
+++ b/web/src/lib/incognito.ts
@@ -8,7 +8,7 @@
 // as the stable incognito API; each getter picks its vocabulary at call time.
 
 import type { Category } from "@/types"
-import { useEffect, useState } from "react"
+import { useClientSetting } from "@/lib/client-settings"
 import { isSpreadsheetDisguiseActive } from "./spreadsheet-disguise"
 
 // Linux ISO names for incognito mode
@@ -630,36 +630,13 @@ export function getLinuxHash(hash: string): string {
 // Storage key for incognito mode
 const INCOGNITO_STORAGE_KEY = "qui-incognito-mode"
 
-// Custom hook for managing incognito mode state with localStorage persistence
+const parseIncognito = (raw: string): boolean => raw === "true"
+
+// Custom hook for managing the DB-backed incognito mode preference
 export function useIncognitoMode(): [boolean, (value: boolean) => void] {
-  const [incognitoMode, setIncognitoModeState] = useState(() => {
-    const stored = localStorage.getItem(INCOGNITO_STORAGE_KEY)
-    return stored === "true"
+  return useClientSetting<boolean>(INCOGNITO_STORAGE_KEY, {
+    defaultValue: false,
+    parse: parseIncognito,
+    serialize: String,
   })
-
-  // Listen for storage changes to sync incognito mode across components
-  useEffect(() => {
-    const handleStorageChange = () => {
-      const stored = localStorage.getItem(INCOGNITO_STORAGE_KEY)
-      setIncognitoModeState(stored === "true")
-    }
-
-    // Listen for both storage events (cross-tab) and custom events (same-tab)
-    window.addEventListener("storage", handleStorageChange)
-    window.addEventListener("incognito-mode-changed", handleStorageChange)
-
-    return () => {
-      window.removeEventListener("storage", handleStorageChange)
-      window.removeEventListener("incognito-mode-changed", handleStorageChange)
-    }
-  }, [])
-
-  const setIncognitoMode = (value: boolean) => {
-    setIncognitoModeState(value)
-    localStorage.setItem(INCOGNITO_STORAGE_KEY, String(value))
-    // Dispatch custom event for same-tab updates
-    window.dispatchEvent(new Event("incognito-mode-changed"))
-  }
-
-  return [incognitoMode, setIncognitoMode]
 }

--- a/web/src/lib/speedUnits.ts
+++ b/web/src/lib/speedUnits.ts
@@ -5,7 +5,7 @@
 
 // Speed units utilities for toggling between B/s and bps display
 
-import { useEffect, useState } from "react"
+import { useClientSetting } from "@/lib/client-settings"
 
 // Speed unit types
 export type SpeedUnit = "bytes" | "bits"
@@ -13,38 +13,15 @@ export type SpeedUnit = "bytes" | "bits"
 // Storage key for speed units preference
 const SPEED_UNITS_STORAGE_KEY = "qui-speed-units"
 
-// Custom hook for managing speed units state with localStorage persistence
+const parseSpeedUnit = (raw: string): SpeedUnit => (raw === "bits" ? "bits" : "bytes")
+
+// Custom hook for managing the DB-backed speed units preference
 export function useSpeedUnits(): [SpeedUnit, (unit: SpeedUnit) => void] {
-  const [speedUnit, setSpeedUnitState] = useState<SpeedUnit>(() => {
-    const stored = localStorage.getItem(SPEED_UNITS_STORAGE_KEY) as SpeedUnit
-    return stored === "bits" ? "bits" : "bytes" // Default to bytes
+  return useClientSetting<SpeedUnit>(SPEED_UNITS_STORAGE_KEY, {
+    defaultValue: "bytes",
+    parse: parseSpeedUnit,
+    serialize: String,
   })
-
-  // Listen for storage changes to sync speed units across components
-  useEffect(() => {
-    const handleStorageChange = () => {
-      const stored = localStorage.getItem(SPEED_UNITS_STORAGE_KEY) as SpeedUnit
-      setSpeedUnitState(stored === "bits" ? "bits" : "bytes")
-    }
-
-    // Listen for both storage events (cross-tab) and custom events (same-tab)
-    window.addEventListener("storage", handleStorageChange)
-    window.addEventListener("speed-units-changed", handleStorageChange)
-
-    return () => {
-      window.removeEventListener("storage", handleStorageChange)
-      window.removeEventListener("speed-units-changed", handleStorageChange)
-    }
-  }, [])
-
-  const setSpeedUnit = (unit: SpeedUnit) => {
-    setSpeedUnitState(unit)
-    localStorage.setItem(SPEED_UNITS_STORAGE_KEY, unit)
-    // Dispatch custom event for same-tab updates
-    window.dispatchEvent(new Event("speed-units-changed"))
-  }
-
-  return [speedUnit, setSpeedUnit]
 }
 
 // Format speed with unit preference

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -19,6 +19,13 @@ if (globalThis.localStorage == null) {
     setItem: (key: string, value: string) => void store.set(key, value),
     removeItem: (key: string) => void store.delete(key),
     clear: () => store.clear(),
+    key: (index: number) => [...store.keys()][index] ?? null,
+  })
+  // jsdom's brand-checked `length` accessor throws on this stand-in instance;
+  // replace it with the store's size so key/length iteration works.
+  Object.defineProperty(Storage.prototype, "length", {
+    get: () => store.size,
+    configurable: true,
   })
   globalThis.localStorage = Object.create(Storage.prototype) as Storage
 }

--- a/web/src/types/activity.ts
+++ b/web/src/types/activity.ts
@@ -17,6 +17,7 @@ export type ActivityEventKind =
   | "search.history"
   | "tracker.icons"
   | "theme.settings"
+  | "client.settings"
 
 // ActivityEvent is a small qui-owned server signal. It carries identifiers only
 // (never payload data); the frontend reacts by invalidating the matching query.


### PR DESCRIPTION
## Description

Adds the frontend half of #2406 on top of #2407: a `useClientSetting` hook backed by the new `client_settings` API, with localStorage kept as the instant-boot cache. Writes persist locally right away and coalesce into one debounced PUT; the server snapshot is applied on load, keys the server does not know are seeded up from localStorage, and a `client.settings` SSE event keeps other tabs and browsers current. Eight settings convert in this PR: delete-files default and lock, start-paused, speed units, incognito mode, date/time preferences, titlebar speeds, cross-seed blocklist default, and language. Table preferences and UI state follow in the next PRs.

Part of #2406

## How has this been tested?

Ran the built binary and exercised it in Chrome: changed the 12-hour time format, saw exactly one coalesced PUT followed by the SSE-invalidation GET with no echo PUT; wiped localStorage and reloaded, and the setting came back from the database (the incognito scenario from the issue); confirmed the login page issues no client-settings requests.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Client preferences now sync securely with your account across sessions and devices.
  - Local preferences upload automatically after sign-in and update when changed remotely.
  - Language selections synchronize with your account and update the interface automatically.
  - Changes are detected promptly, including updates made in another browser or tab.
  - Pending preference changes are saved when leaving or backgrounding the app.

- **Bug Fixes**
  - Improved persistence for theme, date/time, speed, title-bar, incognito, download, and cross-seed preferences.
  - Added more reliable retry handling when settings updates temporarily fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->