### PR TITLE
docs(metrics): document exporter and add Grafana dashboard

### DIFF
--- a/documentation/docs/advanced/metrics.md
+++ b/documentation/docs/advanced/metrics.md
@@ -3,52 +3,166 @@ sidebar_position: 1
 title: Metrics
 ---
 
-# Prometheus Metrics
+# Prometheus metrics
 
-Prometheus metrics can be enabled to monitor your qBittorrent instances. When enabled, metrics are served on a **separate port** (default: 9074) with **no authentication required** for easier monitoring setup.
+Qui can expose Prometheus metrics for its process and qBittorrent instances. The metrics server uses a separate port, which defaults to `9074`.
 
-## Enable Metrics
+The server has no authentication unless you configure basic authentication. Bind it to a private interface or protect it before you expose it to a network.
 
-Metrics are **disabled by default**. Enable them via configuration file or environment variable:
+## Enable metrics
 
-### Config File (`config.toml`)
+Metrics are disabled by default. Enable them in the configuration file or with environment variables.
+
+### Configuration file
 
 ```toml
 metricsEnabled = true
-metricsHost = "127.0.0.1"  # Bind to localhost only (recommended for security)
-metricsPort = 9074         # Standard Prometheus port range
-# metricsBasicAuthUsers = "user:$2y$10$bcrypt_hash_here"  # Optional: basic auth
+metricsHost = "127.0.0.1"
+metricsPort = 9074
+# metricsBasicAuthUsers = "user:password"
 ```
 
-### Environment Variables
+### Environment variables
 
 ```bash
 QUI__METRICS_ENABLED=true
-QUI__METRICS_HOST=0.0.0.0    # Optional: bind to all interfaces if needed
-QUI__METRICS_PORT=9074       # Optional: custom port
-QUI__METRICS_BASIC_AUTH_USERS="user:$2y$10$hash"  # Optional: basic auth
+QUI__METRICS_HOST=127.0.0.1
+QUI__METRICS_PORT=9074
+# QUI__METRICS_BASIC_AUTH_USERS="user:password"
 ```
 
-## Available Metrics
+Qui accepts multiple basic-authentication users as a comma-separated list of `user:password` entries. Qui compares these passwords as plaintext.
 
-- **Torrent counts** by status (downloading, seeding, paused, error)
-- **Transfer speeds** (upload/download bytes per second)
-- **Instance connection status**
+Protect the configuration file or environment that contains the passwords.
 
-## Prometheus Configuration
+## Configure Prometheus
 
-Configure Prometheus to scrape the dedicated metrics port (no authentication required):
+Add Qui to your Prometheus scrape configuration:
 
 ```yaml
 scrape_configs:
-  - job_name: 'qui'
+  - job_name: qui
     static_configs:
-      - targets: ['localhost:9074']
+      - targets: ["localhost:9074"]
     metrics_path: /metrics
     scrape_interval: 30s
-    #basic_auth:
-      #username: prometheus
-      #password: yourpassword
+    # basic_auth:
+    #   username: prometheus
+    #   password: yourpassword
 ```
 
-All metrics are labeled with `instance_id` and `instance_name` for multi-instance monitoring.
+## Qui metrics
+
+The qBittorrent metrics use the `instance_id` and `instance_name` labels. Tracker metrics also use `tracker_name`.
+
+| Metric | Type | Labels | Value and reset behavior |
+|---|---|---|---|
+| `qbittorrent_torrents_downloading` | Gauge | `instance_id`, `instance_name` | Current downloading torrent count. |
+| `qbittorrent_torrents_seeding` | Gauge | `instance_id`, `instance_name` | Current seeding torrent count. |
+| `qbittorrent_torrents_paused` | Gauge | `instance_id`, `instance_name` | Current paused or stopped torrent count. |
+| `qbittorrent_torrents_error` | Gauge | `instance_id`, `instance_name` | Current torrent error count. |
+| `qbittorrent_torrents_checking` | Gauge | `instance_id`, `instance_name` | Current checking torrent count. |
+| `qbittorrent_session_download_bytes` | Counter | `instance_id`, `instance_name` | Bytes downloaded during the current qBittorrent session. A qBittorrent restart resets this value. |
+| `qbittorrent_session_upload_bytes` | Counter | `instance_id`, `instance_name` | Bytes uploaded during the current qBittorrent session. A qBittorrent restart resets this value. |
+| `qbittorrent_alltime_download_bytes` | Counter | `instance_id`, `instance_name` | All-time bytes downloaded by qBittorrent. This value persists across restarts. Clearing qBittorrent's saved statistics resets it. |
+| `qbittorrent_alltime_upload_bytes` | Counter | `instance_id`, `instance_name` | All-time bytes uploaded by qBittorrent. This value persists across restarts. Clearing qBittorrent's saved statistics resets it. |
+| `qbittorrent_instance_connection_status` | Gauge | `instance_id`, `instance_name` | `1` for an active, healthy connection. `0` for a disabled or unhealthy instance. |
+| `qbittorrent_scrape_errors_total` | Counter | `instance_id`, `instance_name`, `type` | A value of `1` for each failed collection sample. A successful collection omits the series. |
+| `qbittorrent_tracker_torrents` | Gauge | `instance_id`, `instance_name`, `tracker_name` | Current torrent count for the tracker group. |
+| `qbittorrent_tracker_uploaded_bytes` | Gauge | `instance_id`, `instance_name`, `tracker_name` | Uploaded bytes from current torrents in the tracker group. |
+| `qbittorrent_tracker_downloaded_bytes` | Gauge | `instance_id`, `instance_name`, `tracker_name` | Downloaded bytes from current torrents in the tracker group. |
+| `qbittorrent_tracker_total_size_bytes` | Gauge | `instance_id`, `instance_name`, `tracker_name` | Current content size for the tracker group. Qui counts a shared content path once within each group. |
+| `qui_db_wedged_transaction_total` | Counter | None | SQLite nested-transaction detections since Qui started. A Qui restart resets this value. |
+
+Qui also exports the standard `go_*` and `process_*` metrics from the Prometheus Go client. Those series depend on the Go and client-library versions.
+
+Disabled and disconnected instances expose only `qbittorrent_instance_connection_status`. Qui omits their torrent and transfer metrics.
+
+## Tracker metric limits
+
+Tracker metrics describe torrents that remain in qBittorrent. Qui does not store tracker history. When you remove a torrent, its transfer totals leave the tracker metrics.
+
+Qui assigns a torrent's full transfer totals to each tracker group associated with that torrent. Do not sum tracker groups to calculate unique instance traffic.
+
+The `tracker_name` label uses the customization display name when one is configured. Otherwise, it uses the tracker domain. Included secondary domains contribute to their configured group.
+
+## PromQL examples
+
+### Tracker totals
+
+Uploaded bytes for the torrents that are currently present:
+
+```promql
+sum by (instance_name, tracker_name) (
+  qbittorrent_tracker_uploaded_bytes
+)
+```
+
+Downloaded bytes for the torrents that are currently present:
+
+```promql
+sum by (instance_name, tracker_name) (
+  qbittorrent_tracker_downloaded_bytes
+)
+```
+
+### Instance transfer rates
+
+The session metrics are counters. `rate()` handles a qBittorrent restart and returns the average bytes per second.
+
+```promql
+sum by (instance_name) (
+  rate(qbittorrent_session_upload_bytes[5m])
+)
+```
+
+```promql
+sum by (instance_name) (
+  rate(qbittorrent_session_download_bytes[5m])
+)
+```
+
+Grafana users can replace `[5m]` with `[$__rate_interval]`.
+
+### Estimated tracker transfer rates
+
+Tracker byte metrics are gauges because their values decrease when torrents leave the library. Use `deriv()` for an estimate:
+
+```promql
+sum by (instance_name, tracker_name) (
+  clamp_min(deriv(qbittorrent_tracker_uploaded_bytes[5m]), 0)
+)
+```
+
+A torrent removal can hide traffic until the removal leaves the selected time range.
+
+### Collection errors
+
+The error collector emits one sample for each failed collection. Count those samples over time:
+
+```promql
+sum by (instance_name, type) (
+  sum_over_time(qbittorrent_scrape_errors_total[5m])
+)
+```
+
+Do not use `rate()` or `increase()` with this metric. It does not retain a cumulative count between scrapes.
+
+### Disconnected instances
+
+```promql
+qbittorrent_instance_connection_status == 0
+```
+
+This query includes disabled instances. Monitor Prometheus's `up{job="qui"}` metric separately because Qui cannot report an unreachable metrics endpoint.
+
+## Grafana dashboard
+
+[Download the Qui Grafana dashboard](/examples/qui-grafana-dashboard.json), then import the JSON file in Grafana. Select the Prometheus data source that scrapes Qui.
+
+The dashboard has an instance filter and four panels:
+
+- qBittorrent connection status
+- session upload and download rates
+- current tracker upload and download totals
+- collection errors during the last five minutes

