### PR TITLE
docs(crossseed): explain that Prowlarr indexer filters also apply

### DIFF
--- a/documentation/docs/features/cross-seed/overview.md
+++ b/documentation/docs/features/cross-seed/overview.md
@@ -28,6 +28,10 @@ Disc-based media (Blu-ray/DVD) requires manual verification. See [troubleshootin
 
 You need Prowlarr or Jackett to provide Torznab indexer feeds. Add your indexers in **Settings → Indexers** using the "1-click sync" feature to import from Prowlarr/Jackett automatically.
 
+:::note Prowlarr filters also apply here
+A Prowlarr indexer's own search filters, such as freeleech only, also apply to cross-seed searches. See [troubleshooting](./troubleshooting.md#prowlarr-filters-remove-expected-results).
+:::
+
 Optional: qui can also query OPS/RED directly via the trackers' Gazelle JSON APIs. This complements Torznab, can handle OPS/RED searches even when no Torznab backend is available, and excludes OPS/RED Torznab indexers for per-torrent searches only when **both** Gazelle keys are configured. See [OPS/RED (Gazelle)](./gazelle-ops-red.md).
 
 **Optional but recommended:** Configure Sonarr/Radarr instances in **Settings → Integrations** to enable external ID lookups (IMDb, TMDb, TVDb, TVMaze). When configured, qui queries your *arr instances to resolve IDs for cross-seed searches, improving match accuracy on indexers that support ID-based queries.

--- a/documentation/docs/features/cross-seed/troubleshooting.md
+++ b/documentation/docs/features/cross-seed/troubleshooting.md
@@ -36,6 +36,12 @@ An exact reported size is evidence, not byte verification. qui still checks the 
 
 By default, season packs only match other season packs. Enable **Find individual episodes** in settings to allow season packs to match individual episode releases.
 
+### Prowlarr filters remove expected results
+
+qui searches the selected Prowlarr indexer directly. If that indexer has a search filter enabled, such as freeleech only, the filter also applies to cross-seed searches. The tracker can return no results even when matching cross-seed candidates exist.
+
+Prowlarr does not support per-search filter overrides. Add a second entry for the tracker in Prowlarr with the filter disabled, then select that second entry in qui.
+
 ## Cross-seed search run statuses
 
 Library scan and completion search rows use **added**, **skipped**, or **failed** as the top-level outcome. Open the row details to see the per-attempt status and message.


### PR DESCRIPTION
## Description

A Prowlarr indexer that has a search filter, for example freeleech only, uses that filter for cross-seed searches as well. The tracker can then return no results while cross-seed candidates exist, and nothing in qui explains why. Prowlarr has no per-search override, so the documented fix is a second entry for the tracker with the filter disabled.

This supersedes #1562, which carries the same content but sits on a fork branch that cannot be updated and conflicts with the current docs. The wording there is by @tomerh2001.

Part of #1561

## How has this been tested?

Built the documentation site and checked that the note renders and its anchor link resolves.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that Prowlarr indexer filters, including freeleech-only settings, apply to cross-seed searches.
  - Added troubleshooting guidance for missing results caused by configured filters.
  - Recommended using a separate unfiltered tracker entry when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->