### PR TITLE
fix(torznab): wait for the test search before reporting ok

### DIFF
--- a/internal/api/handlers/jackett.go
+++ b/internal/api/handlers/jackett.go
@@ -778,7 +778,9 @@ func (h *JackettHandler) TestIndexer(w http.ResponseWriter, r *http.Request) {
 	// itself. The timeout bounds the detached context, and the completion
 	// callback releases it as soon as the search is actually done.
 	testCtx, cancelTest := context.WithTimeout(context.Background(), 30*time.Second) //nolint:gosec // G118: deliberately outlives the request, see above
+	defer cancelTest()
 
+	resultCh := make(chan error, 1)
 	testReq := &jackett.TorznabSearchRequest{
 		Query:            "test",
 		Limit:            1,
@@ -786,16 +788,13 @@ func (h *JackettHandler) TestIndexer(w http.ResponseWriter, r *http.Request) {
 		CacheMode:        jackett.CacheModeBypass,
 		SkipHistory:      true,
 		SkipCachePersist: true,
-		OnAllComplete: func(*jackett.SearchResponse, error) {
-			// Results are irrelevant for a connectivity test; this is only here
-			// to stop holding the detached context once the search finishes.
-			cancelTest()
+		OnAllComplete: func(_ *jackett.SearchResponse, searchErr error) {
+			resultCh <- searchErr
 		},
 	}
 
-	if err = h.service.SearchGeneric(testCtx, testReq); err != nil {
-		cancelTest()
-	}
+	scheduleErr := h.service.SearchGeneric(testCtx, testReq)
+	err = waitForIndexerTestResult(testCtx, scheduleErr, resultCh)
 
 	// Update test status in database
 	if err != nil {
@@ -815,6 +814,22 @@ func (h *JackettHandler) TestIndexer(w http.ResponseWriter, r *http.Request) {
 	}
 
 	RespondJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// waitForIndexerTestResult returns the error from scheduling the search, or
+// the error delivered to OnAllComplete. SearchGeneric is asynchronous: a nil
+// return only means the job was queued, so treating it as success made
+// POST .../test report ok for indexers that then failed (#2388).
+func waitForIndexerTestResult(ctx context.Context, scheduleErr error, result <-chan error) error {
+	if scheduleErr != nil {
+		return scheduleErr
+	}
+	select {
+	case err := <-result:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func (h *JackettHandler) updateTestStatusWithTimeout(id int, status string, errorMsg *string) error {

--- a/internal/api/handlers/jackett_test_status_test.go
+++ b/internal/api/handlers/jackett_test_status_test.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package handlers
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWaitForIndexerTestResultUsesCallbackError(t *testing.T) {
+	ctx := context.Background()
+	ch := make(chan error, 1)
+	ch <- errors.New("connection refused")
+
+	err := waitForIndexerTestResult(ctx, nil, ch)
+	require.EqualError(t, err, "connection refused")
+}
+
+func TestWaitForIndexerTestResultPrefersScheduleError(t *testing.T) {
+	ctx := context.Background()
+	ch := make(chan error, 1)
+	ch <- errors.New("callback")
+
+	err := waitForIndexerTestResult(ctx, errors.New("empty query"), ch)
+	require.EqualError(t, err, "empty query")
+}
+
+func TestWaitForIndexerTestResultSuccess(t *testing.T) {
+	ctx := context.Background()
+	ch := make(chan error, 1)
+	ch <- nil
+
+	require.NoError(t, waitForIndexerTestResult(ctx, nil, ch))
+}
+
+func TestWaitForIndexerTestResultTimeout(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	err := waitForIndexerTestResult(ctx, nil, make(chan error))
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}


### PR DESCRIPTION
`POST /api/torznab/indexers/{id}/test` reported success as soon as `SearchGeneric` queued the job. That call returns nil before the search runs, so an indexer that then failed (connection refused, HTTP 500, error document) still got `last_test_status=ok`, a green badge, and a success toast.

The handler now waits for `OnAllComplete` (or the existing 30s timeout) and records that result. Synchronous schedule errors still fail immediately.

Fixes #2388

## Testing

`go test ./internal/api/handlers -run TestWaitForIndexerTestResult -count=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved indexer connectivity tests to accurately report asynchronous search failures and timeouts.
  * Prevented tests from being marked successful before search completion is confirmed.
* **Tests**
  * Added coverage for callback errors, scheduling failures, successful completion, and timeout handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->