### PR TITLE
fix(docker): make the standalone Dockerfile build again

### DIFF
--- a/distrib/docker/Dockerfile
+++ b/distrib/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:22.18-alpine AS frontend-builder
+FROM node:24.15-alpine AS frontend-builder
 
 # Install git for cloning
 RUN apk add --no-cache git
@@ -10,7 +10,7 @@ RUN npm install -g corepack@latest && \
 
 WORKDIR /app/web
 
-COPY web/package.json web/pnpm-lock.yaml ./
+COPY web/package.json web/pnpm-lock.yaml web/pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 
 COPY web ./


### PR DESCRIPTION
## Description

Copies `web/pnpm-workspace.yaml` into the frontend stage of `distrib/docker/Dockerfile`. Since the pnpm 11 migration, this file holds the `overrides` configuration. Without it, `pnpm install --frozen-lockfile` fails with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`. Also bumps the base image from `node:22.18-alpine` to `node:24.15-alpine` to match CI and the `engines` field in `web/package.json`.

Fixes #2415

## How has this been tested?

Ran `docker build -f distrib/docker/Dockerfile .` locally. The build completed through the frontend stage, the Go stage, and the final image.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the frontend build environment to Node.js 24.15 Alpine.
  * Improved dependency installation setup for workspace-based builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->