### PR TITLE
fix(crossseed): don't reuse cached indexer sets across content types

### DIFF
--- a/internal/services/crossseed/async_filtering_content_type_test.go
+++ b/internal/services/crossseed/async_filtering_content_type_test.go
@@ -1,0 +1,210 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package crossseed
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/autobrr/pkg/ttlcache"
+
+	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/pkg/stringutils"
+)
+
+// The search path must not honor a cached filtering run computed for a
+// different content type; category mapping rules can change the type between
+// runs (#2313).
+func TestSearchIgnoresCachedFilteringStateForDifferentContentType(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name              string
+		cachedContentType string
+		wantSearches      bool
+	}{
+		// Stale audiobook run cached an empty indexer set; a movie search must
+		// not reuse it and must query the indexer.
+		{name: "mismatch refilters", cachedContentType: "audiobook", wantSearches: true},
+		// Matching type with the same empty completed set is honored: no queries.
+		{name: "match reuses", cachedContentType: "movie", wantSearches: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			const (
+				instanceID = 1
+				indexerID  = 42
+			)
+			sourceHash := strings.Repeat("a", 40)
+			sourceName := "Example.Movie.2019.1080p.BluRay.x264-GROUP"
+
+			var searchRequests atomic.Int32
+			var server *httptest.Server
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Query().Get("t") == "caps" {
+					w.Header().Set("Content-Type", "application/xml")
+					fmt.Fprint(w, `<caps><searching>
+						<search available="yes" supportedParams="q"/>
+						<movie-search available="yes" supportedParams="q"/>
+					</searching><categories><category id="2000" name="Movies"/></categories></caps>`)
+					return
+				}
+				searchRequests.Add(1)
+				w.Header().Set("Content-Type", "application/rss+xml")
+				fmt.Fprintf(w, `<rss version="2.0"><channel><title>Movie Indexer</title><item>
+					<title>%s</title><guid>content-type-guard</guid><size>1000</size>
+					<enclosure url="%s/candidate.torrent" length="1000" type="application/x-bittorrent" />
+				</item></channel></rss>`, sourceName, server.URL)
+			}))
+			t.Cleanup(server.Close)
+
+			instance := &models.Instance{ID: instanceID, Name: "main"}
+			source := qbt.Torrent{
+				Hash:      sourceHash,
+				Name:      sourceName,
+				Size:      1000,
+				TotalSize: 1000,
+				Progress:  1,
+			}
+			settings := models.DefaultCrossSeedAutomationSettings()
+
+			filterCache := ttlcache.New(ttlcache.Options[string, *AsyncIndexerFilteringState]{})
+			filterCache.Set(asyncFilteringCacheKey(instanceID, sourceHash), &AsyncIndexerFilteringState{
+				CapabilitiesCompleted: true,
+				ContentCompleted:      true,
+				CapabilityIndexers:    []int{},
+				FilteredIndexers:      []int{},
+				contentType:           tc.cachedContentType,
+			}, ttlcache.DefaultTTL)
+
+			service := &Service{
+				instanceStore: &fakeInstanceStore{instances: map[int]*models.Instance{instanceID: instance}},
+				jackettService: newJackettServiceWithIndexers([]*models.TorznabIndexer{
+					{
+						ID:             indexerID,
+						Name:           "Movie Indexer",
+						BaseURL:        server.URL,
+						Backend:        models.TorznabBackendNative,
+						TimeoutSeconds: 5,
+						Enabled:        true,
+					},
+				}),
+				syncManager: newFakeSyncManager(instance, []qbt.Torrent{source}, map[string]qbt.TorrentFiles{
+					sourceHash: {{Name: sourceName + ".mkv", Size: 1000}},
+				}),
+				asyncFilteringCache: filterCache,
+				releaseCache:        NewReleaseCache(),
+				searchResultCache:   ttlcache.New(ttlcache.Options[string, cachedTorrentSearchResults]{}),
+				stringNormalizer:    stringutils.NewDefaultNormalizer(),
+				automationSettingsLoader: func(context.Context) (*models.CrossSeedAutomationSettings, error) {
+					return settings, nil
+				},
+			}
+
+			_, _, _, err := service.searchTorrentMatches(context.Background(), instanceID, sourceHash, TorrentSearchOptions{SkipGazelle: true}, nil)
+			require.NoError(t, err)
+
+			if tc.wantSearches {
+				require.Positive(t, searchRequests.Load(), "stale content type must trigger fresh filtering and a real search")
+			} else {
+				require.Zero(t, searchRequests.Load(), "matching cached run with empty indexer set must skip searching")
+			}
+		})
+	}
+}
+
+// A background worker whose cache entry was replaced by a newer run must not
+// write itself back into the cache when it finishes (#2313).
+func TestFinishedWorkerCannotRestoreReplacedCacheEntry(t *testing.T) {
+	t.Parallel()
+
+	const instanceID = 1
+	hash := strings.Repeat("b", 40)
+	key := asyncFilteringCacheKey(instanceID, hash)
+
+	svc := &Service{
+		asyncFilteringCache: ttlcache.New(ttlcache.Options[string, *AsyncIndexerFilteringState]{}),
+	}
+
+	stateA := &AsyncIndexerFilteringState{
+		CapabilitiesCompleted: true,
+		contentType:           "audiobook",
+	}
+	stateB := &AsyncIndexerFilteringState{
+		CapabilitiesCompleted: true,
+		ContentCompleted:      true,
+		FilteredIndexers:      []int{7},
+		contentType:           "book",
+	}
+	svc.asyncFilteringCache.Set(key, stateB, ttlcache.DefaultTTL)
+
+	// Worker for the replaced run A completes (empty indexer list short-circuits
+	// content filtering, no other service dependencies needed).
+	svc.performAsyncContentFiltering(context.Background(), instanceID, hash, nil, nil, stateA)
+
+	snapshot := stateA.Clone()
+	require.True(t, snapshot.ContentCompleted, "worker must still complete its own state")
+
+	cached, found := svc.asyncFilteringCache.Get(key)
+	require.True(t, found)
+	require.Same(t, stateB, cached, "finished worker must not clobber the newer cache entry")
+}
+
+// AnalyzeTorrentForSearchAsync only reuses a completed cached run for the same
+// content type (#2313).
+func TestAnalyzeAsyncReusesOnlyMatchingContentType(t *testing.T) {
+	t.Parallel()
+
+	const instanceID = 1
+	hash := "deadbeefcafe"
+	movieName := "Example.Movie.2019.1080p.BluRay.x264-GROUP"
+
+	newService := func(cachedType string) (*Service, *AsyncIndexerFilteringState) {
+		instance := &models.Instance{ID: instanceID, Name: "main"}
+		cachedState := &AsyncIndexerFilteringState{
+			CapabilitiesCompleted: true,
+			ContentCompleted:      true,
+			CapabilityIndexers:    []int{7},
+			FilteredIndexers:      []int{7},
+			contentType:           cachedType,
+		}
+		cache := ttlcache.New(ttlcache.Options[string, *AsyncIndexerFilteringState]{})
+		cache.Set(asyncFilteringCacheKey(instanceID, hash), cachedState, ttlcache.DefaultTTL)
+		return &Service{
+			instanceStore: &fakeInstanceStore{instances: map[int]*models.Instance{instanceID: instance}},
+			syncManager: newFakeSyncManager(instance, []qbt.Torrent{{
+				Hash: hash, Name: movieName, Progress: 1, Size: 1000,
+			}}, map[string]qbt.TorrentFiles{
+				hash: {{Name: movieName + ".mkv", Size: 1000}},
+			}),
+			asyncFilteringCache: cache,
+			releaseCache:        NewReleaseCache(),
+			stringNormalizer:    stringutils.NewDefaultNormalizer(),
+		}, cachedState
+	}
+
+	svc, cachedState := newService("movie")
+	result, err := svc.AnalyzeTorrentForSearchAsync(context.Background(), instanceID, hash, true)
+	require.NoError(t, err)
+	require.Same(t, cachedState, result.FilteringState, "matching content type must reuse the cached run")
+	require.Equal(t, []int{7}, result.TorrentInfo.FilteredIndexers)
+	require.True(t, result.TorrentInfo.ContentFilteringCompleted)
+
+	svc, cachedState = newService("audiobook")
+	result, err = svc.AnalyzeTorrentForSearchAsync(context.Background(), instanceID, hash, true)
+	require.NoError(t, err)
+	require.NotSame(t, cachedState, result.FilteringState, "different content type must not reuse the cached run")
+	require.NotEqual(t, []int{7}, result.TorrentInfo.FilteredIndexers)
+}