--- a/documentation/docs/advanced/metrics.md
+++ b/documentation/docs/advanced/metrics.md
@@ -31,7 +31,7 @@ QUI__METRICS_PORT=9074
 # QUI__METRICS_BASIC_AUTH_USERS="user:password"
 ```
 
-Qui accepts multiple basic-authentication users as a comma-separated list of `user:password` entries. Qui compares these passwords as plaintext.
+Qui accepts a comma-separated list of `user:password` entries. Passwords are plaintext and can contain colons. Usernames cannot contain colons. Commas cannot appear in usernames or passwords.
 
 Protect the configuration file or environment that contains the passwords.
 

--- a/documentation/docs/configuration/environment.md
+++ b/documentation/docs/configuration/environment.md
@@ -117,7 +117,7 @@ QUI__PPROF_ADDR=127.0.0.1:6060 # Optional: pprof bind address (default: 127.0.0.
 QUI__METRICS_ENABLED=true      # Optional: enable Prometheus metrics (default: false)
 QUI__METRICS_HOST=127.0.0.1    # Optional: metrics server bind address (default: 127.0.0.1)
 QUI__METRICS_PORT=9074         # Optional: metrics server port (default: 9074)
-QUI__METRICS_BASIC_AUTH_USERS=user:hash  # Optional: basic auth for metrics (bcrypt hashed)
+QUI__METRICS_BASIC_AUTH_USERS=user:password  # Optional: basic auth for metrics (plaintext password)
 ```
 
 ## Authentication

--- a/documentation/docs/configuration/reference.md
+++ b/documentation/docs/configuration/reference.md
@@ -73,7 +73,7 @@ qui watches `config.toml` for changes. Some settings are applied immediately (fo
 | `metricsEnabled` | `QUI__METRICS_ENABLED` | bool | `false` | Enables a Prometheus metrics server (separate port). Restart required. |
 | `metricsHost` | `QUI__METRICS_HOST` | string | `127.0.0.1` | Metrics server bind address. Restart required. |
 | `metricsPort` | `QUI__METRICS_PORT` | int | `9074` | Metrics server port. Restart required. |
-| `metricsBasicAuthUsers` | `QUI__METRICS_BASIC_AUTH_USERS` | string | empty | Optional basic auth: `user:bcrypt_hash` or `user1:hash1,user2:hash2`. Restart required. |
+| `metricsBasicAuthUsers` | `QUI__METRICS_BASIC_AUTH_USERS` | string | empty | Optional basic auth: `user:password` or `user1:password1,user2:password2`. Passwords are plaintext. Restart required. |
 | `externalProgramAllowList` | (none) | string[] | empty list | Restricts which executables can be launched from the UI. Only configurable via `config.toml` (no env override). |
 | `authDisabled` | `QUI__AUTH_DISABLED` | bool | `false` | Disable all built-in authentication. **Both** this and `I_ACKNOWLEDGE_THIS_IS_A_BAD_IDEA` must be `true` for auth to be disabled. See [Authentication](#authentication) below. Applied on config reload. |
 | `I_ACKNOWLEDGE_THIS_IS_A_BAD_IDEA` | `QUI__I_ACKNOWLEDGE_THIS_IS_A_BAD_IDEA` | bool | `false` | Required confirmation for `authDisabled`. Acknowledges that running without authentication can lead to unauthorized access to your torrent clients and potential bans from private trackers. Applied on config reload. |

--- a/documentation/docs/configuration/reference.md
+++ b/documentation/docs/configuration/reference.md
@@ -73,7 +73,7 @@ qui watches `config.toml` for changes. Some settings are applied immediately (fo
 | `metricsEnabled` | `QUI__METRICS_ENABLED` | bool | `false` | Enables a Prometheus metrics server (separate port). Restart required. |
 | `metricsHost` | `QUI__METRICS_HOST` | string | `127.0.0.1` | Metrics server bind address. Restart required. |
 | `metricsPort` | `QUI__METRICS_PORT` | int | `9074` | Metrics server port. Restart required. |
-| `metricsBasicAuthUsers` | `QUI__METRICS_BASIC_AUTH_USERS` | string | empty | Optional basic auth: `user:password` or `user1:password1,user2:password2`. Passwords are plaintext. Restart required. |
+| `metricsBasicAuthUsers` | `QUI__METRICS_BASIC_AUTH_USERS` | string | empty | Optional basic auth: `user:password` or `user1:password1,user2:password2`. Passwords are plaintext and can contain colons. Usernames cannot contain colons. Commas cannot appear in credentials. Restart required. |
 | `externalProgramAllowList` | (none) | string[] | empty list | Restricts which executables can be launched from the UI. Only configurable via `config.toml` (no env override). |
 | `authDisabled` | `QUI__AUTH_DISABLED` | bool | `false` | Disable all built-in authentication. **Both** this and `I_ACKNOWLEDGE_THIS_IS_A_BAD_IDEA` must be `true` for auth to be disabled. See [Authentication](#authentication) below. Applied on config reload. |
 | `I_ACKNOWLEDGE_THIS_IS_A_BAD_IDEA` | `QUI__I_ACKNOWLEDGE_THIS_IS_A_BAD_IDEA` | bool | `false` | Required confirmation for `authDisabled`. Acknowledges that running without authentication can lead to unauthorized access to your torrent clients and potential bans from private trackers. Applied on config reload. |

--- a/documentation/static/examples/qui-grafana-dashboard.json
+++ b/documentation/static/examples/qui-grafana-dashboard.json
@@ -1,0 +1,458 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus data source that scrapes Qui",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "12.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Connection, transfer, tracker, and collection metrics from Qui.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "Disconnected"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "Connected"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "qbittorrent_instance_connection_status{instance_name=~\"${instance_name:regex}\"}",
+          "instant": true,
+          "legendFormat": "{{instance_name}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "qBittorrent connection",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(sum_over_time(qbittorrent_scrape_errors_total{instance_name=~\"${instance_name:regex}\"}[5m])) or vector(0)",
+          "instant": true,
+          "legendFormat": "Errors",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Collection errors, last 5 minutes",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (instance_name) (rate(qbittorrent_session_download_bytes{instance_name=~\"${instance_name:regex}\"}[$__rate_interval]))",
+          "legendFormat": "{{instance_name}} download",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "sum by (instance_name) (rate(qbittorrent_session_upload_bytes{instance_name=~\"${instance_name:regex}\"}[$__rate_interval]))",
+          "legendFormat": "{{instance_name}} upload",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Session transfer rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "id": 4,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Value"
+          }
+        ]
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "label_replace(sum by (instance_name, tracker_name) (qbittorrent_tracker_uploaded_bytes{instance_name=~\"${instance_name:regex}\"}), \"direction\", \"uploaded\", \"instance_name\", \".*\") or label_replace(sum by (instance_name, tracker_name) (qbittorrent_tracker_downloaded_bytes{instance_name=~\"${instance_name:regex}\"}), \"direction\", \"downloaded\", \"instance_name\", \".*\")",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Current tracker totals",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {
+              "instance_name": 0,
+              "tracker_name": 1,
+              "direction": 2,
+              "Value": 3
+            },
+            "renameByName": {
+              "Value": "Bytes",
+              "direction": "Direction",
+              "instance_name": "Instance",
+              "tracker_name": "Tracker"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 41,
+  "tags": [
+    "qui",
+    "qbittorrent"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(qbittorrent_instance_connection_status, instance_name)",
+        "includeAll": true,
+        "label": "Instance",
+        "multi": true,
+        "name": "instance_name",
+        "options": [],
+        "query": {
+          "query": "label_values(qbittorrent_instance_connection_status, instance_name)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Qui overview",
+  "uid": "qui-overview",
+  "version": 0,
+  "weekStart": ""
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -561,7 +561,7 @@ sessionSecret = "{{ .sessionSecret }}"
 #logLevel = "{{ .logLevel }}"
 
 # Prometheus Metrics
-# Enable Prometheus metrics on separate port (no authentication required)
+# Enable Prometheus metrics on a separate port
 # Default: false
 #metricsEnabled = false
 
@@ -575,9 +575,9 @@ sessionSecret = "{{ .sessionSecret }}"
 #metricsPort = 9074
 
 # Basic authentication for metrics endpoint (optional)
-# Format: "username:bcrypt_hash" or "user1:hash1,user2:hash2" for multiple users
-# Passwords must be bcrypt-hashed. Use tools like htpasswd or online bcrypt generators
-# Example: "prometheus:$2y$10$example_bcrypt_hash_here"
+# Format: "username:password" or "user1:password1,user2:password2" for multiple users
+# Passwords are compared as plaintext. Protect this configuration file.
+# Example: "prometheus:secret"
 # Leave empty to disable authentication (default)
 #metricsBasicAuthUsers = ""
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -576,7 +576,8 @@ sessionSecret = "{{ .sessionSecret }}"
 
 # Basic authentication for metrics endpoint (optional)
 # Format: "username:password" or "user1:password1,user2:password2" for multiple users
-# Passwords are compared as plaintext. Protect this configuration file.
+# Passwords are plaintext and can contain colons. Usernames cannot contain colons.
+# Commas cannot appear in usernames or passwords. Protect this configuration file.
 # Example: "prometheus:secret"
 # Leave empty to disable authentication (default)
 #metricsBasicAuthUsers = ""

--- a/internal/metrics/server.go
+++ b/internal/metrics/server.go
@@ -24,17 +24,18 @@ type Server struct {
 }
 
 func NewMetricsServer(manager *MetricsManager, host string, port int, basicAuthUsersConfig string) *Server {
+	authConfigured := basicAuthUsersConfig != ""
 	s := &Server{
 		basicAuthUsers: make(map[string]string),
 		manager:        manager,
 	}
 
 	// Parse basic auth users
-	if basicAuthUsersConfig != "" {
+	if authConfigured {
 		for cred := range strings.SplitSeq(basicAuthUsersConfig, ",") {
-			parts := strings.Split(strings.TrimSpace(cred), ":")
-			if len(parts) == 2 {
-				s.basicAuthUsers[parts[0]] = parts[1]
+			username, password, ok := strings.Cut(strings.TrimSpace(cred), ":")
+			if ok {
+				s.basicAuthUsers[username] = password
 			} else {
 				log.Warn().Msgf("Invalid metrics basic auth credentials: %s", redact.BasicAuthUser(cred))
 			}
@@ -49,7 +50,7 @@ func NewMetricsServer(manager *MetricsManager, host string, port int, basicAuthU
 	router.Use(middleware.Recoverer)
 
 	// Add basic auth if configured
-	if len(s.basicAuthUsers) > 0 {
+	if authConfigured {
 		router.Use(BasicAuth("metrics", s.basicAuthUsers))
 	}
 

--- a/internal/metrics/server_test.go
+++ b/internal/metrics/server_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package metrics
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetricsServerAllowsColonInPassword(t *testing.T) {
+	server := NewMetricsServer(
+		&MetricsManager{registry: prometheus.NewRegistry()},
+		"127.0.0.1",
+		9074,
+		"alice:secret:with:colons",
+	)
+
+	tests := []struct {
+		name     string
+		password string
+		wantCode int
+	}{
+		{name: "rejects wrong password", password: "wrong", wantCode: http.StatusUnauthorized},
+		{name: "accepts configured password", password: "secret:with:colons", wantCode: http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+			request.SetBasicAuth("alice", tt.password)
+			response := httptest.NewRecorder()
+
+			server.server.Handler.ServeHTTP(response, request)
+
+			assert.Equal(t, tt.wantCode, response.Code)
+		})
+	}
+}
+
+func TestMetricsServerMalformedBasicAuthFailsClosed(t *testing.T) {
+	server := NewMetricsServer(
+		&MetricsManager{registry: prometheus.NewRegistry()},
+		"127.0.0.1",
+		9074,
+		"missing-delimiter",
+	)
+	request := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	response := httptest.NewRecorder()
+
+	server.server.Handler.ServeHTTP(response, request)
+
+	assert.Equal(t, http.StatusUnauthorized, response.Code)
+}


### PR DESCRIPTION
## Description

Document all 16 custom Prometheus metrics, including labels, types, reset behavior, and tracker-library limits.

Add PromQL examples and a downloadable four-panel Grafana dashboard. Fix metrics basic auth so passwords can contain colons and invalid non-empty credentials fail closed.

## How has this been tested?

Imported the dashboard into Grafana 12.4.0 with Prometheus 3.7.0 and synthetic Qui metrics. Verified all four panels and the instance filter. Started the built Qui binary with a colon-containing metrics password. Verified that missing and wrong credentials returned 401, while the configured password returned 200.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded metrics guidance with authentication, configuration, Prometheus scraping, metric details, PromQL examples, and Grafana usage.
  * Clarified plaintext Basic Auth credentials, including rules for colons and commas.

* **New Features**
  * Added a Grafana dashboard for connection status, collection errors, transfer rates, and tracker totals.

* **Bug Fixes**
  * Improved metrics authentication handling for passwords containing colons.
  * Malformed credentials now fail securely instead of allowing unauthenticated access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->