### PR TITLE
test: client settings DB stack field-test bundle

### DIFF
--- a/cmd/qui/main.go
+++ b/cmd/qui/main.go
@@ -537,6 +537,7 @@ func (app *Application) runServer() {
 	automationStore := models.NewAutomationStore(db)
 	trackerCustomizationStore := models.NewTrackerCustomizationStore(db)
 	dashboardSettingsStore := models.NewDashboardSettingsStore(db)
+	clientSettingsStore := models.NewClientSettingsStore(db)
 	themeSettingsStore := models.NewThemeSettingsStore(db)
 	filterViewStore := models.NewFilterViewStore(db)
 	logExclusionsStore := models.NewLogExclusionsStore(db)
@@ -803,6 +804,7 @@ func (app *Application) runServer() {
 		AutomationService:                automationService,
 		TrackerCustomizationStore:        trackerCustomizationStore,
 		DashboardSettingsStore:           dashboardSettingsStore,
+		ClientSettingsStore:              clientSettingsStore,
 		ThemeSettingsStore:               themeSettingsStore,
 		FilterViewStore:                  filterViewStore,
 		LogExclusionsStore:               logExclusionsStore,

--- a/internal/api/handlers/client_settings.go
+++ b/internal/api/handlers/client_settings.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/services/activity"
+)
+
+// maxClientSettingsBodySize caps one PUT payload.
+const maxClientSettingsBodySize = 1 << 20 // 1 MiB
+
+type ClientSettingsHandler struct {
+	store *models.ClientSettingsStore
+	// activity signals stored-settings changes so open tabs refetch instead
+	// of polling.
+	activity activity.Publisher
+}
+
+func NewClientSettingsHandler(store *models.ClientSettingsStore, publisher activity.Publisher) *ClientSettingsHandler {
+	return &ClientSettingsHandler{store: store, activity: publisher}
+}
+
+// GetClientSettings returns every stored setting as a key-value map.
+func (h *ClientSettingsHandler) GetClientSettings(w http.ResponseWriter, r *http.Request) {
+	settings, err := h.store.GetAll(r.Context())
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to load client settings")
+		RespondError(w, http.StatusInternalServerError, "Failed to load client settings")
+		return
+	}
+	RespondJSON(w, http.StatusOK, settings)
+}
+
+// UpdateClientSettings upserts the submitted settings. The payload is a
+// partial map; keys not present stay untouched.
+func (h *ClientSettingsHandler) UpdateClientSettings(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxClientSettingsBodySize)
+
+	var settings map[string]string
+	if err := json.NewDecoder(r.Body).Decode(&settings); err != nil {
+		RespondError(w, http.StatusBadRequest, "Invalid request payload")
+		return
+	}
+	if len(settings) == 0 {
+		RespondError(w, http.StatusBadRequest, "No settings provided")
+		return
+	}
+	for key := range settings {
+		if key == "" {
+			RespondError(w, http.StatusBadRequest, "Invalid setting key")
+			return
+		}
+	}
+
+	if err := h.store.SetMany(r.Context(), settings); err != nil {
+		log.Error().Err(err).Msg("Failed to save client settings")
+		RespondError(w, http.StatusInternalServerError, "Failed to save client settings")
+		return
+	}
+	h.activity.Publish(activity.Event{Kind: activity.KindClientSettings})
+	RespondJSON(w, http.StatusOK, settings)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -79,6 +79,7 @@ type Server struct {
 	automationService                *automations.Service
 	trackerCustomizationStore        *models.TrackerCustomizationStore
 	dashboardSettingsStore           *models.DashboardSettingsStore
+	clientSettingsStore              *models.ClientSettingsStore
 	themeSettingsStore               *models.ThemeSettingsStore
 	filterViewStore                  *models.FilterViewStore
 	logExclusionsStore               *models.LogExclusionsStore
@@ -122,6 +123,7 @@ type Dependencies struct {
 	AutomationService                *automations.Service
 	TrackerCustomizationStore        *models.TrackerCustomizationStore
 	DashboardSettingsStore           *models.DashboardSettingsStore
+	ClientSettingsStore              *models.ClientSettingsStore
 	ThemeSettingsStore               *models.ThemeSettingsStore
 	FilterViewStore                  *models.FilterViewStore
 	LogExclusionsStore               *models.LogExclusionsStore
@@ -188,6 +190,7 @@ func NewServer(deps *Dependencies) *Server {
 		automationService:                deps.AutomationService,
 		trackerCustomizationStore:        deps.TrackerCustomizationStore,
 		dashboardSettingsStore:           deps.DashboardSettingsStore,
+		clientSettingsStore:              deps.ClientSettingsStore,
 		themeSettingsStore:               deps.ThemeSettingsStore,
 		filterViewStore:                  deps.FilterViewStore,
 		logExclusionsStore:               deps.LogExclusionsStore,
@@ -379,6 +382,7 @@ func (s *Server) Handler() (*chi.Mux, error) {
 	rssHandler := handlers.NewRSSHandler(s.syncManager)
 	rssSSEHandler := handlers.NewRSSSSEHandler(s.syncManager)
 	dashboardSettingsHandler := handlers.NewDashboardSettingsHandler(s.dashboardSettingsStore)
+	clientSettingsHandler := handlers.NewClientSettingsHandler(s.clientSettingsStore, s.activityHub)
 	filterViewHandler := handlers.NewFilterViewHandler(s.filterViewStore)
 	logExclusionsHandler := handlers.NewLogExclusionsHandler(s.logExclusionsStore)
 	logsHandler := handlers.NewLogsHandler(s.config)
@@ -451,6 +455,10 @@ func (s *Server) Handler() (*chi.Mux, error) {
 
 			// Persisted theme selection (reads are public above)
 			r.Put("/themes/settings", themesHandler.UpdateThemeSettings)
+
+			// Persisted frontend user settings (opaque key-value map)
+			r.Get("/client-settings", clientSettingsHandler.GetClientSettings)
+			r.Put("/client-settings", clientSettingsHandler.UpdateClientSettings)
 
 			// Jackett routes (if configured)
 			if jackettHandler != nil {

--- a/internal/database/migrations/090_add_client_settings.sql
+++ b/internal/database/migrations/090_add_client_settings.sql
@@ -1,0 +1,8 @@
+-- Copyright (c) 2026, s0up and the autobrr contributors.
+-- SPDX-License-Identifier: GPL-2.0-or-later
+
+CREATE TABLE IF NOT EXISTS client_settings (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/internal/database/postgres_migrations/092_add_client_settings.sql
+++ b/internal/database/postgres_migrations/092_add_client_settings.sql
@@ -1,0 +1,8 @@
+-- Copyright (c) 2026, s0up and the autobrr contributors.
+-- SPDX-License-Identifier: GPL-2.0-or-later
+
+CREATE TABLE IF NOT EXISTS client_settings (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/internal/models/client_settings.go
+++ b/internal/models/client_settings.go
@@ -39,10 +39,17 @@ func (s *ClientSettingsStore) GetAll(ctx context.Context) (map[string]string, er
 	return settings, rows.Err()
 }
 
-// SetMany upserts the given settings, leaving keys not in the map untouched.
+// SetMany upserts the given settings atomically, leaving keys not in the map
+// untouched.
 func (s *ClientSettingsStore) SetMany(ctx context.Context, settings map[string]string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
 	for key, value := range settings {
-		_, err := s.db.ExecContext(ctx, `
+		_, err := tx.ExecContext(ctx, `
 			INSERT INTO client_settings (key, value)
 			VALUES (?, ?)
 			ON CONFLICT (key) DO UPDATE SET
@@ -53,5 +60,5 @@ func (s *ClientSettingsStore) SetMany(ctx context.Context, settings map[string]s
 			return err
 		}
 	}
-	return nil
+	return tx.Commit()
 }

--- a/internal/models/client_settings.go
+++ b/internal/models/client_settings.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package models
+
+import (
+	"context"
+
+	"github.com/autobrr/qui/internal/dbinterface"
+)
+
+// ClientSettingsStore persists frontend user settings as an opaque key-value
+// map. Values are raw strings the backend never parses; the frontend owns the
+// encoding of every key.
+type ClientSettingsStore struct {
+	db dbinterface.Querier
+}
+
+func NewClientSettingsStore(db dbinterface.Querier) *ClientSettingsStore {
+	return &ClientSettingsStore{db: db}
+}
+
+// GetAll returns every stored setting. An empty map means nothing is stored.
+func (s *ClientSettingsStore) GetAll(ctx context.Context) (map[string]string, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT key, value FROM client_settings`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	settings := make(map[string]string)
+	for rows.Next() {
+		var key, value string
+		if err := rows.Scan(&key, &value); err != nil {
+			return nil, err
+		}
+		settings[key] = value
+	}
+	return settings, rows.Err()
+}
+
+// SetMany upserts the given settings, leaving keys not in the map untouched.
+func (s *ClientSettingsStore) SetMany(ctx context.Context, settings map[string]string) error {
+	for key, value := range settings {
+		_, err := s.db.ExecContext(ctx, `
+			INSERT INTO client_settings (key, value)
+			VALUES (?, ?)
+			ON CONFLICT (key) DO UPDATE SET
+				value = excluded.value,
+				updated_at = CURRENT_TIMESTAMP
+		`, key, value)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/models/client_settings_test.go
+++ b/internal/models/client_settings_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package models_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/testutil/testdb"
+)
+
+func TestClientSettingsStore_GetAllEmpty(t *testing.T) {
+	store := models.NewClientSettingsStore(testdb.NewMigratedSQLite(t, "client-settings"))
+
+	settings, err := store.GetAll(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, settings)
+}
+
+func TestClientSettingsStore_SetManyAndOverwrite(t *testing.T) {
+	store := models.NewClientSettingsStore(testdb.NewMigratedSQLite(t, "client-settings"))
+	ctx := context.Background()
+
+	require.NoError(t, store.SetMany(ctx, map[string]string{
+		"qui-speed-units":       `"bits"`,
+		"qui-column-sorting:1":  `[{"id":"name","desc":false}]`,
+		"qui-torrent-view-mode": "compact",
+	}))
+
+	settings, err := store.GetAll(ctx)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{
+		"qui-speed-units":       `"bits"`,
+		"qui-column-sorting:1":  `[{"id":"name","desc":false}]`,
+		"qui-torrent-view-mode": "compact",
+	}, settings)
+
+	// Partial update overwrites one key and leaves the others untouched.
+	require.NoError(t, store.SetMany(ctx, map[string]string{
+		"qui-speed-units": `"bytes"`,
+	}))
+
+	settings, err = store.GetAll(ctx)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{
+		"qui-speed-units":       `"bytes"`,
+		"qui-column-sorting:1":  `[{"id":"name","desc":false}]`,
+		"qui-torrent-view-mode": "compact",
+	}, settings)
+}

--- a/internal/services/activity/activity.go
+++ b/internal/services/activity/activity.go
@@ -36,6 +36,7 @@ const (
 	KindSearchHistory      Kind = "search.history"
 	KindTrackerIcons       Kind = "tracker.icons"
 	KindThemeSettings      Kind = "theme.settings"
+	KindClientSettings     Kind = "client.settings"
 )
 
 // Event is a small, JSON-serializable signal that some qui-owned state changed.

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -3187,6 +3187,50 @@ paths:
         '500':
           description: Failed to save theme settings
 
+  /api/client-settings:
+    get:
+      tags:
+        - Client Settings
+      summary: Get stored client settings
+      description: Get every stored frontend user setting as a key-value map of raw strings. The backend does not parse values.
+      responses:
+        '200':
+          description: All stored client settings
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+        '500':
+          description: Failed to load client settings
+    put:
+      tags:
+        - Client Settings
+      summary: Store client settings
+      description: Upsert the submitted settings. The payload is a partial key-value map; keys not present stay untouched.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: string
+      responses:
+        '200':
+          description: Settings stored; echoes the submitted map
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+        '400':
+          description: Invalid payload, empty map, empty key, or body over 1 MiB
+        '500':
+          description: Failed to save client settings
+
   /api/torrents/export:
     post:
       tags:

--- a/web/src/components/themes/BuiltinThemesLoader.tsx
+++ b/web/src/components/themes/BuiltinThemesLoader.tsx
@@ -4,15 +4,18 @@
  */
 
 import { useBuiltinThemes } from "@/hooks/useBuiltinThemes"
+import { useClientSettingsSync } from "@/hooks/useClientSettingsSync"
 import { useThemeSettingsSync } from "@/hooks/useThemeSettingsSync"
 
 /**
  * Mounts the built-in theme query and the server theme-settings sync app-wide,
  * above auth, so the login page paints the selected theme too. Registration
- * happens in the queryFn.
+ * happens in the queryFn. The client-settings sync rides along; its query is
+ * auth-gated and idles on the login page.
  */
 export function BuiltinThemesLoader(): null {
   useBuiltinThemes()
   useThemeSettingsSync()
+  useClientSettingsSync()
   return null
 }

--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -47,6 +47,7 @@ import { useTorrentsList } from "@/hooks/useTorrentsList"
 import { useTrackerCustomizations } from "@/hooks/useTrackerCustomizations"
 import { useTrackerIcons } from "@/hooks/useTrackerIcons"
 import { api } from "@/lib/api"
+import { useClientSetting } from "@/lib/client-settings"
 import { buildTrackerCustomizationLookup, extractTrackerHost, getTrackerCustomizationsCacheKey, resolveTrackerDisplay, type TrackerCustomizationLookup } from "@/lib/tracker-customizations"
 import { resolveTrackerHealthSupport } from "@/lib/tracker-health-support"
 import { resolveTrackerIconSrc } from "@/lib/tracker-icons"
@@ -565,6 +566,14 @@ function isValidSortField(value: unknown): value is TorrentSortOptionValue {
   return TORRENT_SORT_OPTIONS.some(option => option.value === value)
 }
 
+function parseMobileSortState(raw: string): MobileSortState {
+  const parsed = JSON.parse(raw) as Partial<MobileSortState>
+  const field = isValidSortField(parsed?.field) ? parsed.field : DEFAULT_MOBILE_SORT_STATE.field
+  const defaultOrder = getDefaultSortOrder(field)
+  const order = parsed?.order === "asc" || parsed?.order === "desc" ? parsed.order : defaultOrder
+  return { field, order }
+}
+
 const trackerIconSizeClasses = {
   xs: "h-3 w-3 text-[8px]",
   sm: "h-[14px] w-[14px] text-[9px]",
@@ -1062,26 +1071,10 @@ export function TorrentCardsMobile({
   const { t } = useTranslation("torrents")
   const isAllInstancesView = isAllInstancesScope(instanceId)
   // State
-  const [sortState, setSortState] = useState<MobileSortState>(() => {
-    if (typeof window === "undefined") {
-      return DEFAULT_MOBILE_SORT_STATE
-    }
-
-    try {
-      const stored = window.localStorage.getItem(`${MOBILE_SORT_STORAGE_KEY}:${instanceId}`)
-      if (stored) {
-        const parsed = JSON.parse(stored) as Partial<MobileSortState>
-        const field = isValidSortField(parsed?.field) ? parsed?.field : DEFAULT_MOBILE_SORT_STATE.field
-        const defaultOrder = getDefaultSortOrder(field)
-        const order = parsed?.order === "asc" || parsed?.order === "desc" ? parsed.order : defaultOrder
-        return { field, order }
-      }
-    } catch {
-      // Ignore malformed localStorage entries
-    }
-
-    return DEFAULT_MOBILE_SORT_STATE
-  })
+  const [sortState, setSortState] = useClientSetting<MobileSortState>(
+    `${MOBILE_SORT_STORAGE_KEY}:${instanceId}`,
+    { defaultValue: DEFAULT_MOBILE_SORT_STATE, parse: parseMobileSortState }
+  )
   const [globalFilter, setGlobalFilter] = useState("")
   const [immediateSearch] = useState("")
   // Selection identity: hash for single-instance, `${instanceId}:${hash}` for unified scope.
@@ -1119,14 +1112,14 @@ export function TorrentCardsMobile({
         order: getDefaultSortOrder(value),
       }
     })
-  }, [])
+  }, [setSortState])
 
   const toggleSortOrder = useCallback(() => {
     setSortState(prev => ({
       field: prev.field,
       order: prev.order === "desc" ? "asc" : "desc",
     }))
-  }, [])
+  }, [setSortState])
 
   // Custom "select all" state for handling large datasets
   const [isAllSelected, setIsAllSelected] = useState(false)
@@ -1333,51 +1326,6 @@ export function TorrentCardsMobile({
     refetchIntervalInBackground: true,
   })
   const activeTaskCount = streamActiveTaskCount ?? polledActiveTaskCount
-
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      setSortState(DEFAULT_MOBILE_SORT_STATE)
-      return
-    }
-
-    const storageKey = `${MOBILE_SORT_STORAGE_KEY}:${instanceId}`
-    setSortState(prev => {
-      try {
-        const stored = window.localStorage.getItem(storageKey)
-        if (!stored) {
-          return DEFAULT_MOBILE_SORT_STATE
-        }
-
-        const parsed = JSON.parse(stored) as Partial<MobileSortState>
-        const field = isValidSortField(parsed?.field) ? parsed?.field : DEFAULT_MOBILE_SORT_STATE.field
-        const defaultOrder = getDefaultSortOrder(field)
-        const order = parsed?.order === "asc" || parsed?.order === "desc" ? parsed.order : defaultOrder
-
-        if (prev.field === field && prev.order === order) {
-          return prev
-        }
-
-        return { field, order }
-      } catch {
-        return DEFAULT_MOBILE_SORT_STATE
-      }
-    })
-  }, [instanceId])
-
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return
-    }
-
-    try {
-      window.localStorage.setItem(
-        `${MOBILE_SORT_STORAGE_KEY}:${instanceId}`,
-        JSON.stringify(sortState)
-      )
-    } catch {
-      // Ignore storage quota errors
-    }
-  }, [sortState, instanceId])
 
   // Columns controls removed on mobile
 

--- a/web/src/hooks/useClientSettingsSync.ts
+++ b/web/src/hooks/useClientSettingsSync.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { useEffect } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { api } from "@/lib/api"
+import { useActivityStream } from "@/contexts/SyncStreamContext"
+import { useIsAuthed } from "@/hooks/useIsAuthed"
+import { applyServerSettings, readRaw, seedAndMarkReady } from "@/lib/client-settings"
+import { changeLanguage, supportedLanguages, type AppLanguage } from "@/i18n"
+
+/**
+ * Syncs DB-backed client settings with the server. On load the server
+ * snapshot is applied to localStorage (the instant-boot cache), keys the
+ * server does not know yet are seeded up from localStorage, and the debounced
+ * push queue opens. A "client.settings" activity event invalidates the query
+ * so other open tabs and browsers pull changes.
+ */
+export function useClientSettingsSync(): void {
+  const isAuthed = useIsAuthed()
+
+  useActivityStream(isAuthed)
+
+  const { data } = useQuery({
+    queryKey: ["client-settings"],
+    queryFn: () => api.getClientSettings(),
+    enabled: isAuthed,
+  })
+
+  useEffect(() => {
+    if (!data) return
+    const changed = applyServerSettings(data)
+    // i18n boots from localStorage before React mounts; a language applied
+    // from the server needs the imperative switch too.
+    if (changed.includes("qui.language")) {
+      const language = readRaw("qui.language")
+      if (language && supportedLanguages.includes(language as AppLanguage)) {
+        void changeLanguage(language as AppLanguage)
+      }
+    }
+    seedAndMarkReady(data)
+  }, [data])
+}

--- a/web/src/hooks/useIsAuthed.ts
+++ b/web/src/hooks/useIsAuthed.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { useQuery } from "@tanstack/react-query"
+import { api } from "@/lib/api"
+
+/**
+ * Observes the cached auth state without fetching (enabled: false); useAuth
+ * owns the fetch. Sync hooks gate their auth-only work on this so nothing
+ * runs on the login/setup pages.
+ */
+export function useIsAuthed(): boolean {
+  const { data: user } = useQuery({
+    queryKey: ["auth", "user"],
+    queryFn: () => api.checkAuth(),
+    enabled: false,
+  })
+  return Boolean(user)
+}

--- a/web/src/hooks/usePersistedAccordion.test.ts
+++ b/web/src/hooks/usePersistedAccordion.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { act, renderHook } from "@testing-library/react"
+import { act, cleanup, renderHook } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { usePersistedAccordion } from "./usePersistedAccordion"
 
@@ -15,6 +15,7 @@ describe("usePersistedAccordion", () => {
   })
 
   afterEach(() => {
+    cleanup()
     vi.restoreAllMocks()
   })
 

--- a/web/src/hooks/usePersistedAccordion.test.ts
+++ b/web/src/hooks/usePersistedAccordion.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { renderHook } from "@testing-library/react"
+import { act, renderHook } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { usePersistedAccordion } from "./usePersistedAccordion"
 
@@ -23,11 +23,14 @@ describe("usePersistedAccordion", () => {
     expect(result.current[0]).toEqual(DEFAULT_ITEMS)
   })
 
-  it("falls back to defaults and repairs storage on malformed JSON", () => {
+  it("falls back to defaults on malformed JSON and repairs storage on the next toggle", () => {
     localStorage.setItem("qui-accordion", "{")
     const { result } = renderHook(() => usePersistedAccordion())
     expect(result.current[0]).toEqual(DEFAULT_ITEMS)
-    expect(localStorage.getItem("qui-accordion")).toBe(JSON.stringify(DEFAULT_ITEMS))
+
+    act(() => result.current[1](["status"]))
+
+    expect(localStorage.getItem("qui-accordion")).toBe(JSON.stringify(["status"]))
   })
 
   it("falls back to defaults on valid JSON of the wrong shape, even when seeded", () => {
@@ -37,10 +40,14 @@ describe("usePersistedAccordion", () => {
     expect(result.current[0]).toEqual(DEFAULT_ITEMS)
   })
 
-  it("seeds views into a pre-views stored array exactly once", () => {
+  it("seeds views into a pre-views stored array, marking seeded on the first toggle", () => {
     localStorage.setItem("qui-accordion", JSON.stringify(["status", "tags"]))
     const { result } = renderHook(() => usePersistedAccordion())
     expect(result.current[0]).toEqual(["views", "status", "tags"])
+
+    act(() => result.current[1](prev => prev.filter(item => item !== "tags")))
+
+    expect(result.current[0]).toEqual(["views", "status"])
     expect(localStorage.getItem("qui-accordion-views-seeded")).toBe("1")
   })
 

--- a/web/src/hooks/usePersistedAccordion.ts
+++ b/web/src/hooks/usePersistedAccordion.ts
@@ -3,41 +3,54 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useState, useEffect } from "react"
+import { useCallback, useMemo, useRef, type SetStateAction } from "react"
+
+import { useClientSetting } from "@/lib/client-settings"
 
 const DEFAULT_ITEMS = ["views", "status", "categories", "tags", "trackers"]
 const VIEWS_SEEDED_KEY = "qui-accordion-views-seeded"
 
-export function usePersistedAccordion() {
-  const [expandedItems, setExpandedItems] = useState<string[]>(() => {
-    try {
-      const stored = localStorage.getItem("qui-accordion")
-      if (!stored) return DEFAULT_ITEMS
-      const parsed: unknown = JSON.parse(stored)
-      if (!Array.isArray(parsed) || parsed.some((item) => typeof item !== "string")) {
-        return DEFAULT_ITEMS
-      }
-      const items: string[] = parsed
+const parseAccordionItems = (raw: string): string[] => {
+  const parsed: unknown = JSON.parse(raw)
+  if (!Array.isArray(parsed) || parsed.some((item) => typeof item !== "string")) {
+    throw new Error("invalid accordion state")
+  }
+  return parsed
+}
 
-      // Existing users have a stored array predating "views", so the new section
-      // would ship collapsed. Expand it once; after that their own toggling wins.
-      // The seed marker is written in the effect below, so this stays pure.
-      if (localStorage.getItem(VIEWS_SEEDED_KEY)) return items
-      return items.includes("views") ? items : ["views", ...items]
-    } catch {
-      return DEFAULT_ITEMS
-    }
+const parseRawString = (raw: string): string => raw
+
+export function usePersistedAccordion() {
+  const [storedItems, setStoredItems] = useClientSetting<string[]>("qui-accordion", {
+    defaultValue: DEFAULT_ITEMS,
+    parse: parseAccordionItems,
+  })
+  const [viewsSeeded, setViewsSeeded] = useClientSetting<string>(VIEWS_SEEDED_KEY, {
+    defaultValue: "",
+    parse: parseRawString,
+    serialize: parseRawString,
   })
 
-  useEffect(() => {
-    // A throwing effect unmounts the sidebar to the error boundary; blocked storage must not do that.
-    try {
-      localStorage.setItem("qui-accordion", JSON.stringify(expandedItems))
-      localStorage.setItem(VIEWS_SEEDED_KEY, "1")
-    } catch (error) {
-      console.error("Failed to save accordion state to localStorage:", error)
-    }
-  }, [expandedItems])
+  // Existing users have a stored array predating "views", so the new section
+  // would ship collapsed. Expand it in-memory until the seed marker is set;
+  // the marker is written on the user's first toggle, after which their own
+  // choice wins.
+  const expandedItems = useMemo(() => {
+    if (viewsSeeded || storedItems.includes("views")) return storedItems
+    return ["views", ...storedItems]
+  }, [storedItems, viewsSeeded])
+
+  const expandedRef = useRef(expandedItems)
+  expandedRef.current = expandedItems
+
+  const setExpandedItems = useCallback(
+    (next: SetStateAction<string[]>) => {
+      const resolved = typeof next === "function" ? next(expandedRef.current) : next
+      setStoredItems(resolved)
+      setViewsSeeded("1")
+    },
+    [setStoredItems, setViewsSeeded]
+  )
 
   return [expandedItems, setExpandedItems] as const
 }

--- a/web/src/hooks/usePersistedCollapsedCategories.ts
+++ b/web/src/hooks/usePersistedCollapsedCategories.ts
@@ -3,65 +3,24 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useEffect, useState } from "react"
+import { useClientSetting } from "@/lib/client-settings"
 
-function isBrowser() {
-  return typeof window !== "undefined" && typeof window.localStorage !== "undefined"
+const parseCollapsedCategories = (raw: string): Set<string> => {
+  const parsed = JSON.parse(raw)
+  if (Array.isArray(parsed) && parsed.every(item => typeof item === "string")) {
+    return new Set(parsed)
+  }
+  throw new Error("invalid collapsed categories")
 }
 
+const serializeCollapsedCategories = (value: Set<string>): string => JSON.stringify(Array.from(value))
+
+const NO_COLLAPSED = new Set<string>()
+
 export function usePersistedCollapsedCategories(instanceId: number) {
-  const storageKey = `qui-collapsed-categories-${instanceId}`
-
-  // Initialize state from localStorage
-  const [collapsedCategories, setCollapsedCategories] = useState<Set<string>>(() => {
-    if (!isBrowser()) {
-      return new Set()
-    }
-    try {
-      const stored = window.localStorage.getItem(storageKey)
-      if (stored) {
-        const parsed = JSON.parse(stored)
-        if (Array.isArray(parsed) && parsed.every(item => typeof item === "string")) {
-          return new Set(parsed)
-        }
-      }
-    } catch (error) {
-      console.error("Failed to load collapsed categories from localStorage:", error)
-    }
-    return new Set()
+  return useClientSetting<Set<string>>(`qui-collapsed-categories-${instanceId}`, {
+    defaultValue: NO_COLLAPSED,
+    parse: parseCollapsedCategories,
+    serialize: serializeCollapsedCategories,
   })
-
-  // Reload when instanceId changes
-  useEffect(() => {
-    if (!isBrowser()) {
-      setCollapsedCategories(new Set())
-      return
-    }
-    try {
-      const stored = window.localStorage.getItem(storageKey)
-      if (stored) {
-        const parsed = JSON.parse(stored)
-        if (Array.isArray(parsed) && parsed.every(item => typeof item === "string")) {
-          setCollapsedCategories(new Set(parsed))
-          return
-        }
-      }
-    } catch (error) {
-      console.error("Failed to load collapsed categories from localStorage:", error)
-    }
-    setCollapsedCategories(new Set())
-  }, [storageKey])
-
-  useEffect(() => {
-    if (!isBrowser()) {
-      return
-    }
-    try {
-      window.localStorage.setItem(storageKey, JSON.stringify(Array.from(collapsedCategories)))
-    } catch (error) {
-      console.error("Failed to save collapsed categories to localStorage:", error)
-    }
-  }, [collapsedCategories, storageKey])
-
-  return [collapsedCategories, setCollapsedCategories] as const
 }

--- a/web/src/hooks/usePersistedColumnFilters.ts
+++ b/web/src/hooks/usePersistedColumnFilters.ts
@@ -4,39 +4,20 @@
  */
 
 import type { ColumnFilter } from "@/lib/column-filter-utils"
-import { useEffect, useState } from "react"
+
+import { useClientSetting } from "@/lib/client-settings"
+
+const NO_FILTERS: ColumnFilter[] = []
+
+const parseColumnFilters = (raw: string): ColumnFilter[] => {
+  const parsed = JSON.parse(raw)
+  if (!Array.isArray(parsed)) throw new Error("invalid column filters")
+  return parsed
+}
 
 export function usePersistedColumnFilters(instanceId: number) {
-  const storageKey = `qui-column-filters-${instanceId}`
-
-  // Initialize state with persisted values immediately
-  const [columnFilters, setColumnFilters] = useState<ColumnFilter[]>(() => {
-    try {
-      const stored = localStorage.getItem(storageKey)
-      return stored ? JSON.parse(stored) : []
-    } catch {
-      return []
-    }
+  return useClientSetting<ColumnFilter[]>(`qui-column-filters-${instanceId}`, {
+    defaultValue: NO_FILTERS,
+    parse: parseColumnFilters,
   })
-
-  // Load filters when instanceId changes
-  useEffect(() => {
-    try {
-      const stored = localStorage.getItem(storageKey)
-      setColumnFilters(stored ? JSON.parse(stored) : [])
-    } catch {
-      setColumnFilters([])
-    }
-  }, [instanceId, storageKey])
-
-  // Save filters when they change
-  useEffect(() => {
-    try {
-      localStorage.setItem(storageKey, JSON.stringify(columnFilters))
-    } catch (error) {
-      console.error("Failed to save column filters:", error)
-    }
-  }, [columnFilters, storageKey])
-
-  return [columnFilters, setColumnFilters] as const
 }

--- a/web/src/hooks/usePersistedColumnOrder.ts
+++ b/web/src/hooks/usePersistedColumnOrder.ts
@@ -4,89 +4,60 @@
  */
 
 import type { ColumnOrderState } from "@tanstack/react-table"
-import { useEffect, useState } from "react"
+import { useCallback, useMemo } from "react"
+
+import { useClientSetting, useDropLegacyKey } from "@/lib/client-settings"
+
+const BASE_STORAGE_KEY = "qui-column-order"
+
+function mergeWithDefaults(order: unknown, defaultOrder: ColumnOrderState): ColumnOrderState {
+  if (!Array.isArray(order) || order.some(item => typeof item !== "string")) {
+    return [...defaultOrder]
+  }
+
+  const missingColumns = defaultOrder.filter(col => !order.includes(col))
+  if (missingColumns.length === 0) {
+    return [...order]
+  }
+
+  const result = [...order]
+
+  missingColumns.forEach(columnId => {
+    if (columnId === "tracker_icon" || columnId === "status_icon") {
+      const priorityIndex = result.indexOf("priority")
+      if (priorityIndex !== -1) {
+        result.splice(priorityIndex + 1, 0, columnId)
+        return
+      }
+    }
+
+    const stateIndex = result.indexOf("state")
+    const dlspeedIndex = result.indexOf("dlspeed")
+    if (stateIndex !== -1 && dlspeedIndex !== -1 && columnId !== "tracker_icon" && columnId !== "status_icon") {
+      result.splice(stateIndex + 1, 0, columnId)
+    } else {
+      result.push(columnId)
+    }
+  })
+
+  return result
+}
 
 export function usePersistedColumnOrder(
   defaultOrder: ColumnOrderState = [],
   instanceKey?: string | number
 ) {
-  const baseStorageKey = "qui-column-order"
   const hasInstanceKey = instanceKey !== undefined && instanceKey !== null
-  const storageKey = hasInstanceKey ? `${baseStorageKey}:${instanceKey}` : baseStorageKey
+  const storageKey = hasInstanceKey ? `${BASE_STORAGE_KEY}:${instanceKey}` : BASE_STORAGE_KEY
 
-  const mergeWithDefaults = (order: ColumnOrderState): ColumnOrderState => {
-    if (!Array.isArray(order) || order.some(item => typeof item !== "string")) {
-      return [...defaultOrder]
-    }
+  useDropLegacyKey(BASE_STORAGE_KEY, hasInstanceKey)
 
-    const missingColumns = defaultOrder.filter(col => !order.includes(col))
-    if (missingColumns.length === 0) {
-      return [...order]
-    }
+  const defaultsJson = JSON.stringify(defaultOrder)
+  const defaultValue = useMemo<ColumnOrderState>(() => JSON.parse(defaultsJson), [defaultsJson])
+  const parse = useCallback(
+    (raw: string): ColumnOrderState => mergeWithDefaults(JSON.parse(raw), defaultValue),
+    [defaultValue]
+  )
 
-    const result = [...order]
-
-    missingColumns.forEach(columnId => {
-      if (columnId === "tracker_icon" || columnId === "status_icon") {
-        const priorityIndex = result.indexOf("priority")
-        if (priorityIndex !== -1) {
-          result.splice(priorityIndex + 1, 0, columnId)
-          return
-        }
-      }
-
-      const stateIndex = result.indexOf("state")
-      const dlspeedIndex = result.indexOf("dlspeed")
-      if (stateIndex !== -1 && dlspeedIndex !== -1 && columnId !== "tracker_icon" && columnId !== "status_icon") {
-        result.splice(stateIndex + 1, 0, columnId)
-      } else {
-        result.push(columnId)
-      }
-    })
-
-    return result
-  }
-
-  const loadOrder = (): ColumnOrderState => {
-    try {
-      const stored = localStorage.getItem(storageKey)
-      if (stored) {
-        const parsed = JSON.parse(stored)
-        return mergeWithDefaults(parsed)
-      }
-    } catch (error) {
-      console.error("Failed to load column order from localStorage:", error)
-    }
-
-    return [...defaultOrder]
-  }
-
-  const [columnOrder, setColumnOrder] = useState<ColumnOrderState>(() => loadOrder())
-
-  useEffect(() => {
-    if (!hasInstanceKey) {
-      return
-    }
-
-    try {
-      localStorage.removeItem(baseStorageKey)
-    } catch (error) {
-      console.error("Failed to clear legacy column order state:", error)
-    }
-  }, [hasInstanceKey, baseStorageKey])
-
-  useEffect(() => {
-    setColumnOrder(loadOrder())
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [storageKey, JSON.stringify(defaultOrder)])
-
-  useEffect(() => {
-    try {
-      localStorage.setItem(storageKey, JSON.stringify(columnOrder))
-    } catch (error) {
-      console.error("Failed to save column order to localStorage:", error)
-    }
-  }, [columnOrder, storageKey])
-
-  return [columnOrder, setColumnOrder] as const
+  return useClientSetting<ColumnOrderState>(storageKey, { defaultValue, parse })
 }

--- a/web/src/hooks/usePersistedColumnSizing.ts
+++ b/web/src/hooks/usePersistedColumnSizing.ts
@@ -4,79 +4,52 @@
  */
 
 import type { ColumnSizingState } from "@tanstack/react-table"
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo } from "react"
+
+import { readRaw, useClientSetting, writeRaw } from "@/lib/client-settings"
+
+const BASE_STORAGE_KEY = "qui-column-sizing"
+
+function parseSizing(value: unknown): ColumnSizingState | undefined {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const entries = Object.values(value as Record<string, unknown>)
+    if (entries.every(entry => typeof entry === "number")) {
+      return value as ColumnSizingState
+    }
+  }
+
+  return undefined
+}
 
 export function usePersistedColumnSizing(
   defaultSizing: ColumnSizingState = {},
   instanceKey?: string | number
 ) {
-  const baseStorageKey = "qui-column-sizing"
   const hasInstanceKey = instanceKey !== undefined && instanceKey !== null
-  const storageKey = hasInstanceKey ? `${baseStorageKey}:${instanceKey}` : baseStorageKey
+  const storageKey = hasInstanceKey ? `${BASE_STORAGE_KEY}:${instanceKey}` : BASE_STORAGE_KEY
 
-  const parseSizing = (value: unknown): ColumnSizingState | undefined => {
-    if (value && typeof value === "object" && !Array.isArray(value)) {
-      const entries = Object.values(value as Record<string, unknown>)
-      if (entries.every(entry => typeof entry === "number")) {
-        return value as ColumnSizingState
-      }
-    }
-
-    return undefined
-  }
-
-  const loadSizing = (): ColumnSizingState => {
-    try {
-      const stored = localStorage.getItem(storageKey)
-      if (stored) {
-        const parsed = parseSizing(JSON.parse(stored))
-        if (parsed) {
-          return parsed
-        }
-      }
-
-      if (hasInstanceKey) {
-        const legacyStored = localStorage.getItem(baseStorageKey)
-        if (legacyStored) {
-          const parsedLegacy = parseSizing(JSON.parse(legacyStored))
-          if (parsedLegacy) {
-            return parsedLegacy
-          }
-        }
-      }
-    } catch (error) {
-      console.error("Failed to load column sizing from localStorage:", error)
-    }
-
-    return { ...defaultSizing }
-  }
-
-  const [columnSizing, setColumnSizing] = useState<ColumnSizingState>(() => loadSizing())
-
+  // Migrate the pre-instance-scoping shared key into the instance key once,
+  // then drop it.
   useEffect(() => {
-    if (!hasInstanceKey) {
-      return
-    }
-
+    if (!hasInstanceKey) return
     try {
-      localStorage.removeItem(baseStorageKey)
+      const legacy = localStorage.getItem(BASE_STORAGE_KEY)
+      if (legacy && readRaw(storageKey) == null) {
+        if (parseSizing(JSON.parse(legacy))) writeRaw(storageKey, legacy)
+      }
+      localStorage.removeItem(BASE_STORAGE_KEY)
     } catch (error) {
-      console.error("Failed to clear legacy column sizing state:", error)
+      console.error("Failed to migrate legacy column sizing state:", error)
     }
-  }, [hasInstanceKey, baseStorageKey])
+  }, [hasInstanceKey, storageKey])
 
-  useEffect(() => {
-    setColumnSizing(loadSizing())
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [storageKey])
+  const defaultsJson = JSON.stringify(defaultSizing)
+  const defaultValue = useMemo<ColumnSizingState>(() => JSON.parse(defaultsJson), [defaultsJson])
+  const parse = useCallback((raw: string): ColumnSizingState => {
+    const parsed = parseSizing(JSON.parse(raw))
+    if (!parsed) throw new Error("invalid column sizing state")
+    return parsed
+  }, [])
 
-  useEffect(() => {
-    try {
-      localStorage.setItem(storageKey, JSON.stringify(columnSizing))
-    } catch (error) {
-      console.error("Failed to save column sizing to localStorage:", error)
-    }
-  }, [columnSizing, storageKey])
-
-  return [columnSizing, setColumnSizing] as const
+  return useClientSetting<ColumnSizingState>(storageKey, { defaultValue, parse })
 }

--- a/web/src/hooks/usePersistedColumnSorting.ts
+++ b/web/src/hooks/usePersistedColumnSorting.ts
@@ -4,58 +4,30 @@
  */
 
 import type { SortingState } from "@tanstack/react-table"
-import { useEffect, useState } from "react"
+import { useCallback, useMemo } from "react"
+
+import { useClientSetting, useDropLegacyKey } from "@/lib/client-settings"
+
+const BASE_STORAGE_KEY = "qui-column-sorting"
 
 export function usePersistedColumnSorting(
   defaultSorting: SortingState = [],
   instanceKey?: string | number
 ) {
-  const baseStorageKey = "qui-column-sorting"
   const hasInstanceKey = instanceKey !== undefined && instanceKey !== null
-  const storageKey = hasInstanceKey ? `${baseStorageKey}:${instanceKey}` : baseStorageKey
+  const storageKey = hasInstanceKey ? `${BASE_STORAGE_KEY}:${instanceKey}` : BASE_STORAGE_KEY
 
-  const loadSorting = (): SortingState => {
-    try {
-      const stored = localStorage.getItem(storageKey)
-      if (stored) {
-        const parsed = JSON.parse(stored)
-        if (Array.isArray(parsed)) {
-          return parsed as SortingState
-        }
-      }
-    } catch (error) {
-      console.error("Failed to load column sorting from localStorage:", error)
+  useDropLegacyKey(BASE_STORAGE_KEY, hasInstanceKey)
+
+  const defaultsJson = JSON.stringify(defaultSorting)
+  const defaultValue = useMemo<SortingState>(() => JSON.parse(defaultsJson), [defaultsJson])
+  const parse = useCallback((raw: string): SortingState => {
+    const parsed = JSON.parse(raw)
+    if (Array.isArray(parsed)) {
+      return parsed as SortingState
     }
+    throw new Error("invalid column sorting state")
+  }, [])
 
-    return [...defaultSorting]
-  }
-
-  const [sorting, setSorting] = useState<SortingState>(() => loadSorting())
-
-  useEffect(() => {
-    if (!hasInstanceKey) {
-      return
-    }
-
-    try {
-      localStorage.removeItem(baseStorageKey)
-    } catch (error) {
-      console.error("Failed to clear legacy column sorting state:", error)
-    }
-  }, [hasInstanceKey, baseStorageKey])
-
-  useEffect(() => {
-    setSorting(loadSorting())
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [storageKey])
-
-  useEffect(() => {
-    try {
-      localStorage.setItem(storageKey, JSON.stringify(sorting))
-    } catch (error) {
-      console.error("Failed to save column sorting to localStorage:", error)
-    }
-  }, [sorting, storageKey])
-
-  return [sorting, setSorting] as const
+  return useClientSetting<SortingState>(storageKey, { defaultValue, parse })
 }

--- a/web/src/hooks/usePersistedColumnVisibility.ts
+++ b/web/src/hooks/usePersistedColumnVisibility.ts
@@ -4,59 +4,30 @@
  */
 
 import type { ColumnVisibilityState } from "@tanstack/react-table"
-import { useEffect, useState } from "react"
+import { useCallback, useMemo } from "react"
+
+import { useClientSetting, useDropLegacyKey } from "@/lib/client-settings"
+
+const BASE_STORAGE_KEY = "qui-column-visibility"
 
 export function usePersistedColumnVisibility(
   defaultVisibility: ColumnVisibilityState = {},
   instanceKey?: string | number
 ) {
-  const baseStorageKey = "qui-column-visibility"
   const hasInstanceKey = instanceKey !== undefined && instanceKey !== null
-  const storageKey = hasInstanceKey ? `${baseStorageKey}:${instanceKey}` : baseStorageKey
+  const storageKey = hasInstanceKey ? `${BASE_STORAGE_KEY}:${instanceKey}` : BASE_STORAGE_KEY
 
-  const loadVisibility = (): ColumnVisibilityState => {
-    try {
-      const stored = localStorage.getItem(storageKey)
-      if (stored) {
-        const parsed = JSON.parse(stored)
-        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-          return parsed as ColumnVisibilityState
-        }
-      }
-    } catch (error) {
-      console.error("Failed to load column visibility from localStorage:", error)
+  useDropLegacyKey(BASE_STORAGE_KEY, hasInstanceKey)
+
+  const defaultsJson = JSON.stringify(defaultVisibility)
+  const defaultValue = useMemo<ColumnVisibilityState>(() => JSON.parse(defaultsJson), [defaultsJson])
+  const parse = useCallback((raw: string): ColumnVisibilityState => {
+    const parsed = JSON.parse(raw)
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as ColumnVisibilityState
     }
+    throw new Error("invalid column visibility state")
+  }, [])
 
-    return { ...defaultVisibility }
-  }
-
-  const [columnVisibility, setColumnVisibility] = useState<ColumnVisibilityState>(() => loadVisibility())
-
-  useEffect(() => {
-    if (!hasInstanceKey) {
-      return
-    }
-
-    try {
-      localStorage.removeItem(baseStorageKey)
-    } catch (error) {
-      console.error("Failed to clear legacy column visibility state:", error)
-    }
-  }, [hasInstanceKey, baseStorageKey])
-
-  useEffect(() => {
-    setColumnVisibility(loadVisibility())
-    // We only want to reload when the storage key changes (instance switch)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [storageKey])
-
-  useEffect(() => {
-    try {
-      localStorage.setItem(storageKey, JSON.stringify(columnVisibility))
-    } catch (error) {
-      console.error("Failed to save column visibility to localStorage:", error)
-    }
-  }, [columnVisibility, storageKey])
-
-  return [columnVisibility, setColumnVisibility] as const
+  return useClientSetting<ColumnVisibilityState>(storageKey, { defaultValue, parse })
 }

--- a/web/src/hooks/usePersistedCompactViewState.ts
+++ b/web/src/hooks/usePersistedCompactViewState.ts
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useMemo } from "react"
+
+import { useClientSetting } from "@/lib/client-settings"
 
 const STORAGE_KEY = "qui-torrent-view-mode"
 const ALL_VIEW_MODES = ["normal", "dense", "compact", "ultra-compact"] as const
@@ -21,6 +23,11 @@ function sanitizeAllowedModes(allowedModes?: readonly ViewMode[]): ViewMode[] {
   return filtered.length > 0 ? filtered : [...ALL_VIEW_MODES]
 }
 
+const parseViewMode = (raw: string): ViewMode => {
+  if (ALL_VIEW_MODES.includes(raw as ViewMode)) return raw as ViewMode
+  throw new Error("invalid view mode")
+}
+
 export function usePersistedCompactViewState(
   defaultMode: ViewMode = "normal",
   allowedModesInput?: readonly ViewMode[]
@@ -31,59 +38,20 @@ export function usePersistedCompactViewState(
   // The stored mode is global across every consumer; `allowedModes` only narrows what
   // this consumer can render. Never persist the narrowing, or a mounted-but-hidden
   // consumer (e.g. MobileFooterNav on desktop) clobbers the user's choice on reload.
-  const [storedMode, setStoredMode] = useState<ViewMode>(() => {
-    if (typeof window === "undefined") {
-      return effectiveDefaultMode
-    }
-
-    try {
-      const stored = window.localStorage.getItem(STORAGE_KEY)
-      if (stored && ALL_VIEW_MODES.includes(stored as ViewMode)) {
-        return stored as ViewMode
-      }
-    } catch (error) {
-      console.error("Failed to load view mode state from localStorage:", error)
-    }
-
-    return effectiveDefaultMode
+  const [storedMode, setStoredMode] = useClientSetting<ViewMode>(STORAGE_KEY, {
+    defaultValue: effectiveDefaultMode,
+    parse: parseViewMode,
+    serialize: String,
   })
 
   const viewMode = allowedModes.includes(storedMode) ? storedMode : effectiveDefaultMode
 
-  const setViewMode = useCallback((requested: ViewMode) => {
-    const next = allowedModes.includes(requested) ? requested : allowedModes[0]
-
-    setStoredMode(next)
-
-    if (typeof window === "undefined") {
-      return
-    }
-
-    try {
-      window.localStorage.setItem(STORAGE_KEY, next)
-    } catch (error) {
-      console.error("Failed to save view mode state to localStorage:", error)
-    }
-
-    window.dispatchEvent(new CustomEvent(STORAGE_KEY, { detail: { viewMode: next } }))
-  }, [allowedModes])
-
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return
-    }
-
-    const handleEvent = (e: Event) => {
-      const nextMode = (e as CustomEvent<{ viewMode: ViewMode }>).detail?.viewMode
-
-      if (nextMode && ALL_VIEW_MODES.includes(nextMode)) {
-        setStoredMode(nextMode)
-      }
-    }
-
-    window.addEventListener(STORAGE_KEY, handleEvent as EventListener)
-    return () => window.removeEventListener(STORAGE_KEY, handleEvent as EventListener)
-  }, [])
+  const setViewMode = useCallback(
+    (requested: ViewMode) => {
+      setStoredMode(allowedModes.includes(requested) ? requested : allowedModes[0])
+    },
+    [allowedModes, setStoredMode]
+  )
 
   const cycleViewMode = useCallback(() => {
     setViewMode(allowedModes[(allowedModes.indexOf(viewMode) + 1) % allowedModes.length])

--- a/web/src/hooks/usePersistedCrossSeedBlocklist.ts
+++ b/web/src/hooks/usePersistedCrossSeedBlocklist.ts
@@ -3,50 +3,20 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useCallback, useEffect, useState } from "react"
+import { useState, type Dispatch, type SetStateAction } from "react"
+
+import { parseJsonBoolean, useClientSetting } from "@/lib/client-settings"
 
 export function usePersistedCrossSeedBlocklist(instanceId: number, defaultValue: boolean = false) {
-  const readStoredPreference = useCallback(() => {
-    if (instanceId <= 0) return undefined
-
-    try {
-      const storageKey = `qui-cross-seed-blocklist-${instanceId}`
-      const existingPreference = localStorage.getItem(storageKey)
-      if (existingPreference) {
-        const parsedPreference = JSON.parse(existingPreference)
-        if (typeof parsedPreference === "boolean") {
-          return parsedPreference
-        }
-      }
-    } catch (error) {
-      console.error("Failed to read cross-seed blocklist preference from localStorage:", error)
-    }
-
-    return undefined
-  }, [instanceId])
-
-  const [blockCrossSeeds, setBlockCrossSeeds] = useState<boolean>(() => readStoredPreference() ?? defaultValue)
-
-  useEffect(() => {
-    const storedPreference = readStoredPreference()
-    if (typeof storedPreference === "boolean") {
-      setBlockCrossSeeds(storedPreference)
-      return
-    }
-
-    setBlockCrossSeeds(defaultValue)
-  }, [defaultValue, readStoredPreference])
-
-  useEffect(() => {
-    if (instanceId <= 0) return
-
-    try {
-      const storageKey = `qui-cross-seed-blocklist-${instanceId}`
-      localStorage.setItem(storageKey, JSON.stringify(blockCrossSeeds))
-    } catch (error) {
-      console.error("Failed to save cross-seed blocklist preference to localStorage:", error)
-    }
-  }, [blockCrossSeeds, instanceId])
+  const persisted = useClientSetting<boolean>(`qui-cross-seed-blocklist-${instanceId}`, {
+    defaultValue,
+    parse: parseJsonBoolean,
+  })
+  // Non-positive ids (the all-instances view passes -1) never persisted this
+  // choice; keep it session-local there.
+  const local = useState<boolean>(defaultValue)
+  const blockCrossSeeds = instanceId > 0 ? persisted[0] : local[0]
+  const setBlockCrossSeeds: Dispatch<SetStateAction<boolean>> = instanceId > 0 ? persisted[1] : local[1]
 
   return {
     blockCrossSeeds,

--- a/web/src/hooks/usePersistedDateTimePreferences.ts
+++ b/web/src/hooks/usePersistedDateTimePreferences.ts
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useState, useEffect } from "react"
+import { useCallback } from "react"
+
+import { useClientSetting } from "@/lib/client-settings"
 
 export interface DateTimePreferences {
   timezone: string
@@ -17,67 +19,23 @@ const DEFAULT_PREFERENCES: DateTimePreferences = {
   dateFormat: "iso",
 }
 
+const parseDateTimePreferences = (raw: string): DateTimePreferences => ({
+  ...DEFAULT_PREFERENCES,
+  ...JSON.parse(raw),
+})
+
 export function usePersistedDateTimePreferences() {
-  const storageKey = "qui-datetime-preferences"
-
-  // Initialize state from localStorage or default values
-  const [preferences, setPreferencesState] = useState<DateTimePreferences>(() => {
-    try {
-      const stored = localStorage.getItem(storageKey)
-      if (stored) {
-        const parsed = JSON.parse(stored)
-        return {
-          ...DEFAULT_PREFERENCES,
-          ...parsed,
-        }
-      }
-    } catch (error) {
-      console.error("Failed to load date/time preferences from localStorage:", error)
-    }
-
-    return DEFAULT_PREFERENCES
+  const [preferences, setStored] = useClientSetting<DateTimePreferences>("qui-datetime-preferences", {
+    defaultValue: DEFAULT_PREFERENCES,
+    parse: parseDateTimePreferences,
   })
 
-  // Persist to localStorage whenever preferences change
-  useEffect(() => {
-    try {
-      localStorage.setItem(storageKey, JSON.stringify(preferences))
-    } catch (error) {
-      console.error("Failed to save date/time preferences to localStorage:", error)
-    }
-  }, [preferences])
-
-  // Listen for cross-component updates via CustomEvent within the same tab
-  useEffect(() => {
-    const handleEvent = (e: Event) => {
-      const custom = e as CustomEvent<{ preferences: DateTimePreferences }>
-      if (custom.detail?.preferences) {
-        setPreferencesState(custom.detail.preferences)
-      }
-    }
-
-    window.addEventListener(storageKey, handleEvent as EventListener)
-    return () => window.removeEventListener(storageKey, handleEvent as EventListener)
-  }, [])
-
-  // Update preferences function
-  const setPreferences = (newPreferences: Partial<DateTimePreferences>) => {
-    setPreferencesState((prev) => {
-      const updated = { ...prev, ...newPreferences }
-
-      try {
-        localStorage.setItem(storageKey, JSON.stringify(updated))
-      } catch (error) {
-        console.error("Failed to save date/time preferences to localStorage:", error)
-      }
-
-      // Notify other components via CustomEvent
-      const evt = new CustomEvent(storageKey, { detail: { preferences: updated } })
-      window.dispatchEvent(evt)
-
-      return updated
-    })
-  }
+  const setPreferences = useCallback(
+    (newPreferences: Partial<DateTimePreferences>) => {
+      setStored((prev) => ({ ...prev, ...newPreferences }))
+    },
+    [setStored]
+  )
 
   return {
     preferences,

--- a/web/src/hooks/usePersistedDeleteFiles.ts
+++ b/web/src/hooks/usePersistedDeleteFiles.ts
@@ -3,82 +3,55 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useState, type SetStateAction } from "react"
+
+import { parseJsonBoolean, readRaw, useClientSetting, writeRaw } from "@/lib/client-settings"
+
+const PREF_KEY = "qui-delete-files-default"
+const LOCK_KEY = "qui-delete-files-lock"
 
 export function usePersistedDeleteFiles(defaultValue: boolean = false) {
-  const storageKey = "qui-delete-files-default"
-  const lockKey = "qui-delete-files-lock"
+  const [storedValue, setStoredValue] = useClientSetting<boolean>(PREF_KEY, {
+    defaultValue,
+    parse: parseJsonBoolean,
+  })
+  const [lockRaw, setLockRaw] = useClientSetting<string>(LOCK_KEY, {
+    defaultValue: "",
+    parse: String,
+    serialize: String,
+  })
+  // Unlocked means "don't remember": the choice lives only in this component
+  // instance, like the old useState did.
+  const [localValue, setLocalValue] = useState<boolean>(defaultValue)
 
-  const readStoredPreference = () => {
-    try {
-      const existingPreference = localStorage.getItem(storageKey)
-      if (existingPreference) {
-        const parsedPreference = JSON.parse(existingPreference)
-        if (typeof parsedPreference === "boolean") {
-          return parsedPreference
-        }
+  // Legacy state (pre-lock-key) stored only the preference; its presence
+  // implied the lock. "" is the cleared sentinel.
+  const isLocked = lockRaw !== "" ? lockRaw === "true" : (readRaw(PREF_KEY) ?? "") !== ""
+
+  const deleteFiles = isLocked ? storedValue : localValue
+
+  const setDeleteFiles = useCallback(
+    (value: SetStateAction<boolean>) => {
+      if (isLocked) {
+        setStoredValue(value)
+      } else {
+        setLocalValue(value)
       }
-    } catch (error) {
-      console.error("Failed to read delete files preference from localStorage:", error)
-    }
-
-    return undefined
-  }
-
-  const readStoredLock = () => {
-    try {
-      const storedLock = localStorage.getItem(lockKey)
-      if (storedLock) {
-        return JSON.parse(storedLock) === true
-      }
-
-      const preference = readStoredPreference()
-      return typeof preference === "boolean"
-    } catch (error) {
-      console.error("Failed to read delete files lock state from localStorage:", error)
-    }
-
-    return false
-  }
-
-  const [isLocked, setIsLocked] = useState<boolean>(() => readStoredLock())
-
-  // Initialize state from localStorage or default value
-  const [deleteFiles, setDeleteFiles] = useState<boolean>(() => readStoredPreference() ?? defaultValue)
-
-  // Persist the lock state and clear stored values when unlocking
-  useEffect(() => {
-    if (isLocked) {
-      try {
-        localStorage.setItem(lockKey, JSON.stringify(true))
-      } catch (error) {
-        console.error("Failed to update delete files lock state in localStorage:", error)
-      }
-      return
-    }
-
-    try {
-      localStorage.removeItem(lockKey)
-      localStorage.removeItem(storageKey)
-    } catch (error) {
-      console.error("Failed to clear delete files preference from localStorage:", error)
-    }
-  }, [isLocked, lockKey, storageKey])
-
-  // Persist changes to the preference only when locked
-  useEffect(() => {
-    if (!isLocked) return
-
-    try {
-      localStorage.setItem(storageKey, JSON.stringify(deleteFiles))
-    } catch (error) {
-      console.error("Failed to save delete files preference to localStorage:", error)
-    }
-  }, [deleteFiles, isLocked, storageKey])
+    },
+    [isLocked, setStoredValue]
+  )
 
   const toggleLock = useCallback(() => {
-    setIsLocked(prev => !prev)
-  }, [])
+    if (isLocked) {
+      // Keep the current choice visible, stop remembering it.
+      setLocalValue(storedValue)
+      setLockRaw("false")
+      writeRaw(PREF_KEY, "")
+    } else {
+      setStoredValue(localValue)
+      setLockRaw("true")
+    }
+  }, [isLocked, storedValue, localValue, setStoredValue, setLockRaw])
 
   return {
     deleteFiles,

--- a/web/src/hooks/usePersistedFilterSidebarState.ts
+++ b/web/src/hooks/usePersistedFilterSidebarState.ts
@@ -3,57 +3,11 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useCallback, useEffect, useState } from "react"
+import { parseJsonBoolean, useClientSetting } from "@/lib/client-settings"
 
 export function usePersistedFilterSidebarState(defaultCollapsed: boolean = false) {
-  const storageKey = "qui-filter-sidebar-collapsed"
-
-  // Initialize state from localStorage or default value
-  const [filterSidebarCollapsed, setFilterSidebarCollapsedState] = useState<boolean>(() => {
-    try {
-      const stored = localStorage.getItem(storageKey)
-      if (stored !== null) {
-        return stored === "true"
-      }
-    } catch (error) {
-      console.error("Failed to load filter sidebar state from localStorage:", error)
-    }
-
-    return defaultCollapsed
+  return useClientSetting<boolean>("qui-filter-sidebar-collapsed", {
+    defaultValue: defaultCollapsed,
+    parse: parseJsonBoolean,
   })
-
-  // Persist to localStorage and broadcast to other listeners whenever state changes
-  useEffect(() => {
-    if (typeof window === "undefined") return
-
-    try {
-      localStorage.setItem(storageKey, filterSidebarCollapsed.toString())
-    } catch (error) {
-      console.error("Failed to save filter sidebar state to localStorage:", error)
-    }
-
-    const evt = new CustomEvent(storageKey, { detail: { collapsed: filterSidebarCollapsed } })
-    window.dispatchEvent(evt)
-  }, [filterSidebarCollapsed])
-
-  // Listen for cross-component updates via CustomEvent within the same tab
-  useEffect(() => {
-    const handleEvent = (e: Event) => {
-      const custom = e as CustomEvent<{ collapsed: boolean }>
-      if (typeof custom.detail?.collapsed === "boolean") {
-        setFilterSidebarCollapsedState(custom.detail.collapsed)
-      }
-    }
-    window.addEventListener(storageKey, handleEvent as EventListener)
-    return () => window.removeEventListener(storageKey, handleEvent as EventListener)
-  }, [])
-
-  // Wrapped setter that syncs state and dispatches event
-  const setFilterSidebarCollapsed = useCallback((next: boolean | ((prev: boolean) => boolean)) => {
-    setFilterSidebarCollapsedState((prev) => (
-      typeof next === "function" ? (next as (p: boolean) => boolean)(prev) : next
-    ))
-  }, [])
-
-  return [filterSidebarCollapsed, setFilterSidebarCollapsed] as const
 }

--- a/web/src/hooks/usePersistedFilters.test.tsx
+++ b/web/src/hooks/usePersistedFilters.test.tsx
@@ -127,7 +127,7 @@ describe("usePersistedFilters", () => {
 
   // REGRESSION (#2410): setFilters used to strip the sidebar's derived expandedCategories.
   it("keeps expandedCategories through setFilters and a storage round-trip", () => {
-    const { result } = renderHook(() => usePersistedFilters(4))
+    const { result, unmount } = renderHook(() => usePersistedFilters(4))
 
     act(() => {
       const [, setFilters] = result.current
@@ -143,6 +143,7 @@ describe("usePersistedFilters", () => {
     expect(result.current[0].expandedExcludeCategories).toEqual([])
 
     // A fresh mount reads them back from storage.
+    unmount()
     const remounted = renderHook(() => usePersistedFilters(4))
     expect(remounted.result.current[0].expandedCategories).toEqual(["movies", "movies/4k"])
   })
@@ -160,6 +161,7 @@ describe("usePersistedFilters", () => {
 
     // A second instance mounts and reads from storage. It inherits the shared
     // global status but must NOT see instance 1's categories.
+    hook1.unmount()
     const hook2 = renderHook(() => usePersistedFilters(2))
     const [filters2] = hook2.result.current
 

--- a/web/src/hooks/usePersistedFilters.test.tsx
+++ b/web/src/hooks/usePersistedFilters.test.tsx
@@ -125,6 +125,28 @@ describe("usePersistedFilters", () => {
     })
   })
 
+  // REGRESSION (#2410): setFilters used to strip the sidebar's derived expandedCategories.
+  it("keeps expandedCategories through setFilters and a storage round-trip", () => {
+    const { result } = renderHook(() => usePersistedFilters(4))
+
+    act(() => {
+      const [, setFilters] = result.current
+      setFilters(prev => ({
+        ...prev,
+        categories: ["movies"],
+        expandedCategories: ["movies", "movies/4k"],
+        expandedExcludeCategories: [],
+      }))
+    })
+
+    expect(result.current[0].expandedCategories).toEqual(["movies", "movies/4k"])
+    expect(result.current[0].expandedExcludeCategories).toEqual([])
+
+    // A fresh mount reads them back from storage.
+    const remounted = renderHook(() => usePersistedFilters(4))
+    expect(remounted.result.current[0].expandedCategories).toEqual(["movies", "movies/4k"])
+  })
+
   it("isolates instance fields across instances but shares the global status", () => {
     const hook1 = renderHook(() => usePersistedFilters(1))
     act(() => {

--- a/web/src/hooks/usePersistedFilters.test.tsx
+++ b/web/src/hooks/usePersistedFilters.test.tsx
@@ -167,20 +167,19 @@ describe("usePersistedFilters", () => {
     expect(result.current[0].status).toEqual(["downloading"])
   })
 
-  // ERROR PATH: corrupt per-instance JSON. JSON.parse in the lazy initializer is
-  // NOT guarded by safeGetItem (which only protects localStorage access), so the
-  // hook throws synchronously. This documents the current behavior / gap.
-  it("throws a SyntaxError on corrupt per-instance JSON (unguarded JSON.parse)", () => {
+  // ERROR PATH: corrupt per-instance JSON. useClientSetting catches the parse
+  // throw and falls back to the empty defaults instead of crashing the tree.
+  it("falls back to defaults on corrupt per-instance JSON", () => {
     localStorage.setItem(instanceKey(5), "not-json")
 
-    expect(() => renderHook(() => usePersistedFilters(5))).toThrow(SyntaxError)
+    const { result } = renderHook(() => usePersistedFilters(5))
+
+    expect(result.current[0]).toEqual(makeFilters({ expr: "" }))
   })
 
-  // ERROR PATH: corrupt per-instance JSON reached via the instanceId-change
-  // effect (lines 48-49), a different React surface than the lazy initializer.
-  // Mount clean on id=1, then rerender into id=2 whose stored value is corrupt;
-  // the unguarded JSON.parse inside the effect throws.
-  it("throws on corrupt per-instance JSON via the instanceId-change effect", () => {
+  // ERROR PATH: corrupt per-instance JSON reached via an instance switch. The
+  // clean instance's values load, the corrupt one degrades to defaults.
+  it("falls back to defaults on corrupt per-instance JSON after an instance switch", () => {
     localStorage.setItem(instanceKey(1), JSON.stringify({ categories: ["clean"] }))
     localStorage.setItem(instanceKey(2), "not-json")
 
@@ -191,29 +190,29 @@ describe("usePersistedFilters", () => {
 
     expect(result.current[0].categories).toEqual(["clean"])
 
-    expect(() => {
-      act(() => {
-        rerender({ id: 2 })
-      })
-    }).toThrow(SyntaxError)
+    act(() => {
+      rerender({ id: 2 })
+    })
+
+    expect(result.current[0].categories).toEqual([])
   })
 
-  // ERROR PATH: corrupt GLOBAL JSON in the lazy initializer (line 30). The
-  // global JSON.parse is likewise unguarded, so the hook throws synchronously.
-  it("throws a SyntaxError on corrupt global JSON (unguarded JSON.parse)", () => {
+  // ERROR PATH: corrupt GLOBAL JSON degrades to defaults the same way.
+  it("falls back to defaults on corrupt global JSON", () => {
     localStorage.setItem(GLOBAL_KEY, "not-json")
 
-    expect(() => renderHook(() => usePersistedFilters(8))).toThrow(SyntaxError)
+    const { result } = renderHook(() => usePersistedFilters(8))
+
+    expect(result.current[0]).toEqual(makeFilters({ expr: "" }))
   })
 
-  // ERROR PATH: write failure. safeSetItem swallows the error, logs it, and the
-  // hook does not throw; returned state still updates.
-  it("swallows localStorage write failures and still updates state", () => {
+  // ERROR PATH: write failure. writeRaw logs and drops the write; the hook
+  // must not throw. State follows storage, so the value stays unchanged.
+  it("swallows localStorage write failures without throwing", () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
 
     const { result } = renderHook(() => usePersistedFilters(4))
 
-    // Begin throwing on writes only after the initial mount effects have run.
     const setItemSpy = vi
       .spyOn(Storage.prototype, "setItem")
       .mockImplementation(() => {
@@ -229,14 +228,13 @@ describe("usePersistedFilters", () => {
 
     expect(setItemSpy).toHaveBeenCalled()
     expect(consoleError).toHaveBeenCalled()
-    // State update is independent of persistence and must still take effect.
-    expect(result.current[0].status).toEqual(["seeding"])
+    // Storage-backed state keeps the previous value when the write fails.
+    expect(result.current[0].status).toEqual([])
   })
 
-  // ERROR PATH: read failure. safeGetItem returns null on getItem throw, so the
-  // hook falls back to empty defaults and logs the error.
+  // ERROR PATH: read failure. readRaw returns null on getItem throw, so the
+  // hook falls back to empty defaults without throwing.
   it("falls back to empty defaults when localStorage read throws", () => {
-    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
     vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
       throw new Error("storage disabled")
     })
@@ -244,6 +242,5 @@ describe("usePersistedFilters", () => {
     const { result } = renderHook(() => usePersistedFilters(6))
 
     expect(result.current[0]).toEqual(makeFilters({ expr: "" }))
-    expect(consoleError).toHaveBeenCalled()
   })
 })

--- a/web/src/hooks/usePersistedFilters.test.tsx
+++ b/web/src/hooks/usePersistedFilters.test.tsx
@@ -5,7 +5,7 @@
 
 import { usePersistedFilters } from "@/hooks/usePersistedFilters"
 import { makeFilters } from "@/test/mockFilters"
-import { act, renderHook } from "@testing-library/react"
+import { act, cleanup, renderHook } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const GLOBAL_KEY = "qui-filters-global"
@@ -21,6 +21,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  cleanup()
   vi.restoreAllMocks()
 })
 

--- a/web/src/hooks/usePersistedFilters.ts
+++ b/web/src/hooks/usePersistedFilters.ts
@@ -3,80 +3,80 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useEffect, useState } from "react"
+import { useCallback, useMemo, useRef, type SetStateAction } from "react"
 import type { TorrentFilters } from "@/types"
 
-// Safe localStorage wrapper that returns fallback on error
-function safeGetItem(key: string): string | null {
-  try {
-    return localStorage.getItem(key)
-  } catch (error) {
-    console.error(`Failed to read from localStorage key "${key}":`, error)
-    return null
+import { useClientSetting } from "@/lib/client-settings"
+
+type GlobalFilters = Pick<TorrentFilters, "status" | "excludeStatus">
+type InstanceFilters = Omit<TorrentFilters, "status" | "excludeStatus">
+
+const DEFAULT_GLOBAL: GlobalFilters = { status: [], excludeStatus: [] }
+const DEFAULT_INSTANCE: InstanceFilters = {
+  categories: [],
+  excludeCategories: [],
+  tags: [],
+  excludeTags: [],
+  trackers: [],
+  excludeTrackers: [],
+  expr: "",
+}
+
+const parseGlobalFilters = (raw: string): GlobalFilters => {
+  const parsed = JSON.parse(raw)
+  return {
+    status: parsed.status || [],
+    excludeStatus: parsed.excludeStatus || [],
   }
 }
 
-function safeSetItem(key: string, value: string): void {
-  try {
-    localStorage.setItem(key, value)
-  } catch (error) {
-    console.error(`Failed to write to localStorage key "${key}":`, error)
+const parseInstanceFilters = (raw: string): InstanceFilters => {
+  const parsed = JSON.parse(raw)
+  return {
+    categories: parsed.categories || [],
+    excludeCategories: parsed.excludeCategories || [],
+    tags: parsed.tags || [],
+    excludeTags: parsed.excludeTags || [],
+    trackers: parsed.trackers || [],
+    excludeTrackers: parsed.excludeTrackers || [],
+    expr: parsed.expr || "",
   }
 }
 
 export function usePersistedFilters(instanceId: number) {
-  // Initialize state with persisted values immediately
-  const [filters, setFilters] = useState<TorrentFilters>(() => {
-    const global = JSON.parse(safeGetItem("qui-filters-global") || "{}")
-    const instance = JSON.parse(safeGetItem(`qui-filters-${instanceId}`) || "{}")
-
-    return {
-      status: global.status || [],
-      excludeStatus: global.excludeStatus || [],
-      categories: instance.categories || [],
-      excludeCategories: instance.excludeCategories || [],
-      tags: instance.tags || [],
-      excludeTags: instance.excludeTags || [],
-      trackers: instance.trackers || [],
-      excludeTrackers: instance.excludeTrackers || [],
-      expr: instance.expr || "",
-    }
+  const [globalFilters, setGlobalFilters] = useClientSetting<GlobalFilters>("qui-filters-global", {
+    defaultValue: DEFAULT_GLOBAL,
+    parse: parseGlobalFilters,
+  })
+  const [instanceFilters, setInstanceFilters] = useClientSetting<InstanceFilters>(`qui-filters-${instanceId}`, {
+    defaultValue: DEFAULT_INSTANCE,
+    parse: parseInstanceFilters,
   })
 
-  // Load filters when instanceId changes
-  useEffect(() => {
-    const global = JSON.parse(safeGetItem("qui-filters-global") || "{}")
-    const instance = JSON.parse(safeGetItem(`qui-filters-${instanceId}`) || "{}")
+  const filters = useMemo<TorrentFilters>(
+    () => ({ ...globalFilters, ...instanceFilters }),
+    [globalFilters, instanceFilters]
+  )
 
-    setFilters({
-      status: global.status || [],
-      excludeStatus: global.excludeStatus || [],
-      categories: instance.categories || [],
-      excludeCategories: instance.excludeCategories || [],
-      tags: instance.tags || [],
-      excludeTags: instance.excludeTags || [],
-      trackers: instance.trackers || [],
-      excludeTrackers: instance.excludeTrackers || [],
-      expr: instance.expr || "",
-    })
-  }, [instanceId])
+  const filtersRef = useRef(filters)
+  filtersRef.current = filters
 
-  // Save filters when they change
-  useEffect(() => {
-    safeSetItem("qui-filters-global", JSON.stringify({
-      status: filters.status,
-      excludeStatus: filters.excludeStatus,
-    }))
-    safeSetItem(`qui-filters-${instanceId}`, JSON.stringify({
-      categories: filters.categories,
-      excludeCategories: filters.excludeCategories,
-      tags: filters.tags,
-      excludeTags: filters.excludeTags,
-      trackers: filters.trackers,
-      excludeTrackers: filters.excludeTrackers,
-      expr: filters.expr,
-    }))
-  }, [filters, instanceId])
+  const setFilters = useCallback(
+    (next: SetStateAction<TorrentFilters>) => {
+      const resolved = typeof next === "function" ? next(filtersRef.current) : next
+      setGlobalFilters({ status: resolved.status, excludeStatus: resolved.excludeStatus })
+      setInstanceFilters({
+        categories: resolved.categories,
+        excludeCategories: resolved.excludeCategories,
+        tags: resolved.tags,
+        excludeTags: resolved.excludeTags,
+        trackers: resolved.trackers,
+        excludeTrackers: resolved.excludeTrackers,
+        expr: resolved.expr,
+      })
+    },
+    [setGlobalFilters, setInstanceFilters]
+  )
 
   return [filters, setFilters] as const
 }

--- a/web/src/hooks/usePersistedFilters.ts
+++ b/web/src/hooks/usePersistedFilters.ts
@@ -22,26 +22,9 @@ const DEFAULT_INSTANCE: InstanceFilters = {
   expr: "",
 }
 
-const parseGlobalFilters = (raw: string): GlobalFilters => {
-  const parsed = JSON.parse(raw)
-  return {
-    status: parsed.status || [],
-    excludeStatus: parsed.excludeStatus || [],
-  }
-}
+const parseGlobalFilters = (raw: string): GlobalFilters => ({ ...DEFAULT_GLOBAL, ...JSON.parse(raw) })
 
-const parseInstanceFilters = (raw: string): InstanceFilters => {
-  const parsed = JSON.parse(raw)
-  return {
-    categories: parsed.categories || [],
-    excludeCategories: parsed.excludeCategories || [],
-    tags: parsed.tags || [],
-    excludeTags: parsed.excludeTags || [],
-    trackers: parsed.trackers || [],
-    excludeTrackers: parsed.excludeTrackers || [],
-    expr: parsed.expr || "",
-  }
-}
+const parseInstanceFilters = (raw: string): InstanceFilters => ({ ...DEFAULT_INSTANCE, ...JSON.parse(raw) })
 
 export function usePersistedFilters(instanceId: number) {
   const [globalFilters, setGlobalFilters] = useClientSetting<GlobalFilters>("qui-filters-global", {
@@ -64,16 +47,11 @@ export function usePersistedFilters(instanceId: number) {
   const setFilters = useCallback(
     (next: SetStateAction<TorrentFilters>) => {
       const resolved = typeof next === "function" ? next(filtersRef.current) : next
-      setGlobalFilters({ status: resolved.status, excludeStatus: resolved.excludeStatus })
-      setInstanceFilters({
-        categories: resolved.categories,
-        excludeCategories: resolved.excludeCategories,
-        tags: resolved.tags,
-        excludeTags: resolved.excludeTags,
-        trackers: resolved.trackers,
-        excludeTrackers: resolved.excludeTrackers,
-        expr: resolved.expr,
-      })
+      // Keep every instance-scoped field, including the derived
+      // expandedCategories the sidebar computes for subcategory requests.
+      const { status, excludeStatus, ...instance } = resolved
+      setGlobalFilters({ status, excludeStatus })
+      setInstanceFilters(instance)
     },
     [setGlobalFilters, setInstanceFilters]
   )

--- a/web/src/hooks/usePersistedInstanceSelection.test.ts
+++ b/web/src/hooks/usePersistedInstanceSelection.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { describe, expect, it } from "vitest"
+
+import { resolveInstanceSelection } from "@/hooks/usePersistedInstanceSelection"
+
+const instances = [
+  { id: 101, connected: false },
+  { id: 202, connected: true },
+]
+
+describe("resolveInstanceSelection", () => {
+  it("keeps the saved selection while instances are still loading", () => {
+    // The instances query resolving later must not clear a saved id; clearing
+    // here persisted the "" sentinel and the fallback then overwrote the
+    // saved selection on every reload.
+    expect(resolveInstanceSelection(undefined, 101)).toBe(101)
+    expect(resolveInstanceSelection(undefined, undefined)).toBeUndefined()
+  })
+
+  it("clears the selection when the instance list is confirmed empty", () => {
+    expect(resolveInstanceSelection([], 101)).toBeUndefined()
+  })
+
+  it("keeps a saved selection that exists, connected or not", () => {
+    expect(resolveInstanceSelection(instances, 101)).toBe(101)
+    expect(resolveInstanceSelection(instances, 202)).toBe(202)
+  })
+
+  it("falls back to the first connected instance when the saved id is gone", () => {
+    expect(resolveInstanceSelection(instances, 999)).toBe(202)
+  })
+
+  it("picks the first connected instance when nothing is saved", () => {
+    expect(resolveInstanceSelection(instances, undefined)).toBe(202)
+  })
+
+  it("picks the first instance when none are connected", () => {
+    const disconnected = [{ id: 101, connected: false }, { id: 303, connected: false }]
+    expect(resolveInstanceSelection(disconnected, undefined)).toBe(101)
+    expect(resolveInstanceSelection(disconnected, 999)).toBe(101)
+  })
+})

--- a/web/src/hooks/usePersistedInstanceSelection.ts
+++ b/web/src/hooks/usePersistedInstanceSelection.ts
@@ -3,33 +3,22 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useEffect, useState } from "react"
+import { useClientSetting } from "@/lib/client-settings"
+
+const parseInstanceId = (raw: string): number | undefined => {
+  const parsed = JSON.parse(raw)
+  if (typeof parsed !== "number") throw new Error("invalid instance id")
+  return parsed
+}
+
+// "" is the cleared sentinel; settings never remove their key.
+const serializeInstanceId = (value: number | undefined): string =>
+  typeof value === "number" ? JSON.stringify(value) : ""
 
 export function usePersistedInstanceSelection(storageNamespace: string) {
-  const storageKey = `qui-selected-instance-${storageNamespace}`
-
-  const [selectedInstanceId, setSelectedInstanceId] = useState<number | undefined>(() => {
-    try {
-      const raw = localStorage.getItem(storageKey)
-      if (!raw) return undefined
-      const parsed = JSON.parse(raw)
-      return typeof parsed === "number" ? parsed : undefined
-    } catch {
-      return undefined
-    }
+  return useClientSetting<number | undefined>(`qui-selected-instance-${storageNamespace}`, {
+    defaultValue: undefined,
+    parse: parseInstanceId,
+    serialize: serializeInstanceId,
   })
-
-  useEffect(() => {
-    try {
-      if (typeof selectedInstanceId === "number") {
-        localStorage.setItem(storageKey, JSON.stringify(selectedInstanceId))
-      } else {
-        localStorage.removeItem(storageKey)
-      }
-    } catch (error) {
-      console.error("Failed to persist selected instance:", error)
-    }
-  }, [selectedInstanceId, storageKey])
-
-  return [selectedInstanceId, setSelectedInstanceId] as const
 }

--- a/web/src/hooks/usePersistedInstanceSelection.ts
+++ b/web/src/hooks/usePersistedInstanceSelection.ts
@@ -22,3 +22,18 @@ export function usePersistedInstanceSelection(storageNamespace: string) {
     serialize: serializeInstanceId,
   })
 }
+
+/**
+ * The selection an instance picker should hold given the current instance
+ * list. Keeps the saved selection while the list is still loading (undefined).
+ */
+export function resolveInstanceSelection(
+  instances: Array<{ id: number; connected: boolean }> | undefined,
+  selected: number | undefined
+): number | undefined {
+  if (!instances) return selected
+  if (instances.length === 0) return undefined
+  if (selected !== undefined && instances.some((i) => i.id === selected)) return selected
+  const fallback = instances.find((i) => i.connected) ?? instances[0]
+  return fallback.id
+}

--- a/web/src/hooks/usePersistedShowEmptyState.ts
+++ b/web/src/hooks/usePersistedShowEmptyState.ts
@@ -3,38 +3,15 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useState, useEffect } from "react"
+import { parseJsonBoolean, useClientSetting } from "@/lib/client-settings"
 
 /**
- * Hook to persist the show/hide empty items state in localStorage
- * Used for toggling visibility of empty statuses, categories, and tags in the filter sidebar
+ * Persists the show/hide empty items state.
+ * Used for toggling visibility of empty statuses, categories, and tags in the filter sidebar.
  */
 export function usePersistedShowEmptyState(key: string, defaultValue: boolean = false) {
-  const storageKey = `qui-show-empty-${key}`
-
-  // Initialize state from localStorage or default value
-  const [showEmpty, setShowEmpty] = useState<boolean>(() => {
-    try {
-      const stored = localStorage.getItem(storageKey)
-      if (stored !== null) {
-        const parsed = JSON.parse(stored)
-        return typeof parsed === "boolean" ? parsed : defaultValue
-      }
-    } catch (error) {
-      console.error(`Failed to load show empty state from localStorage (${key}):`, error)
-    }
-
-    return defaultValue
+  return useClientSetting<boolean>(`qui-show-empty-${key}`, {
+    defaultValue,
+    parse: parseJsonBoolean,
   })
-
-  // Persist to localStorage whenever state changes
-  useEffect(() => {
-    try {
-      localStorage.setItem(storageKey, JSON.stringify(showEmpty))
-    } catch (error) {
-      console.error(`Failed to save show empty state to localStorage (${key}):`, error)
-    }
-  }, [showEmpty, storageKey])
-
-  return [showEmpty, setShowEmpty] as const
 }

--- a/web/src/hooks/usePersistedSidebarState.ts
+++ b/web/src/hooks/usePersistedSidebarState.ts
@@ -3,33 +3,11 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useState, useEffect } from "react"
+import { parseJsonBoolean, useClientSetting } from "@/lib/client-settings"
 
 export function usePersistedSidebarState(defaultCollapsed: boolean = false) {
-  const storageKey = "qui-sidebar-collapsed"
-
-  // Initialize state from localStorage or default value
-  const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(() => {
-    try {
-      const stored = localStorage.getItem(storageKey)
-      if (stored !== null) {
-        return stored === "true"
-      }
-    } catch (error) {
-      console.error("Failed to load sidebar state from localStorage:", error)
-    }
-
-    return defaultCollapsed
+  return useClientSetting<boolean>("qui-sidebar-collapsed", {
+    defaultValue: defaultCollapsed,
+    parse: parseJsonBoolean,
   })
-
-  // Persist to localStorage whenever state changes
-  useEffect(() => {
-    try {
-      localStorage.setItem(storageKey, sidebarCollapsed.toString())
-    } catch (error) {
-      console.error("Failed to save sidebar state to localStorage:", error)
-    }
-  }, [sidebarCollapsed])
-
-  return [sidebarCollapsed, setSidebarCollapsed] as const
 }

--- a/web/src/hooks/usePersistedStartPaused.ts
+++ b/web/src/hooks/usePersistedStartPaused.ts
@@ -3,41 +3,19 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useState, useEffect } from "react"
+import { parseJsonBoolean, useClientSetting } from "@/lib/client-settings"
 
 /**
- * Hook to persist the "Start Torrents Paused" preference per instance in localStorage
+ * Persists the "Start Torrents Paused" preference per instance.
  *
  * NOTE: This is a workaround for qBittorrent's API limitation where the start_paused_enabled
  * preference cannot be set via app/setPreferences (it gets rejected/ignored). Instead of
- * relying on qBittorrent's global preference, we store this setting in localStorage and
+ * relying on qBittorrent's global preference, we store this setting ourselves and
  * apply it when adding torrents.
  */
 export function usePersistedStartPaused(instanceId: number, defaultValue: boolean = false) {
-  const storageKey = `qui-start-paused-instance-${instanceId}`
-
-  // Initialize state from localStorage or default value
-  const [startPaused, setStartPaused] = useState<boolean>(() => {
-    try {
-      const stored = localStorage.getItem(storageKey)
-      if (stored !== null) {
-        return JSON.parse(stored)
-      }
-    } catch (error) {
-      console.error("Failed to load start paused preference from localStorage:", error)
-    }
-
-    return defaultValue
+  return useClientSetting<boolean>(`qui-start-paused-instance-${instanceId}`, {
+    defaultValue,
+    parse: parseJsonBoolean,
   })
-
-  // Persist to localStorage whenever state changes
-  useEffect(() => {
-    try {
-      localStorage.setItem(storageKey, JSON.stringify(startPaused))
-    } catch (error) {
-      console.error("Failed to save start paused preference to localStorage:", error)
-    }
-  }, [startPaused, storageKey])
-
-  return [startPaused, setStartPaused] as const
 }

--- a/web/src/hooks/usePersistedTabState.ts
+++ b/web/src/hooks/usePersistedTabState.ts
@@ -3,35 +3,17 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useEffect, useState } from "react"
+import { useClientSetting } from "@/lib/client-settings"
 
 export function usePersistedTabState<T extends string>(
   storageKey: string,
   defaultValue: T,
   isValid?: (value: string) => value is T
 ) {
-  const [value, setValue] = useState<T>(() => {
-    try {
-      const stored = localStorage.getItem(storageKey)
-      if (stored !== null) {
-        if (!isValid || isValid(stored)) {
-          return stored as T
-        }
-      }
-    } catch (error) {
-      console.error(`Failed to load tab state from localStorage (${storageKey}):`, error)
-    }
+  const parse = (raw: string): T => {
+    if (!isValid || isValid(raw)) return raw as T
+    throw new Error("invalid tab value")
+  }
 
-    return defaultValue
-  })
-
-  useEffect(() => {
-    try {
-      localStorage.setItem(storageKey, value)
-    } catch (error) {
-      console.error(`Failed to save tab state to localStorage (${storageKey}):`, error)
-    }
-  }, [storageKey, value])
-
-  return [value, setValue] as const
+  return useClientSetting<T>(storageKey, { defaultValue, parse, serialize: String })
 }

--- a/web/src/hooks/usePersistedTitleBarSpeeds.ts
+++ b/web/src/hooks/usePersistedTitleBarSpeeds.ts
@@ -3,34 +3,10 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useEffect, useState } from "react"
+import { parseJsonBoolean, useClientSetting } from "@/lib/client-settings"
 
 const STORAGE_KEY = "qui-titlebar-speeds-enabled"
 
 export function usePersistedTitleBarSpeeds(defaultValue: boolean = false) {
-  const [isEnabled, setIsEnabled] = useState<boolean>(() => {
-    try {
-      const stored = localStorage.getItem(STORAGE_KEY)
-      if (stored !== null) {
-        const parsed = JSON.parse(stored)
-        if (typeof parsed === "boolean") {
-          return parsed
-        }
-      }
-    } catch (error) {
-      console.error("Failed to load title bar speed preference from localStorage:", error)
-    }
-
-    return defaultValue
-  })
-
-  useEffect(() => {
-    try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(isEnabled))
-    } catch (error) {
-      console.error("Failed to save title bar speed preference to localStorage:", error)
-    }
-  }, [isEnabled])
-
-  return [isEnabled, setIsEnabled] as const
+  return useClientSetting<boolean>(STORAGE_KEY, { defaultValue, parse: parseJsonBoolean })
 }

--- a/web/src/hooks/usePersistedUnifiedInstanceFilter.ts
+++ b/web/src/hooks/usePersistedUnifiedInstanceFilter.ts
@@ -3,56 +3,22 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useCallback, useMemo, useSyncExternalStore } from "react"
 import { encodeUnifiedInstanceIds, parseUnifiedInstanceIds } from "@/lib/instances"
+import { useClientSetting } from "@/lib/client-settings"
 
-const STORAGE_KEY = "qui-unified-instance-filter"
-const CHANGE_EVENT = "qui-unified-instance-filter-changed"
+const NO_IDS: readonly number[] = []
 
-function subscribe(callback: () => void): () => void {
-  const handleStorage = (e: StorageEvent) => {
-    if (e.key === STORAGE_KEY) callback()
-  }
-  window.addEventListener("storage", handleStorage)
-  window.addEventListener(CHANGE_EVENT, callback as EventListener)
-  return () => {
-    window.removeEventListener("storage", handleStorage)
-    window.removeEventListener(CHANGE_EVENT, callback as EventListener)
-  }
-}
-
-function getSnapshot(): string {
-  try {
-    return localStorage.getItem(STORAGE_KEY) ?? ""
-  } catch {
-    return ""
-  }
-}
+// An empty selection stores "" (the cleared sentinel); parse never sees it.
+const parseIds = (raw: string): readonly number[] => parseUnifiedInstanceIds(raw)
+const serializeIds = (ids: readonly number[]): string => encodeUnifiedInstanceIds(ids) ?? ""
 
 export function usePersistedUnifiedInstanceFilter(): [
   readonly number[],
   (ids: readonly number[]) => void
 ] {
-  const storedString = useSyncExternalStore(subscribe, getSnapshot)
-
-  const persistedIds = useMemo(
-    () => parseUnifiedInstanceIds(storedString),
-    [storedString]
-  )
-
-  const saveFilter = useCallback((ids: readonly number[]) => {
-    try {
-      const encoded = encodeUnifiedInstanceIds(ids)
-      if (encoded) {
-        localStorage.setItem(STORAGE_KEY, encoded)
-      } else {
-        localStorage.removeItem(STORAGE_KEY)
-      }
-      window.dispatchEvent(new Event(CHANGE_EVENT))
-    } catch (error) {
-      console.error("Failed to save unified instance filter:", error)
-    }
-  }, [])
-
-  return [persistedIds, saveFilter]
+  return useClientSetting<readonly number[]>("qui-unified-instance-filter", {
+    defaultValue: NO_IDS,
+    parse: parseIds,
+    serialize: serializeIds,
+  })
 }

--- a/web/src/hooks/useThemeSettingsSync.ts
+++ b/web/src/hooks/useThemeSettingsSync.ts
@@ -8,6 +8,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { api } from "@/lib/api"
 import { useActivityStream } from "@/contexts/SyncStreamContext"
 import { useBuiltinThemes } from "@/hooks/useBuiltinThemes"
+import { useIsAuthed } from "@/hooks/useIsAuthed"
 import { getStoredVariation } from "@/hooks/usePersistedThemeVariation"
 import { getThemeById } from "@/config/themes"
 import { setTheme } from "@/utils/theme"
@@ -25,15 +26,9 @@ export function useThemeSettingsSync(): void {
   // value straight back as a PUT.
   const lastSynced = useRef<string | null>(null)
 
-  // Observe the cached auth state without fetching (enabled: false); useAuth
-  // owns the fetch. Pre-auth the activity stream would 401 and retry forever,
-  // so registration must wait for a user.
-  const { data: user } = useQuery({
-    queryKey: ["auth", "user"],
-    queryFn: () => api.checkAuth(),
-    enabled: false,
-  })
-  const isAuthed = Boolean(user)
+  // Pre-auth the activity stream would 401 and retry forever, so
+  // registration must wait for a user.
+  const isAuthed = useIsAuthed()
 
   // Authed tabs hear about API-side theme changes over the activity SSE
   // channel ("theme.settings" invalidates ["theme-settings"]); the login/setup

--- a/web/src/i18n/index.ts
+++ b/web/src/i18n/index.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
+import { writeRaw } from "@/lib/client-settings"
 import { spreadsheetPostProcessor } from "@/lib/spreadsheet-disguise"
 import i18n, { type ResourceKey, type ResourceLanguage } from "i18next"
 import { initReactI18next } from "react-i18next"
@@ -98,11 +99,8 @@ function getStoredLanguage(): AppLanguage | null {
 }
 
 function persistLanguage(lng: AppLanguage) {
-  try {
-    localStorage.setItem(LANGUAGE_STORAGE_KEY, lng)
-  } catch (error) {
-    console.error("Failed to save language preference to localStorage:", error)
-  }
+  // writeRaw caches locally and queues the server push (issue #2406).
+  writeRaw(LANGUAGE_STORAGE_KEY, lng)
 }
 
 // Monotonic token so that rapid language switches can't apply out of order: a slow

--- a/web/src/lib/__tests__/activity-invalidation.test.ts
+++ b/web/src/lib/__tests__/activity-invalidation.test.ts
@@ -29,6 +29,7 @@ const ALL_KINDS_MAP = {
   "search.history": true,
   "tracker.icons": true,
   "theme.settings": true,
+  "client.settings": true,
 } satisfies Record<ActivityEvent["kind"], true>
 
 const ALL_KINDS = Object.keys(ALL_KINDS_MAP) as ActivityEvent["kind"][]

--- a/web/src/lib/__tests__/client-settings.test.ts
+++ b/web/src/lib/__tests__/client-settings.test.ts
@@ -107,6 +107,43 @@ describe("push queue", () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
+  // REGRESSION (itoqa on #2409/#2410): pending cleared before the PUT resolved,
+  // so a server apply during the in-flight window clobbered the newer value.
+  it("keeps in-flight keys guarded against a concurrent server apply", async () => {
+    let resolvePut: (value: unknown) => void = () => {}
+    fetchMock.mockReturnValueOnce(new Promise((resolve) => { resolvePut = resolve }))
+    seedAndMarkReady({})
+    writeRaw("qui-test-bool", "true")
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    // PUT is in flight; a stale snapshot must not overwrite the newer value.
+    const changed = applyServerSettings({ "qui-test-bool": "false" })
+    expect(changed).toEqual([])
+    expect(localStorage.getItem("qui-test-bool")).toBe("true")
+
+    resolvePut({ ok: true, status: 200 })
+    await vi.runAllTimersAsync()
+    expect(localStorage.getItem("qui-test-bool")).toBe("true")
+  })
+
+  it("flushes a value written while a PUT for the same key is in flight", async () => {
+    let resolvePut: (value: unknown) => void = () => {}
+    fetchMock.mockReturnValueOnce(new Promise((resolve) => { resolvePut = resolve }))
+    seedAndMarkReady({})
+    writeRaw("qui-test-bool", "true")
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    // Newer write lands mid-flight; it must survive the first PUT's cleanup.
+    writeRaw("qui-test-bool", "false")
+    resolvePut({ ok: true, status: 200 })
+    await vi.runAllTimersAsync()
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({ "qui-test-bool": "false" })
+  })
+
   it("requeues a failed batch for the next flush", async () => {
     fetchMock.mockResolvedValueOnce({ ok: false, status: 500 })
     seedAndMarkReady({})

--- a/web/src/lib/__tests__/client-settings.test.ts
+++ b/web/src/lib/__tests__/client-settings.test.ts
@@ -107,8 +107,8 @@ describe("push queue", () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  // REGRESSION (itoqa on #2409/#2410): pending cleared before the PUT resolved,
-  // so a server apply during the in-flight window clobbered the newer value.
+  // REGRESSION: pending was cleared before the PUT resolved, so a server
+  // apply during the in-flight window clobbered the newer value.
   it("keeps in-flight keys guarded against a concurrent server apply", async () => {
     let resolvePut: (value: unknown) => void = () => {}
     fetchMock.mockReturnValueOnce(new Promise((resolve) => { resolvePut = resolve }))

--- a/web/src/lib/__tests__/client-settings.test.ts
+++ b/web/src/lib/__tests__/client-settings.test.ts
@@ -107,6 +107,20 @@ describe("push queue", () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
+  // REGRESSION: only visibilitychange flushed the queue, and a same-tab
+  // reload does not fire it, so a write inside the debounce window was lost
+  // and the stale server snapshot reverted it at next boot.
+  it("flushes pending writes on pagehide without waiting for the debounce", () => {
+    seedAndMarkReady({})
+    writeRaw("qui-test-bool", "true")
+    expect(fetchMock).not.toHaveBeenCalled()
+
+    window.dispatchEvent(new Event("pagehide"))
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({ "qui-test-bool": "true" })
+  })
+
   // REGRESSION: pending was cleared before the PUT resolved, so a server
   // apply during the in-flight window clobbered the newer value.
   it("keeps in-flight keys guarded against a concurrent server apply", async () => {

--- a/web/src/lib/__tests__/client-settings.test.ts
+++ b/web/src/lib/__tests__/client-settings.test.ts
@@ -202,6 +202,40 @@ describe("push queue", () => {
   })
 })
 
+describe("outbox persistence", () => {
+  it("replays a write whose unload flush never reached the server", async () => {
+    // A pagehide keepalive PUT can die in flight (Chrome drops keepalive
+    // fetches from service-worker-controlled pages on unload), so an instant
+    // reload after a write must recover from the persisted outbox.
+    seedAndMarkReady({})
+    writeRaw("qui-test-bool", "true")
+
+    // Page dies before the debounced flush is acked; next boot, stale server.
+    _resetClientSettingsForTests()
+    fetchMock.mockClear()
+
+    applyServerSettings({ "qui-test-bool": "false" })
+    expect(localStorage.getItem("qui-test-bool")).toBe("true")
+
+    seedAndMarkReady({ "qui-test-bool": "false" })
+    await vi.runAllTimersAsync()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({ "qui-test-bool": "true" })
+  })
+
+  it("an acked write leaves no outbox entry to replay", async () => {
+    seedAndMarkReady({})
+    writeRaw("qui-test-bool", "true")
+    await vi.runAllTimersAsync()
+
+    _resetClientSettingsForTests()
+
+    const changed = applyServerSettings({ "qui-test-bool": "false" })
+    expect(changed).toEqual(["qui-test-bool"])
+    expect(localStorage.getItem("qui-test-bool")).toBe("false")
+  })
+})
+
 describe("applyServerSettings", () => {
   it("writes changed keys, reports them, and notifies live hooks", () => {
     const { result } = renderHook(() => useClientSetting("qui-test-bool", boolSetting))

--- a/web/src/lib/__tests__/client-settings.test.ts
+++ b/web/src/lib/__tests__/client-settings.test.ts
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { act, cleanup, renderHook } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  _resetClientSettingsForTests,
+  applyServerSettings,
+  parseJsonBoolean,
+  seedAndMarkReady,
+  useClientSetting,
+  writeRaw
+} from "@/lib/client-settings"
+
+const fetchMock = vi.fn()
+
+beforeEach(() => {
+  localStorage.clear()
+  _resetClientSettingsForTests()
+  fetchMock.mockReset()
+  fetchMock.mockResolvedValue({ ok: true, status: 200 })
+  vi.stubGlobal("fetch", fetchMock)
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+const boolSetting = { defaultValue: false, parse: parseJsonBoolean }
+
+describe("useClientSetting", () => {
+  it("returns the default when nothing is stored or the raw value is invalid", () => {
+    const { result } = renderHook(() => useClientSetting("qui-test-bool", boolSetting))
+    expect(result.current[0]).toBe(false)
+
+    localStorage.setItem("qui-test-bool", "garbage")
+    const second = renderHook(() => useClientSetting("qui-test-bool", boolSetting))
+    expect(second.result.current[0]).toBe(false)
+  })
+
+  it("persists writes and keeps a second hook instance in sync", () => {
+    const hookA = renderHook(() => useClientSetting("qui-test-bool", boolSetting))
+    const hookB = renderHook(() => useClientSetting("qui-test-bool", boolSetting))
+
+    act(() => hookA.result.current[1](true))
+
+    expect(localStorage.getItem("qui-test-bool")).toBe("true")
+    expect(hookB.result.current[0]).toBe(true)
+  })
+
+  it("supports functional updates", () => {
+    const { result } = renderHook(() => useClientSetting("qui-test-bool", boolSetting))
+
+    act(() => result.current[1]((prev) => !prev))
+
+    expect(result.current[0]).toBe(true)
+  })
+
+  it("re-reads on a cross-tab storage event", () => {
+    const { result } = renderHook(() => useClientSetting("qui-test-bool", boolSetting))
+
+    localStorage.setItem("qui-test-bool", "true")
+    act(() => {
+      window.dispatchEvent(new Event("storage"))
+    })
+
+    expect(result.current[0]).toBe(true)
+  })
+})
+
+describe("push queue", () => {
+  it("sends nothing before the first successful GET opens the gate", () => {
+    writeRaw("qui-test-bool", "true")
+    vi.advanceTimersByTime(5_000)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("coalesces rapid writes into one debounced PUT with the last value per key", async () => {
+    seedAndMarkReady({})
+    writeRaw("qui-test-bool", "true")
+    writeRaw("qui-test-other", "1")
+    writeRaw("qui-test-bool", "false")
+
+    await vi.runAllTimersAsync()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(String(url)).toContain("/client-settings")
+    expect(init.method).toBe("PUT")
+    expect(JSON.parse(init.body)).toEqual({ "qui-test-bool": "false", "qui-test-other": "1" })
+  })
+
+  it("skips the push when the value is unchanged", async () => {
+    localStorage.setItem("qui-test-bool", "true")
+    seedAndMarkReady({ "qui-test-bool": "true" })
+    writeRaw("qui-test-bool", "true")
+
+    await vi.runAllTimersAsync()
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("requeues a failed batch for the next flush", async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 500 })
+    seedAndMarkReady({})
+    writeRaw("qui-test-bool", "true")
+    await vi.runAllTimersAsync()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    // The next write flushes the failed key again alongside the new one.
+    writeRaw("qui-test-other", "1")
+    await vi.runAllTimersAsync()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({
+      "qui-test-bool": "true",
+      "qui-test-other": "1",
+    })
+  })
+})
+
+describe("applyServerSettings", () => {
+  it("writes changed keys, reports them, and notifies live hooks", () => {
+    const { result } = renderHook(() => useClientSetting("qui-test-bool", boolSetting))
+
+    let changed: string[] = []
+    act(() => {
+      changed = applyServerSettings({ "qui-test-bool": "true", "qui-test-other": "1" })
+    })
+
+    expect(changed.sort()).toEqual(["qui-test-bool", "qui-test-other"])
+    expect(result.current[0]).toBe(true)
+    expect(localStorage.getItem("qui-test-other")).toBe("1")
+  })
+
+  it("never clobbers a pending local write (echo guard)", () => {
+    writeRaw("qui-test-bool", "true")
+
+    const changed = applyServerSettings({ "qui-test-bool": "false" })
+
+    expect(changed).toEqual([])
+    expect(localStorage.getItem("qui-test-bool")).toBe("true")
+  })
+})
+
+describe("seedAndMarkReady", () => {
+  it("pushes synced keys the server does not know, and only those", async () => {
+    localStorage.setItem("qui-speed-units", "bits")
+    localStorage.setItem("qui-incognito-mode", "true")
+    localStorage.setItem("theme-cache", "{}") // not a synced key
+
+    seedAndMarkReady({ "qui-incognito-mode": "true" })
+    await vi.runAllTimersAsync()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({ "qui-speed-units": "bits" })
+  })
+})

--- a/web/src/lib/__tests__/client-settings.test.ts
+++ b/web/src/lib/__tests__/client-settings.test.ts
@@ -144,6 +144,32 @@ describe("push queue", () => {
     expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({ "qui-test-bool": "false" })
   })
 
+  // REGRESSION: a flush whose timer fired during an in-flight PUT was
+  // swallowed; if that PUT then failed, the newer write stalled until the
+  // next write or tab-hide.
+  it("replays a flush swallowed during a failed in-flight PUT", async () => {
+    let rejectPut: (reason: unknown) => void = () => {}
+    fetchMock.mockReturnValueOnce(new Promise((_resolve, reject) => { rejectPut = reject }))
+    seedAndMarkReady({})
+    writeRaw("qui-test-bool", "true")
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    // New write mid-flight; its timer fires while the PUT is still pending.
+    writeRaw("qui-test-other", "1")
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    rejectPut(new Error("network down"))
+    await vi.runAllTimersAsync()
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({
+      "qui-test-bool": "true",
+      "qui-test-other": "1",
+    })
+  })
+
   it("requeues a failed batch for the next flush", async () => {
     fetchMock.mockResolvedValueOnce({ ok: false, status: 500 })
     seedAndMarkReady({})

--- a/web/src/lib/__tests__/speedUnits.test.ts
+++ b/web/src/lib/__tests__/speedUnits.test.ts
@@ -101,13 +101,13 @@ describe("useSpeedUnits listener cleanup", () => {
     unmount()
 
     expect(removeSpy).toHaveBeenCalledWith("storage", expect.any(Function))
-    expect(removeSpy).toHaveBeenCalledWith("speed-units-changed", expect.any(Function))
+    expect(removeSpy).toHaveBeenCalledWith("qui-client-setting-changed", expect.any(Function))
 
     // After unmount, external events must not throw or update the stale state.
     localStorage.setItem(STORAGE_KEY, "bits")
     expect(() => {
       window.dispatchEvent(new Event("storage"))
-      window.dispatchEvent(new Event("speed-units-changed"))
+      window.dispatchEvent(new CustomEvent("qui-client-setting-changed", { detail: { key: STORAGE_KEY } }))
     }).not.toThrow()
     expect(last()).toBe("bytes")
   })

--- a/web/src/lib/__tests__/speedUnits.test.ts
+++ b/web/src/lib/__tests__/speedUnits.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { act, renderHook } from "@testing-library/react"
+import { act, cleanup, renderHook } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { formatSpeedWithUnit, useSpeedUnits } from "@/lib/speedUnits"
 
@@ -14,6 +14,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  cleanup()
   vi.restoreAllMocks()
 })
 

--- a/web/src/lib/activity-invalidation.ts
+++ b/web/src/lib/activity-invalidation.ts
@@ -42,6 +42,8 @@ export function activityQueryKeys(event: ActivityEvent): QueryKey[] {
       return [["tracker-icons"]]
     case "theme.settings":
       return [["theme-settings"]]
+    case "client.settings":
+      return [["client-settings"]]
     default:
       return []
   }
@@ -77,6 +79,7 @@ export const ACTIVITY_FEATURE_PREFIXES: QueryKey[] = [
   ["searchHistory"],
   ["tracker-icons"],
   ["theme-settings"],
+  ["client-settings"],
 ]
 
 /**

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2065,6 +2065,12 @@ class ApiClient {
     })
   }
 
+  // Client settings (frontend user settings stored in the database as opaque key-value pairs;
+  // writes go through the debounced push queue in lib/client-settings.ts, not this client)
+  async getClientSettings(): Promise<Record<string, string>> {
+    return this.request<Record<string, string>>("/client-settings")
+  }
+
   // Preferences endpoints
   async getInstancePreferences(instanceId: number): Promise<AppPreferences> {
     return this.request<AppPreferences>(`/instances/${instanceId}/preferences`)

--- a/web/src/lib/client-settings.ts
+++ b/web/src/lib/client-settings.ts
@@ -34,6 +34,13 @@ const SYNCED_KEYS = new Set<string>([
   "qui-datetime-preferences",
   "qui-titlebar-speeds-enabled",
   "qui.language",
+  "qui-sidebar-collapsed",
+  "qui-filter-sidebar-collapsed",
+  "qui-accordion",
+  "qui-accordion-views-seeded",
+  "qui-torrent-view-mode",
+  "qui-unified-instance-filter",
+  "torrent-details-last-tab",
 ])
 const SYNCED_PREFIXES = [
   "qui-start-paused-instance-",
@@ -47,6 +54,8 @@ const SYNCED_PREFIXES = [
   "qui-collapsed-categories-",
   "qui-filters-",
   "qui:torrent-mobile-sort:",
+  "qui-show-empty-",
+  "qui-selected-instance-",
 ]
 
 function isSyncedKey(key: string): boolean {

--- a/web/src/lib/client-settings.ts
+++ b/web/src/lib/client-settings.ts
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { useCallback, useMemo, useRef, useSyncExternalStore } from "react"
+import { getApiBaseUrl } from "@/lib/base-url"
+
+/**
+ * DB-backed client settings (issue #2406).
+ *
+ * localStorage stays as the instant-boot cache; the server's client_settings
+ * table is the source of truth. Every write goes to localStorage immediately
+ * and is queued for a debounced bulk PUT. useClientSettingsSync pulls the
+ * server state, applies it locally, seeds missing keys from localStorage and
+ * opens the push gate.
+ *
+ * Values are raw strings end to end; each setting keeps the exact encoding it
+ * always had in localStorage, and the backend never parses them. A cleared
+ * setting stores "" instead of removing the key, so "absent on the server"
+ * always means "never synced".
+ */
+
+const CHANGE_EVENT = "qui-client-setting-changed"
+const FLUSH_DELAY_MS = 800
+
+// Keys synced to the server. Grown as hooks convert; keys not listed here
+// (theme boot caches, dismissed banners, sessionStorage) stay local-only.
+const SYNCED_KEYS = new Set<string>([
+  "qui-delete-files-default",
+  "qui-delete-files-lock",
+  "qui-speed-units",
+  "qui-incognito-mode",
+  "qui-datetime-preferences",
+  "qui-titlebar-speeds-enabled",
+  "qui.language",
+])
+const SYNCED_PREFIXES = [
+  "qui-start-paused-instance-",
+  "qui-cross-seed-blocklist-",
+]
+
+function isSyncedKey(key: string): boolean {
+  return SYNCED_KEYS.has(key) || SYNCED_PREFIXES.some((prefix) => key.startsWith(prefix))
+}
+
+export function readRaw(key: string): string | null {
+  try {
+    return localStorage.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+function writeLocal(key: string, raw: string): boolean {
+  try {
+    localStorage.setItem(key, raw)
+  } catch (error) {
+    console.error("Failed to write client setting to localStorage:", error)
+    return false
+  }
+  window.dispatchEvent(new CustomEvent(CHANGE_EVENT, { detail: { key } }))
+  return true
+}
+
+/**
+ * Store a setting locally and queue it for the server. No-op when the value
+ * is unchanged, which also breaks server-apply echo loops.
+ */
+export function writeRaw(key: string, raw: string): void {
+  if (readRaw(key) === raw) return
+  if (writeLocal(key, raw)) enqueuePush(key, raw)
+}
+
+// --- push queue ---
+
+const pending = new Map<string, string>()
+let flushTimer: ReturnType<typeof setTimeout> | null = null
+// Opens after the first successful GET, so nothing fires while logged out.
+let syncReady = false
+
+function enqueuePush(key: string, raw: string): void {
+  pending.set(key, raw)
+  scheduleFlush()
+}
+
+function scheduleFlush(): void {
+  if (!syncReady || pending.size === 0) return
+  if (flushTimer !== null) clearTimeout(flushTimer)
+  flushTimer = setTimeout(() => {
+    flushTimer = null
+    void flushPending()
+  }, FLUSH_DELAY_MS)
+}
+
+async function flushPending(): Promise<void> {
+  if (!syncReady || pending.size === 0) return
+  const batch = Object.fromEntries(pending)
+  pending.clear()
+  try {
+    // Plain fetch instead of the api client: keepalive lets the tab-hidden
+    // flush finish, and this module must stay import-light (i18n boots on it).
+    const response = await fetch(`${getApiBaseUrl()}/client-settings`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(batch),
+      keepalive: true,
+    })
+    if (!response.ok) throw new Error(`HTTP ${response.status}`)
+  } catch (error) {
+    console.error("Failed to push client settings:", error)
+    // Requeue for the next flush; a newer write for the same key wins.
+    for (const [key, raw] of Object.entries(batch)) {
+      if (!pending.has(key)) pending.set(key, raw)
+    }
+  }
+}
+
+if (typeof document !== "undefined") {
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState !== "hidden") return
+    if (flushTimer !== null) {
+      clearTimeout(flushTimer)
+      flushTimer = null
+    }
+    void flushPending()
+  })
+}
+
+// --- server sync (called by useClientSettingsSync) ---
+
+/**
+ * Apply a server snapshot to localStorage. Keys with a pending local push and
+ * keys already equal are skipped. Returns the keys that changed.
+ */
+export function applyServerSettings(settings: Record<string, string>): string[] {
+  const changed: string[] = []
+  for (const [key, raw] of Object.entries(settings)) {
+    if (pending.has(key)) continue
+    if (readRaw(key) === raw) continue
+    if (writeLocal(key, raw)) changed.push(key)
+  }
+  return changed
+}
+
+/**
+ * Queue every synced localStorage key the server does not know yet, then open
+ * the push gate. Idempotent: after one push the server has the key.
+ */
+export function seedAndMarkReady(serverSettings: Record<string, string>): void {
+  try {
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i)
+      if (!key || !isSyncedKey(key) || key in serverSettings || pending.has(key)) continue
+      const raw = localStorage.getItem(key)
+      if (raw !== null) pending.set(key, raw)
+    }
+  } catch (error) {
+    console.error("Failed to scan localStorage for client settings seed:", error)
+  }
+  syncReady = true
+  scheduleFlush()
+}
+
+// Test-only: reset module state between vitest cases.
+export function _resetClientSettingsForTests(): void {
+  pending.clear()
+  if (flushTimer !== null) clearTimeout(flushTimer)
+  flushTimer = null
+  syncReady = false
+}
+
+// --- React hook ---
+
+/** JSON-parse a raw value, accepting only a real boolean. */
+export function parseJsonBoolean(raw: string): boolean {
+  const parsed = JSON.parse(raw)
+  if (typeof parsed !== "boolean") throw new Error("not a boolean")
+  return parsed
+}
+
+interface ClientSettingOptions<T> {
+  defaultValue: T
+  /** Raw string to value; throw to fall back to defaultValue. Pass a stable function. */
+  parse: (raw: string) => T
+  /** Value to raw string; defaults to JSON.stringify. Pass a stable function. */
+  serialize?: (value: T) => string
+}
+
+/**
+ * One DB-backed setting as React state. All hook instances for a key stay in
+ * sync in the same tab (change event) and across tabs (storage event); writes
+ * persist to localStorage and queue a debounced server push.
+ */
+export function useClientSetting<T>(
+  key: string,
+  { defaultValue, parse, serialize = (value) => JSON.stringify(value) }: ClientSettingOptions<T>
+): [T, (value: T | ((prev: T) => T)) => void] {
+  const subscribe = useCallback(
+    (callback: () => void) => {
+      // A storage event without a key is localStorage.clear() (or a test's
+      // bare Event); re-read for those too.
+      const onStorage = (e: StorageEvent) => {
+        if (e.key == null || e.key === key) callback()
+      }
+      const onChange = (e: Event) => {
+        if ((e as CustomEvent<{ key?: string }>).detail?.key === key) callback()
+      }
+      window.addEventListener("storage", onStorage)
+      window.addEventListener(CHANGE_EVENT, onChange)
+      return () => {
+        window.removeEventListener("storage", onStorage)
+        window.removeEventListener(CHANGE_EVENT, onChange)
+      }
+    },
+    [key]
+  )
+
+  const raw = useSyncExternalStore(subscribe, () => readRaw(key))
+
+  const value = useMemo(() => {
+    // "" is the cleared sentinel (settings never remove their key).
+    if (raw == null || raw === "") return defaultValue
+    try {
+      return parse(raw)
+    } catch {
+      return defaultValue
+    }
+  }, [raw, parse, defaultValue])
+
+  const valueRef = useRef(value)
+  valueRef.current = value
+
+  const set = useCallback(
+    (next: T | ((prev: T) => T)) => {
+      const resolved = typeof next === "function" ? (next as (prev: T) => T)(valueRef.current) : next
+      writeRaw(key, serialize(resolved))
+    },
+    [key, serialize]
+  )
+
+  return [value, set]
+}

--- a/web/src/lib/client-settings.ts
+++ b/web/src/lib/client-settings.ts
@@ -94,9 +94,16 @@ function scheduleFlush(): void {
 }
 
 let flushInFlight = false
+// A timer or tab-hide flush that fired while a PUT was in flight; replayed
+// once the PUT settles so the write it carried is not stalled.
+let flushRequestedInFlight = false
 
 async function flushPending(): Promise<void> {
-  if (flushInFlight || !syncReady || pending.size === 0) return
+  if (flushInFlight) {
+    flushRequestedInFlight = true
+    return
+  }
+  if (!syncReady || pending.size === 0) return
   // Keys stay in pending while the PUT is in flight so a concurrent server
   // apply cannot clobber the newer local value (the echo guard checks
   // pending). On failure they simply stay queued for the next flush.
@@ -112,15 +119,19 @@ async function flushPending(): Promise<void> {
       keepalive: true,
     })
     if (!response.ok) throw new Error(`HTTP ${response.status}`)
-    // Drop what this PUT delivered.
+    // Drop what this PUT delivered. Entries replaced mid-flight stay queued;
+    // their own scheduleFlush timer (or the replay below) picks them up.
     for (const [key, raw] of Object.entries(batch)) {
       if (pending.get(key) === raw) pending.delete(key)
     }
-    scheduleFlush()
   } catch (error) {
     console.error("Failed to push client settings:", error)
   } finally {
     flushInFlight = false
+    if (flushRequestedInFlight) {
+      flushRequestedInFlight = false
+      scheduleFlush()
+    }
   }
 }
 
@@ -176,6 +187,7 @@ export function _resetClientSettingsForTests(): void {
   if (flushTimer !== null) clearTimeout(flushTimer)
   flushTimer = null
   flushInFlight = false
+  flushRequestedInFlight = false
   syncReady = false
 }
 

--- a/web/src/lib/client-settings.ts
+++ b/web/src/lib/client-settings.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useCallback, useMemo, useRef, useSyncExternalStore } from "react"
+import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from "react"
 import { getApiBaseUrl } from "@/lib/base-url"
 
 /**
@@ -38,6 +38,15 @@ const SYNCED_KEYS = new Set<string>([
 const SYNCED_PREFIXES = [
   "qui-start-paused-instance-",
   "qui-cross-seed-blocklist-",
+  // "qui-filters-" covers "qui-filters-global" and the per-instance keys.
+  "qui-column-visibility:",
+  "qui-column-order:",
+  "qui-column-sorting:",
+  "qui-column-sizing:",
+  "qui-column-filters-",
+  "qui-collapsed-categories-",
+  "qui-filters-",
+  "qui:torrent-mobile-sort:",
 ]
 
 function isSyncedKey(key: string): boolean {
@@ -179,6 +188,25 @@ export function parseJsonBoolean(raw: string): boolean {
   return parsed
 }
 
+// Module-level so the setter's useCallback identity stays stable when no
+// custom serializer is passed.
+const defaultSerialize = (value: unknown): string => JSON.stringify(value)
+
+/**
+ * Drop a pre-instance-scoping shared localStorage key once the caller uses
+ * instance-scoped keys. Local-only: legacy keys are never synced.
+ */
+export function useDropLegacyKey(baseKey: string, enabled: boolean): void {
+  useEffect(() => {
+    if (!enabled) return
+    try {
+      localStorage.removeItem(baseKey)
+    } catch (error) {
+      console.error("Failed to clear legacy state key:", baseKey, error)
+    }
+  }, [baseKey, enabled])
+}
+
 interface ClientSettingOptions<T> {
   defaultValue: T
   /** Raw string to value; throw to fall back to defaultValue. Pass a stable function. */
@@ -194,7 +222,7 @@ interface ClientSettingOptions<T> {
  */
 export function useClientSetting<T>(
   key: string,
-  { defaultValue, parse, serialize = (value) => JSON.stringify(value) }: ClientSettingOptions<T>
+  { defaultValue, parse, serialize = defaultSerialize }: ClientSettingOptions<T>
 ): [T, (value: T | ((prev: T) => T)) => void] {
   const subscribe = useCallback(
     (callback: () => void) => {

--- a/web/src/lib/client-settings.ts
+++ b/web/src/lib/client-settings.ts
@@ -79,8 +79,45 @@ let flushTimer: ReturnType<typeof setTimeout> | null = null
 // Opens after the first successful GET, so nothing fires while logged out.
 let syncReady = false
 
+// Durable outbox: the dirty key list mirrored to localStorage. The pagehide
+// keepalive PUT is not reliable (Chrome drops keepalive fetches from
+// service-worker-controlled pages on unload), so unacked writes must survive
+// the page. The next boot loads them back into pending, which both blocks the
+// stale server snapshot from reverting them and replays their push. Only keys
+// are stored; the values already live in localStorage under those keys.
+// ponytail: single outbox key is last-writer-wins across tabs, so one tab's
+// crash can drop another tab's unacked key; read-merge-write if that bites.
+const OUTBOX_KEY = "qui-client-settings-outbox"
+
+function persistPending(): void {
+  try {
+    if (pending.size === 0) localStorage.removeItem(OUTBOX_KEY)
+    else localStorage.setItem(OUTBOX_KEY, JSON.stringify([...pending.keys()]))
+  } catch {
+    // Best effort; losing the outbox only reopens the unload race.
+  }
+}
+
+function loadPersistedPending(): void {
+  try {
+    const raw = localStorage.getItem(OUTBOX_KEY)
+    if (!raw) return
+    for (const key of JSON.parse(raw) as string[]) {
+      // A key gone from localStorage has no value to replay; "" would push
+      // the cleared sentinel, so skip it.
+      const value = readRaw(key)
+      if (value !== null) pending.set(key, value)
+    }
+  } catch {
+    // Corrupt outbox: drop it, the values themselves are still in localStorage.
+  }
+}
+
+loadPersistedPending()
+
 function enqueuePush(key: string, raw: string): void {
   pending.set(key, raw)
+  persistPending()
   scheduleFlush()
 }
 
@@ -124,6 +161,7 @@ async function flushPending(): Promise<void> {
     for (const [key, raw] of Object.entries(batch)) {
       if (pending.get(key) === raw) pending.delete(key)
     }
+    persistPending()
   } catch (error) {
     console.error("Failed to push client settings:", error)
   } finally {
@@ -189,7 +227,8 @@ export function seedAndMarkReady(serverSettings: Record<string, string>): void {
   scheduleFlush()
 }
 
-// Test-only: reset module state between vitest cases.
+// Test-only: reset module state between vitest cases. Mirrors a fresh page
+// boot: in-memory state resets, then the persisted outbox loads back in.
 export function _resetClientSettingsForTests(): void {
   pending.clear()
   if (flushTimer !== null) clearTimeout(flushTimer)
@@ -197,6 +236,7 @@ export function _resetClientSettingsForTests(): void {
   flushInFlight = false
   flushRequestedInFlight = false
   syncReady = false
+  loadPersistedPending()
 }
 
 // --- React hook ---

--- a/web/src/lib/client-settings.ts
+++ b/web/src/lib/client-settings.ts
@@ -93,10 +93,15 @@ function scheduleFlush(): void {
   }, FLUSH_DELAY_MS)
 }
 
+let flushInFlight = false
+
 async function flushPending(): Promise<void> {
-  if (!syncReady || pending.size === 0) return
+  if (flushInFlight || !syncReady || pending.size === 0) return
+  // Keys stay in pending while the PUT is in flight so a concurrent server
+  // apply cannot clobber the newer local value (the echo guard checks
+  // pending). On failure they simply stay queued for the next flush.
   const batch = Object.fromEntries(pending)
-  pending.clear()
+  flushInFlight = true
   try {
     // Plain fetch instead of the api client: keepalive lets the tab-hidden
     // flush finish, and this module must stay import-light (i18n boots on it).
@@ -107,12 +112,15 @@ async function flushPending(): Promise<void> {
       keepalive: true,
     })
     if (!response.ok) throw new Error(`HTTP ${response.status}`)
+    // Drop what this PUT delivered.
+    for (const [key, raw] of Object.entries(batch)) {
+      if (pending.get(key) === raw) pending.delete(key)
+    }
+    scheduleFlush()
   } catch (error) {
     console.error("Failed to push client settings:", error)
-    // Requeue for the next flush; a newer write for the same key wins.
-    for (const [key, raw] of Object.entries(batch)) {
-      if (!pending.has(key)) pending.set(key, raw)
-    }
+  } finally {
+    flushInFlight = false
   }
 }
 
@@ -167,6 +175,7 @@ export function _resetClientSettingsForTests(): void {
   pending.clear()
   if (flushTimer !== null) clearTimeout(flushTimer)
   flushTimer = null
+  flushInFlight = false
   syncReady = false
 }
 

--- a/web/src/lib/client-settings.ts
+++ b/web/src/lib/client-settings.ts
@@ -135,15 +135,23 @@ async function flushPending(): Promise<void> {
   }
 }
 
+function flushNow(): void {
+  if (flushTimer !== null) {
+    clearTimeout(flushTimer)
+    flushTimer = null
+  }
+  void flushPending()
+}
+
 if (typeof document !== "undefined") {
   document.addEventListener("visibilitychange", () => {
-    if (document.visibilityState !== "hidden") return
-    if (flushTimer !== null) {
-      clearTimeout(flushTimer)
-      flushTimer = null
-    }
-    void flushPending()
+    if (document.visibilityState === "hidden") flushNow()
   })
+  // Chrome does not fire visibilitychange on a same-tab reload or navigation,
+  // so a write inside the debounce window would die with the page and the
+  // stale server snapshot would revert it at next boot. keepalive lets the
+  // PUT outlive the page.
+  window.addEventListener("pagehide", flushNow)
 }
 
 // --- server sync (called by useClientSettingsSync) ---

--- a/web/src/lib/incognito.ts
+++ b/web/src/lib/incognito.ts
@@ -8,7 +8,7 @@
 // as the stable incognito API; each getter picks its vocabulary at call time.
 
 import type { Category } from "@/types"
-import { useEffect, useState } from "react"
+import { useClientSetting } from "@/lib/client-settings"
 import { isSpreadsheetDisguiseActive } from "./spreadsheet-disguise"
 
 // Linux ISO names for incognito mode
@@ -630,36 +630,13 @@ export function getLinuxHash(hash: string): string {
 // Storage key for incognito mode
 const INCOGNITO_STORAGE_KEY = "qui-incognito-mode"
 
-// Custom hook for managing incognito mode state with localStorage persistence
+const parseIncognito = (raw: string): boolean => raw === "true"
+
+// Custom hook for managing the DB-backed incognito mode preference
 export function useIncognitoMode(): [boolean, (value: boolean) => void] {
-  const [incognitoMode, setIncognitoModeState] = useState(() => {
-    const stored = localStorage.getItem(INCOGNITO_STORAGE_KEY)
-    return stored === "true"
+  return useClientSetting<boolean>(INCOGNITO_STORAGE_KEY, {
+    defaultValue: false,
+    parse: parseIncognito,
+    serialize: String,
   })
-
-  // Listen for storage changes to sync incognito mode across components
-  useEffect(() => {
-    const handleStorageChange = () => {
-      const stored = localStorage.getItem(INCOGNITO_STORAGE_KEY)
-      setIncognitoModeState(stored === "true")
-    }
-
-    // Listen for both storage events (cross-tab) and custom events (same-tab)
-    window.addEventListener("storage", handleStorageChange)
-    window.addEventListener("incognito-mode-changed", handleStorageChange)
-
-    return () => {
-      window.removeEventListener("storage", handleStorageChange)
-      window.removeEventListener("incognito-mode-changed", handleStorageChange)
-    }
-  }, [])
-
-  const setIncognitoMode = (value: boolean) => {
-    setIncognitoModeState(value)
-    localStorage.setItem(INCOGNITO_STORAGE_KEY, String(value))
-    // Dispatch custom event for same-tab updates
-    window.dispatchEvent(new Event("incognito-mode-changed"))
-  }
-
-  return [incognitoMode, setIncognitoMode]
 }

--- a/web/src/lib/speedUnits.ts
+++ b/web/src/lib/speedUnits.ts
@@ -5,7 +5,7 @@
 
 // Speed units utilities for toggling between B/s and bps display
 
-import { useEffect, useState } from "react"
+import { useClientSetting } from "@/lib/client-settings"
 
 // Speed unit types
 export type SpeedUnit = "bytes" | "bits"
@@ -13,38 +13,15 @@ export type SpeedUnit = "bytes" | "bits"
 // Storage key for speed units preference
 const SPEED_UNITS_STORAGE_KEY = "qui-speed-units"
 
-// Custom hook for managing speed units state with localStorage persistence
+const parseSpeedUnit = (raw: string): SpeedUnit => (raw === "bits" ? "bits" : "bytes")
+
+// Custom hook for managing the DB-backed speed units preference
 export function useSpeedUnits(): [SpeedUnit, (unit: SpeedUnit) => void] {
-  const [speedUnit, setSpeedUnitState] = useState<SpeedUnit>(() => {
-    const stored = localStorage.getItem(SPEED_UNITS_STORAGE_KEY) as SpeedUnit
-    return stored === "bits" ? "bits" : "bytes" // Default to bytes
+  return useClientSetting<SpeedUnit>(SPEED_UNITS_STORAGE_KEY, {
+    defaultValue: "bytes",
+    parse: parseSpeedUnit,
+    serialize: String,
   })
-
-  // Listen for storage changes to sync speed units across components
-  useEffect(() => {
-    const handleStorageChange = () => {
-      const stored = localStorage.getItem(SPEED_UNITS_STORAGE_KEY) as SpeedUnit
-      setSpeedUnitState(stored === "bits" ? "bits" : "bytes")
-    }
-
-    // Listen for both storage events (cross-tab) and custom events (same-tab)
-    window.addEventListener("storage", handleStorageChange)
-    window.addEventListener("speed-units-changed", handleStorageChange)
-
-    return () => {
-      window.removeEventListener("storage", handleStorageChange)
-      window.removeEventListener("speed-units-changed", handleStorageChange)
-    }
-  }, [])
-
-  const setSpeedUnit = (unit: SpeedUnit) => {
-    setSpeedUnitState(unit)
-    localStorage.setItem(SPEED_UNITS_STORAGE_KEY, unit)
-    // Dispatch custom event for same-tab updates
-    window.dispatchEvent(new Event("speed-units-changed"))
-  }
-
-  return [speedUnit, setSpeedUnit]
 }
 
 // Format speed with unit preference

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -53,6 +53,7 @@ import { usePersistedTitleBarSpeeds } from "@/hooks/usePersistedTitleBarSpeeds"
 import { useQBittorrentAppInfo } from "@/hooks/useQBittorrentAppInfo"
 import { useTitleBarSpeeds } from "@/hooks/useTitleBarSpeeds"
 import { api } from "@/lib/api"
+import { writeRaw } from "@/lib/client-settings"
 import {
   DASHBOARD_STATS_FALLBACK_ORDER,
   DASHBOARD_STATS_FALLBACK_SORT,
@@ -1053,14 +1054,10 @@ function InstanceCard({
                     to="/instances/$instanceId"
                     params={{ instanceId: instance.id.toString() }}
                     onClick={() => {
-                      try {
-                        localStorage.setItem("qui-filters-global", JSON.stringify({
-                          status: ["unregistered"],
-                          excludeStatus: [],
-                        }))
-                      } catch (error) {
-                        console.error("Failed to set filter state:", error)
-                      }
+                      writeRaw("qui-filters-global", JSON.stringify({
+                        status: ["unregistered"],
+                        excludeStatus: [],
+                      }))
                     }}
                     className="flex items-center gap-2 text-xs w-full rounded px-1 -mx-1 hover:bg-destructive/10 transition-colors"
                   >
@@ -1074,14 +1071,10 @@ function InstanceCard({
                     to="/instances/$instanceId"
                     params={{ instanceId: instance.id.toString() }}
                     onClick={() => {
-                      try {
-                        localStorage.setItem("qui-filters-global", JSON.stringify({
-                          status: ["tracker_down"],
-                          excludeStatus: [],
-                        }))
-                      } catch (error) {
-                        console.error("Failed to set filter state:", error)
-                      }
+                      writeRaw("qui-filters-global", JSON.stringify({
+                        status: ["tracker_down"],
+                        excludeStatus: [],
+                      }))
                     }}
                     className="flex items-center gap-2 text-xs w-full rounded px-1 -mx-1 hover:bg-yellow-500/10 transition-colors"
                   >
@@ -1095,14 +1088,10 @@ function InstanceCard({
                     to="/instances/$instanceId"
                     params={{ instanceId: instance.id.toString() }}
                     onClick={() => {
-                      try {
-                        localStorage.setItem("qui-filters-global", JSON.stringify({
-                          status: ["errored"],
-                          excludeStatus: [],
-                        }))
-                      } catch (error) {
-                        console.error("Failed to set filter state:", error)
-                      }
+                      writeRaw("qui-filters-global", JSON.stringify({
+                        status: ["errored"],
+                        excludeStatus: [],
+                      }))
                     }}
                     className="flex items-center gap-2 text-xs w-full rounded px-1 -mx-1 hover:bg-destructive/10 transition-colors"
                   >

--- a/web/src/pages/InstanceBackups.tsx
+++ b/web/src/pages/InstanceBackups.tsx
@@ -159,6 +159,13 @@ export function InstanceBackups() {
   const instanceCapabilitiesPending = (instances?.length ?? 0) > 0
     && instanceCapabilitiesQueries.some(query => query.isPending)
 
+  // An errored capabilities query is as unresolved as a pending one: deciding
+  // on it would drop its instance from supportedInstances and clear a saved
+  // selection over a transient failure. Only the selection effect cares; the
+  // UI keeps treating an error as "not checking".
+  const instanceCapabilitiesUnresolved = instanceCapabilitiesPending
+    || instanceCapabilitiesQueries.some(query => query.isError)
+
   // Filter instances to only show those that support backups
   const supportedInstances = useMemo(() => {
     if (!instances) return []
@@ -178,7 +185,7 @@ export function InstanceBackups() {
     if (!instances) {
       return
     }
-    if (instanceCapabilitiesPending) {
+    if (instanceCapabilitiesUnresolved) {
       return
     }
 
@@ -186,7 +193,7 @@ export function InstanceBackups() {
     if (!stillSupported) {
       setSelectedInstanceId(undefined)
     }
-  }, [selectedInstanceId, setSelectedInstanceId, supportedInstances, instances, instanceCapabilitiesPending])
+  }, [selectedInstanceId, setSelectedInstanceId, supportedInstances, instances, instanceCapabilitiesUnresolved])
 
   const instanceId = selectedInstanceId
 

--- a/web/src/pages/RSSPage.tsx
+++ b/web/src/pages/RSSPage.tsx
@@ -79,7 +79,7 @@ import { useInstanceCapabilities } from "@/hooks/useInstanceCapabilities"
 import { useInstanceMetadata } from "@/hooks/useInstanceMetadata"
 import { useInstancePreferences } from "@/hooks/useInstancePreferences"
 import { useInstances } from "@/hooks/useInstances"
-import { usePersistedInstanceSelection } from "@/hooks/usePersistedInstanceSelection"
+import { resolveInstanceSelection, usePersistedInstanceSelection } from "@/hooks/usePersistedInstanceSelection"
 import {
   rssKeys,
   useAddRSSFeed,
@@ -134,28 +134,9 @@ export function RSSPage({
 
   // Auto-select/validate instance selection
   useEffect(() => {
-    if (!instances || instances.length === 0) {
-      if (selectedInstanceId !== undefined) {
-        setSelectedInstanceId(undefined)
-      }
-      return
-    }
-
-    if (selectedInstanceId !== undefined) {
-      const exists = instances.some((i) => i.id === selectedInstanceId)
-      if (exists) {
-        return
-      }
-      const fallbackInstance = instances.find((i) => i.connected) ?? instances[0]
-      setSelectedInstanceId(fallbackInstance?.id)
-      return
-    }
-
-    const firstConnected = instances.find((i) => i.connected)
-    if (firstConnected) {
-      setSelectedInstanceId(firstConnected.id)
-    } else if (instances[0]) {
-      setSelectedInstanceId(instances[0].id)
+    const next = resolveInstanceSelection(instances, selectedInstanceId)
+    if (next !== selectedInstanceId) {
+      setSelectedInstanceId(next)
     }
   }, [selectedInstanceId, setSelectedInstanceId, instances])
 

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -19,6 +19,13 @@ if (globalThis.localStorage == null) {
     setItem: (key: string, value: string) => void store.set(key, value),
     removeItem: (key: string) => void store.delete(key),
     clear: () => store.clear(),
+    key: (index: number) => [...store.keys()][index] ?? null,
+  })
+  // jsdom's brand-checked `length` accessor throws on this stand-in instance;
+  // replace it with the store's size so key/length iteration works.
+  Object.defineProperty(Storage.prototype, "length", {
+    get: () => store.size,
+    configurable: true,
   })
   globalThis.localStorage = Object.create(Storage.prototype) as Storage
 }

--- a/web/src/types/activity.ts
+++ b/web/src/types/activity.ts
@@ -17,6 +17,7 @@ export type ActivityEventKind =
   | "search.history"
   | "tracker.icons"
   | "theme.settings"
+  | "client.settings"
 
 // ActivityEvent is a small qui-owned server signal. It carries identifiers only
 // (never payload data); the frontend reacts by invalidating the matching query.


### PR DESCRIPTION
## Description

Test bundle of the client-settings stack (#2407, #2409, #2410, #2412) for a live field test on a real library. Not for merge; the stack merges through its own PRs.

## How has this been tested?

This PR exists to run the field test. Pull the `pr-2413` image on the media server and exercise: settings restore after a localStorage wipe, filter subcategory expansion, column-sizing drag coalescing, and cross-browser sync.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL