### PR TITLE
fix(mobile): make Back close torrent details instead of leaving the page

### DIFF
--- a/web/src/pages/Torrents.tsx
+++ b/web/src/pages/Torrents.tsx
@@ -33,12 +33,19 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useDefaultLayout, usePanelRef } from "react-resizable-panels"
 
+export interface TorrentsSearch {
+  modal?: "add-torrent" | "create-torrent" | "tasks"
+  torrent?: string
+  tab?: string
+  instance?: number
+}
+
 interface TorrentsProps {
   instanceId: number
   instanceName: string
   isAllInstancesView?: boolean
-  search: { modal?: "add-torrent" | "create-torrent" | "tasks" | undefined; torrent?: string; tab?: string }
-  onSearchChange: (search: { modal?: "add-torrent" | "create-torrent" | "tasks" | undefined; torrent?: string; tab?: string }) => void
+  search: TorrentsSearch
+  onSearchChange: (search: TorrentsSearch) => void
 }
 
 export function Torrents({ instanceId, instanceName, isAllInstancesView = false, search, onSearchChange }: TorrentsProps) {
@@ -95,14 +102,6 @@ export function Torrents({ instanceId, instanceName, isAllInstancesView = false,
   // sheet whose history entry it owns.
   const urlTorrentRef = useRef<string | undefined>(undefined)
 
-  // Push a history entry for the sheet so mobile Back closes it instead of
-  // leaving the page
-  const pushMobileDetailsEntry = useCallback((torrent: Torrent, initialTab?: string) => {
-    navigate({
-      to: ".",
-      search: (prev) => ({ ...prev, torrent: torrent.hash, tab: initialTab }),
-    })
-  }, [navigate])
   const getTorrentInstanceId = useCallback((torrent: Torrent | null | undefined) => {
     if (!torrent) {
       return instanceId
@@ -117,13 +116,32 @@ export function Torrents({ instanceId, instanceName, isAllInstancesView = false,
   }, [instanceId])
   const selectedTorrentInstanceId = getTorrentInstanceId(selectedTorrent)
 
+  // Push a history entry for the sheet so mobile Back closes it instead of
+  // leaving the page. The unified view also records the owning instance, since
+  // the same hash can exist on several instances.
+  const pushMobileDetailsEntry = useCallback((torrent: Torrent, initialTab?: string) => {
+    navigate({
+      to: ".",
+      search: (prev) => ({
+        ...prev,
+        torrent: torrent.hash,
+        tab: initialTab,
+        instance: isAllInstances ? getTorrentInstanceId(torrent) : undefined,
+      }),
+    })
+  }, [getTorrentInstanceId, isAllInstances, navigate])
+
   // Handle deep link to a specific torrent (from cross-seed navigation)
   useEffect(() => {
     if (!search.torrent) return
     // Already selected (mobile keeps the hash in the URL); nothing to fetch
-    if (selectedTorrent?.hash === search.torrent) return
+    if (
+      selectedTorrent?.hash === search.torrent &&
+      (!search.instance || getTorrentInstanceId(selectedTorrent) === search.instance)
+    ) return
     let cancelled = false
 
+    const clearDeepLinkParams = () => onSearchChange({ ...search, torrent: undefined, tab: undefined, instance: undefined })
     const hash = search.torrent
     const tab = search.tab
     const escapedHash = hash.replaceAll("\"", "\\\"")
@@ -143,7 +161,7 @@ export function Torrents({ instanceId, instanceName, isAllInstancesView = false,
       },
       limit: 1,
       // Deep links should resolve even when the saved unified scope excludes the owning instance.
-      instanceIds: activeInstanceIds.length > 0 ? activeInstanceIds : undefined,
+      instanceIds: search.instance? [search.instance]: activeInstanceIds.length > 0 ? activeInstanceIds : undefined,
     }).then((response) => response.crossInstanceTorrents?.[0] ?? response.cross_instance_torrents?.[0] ?? null): api.getTorrents(instanceId, {
       filters: {
         expr: `Hash == "${escapedHash}"`,
@@ -172,27 +190,19 @@ export function Torrents({ instanceId, instanceName, isAllInstancesView = false,
       // Mobile keeps the params: Back closes the sheet and refresh restores it
       if (torrent && isMobile) return
       // Clear the search params after consuming
-      onSearchChange({
-        ...search,
-        torrent: undefined,
-        tab: undefined,
-      })
+      clearDeepLinkParams()
     }).catch(() => {
       if (cancelled) {
         return
       }
       // Silently fail - torrent might not exist
-      onSearchChange({
-        ...search,
-        torrent: undefined,
-        tab: undefined,
-      })
+      clearDeepLinkParams()
     })
 
     return () => {
       cancelled = true
     }
-  }, [activeInstanceIds, instanceId, isAllInstances, isMobile, onSearchChange, search, selectedTorrent])
+  }, [activeInstanceIds, getTorrentInstanceId, instanceId, isAllInstances, isMobile, onSearchChange, search, selectedTorrent])
 
   // Navigate to a cross-seed match torrent
   const handleNavigateToTorrent = useCallback((targetInstanceId: number, torrentHash: string) => {
@@ -314,7 +324,7 @@ export function Torrents({ instanceId, instanceName, isAllInstancesView = false,
     setInitialDetailsTab(undefined)
     if (urlTorrentRef.current) {
       urlTorrentRef.current = undefined
-      onSearchChange({ ...search, torrent: undefined, tab: undefined })
+      onSearchChange({ ...search, torrent: undefined, tab: undefined, instance: undefined })
     }
   }, [onSearchChange, search])
 

--- a/web/src/pages/Torrents.tsx
+++ b/web/src/pages/Torrents.tsx
@@ -29,7 +29,7 @@ import { useSpreadsheetDisguise } from "@/lib/spreadsheet-disguise"
 import { cn } from "@/lib/utils"
 import type { Category, CrossInstanceTorrent, Torrent, TorrentCounts } from "@/types"
 import { useNavigate } from "@tanstack/react-router"
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useDefaultLayout, usePanelRef } from "react-resizable-panels"
 
@@ -87,6 +87,22 @@ export function Torrents({ instanceId, instanceName, isAllInstancesView = false,
   const [mobileFilterOpen, setMobileFilterOpen] = useState(false)
   const handleInitialTabConsumed = useCallback(() => setInitialDetailsTab(undefined), [])
   const navigate = useNavigate()
+
+  // Mobile detection for responsive layout
+  const isMobile = useIsMobile()
+
+  // Hash currently reflected in the URL, so the Back handler only closes a
+  // sheet whose history entry it owns.
+  const urlTorrentRef = useRef<string | undefined>(undefined)
+
+  // Push a history entry for the sheet so mobile Back closes it instead of
+  // leaving the page
+  const pushMobileDetailsEntry = useCallback((torrent: Torrent, initialTab?: string) => {
+    navigate({
+      to: ".",
+      search: (prev) => ({ ...prev, torrent: torrent.hash, tab: initialTab }),
+    })
+  }, [navigate])
   const getTorrentInstanceId = useCallback((torrent: Torrent | null | undefined) => {
     if (!torrent) {
       return instanceId
@@ -104,6 +120,8 @@ export function Torrents({ instanceId, instanceName, isAllInstancesView = false,
   // Handle deep link to a specific torrent (from cross-seed navigation)
   useEffect(() => {
     if (!search.torrent) return
+    // Already selected (mobile keeps the hash in the URL); nothing to fetch
+    if (selectedTorrent?.hash === search.torrent) return
     let cancelled = false
 
     const hash = search.torrent
@@ -151,6 +169,8 @@ export function Torrents({ instanceId, instanceName, isAllInstancesView = false,
           setInitialDetailsTab(tab)
         }
       }
+      // Mobile keeps the params: Back closes the sheet and refresh restores it
+      if (torrent && isMobile) return
       // Clear the search params after consuming
       onSearchChange({
         ...search,
@@ -172,7 +192,7 @@ export function Torrents({ instanceId, instanceName, isAllInstancesView = false,
     return () => {
       cancelled = true
     }
-  }, [activeInstanceIds, instanceId, isAllInstances, onSearchChange, search])
+  }, [activeInstanceIds, instanceId, isAllInstances, isMobile, onSearchChange, search, selectedTorrent])
 
   // Navigate to a cross-seed match torrent
   const handleNavigateToTorrent = useCallback((targetInstanceId: number, torrentHash: string) => {
@@ -196,6 +216,9 @@ export function Torrents({ instanceId, instanceName, isAllInstancesView = false,
         if (torrent) {
           setSelectedTorrent(torrent)
           setInitialDetailsTab("general")
+          if (isMobile) {
+            pushMobileDetailsEntry(torrent, "general")
+          }
         }
       })
     } else {
@@ -206,10 +229,7 @@ export function Torrents({ instanceId, instanceName, isAllInstancesView = false,
         search: { torrent: torrentHash, tab: "general" },
       })
     }
-  }, [instanceId, isAllInstances, navigate])
-
-  // Mobile detection for responsive layout
-  const isMobile = useIsMobile()
+  }, [instanceId, isAllInstances, isMobile, navigate, pushMobileDetailsEntry])
 
   const [detailsPanelReady, setDetailsPanelReady] = useState(false)
 
@@ -287,16 +307,43 @@ export function Torrents({ instanceId, instanceName, isAllInstancesView = false,
     return left.hash === right.hash && getTorrentInstanceId(left) === getTorrentInstanceId(right)
   }, [getTorrentInstanceId])
 
+  // Close the details view: drop the URL params in place so Back does not
+  // reopen the mobile sheet
+  const closeMobileDetails = useCallback(() => {
+    setSelectedTorrent(null)
+    setInitialDetailsTab(undefined)
+    if (urlTorrentRef.current) {
+      urlTorrentRef.current = undefined
+      onSearchChange({ ...search, torrent: undefined, tab: undefined })
+    }
+  }, [onSearchChange, search])
+
   const handleTorrentSelect = useCallback((torrent: Torrent | null, initialTab?: string) => {
     // Toggle selection: if the same torrent is clicked without a tab override, deselect it
     if (torrent && isSameTorrent(selectedTorrent, torrent) && !initialTab) {
-      setSelectedTorrent(null)
-      setInitialDetailsTab(undefined)
+      closeMobileDetails()
     } else {
       setSelectedTorrent(torrent)
       setInitialDetailsTab(initialTab)
+      if (isMobile && torrent) {
+        pushMobileDetailsEntry(torrent, initialTab)
+      }
     }
-  }, [isSameTorrent, selectedTorrent])
+  }, [closeMobileDetails, isMobile, isSameTorrent, pushMobileDetailsEntry, selectedTorrent])
+
+  // Track the URL hash on mobile; when Back removes it, close the sheet
+  useEffect(() => {
+    if (!isMobile) return
+    if (search.torrent) {
+      urlTorrentRef.current = search.torrent
+      return
+    }
+    if (selectedTorrent && urlTorrentRef.current === selectedTorrent.hash) {
+      urlTorrentRef.current = undefined
+      setSelectedTorrent(null)
+      setInitialDetailsTab(undefined)
+    }
+  }, [isMobile, search.torrent, selectedTorrent])
 
   // Clear selected torrent and mark data as potentially stale when instance changes
   // Don't immediately clear torrentCounts/categories/tags to prevent showing 0 values
@@ -594,7 +641,7 @@ export function Torrents({ instanceId, instanceName, isAllInstancesView = false,
           open={!!selectedTorrent}
           onOpenChange={(open) => {
             if (!open) {
-              setSelectedTorrent(null)
+              closeMobileDetails()
             }
           }}
         >
@@ -616,7 +663,7 @@ export function Torrents({ instanceId, instanceName, isAllInstancesView = false,
                 torrent={selectedTorrent}
                 initialTab={initialDetailsTab}
                 onInitialTabConsumed={handleInitialTabConsumed}
-                onClose={() => setSelectedTorrent(null)}
+                onClose={closeMobileDetails}
                 onNavigateToTorrent={handleNavigateToTorrent}
               />
             )}

--- a/web/src/routes/_authenticated/instances.index.tsx
+++ b/web/src/routes/_authenticated/instances.index.tsx
@@ -5,7 +5,7 @@
 
 import { useLayoutRoute } from "@/contexts/LayoutRouteContext"
 import { ALL_INSTANCES_ID } from "@/lib/instances"
-import { Torrents } from "@/pages/Torrents"
+import { Torrents, type TorrentsSearch } from "@/pages/Torrents"
 import { createFileRoute } from "@tanstack/react-router"
 import { useLayoutEffect } from "react"
 import { useTranslation } from "react-i18next"
@@ -15,6 +15,7 @@ const unifiedSearchSchema = z.object({
   modal: z.enum(["add-torrent", "create-torrent", "tasks"]).optional(),
   torrent: z.string().optional(),
   tab: z.string().optional(),
+  instance: z.coerce.number().optional(),
 })
 
 export const Route = createFileRoute("/_authenticated/instances/")({
@@ -43,11 +44,7 @@ function UnifiedInstanceTorrents() {
     }
   }, [resetLayoutRouteState, setLayoutRouteState])
 
-  const handleSearchChange = (newSearch: {
-    modal?: "add-torrent" | "create-torrent" | "tasks" | undefined
-    torrent?: string
-    tab?: string
-  }) => {
+  const handleSearchChange = (newSearch: TorrentsSearch) => {
     navigate({
       search: newSearch,
       replace: true,


### PR DESCRIPTION
## Description

Back from the mobile torrent details sheet left the page, because the sheet only lived in React state and opening it created no history entry. Selecting a torrent on mobile now pushes a history entry with the torrent hash, so Back closes the sheet and stays on the instance.

Forward reopens the same torrent, a refresh restores it through the existing deep-link fetch, and closing the sheet from the UI clears the params in place so Back does not reopen it. The unified view also records the owning instance in the entry, since the same hash can exist on several instances and a restore by hash alone can pick the wrong one. Desktop is unchanged.

## How has this been tested?

Ran a dev build against a live instance with DevTools mobile emulation. Selecting a torrent pushes `?torrent=<hash>`. Back closes the sheet and stays on the instance. Forward reopens the same torrent. A refresh restores the sheet. Closing with the X clears the URL, and a later Back does not reopen it. The unified view got the same pass, with `instance` in the pushed entry, and a deep link with an instance that does not hold the hash clears the params without opening anything.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile torrent detail navigation with browser history and URL synchronization.
  * Torrent links can now target a specific instance when applicable.
  * Closing the details view clears the selected torrent and related URL parameters without reopening the sheet.
  * Deep links preserve valid torrent selections and avoid unnecessary reloads.
  * Improved navigation between related torrents on mobile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->