### PR TITLE
feat(crossseed): show why a manual search accepted or rejected candidates

### DIFF
--- a/documentation/docs/features/cross-seed/troubleshooting.md
+++ b/documentation/docs/features/cross-seed/troubleshooting.md
@@ -90,7 +90,7 @@ See [Season Packs](./season-packs.md) for the full flow, setup requirements, and
 
 ## How do I see why a release was filtered?
 
-For a manual search, open the **Search breakdown** section in the search dialog. It appears under the results after each search. It shows:
+For a manual search, open the **Search breakdown** section in the search dialog. It appears under the results when Qui searched Torznab indexers. A Gazelle-only search does not show it. It shows:
 
 - One row for each indexer with its outcome: searched, incomplete, error, or excluded
 - The count for each rejection reason

--- a/documentation/docs/features/cross-seed/troubleshooting.md
+++ b/documentation/docs/features/cross-seed/troubleshooting.md
@@ -90,6 +90,16 @@ See [Season Packs](./season-packs.md) for the full flow, setup requirements, and
 
 ## How do I see why a release was filtered?
 
+For a manual search, open the **Search breakdown** section in the search dialog. It appears under the results after each search. It shows:
+
+- One row for each indexer with its outcome: searched, incomplete, error, or excluded
+- The count for each rejection reason
+- The first rejected candidates for each reason, with the indexer, title, and size
+
+Use **Copy report** to copy a plain-text summary for a bug report. The report contains the source torrent name and the rejected candidate titles.
+
+The sections below cover the same decisions in the logs. Use the logs for automatic runs, or when you need the fully parsed release fields.
+
 Rejection reasons are logged at `DEBUG`, which is the default level:
 
 ```toml

--- a/internal/services/crossseed/models.go
+++ b/internal/services/crossseed/models.go
@@ -306,6 +306,10 @@ type TorrentSearchResponse struct {
 	// stamp per-indexer search history; an indexer missing here was rate
 	// limited or failed a pass and stays eligible for the next run.
 	CoveredIndexerIDs []int `json:"-"`
+	// DecisionTrace explains why the Torznab passes accepted or rejected
+	// candidates. Ephemeral diagnostics for the manual search dialog; unset
+	// when no Torznab search ran (Gazelle-only or failed searches).
+	DecisionTrace *SearchDecisionTrace `json:"decisionTrace,omitempty"`
 }
 
 // TorrentSearchSelection represents a user-selected search result that should be added for cross-seeding.

--- a/internal/services/crossseed/search_torznab_failure_gazelle_test.go
+++ b/internal/services/crossseed/search_torznab_failure_gazelle_test.go
@@ -167,3 +167,26 @@ func TestSearchTorrentMatches_CallerDeadlineIsNotPartialSuccess(t *testing.T) {
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 	require.Nil(t, resp)
 }
+
+// Regression (PR #2427 review): the Search breakdown explains the Torznab
+// funnel only. A Gazelle match reaches the response without passing through
+// that funnel, so it must not raise the reported match count.
+func TestSearchTorrentMatches_TraceExcludesGazelleFromFinalMatches(t *testing.T) {
+	emptyFeed := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed"><channel><title>Empty</title></channel></rss>`))
+	}))
+	t.Cleanup(emptyFeed.Close)
+
+	svc, instanceID, clients := newTorznabGazelleFixture(t, "crossseed-trace-gazelle-matches", emptyFeed.URL)
+
+	resp, _, _, err := svc.searchTorrentMatches(context.Background(), instanceID, torznabGazelleSourceHash, TorrentSearchOptions{
+		IndexerIDs: []int{1},
+	}, clients)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Len(t, resp.Results, 1, "the gazelle match still reaches the response")
+	require.NotNil(t, resp.DecisionTrace)
+	require.Equal(t, 0, resp.DecisionTrace.FinalMatches, "no torznab candidate was accepted")
+}

--- a/internal/services/crossseed/search_trace.go
+++ b/internal/services/crossseed/search_trace.go
@@ -1,0 +1,155 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package crossseed
+
+import (
+	"maps"
+	"slices"
+	"sort"
+	"sync"
+
+	"github.com/autobrr/qui/internal/services/jackett"
+	"github.com/autobrr/qui/pkg/redact"
+)
+
+// Statuses for SearchIndexerOutcome.Status.
+const (
+	// searchIndexerStatusSearched means the indexer answered every pass of the search.
+	searchIndexerStatusSearched = "searched"
+	// searchIndexerStatusNotCovered means the indexer missed at least one pass
+	// (rate limited or a retry pass failed) and stays eligible for the next run.
+	searchIndexerStatusNotCovered = "not_covered"
+	// searchIndexerStatusError means the indexer reported an error during a search pass.
+	searchIndexerStatusError = "error"
+	// searchIndexerStatusExcluded means content filtering excluded the indexer.
+	searchIndexerStatusExcluded = "excluded"
+)
+
+// maxTraceRejectedPerReason caps the rejected-candidate detail per reason;
+// RejectionCounts still reports the full totals.
+const maxTraceRejectedPerReason = 5
+
+// SearchRejectedCandidate is one Torznab result the search classifier rejected.
+type SearchRejectedCandidate struct {
+	Indexer   string `json:"indexer"`
+	IndexerID int    `json:"indexerId"`
+	Title     string `json:"title"`
+	Size      int64  `json:"size"`
+	Reason    string `json:"reason"`
+}
+
+// SearchIndexerOutcome reports how one indexer fared during the Torznab passes.
+type SearchIndexerOutcome struct {
+	IndexerID int    `json:"indexerId"`
+	Status    string `json:"status"`
+	Detail    string `json:"detail,omitempty"`
+	// Candidates is the number of raw results this indexer contributed before filtering.
+	Candidates int `json:"candidates"`
+}
+
+// SearchDecisionTrace explains why a search accepted or rejected candidates.
+// It travels with the response for the manual search dialog and is never persisted.
+type SearchDecisionTrace struct {
+	SourceSize          int64                     `json:"sourceSize"`
+	TolerancePercent    float64                   `json:"tolerancePercent"`
+	TotalResults        int                       `json:"totalResults"`
+	SizeFiltered        int                       `json:"sizeFiltered"`
+	ReleaseFiltered     int                       `json:"releaseFiltered"`
+	LateContentFiltered int                       `json:"lateContentFiltered"`
+	DuplicateFiltered   int                       `json:"duplicateFiltered"`
+	FinalMatches        int                       `json:"finalMatches"`
+	RejectionCounts     map[string]int            `json:"rejectionCounts,omitempty"`
+	RejectedCandidates  []SearchRejectedCandidate `json:"rejectedCandidates,omitempty"`
+	Indexers            []SearchIndexerOutcome    `json:"indexers,omitempty"`
+}
+
+// searchTraceRejections samples rejected candidates for the trace. Counts live
+// in the caller's releaseFilterReasons map (plus the size-filter counter);
+// runningCount is that count after the current rejection.
+type searchTraceRejections struct {
+	candidates []SearchRejectedCandidate
+}
+
+func (r *searchTraceRejections) add(res jackett.SearchResult, reason string, runningCount int) {
+	if runningCount > maxTraceRejectedPerReason {
+		return
+	}
+	r.candidates = append(r.candidates, SearchRejectedCandidate{
+		Indexer:   res.Indexer,
+		IndexerID: res.IndexerID,
+		Title:     res.Title,
+		Size:      res.Size,
+		Reason:    reason,
+	})
+}
+
+// searchIndexerErrors captures per-indexer failures from the jackett
+// per-indexer completion callback, which fires from scheduler goroutines.
+type searchIndexerErrors struct {
+	mu   sync.Mutex
+	errs map[int]string
+}
+
+// record keeps the first error per indexer, redacted for API exposure.
+func (e *searchIndexerErrors) record(_ uint64, indexerID int, err error) {
+	if err == nil || indexerID <= 0 {
+		return
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.errs == nil {
+		e.errs = make(map[int]string)
+	}
+	if _, ok := e.errs[indexerID]; !ok {
+		e.errs[indexerID] = redact.String(err.Error())
+	}
+}
+
+func (e *searchIndexerErrors) snapshot() map[int]string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return maps.Clone(e.errs)
+}
+
+// buildSearchIndexerOutcomes derives one outcome row per indexer involved in
+// the search: the requested set plus content-excluded indexers.
+func buildSearchIndexerOutcomes(requested, covered []int, errs map[int]string, excluded map[int]string, candidates map[int]int) []SearchIndexerOutcome {
+	if len(requested) == 0 && len(excluded) == 0 {
+		return nil
+	}
+
+	requestedSet := make(map[int]struct{}, len(requested))
+	outcomes := make([]SearchIndexerOutcome, 0, len(requested)+len(excluded))
+	for _, id := range requested {
+		requestedSet[id] = struct{}{}
+		out := SearchIndexerOutcome{IndexerID: id, Candidates: candidates[id]}
+		switch {
+		case excluded[id] != "":
+			out.Status = searchIndexerStatusExcluded
+			out.Detail = excluded[id]
+		case errs[id] != "":
+			out.Status = searchIndexerStatusError
+			out.Detail = errs[id]
+		case slices.Contains(covered, id):
+			out.Status = searchIndexerStatusSearched
+		default:
+			out.Status = searchIndexerStatusNotCovered
+		}
+		outcomes = append(outcomes, out)
+	}
+
+	for id, reason := range excluded {
+		if _, ok := requestedSet[id]; ok {
+			continue
+		}
+		outcomes = append(outcomes, SearchIndexerOutcome{
+			IndexerID: id,
+			Status:    searchIndexerStatusExcluded,
+			Detail:    reason,
+		})
+	}
+
+	sort.Slice(outcomes, func(i, j int) bool { return outcomes[i].IndexerID < outcomes[j].IndexerID })
+	return outcomes
+}

