### PR TITLE
fix(build): add Windows executable extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev
 GIT_COMMIT := $(shell git rev-parse HEAD 2> /dev/null)
 GIT_TAG := $(shell git describe --abbrev=0 --tags)
 BUILD_DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-BINARY_NAME = qui
+BINARY_NAME = qui$(if $(filter Windows_NT,$(OS)),.exe)
 BUILD_DIR = build
 WEB_DIR = web
 INTERNAL_WEB_DIR = internal/web


### PR DESCRIPTION
## Description

Make the Makefile append `.exe` to the backend binary name when `OS` is `Windows_NT`, while preserving the existing `qui` name on other platforms. The shared binary variable also keeps `make clean` aligned with the platform-specific output.

## How has this been tested?

- `make precommit`
- `make build`
- Verified Make resolves `qui.exe` on Windows and `qui` with `OS=Linux`.
- Built `qui.exe`, ran its version command, started it with isolated config/data, and received HTTP 200 from the web UI.
- Verified `make clean` removes `qui.exe` on Windows.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] This change does not modify the database schema

## AI disclosure

Yes. OpenAI Codex (GPT-5) wrote the one-line Makefile change and handled validation and PR preparation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows compatibility by generating the correct executable filename.
  * Preserved the existing executable naming on other platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->