### PR TITLE
docs: explain when to pick postgres over sqlite

### DIFF
--- a/documentation/docs/configuration/environment.md
+++ b/documentation/docs/configuration/environment.md
@@ -84,7 +84,7 @@ QUI__DATABASE_CONN_MAX_LIFETIME=300    # Max connection lifetime in seconds
 
 ### SQLite or Postgres
 
-Both engines run the same features. A switch gives no performance benefit for most installs: qui runs SQLite in WAL mode with a separate read pool, so reads perform like Postgres. Pick Postgres to put the database on a different host, or when SQLite's one-write-at-a-time limit shows (many instances with heavy automation or cross-seed activity). The migration runs one way, with no way back: see [`qui db migrate`](./cli-commands.md).
+Both engines run the same features. For most installs, a switch gives no performance benefit: qui runs SQLite in WAL mode with a separate read pool, so reads do not block on writes. Pick Postgres to put the database on a different host, or when SQLite's one-write-at-a-time limit shows (many instances with heavy automation or cross-seed activity). The migration runs one way, with no way back: see [`qui db migrate`](./cli-commands.md).
 
 ## Cross-Seed
 

--- a/documentation/docs/configuration/environment.md
+++ b/documentation/docs/configuration/environment.md
@@ -82,6 +82,10 @@ QUI__DATABASE_MAX_IDLE_CONNS=5         # Postgres pool max idle connections
 QUI__DATABASE_CONN_MAX_LIFETIME=300    # Max connection lifetime in seconds
 ```
 
+### SQLite or Postgres
+
+Both engines run the same features. A switch gives no performance benefit for most installs: qui runs SQLite in WAL mode with a separate read pool, so reads perform like Postgres. Pick Postgres to put the database on a different host, or when SQLite's one-write-at-a-time limit shows (many instances with heavy automation or cross-seed activity). The migration runs one way, with no way back: see [`qui db migrate`](./cli-commands.md).
+
 ## Cross-Seed
 
 ```bash


### PR DESCRIPTION
## Description

Adds a short "SQLite or Postgres" section to the environment configuration page, so users can decide which engine to pick. The docs list the Postgres settings but never say when to use them, and the question comes up in Discord.

The facts match the code: both engines run the same features, reads perform the same (WAL mode plus a separate read pool for SQLite), writes are serialized on SQLite only, and the migration is one way.

## How has this been tested?

Docs-only change. CI covers the docs build.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] I have read [CONTRIBUTING.md](https://github.com/autobrr/qui/blob/develop/.github/CONTRIBUTING.md)
- [ ] I ran `make precommit` and the tests pass locally
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that SQLite reads do not block when writes are in progress.
  * Updated the SQLite and Postgres comparison to accurately describe read behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->