### PR TITLE
feat(mobile): add torrent export to actions sheet

### DIFF
--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -43,6 +43,7 @@ import { useDebounce } from "@/hooks/useDebounce"
 import { useDelayedVisibility } from "@/hooks/useDelayedVisibility"
 import { useInstances } from "@/hooks/useInstances"
 import { TORRENT_ACTIONS, useTorrentActions, type TorrentAction } from "@/hooks/useTorrentActions"
+import { useTorrentExporter } from "@/hooks/useTorrentExporter"
 import { useTorrentsList } from "@/hooks/useTorrentsList"
 import { useTrackerCustomizations } from "@/hooks/useTrackerCustomizations"
 import { useTrackerIcons } from "@/hooks/useTrackerIcons"
@@ -64,6 +65,7 @@ import {
   ChevronDown,
   ChevronUp,
   Clock,
+  Download,
   Eye,
   EyeOff,
   FastForward,
@@ -1388,6 +1390,7 @@ export function TorrentCardsMobile({
   })
 
   const { data: capabilities } = useInstanceCapabilities(instanceId, { enabled: instanceId > 0 })
+  const { exportTorrents, isExporting } = useTorrentExporter({ instanceId, incognitoMode })
   const supportsTrackerHealth = resolveTrackerHealthSupport({
     isUnifiedView: isAllInstancesView,
     capabilitySupport: capabilities?.supportsTrackerHealth,
@@ -2001,6 +2004,23 @@ export function TorrentCardsMobile({
     }
   }, [torrents, isAllSelected, excludedFromSelectAll, getSelectionIdentity, selectedTorrentsForRequest])
 
+  const handleExport = () => {
+    exportTorrents({
+      hashes: isAllSelected ? [] : selectedRequestHashes,
+      torrents: getSelectedTorrents,
+      isAllSelected,
+      totalSelected: effectiveSelectionCount,
+      filters,
+      search: effectiveSearch,
+      excludeHashes: excludeHashesForRequest,
+      excludeTargets: isAllSelected && isAllInstancesView ? buildTorrentActionTargets(excludedTorrents, instanceId) : undefined,
+      instanceIds: isAllInstancesView ? instanceIds : undefined,
+      sortField: backendSortField,
+      sortOrder,
+    })
+    setShowActionsSheet(false)
+  }
+
   const { isFilteringCrossSeeds, filterCrossSeeds } = useCrossSeedFilter({
     instanceId,
     onFilterChange,
@@ -2543,6 +2563,17 @@ export function TorrentCardsMobile({
               <FolderOpen className="mr-2 h-4 w-4" />
               {t("managementBar.setLocation")}
             </Button>
+            {(capabilities?.supportsTorrentExport ?? true) && (
+              <Button
+                variant="outline"
+                onClick={handleExport}
+                disabled={isExporting}
+                className="justify-start"
+              >
+                <Download className="mr-2 h-4 w-4" />
+                {effectiveSelectionCount > 1 ? t("contextMenu.exportTorrents", { count: effectiveSelectionCount }) : t("contextMenu.exportTorrent")}
+              </Button>
+            )}
             <Button
               variant="destructive"
               onClick={() => {


### PR DESCRIPTION
## Description

Adds an Export Torrent button to the mobile selection "More" sheet, reusing the existing export hook, so .torrent files can be exported from the mobile UI (reported on Discord).

## How has this been tested?

Live on a real instance (5950 torrents) in a phone viewport: long-press select → More → Export downloads the .torrent; multi-select and >10 select (zip archive path) verified working.

## Screenshots (for UI changes)

None captured without real torrent names in frame; the button matches the existing sheet buttons (Set Location style). Can add a synthetic-library shot if wanted.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added torrent export support to mobile torrent cards.
  * Export actions now respect current selections, filters, sorting, exclusions, and instance scope.
  * The export option appears only when supported by the current instance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->