### PR TITLE
fix(docker): copy pnpm-workspace.yaml into the frontend build

### DIFF
--- a/distrib/docker/Dockerfile
+++ b/distrib/docker/Dockerfile
@@ -10,7 +10,10 @@ RUN npm install -g corepack@latest && \
 
 WORKDIR /app/web
 
-COPY web/package.json web/pnpm-lock.yaml ./
+# pnpm-workspace.yaml carries the overrides that pnpm-lock.yaml records;
+# omitting it makes `pnpm install --frozen-lockfile` fail with
+# ERR_PNPM_LOCKFILE_CONFIG_MISMATCH (see #2415).
+COPY web/package.json web/pnpm-lock.yaml web/pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 
 COPY web ./


### PR DESCRIPTION
`docker build -f distrib/docker/Dockerfile .` fails in the frontend stage:

```
[ERR_PNPM_LOCKFILE_CONFIG_MISMATCH] Cannot proceed with the frozen installation. The current "overrides" configuration doesn't match the value found in the lockfile
```

The stage copied `web/package.json` and `web/pnpm-lock.yaml` but the overrides live in `web/pnpm-workspace.yaml`. Copying the workspace file into the stage makes the frozen install see the same config the lockfile was generated with.

CI/releases are unaffected; they use `ci.Dockerfile` with a prebuilt frontend.

Fixes #2415

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker builds by including the workspace configuration required for consistent dependency installation.
  * Prevented lockfile configuration mismatch errors during container builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->