--- a/internal/services/crossseed/search_trace.go
+++ b/internal/services/crossseed/search_trace.go
@@ -50,6 +50,8 @@ type SearchIndexerOutcome struct {
 
 // SearchDecisionTrace explains why a search accepted or rejected candidates.
 // It travels with the response for the manual search dialog and is never persisted.
+// Every count covers the Torznab passes only. Gazelle results reach the response
+// without passing through this funnel.
 type SearchDecisionTrace struct {
 	SourceSize          int64                     `json:"sourceSize"`
 	TolerancePercent    float64                   `json:"tolerancePercent"`

--- a/internal/services/crossseed/search_trace_test.go
+++ b/internal/services/crossseed/search_trace_test.go
@@ -4,8 +4,18 @@
 package crossseed
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/autobrr/autobrr/pkg/ttlcache"
+	qbt "github.com/autobrr/go-qbittorrent"
+
+	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/pkg/stringutils"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -84,4 +94,66 @@ func TestBuildSearchIndexerOutcomes(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// Regression (PR #2427 review): the breakdown subtracts the late content
+// filter from the candidate total, so the total and the per-indexer counts
+// must come from the raw results, before that filter removes any.
+func TestSearchTorrentMatches_TraceCountsRawCandidates(t *testing.T) {
+	const (
+		instanceID = 1
+		sourceHash = "0123456789abcdef0123456789abcdef01234567"
+		sourceName = "Example.Show.S01E01.1080p.WEB-DL.DDP5.1.H.264-GROUP"
+	)
+
+	filterCache := ttlcache.New(ttlcache.Options[string, *AsyncIndexerFilteringState]{})
+	cacheKey := asyncFilteringCacheKey(instanceID, sourceHash)
+	filterCache.Set(cacheKey, &AsyncIndexerFilteringState{
+		CapabilitiesCompleted: true,
+		CapabilityIndexers:    []int{1},
+		FilteredIndexers:      []int{1},
+	}, ttlcache.DefaultTTL)
+
+	// The content filter finishes while the search runs and excludes the only
+	// indexer, so its one result is dropped after it was already returned.
+	lateState := &AsyncIndexerFilteringState{
+		CapabilitiesCompleted: true,
+		ContentCompleted:      true,
+		CapabilityIndexers:    []int{1},
+		FilteredIndexers:      nil,
+		ExcludedIndexers:      map[int]string{1: "already seeded from Tracker One"},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		filterCache.Set(cacheKey, lateState, ttlcache.DefaultTTL)
+		w.Header().Set("Content-Type", "application/rss+xml")
+		_, _ = fmt.Fprintf(w, `<rss version="2.0"><channel><title>Tracker One</title><item><title>%s</title><guid>candidate-guid</guid><size>123</size><enclosure url="https://example.invalid/candidate.torrent" length="123" type="application/x-bittorrent" /></item></channel></rss>`, sourceName)
+	}))
+	t.Cleanup(server.Close)
+
+	instance := &models.Instance{ID: instanceID, Name: "main"}
+	source := qbt.Torrent{Hash: sourceHash, Name: sourceName, Size: 123, Progress: 1}
+	service := &Service{
+		instanceStore: &fakeInstanceStore{instances: map[int]*models.Instance{instanceID: instance}},
+		jackettService: newJackettServiceWithIndexers([]*models.TorznabIndexer{
+			{ID: 1, Name: "Tracker One", BaseURL: server.URL, Backend: models.TorznabBackendNative, TimeoutSeconds: 5, Enabled: true},
+		}),
+		syncManager: newFakeSyncManager(instance, []qbt.Torrent{source}, map[string]qbt.TorrentFiles{
+			sourceHash: {{Name: sourceName + ".mkv", Size: source.Size}},
+		}),
+		asyncFilteringCache: filterCache,
+		releaseCache:        NewReleaseCache(),
+		stringNormalizer:    stringutils.NewDefaultNormalizer(),
+	}
+
+	resp, _, _, err := service.searchTorrentMatches(context.Background(), instanceID, sourceHash, TorrentSearchOptions{}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.DecisionTrace)
+
+	trace := resp.DecisionTrace
+	assert.Equal(t, 1, trace.TotalResults, "the raw candidate still counts toward the total")
+	assert.Equal(t, 1, trace.LateContentFiltered)
+	assert.Equal(t, 0, trace.FinalMatches)
+	require.Len(t, trace.Indexers, 1)
+	assert.Equal(t, 1, trace.Indexers[0].Candidates, "the indexer contributed one raw candidate")
 }

