### PR TITLE
feat(settings): sync UI state to the database

### DIFF
--- a/web/src/hooks/usePersistedAccordion.test.ts
+++ b/web/src/hooks/usePersistedAccordion.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { act, renderHook } from "@testing-library/react"
+import { act, cleanup, renderHook } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { usePersistedAccordion } from "./usePersistedAccordion"
 
@@ -15,6 +15,7 @@ describe("usePersistedAccordion", () => {
   })
 
   afterEach(() => {
+    cleanup()
     vi.restoreAllMocks()
   })
 

--- a/web/src/hooks/usePersistedAccordion.test.ts
+++ b/web/src/hooks/usePersistedAccordion.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { renderHook } from "@testing-library/react"
+import { act, renderHook } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { usePersistedAccordion } from "./usePersistedAccordion"
 
@@ -23,11 +23,14 @@ describe("usePersistedAccordion", () => {
     expect(result.current[0]).toEqual(DEFAULT_ITEMS)
   })
 
-  it("falls back to defaults and repairs storage on malformed JSON", () => {
+  it("falls back to defaults on malformed JSON and repairs storage on the next toggle", () => {
     localStorage.setItem("qui-accordion", "{")
     const { result } = renderHook(() => usePersistedAccordion())
     expect(result.current[0]).toEqual(DEFAULT_ITEMS)
-    expect(localStorage.getItem("qui-accordion")).toBe(JSON.stringify(DEFAULT_ITEMS))
+
+    act(() => result.current[1](["status"]))
+
+    expect(localStorage.getItem("qui-accordion")).toBe(JSON.stringify(["status"]))
   })
 
   it("falls back to defaults on valid JSON of the wrong shape, even when seeded", () => {
@@ -37,10 +40,14 @@ describe("usePersistedAccordion", () => {
     expect(result.current[0]).toEqual(DEFAULT_ITEMS)
   })
 
-  it("seeds views into a pre-views stored array exactly once", () => {
+  it("seeds views into a pre-views stored array, marking seeded on the first toggle", () => {
     localStorage.setItem("qui-accordion", JSON.stringify(["status", "tags"]))
     const { result } = renderHook(() => usePersistedAccordion())
     expect(result.current[0]).toEqual(["views", "status", "tags"])
+
+    act(() => result.current[1](prev => prev.filter(item => item !== "tags")))
+
+    expect(result.current[0]).toEqual(["views", "status"])
     expect(localStorage.getItem("qui-accordion-views-seeded")).toBe("1")
   })
 

--- a/web/src/hooks/usePersistedAccordion.ts
+++ b/web/src/hooks/usePersistedAccordion.ts
@@ -3,41 +3,54 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useState, useEffect } from "react"
+import { useCallback, useMemo, useRef, type SetStateAction } from "react"
+
+import { useClientSetting } from "@/lib/client-settings"
 
 const DEFAULT_ITEMS = ["views", "status", "categories", "tags", "trackers"]
 const VIEWS_SEEDED_KEY = "qui-accordion-views-seeded"
 
-export function usePersistedAccordion() {
-  const [expandedItems, setExpandedItems] = useState<string[]>(() => {
-    try {
-      const stored = localStorage.getItem("qui-accordion")
-      if (!stored) return DEFAULT_ITEMS
-      const parsed: unknown = JSON.parse(stored)
-      if (!Array.isArray(parsed) || parsed.some((item) => typeof item !== "string")) {
-        return DEFAULT_ITEMS
-      }
-      const items: string[] = parsed
+const parseAccordionItems = (raw: string): string[] => {
+  const parsed: unknown = JSON.parse(raw)
+  if (!Array.isArray(parsed) || parsed.some((item) => typeof item !== "string")) {
+    throw new Error("invalid accordion state")
+  }
+  return parsed
+}
 
-      // Existing users have a stored array predating "views", so the new section
-      // would ship collapsed. Expand it once; after that their own toggling wins.
-      // The seed marker is written in the effect below, so this stays pure.
-      if (localStorage.getItem(VIEWS_SEEDED_KEY)) return items
-      return items.includes("views") ? items : ["views", ...items]
-    } catch {
-      return DEFAULT_ITEMS
-    }
+const parseRawString = (raw: string): string => raw
+
+export function usePersistedAccordion() {
+  const [storedItems, setStoredItems] = useClientSetting<string[]>("qui-accordion", {
+    defaultValue: DEFAULT_ITEMS,
+    parse: parseAccordionItems,
+  })
+  const [viewsSeeded, setViewsSeeded] = useClientSetting<string>(VIEWS_SEEDED_KEY, {
+    defaultValue: "",
+    parse: parseRawString,
+    serialize: parseRawString,
   })
 
-  useEffect(() => {
-    // A throwing effect unmounts the sidebar to the error boundary; blocked storage must not do that.
-    try {
-      localStorage.setItem("qui-accordion", JSON.stringify(expandedItems))
-      localStorage.setItem(VIEWS_SEEDED_KEY, "1")
-    } catch (error) {
-      console.error("Failed to save accordion state to localStorage:", error)
-    }
-  }, [expandedItems])
+  // Existing users have a stored array predating "views", so the new section
+  // would ship collapsed. Expand it in-memory until the seed marker is set;
+  // the marker is written on the user's first toggle, after which their own
+  // choice wins.
+  const expandedItems = useMemo(() => {
+    if (viewsSeeded || storedItems.includes("views")) return storedItems
+    return ["views", ...storedItems]
+  }, [storedItems, viewsSeeded])
+
+  const expandedRef = useRef(expandedItems)
+  expandedRef.current = expandedItems
+
+  const setExpandedItems = useCallback(
+    (next: SetStateAction<string[]>) => {
+      const resolved = typeof next === "function" ? next(expandedRef.current) : next
+      setStoredItems(resolved)
+      setViewsSeeded("1")
+    },
+    [setStoredItems, setViewsSeeded]
+  )
 
   return [expandedItems, setExpandedItems] as const
 }

--- a/web/src/hooks/usePersistedCompactViewState.ts
+++ b/web/src/hooks/usePersistedCompactViewState.ts
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useMemo } from "react"
+
+import { useClientSetting } from "@/lib/client-settings"
 
 const STORAGE_KEY = "qui-torrent-view-mode"
 const ALL_VIEW_MODES = ["normal", "dense", "compact", "ultra-compact"] as const
@@ -21,6 +23,11 @@ function sanitizeAllowedModes(allowedModes?: readonly ViewMode[]): ViewMode[] {
   return filtered.length > 0 ? filtered : [...ALL_VIEW_MODES]
 }
 
+const parseViewMode = (raw: string): ViewMode => {
+  if (ALL_VIEW_MODES.includes(raw as ViewMode)) return raw as ViewMode
+  throw new Error("invalid view mode")
+}
+
 export function usePersistedCompactViewState(
   defaultMode: ViewMode = "normal",
   allowedModesInput?: readonly ViewMode[]
@@ -31,59 +38,20 @@ export function usePersistedCompactViewState(
   // The stored mode is global across every consumer; `allowedModes` only narrows what
   // this consumer can render. Never persist the narrowing, or a mounted-but-hidden
   // consumer (e.g. MobileFooterNav on desktop) clobbers the user's choice on reload.
-  const [storedMode, setStoredMode] = useState<ViewMode>(() => {
-    if (typeof window === "undefined") {
-      return effectiveDefaultMode
-    }
-
-    try {
-      const stored = window.localStorage.getItem(STORAGE_KEY)
-      if (stored && ALL_VIEW_MODES.includes(stored as ViewMode)) {
-        return stored as ViewMode
-      }
-    } catch (error) {
-      console.error("Failed to load view mode state from localStorage:", error)
-    }
-
-    return effectiveDefaultMode
+  const [storedMode, setStoredMode] = useClientSetting<ViewMode>(STORAGE_KEY, {
+    defaultValue: effectiveDefaultMode,
+    parse: parseViewMode,
+    serialize: String,
   })
 
   const viewMode = allowedModes.includes(storedMode) ? storedMode : effectiveDefaultMode
 
-  const setViewMode = useCallback((requested: ViewMode) => {
-    const next = allowedModes.includes(requested) ? requested : allowedModes[0]
-
-    setStoredMode(next)
-
-    if (typeof window === "undefined") {
-      return
-    }
-
-    try {
-      window.localStorage.setItem(STORAGE_KEY, next)
-    } catch (error) {
-      console.error("Failed to save view mode state to localStorage:", error)
-    }
-
-    window.dispatchEvent(new CustomEvent(STORAGE_KEY, { detail: { viewMode: next } }))
-  }, [allowedModes])
-
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return
-    }
-
-    const handleEvent = (e: Event) => {
-      const nextMode = (e as CustomEvent<{ viewMode: ViewMode }>).detail?.viewMode
-
-      if (nextMode && ALL_VIEW_MODES.includes(nextMode)) {
-        setStoredMode(nextMode)
-      }
-    }
-
-    window.addEventListener(STORAGE_KEY, handleEvent as EventListener)
-    return () => window.removeEventListener(STORAGE_KEY, handleEvent as EventListener)
-  }, [])
+  const setViewMode = useCallback(
+    (requested: ViewMode) => {
+      setStoredMode(allowedModes.includes(requested) ? requested : allowedModes[0])
+    },
+    [allowedModes, setStoredMode]
+  )
 
   const cycleViewMode = useCallback(() => {
     setViewMode(allowedModes[(allowedModes.indexOf(viewMode) + 1) % allowedModes.length])

--- a/web/src/hooks/usePersistedFilterSidebarState.ts
+++ b/web/src/hooks/usePersistedFilterSidebarState.ts
@@ -3,57 +3,11 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useCallback, useEffect, useState } from "react"
+import { parseJsonBoolean, useClientSetting } from "@/lib/client-settings"
 
 export function usePersistedFilterSidebarState(defaultCollapsed: boolean = false) {
-  const storageKey = "qui-filter-sidebar-collapsed"
-
-  // Initialize state from localStorage or default value
-  const [filterSidebarCollapsed, setFilterSidebarCollapsedState] = useState<boolean>(() => {
-    try {
-      const stored = localStorage.getItem(storageKey)
-      if (stored !== null) {
-        return stored === "true"
-      }
-    } catch (error) {
-      console.error("Failed to load filter sidebar state from localStorage:", error)
-    }
-
-    return defaultCollapsed
+  return useClientSetting<boolean>("qui-filter-sidebar-collapsed", {
+    defaultValue: defaultCollapsed,
+    parse: parseJsonBoolean,
   })
-
-  // Persist to localStorage and broadcast to other listeners whenever state changes
-  useEffect(() => {
-    if (typeof window === "undefined") return
-
-    try {
-      localStorage.setItem(storageKey, filterSidebarCollapsed.toString())
-    } catch (error) {
-      console.error("Failed to save filter sidebar state to localStorage:", error)
-    }
-
-    const evt = new CustomEvent(storageKey, { detail: { collapsed: filterSidebarCollapsed } })
-    window.dispatchEvent(evt)
-  }, [filterSidebarCollapsed])
-
-  // Listen for cross-component updates via CustomEvent within the same tab
-  useEffect(() => {
-    const handleEvent = (e: Event) => {
-      const custom = e as CustomEvent<{ collapsed: boolean }>
-      if (typeof custom.detail?.collapsed === "boolean") {
-        setFilterSidebarCollapsedState(custom.detail.collapsed)
-      }
-    }
-    window.addEventListener(storageKey, handleEvent as EventListener)
-    return () => window.removeEventListener(storageKey, handleEvent as EventListener)
-  }, [])
-
-  // Wrapped setter that syncs state and dispatches event
-  const setFilterSidebarCollapsed = useCallback((next: boolean | ((prev: boolean) => boolean)) => {
-    setFilterSidebarCollapsedState((prev) => (
-      typeof next === "function" ? (next as (p: boolean) => boolean)(prev) : next
-    ))
-  }, [])
-
-  return [filterSidebarCollapsed, setFilterSidebarCollapsed] as const
 }

--- a/web/src/hooks/usePersistedInstanceSelection.test.ts
+++ b/web/src/hooks/usePersistedInstanceSelection.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { describe, expect, it } from "vitest"
+
+import { resolveInstanceSelection } from "@/hooks/usePersistedInstanceSelection"
+
+const instances = [
+  { id: 101, connected: false },
+  { id: 202, connected: true },
+]
+
+describe("resolveInstanceSelection", () => {
+  it("keeps the saved selection while instances are still loading", () => {
+    // The instances query resolving later must not clear a saved id; clearing
+    // here persisted the "" sentinel and the fallback then overwrote the
+    // saved selection on every reload.
+    expect(resolveInstanceSelection(undefined, 101)).toBe(101)
+    expect(resolveInstanceSelection(undefined, undefined)).toBeUndefined()
+  })
+
+  it("clears the selection when the instance list is confirmed empty", () => {
+    expect(resolveInstanceSelection([], 101)).toBeUndefined()
+  })
+
+  it("keeps a saved selection that exists, connected or not", () => {
+    expect(resolveInstanceSelection(instances, 101)).toBe(101)
+    expect(resolveInstanceSelection(instances, 202)).toBe(202)
+  })
+
+  it("falls back to the first connected instance when the saved id is gone", () => {
+    expect(resolveInstanceSelection(instances, 999)).toBe(202)
+  })
+
+  it("picks the first connected instance when nothing is saved", () => {
+    expect(resolveInstanceSelection(instances, undefined)).toBe(202)
+  })
+
+  it("picks the first instance when none are connected", () => {
+    const disconnected = [{ id: 101, connected: false }, { id: 303, connected: false }]
+    expect(resolveInstanceSelection(disconnected, undefined)).toBe(101)
+    expect(resolveInstanceSelection(disconnected, 999)).toBe(101)
+  })
+})

--- a/web/src/hooks/usePersistedInstanceSelection.ts
+++ b/web/src/hooks/usePersistedInstanceSelection.ts
@@ -3,33 +3,22 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useEffect, useState } from "react"
+import { useClientSetting } from "@/lib/client-settings"
+
+const parseInstanceId = (raw: string): number | undefined => {
+  const parsed = JSON.parse(raw)
+  if (typeof parsed !== "number") throw new Error("invalid instance id")
+  return parsed
+}
+
+// "" is the cleared sentinel; settings never remove their key.
+const serializeInstanceId = (value: number | undefined): string =>
+  typeof value === "number" ? JSON.stringify(value) : ""
 
 export function usePersistedInstanceSelection(storageNamespace: string) {
-  const storageKey = `qui-selected-instance-${storageNamespace}`
-
-  const [selectedInstanceId, setSelectedInstanceId] = useState<number | undefined>(() => {
-    try {
-      const raw = localStorage.getItem(storageKey)
-      if (!raw) return undefined
-      const parsed = JSON.parse(raw)
-      return typeof parsed === "number" ? parsed : undefined
-    } catch {
-      return undefined
-    }
+  return useClientSetting<number | undefined>(`qui-selected-instance-${storageNamespace}`, {
+    defaultValue: undefined,
+    parse: parseInstanceId,
+    serialize: serializeInstanceId,
   })
-
-  useEffect(() => {
-    try {
-      if (typeof selectedInstanceId === "number") {
-        localStorage.setItem(storageKey, JSON.stringify(selectedInstanceId))
-      } else {
-        localStorage.removeItem(storageKey)
-      }
-    } catch (error) {
-      console.error("Failed to persist selected instance:", error)
-    }
-  }, [selectedInstanceId, storageKey])
-
-  return [selectedInstanceId, setSelectedInstanceId] as const
 }

--- a/web/src/hooks/usePersistedInstanceSelection.ts
+++ b/web/src/hooks/usePersistedInstanceSelection.ts
@@ -22,3 +22,18 @@ export function usePersistedInstanceSelection(storageNamespace: string) {
     serialize: serializeInstanceId,
   })
 }
+
+/**
+ * The selection an instance picker should hold given the current instance
+ * list. Keeps the saved selection while the list is still loading (undefined).
+ */
+export function resolveInstanceSelection(
+  instances: Array<{ id: number; connected: boolean }> | undefined,
+  selected: number | undefined
+): number | undefined {
+  if (!instances) return selected
+  if (instances.length === 0) return undefined
+  if (selected !== undefined && instances.some((i) => i.id === selected)) return selected
+  const fallback = instances.find((i) => i.connected) ?? instances[0]
+  return fallback.id
+}

--- a/web/src/hooks/usePersistedShowEmptyState.ts
+++ b/web/src/hooks/usePersistedShowEmptyState.ts
@@ -3,38 +3,15 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useState, useEffect } from "react"
+import { parseJsonBoolean, useClientSetting } from "@/lib/client-settings"
 
 /**
- * Hook to persist the show/hide empty items state in localStorage
- * Used for toggling visibility of empty statuses, categories, and tags in the filter sidebar
+ * Persists the show/hide empty items state.
+ * Used for toggling visibility of empty statuses, categories, and tags in the filter sidebar.
  */
 export function usePersistedShowEmptyState(key: string, defaultValue: boolean = false) {
-  const storageKey = `qui-show-empty-${key}`
-
-  // Initialize state from localStorage or default value
-  const [showEmpty, setShowEmpty] = useState<boolean>(() => {
-    try {
-      const stored = localStorage.getItem(storageKey)
-      if (stored !== null) {
-        const parsed = JSON.parse(stored)
-        return typeof parsed === "boolean" ? parsed : defaultValue
-      }
-    } catch (error) {
-      console.error(`Failed to load show empty state from localStorage (${key}):`, error)
-    }
-
-    return defaultValue
+  return useClientSetting<boolean>(`qui-show-empty-${key}`, {
+    defaultValue,
+    parse: parseJsonBoolean,
   })
-
-  // Persist to localStorage whenever state changes
-  useEffect(() => {
-    try {
-      localStorage.setItem(storageKey, JSON.stringify(showEmpty))
-    } catch (error) {
-      console.error(`Failed to save show empty state to localStorage (${key}):`, error)
-    }
-  }, [showEmpty, storageKey])
-
-  return [showEmpty, setShowEmpty] as const
 }

--- a/web/src/hooks/usePersistedSidebarState.ts
+++ b/web/src/hooks/usePersistedSidebarState.ts
@@ -3,33 +3,11 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useState, useEffect } from "react"
+import { parseJsonBoolean, useClientSetting } from "@/lib/client-settings"
 
 export function usePersistedSidebarState(defaultCollapsed: boolean = false) {
-  const storageKey = "qui-sidebar-collapsed"
-
-  // Initialize state from localStorage or default value
-  const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(() => {
-    try {
-      const stored = localStorage.getItem(storageKey)
-      if (stored !== null) {
-        return stored === "true"
-      }
-    } catch (error) {
-      console.error("Failed to load sidebar state from localStorage:", error)
-    }
-
-    return defaultCollapsed
+  return useClientSetting<boolean>("qui-sidebar-collapsed", {
+    defaultValue: defaultCollapsed,
+    parse: parseJsonBoolean,
   })
-
-  // Persist to localStorage whenever state changes
-  useEffect(() => {
-    try {
-      localStorage.setItem(storageKey, sidebarCollapsed.toString())
-    } catch (error) {
-      console.error("Failed to save sidebar state to localStorage:", error)
-    }
-  }, [sidebarCollapsed])
-
-  return [sidebarCollapsed, setSidebarCollapsed] as const
 }

--- a/web/src/hooks/usePersistedTabState.ts
+++ b/web/src/hooks/usePersistedTabState.ts
@@ -3,35 +3,17 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useEffect, useState } from "react"
+import { useClientSetting } from "@/lib/client-settings"
 
 export function usePersistedTabState<T extends string>(
   storageKey: string,
   defaultValue: T,
   isValid?: (value: string) => value is T
 ) {
-  const [value, setValue] = useState<T>(() => {
-    try {
-      const stored = localStorage.getItem(storageKey)
-      if (stored !== null) {
-        if (!isValid || isValid(stored)) {
-          return stored as T
-        }
-      }
-    } catch (error) {
-      console.error(`Failed to load tab state from localStorage (${storageKey}):`, error)
-    }
+  const parse = (raw: string): T => {
+    if (!isValid || isValid(raw)) return raw as T
+    throw new Error("invalid tab value")
+  }
 
-    return defaultValue
-  })
-
-  useEffect(() => {
-    try {
-      localStorage.setItem(storageKey, value)
-    } catch (error) {
-      console.error(`Failed to save tab state to localStorage (${storageKey}):`, error)
-    }
-  }, [storageKey, value])
-
-  return [value, setValue] as const
+  return useClientSetting<T>(storageKey, { defaultValue, parse, serialize: String })
 }

--- a/web/src/hooks/usePersistedUnifiedInstanceFilter.ts
+++ b/web/src/hooks/usePersistedUnifiedInstanceFilter.ts
@@ -3,56 +3,22 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useCallback, useMemo, useSyncExternalStore } from "react"
 import { encodeUnifiedInstanceIds, parseUnifiedInstanceIds } from "@/lib/instances"
+import { useClientSetting } from "@/lib/client-settings"
 
-const STORAGE_KEY = "qui-unified-instance-filter"
-const CHANGE_EVENT = "qui-unified-instance-filter-changed"
+const NO_IDS: readonly number[] = []
 
-function subscribe(callback: () => void): () => void {
-  const handleStorage = (e: StorageEvent) => {
-    if (e.key === STORAGE_KEY) callback()
-  }
-  window.addEventListener("storage", handleStorage)
-  window.addEventListener(CHANGE_EVENT, callback as EventListener)
-  return () => {
-    window.removeEventListener("storage", handleStorage)
-    window.removeEventListener(CHANGE_EVENT, callback as EventListener)
-  }
-}
-
-function getSnapshot(): string {
-  try {
-    return localStorage.getItem(STORAGE_KEY) ?? ""
-  } catch {
-    return ""
-  }
-}
+// An empty selection stores "" (the cleared sentinel); parse never sees it.
+const parseIds = (raw: string): readonly number[] => parseUnifiedInstanceIds(raw)
+const serializeIds = (ids: readonly number[]): string => encodeUnifiedInstanceIds(ids) ?? ""
 
 export function usePersistedUnifiedInstanceFilter(): [
   readonly number[],
   (ids: readonly number[]) => void
 ] {
-  const storedString = useSyncExternalStore(subscribe, getSnapshot)
-
-  const persistedIds = useMemo(
-    () => parseUnifiedInstanceIds(storedString),
-    [storedString]
-  )
-
-  const saveFilter = useCallback((ids: readonly number[]) => {
-    try {
-      const encoded = encodeUnifiedInstanceIds(ids)
-      if (encoded) {
-        localStorage.setItem(STORAGE_KEY, encoded)
-      } else {
-        localStorage.removeItem(STORAGE_KEY)
-      }
-      window.dispatchEvent(new Event(CHANGE_EVENT))
-    } catch (error) {
-      console.error("Failed to save unified instance filter:", error)
-    }
-  }, [])
-
-  return [persistedIds, saveFilter]
+  return useClientSetting<readonly number[]>("qui-unified-instance-filter", {
+    defaultValue: NO_IDS,
+    parse: parseIds,
+    serialize: serializeIds,
+  })
 }

--- a/web/src/lib/client-settings.ts
+++ b/web/src/lib/client-settings.ts
@@ -34,6 +34,13 @@ const SYNCED_KEYS = new Set<string>([
   "qui-datetime-preferences",
   "qui-titlebar-speeds-enabled",
   "qui.language",
+  "qui-sidebar-collapsed",
+  "qui-filter-sidebar-collapsed",
+  "qui-accordion",
+  "qui-accordion-views-seeded",
+  "qui-torrent-view-mode",
+  "qui-unified-instance-filter",
+  "torrent-details-last-tab",
 ])
 const SYNCED_PREFIXES = [
   "qui-start-paused-instance-",
@@ -47,6 +54,8 @@ const SYNCED_PREFIXES = [
   "qui-collapsed-categories-",
   "qui-filters-",
   "qui:torrent-mobile-sort:",
+  "qui-show-empty-",
+  "qui-selected-instance-",
 ]
 
 function isSyncedKey(key: string): boolean {

--- a/web/src/pages/InstanceBackups.tsx
+++ b/web/src/pages/InstanceBackups.tsx
@@ -159,6 +159,13 @@ export function InstanceBackups() {
   const instanceCapabilitiesPending = (instances?.length ?? 0) > 0
     && instanceCapabilitiesQueries.some(query => query.isPending)
 
+  // An errored capabilities query is as unresolved as a pending one: deciding
+  // on it would drop its instance from supportedInstances and clear a saved
+  // selection over a transient failure. Only the selection effect cares; the
+  // UI keeps treating an error as "not checking".
+  const instanceCapabilitiesUnresolved = instanceCapabilitiesPending
+    || instanceCapabilitiesQueries.some(query => query.isError)
+
   // Filter instances to only show those that support backups
   const supportedInstances = useMemo(() => {
     if (!instances) return []
@@ -178,7 +185,7 @@ export function InstanceBackups() {
     if (!instances) {
       return
     }
-    if (instanceCapabilitiesPending) {
+    if (instanceCapabilitiesUnresolved) {
       return
     }
 
@@ -186,7 +193,7 @@ export function InstanceBackups() {
     if (!stillSupported) {
       setSelectedInstanceId(undefined)
     }
-  }, [selectedInstanceId, setSelectedInstanceId, supportedInstances, instances, instanceCapabilitiesPending])
+  }, [selectedInstanceId, setSelectedInstanceId, supportedInstances, instances, instanceCapabilitiesUnresolved])
 
   const instanceId = selectedInstanceId
 

--- a/web/src/pages/RSSPage.tsx
+++ b/web/src/pages/RSSPage.tsx
@@ -79,7 +79,7 @@ import { useInstanceCapabilities } from "@/hooks/useInstanceCapabilities"
 import { useInstanceMetadata } from "@/hooks/useInstanceMetadata"
 import { useInstancePreferences } from "@/hooks/useInstancePreferences"
 import { useInstances } from "@/hooks/useInstances"
-import { usePersistedInstanceSelection } from "@/hooks/usePersistedInstanceSelection"
+import { resolveInstanceSelection, usePersistedInstanceSelection } from "@/hooks/usePersistedInstanceSelection"
 import {
   rssKeys,
   useAddRSSFeed,
@@ -134,28 +134,9 @@ export function RSSPage({
 
   // Auto-select/validate instance selection
   useEffect(() => {
-    if (!instances || instances.length === 0) {
-      if (selectedInstanceId !== undefined) {
-        setSelectedInstanceId(undefined)
-      }
-      return
-    }
-
-    if (selectedInstanceId !== undefined) {
-      const exists = instances.some((i) => i.id === selectedInstanceId)
-      if (exists) {
-        return
-      }
-      const fallbackInstance = instances.find((i) => i.connected) ?? instances[0]
-      setSelectedInstanceId(fallbackInstance?.id)
-      return
-    }
-
-    const firstConnected = instances.find((i) => i.connected)
-    if (firstConnected) {
-      setSelectedInstanceId(firstConnected.id)
-    } else if (instances[0]) {
-      setSelectedInstanceId(instances[0].id)
+    const next = resolveInstanceSelection(instances, selectedInstanceId)
+    if (next !== selectedInstanceId) {
+      setSelectedInstanceId(next)
     }
   }, [selectedInstanceId, setSelectedInstanceId, instances])
 


### PR DESCRIPTION
## Description

Final conversion batch for #2406: sidebar and filter-sidebar collapse, accordion sections with the views-seed marker, torrent view mode, show-empty toggles, last details tab, per-page instance selection, and the unified instance filter all move onto the DB-backed setting hook. Three hook-private CustomEvents and the bespoke useSyncExternalStore plumbing in the unified filter are deleted since the shared hook covers same-tab and cross-tab sync.

Part of #2406

## How has this been tested?

Ran the built binary in Chrome: toggled the filter sidebar and accordion, confirmed the new keys and both seed markers landed in the client_settings table alongside the earlier batches, then wiped localStorage and reloaded, and accordion state, seed marker, filters, and date/time preferences all came back from the database. One rig note: the service worker serves the previous bundle until a reload, so the first exercise ran old code — a second reload picked up the new build.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persisted interface preferences—including accordion, sidebar, tab, compact view, empty-state, and instance selections—now synchronize through a shared settings system.
  * Selected instance and unified filter preferences are retained more consistently across sessions and contexts.
* **Bug Fixes**
  * Invalid or malformed saved settings now safely fall back to valid defaults.
  * Instance selections are preserved while data is loading or temporarily unavailable, with sensible connected-instance fallbacks.
  * Accordion preferences are repaired and finalized when users change their selections.
  * Pending preference changes are preserved for retry, including when leaving the page or during interrupted updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->