--- a/internal/services/crossseed/async_filtering_content_type_test.go
+++ b/internal/services/crossseed/async_filtering_content_type_test.go
@@ -207,4 +207,9 @@ func TestAnalyzeAsyncReusesOnlyMatchingContentType(t *testing.T) {
 	require.NoError(t, err)
 	require.NotSame(t, cachedState, result.FilteringState, "different content type must not reuse the cached run")
 	require.NotEqual(t, []int{7}, result.TorrentInfo.FilteredIndexers)
+
+	// no indexers available here (nil jackett)
+	cached, found := svc.asyncFilteringCache.Get(asyncFilteringCacheKey(instanceID, hash))
+	require.True(t, found)
+	require.Same(t, result.FilteringState, cached, "fresh analysis must replace the stale differently typed cache entry")
 }

--- a/internal/services/crossseed/async_filtering_content_type_test.go
+++ b/internal/services/crossseed/async_filtering_content_type_test.go
@@ -5,6 +5,7 @@ package crossseed
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -18,6 +19,7 @@ import (
 	"github.com/autobrr/autobrr/pkg/ttlcache"
 
 	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/services/jackett"
 	"github.com/autobrr/qui/pkg/stringutils"
 )
 
@@ -160,6 +162,56 @@ func TestFinishedWorkerCannotRestoreReplacedCacheEntry(t *testing.T) {
 	cached, found := svc.asyncFilteringCache.Get(key)
 	require.True(t, found)
 	require.Same(t, stateB, cached, "finished worker must not clobber the newer cache entry")
+}
+
+// failingListIndexerStore errors on List, the call AnalyzeTorrentForSearchAsync
+// uses for indexer discovery.
+type failingListIndexerStore struct {
+	failingEnabledIndexerStore
+}
+
+func (s *failingListIndexerStore) List(context.Context) ([]*models.TorznabIndexer, error) {
+	return nil, s.err
+}
+
+// A failed indexer lookup must not be cached: it would complete as an empty
+// run and suppress searches for the whole TTL.
+func TestAnalyzeAsyncDoesNotCacheFailedIndexerDiscovery(t *testing.T) {
+	t.Parallel()
+
+	const instanceID = 1
+	hash := "deadbeefcafe"
+	movieName := "Example.Movie.2019.1080p.BluRay.x264-GROUP"
+	instance := &models.Instance{ID: instanceID, Name: "main"}
+
+	staleState := &AsyncIndexerFilteringState{
+		CapabilitiesCompleted: true,
+		ContentCompleted:      true,
+		FilteredIndexers:      []int{7},
+		contentType:           "audiobook",
+	}
+	cache := ttlcache.New(ttlcache.Options[string, *AsyncIndexerFilteringState]{})
+	cache.Set(asyncFilteringCacheKey(instanceID, hash), staleState, ttlcache.DefaultTTL)
+
+	svc := &Service{
+		instanceStore:  &fakeInstanceStore{instances: map[int]*models.Instance{instanceID: instance}},
+		jackettService: jackett.NewService(&failingListIndexerStore{failingEnabledIndexerStore{err: errors.New("temporarily unreachable")}}),
+		syncManager: newFakeSyncManager(instance, []qbt.Torrent{{
+			Hash: hash, Name: movieName, Progress: 1, Size: 1000,
+		}}, map[string]qbt.TorrentFiles{
+			hash: {{Name: movieName + ".mkv", Size: 1000}},
+		}),
+		asyncFilteringCache: cache,
+		releaseCache:        NewReleaseCache(),
+		stringNormalizer:    stringutils.NewDefaultNormalizer(),
+	}
+
+	result, err := svc.AnalyzeTorrentForSearchAsync(context.Background(), instanceID, hash, true)
+	require.NoError(t, err)
+
+	cached, found := svc.asyncFilteringCache.Get(asyncFilteringCacheKey(instanceID, hash))
+	require.True(t, found)
+	require.NotSame(t, result.FilteringState, cached, "failed discovery run must not enter the cache")
 }
 
 // AnalyzeTorrentForSearchAsync only reuses a completed cached run for the same

