### PR TITLE
docs(agents): scope local test runs to the packages you touched

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,10 @@ Before changing cross-module data flow, service boundaries, API routing, or long
 - Go tests: always use `-race -count=1`
 - Full Go suite: `make test` (`go test -race -count=1 -v ./...`)
 - OpenAPI changes under `internal/web/swagger`: run `make test-openapi`
+- Leave `GOCACHE`, `GOMODCACHE`, and `GOTMPDIR` at their defaults under `~/.cache`. `/tmp` is a tmpfs here, so a cache under it spends RAM the running programs need.
+- `internal/services/crossseed` tests need `TMPDIR=/var/tmp/qui-tests`. Hardlink and reflink cases fail when the scratch dir sits on a different filesystem from the repo.
 
-For changes under `internal/services/crossseed` or `internal/qbittorrent`, run targeted package tests first. Skip local full `make test` by default; CI covers it unless requested.
+CI runs `make test` on every push. Run the full suite locally only when asked, or when one change crosses many packages.
 
 ## Lint / Format
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,6 @@ Before changing cross-module data flow, service boundaries, API routing, or long
 - Go tests: always use `-race -count=1`
 - Full Go suite: `make test` (`go test -race -count=1 -v ./...`)
 - OpenAPI changes under `internal/web/swagger`: run `make test-openapi`
-- Leave `GOCACHE`, `GOMODCACHE`, and `GOTMPDIR` at their defaults under `~/.cache`. `/tmp` is a tmpfs here, so a cache under it spends RAM the running programs need.
-- `internal/services/crossseed` tests need `TMPDIR=/var/tmp/qui-tests`. Hardlink and reflink cases fail when the scratch dir sits on a different filesystem from the repo.
 
 CI runs `make test` on every push. Run the full suite locally only when asked, or when one change crosses many packages.
 


### PR DESCRIPTION
## Description

The test guidance named `internal/services/crossseed` and `internal/qbittorrent`, but the rule holds for every package: run the tests for the code you changed, because CI runs `make test` on every push. The replacement says that once, for all packages.

Machine-specific setup, such as where the Go caches live and which `TMPDIR` the hardlink tests need, stays out of this file. It depends on how a given machine is partitioned, so it belongs in a personal agent config.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL