### PR TITLE
feat(settings): sync table preferences and sidebar filters to the database

### DIFF
--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -47,6 +47,7 @@ import { useTorrentsList } from "@/hooks/useTorrentsList"
 import { useTrackerCustomizations } from "@/hooks/useTrackerCustomizations"
 import { useTrackerIcons } from "@/hooks/useTrackerIcons"
 import { api } from "@/lib/api"
+import { useClientSetting } from "@/lib/client-settings"
 import { buildTrackerCustomizationLookup, extractTrackerHost, getTrackerCustomizationsCacheKey, resolveTrackerDisplay, type TrackerCustomizationLookup } from "@/lib/tracker-customizations"
 import { resolveTrackerHealthSupport } from "@/lib/tracker-health-support"
 import { resolveTrackerIconSrc } from "@/lib/tracker-icons"
@@ -565,6 +566,14 @@ function isValidSortField(value: unknown): value is TorrentSortOptionValue {
   return TORRENT_SORT_OPTIONS.some(option => option.value === value)
 }
 
+function parseMobileSortState(raw: string): MobileSortState {
+  const parsed = JSON.parse(raw) as Partial<MobileSortState>
+  const field = isValidSortField(parsed?.field) ? parsed.field : DEFAULT_MOBILE_SORT_STATE.field
+  const defaultOrder = getDefaultSortOrder(field)
+  const order = parsed?.order === "asc" || parsed?.order === "desc" ? parsed.order : defaultOrder
+  return { field, order }
+}
+
 const trackerIconSizeClasses = {
   xs: "h-3 w-3 text-[8px]",
   sm: "h-[14px] w-[14px] text-[9px]",
@@ -1062,26 +1071,10 @@ export function TorrentCardsMobile({
   const { t } = useTranslation("torrents")
   const isAllInstancesView = isAllInstancesScope(instanceId)
   // State
-  const [sortState, setSortState] = useState<MobileSortState>(() => {
-    if (typeof window === "undefined") {
-      return DEFAULT_MOBILE_SORT_STATE
-    }
-
-    try {
-      const stored = window.localStorage.getItem(`${MOBILE_SORT_STORAGE_KEY}:${instanceId}`)
-      if (stored) {
-        const parsed = JSON.parse(stored) as Partial<MobileSortState>
-        const field = isValidSortField(parsed?.field) ? parsed?.field : DEFAULT_MOBILE_SORT_STATE.field
-        const defaultOrder = getDefaultSortOrder(field)
-        const order = parsed?.order === "asc" || parsed?.order === "desc" ? parsed.order : defaultOrder
-        return { field, order }
-      }
-    } catch {
-      // Ignore malformed localStorage entries
-    }
-
-    return DEFAULT_MOBILE_SORT_STATE
-  })
+  const [sortState, setSortState] = useClientSetting<MobileSortState>(
+    `${MOBILE_SORT_STORAGE_KEY}:${instanceId}`,
+    { defaultValue: DEFAULT_MOBILE_SORT_STATE, parse: parseMobileSortState }
+  )
   const [globalFilter, setGlobalFilter] = useState("")
   const [immediateSearch] = useState("")
   // Selection identity: hash for single-instance, `${instanceId}:${hash}` for unified scope.
@@ -1119,14 +1112,14 @@ export function TorrentCardsMobile({
         order: getDefaultSortOrder(value),
       }
     })
-  }, [])
+  }, [setSortState])
 
   const toggleSortOrder = useCallback(() => {
     setSortState(prev => ({
       field: prev.field,
       order: prev.order === "desc" ? "asc" : "desc",
     }))
-  }, [])
+  }, [setSortState])
 
   // Custom "select all" state for handling large datasets
   const [isAllSelected, setIsAllSelected] = useState(false)
@@ -1333,51 +1326,6 @@ export function TorrentCardsMobile({
     refetchIntervalInBackground: true,
   })
   const activeTaskCount = streamActiveTaskCount ?? polledActiveTaskCount
-
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      setSortState(DEFAULT_MOBILE_SORT_STATE)
-      return
-    }
-
-    const storageKey = `${MOBILE_SORT_STORAGE_KEY}:${instanceId}`
-    setSortState(prev => {
-      try {
-        const stored = window.localStorage.getItem(storageKey)
-        if (!stored) {
-          return DEFAULT_MOBILE_SORT_STATE
-        }
-
-        const parsed = JSON.parse(stored) as Partial<MobileSortState>
-        const field = isValidSortField(parsed?.field) ? parsed?.field : DEFAULT_MOBILE_SORT_STATE.field
-        const defaultOrder = getDefaultSortOrder(field)
-        const order = parsed?.order === "asc" || parsed?.order === "desc" ? parsed.order : defaultOrder
-
-        if (prev.field === field && prev.order === order) {
-          return prev
-        }
-
-        return { field, order }
-      } catch {
-        return DEFAULT_MOBILE_SORT_STATE
-      }
-    })
-  }, [instanceId])
-
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return
-    }
-
-    try {
-      window.localStorage.setItem(
-        `${MOBILE_SORT_STORAGE_KEY}:${instanceId}`,
-        JSON.stringify(sortState)
-      )
-    } catch {
-      // Ignore storage quota errors
-    }
-  }, [sortState, instanceId])
 
   // Columns controls removed on mobile
 

--- a/web/src/hooks/usePersistedCollapsedCategories.ts
+++ b/web/src/hooks/usePersistedCollapsedCategories.ts
@@ -3,65 +3,24 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useEffect, useState } from "react"
+import { useClientSetting } from "@/lib/client-settings"
 
-function isBrowser() {
-  return typeof window !== "undefined" && typeof window.localStorage !== "undefined"
+const parseCollapsedCategories = (raw: string): Set<string> => {
+  const parsed = JSON.parse(raw)
+  if (Array.isArray(parsed) && parsed.every(item => typeof item === "string")) {
+    return new Set(parsed)
+  }
+  throw new Error("invalid collapsed categories")
 }
 
+const serializeCollapsedCategories = (value: Set<string>): string => JSON.stringify(Array.from(value))
+
+const NO_COLLAPSED = new Set<string>()
+
 export function usePersistedCollapsedCategories(instanceId: number) {
-  const storageKey = `qui-collapsed-categories-${instanceId}`
-
-  // Initialize state from localStorage
-  const [collapsedCategories, setCollapsedCategories] = useState<Set<string>>(() => {
-    if (!isBrowser()) {
-      return new Set()
-    }
-    try {
-      const stored = window.localStorage.getItem(storageKey)
-      if (stored) {
-        const parsed = JSON.parse(stored)
-        if (Array.isArray(parsed) && parsed.every(item => typeof item === "string")) {
-          return new Set(parsed)
-        }
-      }
-    } catch (error) {
-      console.error("Failed to load collapsed categories from localStorage:", error)
-    }
-    return new Set()
+  return useClientSetting<Set<string>>(`qui-collapsed-categories-${instanceId}`, {
+    defaultValue: NO_COLLAPSED,
+    parse: parseCollapsedCategories,
+    serialize: serializeCollapsedCategories,
   })
-
-  // Reload when instanceId changes
-  useEffect(() => {
-    if (!isBrowser()) {
-      setCollapsedCategories(new Set())
-      return
-    }
-    try {
-      const stored = window.localStorage.getItem(storageKey)
-      if (stored) {
-        const parsed = JSON.parse(stored)
-        if (Array.isArray(parsed) && parsed.every(item => typeof item === "string")) {
-          setCollapsedCategories(new Set(parsed))
-          return
-        }
-      }
-    } catch (error) {
-      console.error("Failed to load collapsed categories from localStorage:", error)
-    }
-    setCollapsedCategories(new Set())
-  }, [storageKey])
-
-  useEffect(() => {
-    if (!isBrowser()) {
-      return
-    }
-    try {
-      window.localStorage.setItem(storageKey, JSON.stringify(Array.from(collapsedCategories)))
-    } catch (error) {
-      console.error("Failed to save collapsed categories to localStorage:", error)
-    }
-  }, [collapsedCategories, storageKey])
-
-  return [collapsedCategories, setCollapsedCategories] as const
 }

--- a/web/src/hooks/usePersistedColumnFilters.ts
+++ b/web/src/hooks/usePersistedColumnFilters.ts
@@ -4,39 +4,20 @@
  */
 
 import type { ColumnFilter } from "@/lib/column-filter-utils"
-import { useEffect, useState } from "react"
+
+import { useClientSetting } from "@/lib/client-settings"
+
+const NO_FILTERS: ColumnFilter[] = []
+
+const parseColumnFilters = (raw: string): ColumnFilter[] => {
+  const parsed = JSON.parse(raw)
+  if (!Array.isArray(parsed)) throw new Error("invalid column filters")
+  return parsed
+}
 
 export function usePersistedColumnFilters(instanceId: number) {
-  const storageKey = `qui-column-filters-${instanceId}`
-
-  // Initialize state with persisted values immediately
-  const [columnFilters, setColumnFilters] = useState<ColumnFilter[]>(() => {
-    try {
-      const stored = localStorage.getItem(storageKey)
-      return stored ? JSON.parse(stored) : []
-    } catch {
-      return []
-    }
+  return useClientSetting<ColumnFilter[]>(`qui-column-filters-${instanceId}`, {
+    defaultValue: NO_FILTERS,
+    parse: parseColumnFilters,
   })
-
-  // Load filters when instanceId changes
-  useEffect(() => {
-    try {
-      const stored = localStorage.getItem(storageKey)
-      setColumnFilters(stored ? JSON.parse(stored) : [])
-    } catch {
-      setColumnFilters([])
-    }
-  }, [instanceId, storageKey])
-
-  // Save filters when they change
-  useEffect(() => {
-    try {
-      localStorage.setItem(storageKey, JSON.stringify(columnFilters))
-    } catch (error) {
-      console.error("Failed to save column filters:", error)
-    }
-  }, [columnFilters, storageKey])
-
-  return [columnFilters, setColumnFilters] as const
 }

--- a/web/src/hooks/usePersistedColumnOrder.ts
+++ b/web/src/hooks/usePersistedColumnOrder.ts
@@ -4,89 +4,60 @@
  */
 
 import type { ColumnOrderState } from "@tanstack/react-table"
-import { useEffect, useState } from "react"
+import { useCallback, useMemo } from "react"
+
+import { useClientSetting, useDropLegacyKey } from "@/lib/client-settings"
+
+const BASE_STORAGE_KEY = "qui-column-order"
+
+function mergeWithDefaults(order: unknown, defaultOrder: ColumnOrderState): ColumnOrderState {
+  if (!Array.isArray(order) || order.some(item => typeof item !== "string")) {
+    return [...defaultOrder]
+  }
+
+  const missingColumns = defaultOrder.filter(col => !order.includes(col))
+  if (missingColumns.length === 0) {
+    return [...order]
+  }
+
+  const result = [...order]
+
+  missingColumns.forEach(columnId => {
+    if (columnId === "tracker_icon" || columnId === "status_icon") {
+      const priorityIndex = result.indexOf("priority")
+      if (priorityIndex !== -1) {
+        result.splice(priorityIndex + 1, 0, columnId)
+        return
+      }
+    }
+
+    const stateIndex = result.indexOf("state")
+    const dlspeedIndex = result.indexOf("dlspeed")
+    if (stateIndex !== -1 && dlspeedIndex !== -1 && columnId !== "tracker_icon" && columnId !== "status_icon") {
+      result.splice(stateIndex + 1, 0, columnId)
+    } else {
+      result.push(columnId)
+    }
+  })
+
+  return result
+}
 
 export function usePersistedColumnOrder(
   defaultOrder: ColumnOrderState = [],
   instanceKey?: string | number
 ) {
-  const baseStorageKey = "qui-column-order"
   const hasInstanceKey = instanceKey !== undefined && instanceKey !== null
-  const storageKey = hasInstanceKey ? `${baseStorageKey}:${instanceKey}` : baseStorageKey
+  const storageKey = hasInstanceKey ? `${BASE_STORAGE_KEY}:${instanceKey}` : BASE_STORAGE_KEY
 
-  const mergeWithDefaults = (order: ColumnOrderState): ColumnOrderState => {
-    if (!Array.isArray(order) || order.some(item => typeof item !== "string")) {
-      return [...defaultOrder]
-    }
+  useDropLegacyKey(BASE_STORAGE_KEY, hasInstanceKey)
 
-    const missingColumns = defaultOrder.filter(col => !order.includes(col))
-    if (missingColumns.length === 0) {
-      return [...order]
-    }
+  const defaultsJson = JSON.stringify(defaultOrder)
+  const defaultValue = useMemo<ColumnOrderState>(() => JSON.parse(defaultsJson), [defaultsJson])
+  const parse = useCallback(
+    (raw: string): ColumnOrderState => mergeWithDefaults(JSON.parse(raw), defaultValue),
+    [defaultValue]
+  )
 
-    const result = [...order]
-
-    missingColumns.forEach(columnId => {
-      if (columnId === "tracker_icon" || columnId === "status_icon") {
-        const priorityIndex = result.indexOf("priority")
-        if (priorityIndex !== -1) {
-          result.splice(priorityIndex + 1, 0, columnId)
-          return
-        }
-      }
-
-      const stateIndex = result.indexOf("state")
-      const dlspeedIndex = result.indexOf("dlspeed")
-      if (stateIndex !== -1 && dlspeedIndex !== -1 && columnId !== "tracker_icon" && columnId !== "status_icon") {
-        result.splice(stateIndex + 1, 0, columnId)
-      } else {
-        result.push(columnId)
-      }
-    })
-
-    return result
-  }
-
-  const loadOrder = (): ColumnOrderState => {
-    try {
-      const stored = localStorage.getItem(storageKey)
-      if (stored) {
-        const parsed = JSON.parse(stored)
-        return mergeWithDefaults(parsed)
-      }
-    } catch (error) {
-      console.error("Failed to load column order from localStorage:", error)
-    }
-
-    return [...defaultOrder]
-  }
-
-  const [columnOrder, setColumnOrder] = useState<ColumnOrderState>(() => loadOrder())
-
-  useEffect(() => {
-    if (!hasInstanceKey) {
-      return
-    }
-
-    try {
-      localStorage.removeItem(baseStorageKey)
-    } catch (error) {
-      console.error("Failed to clear legacy column order state:", error)
-    }
-  }, [hasInstanceKey, baseStorageKey])
-
-  useEffect(() => {
-    setColumnOrder(loadOrder())
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [storageKey, JSON.stringify(defaultOrder)])
-
-  useEffect(() => {
-    try {
-      localStorage.setItem(storageKey, JSON.stringify(columnOrder))
-    } catch (error) {
-      console.error("Failed to save column order to localStorage:", error)
-    }
-  }, [columnOrder, storageKey])
-
-  return [columnOrder, setColumnOrder] as const
+  return useClientSetting<ColumnOrderState>(storageKey, { defaultValue, parse })
 }

--- a/web/src/hooks/usePersistedColumnSizing.ts
+++ b/web/src/hooks/usePersistedColumnSizing.ts
@@ -4,79 +4,52 @@
  */
 
 import type { ColumnSizingState } from "@tanstack/react-table"
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo } from "react"
+
+import { readRaw, useClientSetting, writeRaw } from "@/lib/client-settings"
+
+const BASE_STORAGE_KEY = "qui-column-sizing"
+
+function parseSizing(value: unknown): ColumnSizingState | undefined {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const entries = Object.values(value as Record<string, unknown>)
+    if (entries.every(entry => typeof entry === "number")) {
+      return value as ColumnSizingState
+    }
+  }
+
+  return undefined
+}
 
 export function usePersistedColumnSizing(
   defaultSizing: ColumnSizingState = {},
   instanceKey?: string | number
 ) {
-  const baseStorageKey = "qui-column-sizing"
   const hasInstanceKey = instanceKey !== undefined && instanceKey !== null
-  const storageKey = hasInstanceKey ? `${baseStorageKey}:${instanceKey}` : baseStorageKey
+  const storageKey = hasInstanceKey ? `${BASE_STORAGE_KEY}:${instanceKey}` : BASE_STORAGE_KEY
 
-  const parseSizing = (value: unknown): ColumnSizingState | undefined => {
-    if (value && typeof value === "object" && !Array.isArray(value)) {
-      const entries = Object.values(value as Record<string, unknown>)
-      if (entries.every(entry => typeof entry === "number")) {
-        return value as ColumnSizingState
-      }
-    }
-
-    return undefined
-  }
-
-  const loadSizing = (): ColumnSizingState => {
-    try {
-      const stored = localStorage.getItem(storageKey)
-      if (stored) {
-        const parsed = parseSizing(JSON.parse(stored))
-        if (parsed) {
-          return parsed
-        }
-      }
-
-      if (hasInstanceKey) {
-        const legacyStored = localStorage.getItem(baseStorageKey)
-        if (legacyStored) {
-          const parsedLegacy = parseSizing(JSON.parse(legacyStored))
-          if (parsedLegacy) {
-            return parsedLegacy
-          }
-        }
-      }
-    } catch (error) {
-      console.error("Failed to load column sizing from localStorage:", error)
-    }
-
-    return { ...defaultSizing }
-  }
-
-  const [columnSizing, setColumnSizing] = useState<ColumnSizingState>(() => loadSizing())
-
+  // Migrate the pre-instance-scoping shared key into the instance key once,
+  // then drop it.
   useEffect(() => {
-    if (!hasInstanceKey) {
-      return
-    }
-
+    if (!hasInstanceKey) return
     try {
-      localStorage.removeItem(baseStorageKey)
+      const legacy = localStorage.getItem(BASE_STORAGE_KEY)
+      if (legacy && readRaw(storageKey) == null) {
+        if (parseSizing(JSON.parse(legacy))) writeRaw(storageKey, legacy)
+      }
+      localStorage.removeItem(BASE_STORAGE_KEY)
     } catch (error) {
-      console.error("Failed to clear legacy column sizing state:", error)
+      console.error("Failed to migrate legacy column sizing state:", error)
     }
-  }, [hasInstanceKey, baseStorageKey])
+  }, [hasInstanceKey, storageKey])
 
-  useEffect(() => {
-    setColumnSizing(loadSizing())
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [storageKey])
+  const defaultsJson = JSON.stringify(defaultSizing)
+  const defaultValue = useMemo<ColumnSizingState>(() => JSON.parse(defaultsJson), [defaultsJson])
+  const parse = useCallback((raw: string): ColumnSizingState => {
+    const parsed = parseSizing(JSON.parse(raw))
+    if (!parsed) throw new Error("invalid column sizing state")
+    return parsed
+  }, [])
 
-  useEffect(() => {
-    try {
-      localStorage.setItem(storageKey, JSON.stringify(columnSizing))
-    } catch (error) {
-      console.error("Failed to save column sizing to localStorage:", error)
-    }
-  }, [columnSizing, storageKey])
-
-  return [columnSizing, setColumnSizing] as const
+  return useClientSetting<ColumnSizingState>(storageKey, { defaultValue, parse })
 }

--- a/web/src/hooks/usePersistedColumnSorting.ts
+++ b/web/src/hooks/usePersistedColumnSorting.ts
@@ -4,58 +4,30 @@
  */
 
 import type { SortingState } from "@tanstack/react-table"
-import { useEffect, useState } from "react"
+import { useCallback, useMemo } from "react"
+
+import { useClientSetting, useDropLegacyKey } from "@/lib/client-settings"
+
+const BASE_STORAGE_KEY = "qui-column-sorting"
 
 export function usePersistedColumnSorting(
   defaultSorting: SortingState = [],
   instanceKey?: string | number
 ) {
-  const baseStorageKey = "qui-column-sorting"
   const hasInstanceKey = instanceKey !== undefined && instanceKey !== null
-  const storageKey = hasInstanceKey ? `${baseStorageKey}:${instanceKey}` : baseStorageKey
+  const storageKey = hasInstanceKey ? `${BASE_STORAGE_KEY}:${instanceKey}` : BASE_STORAGE_KEY
 
-  const loadSorting = (): SortingState => {
-    try {
-      const stored = localStorage.getItem(storageKey)
-      if (stored) {
-        const parsed = JSON.parse(stored)
-        if (Array.isArray(parsed)) {
-          return parsed as SortingState
-        }
-      }
-    } catch (error) {
-      console.error("Failed to load column sorting from localStorage:", error)
+  useDropLegacyKey(BASE_STORAGE_KEY, hasInstanceKey)
+
+  const defaultsJson = JSON.stringify(defaultSorting)
+  const defaultValue = useMemo<SortingState>(() => JSON.parse(defaultsJson), [defaultsJson])
+  const parse = useCallback((raw: string): SortingState => {
+    const parsed = JSON.parse(raw)
+    if (Array.isArray(parsed)) {
+      return parsed as SortingState
     }
+    throw new Error("invalid column sorting state")
+  }, [])
 
-    return [...defaultSorting]
-  }
-
-  const [sorting, setSorting] = useState<SortingState>(() => loadSorting())
-
-  useEffect(() => {
-    if (!hasInstanceKey) {
-      return
-    }
-
-    try {
-      localStorage.removeItem(baseStorageKey)
-    } catch (error) {
-      console.error("Failed to clear legacy column sorting state:", error)
-    }
-  }, [hasInstanceKey, baseStorageKey])
-
-  useEffect(() => {
-    setSorting(loadSorting())
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [storageKey])
-
-  useEffect(() => {
-    try {
-      localStorage.setItem(storageKey, JSON.stringify(sorting))
-    } catch (error) {
-      console.error("Failed to save column sorting to localStorage:", error)
-    }
-  }, [sorting, storageKey])
-
-  return [sorting, setSorting] as const
+  return useClientSetting<SortingState>(storageKey, { defaultValue, parse })
 }

--- a/web/src/hooks/usePersistedColumnVisibility.ts
+++ b/web/src/hooks/usePersistedColumnVisibility.ts
@@ -4,59 +4,30 @@
  */
 
 import type { ColumnVisibilityState } from "@tanstack/react-table"
-import { useEffect, useState } from "react"
+import { useCallback, useMemo } from "react"
+
+import { useClientSetting, useDropLegacyKey } from "@/lib/client-settings"
+
+const BASE_STORAGE_KEY = "qui-column-visibility"
 
 export function usePersistedColumnVisibility(
   defaultVisibility: ColumnVisibilityState = {},
   instanceKey?: string | number
 ) {
-  const baseStorageKey = "qui-column-visibility"
   const hasInstanceKey = instanceKey !== undefined && instanceKey !== null
-  const storageKey = hasInstanceKey ? `${baseStorageKey}:${instanceKey}` : baseStorageKey
+  const storageKey = hasInstanceKey ? `${BASE_STORAGE_KEY}:${instanceKey}` : BASE_STORAGE_KEY
 
-  const loadVisibility = (): ColumnVisibilityState => {
-    try {
-      const stored = localStorage.getItem(storageKey)
-      if (stored) {
-        const parsed = JSON.parse(stored)
-        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-          return parsed as ColumnVisibilityState
-        }
-      }
-    } catch (error) {
-      console.error("Failed to load column visibility from localStorage:", error)
+  useDropLegacyKey(BASE_STORAGE_KEY, hasInstanceKey)
+
+  const defaultsJson = JSON.stringify(defaultVisibility)
+  const defaultValue = useMemo<ColumnVisibilityState>(() => JSON.parse(defaultsJson), [defaultsJson])
+  const parse = useCallback((raw: string): ColumnVisibilityState => {
+    const parsed = JSON.parse(raw)
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as ColumnVisibilityState
     }
+    throw new Error("invalid column visibility state")
+  }, [])
 
-    return { ...defaultVisibility }
-  }
-
-  const [columnVisibility, setColumnVisibility] = useState<ColumnVisibilityState>(() => loadVisibility())
-
-  useEffect(() => {
-    if (!hasInstanceKey) {
-      return
-    }
-
-    try {
-      localStorage.removeItem(baseStorageKey)
-    } catch (error) {
-      console.error("Failed to clear legacy column visibility state:", error)
-    }
-  }, [hasInstanceKey, baseStorageKey])
-
-  useEffect(() => {
-    setColumnVisibility(loadVisibility())
-    // We only want to reload when the storage key changes (instance switch)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [storageKey])
-
-  useEffect(() => {
-    try {
-      localStorage.setItem(storageKey, JSON.stringify(columnVisibility))
-    } catch (error) {
-      console.error("Failed to save column visibility to localStorage:", error)
-    }
-  }, [columnVisibility, storageKey])
-
-  return [columnVisibility, setColumnVisibility] as const
+  return useClientSetting<ColumnVisibilityState>(storageKey, { defaultValue, parse })
 }

--- a/web/src/hooks/usePersistedFilters.test.tsx
+++ b/web/src/hooks/usePersistedFilters.test.tsx
@@ -127,7 +127,7 @@ describe("usePersistedFilters", () => {
 
   // REGRESSION (#2410): setFilters used to strip the sidebar's derived expandedCategories.
   it("keeps expandedCategories through setFilters and a storage round-trip", () => {
-    const { result } = renderHook(() => usePersistedFilters(4))
+    const { result, unmount } = renderHook(() => usePersistedFilters(4))
 
     act(() => {
       const [, setFilters] = result.current
@@ -143,6 +143,7 @@ describe("usePersistedFilters", () => {
     expect(result.current[0].expandedExcludeCategories).toEqual([])
 
     // A fresh mount reads them back from storage.
+    unmount()
     const remounted = renderHook(() => usePersistedFilters(4))
     expect(remounted.result.current[0].expandedCategories).toEqual(["movies", "movies/4k"])
   })
@@ -160,6 +161,7 @@ describe("usePersistedFilters", () => {
 
     // A second instance mounts and reads from storage. It inherits the shared
     // global status but must NOT see instance 1's categories.
+    hook1.unmount()
     const hook2 = renderHook(() => usePersistedFilters(2))
     const [filters2] = hook2.result.current
 

--- a/web/src/hooks/usePersistedFilters.test.tsx
+++ b/web/src/hooks/usePersistedFilters.test.tsx
@@ -125,6 +125,28 @@ describe("usePersistedFilters", () => {
     })
   })
 
+  // REGRESSION (#2410): setFilters used to strip the sidebar's derived expandedCategories.
+  it("keeps expandedCategories through setFilters and a storage round-trip", () => {
+    const { result } = renderHook(() => usePersistedFilters(4))
+
+    act(() => {
+      const [, setFilters] = result.current
+      setFilters(prev => ({
+        ...prev,
+        categories: ["movies"],
+        expandedCategories: ["movies", "movies/4k"],
+        expandedExcludeCategories: [],
+      }))
+    })
+
+    expect(result.current[0].expandedCategories).toEqual(["movies", "movies/4k"])
+    expect(result.current[0].expandedExcludeCategories).toEqual([])
+
+    // A fresh mount reads them back from storage.
+    const remounted = renderHook(() => usePersistedFilters(4))
+    expect(remounted.result.current[0].expandedCategories).toEqual(["movies", "movies/4k"])
+  })
+
   it("isolates instance fields across instances but shares the global status", () => {
     const hook1 = renderHook(() => usePersistedFilters(1))
     act(() => {

--- a/web/src/hooks/usePersistedFilters.test.tsx
+++ b/web/src/hooks/usePersistedFilters.test.tsx
@@ -167,20 +167,19 @@ describe("usePersistedFilters", () => {
     expect(result.current[0].status).toEqual(["downloading"])
   })
 
-  // ERROR PATH: corrupt per-instance JSON. JSON.parse in the lazy initializer is
-  // NOT guarded by safeGetItem (which only protects localStorage access), so the
-  // hook throws synchronously. This documents the current behavior / gap.
-  it("throws a SyntaxError on corrupt per-instance JSON (unguarded JSON.parse)", () => {
+  // ERROR PATH: corrupt per-instance JSON. useClientSetting catches the parse
+  // throw and falls back to the empty defaults instead of crashing the tree.
+  it("falls back to defaults on corrupt per-instance JSON", () => {
     localStorage.setItem(instanceKey(5), "not-json")
 
-    expect(() => renderHook(() => usePersistedFilters(5))).toThrow(SyntaxError)
+    const { result } = renderHook(() => usePersistedFilters(5))
+
+    expect(result.current[0]).toEqual(makeFilters({ expr: "" }))
   })
 
-  // ERROR PATH: corrupt per-instance JSON reached via the instanceId-change
-  // effect (lines 48-49), a different React surface than the lazy initializer.
-  // Mount clean on id=1, then rerender into id=2 whose stored value is corrupt;
-  // the unguarded JSON.parse inside the effect throws.
-  it("throws on corrupt per-instance JSON via the instanceId-change effect", () => {
+  // ERROR PATH: corrupt per-instance JSON reached via an instance switch. The
+  // clean instance's values load, the corrupt one degrades to defaults.
+  it("falls back to defaults on corrupt per-instance JSON after an instance switch", () => {
     localStorage.setItem(instanceKey(1), JSON.stringify({ categories: ["clean"] }))
     localStorage.setItem(instanceKey(2), "not-json")
 
@@ -191,29 +190,29 @@ describe("usePersistedFilters", () => {
 
     expect(result.current[0].categories).toEqual(["clean"])
 
-    expect(() => {
-      act(() => {
-        rerender({ id: 2 })
-      })
-    }).toThrow(SyntaxError)
+    act(() => {
+      rerender({ id: 2 })
+    })
+
+    expect(result.current[0].categories).toEqual([])
   })
 
-  // ERROR PATH: corrupt GLOBAL JSON in the lazy initializer (line 30). The
-  // global JSON.parse is likewise unguarded, so the hook throws synchronously.
-  it("throws a SyntaxError on corrupt global JSON (unguarded JSON.parse)", () => {
+  // ERROR PATH: corrupt GLOBAL JSON degrades to defaults the same way.
+  it("falls back to defaults on corrupt global JSON", () => {
     localStorage.setItem(GLOBAL_KEY, "not-json")
 
-    expect(() => renderHook(() => usePersistedFilters(8))).toThrow(SyntaxError)
+    const { result } = renderHook(() => usePersistedFilters(8))
+
+    expect(result.current[0]).toEqual(makeFilters({ expr: "" }))
   })
 
-  // ERROR PATH: write failure. safeSetItem swallows the error, logs it, and the
-  // hook does not throw; returned state still updates.
-  it("swallows localStorage write failures and still updates state", () => {
+  // ERROR PATH: write failure. writeRaw logs and drops the write; the hook
+  // must not throw. State follows storage, so the value stays unchanged.
+  it("swallows localStorage write failures without throwing", () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
 
     const { result } = renderHook(() => usePersistedFilters(4))
 
-    // Begin throwing on writes only after the initial mount effects have run.
     const setItemSpy = vi
       .spyOn(Storage.prototype, "setItem")
       .mockImplementation(() => {
@@ -229,14 +228,13 @@ describe("usePersistedFilters", () => {
 
     expect(setItemSpy).toHaveBeenCalled()
     expect(consoleError).toHaveBeenCalled()
-    // State update is independent of persistence and must still take effect.
-    expect(result.current[0].status).toEqual(["seeding"])
+    // Storage-backed state keeps the previous value when the write fails.
+    expect(result.current[0].status).toEqual([])
   })
 
-  // ERROR PATH: read failure. safeGetItem returns null on getItem throw, so the
-  // hook falls back to empty defaults and logs the error.
+  // ERROR PATH: read failure. readRaw returns null on getItem throw, so the
+  // hook falls back to empty defaults without throwing.
   it("falls back to empty defaults when localStorage read throws", () => {
-    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
     vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
       throw new Error("storage disabled")
     })
@@ -244,6 +242,5 @@ describe("usePersistedFilters", () => {
     const { result } = renderHook(() => usePersistedFilters(6))
 
     expect(result.current[0]).toEqual(makeFilters({ expr: "" }))
-    expect(consoleError).toHaveBeenCalled()
   })
 })

--- a/web/src/hooks/usePersistedFilters.test.tsx
+++ b/web/src/hooks/usePersistedFilters.test.tsx
@@ -5,7 +5,7 @@
 
 import { usePersistedFilters } from "@/hooks/usePersistedFilters"
 import { makeFilters } from "@/test/mockFilters"
-import { act, renderHook } from "@testing-library/react"
+import { act, cleanup, renderHook } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const GLOBAL_KEY = "qui-filters-global"
@@ -21,6 +21,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  cleanup()
   vi.restoreAllMocks()
 })
 

--- a/web/src/hooks/usePersistedFilters.ts
+++ b/web/src/hooks/usePersistedFilters.ts
@@ -3,80 +3,80 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useEffect, useState } from "react"
+import { useCallback, useMemo, useRef, type SetStateAction } from "react"
 import type { TorrentFilters } from "@/types"
 
-// Safe localStorage wrapper that returns fallback on error
-function safeGetItem(key: string): string | null {
-  try {
-    return localStorage.getItem(key)
-  } catch (error) {
-    console.error(`Failed to read from localStorage key "${key}":`, error)
-    return null
+import { useClientSetting } from "@/lib/client-settings"
+
+type GlobalFilters = Pick<TorrentFilters, "status" | "excludeStatus">
+type InstanceFilters = Omit<TorrentFilters, "status" | "excludeStatus">
+
+const DEFAULT_GLOBAL: GlobalFilters = { status: [], excludeStatus: [] }
+const DEFAULT_INSTANCE: InstanceFilters = {
+  categories: [],
+  excludeCategories: [],
+  tags: [],
+  excludeTags: [],
+  trackers: [],
+  excludeTrackers: [],
+  expr: "",
+}
+
+const parseGlobalFilters = (raw: string): GlobalFilters => {
+  const parsed = JSON.parse(raw)
+  return {
+    status: parsed.status || [],
+    excludeStatus: parsed.excludeStatus || [],
   }
 }
 
-function safeSetItem(key: string, value: string): void {
-  try {
-    localStorage.setItem(key, value)
-  } catch (error) {
-    console.error(`Failed to write to localStorage key "${key}":`, error)
+const parseInstanceFilters = (raw: string): InstanceFilters => {
+  const parsed = JSON.parse(raw)
+  return {
+    categories: parsed.categories || [],
+    excludeCategories: parsed.excludeCategories || [],
+    tags: parsed.tags || [],
+    excludeTags: parsed.excludeTags || [],
+    trackers: parsed.trackers || [],
+    excludeTrackers: parsed.excludeTrackers || [],
+    expr: parsed.expr || "",
   }
 }
 
 export function usePersistedFilters(instanceId: number) {
-  // Initialize state with persisted values immediately
-  const [filters, setFilters] = useState<TorrentFilters>(() => {
-    const global = JSON.parse(safeGetItem("qui-filters-global") || "{}")
-    const instance = JSON.parse(safeGetItem(`qui-filters-${instanceId}`) || "{}")
-
-    return {
-      status: global.status || [],
-      excludeStatus: global.excludeStatus || [],
-      categories: instance.categories || [],
-      excludeCategories: instance.excludeCategories || [],
-      tags: instance.tags || [],
-      excludeTags: instance.excludeTags || [],
-      trackers: instance.trackers || [],
-      excludeTrackers: instance.excludeTrackers || [],
-      expr: instance.expr || "",
-    }
+  const [globalFilters, setGlobalFilters] = useClientSetting<GlobalFilters>("qui-filters-global", {
+    defaultValue: DEFAULT_GLOBAL,
+    parse: parseGlobalFilters,
+  })
+  const [instanceFilters, setInstanceFilters] = useClientSetting<InstanceFilters>(`qui-filters-${instanceId}`, {
+    defaultValue: DEFAULT_INSTANCE,
+    parse: parseInstanceFilters,
   })
 
-  // Load filters when instanceId changes
-  useEffect(() => {
-    const global = JSON.parse(safeGetItem("qui-filters-global") || "{}")
-    const instance = JSON.parse(safeGetItem(`qui-filters-${instanceId}`) || "{}")
+  const filters = useMemo<TorrentFilters>(
+    () => ({ ...globalFilters, ...instanceFilters }),
+    [globalFilters, instanceFilters]
+  )
 
-    setFilters({
-      status: global.status || [],
-      excludeStatus: global.excludeStatus || [],
-      categories: instance.categories || [],
-      excludeCategories: instance.excludeCategories || [],
-      tags: instance.tags || [],
-      excludeTags: instance.excludeTags || [],
-      trackers: instance.trackers || [],
-      excludeTrackers: instance.excludeTrackers || [],
-      expr: instance.expr || "",
-    })
-  }, [instanceId])
+  const filtersRef = useRef(filters)
+  filtersRef.current = filters
 
-  // Save filters when they change
-  useEffect(() => {
-    safeSetItem("qui-filters-global", JSON.stringify({
-      status: filters.status,
-      excludeStatus: filters.excludeStatus,
-    }))
-    safeSetItem(`qui-filters-${instanceId}`, JSON.stringify({
-      categories: filters.categories,
-      excludeCategories: filters.excludeCategories,
-      tags: filters.tags,
-      excludeTags: filters.excludeTags,
-      trackers: filters.trackers,
-      excludeTrackers: filters.excludeTrackers,
-      expr: filters.expr,
-    }))
-  }, [filters, instanceId])
+  const setFilters = useCallback(
+    (next: SetStateAction<TorrentFilters>) => {
+      const resolved = typeof next === "function" ? next(filtersRef.current) : next
+      setGlobalFilters({ status: resolved.status, excludeStatus: resolved.excludeStatus })
+      setInstanceFilters({
+        categories: resolved.categories,
+        excludeCategories: resolved.excludeCategories,
+        tags: resolved.tags,
+        excludeTags: resolved.excludeTags,
+        trackers: resolved.trackers,
+        excludeTrackers: resolved.excludeTrackers,
+        expr: resolved.expr,
+      })
+    },
+    [setGlobalFilters, setInstanceFilters]
+  )
 
   return [filters, setFilters] as const
 }

--- a/web/src/hooks/usePersistedFilters.ts
+++ b/web/src/hooks/usePersistedFilters.ts
@@ -22,26 +22,9 @@ const DEFAULT_INSTANCE: InstanceFilters = {
   expr: "",
 }
 
-const parseGlobalFilters = (raw: string): GlobalFilters => {
-  const parsed = JSON.parse(raw)
-  return {
-    status: parsed.status || [],
-    excludeStatus: parsed.excludeStatus || [],
-  }
-}
+const parseGlobalFilters = (raw: string): GlobalFilters => ({ ...DEFAULT_GLOBAL, ...JSON.parse(raw) })
 
-const parseInstanceFilters = (raw: string): InstanceFilters => {
-  const parsed = JSON.parse(raw)
-  return {
-    categories: parsed.categories || [],
-    excludeCategories: parsed.excludeCategories || [],
-    tags: parsed.tags || [],
-    excludeTags: parsed.excludeTags || [],
-    trackers: parsed.trackers || [],
-    excludeTrackers: parsed.excludeTrackers || [],
-    expr: parsed.expr || "",
-  }
-}
+const parseInstanceFilters = (raw: string): InstanceFilters => ({ ...DEFAULT_INSTANCE, ...JSON.parse(raw) })
 
 export function usePersistedFilters(instanceId: number) {
   const [globalFilters, setGlobalFilters] = useClientSetting<GlobalFilters>("qui-filters-global", {
@@ -64,16 +47,11 @@ export function usePersistedFilters(instanceId: number) {
   const setFilters = useCallback(
     (next: SetStateAction<TorrentFilters>) => {
       const resolved = typeof next === "function" ? next(filtersRef.current) : next
-      setGlobalFilters({ status: resolved.status, excludeStatus: resolved.excludeStatus })
-      setInstanceFilters({
-        categories: resolved.categories,
-        excludeCategories: resolved.excludeCategories,
-        tags: resolved.tags,
-        excludeTags: resolved.excludeTags,
-        trackers: resolved.trackers,
-        excludeTrackers: resolved.excludeTrackers,
-        expr: resolved.expr,
-      })
+      // Keep every instance-scoped field, including the derived
+      // expandedCategories the sidebar computes for subcategory requests.
+      const { status, excludeStatus, ...instance } = resolved
+      setGlobalFilters({ status, excludeStatus })
+      setInstanceFilters(instance)
     },
     [setGlobalFilters, setInstanceFilters]
   )

--- a/web/src/lib/client-settings.ts
+++ b/web/src/lib/client-settings.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useCallback, useMemo, useRef, useSyncExternalStore } from "react"
+import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from "react"
 import { getApiBaseUrl } from "@/lib/base-url"
 
 /**
@@ -38,6 +38,15 @@ const SYNCED_KEYS = new Set<string>([
 const SYNCED_PREFIXES = [
   "qui-start-paused-instance-",
   "qui-cross-seed-blocklist-",
+  // "qui-filters-" covers "qui-filters-global" and the per-instance keys.
+  "qui-column-visibility:",
+  "qui-column-order:",
+  "qui-column-sorting:",
+  "qui-column-sizing:",
+  "qui-column-filters-",
+  "qui-collapsed-categories-",
+  "qui-filters-",
+  "qui:torrent-mobile-sort:",
 ]
 
 function isSyncedKey(key: string): boolean {
@@ -179,6 +188,25 @@ export function parseJsonBoolean(raw: string): boolean {
   return parsed
 }
 
+// Module-level so the setter's useCallback identity stays stable when no
+// custom serializer is passed.
+const defaultSerialize = (value: unknown): string => JSON.stringify(value)
+
+/**
+ * Drop a pre-instance-scoping shared localStorage key once the caller uses
+ * instance-scoped keys. Local-only: legacy keys are never synced.
+ */
+export function useDropLegacyKey(baseKey: string, enabled: boolean): void {
+  useEffect(() => {
+    if (!enabled) return
+    try {
+      localStorage.removeItem(baseKey)
+    } catch (error) {
+      console.error("Failed to clear legacy state key:", baseKey, error)
+    }
+  }, [baseKey, enabled])
+}
+
 interface ClientSettingOptions<T> {
   defaultValue: T
   /** Raw string to value; throw to fall back to defaultValue. Pass a stable function. */
@@ -194,7 +222,7 @@ interface ClientSettingOptions<T> {
  */
 export function useClientSetting<T>(
   key: string,
-  { defaultValue, parse, serialize = (value) => JSON.stringify(value) }: ClientSettingOptions<T>
+  { defaultValue, parse, serialize = defaultSerialize }: ClientSettingOptions<T>
 ): [T, (value: T | ((prev: T) => T)) => void] {
   const subscribe = useCallback(
     (callback: () => void) => {

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -53,6 +53,7 @@ import { usePersistedTitleBarSpeeds } from "@/hooks/usePersistedTitleBarSpeeds"
 import { useQBittorrentAppInfo } from "@/hooks/useQBittorrentAppInfo"
 import { useTitleBarSpeeds } from "@/hooks/useTitleBarSpeeds"
 import { api } from "@/lib/api"
+import { writeRaw } from "@/lib/client-settings"
 import {
   DASHBOARD_STATS_FALLBACK_ORDER,
   DASHBOARD_STATS_FALLBACK_SORT,
@@ -1053,14 +1054,10 @@ function InstanceCard({
                     to="/instances/$instanceId"
                     params={{ instanceId: instance.id.toString() }}
                     onClick={() => {
-                      try {
-                        localStorage.setItem("qui-filters-global", JSON.stringify({
-                          status: ["unregistered"],
-                          excludeStatus: [],
-                        }))
-                      } catch (error) {
-                        console.error("Failed to set filter state:", error)
-                      }
+                      writeRaw("qui-filters-global", JSON.stringify({
+                        status: ["unregistered"],
+                        excludeStatus: [],
+                      }))
                     }}
                     className="flex items-center gap-2 text-xs w-full rounded px-1 -mx-1 hover:bg-destructive/10 transition-colors"
                   >
@@ -1074,14 +1071,10 @@ function InstanceCard({
                     to="/instances/$instanceId"
                     params={{ instanceId: instance.id.toString() }}
                     onClick={() => {
-                      try {
-                        localStorage.setItem("qui-filters-global", JSON.stringify({
-                          status: ["tracker_down"],
-                          excludeStatus: [],
-                        }))
-                      } catch (error) {
-                        console.error("Failed to set filter state:", error)
-                      }
+                      writeRaw("qui-filters-global", JSON.stringify({
+                        status: ["tracker_down"],
+                        excludeStatus: [],
+                      }))
                     }}
                     className="flex items-center gap-2 text-xs w-full rounded px-1 -mx-1 hover:bg-yellow-500/10 transition-colors"
                   >
@@ -1095,14 +1088,10 @@ function InstanceCard({
                     to="/instances/$instanceId"
                     params={{ instanceId: instance.id.toString() }}
                     onClick={() => {
-                      try {
-                        localStorage.setItem("qui-filters-global", JSON.stringify({
-                          status: ["errored"],
-                          excludeStatus: [],
-                        }))
-                      } catch (error) {
-                        console.error("Failed to set filter state:", error)
-                      }
+                      writeRaw("qui-filters-global", JSON.stringify({
+                        status: ["errored"],
+                        excludeStatus: [],
+                      }))
                     }}
                     className="flex items-center gap-2 text-xs w-full rounded px-1 -mx-1 hover:bg-destructive/10 transition-colors"
                   >


### PR DESCRIPTION
## Description

Converts the per-instance table preferences and sidebar filters to the DB-backed setting hook from #2409: column visibility, order, sorting, sizing and filters, collapsed categories, mobile sort, and the split global/per-instance sidebar filters (including the raw Dashboard shortcut writes). This is the change the issue reporter asked for: column toggles now survive incognito mode and browser switches. Corrupt stored JSON now degrades to defaults instead of crashing the tree, and the tests that pinned the old crash behavior were updated to pin the new fallback contract.

Part of #2406, closes the reported case.

## How has this been tested?

Ran the built binary against a throwaway qBittorrent container: selected a Downloading status filter, confirmed it landed in the client_settings table, then wiped localStorage and reloaded, and the filter came back checked and applied from the database. Column-sizing drag needs a manual smoke pass on a real library since jsdom cannot exercise it.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved persistence for torrent sorting, filters, column layouts, visibility, sizing, ordering, and collapsed categories.
  * Preferences are now kept separate across instances, with existing settings migrated where applicable.
  * Invalid or corrupted saved preferences now fall back safely to stable defaults.
  * Expanded filter state is preserved during updates and persistence round-trips.
  * Dashboard filter navigation saves more reliably, including during browser visibility changes or page exits.

* **Refactor**
  * Standardized client-side preference handling for more consistent settings behavior.
  * Improved synchronization reliability with safer retries and handling for temporary save failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->