### PR TITLE
fix(rss): improve large feed performance

### DIFF
--- a/internal/api/handlers/rss_sse.go
+++ b/internal/api/handlers/rss_sse.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	qbt "github.com/autobrr/go-qbittorrent"
 	"github.com/rs/zerolog/log"
 
 	"github.com/autobrr/qui/internal/qbittorrent"
@@ -19,7 +20,7 @@ import (
 
 // RSSSSEHandler manages Server-Sent Events for RSS updates
 type RSSSSEHandler struct {
-	syncManager *qbittorrent.SyncManager
+	getRSSItems func(context.Context, int, bool) (qbt.RSSItems, error)
 
 	// Client management
 	mu      sync.RWMutex
@@ -47,6 +48,8 @@ type rssSSEEvent struct {
 const (
 	rssEventConnected   = "connected"
 	rssEventFeedsUpdate = "feeds_update"
+	rssPollInterval     = 5 * time.Second
+	rssMaxPollInterval  = 5 * time.Minute
 )
 
 // FeedsUpdatePayload contains the full RSS items tree
@@ -59,7 +62,7 @@ type FeedsUpdatePayload struct {
 // NewRSSSSEHandler creates a new RSS SSE handler
 func NewRSSSSEHandler(syncManager *qbittorrent.SyncManager) *RSSSSEHandler {
 	return &RSSSSEHandler{
-		syncManager: syncManager,
+		getRSSItems: syncManager.GetRSSItems,
 		clients:     make(map[int]map[*rssSSEClient]struct{}),
 		pollers:     make(map[int]context.CancelFunc),
 	}
@@ -81,7 +84,7 @@ func (h *RSSSSEHandler) HandleSSE(w http.ResponseWriter, r *http.Request) {
 
 	// Don't report SSE as "connected" until we know RSS polling can succeed at least once.
 	// This avoids a confusing "SSE Live" UI state when the instance is disabled or RSS fetch fails.
-	if _, err := h.syncManager.GetRSSItems(r.Context(), instanceID, true); err != nil {
+	if _, err := h.getRSSItems(r.Context(), instanceID, false); err != nil {
 		if respondIfInstanceDisabled(w, err, instanceID, "GetRSSItems") {
 			return
 		}
@@ -244,47 +247,53 @@ func (h *RSSSSEHandler) pollLoop(ctx context.Context, instanceID int) {
 	log.Debug().Int("instanceID", instanceID).Msg("RSS SSE poll loop started")
 
 	var lastItems []byte
-
-	// Initial poll
-	lastItems = h.pollAndBroadcast(ctx, instanceID, lastItems)
-
-	// Poll every 5 seconds
-	ticker := time.NewTicker(5 * time.Second)
-	defer ticker.Stop()
+	pollInterval := rssPollInterval
+	timer := time.NewTimer(pollInterval)
+	defer timer.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
 			log.Debug().Int("instanceID", instanceID).Msg("RSS SSE poll loop stopped")
 			return
-		case <-ticker.C:
-			lastItems = h.pollAndBroadcast(ctx, instanceID, lastItems)
+		case <-timer.C:
+			var unchanged bool
+			lastItems, unchanged = h.pollAndBroadcast(ctx, instanceID, lastItems)
+			pollInterval = nextRSSPollInterval(pollInterval, unchanged)
+			timer.Reset(pollInterval)
 		}
 	}
 }
 
-func (h *RSSSSEHandler) pollAndBroadcast(ctx context.Context, instanceID int, lastItems []byte) []byte {
-	items, err := h.syncManager.GetRSSItems(ctx, instanceID, true)
+func nextRSSPollInterval(current time.Duration, unchanged bool) time.Duration {
+	if !unchanged {
+		return rssPollInterval
+	}
+	return min(current*2, rssMaxPollInterval)
+}
+
+func (h *RSSSSEHandler) pollAndBroadcast(ctx context.Context, instanceID int, lastItems []byte) ([]byte, bool) {
+	items, err := h.getRSSItems(ctx, instanceID, true)
 	if err != nil {
 		// Context cancellation is expected during shutdown
 		if ctx.Err() != nil {
 			log.Debug().Int("instanceID", instanceID).Msg("RSS SSE poll cancelled")
-			return lastItems
+			return lastItems, false
 		}
 		log.Warn().Err(err).Int("instanceID", instanceID).Msg("RSS SSE poll failed")
-		return lastItems
+		return lastItems, false
 	}
 
 	// Serialize for comparison
 	currentItems, err := json.Marshal(items)
 	if err != nil {
 		log.Error().Err(err).Int("instanceID", instanceID).Msg("failed to marshal RSS items for SSE comparison")
-		return lastItems
+		return lastItems, false
 	}
 
 	// Check for changes
 	if bytes.Equal(currentItems, lastItems) {
-		return lastItems // No changes
+		return lastItems, true
 	}
 
 	log.Debug().Int("instanceID", instanceID).Msg("RSS SSE broadcasting update")
@@ -299,5 +308,5 @@ func (h *RSSSSEHandler) pollAndBroadcast(ctx context.Context, instanceID int, la
 		},
 	})
 
-	return currentItems
+	return currentItems, false
 }

--- a/internal/api/handlers/rss_sse_test.go
+++ b/internal/api/handlers/rss_sse_test.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func syntheticRSSItems(t *testing.T, feedCount, articleCount int) qbt.RSSItems {
+	t.Helper()
+
+	items := make(qbt.RSSItems, feedCount)
+	for feedIndex := range feedCount {
+		articles := make([]qbt.RSSArticle, articleCount)
+		for articleIndex := range articleCount {
+			articles[articleIndex] = qbt.RSSArticle{
+				ID:          fmt.Sprintf("feed-%d-article-%d", feedIndex, articleIndex),
+				Date:        "2026-08-25T12:00:00Z",
+				Title:       fmt.Sprintf("Synthetic article %d", articleIndex),
+				Description: "Synthetic RSS article content used to exercise a realistically sized payload.",
+			}
+		}
+
+		feed, err := json.Marshal(qbt.RSSFeed{
+			UID:      fmt.Sprintf("feed-%d", feedIndex),
+			URL:      fmt.Sprintf("https://example.invalid/feed/%d", feedIndex),
+			Title:    fmt.Sprintf("Synthetic feed %d", feedIndex),
+			Articles: articles,
+		})
+		require.NoError(t, err)
+		items[fmt.Sprintf("Feed %03d", feedIndex)] = feed
+	}
+
+	return items
+}
+
+func TestRSSPollAndBroadcastHandlesLargeUnchangedPayload(t *testing.T) {
+	t.Parallel()
+
+	items := syntheticRSSItems(t, 200, 50)
+	client := &rssSSEClient{
+		instanceID: 1,
+		events:     make(chan rssSSEEvent, 1),
+		done:       make(chan struct{}),
+	}
+	handler := &RSSSSEHandler{
+		getRSSItems: func(context.Context, int, bool) (qbt.RSSItems, error) {
+			return items, nil
+		},
+		clients: map[int]map[*rssSSEClient]struct{}{
+			1: {client: {}},
+		},
+		pollers: make(map[int]context.CancelFunc),
+	}
+
+	lastItems, unchanged := handler.pollAndBroadcast(t.Context(), 1, nil)
+	require.False(t, unchanged)
+	require.NotEmpty(t, lastItems)
+
+	event := <-client.events
+	payload, ok := event.Data.(FeedsUpdatePayload)
+	require.True(t, ok)
+	var decoded qbt.RSSItems
+	require.NoError(t, json.Unmarshal(payload.Items, &decoded))
+	require.Len(t, decoded, 200)
+
+	nextItems, unchanged := handler.pollAndBroadcast(t.Context(), 1, lastItems)
+	require.True(t, unchanged)
+	require.Equal(t, lastItems, nextItems)
+	select {
+	case <-client.events:
+		t.Fatal("unchanged RSS data was broadcast")
+	default:
+	}
+}
+
+func TestNextRSSPollInterval(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, 10*time.Second, nextRSSPollInterval(rssPollInterval, true))
+	require.Equal(t, rssMaxPollInterval, nextRSSPollInterval(rssMaxPollInterval, true))
+	require.Equal(t, rssPollInterval, nextRSSPollInterval(time.Minute, false))
+}
+
+func TestRSSSSEInitialCheckOmitsArticleData(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	calls := make(chan bool, 2)
+	handler := &RSSSSEHandler{
+		getRSSItems: func(_ context.Context, _ int, withData bool) (qbt.RSSItems, error) {
+			calls <- withData
+			cancel()
+			return qbt.RSSItems{}, nil
+		},
+		clients: make(map[int]map[*rssSSEClient]struct{}),
+		pollers: make(map[int]context.CancelFunc),
+	}
+
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/api/instances/1/rss/events", nil)
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("instanceID", "1")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+
+	handler.HandleSSE(httptest.NewRecorder(), req)
+
+	require.False(t, <-calls)
+	select {
+	case <-calls:
+		t.Fatal("RSS SSE performed an eager full-data poll")
+	default:
+	}
+}

--- a/web/src/hooks/useRSS.test.tsx
+++ b/web/src/hooks/useRSS.test.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { ReactNode } from "react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import type { FeedsUpdatePayload, RSSEventHandlers } from "@/lib/rss-events"
+import type { RSSItems } from "@/types"
+import { rssKeys, useRSSFeeds } from "./useRSS"
+
+const { mockApi, rssEventState } = vi.hoisted(() => ({
+  mockApi: {
+    getRSSItems: vi.fn(() => Promise.resolve({})),
+  },
+  rssEventState: {
+    handlers: undefined as RSSEventHandlers | undefined,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  },
+}))
+
+vi.mock("@/lib/api", () => ({ api: mockApi }))
+vi.mock("@/lib/rss-events", () => ({
+  RSSEventSource: class {
+    constructor(_instanceId: number, handlers: RSSEventHandlers) {
+      rssEventState.handlers = handlers
+    }
+
+    connect() {
+      rssEventState.connect()
+    }
+
+    disconnect() {
+      rssEventState.disconnect()
+    }
+  },
+}))
+
+function syntheticRSSItems(feedCount: number, articleCount: number): RSSItems {
+  return Object.fromEntries(Array.from({ length: feedCount }, (_, feedIndex) => [
+    `Feed ${feedIndex}`,
+    {
+      uid: `feed-${feedIndex}`,
+      url: `https://example.invalid/feed/${feedIndex}`,
+      hasError: false,
+      isLoading: false,
+      articles: Array.from({ length: articleCount }, (_, articleIndex) => ({
+        id: `feed-${feedIndex}-article-${articleIndex}`,
+        date: "2026-08-25T12:00:00Z",
+        title: `Synthetic article ${articleIndex}`,
+        description: "Synthetic RSS article content used to exercise a realistically sized payload.",
+        isRead: false,
+      })),
+    },
+  ]))
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+  rssEventState.handlers = undefined
+})
+
+describe("useRSSFeeds", () => {
+  it("stores a large SSE update without invalidating the same query", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries")
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
+    renderHook(() => useRSSFeeds(1), { wrapper })
+    await waitFor(() => {
+      expect(mockApi.getRSSItems).toHaveBeenCalledExactlyOnceWith(1, true)
+    })
+
+    const items = syntheticRSSItems(200, 50)
+    act(() => {
+      rssEventState.handlers?.onFeedsUpdate?.({ instanceId: 1, items, timestamp: 0 } as FeedsUpdatePayload)
+    })
+
+    expect(Object.keys(queryClient.getQueryData<RSSItems>(rssKeys.feeds(1)) ?? {})).toHaveLength(200)
+    expect(invalidateSpy).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/hooks/useRSS.ts
+++ b/web/src/hooks/useRSS.ts
@@ -47,9 +47,7 @@ export function useRSSFeeds(instanceId: number, options?: { enabled?: boolean; w
   const handleFeedsUpdate = useCallback(
     (data: FeedsUpdatePayload) => {
       if (data.instanceId === instanceId) {
-        // Set the data and invalidate to ensure re-render
         queryClient.setQueryData(rssKeys.feeds(instanceId), data.items)
-        queryClient.invalidateQueries({ queryKey: rssKeys.feeds(instanceId), refetchType: "none" })
       }
     },
     [instanceId, queryClient]

--- a/web/src/pages/RSSPage.test.tsx
+++ b/web/src/pages/RSSPage.test.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { ArticlesPanel } from "@/pages/RSSPage"
+import type { RSSArticle } from "@/types"
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  markAsRead: vi.fn(),
+  virtualizer: {
+    getTotalSize: () => 156,
+    getVirtualItems: () => [
+      { index: 0, key: "article-0", start: 0, size: 52, end: 52, lane: 0 },
+      { index: 1, key: "article-1", start: 52, size: 52, end: 104, lane: 0 },
+      { index: 2, key: "article-2", start: 104, size: 52, end: 156, lane: 0 },
+    ],
+    measureElement: vi.fn(),
+  },
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock("@/hooks/useDateTimeFormatters", () => ({
+  useDateTimeFormatters: () => ({ formatDate: () => "date" }),
+}))
+
+vi.mock("@/hooks/useRSS", async (importOriginal) => ({
+  ...await importOriginal<typeof import("@/hooks/useRSS")>(),
+  useMarkRSSAsRead: () => ({ mutateAsync: mocks.markAsRead }),
+}))
+
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: () => mocks.virtualizer,
+}))
+
+afterEach(cleanup)
+
+describe("ArticlesPanel", () => {
+  it("mounts only virtual rows for a synthetic 1,000-article feed", () => {
+    const articles: RSSArticle[] = Array.from({ length: 1000 }, (_, index) => ({
+      id: `article-${index}`,
+      date: new Date(2026, 0, 1, 0, 0, 1000 - index).toISOString(),
+      title: `Article ${index}`,
+      description: `Synthetic description ${index}`,
+      isRead: false,
+    }))
+
+    render(
+      <ArticlesPanel
+        instanceId={1}
+        feed={{ uid: "feed", url: "https://example.invalid/feed", hasError: false, isLoading: false, articles }}
+        feedPath="Synthetic Feed"
+        onDownload={() => {}}
+      />
+    )
+
+    expect(document.querySelectorAll("[data-index]")).toHaveLength(3)
+    expect(screen.queryByText("Article 0")).not.toBeNull()
+    expect(screen.queryByText("Article 999")).toBeNull()
+  })
+})

--- a/web/src/pages/RSSPage.tsx
+++ b/web/src/pages/RSSPage.tsx
@@ -25,7 +25,7 @@ import {
   Tag,
   Trash2
 } from "lucide-react"
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { toast } from "sonner"
 
@@ -108,6 +108,7 @@ import type {
 } from "@/types"
 import { isRSSFeed } from "@/types"
 import { useQueryClient } from "@tanstack/react-query"
+import { useVirtualizer } from "@tanstack/react-virtual"
 
 import { AddTorrentDialog, type AddTorrentDropPayload } from "@/components/torrents/AddTorrentDialog"
 
@@ -1058,13 +1059,14 @@ interface ArticlesPanelProps {
   onDownload: (torrentURL: string) => void
 }
 
-function ArticlesPanel({ instanceId, feed, feedPath, onDownload }: ArticlesPanelProps) {
+export function ArticlesPanel({ instanceId, feed, feedPath, onDownload }: ArticlesPanelProps) {
   const { t } = useTranslation("rss")
   const { formatDate } = useDateTimeFormatters()
   const markAsRead = useMarkRSSAsRead(instanceId)
   const [search, setSearch] = useState("")
+  const articleListRef = useRef<HTMLDivElement>(null)
 
-  const articles = feed.articles ?? []
+  const articles = useMemo(() => feed.articles ?? [], [feed.articles])
 
   const sortedArticles = useMemo(() => {
     if (articles.length <= 1) return articles
@@ -1098,6 +1100,17 @@ function ArticlesPanel({ instanceId, feed, feedPath, onDownload }: ArticlesPanel
     )
   }, [sortedArticles, search])
 
+  const articleVirtualizer = useVirtualizer({
+    count: filteredArticles.length,
+    getScrollElement: () => articleListRef.current,
+    estimateSize: () => 56,
+    overscan: 10,
+    getItemKey: useCallback(
+      (index: number) => filteredArticles[index]?.id ?? index,
+      [filteredArticles]
+    ),
+  })
+
   const handleMarkAsRead = async (articleId: string) => {
     try {
       await markAsRead.mutateAsync({ itemPath: feedPath, articleId })
@@ -1127,22 +1140,44 @@ function ArticlesPanel({ instanceId, feed, feedPath, onDownload }: ArticlesPanel
           className="pl-8 h-8"
         />
       </div>
-      <div className="flex-1 min-h-0 overflow-y-auto">
+      <div ref={articleListRef} className="flex-1 min-h-0 overflow-y-auto contain-paint">
         {filteredArticles.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-32 text-muted-foreground">
             <p className="text-sm">{t("feeds.noMatchingArticles")}</p>
           </div>
         ) : (
-          <div className="space-y-1 pr-1">
-            {filteredArticles.map((article) => (
-              <ArticleRow
-                key={article.id}
-                article={article}
-                formatDate={formatDate}
-                onMarkAsRead={() => handleMarkAsRead(article.id)}
-                onDownload={onDownload}
-              />
-            ))}
+          <div
+            className="relative pr-1"
+            style={{ height: `${articleVirtualizer.getTotalSize()}px` }}
+          >
+            {articleVirtualizer.getVirtualItems().map((virtualRow) => {
+              const article = filteredArticles[virtualRow.index]
+              if (!article) return null
+
+              return (
+                <div
+                  key={virtualRow.key}
+                  data-index={virtualRow.index}
+                  ref={articleVirtualizer.measureElement}
+                  className="pb-1"
+                  style={{
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    width: "100%",
+                    transform: `translateY(${virtualRow.start}px)`,
+                    contain: "layout style",
+                  }}
+                >
+                  <ArticleRow
+                    article={article}
+                    formatDate={formatDate}
+                    onMarkAsRead={() => handleMarkAsRead(article.id)}
+                    onDownload={onDownload}
+                  />
+                </div>
+              )
+            })}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Description

Reduce RSS page work for large qBittorrent feed collections.

- Use a lightweight RSS stream handshake without article data.
- Back off unchanged full-feed polls from 5 seconds to a maximum of 5 minutes.
- Update the query cache directly instead of scheduling a redundant invalidation.
- Virtualize article rows so feeds with 1,000 or more entries do not mount every row at once.

This also covers the 1,000+ article slowdown reported in the linked discussion.

Fixes #2437

## How has this been tested?

- Started the production build against a local synthetic qBittorrent server with 200 feeds and a 1,000-article feed.
- Scrolled from article 0 to article 999 while the browser kept 23 article rows mounted.
- Checked filtering and switching between large and small feeds with no browser errors.
- Observed unchanged polling back off from 5 to 10, 20, and 40 seconds.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - RSS article lists now use virtualized scrolling for smoother performance with large feeds.
  - RSS updates use adaptive polling, checking more frequently when content changes and less often when unchanged.

- **Performance Improvements**
  - Large RSS updates are handled without unnecessary refreshes.
  - Incoming feed data updates the displayed results directly, reducing redundant requests.
  - Only visible articles are rendered while scrolling, improving responsiveness for extensive feeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->