### PR TITLE
docs(agents): stack cross-layer PRs and trim diffs before commit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,8 @@ Frontend-specific rules live in `web/AGENTS.md`. Read that file before editing `
 
 - Keep Superpowers workflow files local and untracked; never add or commit `docs/superpowers/`.
 - Conventional commits: `feat(scope):`, `fix(scope):`, etc.
-- Keep commits focused; split backend/frontend when practical.
+- Keep commits focused; split backend/frontend when practical. If a feature spans schema, backend service, and web UI, stack PRs: schema + models, then service logic, then UI.
+- Before each commit, review the diff for over-engineering. If the ponytail plugin (<https://github.com/DietrichGebert/ponytail>) is installed, use its `ponytail:ponytail-review` skill. If it is not, do a trim pass: remove speculative config, unused states, single-caller layers, and duplicate helpers.
 - Update PR branches by merging develop into them, never rebase/force-push. PRs are squash-merged, so rebase gains nothing and force-pushes break review history and contributors' local branches.
 - Never add AI advertising/attribution/co-author lines.
 - Fill `.github/pull_request_template.md` into the PR body; `gh pr create --body` does not auto-fill it.


### PR DESCRIPTION
## Description

Adds two PR rules to AGENTS.md: stack PRs for features that span schema, service, and UI, and review each diff for over-engineering before commit (ponytail-review when the plugin is installed, a manual trim pass when it is not).

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidance for structuring and reviewing commits and pull requests.
  * Added recommendations to avoid unnecessary configuration, unused states, one-off layers, and duplicate helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->