--- a/internal/services/crossseed/search_trace_test.go
+++ b/internal/services/crossseed/search_trace_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package crossseed
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/services/jackett"
+)
+
+func TestSearchTraceRejectionsCapsPerReason(t *testing.T) {
+	rejections := &searchTraceRejections{}
+	counts := make(map[string]int)
+	for i := range 8 {
+		counts["hdr mismatch"]++
+		rejections.add(jackett.SearchResult{IndexerID: 1, Indexer: "alpha", Title: "Show.S01.1080p", Size: int64(i)}, "hdr mismatch", counts["hdr mismatch"])
+	}
+	counts["size mismatch"]++
+	rejections.add(jackett.SearchResult{IndexerID: 2, Indexer: "beta", Title: "Show.S01.720p"}, "size mismatch", counts["size mismatch"])
+
+	require.Len(t, rejections.candidates, maxTraceRejectedPerReason+1)
+	assert.Equal(t, "size mismatch", rejections.candidates[maxTraceRejectedPerReason].Reason)
+}
+
+func TestSearchIndexerErrorsKeepsFirstError(t *testing.T) {
+	capture := &searchIndexerErrors{}
+	capture.record(1, 7, errors.New("connection refused"))
+	capture.record(2, 7, errors.New("second failure"))
+	capture.record(3, 8, nil)
+	capture.record(4, 0, errors.New("no indexer id"))
+
+	snap := capture.snapshot()
+	assert.Equal(t, map[int]string{7: "connection refused"}, snap)
+}
+
+func TestBuildSearchIndexerOutcomes(t *testing.T) {
+	tests := []struct {
+		name       string
+		requested  []int
+		covered    []int
+		errs       map[int]string
+		excluded   map[int]string
+		candidates map[int]int
+		want       []SearchIndexerOutcome
+	}{
+		{
+			name: "empty inputs return nil",
+			want: nil,
+		},
+		{
+			name:       "statuses partition the requested set",
+			requested:  []int{4, 1, 2, 3},
+			covered:    []int{1},
+			errs:       map[int]string{2: "timeout"},
+			excluded:   map[int]string{3: "already seeded from this tracker"},
+			candidates: map[int]int{1: 6},
+			want: []SearchIndexerOutcome{
+				{IndexerID: 1, Status: searchIndexerStatusSearched, Candidates: 6},
+				{IndexerID: 2, Status: searchIndexerStatusError, Detail: "timeout"},
+				{IndexerID: 3, Status: searchIndexerStatusExcluded, Detail: "already seeded from this tracker"},
+				{IndexerID: 4, Status: searchIndexerStatusNotCovered},
+			},
+		},
+		{
+			name:      "excluded indexers outside the requested set are appended",
+			requested: []int{1},
+			covered:   []int{1},
+			excluded:  map[int]string{9: "has matching content"},
+			want: []SearchIndexerOutcome{
+				{IndexerID: 1, Status: searchIndexerStatusSearched},
+				{IndexerID: 9, Status: searchIndexerStatusExcluded, Detail: "has matching content"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildSearchIndexerOutcomes(tt.requested, tt.covered, tt.errs, tt.excluded, tt.candidates)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -9146,6 +9146,11 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 		}, gazelleLookupAttempted, remoteRequestsMade, nil
 	}
 
+	// Capture per-indexer failures for the decision trace. The callback is
+	// copied into every retry pass request, so later passes report here too.
+	traceIndexerErrs := &searchIndexerErrors{}
+	searchReq.OnComplete = traceIndexerErrs.record
+
 	searchReq.OnAllComplete = func(resp *jackett.SearchResponse, err error) {
 		onAllCompleteOnce.Do(func() {
 			if err != nil {
@@ -9382,7 +9387,10 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 	exactSizeHardRejected := 0
 
 	sourceSizeForSearch := searchSourceSize(sourceTorrent)
+	traceRejections := &searchTraceRejections{}
+	traceCandidateCounts := make(map[int]int)
 	for _, res := range searchResults {
+		traceCandidateCounts[res.IndexerID]++
 		candidateRelease := s.releaseCache.Parse(res.Title)
 		// Search has only the source torrent's full size and Torznab's advertised
 		// candidate size. Positive exact equality may replace a relaxable release
@@ -9404,11 +9412,15 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 		if !decision.Accepted {
 			if decision.SizeRejected {
 				sizeFilteredCount++
+				traceRejections.add(res, "size mismatch", sizeFilteredCount)
 			} else {
 				releaseFilteredCount++
 				reason := decision.RejectReason
 				if reason == "" {
 					reason = decision.StrictMismatchReason
+				}
+				if reason == "" {
+					reason = "release mismatch"
 				}
 				recordReleaseRejection(
 					releaseFilterReasons,
@@ -9420,6 +9432,7 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 					releaseFilterDebugInfoFrom(candidateRelease),
 					"[CROSSSEED-SEARCH] Candidate rejected by search classifier",
 				)
+				traceRejections.add(res, reason, releaseFilterReasons[reason])
 			}
 			if decision.StrictMismatchReason != "" && decision.SizeEvidence == searchSizeEvidenceExact {
 				exactSizeHardRejected++
@@ -9496,6 +9509,29 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 			Msg("[CROSSSEED-SEARCH] Release filtering rejection summary")
 	}
 
+	buildDecisionTrace := func(finalMatches, duplicateFiltered int) *SearchDecisionTrace {
+		rejectionCounts := maps.Clone(releaseFilterReasons)
+		if sizeFilteredCount > 0 {
+			if rejectionCounts == nil {
+				rejectionCounts = make(map[string]int, 1)
+			}
+			rejectionCounts["size mismatch"] = sizeFilteredCount
+		}
+		return &SearchDecisionTrace{
+			SourceSize:          sourceSizeForSearch,
+			TolerancePercent:    tolerancePercent,
+			TotalResults:        totalResults,
+			SizeFiltered:        sizeFilteredCount,
+			ReleaseFiltered:     releaseFilteredCount,
+			LateContentFiltered: lateExcludedCount,
+			DuplicateFiltered:   duplicateFiltered,
+			FinalMatches:        finalMatches,
+			RejectionCounts:     rejectionCounts,
+			RejectedCandidates:  traceRejections.candidates,
+			Indexers:            buildSearchIndexerOutcomes(searchResp.RequestedIndexerIDs, coveredIndexerIDs, traceIndexerErrs.snapshot(), sourceInfo.ExcludedIndexers, traceCandidateCounts),
+		}
+	}
+
 	if len(scored) == 0 {
 		combined := mergeTorrentSearchResults(gazelleResults, nil)
 		s.cacheSearchResults(instanceID, sourceTorrent.Hash, combined)
@@ -9507,6 +9543,7 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 			JobID:             searchResp.JobID,
 			CoveredIndexerIDs: coveredIndexerIDs,
 			QueryDegraded:     queryDegraded,
+			DecisionTrace:     buildDecisionTrace(len(combined), 0),
 		}, gazelleLookupAttempted, remoteRequestsMade, nil
 	}
 
@@ -9540,6 +9577,7 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 		JobID:             searchResp.JobID,
 		CoveredIndexerIDs: coveredIndexerIDs,
 		QueryDegraded:     queryDegraded,
+		DecisionTrace:     buildDecisionTrace(len(combined), duplicateFilteredCount),
 	}, gazelleLookupAttempted, remoteRequestsMade, nil
 }
 

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -9369,6 +9369,13 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 		}
 	}
 
+	// Count raw results before the late content filter drops any; the breakdown subtracts LateContentFiltered from this total.
+	totalResults := len(searchResults)
+	traceCandidateCounts := make(map[int]int)
+	for _, res := range searchResults {
+		traceCandidateCounts[res.IndexerID]++
+	}
+
 	searchResults, lateFilterSnapshot, lateExcludedCount = s.filterSearchResultsByLateContentFilter(instanceID, sourceTorrent, searchResults)
 	if lateFilterSnapshot != nil {
 		sourceInfo.AvailableIndexers = lateFilterSnapshot.CapabilityIndexers
@@ -9388,9 +9395,7 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 
 	sourceSizeForSearch := searchSourceSize(sourceTorrent)
 	traceRejections := &searchTraceRejections{}
-	traceCandidateCounts := make(map[int]int)
 	for _, res := range searchResults {
-		traceCandidateCounts[res.IndexerID]++
 		candidateRelease := s.releaseCache.Parse(res.Title)
 		// Search has only the source torrent's full size and Torznab's advertised
 		// candidate size. Positive exact equality may replace a relaxable release
@@ -9486,7 +9491,6 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 	scored = deduplicateScoredTorrentSearchResults(scored)
 
 	// Log filtering statistics
-	totalResults := len(searchResults)
 	matchedResults := len(scored)
 	log.Debug().
 		Str("torrentName", sourceTorrent.Name).
@@ -9543,7 +9547,7 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 			JobID:             searchResp.JobID,
 			CoveredIndexerIDs: coveredIndexerIDs,
 			QueryDegraded:     queryDegraded,
-			DecisionTrace:     buildDecisionTrace(len(combined), 0),
+			DecisionTrace:     buildDecisionTrace(0, 0),
 		}, gazelleLookupAttempted, remoteRequestsMade, nil
 	}
 
@@ -9577,7 +9581,7 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 		JobID:             searchResp.JobID,
 		CoveredIndexerIDs: coveredIndexerIDs,
 		QueryDegraded:     queryDegraded,
-		DecisionTrace:     buildDecisionTrace(len(combined), duplicateFilteredCount),
+		DecisionTrace:     buildDecisionTrace(len(results), duplicateFilteredCount),
 	}, gazelleLookupAttempted, remoteRequestsMade, nil
 }
 

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -7840,6 +7840,76 @@ components:
           enum:
             - arr_lookup_failed
             - arr_no_ids
+        decisionTrace:
+          $ref: '#/components/schemas/CrossSeedSearchDecisionTrace'
+
+    CrossSeedSearchDecisionTrace:
+      type: object
+      description: Explains why the Torznab passes accepted or rejected candidates. Absent when no Torznab search ran.
+      properties:
+        sourceSize:
+          type: integer
+          format: int64
+        tolerancePercent:
+          type: number
+        totalResults:
+          type: integer
+        sizeFiltered:
+          type: integer
+        releaseFiltered:
+          type: integer
+        lateContentFiltered:
+          type: integer
+        duplicateFiltered:
+          type: integer
+        finalMatches:
+          type: integer
+        rejectionCounts:
+          type: object
+          additionalProperties:
+            type: integer
+        rejectedCandidates:
+          type: array
+          description: Capped at 5 candidates per rejection reason; rejectionCounts holds the full totals.
+          items:
+            $ref: '#/components/schemas/CrossSeedSearchRejectedCandidate'
+        indexers:
+          type: array
+          items:
+            $ref: '#/components/schemas/CrossSeedSearchIndexerOutcome'
+
+    CrossSeedSearchRejectedCandidate:
+      type: object
+      properties:
+        indexer:
+          type: string
+        indexerId:
+          type: integer
+        title:
+          type: string
+        size:
+          type: integer
+          format: int64
+        reason:
+          type: string
+
+    CrossSeedSearchIndexerOutcome:
+      type: object
+      properties:
+        indexerId:
+          type: integer
+        status:
+          type: string
+          enum:
+            - searched
+            - not_covered
+            - error
+            - excluded
+        detail:
+          type: string
+        candidates:
+          type: integer
+          description: Raw results this indexer contributed before filtering.
 
     CrossSeedApplySelection:
       type: object

--- a/web/src/components/torrents/CrossSeedDialog.test.tsx
+++ b/web/src/components/torrents/CrossSeedDialog.test.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import type { CrossSeedSearchDecisionTrace } from "@/types"
+import { describe, expect, it } from "vitest"
+import { buildCrossSeedTraceReport } from "./CrossSeedDialog"
+
+describe("buildCrossSeedTraceReport", () => {
+  it("renders counts, indexer outcomes, and capped rejection detail", () => {
+    const trace: CrossSeedSearchDecisionTrace = {
+      sourceSize: 1073741824,
+      tolerancePercent: 2,
+      totalResults: 9,
+      sizeFiltered: 1,
+      releaseFiltered: 7,
+      lateContentFiltered: 0,
+      duplicateFiltered: 0,
+      finalMatches: 1,
+      rejectionCounts: { "hdr mismatch": 7, "size mismatch": 1 },
+      rejectedCandidates: [
+        { indexer: "alpha", indexerId: 1, title: "Show.S01.2160p.HDR.WEB-DL-GROUP", size: 2147483648, reason: "hdr mismatch" },
+        { indexer: "beta", indexerId: 2, title: "Show.S01.1080p.WEB-DL-OTHER", size: 999, reason: "size mismatch" },
+      ],
+      indexers: [
+        { indexerId: 1, status: "searched", candidates: 9 },
+        { indexerId: 2, status: "error", detail: "connection refused", candidates: 0 },
+        { indexerId: 3, status: "not_covered", candidates: 0 },
+      ],
+    }
+
+    const report = buildCrossSeedTraceReport(trace, "Show.S01.2160p.WEB-DL-GROUP", { 1: "alpha", 2: "beta" })
+
+    expect(report).toContain("source: Show.S01.2160p.WEB-DL-GROUP (1 GiB)")
+    expect(report).toContain("size tolerance: 2%")
+    expect(report).toContain("results: 9 candidates, 7 release-filtered, 1 size-filtered, 0 late-content-filtered, 0 duplicates, 1 matches")
+    expect(report).toContain("alpha: searched, 9 candidates")
+    expect(report).toContain("beta: error - connection refused")
+    expect(report).toContain("indexer 3: not_covered")
+    expect(report).toContain("hdr mismatch: 7")
+    expect(report).toContain("- Show.S01.2160p.HDR.WEB-DL-GROUP [alpha] 2 GiB")
+    expect(report).toContain("(+6 more)")
+  })
+
+  it("omits indexer and rejection sections when empty", () => {
+    const trace: CrossSeedSearchDecisionTrace = {
+      sourceSize: 0,
+      tolerancePercent: 0,
+      totalResults: 0,
+      sizeFiltered: 0,
+      releaseFiltered: 0,
+      lateContentFiltered: 0,
+      duplicateFiltered: 0,
+      finalMatches: 0,
+    }
+
+    const report = buildCrossSeedTraceReport(trace, "Some.Release", {})
+
+    expect(report).not.toContain("indexers:")
+    expect(report).not.toContain("rejections:")
+  })
+})

--- a/web/src/components/torrents/CrossSeedDialog.tsx
+++ b/web/src/components/torrents/CrossSeedDialog.tsx
@@ -35,10 +35,12 @@ import { formatRelativeTime } from "@/lib/dateTimeUtils"
 import { formatBytes } from "@/lib/utils"
 import type {
   CrossSeedApplyResponse,
+  CrossSeedSearchDecisionTrace,
+  CrossSeedSearchRejectedCandidate,
   CrossSeedTorrentSearchResponse,
   Torrent
 } from "@/types"
-import { AlertTriangle, ChevronDown, ChevronRight, ExternalLink, Loader2, RefreshCw, SlidersHorizontal } from "lucide-react"
+import { AlertTriangle, ChevronDown, ChevronRight, Copy, ExternalLink, Loader2, RefreshCw, SlidersHorizontal } from "lucide-react"
 import { memo, useCallback, useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { toast } from "sonner"
@@ -91,6 +93,7 @@ export interface CrossSeedDialogProps {
   cacheMetadata?: CrossSeedTorrentSearchResponse["cache"] | null
   partial?: boolean
   queryDegraded?: string
+  decisionTrace?: CrossSeedSearchDecisionTrace
   canForceRefresh?: boolean
   refreshCooldownLabel?: string
   onForceRefresh?: () => void
@@ -140,6 +143,7 @@ const CrossSeedDialogComponent = ({
   cacheMetadata,
   partial,
   queryDegraded,
+  decisionTrace,
   canForceRefresh,
   refreshCooldownLabel,
   onForceRefresh,
@@ -177,8 +181,41 @@ const CrossSeedDialogComponent = ({
   }, [indexerNameMap, sourceTorrent?.availableIndexers])
 
   const [excludedOpen, setExcludedOpen] = useState(false)
+  const [traceOpen, setTraceOpen] = useState(false)
   const [applyResultOpen, setApplyResultOpen] = useState(true)
   const [blocklistPendingKeys, setBlocklistPendingKeys] = useState<Set<string>>(() => new Set())
+
+  const traceIndexerRows = useMemo(() => {
+    if (!decisionTrace?.indexers) {
+      return []
+    }
+    // Content-excluded indexers already have their own section above.
+    return decisionTrace.indexers
+      .filter(outcome => outcome.status !== "excluded")
+      .map(outcome => ({
+        ...outcome,
+        name: indexerNameMap[outcome.indexerId] ?? `Indexer ${outcome.indexerId}`,
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name))
+  }, [decisionTrace?.indexers, indexerNameMap])
+
+  const traceReasonGroups = useMemo(
+    () => (decisionTrace ? groupTraceReasons(decisionTrace) : []),
+    [decisionTrace]
+  )
+
+  const handleCopyTraceReport = useCallback(async () => {
+    if (!decisionTrace) {
+      return
+    }
+    const report = buildCrossSeedTraceReport(decisionTrace, sourceTorrent?.name ?? torrent?.name ?? "", indexerNameMap)
+    try {
+      await navigator.clipboard.writeText(report)
+      toast.success(t("crossSeedDialog.trace.copied"))
+    } catch {
+      toast.error(t("crossSeedDialog.trace.copyFailed"))
+    }
+  }, [decisionTrace, sourceTorrent?.name, torrent?.name, indexerNameMap, t])
 
   // Auto-expand results when there are failures
   const hasFailures = applyResult?.results.some(r => !r.success || r.instanceResults?.some(ir => !ir.success))
@@ -493,6 +530,87 @@ const CrossSeedDialogComponent = ({
                   </div>
                 </>
               )}
+              {decisionTrace && (
+                <Collapsible open={traceOpen} onOpenChange={setTraceOpen}>
+                  <div className="rounded-lg border bg-muted/20">
+                    <CollapsibleTrigger className="w-full p-2.5 text-left hover:bg-muted/40 transition-colors">
+                      <div className="flex items-center gap-2 text-sm">
+                        <ChevronRight className={`h-3.5 w-3.5 transition-transform ${traceOpen ? "rotate-90" : ""}`} />
+                        <span className="font-medium">{t("crossSeedDialog.trace.title")}</span>
+                        <Badge variant="secondary" className="text-xs">
+                          {t("crossSeedDialog.trace.summaryBadge", { total: decisionTrace.totalResults, matches: decisionTrace.finalMatches })}
+                        </Badge>
+                      </div>
+                    </CollapsibleTrigger>
+                    <CollapsibleContent>
+                      <div className="space-y-2.5 px-2.5 pb-2.5 text-xs">
+                        <p className="text-muted-foreground">
+                          {t("crossSeedDialog.trace.summary", {
+                            total: decisionTrace.totalResults,
+                            release: decisionTrace.releaseFiltered,
+                            size: decisionTrace.sizeFiltered,
+                            late: decisionTrace.lateContentFiltered,
+                            duplicates: decisionTrace.duplicateFiltered,
+                            matches: decisionTrace.finalMatches,
+                          })}
+                        </p>
+                        {traceIndexerRows.length > 0 && (
+                          <div className="space-y-1">
+                            <p className="font-medium text-foreground">{t("crossSeedDialog.trace.indexersHeading")}</p>
+                            <ul className="space-y-0.5">
+                              {traceIndexerRows.map(row => (
+                                <li key={row.indexerId} className="flex min-w-0 flex-wrap items-center gap-1.5">
+                                  <span className="min-w-0 truncate">{row.name}</span>
+                                  <Badge
+                                    variant={row.status === "error" ? "destructive" : row.status === "searched" ? "outline" : "secondary"}
+                                    className="h-4 shrink-0 px-1 text-[10px]"
+                                  >
+                                    {t(`crossSeedDialog.trace.status.${row.status === "not_covered" ? "notCovered" : row.status}`)}
+                                  </Badge>
+                                  {row.candidates > 0 && (
+                                    <span className="shrink-0 text-muted-foreground">
+                                      {t("crossSeedDialog.trace.candidateCount", { count: row.candidates })}
+                                    </span>
+                                  )}
+                                  {row.detail && <span className="min-w-0 break-words text-muted-foreground">{row.detail}</span>}
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
+                        )}
+                        {traceReasonGroups.length > 0 && (
+                          <div className="space-y-1.5">
+                            <p className="font-medium text-foreground">{t("crossSeedDialog.trace.rejectionsHeading")}</p>
+                            {traceReasonGroups.map(group => (
+                              <div key={group.reason} className="space-y-0.5">
+                                <p className="text-muted-foreground">{t("crossSeedDialog.trace.reasonCount", { reason: group.reason, count: group.count })}</p>
+                                <ul className="ml-3 space-y-0.5">
+                                  {group.candidates.map((candidate, index) => (
+                                    <li key={`${group.reason}-${index}`} className="flex min-w-0 items-center gap-1.5">
+                                      <span className="min-w-0 truncate" title={candidate.title}>{candidate.title}</span>
+                                      <Badge variant="outline" className="h-4 shrink-0 px-1 text-[10px]">{candidate.indexer}</Badge>
+                                      <span className="shrink-0 text-muted-foreground">{formatBytes(candidate.size)}</span>
+                                    </li>
+                                  ))}
+                                  {group.count > group.candidates.length && (
+                                    <li className="text-muted-foreground">
+                                      {t("crossSeedDialog.trace.moreCandidates", { count: group.count - group.candidates.length })}
+                                    </li>
+                                  )}
+                                </ul>
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                        <Button type="button" variant="outline" size="sm" onClick={handleCopyTraceReport} className="h-7">
+                          <Copy className="mr-1.5 h-3 w-3" />
+                          {t("crossSeedDialog.trace.copyReport")}
+                        </Button>
+                      </div>
+                    </CollapsibleContent>
+                  </div>
+                </Collapsible>
+              )}
               {applyResult && (
                 <Collapsible open={applyResultOpen} onOpenChange={setApplyResultOpen}>
                   <div className="min-w-0 space-y-2 rounded-md border">
@@ -601,6 +719,58 @@ const CrossSeedDialogComponent = ({
 
 export const CrossSeedDialog = memo(CrossSeedDialogComponent)
 CrossSeedDialog.displayName = "CrossSeedDialog"
+
+// Plain-text report for sharing in bug reports; deliberately not localized.
+export function buildCrossSeedTraceReport(
+  trace: CrossSeedSearchDecisionTrace,
+  sourceName: string,
+  indexerNameMap: Record<number, string>
+): string {
+  const lines: string[] = []
+  lines.push("qui cross-seed search report")
+  lines.push(`source: ${sourceName} (${formatBytes(trace.sourceSize)})`)
+  lines.push(`size tolerance: ${trace.tolerancePercent}%`)
+  lines.push(
+    `results: ${trace.totalResults} candidates, ${trace.releaseFiltered} release-filtered, ${trace.sizeFiltered} size-filtered, ${trace.lateContentFiltered} late-content-filtered, ${trace.duplicateFiltered} duplicates, ${trace.finalMatches} matches`
+  )
+  if (trace.indexers?.length) {
+    lines.push("indexers:")
+    for (const outcome of trace.indexers) {
+      const name = indexerNameMap[outcome.indexerId] ?? `indexer ${outcome.indexerId}`
+      const candidates = outcome.candidates > 0 ? `, ${outcome.candidates} candidates` : ""
+      const detail = outcome.detail ? ` - ${outcome.detail}` : ""
+      lines.push(`  ${name}: ${outcome.status}${candidates}${detail}`)
+    }
+  }
+  const groups = groupTraceReasons(trace)
+  if (groups.length > 0) {
+    lines.push("rejections:")
+    for (const group of groups) {
+      lines.push(`  ${group.reason}: ${group.count}`)
+      for (const candidate of group.candidates) {
+        lines.push(`    - ${candidate.title} [${candidate.indexer}] ${formatBytes(candidate.size)}`)
+      }
+      if (group.count > group.candidates.length) {
+        lines.push(`    (+${group.count - group.candidates.length} more)`)
+      }
+    }
+  }
+  return lines.join("\n")
+}
+
+function groupTraceReasons(trace: CrossSeedSearchDecisionTrace): Array<{
+  reason: string
+  count: number
+  candidates: CrossSeedSearchRejectedCandidate[]
+}> {
+  return Object.entries(trace.rejectionCounts ?? {})
+    .sort((a, b) => b[1] - a[1])
+    .map(([reason, count]) => ({
+      reason,
+      count,
+      candidates: trace.rejectedCandidates?.filter(candidate => candidate.reason === reason) ?? [],
+    }))
+}
 
 function formatCrossSeedPublishDate(value: string): string {
   const parsed = new Date(value)

--- a/web/src/hooks/useCrossSeedSearch.tsx
+++ b/web/src/hooks/useCrossSeedSearch.tsx
@@ -590,6 +590,7 @@ export function useCrossSeedSearch(instanceId: number) {
       cacheMetadata={crossSeedSearchResponse?.cache ?? null}
       partial={crossSeedSearchResponse?.partial ?? false}
       queryDegraded={crossSeedSearchResponse?.queryDegraded}
+      decisionTrace={crossSeedSearchResponse?.decisionTrace}
       onForceRefresh={canForceCrossSeedRefresh ? handleCrossSeedForceRefresh : undefined}
       canForceRefresh={canForceCrossSeedRefresh}
       refreshCooldownLabel={crossSeedRefreshLabel}

--- a/web/src/i18n/locales/cs/torrents.json
+++ b/web/src/i18n/locales/cs/torrents.json
@@ -719,6 +719,25 @@
     "block": "Blokovat",
     "addedToBlocklist": "Přidáno do blokovacího seznamu",
     "missingInstance": "Chybí instance pro blokovací seznam",
+    "trace": {
+      "title": "Rozpis vyhledávání",
+      "summaryBadge": "{{total}} kandidátů, {{matches}} shod",
+      "summary": "Vráceno {{total}} kandidátů. Odmítnuto: {{release}} neshoda release, {{size}} neshoda velikosti, {{late}} filtr obsahu, {{duplicates}} duplicity. Zbývá {{matches}} shod.",
+      "indexersHeading": "Indexery",
+      "status": {
+        "searched": "prohledáno",
+        "notCovered": "neúplné",
+        "error": "chyba",
+        "excluded": "vyloučeno"
+      },
+      "candidateCount": "{{count}} kandidátů",
+      "rejectionsHeading": "Odmítnutí kandidáti",
+      "reasonCount": "{{reason}} · {{count}}",
+      "moreCandidates": "+{{count}} dalších se stejným důvodem",
+      "copyReport": "Kopírovat report",
+      "copied": "Report zkopírován do schránky",
+      "copyFailed": "Report se nepodařilo zkopírovat"
+    },
     "scope": {
       "allIndexers": "Všechny indexery",
       "selectCustom": "Vybrat vlastní",

--- a/web/src/i18n/locales/de/torrents.json
+++ b/web/src/i18n/locales/de/torrents.json
@@ -719,6 +719,25 @@
     "block": "Blockieren",
     "addedToBlocklist": "Zur Blockliste hinzugefügt",
     "missingInstance": "Fehlende Instanz für Blockliste",
+    "trace": {
+      "title": "Suchaufschlüsselung",
+      "summaryBadge": "{{total}} Kandidaten, {{matches}} Treffer",
+      "summary": "{{total}} Kandidaten zurückgegeben. Abgelehnt: {{release}} Release-Abweichung, {{size}} Größenabweichung, {{late}} Inhaltsfilter, {{duplicates}} Duplikate. {{matches}} Treffer verbleiben.",
+      "indexersHeading": "Indexer",
+      "status": {
+        "searched": "durchsucht",
+        "notCovered": "unvollständig",
+        "error": "Fehler",
+        "excluded": "ausgeschlossen"
+      },
+      "candidateCount": "{{count}} Kandidaten",
+      "rejectionsHeading": "Abgelehnte Kandidaten",
+      "reasonCount": "{{reason}} · {{count}}",
+      "moreCandidates": "+{{count}} weitere mit diesem Grund",
+      "copyReport": "Bericht kopieren",
+      "copied": "Bericht in die Zwischenablage kopiert",
+      "copyFailed": "Bericht konnte nicht kopiert werden"
+    },
     "scope": {
       "allIndexers": "Alle Indexer",
       "selectCustom": "Benutzerdefiniert auswählen",

--- a/web/src/i18n/locales/en/torrents.json
+++ b/web/src/i18n/locales/en/torrents.json
@@ -719,6 +719,25 @@
     "block": "Block",
     "addedToBlocklist": "Added to blocklist",
     "missingInstance": "Missing instance for blocklist",
+    "trace": {
+      "title": "Search breakdown",
+      "summaryBadge": "{{total}} candidates, {{matches}} matches",
+      "summary": "{{total}} candidates returned. Rejected: {{release}} release mismatch, {{size}} size mismatch, {{late}} content filter, {{duplicates}} duplicates. {{matches}} matches remain.",
+      "indexersHeading": "Indexers",
+      "status": {
+        "searched": "searched",
+        "notCovered": "incomplete",
+        "error": "error",
+        "excluded": "excluded"
+      },
+      "candidateCount": "{{count}} candidates",
+      "rejectionsHeading": "Rejected candidates",
+      "reasonCount": "{{reason}} · {{count}}",
+      "moreCandidates": "+{{count}} more with this reason",
+      "copyReport": "Copy report",
+      "copied": "Report copied to clipboard",
+      "copyFailed": "Could not copy the report"
+    },
     "scope": {
       "allIndexers": "All indexers",
       "selectCustom": "Select Custom",

--- a/web/src/i18n/locales/fr/torrents.json
+++ b/web/src/i18n/locales/fr/torrents.json
@@ -719,6 +719,25 @@
     "block": "Bloquer",
     "addedToBlocklist": "Ajouté à la liste de blocage",
     "missingInstance": "Instance manquante pour la liste de blocage",
+    "trace": {
+      "title": "Détail de la recherche",
+      "summaryBadge": "{{total}} candidats, {{matches}} correspondances",
+      "summary": "{{total}} candidats renvoyés. Rejetés : {{release}} release non conforme, {{size}} taille non conforme, {{late}} filtre de contenu, {{duplicates}} doublons. {{matches}} correspondances restantes.",
+      "indexersHeading": "Indexeurs",
+      "status": {
+        "searched": "interrogé",
+        "notCovered": "incomplet",
+        "error": "erreur",
+        "excluded": "exclu"
+      },
+      "candidateCount": "{{count}} candidats",
+      "rejectionsHeading": "Candidats rejetés",
+      "reasonCount": "{{reason}} · {{count}}",
+      "moreCandidates": "+{{count}} autres pour cette raison",
+      "copyReport": "Copier le rapport",
+      "copied": "Rapport copié dans le presse-papiers",
+      "copyFailed": "Impossible de copier le rapport"
+    },
     "scope": {
       "allIndexers": "Tous les indexeurs",
       "selectCustom": "Sélection personnalisée",

--- a/web/src/i18n/locales/it/torrents.json
+++ b/web/src/i18n/locales/it/torrents.json
@@ -719,6 +719,25 @@
     "block": "Blocca",
     "addedToBlocklist": "Aggiunto alla lista di blocco",
     "missingInstance": "Istanza mancante per la lista di blocco",
+    "trace": {
+      "title": "Dettaglio della ricerca",
+      "summaryBadge": "{{total}} candidati, {{matches}} corrispondenze",
+      "summary": "{{total}} candidati restituiti. Rifiutati: {{release}} release non corrispondente, {{size}} dimensione non corrispondente, {{late}} filtro contenuti, {{duplicates}} duplicati. Restano {{matches}} corrispondenze.",
+      "indexersHeading": "Indexer",
+      "status": {
+        "searched": "cercato",
+        "notCovered": "incompleto",
+        "error": "errore",
+        "excluded": "escluso"
+      },
+      "candidateCount": "{{count}} candidati",
+      "rejectionsHeading": "Candidati rifiutati",
+      "reasonCount": "{{reason}} · {{count}}",
+      "moreCandidates": "+{{count}} altri con questo motivo",
+      "copyReport": "Copia report",
+      "copied": "Report copiato negli appunti",
+      "copyFailed": "Impossibile copiare il report"
+    },
     "scope": {
       "allIndexers": "Tutti gli indexer",
       "selectCustom": "Selezione personalizzata",

--- a/web/src/i18n/locales/ko/torrents.json
+++ b/web/src/i18n/locales/ko/torrents.json
@@ -671,6 +671,25 @@
     "block": "차단",
     "addedToBlocklist": "차단 목록에 추가됨",
     "missingInstance": "차단 목록에 대한 인스턴스 누락",
+    "trace": {
+      "title": "검색 상세",
+      "summaryBadge": "후보 {{total}}개, 일치 {{matches}}개",
+      "summary": "후보 {{total}}개가 반환되었습니다. 거부됨: 릴리스 불일치 {{release}}개, 크기 불일치 {{size}}개, 콘텐츠 필터 {{late}}개, 중복 {{duplicates}}개. 일치 {{matches}}개가 남았습니다.",
+      "indexersHeading": "인덱서",
+      "status": {
+        "searched": "검색됨",
+        "notCovered": "불완전",
+        "error": "오류",
+        "excluded": "제외됨"
+      },
+      "candidateCount": "후보 {{count}}개",
+      "rejectionsHeading": "거부된 후보",
+      "reasonCount": "{{reason}} · {{count}}",
+      "moreCandidates": "같은 이유의 후보 {{count}}개 더 있음",
+      "copyReport": "보고서 복사",
+      "copied": "보고서가 클립보드에 복사되었습니다",
+      "copyFailed": "보고서를 복사할 수 없습니다"
+    },
     "scope": {
       "allIndexers": "모든 인덱서",
       "selectCustom": "사용자 지정 선택",

--- a/web/src/i18n/locales/pt-BR/torrents.json
+++ b/web/src/i18n/locales/pt-BR/torrents.json
@@ -719,6 +719,25 @@
     "block": "Bloquear",
     "addedToBlocklist": "Adicionado à lista de bloqueio",
     "missingInstance": "Faltando instância para a lista de bloqueio",
+    "trace": {
+      "title": "Detalhes da busca",
+      "summaryBadge": "{{total}} candidatos, {{matches}} correspondências",
+      "summary": "{{total}} candidatos retornados. Rejeitados: {{release}} release divergente, {{size}} tamanho divergente, {{late}} filtro de conteúdo, {{duplicates}} duplicados. Restam {{matches}} correspondências.",
+      "indexersHeading": "Indexadores",
+      "status": {
+        "searched": "pesquisado",
+        "notCovered": "incompleto",
+        "error": "erro",
+        "excluded": "excluído"
+      },
+      "candidateCount": "{{count}} candidatos",
+      "rejectionsHeading": "Candidatos rejeitados",
+      "reasonCount": "{{reason}} · {{count}}",
+      "moreCandidates": "+{{count}} outros com este motivo",
+      "copyReport": "Copiar relatório",
+      "copied": "Relatório copiado para a área de transferência",
+      "copyFailed": "Não foi possível copiar o relatório"
+    },
     "scope": {
       "allIndexers": "Todos os indexadores",
       "selectCustom": "Seleção Personalizada",

--- a/web/src/i18n/locales/uk/torrents.json
+++ b/web/src/i18n/locales/uk/torrents.json
@@ -815,6 +815,25 @@
     "block": "Блокувати",
     "addedToBlocklist": "Додано до чорного списку",
     "missingInstance": "Відсутній екземпляр для списку блокувань",
+    "trace": {
+      "title": "Деталі пошуку",
+      "summaryBadge": "{{total}} кандидатів, {{matches}} збігів",
+      "summary": "Повернуто {{total}} кандидатів. Відхилено: {{release}} невідповідність релізу, {{size}} невідповідність розміру, {{late}} фільтр вмісту, {{duplicates}} дублікати. Залишилось {{matches}} збігів.",
+      "indexersHeading": "Індексери",
+      "status": {
+        "searched": "виконано пошук",
+        "notCovered": "неповний",
+        "error": "помилка",
+        "excluded": "виключено"
+      },
+      "candidateCount": "{{count}} кандидатів",
+      "rejectionsHeading": "Відхилені кандидати",
+      "reasonCount": "{{reason}} · {{count}}",
+      "moreCandidates": "+{{count}} ще з цієї причини",
+      "copyReport": "Копіювати звіт",
+      "copied": "Звіт скопійовано в буфер обміну",
+      "copyFailed": "Не вдалося скопіювати звіт"
+    },
     "scope": {
       "allIndexers": "Усі індексатори",
       "selectCustom": "Вибрати власні",

--- a/web/src/i18n/locales/zh-CN/torrents.json
+++ b/web/src/i18n/locales/zh-CN/torrents.json
@@ -671,6 +671,25 @@
     "block": "屏蔽",
     "addedToBlocklist": "已添加到屏蔽列表",
     "missingInstance": "屏蔽列表缺少实例",
+    "trace": {
+      "title": "搜索明细",
+      "summaryBadge": "{{total}} 个候选，{{matches}} 个匹配",
+      "summary": "共返回 {{total}} 个候选。被拒绝：发布信息不符 {{release}} 个，大小不符 {{size}} 个，内容过滤 {{late}} 个，重复 {{duplicates}} 个。剩余 {{matches}} 个匹配。",
+      "indexersHeading": "索引器",
+      "status": {
+        "searched": "已搜索",
+        "notCovered": "未完成",
+        "error": "错误",
+        "excluded": "已排除"
+      },
+      "candidateCount": "{{count}} 个候选",
+      "rejectionsHeading": "被拒绝的候选",
+      "reasonCount": "{{reason}} · {{count}}",
+      "moreCandidates": "还有 {{count}} 个相同原因的候选",
+      "copyReport": "复制报告",
+      "copied": "报告已复制到剪贴板",
+      "copyFailed": "无法复制报告"
+    },
     "scope": {
       "allIndexers": "所有索引器",
       "selectCustom": "自定义选择",

--- a/web/src/i18n/locales/zh-TW/torrents.json
+++ b/web/src/i18n/locales/zh-TW/torrents.json
@@ -671,6 +671,25 @@
     "block": "封鎖",
     "addedToBlocklist": "已新增到封鎖清單",
     "missingInstance": "封鎖清單缺少實例",
+    "trace": {
+      "title": "搜尋明細",
+      "summaryBadge": "{{total}} 個候選，{{matches}} 個符合",
+      "summary": "共傳回 {{total}} 個候選。被拒絕：發布資訊不符 {{release}} 個，大小不符 {{size}} 個，內容過濾 {{late}} 個，重複 {{duplicates}} 個。剩餘 {{matches}} 個符合。",
+      "indexersHeading": "索引器",
+      "status": {
+        "searched": "已搜尋",
+        "notCovered": "未完成",
+        "error": "錯誤",
+        "excluded": "已排除"
+      },
+      "candidateCount": "{{count}} 個候選",
+      "rejectionsHeading": "被拒絕的候選",
+      "reasonCount": "{{reason}} · {{count}}",
+      "moreCandidates": "還有 {{count}} 個相同原因的候選",
+      "copyReport": "複製報告",
+      "copied": "報告已複製到剪貼簿",
+      "copyFailed": "無法複製報告"
+    },
     "scope": {
       "allIndexers": "所有索引器",
       "selectCustom": "自訂選擇",

--- a/web/src/i18n/locales/zh-TW/torrents.json
+++ b/web/src/i18n/locales/zh-TW/torrents.json
@@ -673,8 +673,8 @@
     "missingInstance": "封鎖清單缺少實例",
     "trace": {
       "title": "搜尋明細",
-      "summaryBadge": "{{total}} 個候選，{{matches}} 個符合",
-      "summary": "共傳回 {{total}} 個候選。被拒絕：發布資訊不符 {{release}} 個，大小不符 {{size}} 個，內容過濾 {{late}} 個，重複 {{duplicates}} 個。剩餘 {{matches}} 個符合。",
+      "summaryBadge": "{{total}} 個候選，{{matches}} 個匹配項",
+      "summary": "共傳回 {{total}} 個候選。被拒絕：發布資訊不符 {{release}} 個，大小不符 {{size}} 個，內容過濾 {{late}} 個，重複 {{duplicates}} 個。剩餘 {{matches}} 個匹配項。",
       "indexersHeading": "索引器",
       "status": {
         "searched": "已搜尋",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -30,6 +30,7 @@ import type {
   CrossSeedBlocklistEntry,
   CrossSeedInstanceResult,
   CrossSeedQueryDegradedReason,
+  CrossSeedSearchDecisionTrace,
   CrossSeedRun,
   CrossSeedSearchRun,
   CrossSeedSearchSettings,
@@ -1299,6 +1300,8 @@ class ApiClient {
       cache?: TorznabSearchCacheMetadata
       partial?: boolean
       query_degraded?: CrossSeedQueryDegradedReason
+      // Already camelCase over the wire, like cache.
+      decisionTrace?: CrossSeedSearchDecisionTrace
     }
 
     const response = await this.request<RawSearchResponse>(`/cross-seed/torrents/${instanceId}/${hash}/search`, {
@@ -1356,6 +1359,7 @@ class ApiClient {
       cache: response.cache,
       partial: response.partial ?? undefined,
       queryDegraded: response.query_degraded ?? undefined,
+      decisionTrace: response.decisionTrace,
     }
   }
 

--- a/web/src/types/crossseed.ts
+++ b/web/src/types/crossseed.ts
@@ -80,12 +80,46 @@ export interface CrossSeedTorrentSearchResult {
 /** Set when the ARR external-ID lookup could not supply IDs and the search ran title-only. */
 export type CrossSeedQueryDegradedReason = "arr_lookup_failed" | "arr_no_ids"
 
+export interface CrossSeedSearchRejectedCandidate {
+  indexer: string
+  indexerId: number
+  title: string
+  size: number
+  reason: string
+}
+
+export type CrossSeedSearchIndexerStatus = "searched" | "not_covered" | "error" | "excluded"
+
+export interface CrossSeedSearchIndexerOutcome {
+  indexerId: number
+  status: CrossSeedSearchIndexerStatus
+  detail?: string
+  candidates: number
+}
+
+/** Explains why the Torznab passes accepted or rejected candidates. Absent when no Torznab search ran. */
+export interface CrossSeedSearchDecisionTrace {
+  sourceSize: number
+  tolerancePercent: number
+  totalResults: number
+  sizeFiltered: number
+  releaseFiltered: number
+  lateContentFiltered: number
+  duplicateFiltered: number
+  finalMatches: number
+  rejectionCounts?: Record<string, number>
+  /** Capped at 5 candidates per rejection reason; rejectionCounts holds the full totals. */
+  rejectedCandidates?: CrossSeedSearchRejectedCandidate[]
+  indexers?: CrossSeedSearchIndexerOutcome[]
+}
+
 export interface CrossSeedTorrentSearchResponse {
   sourceTorrent: CrossSeedTorrentInfo
   results: CrossSeedTorrentSearchResult[]
   cache?: TorznabSearchCacheMetadata
   partial?: boolean
   queryDegraded?: CrossSeedQueryDegradedReason
+  decisionTrace?: CrossSeedSearchDecisionTrace
 }
 
 export interface CrossSeedTorrentSearchSelection {


### PR DESCRIPTION
## Description

Manual cross-seed searches now return an ephemeral `decisionTrace` with the search response: filter counters, a count per rejection reason, the first 5 rejected candidates per reason, and one outcome row per indexer (searched, incomplete, error, or excluded). The search dialog shows it in a collapsible "Search breakdown" section with a plain-text copy button for bug reports.

The service already computed all of this and dropped it. Until now the only way to see why a search rejected candidates was to read `DEBUG`/`TRACE` logs. Nothing is persisted, the trace lives in the response and dies with the dialog.

## How has this been tested?

Ran the built binary against a real qBittorrent instance plus a mock Torznab pair, one healthy indexer serving crafted candidates and one that always returns 500. A manual search returned the exact-size candidate as the only match, and the trace reported the expected rejection reasons (resolution, group, size, and episode mismatch), the per-indexer candidate counts, and an error row for the failing indexer with the API key redacted from its detail.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Search breakdown panel to cross-seed results, showing indexer outcomes, candidate counts, rejection reasons, and sample rejected candidates.
  * Added a Copy report action for sharing plain-text search diagnostics.
  * Added localized support for cross-seed search details across supported languages.

* **Documentation**
  * Updated troubleshooting guidance to clarify that Search breakdown appears for manual searches using Torznab indexers, not Gazelle-only searches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