--- a/internal/services/crossseed/models.go
+++ b/internal/services/crossseed/models.go
@@ -377,6 +377,12 @@ type AsyncIndexerFilteringState struct {
 	ContentMatches        []string       `json:"content_matches,omitempty"`
 	Error                 string         `json:"error,omitempty"`
 
+	// contentType records which content type this filtering run was computed
+	// for; category mapping rules can change a torrent's type at runtime, so
+	// readers must not reuse a run computed for a different type (#2313).
+	// Unexported to stay out of the /async-status API payload.
+	contentType string
+
 	rejectedContentCandidates map[string]contentPrefilterRejectedTorrent
 }
 
@@ -389,6 +395,7 @@ func (s *AsyncIndexerFilteringState) cloneLocked() *AsyncIndexerFilteringState {
 		CapabilitiesCompleted: s.CapabilitiesCompleted,
 		ContentCompleted:      s.ContentCompleted,
 		Error:                 s.Error,
+		contentType:           s.contentType,
 	}
 	if len(s.CapabilityIndexers) > 0 {
 		clone.CapabilityIndexers = append([]int(nil), s.CapabilityIndexers...)

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -7512,10 +7512,12 @@ func (s *Service) AnalyzeTorrentForSearchAsync(ctx context.Context, instanceID i
 
 	// Get all available indexers first
 	var allIndexers []int
+	indexerDiscoveryFailed := false
 	if s.jackettService != nil {
 		indexersResponse, err := s.jackettService.GetIndexers(ctx)
 		if err != nil {
 			log.Warn().Err(err).Msg("Failed to get indexers during async analysis")
+			indexerDiscoveryFailed = true
 		} else {
 			for _, indexer := range indexersResponse.Indexers {
 				if indexer.Configured {
@@ -7585,12 +7587,10 @@ func (s *Service) AnalyzeTorrentForSearchAsync(ctx context.Context, instanceID i
 		FilteringState: filteringState,
 	}
 
-	// Cache the live state before any indexer lookups: even when no indexers
-	// are available, the correctly typed state must replace a stale entry left
-	// by a previous content type (#2313). Capability-only runs
-	// (enableContentFiltering=false) skip the cache: their local state gets
-	// marked completed below without content filtering having run.
-	if s.asyncFilteringCache != nil && enableContentFiltering {
+	// Publish the correctly typed state so it replaces a stale entry (#2313).
+	// Skipped when discovery failed (it would cache an empty run) or when
+	// content filtering is off (the state completes below without filtering).
+	if s.asyncFilteringCache != nil && enableContentFiltering && !indexerDiscoveryFailed {
 		s.asyncFilteringCache.Set(asyncFilteringCacheKey(instanceID, hash), filteringState, ttlcache.DefaultTTL)
 	}
 
@@ -7709,6 +7709,7 @@ func (s *Service) performAsyncContentFiltering(ctx context.Context, instanceID i
 
 	// No cache write here: the cache already holds this state (or a newer run's
 	// state that replaced it, which a finished worker must not clobber, #2313).
+	// An entry that expired mid-run stays gone; the next request refilters.
 
 	log.Debug().
 		Str("torrentHash", hash).

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -7585,6 +7585,15 @@ func (s *Service) AnalyzeTorrentForSearchAsync(ctx context.Context, instanceID i
 		FilteringState: filteringState,
 	}
 
+	// Cache the live state before any indexer lookups: even when no indexers
+	// are available, the correctly typed state must replace a stale entry left
+	// by a previous content type (#2313). Capability-only runs
+	// (enableContentFiltering=false) skip the cache: their local state gets
+	// marked completed below without content filtering having run.
+	if s.asyncFilteringCache != nil && enableContentFiltering {
+		s.asyncFilteringCache.Set(asyncFilteringCacheKey(instanceID, hash), filteringState, ttlcache.DefaultTTL)
+	}
+
 	log.Trace().
 		Str("torrentHash", hash).
 		Int("instanceID", instanceID).
@@ -7605,16 +7614,6 @@ func (s *Service) AnalyzeTorrentForSearchAsync(ctx context.Context, instanceID i
 		filteringState.CapabilitiesCompleted = true
 		filteringState.Unlock()
 		torrentInfo.AvailableIndexers = capabilityIndexers
-
-		// Cache the live state: the background worker mutates it under its
-		// lock, so the slot always shows current progress, and a worker whose
-		// entry was replaced keeps mutating its own detached state without
-		// being able to write itself back into the cache (#2313). Capability-only
-		// runs (enableContentFiltering=false) skip the cache: their local state
-		// gets marked completed below without content filtering having run.
-		if s.asyncFilteringCache != nil && enableContentFiltering {
-			s.asyncFilteringCache.Set(asyncFilteringCacheKey(instanceID, hash), filteringState, ttlcache.DefaultTTL)
-		}
 
 		log.Trace().
 			Str("torrentHash", hash).

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -562,7 +562,10 @@ func NewService(
 		SetDefaultTTL(searchResultCacheTTL))
 
 	asyncFilteringCache := ttlcache.New(ttlcache.Options[string, *AsyncIndexerFilteringState]{}.
-		SetDefaultTTL(searchResultCacheTTL)) // Use same TTL as search results
+		SetDefaultTTL(searchResultCacheTTL). // Use same TTL as search results
+		// The cache holds live state pointers; the TTL-refresh write-back on Get
+		// could restore a replaced entry (autobrr#2637), so disable it.
+		DisableUpdateTime(true))
 	indexerDomainCache := ttlcache.New(ttlcache.Options[string, string]{}.
 		SetDefaultTTL(indexerDomainCacheTTL))
 	contentFilesCache := ttlcache.New(ttlcache.Options[string, qbt.TorrentFiles]{}.
@@ -3042,7 +3045,7 @@ func (s *Service) executeCompletionSearch(ctx context.Context, instanceID int, t
 				}
 				requestedIndexerIDs = resolvedRequested
 
-				asyncAnalysis, err := s.filterIndexerIDsForTorrentAsync(ctx, instanceID, torrent.Hash, requestedIndexerIDs, true)
+				asyncAnalysis, err := s.AnalyzeTorrentForSearchAsync(ctx, instanceID, torrent.Hash, true)
 				var allowedIndexerIDs []int
 				var skipReason string
 				if err != nil {
@@ -7541,12 +7544,40 @@ func (s *Service) AnalyzeTorrentForSearchAsync(ctx context.Context, instanceID i
 		DiscMarker:       discMarker,
 	}
 
+	// Reuse a completed filtering run only when it was computed for the same
+	// content type; category mapping rules can change the type at runtime (#2313).
+	if s.asyncFilteringCache != nil {
+		cacheKey := asyncFilteringCacheKey(instanceID, hash)
+		if existing, found := s.asyncFilteringCache.Get(cacheKey); found {
+			if snapshot := existing.Clone(); snapshot != nil && snapshot.ContentCompleted && snapshot.contentType == contentInfo.ContentType {
+				torrentInfo.AvailableIndexers = snapshot.CapabilityIndexers
+				torrentInfo.FilteredIndexers = snapshot.FilteredIndexers
+				torrentInfo.ExcludedIndexers = snapshot.ExcludedIndexers
+				torrentInfo.ContentMatches = snapshot.ContentMatches
+				torrentInfo.ContentFilteringCompleted = true
+
+				log.Debug().
+					Str("torrentHash", hash).
+					Int("instanceID", instanceID).
+					Str("contentType", contentInfo.ContentType).
+					Int("filteredIndexersCount", len(snapshot.FilteredIndexers)).
+					Msg("[CROSSSEED-ASYNC] Reusing completed filtering state for matching content type")
+
+				return &AsyncTorrentAnalysis{
+					TorrentInfo:    torrentInfo,
+					FilteringState: existing,
+				}, nil
+			}
+		}
+	}
+
 	// Initialize filtering state
 	filteringState := &AsyncIndexerFilteringState{
 		CapabilitiesCompleted: false,
 		ContentCompleted:      false,
 		ExcludedIndexers:      make(map[int]string),
 		ContentMatches:        make([]string, 0),
+		contentType:           contentInfo.ContentType,
 	}
 
 	result := &AsyncTorrentAnalysis{
@@ -7575,35 +7606,14 @@ func (s *Service) AnalyzeTorrentForSearchAsync(ctx context.Context, instanceID i
 		filteringState.Unlock()
 		torrentInfo.AvailableIndexers = capabilityIndexers
 
-		if s.asyncFilteringCache != nil {
-			cacheKey := asyncFilteringCacheKey(instanceID, hash)
-			skipCacheStore := false
-
-			if existing, found := s.asyncFilteringCache.Get(cacheKey); found {
-				existingSnapshot := existing.Clone()
-				if existingSnapshot != nil && existingSnapshot.ContentCompleted {
-					log.Trace().
-						Str("torrentHash", hash).
-						Int("instanceID", instanceID).
-						Str("cacheKey", cacheKey).
-						Bool("existingContentCompleted", existingSnapshot.ContentCompleted).
-						Int("existingFilteredCount", len(existingSnapshot.FilteredIndexers)).
-						Msg("[CROSSSEED-ASYNC] Skipping initial cache storage - content filtering already completed")
-					skipCacheStore = true
-				}
-			}
-
-			if !skipCacheStore {
-				cachedState := &AsyncIndexerFilteringState{
-					CapabilitiesCompleted: true,
-					ContentCompleted:      false,
-					CapabilityIndexers:    append([]int(nil), capabilityIndexers...),
-					FilteredIndexers:      append([]int(nil), capabilityIndexers...),
-					ExcludedIndexers:      make(map[int]string),
-					ContentMatches:        make([]string, 0),
-				}
-				s.asyncFilteringCache.Set(cacheKey, cachedState, ttlcache.DefaultTTL)
-			}
+		// Cache the live state: the background worker mutates it under its
+		// lock, so the slot always shows current progress, and a worker whose
+		// entry was replaced keeps mutating its own detached state without
+		// being able to write itself back into the cache (#2313). Capability-only
+		// runs (enableContentFiltering=false) skip the cache: their local state
+		// gets marked completed below without content filtering having run.
+		if s.asyncFilteringCache != nil && enableContentFiltering {
+			s.asyncFilteringCache.Set(asyncFilteringCacheKey(instanceID, hash), filteringState, ttlcache.DefaultTTL)
 		}
 
 		log.Trace().
@@ -7698,16 +7708,8 @@ func (s *Service) performAsyncContentFiltering(ctx context.Context, instanceID i
 		Bool("contentCompleted", snapshot.ContentCompleted).
 		Msg("[CROSSSEED-ASYNC] Content filtering completed successfully")
 
-	// Store the completed state in cache for UI polling
-	if s.asyncFilteringCache != nil {
-		cacheKey := asyncFilteringCacheKey(instanceID, hash)
-		cachedState := snapshot.Clone()
-		if cachedState == nil {
-			cachedState = &AsyncIndexerFilteringState{}
-		}
-
-		s.asyncFilteringCache.Set(cacheKey, cachedState, ttlcache.DefaultTTL)
-	}
+	// No cache write here: the cache already holds this state (or a newer run's
+	// state that replaced it, which a finished worker must not clobber, #2313).
 
 	log.Debug().
 		Str("torrentHash", hash).
@@ -7723,63 +7725,27 @@ func (s *Service) performAsyncContentFiltering(ctx context.Context, instanceID i
 // without actually performing the search. This method now uses async filtering with immediate capability
 // results and optional content filtering for better performance.
 func (s *Service) AnalyzeTorrentForSearch(ctx context.Context, instanceID int, hash string) (*TorrentInfo, error) {
-	// Check if we have cached async state with completed content filtering
-	if s.asyncFilteringCache != nil {
-		cacheKey := asyncFilteringCacheKey(instanceID, hash)
-		if cached, found := s.asyncFilteringCache.Get(cacheKey); found {
-			cachedSnapshot := cached.Clone()
-			if cachedSnapshot != nil && cachedSnapshot.ContentCompleted {
-				// We have completed filtering results, use those instead of running new analysis
-				asyncResult, err := s.AnalyzeTorrentForSearchAsync(ctx, instanceID, hash, false) // Don't restart content filtering
-				if err != nil {
-					// Fall back to cached state if torrent analysis fails
-					log.Warn().Err(err).Msg("Failed to get torrent info, using cached filtering state only")
-					return &TorrentInfo{
-						AvailableIndexers:         cachedSnapshot.CapabilityIndexers,
-						FilteredIndexers:          cachedSnapshot.FilteredIndexers,
-						ExcludedIndexers:          cachedSnapshot.ExcludedIndexers,
-						ContentMatches:            cachedSnapshot.ContentMatches,
-						ContentFilteringCompleted: cachedSnapshot.ContentCompleted,
-					}, nil
-				}
-
-				torrentInfo := asyncResult.TorrentInfo
-				// Use the completed filtering results from cache
-				torrentInfo.AvailableIndexers = cachedSnapshot.CapabilityIndexers
-				torrentInfo.FilteredIndexers = cachedSnapshot.FilteredIndexers
-				torrentInfo.ExcludedIndexers = cachedSnapshot.ExcludedIndexers
-				torrentInfo.ContentMatches = cachedSnapshot.ContentMatches
-				torrentInfo.ContentFilteringCompleted = cachedSnapshot.ContentCompleted
-
-				log.Debug().
-					Str("torrentHash", hash).
-					Int("instanceID", instanceID).
-					Bool("contentCompleted", cachedSnapshot.ContentCompleted).
-					Int("filteredIndexersCount", len(cachedSnapshot.FilteredIndexers)).
-					Msg("[CROSSSEED-ANALYZE] Using cached content filtering results")
-
-				return torrentInfo, nil
-			}
-		}
-	}
-
-	// Use the async version with content filtering enabled
+	// The async analysis reuses a completed same-content-type filtering run from
+	// cache or starts a fresh one; that post-detection decision lives there (#2313).
 	asyncResult, err := s.AnalyzeTorrentForSearchAsync(ctx, instanceID, hash, true)
 	if err != nil {
 		return nil, err
 	}
 
-	// Return immediate results with capability filtering
-	// Content filtering will continue in background but we don't wait for it
 	torrentInfo := asyncResult.TorrentInfo
 
-	// Use capability-filtered indexers as the primary result
 	stateSnapshot := asyncResult.FilteringState.Clone()
 	if stateSnapshot != nil && stateSnapshot.CapabilitiesCompleted {
 		torrentInfo.AvailableIndexers = stateSnapshot.CapabilityIndexers
-		// For immediate response, use capability indexers as filtered indexers
-		// The UI can poll for refined results if needed
-		torrentInfo.FilteredIndexers = stateSnapshot.CapabilityIndexers
+		if stateSnapshot.ContentCompleted {
+			torrentInfo.FilteredIndexers = stateSnapshot.FilteredIndexers
+			torrentInfo.ExcludedIndexers = stateSnapshot.ExcludedIndexers
+			torrentInfo.ContentMatches = stateSnapshot.ContentMatches
+		} else {
+			// Content filtering still running in background; return capability
+			// results now, the UI can poll for refined results.
+			torrentInfo.FilteredIndexers = stateSnapshot.CapabilityIndexers
+		}
 		torrentInfo.ContentFilteringCompleted = stateSnapshot.ContentCompleted
 
 		log.Debug().
@@ -7787,8 +7753,8 @@ func (s *Service) AnalyzeTorrentForSearch(ctx context.Context, instanceID int, h
 			Int("instanceID", instanceID).
 			Bool("capabilitiesCompleted", stateSnapshot.CapabilitiesCompleted).
 			Bool("contentCompleted", stateSnapshot.ContentCompleted).
-			Int("capabilityIndexersCount", len(stateSnapshot.CapabilityIndexers)).
-			Msg("[CROSSSEED-ANALYZE] Returning immediate capability-filtered results")
+			Int("filteredIndexersCount", len(torrentInfo.FilteredIndexers)).
+			Msg("[CROSSSEED-ANALYZE] Returning filtering results")
 	} else {
 		log.Warn().
 			Str("torrentHash", hash).
@@ -8838,10 +8804,20 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 	filteringResolved := false
 	cacheKey := asyncFilteringCacheKey(instanceID, hash)
 
-	// Check for cached content-filtered results first
+	// Check for cached content-filtered results first; a cached run only counts
+	// when it was computed for the current content type (#2313).
 	if s.asyncFilteringCache != nil {
 		if cached, found := s.asyncFilteringCache.Get(cacheKey); found {
 			cachedSnapshot := cached.Clone()
+			if cachedSnapshot != nil && cachedSnapshot.contentType != contentInfo.ContentType {
+				log.Debug().
+					Str("torrentHash", hash).
+					Int("instanceID", instanceID).
+					Str("cachedContentType", cachedSnapshot.contentType).
+					Str("currentContentType", contentInfo.ContentType).
+					Msg("[CROSSSEED-SEARCH] Ignoring cached filtering state for different content type")
+				cachedSnapshot = nil
+			}
 			if cachedSnapshot != nil {
 				log.Debug().
 					Str("torrentHash", hash).
@@ -8894,14 +8870,18 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 			Int("instanceID", instanceID).
 			Msg("[CROSSSEED-SEARCH] Performing new filtering")
 
-		asyncAnalysis, err := s.filterIndexerIDsForTorrentAsync(ctx, instanceID, hash, opts.IndexerIDs, true)
+		asyncAnalysis, err := s.AnalyzeTorrentForSearchAsync(ctx, instanceID, hash, true)
 		if err != nil {
 			log.Warn().Err(err).Msg("Failed to perform async indexer filtering for torrent search, using original list")
 			filteredIndexerIDs = opts.IndexerIDs
 		} else {
 			// Use capability-filtered indexers immediately for search
 			if stateSnapshot := asyncAnalysis.FilteringState.Clone(); stateSnapshot != nil && stateSnapshot.CapabilitiesCompleted {
-				filteredIndexerIDs = append([]int(nil), stateSnapshot.CapabilityIndexers...)
+				if stateSnapshot.ContentCompleted {
+					filteredIndexerIDs = append([]int(nil), stateSnapshot.FilteredIndexers...)
+				} else {
+					filteredIndexerIDs = append([]int(nil), stateSnapshot.CapabilityIndexers...)
+				}
 				sourceInfo = *asyncAnalysis.TorrentInfo
 
 				log.Debug().
@@ -11281,7 +11261,7 @@ func (s *Service) processSearchCandidate(ctx context.Context, state *searchRunSt
 	skipReasonForNoIndexers := ""
 	if !searchDisableTorznab && len(requestedIndexerIDs) > 0 {
 		// Use async filtering for better performance - capability filtering returns immediately.
-		asyncAnalysis, err := s.filterIndexerIDsForTorrentAsync(ctx, state.opts.InstanceID, torrent.Hash, requestedIndexerIDs, true)
+		asyncAnalysis, err := s.AnalyzeTorrentForSearchAsync(ctx, state.opts.InstanceID, torrent.Hash, true)
 		if err != nil {
 			s.searchMu.Lock()
 			state.run.TorrentsFailed++
@@ -11919,81 +11899,6 @@ func extractFailureMessage(results []InstanceCrossSeedResult, indexer string) st
 	return fallback
 }
 
-// filterIndexerIDsForTorrentAsync performs indexer filtering with async content filtering support.
-// This allows immediate return of capability-filtered results while content filtering continues in background.
-func (s *Service) filterIndexerIDsForTorrentAsync(ctx context.Context, instanceID int, hash string, requested []int, enableContentFiltering bool) (*AsyncTorrentAnalysis, error) {
-	cacheKey := asyncFilteringCacheKey(instanceID, hash)
-
-	// Check if we already have completed content filtering to avoid overwriting
-	if s.asyncFilteringCache != nil {
-		if existing, found := s.asyncFilteringCache.Get(cacheKey); found {
-			existingSnapshot := existing.Clone()
-			if existingSnapshot != nil && existingSnapshot.ContentCompleted {
-				log.Debug().
-					Str("torrentHash", hash).
-					Int("instanceID", instanceID).
-					Str("cacheKey", cacheKey).
-					Bool("existingContentCompleted", existingSnapshot.ContentCompleted).
-					Int("existingFilteredCount", len(existingSnapshot.FilteredIndexers)).
-					Msg("[crossseed-async] Reusing completed content-filtering cache entry")
-
-				var torrentInfo *TorrentInfo
-				asyncAnalysis, err := s.AnalyzeTorrentForSearchAsync(ctx, instanceID, hash, false)
-				if err != nil {
-					log.Warn().
-						Err(err).
-						Str("torrentHash", hash).
-						Int("instanceID", instanceID).
-						Msg("[CROSSSEED-ASYNC] Failed to rebuild torrent info from cache, falling back to minimal info")
-					torrentInfo = &TorrentInfo{
-						InstanceID: instanceID,
-						Hash:       hash,
-					}
-				} else if asyncAnalysis != nil && asyncAnalysis.TorrentInfo != nil {
-					torrentInfo = asyncAnalysis.TorrentInfo
-				}
-
-				if torrentInfo != nil {
-					// Ensure runtime fields reflect the cached completed state
-					torrentInfo.AvailableIndexers = append([]int(nil), existingSnapshot.CapabilityIndexers...)
-					torrentInfo.FilteredIndexers = append([]int(nil), existingSnapshot.FilteredIndexers...)
-					if len(existingSnapshot.ExcludedIndexers) > 0 {
-						torrentInfo.ExcludedIndexers = make(map[int]string, len(existingSnapshot.ExcludedIndexers))
-						maps.Copy(torrentInfo.ExcludedIndexers, existingSnapshot.ExcludedIndexers)
-					} else {
-						torrentInfo.ExcludedIndexers = nil
-					}
-					torrentInfo.ContentMatches = append([]string(nil), existingSnapshot.ContentMatches...)
-					torrentInfo.ContentFilteringCompleted = existingSnapshot.ContentCompleted
-				} else {
-					// Absolute fallback so callers never see a nil TorrentInfo
-					torrentInfo = &TorrentInfo{
-						InstanceID: instanceID,
-						Hash:       hash,
-					}
-				}
-
-				// Return existing completed state instead of creating new filtering
-				return &AsyncTorrentAnalysis{
-					FilteringState: existingSnapshot,
-					TorrentInfo:    torrentInfo,
-				}, nil
-			}
-		}
-	}
-
-	log.Trace().
-		Str("torrentHash", hash).
-		Int("instanceID", instanceID).
-		Str("cacheKey", cacheKey).
-		Bool("enableContentFiltering", enableContentFiltering).
-		Ints("requestedIndexers", requested).
-		Msg("[CROSSSEED-ASYNC] Starting new async filtering (may overwrite existing cache)")
-
-	// Use the async analysis method
-	return s.AnalyzeTorrentForSearchAsync(ctx, instanceID, hash, enableContentFiltering)
-}
-
 // GetAsyncFilteringStatus returns the current status of async filtering for a torrent.
 // This can be used by the UI to poll for updates after capability filtering is complete.
 func (s *Service) GetAsyncFilteringStatus(ctx context.Context, instanceID int, hash string) (*AsyncIndexerFilteringState, error) {
@@ -12028,16 +11933,17 @@ func (s *Service) GetAsyncFilteringStatus(ctx context.Context, instanceID int, h
 		return nil, err
 	}
 
-	if snapshot := asyncResult.FilteringState.Clone(); snapshot != nil {
-		log.Trace().
-			Str("torrentHash", hash).
-			Int("instanceID", instanceID).
-			Bool("capabilitiesCompleted", snapshot.CapabilitiesCompleted).
-			Bool("contentCompleted", snapshot.ContentCompleted).
-			Msg("[CROSSSEED-ASYNC] Generated new filtering status (no cache)")
-	}
+	// Return a snapshot: the live state is shared with the background worker
+	// (and the cache), and the handler marshals the result to JSON.
+	snapshot := asyncResult.FilteringState.Clone()
+	log.Trace().
+		Str("torrentHash", hash).
+		Int("instanceID", instanceID).
+		Bool("capabilitiesCompleted", snapshot.CapabilitiesCompleted).
+		Bool("contentCompleted", snapshot.ContentCompleted).
+		Msg("[CROSSSEED-ASYNC] Generated new filtering status (no cache)")
 
-	return asyncResult.FilteringState, nil
+	return snapshot, nil
 }
 
 // filterIndexersByExistingContent removes indexers for which we already have matching content


### PR DESCRIPTION
## Description

The async indexer filtering cache is keyed by instance and hash. However, the cached indexer set depends on the detected content type, which category mapping rules (#2306) and qBittorrent recategorization can change at runtime. Searches following such a change reused the previous content type's indexer set until the 5 minute TTL expired.

The filtering state now includes its content type, and both post-detection readers treat a mismatch as a cache miss. The cache also stores the live state pointer instead of copies: the worker no longer writes to the cache on completion, preventing a replaced run's worker from overwriting a newer entry. The Get-side TTL refresh is disabled because its non-atomic write-back can restore a replaced entry (autobrr/autobrr#2637). Finally, the `filterIndexerIDsForTorrentAsync` wrapper and the pre-detection cache lookups it existed for are removed.

Fixes #2313

## How has this been tested?

Field tested on a live instance with the `pr-2420` image: searched an ebook torrent (cached as `book`), flipped its category mapping rule to `audiobook`, and searched again within the TTL. The log showed the cached state being ignored for the different content type, and a fresh filtering run replaced it. The reverse flip fired the guard again, and no panics or races appeared in the logs.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL
