### PR TITLE
feat(preferences): add slow torrent settings to the queue form

### DIFF
--- a/web/src/components/instances/preferences/QueueManagementForm.tsx
+++ b/web/src/components/instances/preferences/QueueManagementForm.tsx
@@ -61,6 +61,10 @@ export function QueueManagementForm({ instanceId, onSuccess }: QueueManagementFo
       max_active_uploads: 0,
       max_active_torrents: 0,
       max_active_checking_torrents: 0,
+      dont_count_slow_torrents: false,
+      slow_torrent_dl_rate_threshold: 2,
+      slow_torrent_ul_rate_threshold: 2,
+      slow_torrent_inactive_timer: 60,
     },
     onSubmit: async ({ value }) => {
       try {
@@ -81,6 +85,10 @@ export function QueueManagementForm({ instanceId, onSuccess }: QueueManagementFo
       form.setFieldValue("max_active_uploads", preferences.max_active_uploads)
       form.setFieldValue("max_active_torrents", preferences.max_active_torrents)
       form.setFieldValue("max_active_checking_torrents", preferences.max_active_checking_torrents)
+      form.setFieldValue("dont_count_slow_torrents", preferences.dont_count_slow_torrents)
+      form.setFieldValue("slow_torrent_dl_rate_threshold", preferences.slow_torrent_dl_rate_threshold)
+      form.setFieldValue("slow_torrent_ul_rate_threshold", preferences.slow_torrent_ul_rate_threshold)
+      form.setFieldValue("slow_torrent_inactive_timer", preferences.slow_torrent_inactive_timer)
     }
   }, [preferences, form])
 
@@ -233,6 +241,60 @@ export function QueueManagementForm({ instanceId, onSuccess }: QueueManagementFo
               )}
             </form.Field>
           </div>
+
+          <form.Field name="dont_count_slow_torrents">
+            {(field) => (
+              <SwitchSetting
+                label={t("preferences.queueManagement.dontCountSlowTorrents")}
+                checked={(field.state.value as boolean) ?? false}
+                onCheckedChange={field.handleChange}
+                description={t("preferences.queueManagement.dontCountSlowTorrentsDescription")}
+              />
+            )}
+          </form.Field>
+
+          <form.Subscribe selector={(state) => state.values.dont_count_slow_torrents}>
+            {(dontCountSlowTorrents) => (
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <form.Field name="slow_torrent_dl_rate_threshold">
+                  {(field) => (
+                    <NumberInputWithUnlimited
+                      label={t("preferences.queueManagement.slowTorrentDlRateThreshold")}
+                      value={(field.state.value as number) ?? 2}
+                      onChange={field.handleChange}
+                      max={2000000}
+                      disabled={!dontCountSlowTorrents}
+                    />
+                  )}
+                </form.Field>
+
+                <form.Field name="slow_torrent_ul_rate_threshold">
+                  {(field) => (
+                    <NumberInputWithUnlimited
+                      label={t("preferences.queueManagement.slowTorrentUlRateThreshold")}
+                      value={(field.state.value as number) ?? 2}
+                      onChange={field.handleChange}
+                      max={2000000}
+                      disabled={!dontCountSlowTorrents}
+                    />
+                  )}
+                </form.Field>
+
+                <form.Field name="slow_torrent_inactive_timer">
+                  {(field) => (
+                    <NumberInputWithUnlimited
+                      label={t("preferences.queueManagement.slowTorrentInactiveTimer")}
+                      value={(field.state.value as number) ?? 60}
+                      onChange={field.handleChange}
+                      min={1}
+                      description={t("preferences.queueManagement.slowTorrentInactiveTimerDescription")}
+                      disabled={!dontCountSlowTorrents}
+                    />
+                  )}
+                </form.Field>
+              </div>
+            )}
+          </form.Subscribe>
         </div>
       </div>
     </PreferencesFormShell>

--- a/web/src/i18n/locales/cs/instances.json
+++ b/web/src/i18n/locales/cs/instances.json
@@ -319,6 +319,12 @@
       "maxActiveTorrentsDescription": "Celkový maximální počet aktivních torrentů",
       "maxCheckingTorrents": "Maximální počet kontrolovaných torrentů",
       "maxCheckingTorrentsDescription": "Maximální počet kontrolovaných aktivních torrentů",
+      "dontCountSlowTorrents": "Nepočítat pomalé torrenty",
+      "dontCountSlowTorrentsDescription": "Pomalé torrenty se nezapočítávají do výše uvedených limitů aktivních torrentů",
+      "slowTorrentDlRateThreshold": "Práh rychlosti stahování (KiB/s)",
+      "slowTorrentUlRateThreshold": "Práh rychlosti odesílání (KiB/s)",
+      "slowTorrentInactiveTimer": "Časovač nečinnosti torrentu (sekundy)",
+      "slowTorrentInactiveTimerDescription": "Jak dlouho musí obě rychlosti zůstat pod prahy, než se torrent považuje za pomalý",
       "validation": {
         "maxActiveDownloads": "Maximální počet aktivních stahování musí být větší než -1",
         "maxActiveUploads": "Maximální počet aktivních odesílání musí být větší než -1",

--- a/web/src/i18n/locales/de/instances.json
+++ b/web/src/i18n/locales/de/instances.json
@@ -319,6 +319,12 @@
       "maxActiveTorrentsDescription": "Maximale Gesamtzahl aktiver Torrents",
       "maxCheckingTorrents": "Max. prüfende Torrents",
       "maxCheckingTorrentsDescription": "Maximale Anzahl gleichzeitig prüfender Torrents",
+      "dontCountSlowTorrents": "Langsame Torrents nicht zählen",
+      "dontCountSlowTorrentsDescription": "Langsame Torrents zählen nicht zu den oben genannten aktiven Limits",
+      "slowTorrentDlRateThreshold": "Download-Raten-Schwelle (KiB/s)",
+      "slowTorrentUlRateThreshold": "Upload-Raten-Schwelle (KiB/s)",
+      "slowTorrentInactiveTimer": "Torrent-Inaktivitäts-Timer (Sekunden)",
+      "slowTorrentInactiveTimerDescription": "Wie lange beide Raten unter den Schwellen bleiben müssen, bevor der Torrent als langsam gilt",
       "validation": {
         "maxActiveDownloads": "Maximale aktive Downloads müssen größer als -1 sein",
         "maxActiveUploads": "Maximale aktive Uploads müssen größer als -1 sein",

--- a/web/src/i18n/locales/en/instances.json
+++ b/web/src/i18n/locales/en/instances.json
@@ -319,6 +319,12 @@
       "maxActiveTorrentsDescription": "Total maximum active torrents",
       "maxCheckingTorrents": "Max Checking Torrents",
       "maxCheckingTorrentsDescription": "Maximum torrents checking simultaneously",
+      "dontCountSlowTorrents": "Do Not Count Slow Torrents",
+      "dontCountSlowTorrentsDescription": "Slow torrents do not count against the active limits above",
+      "slowTorrentDlRateThreshold": "Download Rate Threshold (KiB/s)",
+      "slowTorrentUlRateThreshold": "Upload Rate Threshold (KiB/s)",
+      "slowTorrentInactiveTimer": "Torrent Inactivity Timer (seconds)",
+      "slowTorrentInactiveTimerDescription": "How long both rates must stay below the thresholds before the torrent counts as slow",
       "validation": {
         "maxActiveDownloads": "Maximum active downloads must be greater than -1",
         "maxActiveUploads": "Maximum active uploads must be greater than -1",

--- a/web/src/i18n/locales/fr/instances.json
+++ b/web/src/i18n/locales/fr/instances.json
@@ -319,6 +319,12 @@
       "maxActiveTorrentsDescription": "Nombre total maximum de torrents actifs",
       "maxCheckingTorrents": "Vérifications Max",
       "maxCheckingTorrentsDescription": "Nombre maximal de torrents en vérification simultanée",
+      "dontCountSlowTorrents": "Ne Pas Compter les Torrents Lents",
+      "dontCountSlowTorrentsDescription": "Les torrents lents ne comptent pas dans les limites actives ci-dessus",
+      "slowTorrentDlRateThreshold": "Seuil de Débit de Téléchargement (KiB/s)",
+      "slowTorrentUlRateThreshold": "Seuil de Débit d'Envoi (KiB/s)",
+      "slowTorrentInactiveTimer": "Minuteur d'Inactivité du Torrent (secondes)",
+      "slowTorrentInactiveTimerDescription": "Durée pendant laquelle les deux débits doivent rester sous les seuils avant que le torrent soit considéré comme lent",
       "validation": {
         "maxActiveDownloads": "Le max de téléchargements actifs doit être supérieur à -1",
         "maxActiveUploads": "Le max d'envois actifs doit être supérieur à -1",

--- a/web/src/i18n/locales/it/instances.json
+++ b/web/src/i18n/locales/it/instances.json
@@ -319,6 +319,12 @@
       "maxActiveTorrentsDescription": "Numero totale massimo di torrent attivi",
       "maxCheckingTorrents": "Verifiche massime",
       "maxCheckingTorrentsDescription": "Numero massimo di torrent in verifica simultanea",
+      "dontCountSlowTorrents": "Non contare i torrent lenti",
+      "dontCountSlowTorrentsDescription": "I torrent lenti non contano nei limiti attivi sopra indicati",
+      "slowTorrentDlRateThreshold": "Soglia velocità di download (KiB/s)",
+      "slowTorrentUlRateThreshold": "Soglia velocità di upload (KiB/s)",
+      "slowTorrentInactiveTimer": "Timer di inattività del torrent (secondi)",
+      "slowTorrentInactiveTimerDescription": "Per quanto tempo entrambe le velocità devono restare sotto le soglie prima che il torrent sia considerato lento",
       "validation": {
         "maxActiveDownloads": "Il numero massimo di download attivi deve essere maggiore di -1",
         "maxActiveUploads": "Il numero massimo di upload attivi deve essere maggiore di -1",

--- a/web/src/i18n/locales/ko/instances.json
+++ b/web/src/i18n/locales/ko/instances.json
@@ -319,6 +319,12 @@
       "maxActiveTorrentsDescription": "전체 최대 활성 토렌트",
       "maxCheckingTorrents": "최대 확인 토렌트",
       "maxCheckingTorrentsDescription": "동시에 확인하는 최대 토렌트 수",
+      "dontCountSlowTorrents": "느린 토렌트 제외",
+      "dontCountSlowTorrentsDescription": "느린 토렌트는 위의 활성 제한에 포함되지 않습니다",
+      "slowTorrentDlRateThreshold": "다운로드 속도 임계값 (KiB/s)",
+      "slowTorrentUlRateThreshold": "업로드 속도 임계값 (KiB/s)",
+      "slowTorrentInactiveTimer": "토렌트 비활성 타이머 (초)",
+      "slowTorrentInactiveTimerDescription": "두 속도가 임계값 아래로 얼마나 유지되어야 느린 토렌트로 간주하는지",
       "validation": {
         "maxActiveDownloads": "최대 활성 다운로드는 -1보다 커야 합니다",
         "maxActiveUploads": "최대 활성 업로드는 -1보다 커야 합니다",

--- a/web/src/i18n/locales/pt-BR/instances.json
+++ b/web/src/i18n/locales/pt-BR/instances.json
@@ -319,6 +319,12 @@
       "maxActiveTorrentsDescription": "Total máximo de torrents ativos",
       "maxCheckingTorrents": "Máximo de Torrents em Verificação",
       "maxCheckingTorrentsDescription": "Máximo de torrents verificando os arquivos simultaneamente",
+      "dontCountSlowTorrents": "Não Contar Torrents Lentos",
+      "dontCountSlowTorrentsDescription": "Torrents lentos não contam nos limites ativos acima",
+      "slowTorrentDlRateThreshold": "Limite de Taxa de Download (KiB/s)",
+      "slowTorrentUlRateThreshold": "Limite de Taxa de Upload (KiB/s)",
+      "slowTorrentInactiveTimer": "Temporizador de Inatividade do Torrent (segundos)",
+      "slowTorrentInactiveTimerDescription": "Por quanto tempo ambas as taxas devem permanecer abaixo dos limites antes de o torrent ser considerado lento",
       "validation": {
         "maxActiveDownloads": "Downloads ativos devem ser > -1",
         "maxActiveUploads": "Uploads ativos devem ser > -1",

--- a/web/src/i18n/locales/uk/instances.json
+++ b/web/src/i18n/locales/uk/instances.json
@@ -319,6 +319,12 @@
       "maxActiveTorrentsDescription": "Загальна максимальна кількість активних торентів",
       "maxCheckingTorrents": "Максимальна перевірка торентів",
       "maxCheckingTorrentsDescription": "Одночасна перевірка максимальної кількості торентів",
+      "dontCountSlowTorrents": "Не рахувати повільні торенти",
+      "dontCountSlowTorrentsDescription": "Повільні торенти не враховуються в наведених вище лімітах активних торентів",
+      "slowTorrentDlRateThreshold": "Поріг швидкості завантаження (KiB/s)",
+      "slowTorrentUlRateThreshold": "Поріг швидкості вивантаження (KiB/s)",
+      "slowTorrentInactiveTimer": "Таймер неактивності торента (секунди)",
+      "slowTorrentInactiveTimerDescription": "Як довго обидві швидкості мають залишатися нижче порогів, перш ніж торент вважатиметься повільним",
       "validation": {
         "maxActiveDownloads": "Максимальна кількість активних завантажень має бути більше -1",
         "maxActiveUploads": "Максимальна кількість активних вивантажень має бути більше -1",

--- a/web/src/i18n/locales/zh-CN/instances.json
+++ b/web/src/i18n/locales/zh-CN/instances.json
@@ -319,6 +319,12 @@
       "maxActiveTorrentsDescription": "活跃种子总数上限",
       "maxCheckingTorrents": "最大校验种子数",
       "maxCheckingTorrentsDescription": "同时校验的种子最大数量",
+      "dontCountSlowTorrents": "不计入慢速种子",
+      "dontCountSlowTorrentsDescription": "慢速种子不计入上述活跃数量限制",
+      "slowTorrentDlRateThreshold": "下载速率阈值 (KiB/s)",
+      "slowTorrentUlRateThreshold": "上传速率阈值 (KiB/s)",
+      "slowTorrentInactiveTimer": "种子不活跃计时 (秒)",
+      "slowTorrentInactiveTimerDescription": "两项速率需持续低于阈值多久才将种子视为慢速",
       "validation": {
         "maxActiveDownloads": "最大活跃下载数必须大于 -1",
         "maxActiveUploads": "最大活跃上传数必须大于 -1",

--- a/web/src/i18n/locales/zh-CN/instances.json
+++ b/web/src/i18n/locales/zh-CN/instances.json
@@ -321,9 +321,9 @@
       "maxCheckingTorrentsDescription": "同时校验的种子最大数量",
       "dontCountSlowTorrents": "不计入慢速种子",
       "dontCountSlowTorrentsDescription": "慢速种子不计入上述活跃数量限制",
-      "slowTorrentDlRateThreshold": "下载速率阈值 (KiB/s)",
-      "slowTorrentUlRateThreshold": "上传速率阈值 (KiB/s)",
-      "slowTorrentInactiveTimer": "种子不活跃计时 (秒)",
+      "slowTorrentDlRateThreshold": "下载速率阈值（KiB/s）",
+      "slowTorrentUlRateThreshold": "上传速率阈值（KiB/s）",
+      "slowTorrentInactiveTimer": "种子不活跃计时（秒）",
       "slowTorrentInactiveTimerDescription": "两项速率需持续低于阈值多久才将种子视为慢速",
       "validation": {
         "maxActiveDownloads": "最大活跃下载数必须大于 -1",

--- a/web/src/i18n/locales/zh-TW/instances.json
+++ b/web/src/i18n/locales/zh-TW/instances.json
@@ -319,6 +319,12 @@
       "maxActiveTorrentsDescription": "活躍種子總數上限",
       "maxCheckingTorrents": "最大檢查種子數",
       "maxCheckingTorrentsDescription": "同時檢查的種子最大數量",
+      "dontCountSlowTorrents": "不計入慢速種子",
+      "dontCountSlowTorrentsDescription": "慢速種子不計入上述活躍數量限制",
+      "slowTorrentDlRateThreshold": "下載速率閾值 (KiB/s)",
+      "slowTorrentUlRateThreshold": "上傳速率閾值 (KiB/s)",
+      "slowTorrentInactiveTimer": "種子不活躍計時 (秒)",
+      "slowTorrentInactiveTimerDescription": "兩項速率需持續低於閾值多久才將種子視為慢速",
       "validation": {
         "maxActiveDownloads": "最大活躍下載數必須大於 -1",
         "maxActiveUploads": "最大活躍上傳數必須大於 -1",

--- a/web/src/i18n/locales/zh-TW/instances.json
+++ b/web/src/i18n/locales/zh-TW/instances.json
@@ -321,9 +321,9 @@
       "maxCheckingTorrentsDescription": "同時檢查的種子最大數量",
       "dontCountSlowTorrents": "不計入慢速種子",
       "dontCountSlowTorrentsDescription": "慢速種子不計入上述活躍數量限制",
-      "slowTorrentDlRateThreshold": "下載速率閾值 (KiB/s)",
-      "slowTorrentUlRateThreshold": "上傳速率閾值 (KiB/s)",
-      "slowTorrentInactiveTimer": "種子不活躍計時 (秒)",
+      "slowTorrentDlRateThreshold": "下載速率閾值（KiB/s）",
+      "slowTorrentUlRateThreshold": "上傳速率閾值（KiB/s）",
+      "slowTorrentInactiveTimer": "種子不活躍計時（秒）",
       "slowTorrentInactiveTimerDescription": "兩項速率需持續低於閾值多久才將種子視為慢速",
       "validation": {
         "maxActiveDownloads": "最大活躍下載數必須大於 -1",


### PR DESCRIPTION
## Description

qBittorrent can keep slow torrents out of the active torrent limits, but qui did not show the settings. This adds them to the Queue tab: the `dont_count_slow_torrents` switch, the download and upload rate thresholds in KiB/s, and the inactivity timer in seconds. The three fields are disabled while the switch is off, as in qBittorrent.

The keys, the units and the defaults are the same in every qBittorrent from 4.3.9 to current, so there is no version check. The change is frontend only, because the preferences endpoint passes the payload through.

## How has this been tested?

Ran the built binary against a live qBittorrent, saved the settings from the Queue tab, and confirmed the new values in the native WebUI.

## Screenshots (for UI changes)
<img width="2240" height="1460" alt="image" src="https://github.com/user-attachments/assets/9757cdb2-36f4-45d4-ac72-ac5cf9fb4efb" />


## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added queue management settings to exclude slow torrents from active torrent limits.
  - Configure download and upload rate thresholds plus an inactivity timer for identifying slow torrents.
  - Related controls remain disabled until slow-torrent handling is enabled.

- **Localization**
  - Added translated labels and descriptions for the new settings across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->