### PR TITLE
fix(orphanscan): skip torrents without metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/andybalholm/brotli v1.2.2
 	github.com/autobrr/autobrr v1.82.1
 	github.com/autobrr/go-mediainfo v0.8.0
-	github.com/autobrr/go-qbittorrent v1.17.1-0.20260815045428-fe3b4cb79f3e
+	github.com/autobrr/go-qbittorrent v1.18.1-0.20260825184924-ed7e9179e725
 	github.com/autobrr/go-torrent v1.1.1-0.20260811091921-e2224c4f4e34
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/cespare/xxhash/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/autobrr/go-mediainfo v0.8.0 h1:XzsjHvBOlGx2BnwYCqwCOIJsmrFy4BJb0jgoB2
 github.com/autobrr/go-mediainfo v0.8.0/go.mod h1:P3LGxIPznO2TLKV/e58YgN0/ozP5pLCAncFzsdxMDcY=
 github.com/autobrr/go-qbittorrent v1.17.1-0.20260815045428-fe3b4cb79f3e h1:bzRlD5PdJ+edMyjI3bjpcfUlZSNtJDoSZwZq3Zg8+HM=
 github.com/autobrr/go-qbittorrent v1.17.1-0.20260815045428-fe3b4cb79f3e/go.mod h1:9ujARiuSKZf8+NtApflTB69Wsptsp0Qk1mSVVC0tGzM=
+github.com/autobrr/go-qbittorrent v1.18.1-0.20260825184924-ed7e9179e725 h1:BFf040TbBQnE39tAIfvd0Vrd5d7Zh3PCTHy9YrUxHrw=
+github.com/autobrr/go-qbittorrent v1.18.1-0.20260825184924-ed7e9179e725/go.mod h1:spB3GP7xDu0btv59uUdxkLPEzoT+9xpx86QpJr4DUOw=
 github.com/autobrr/go-torrent v1.1.1-0.20260811091921-e2224c4f4e34 h1:ubxfEt1oWe2B3otV6mhHiONaeO7ydAJaveOsQyPiIz0=
 github.com/autobrr/go-torrent v1.1.1-0.20260811091921-e2224c4f4e34/go.mod h1:MNqAUt4SVvZTVyVSD3iQHXgi+ARVM3Z6dY0aTvXTnvY=
 github.com/autobrr/rls v0.8.1 h1:OjoFFVGcTibGrwf6b4pfk7JHsSYrGOX7F5P/8WtS3aE=

--- a/internal/api/sse/delta.go
+++ b/internal/api/sse/delta.go
@@ -245,6 +245,8 @@ func (b *fpBuf) torrent(t *qbt.Torrent) {
 	b.bit(t.FirstLastPiecePrio)
 	b.bit(t.ForceStart)
 	b.str(t.Hash)
+	b.bit(t.HasMetadata != nil)
+	b.bit(t.HasMetadata != nil && *t.HasMetadata)
 	b.str(t.InfohashV1)
 	b.str(t.InfohashV2)
 	b.bit(t.Private)

--- a/internal/api/sse/fingerprint_test.go
+++ b/internal/api/sse/fingerprint_test.go
@@ -61,6 +61,8 @@ func setSampleValue(t *testing.T, f reflect.Value) {
 		m := reflect.MakeMap(f.Type())
 		m.SetMapIndex(reflect.ValueOf("x"), reflect.New(f.Type().Elem()).Elem())
 		f.Set(m)
+	case reflect.Pointer:
+		f.Set(reflect.New(f.Type().Elem()))
 	default:
 		t.Fatalf("field kind %s not handled; extend setSampleValue", f.Kind())
 	}
@@ -99,6 +101,18 @@ func TestMagnetOnlyChangeDoesNotResendRow(t *testing.T) {
 	_, _, baseFP := computeRowDelta(before, singleRowKey, singleRowFingerprint, nil)
 	_, changed, _ := computeRowDelta(after, singleRowKey, singleRowFingerprint, baseFP)
 	require.Empty(t, changed, "magnet-only change must not resend the row")
+}
+
+func TestTorrentFingerprintDistinguishesHasMetadataStates(t *testing.T) {
+	metadataUnavailable := false
+	metadataAvailable := true
+
+	fingerprints := map[uint64]struct{}{
+		singleRowFingerprint(new(fpBuf), qbittorrent.TorrentView{Torrent: &qbt.Torrent{}}):                                  {},
+		singleRowFingerprint(new(fpBuf), qbittorrent.TorrentView{Torrent: &qbt.Torrent{HasMetadata: &metadataUnavailable}}): {},
+		singleRowFingerprint(new(fpBuf), qbittorrent.TorrentView{Torrent: &qbt.Torrent{HasMetadata: &metadataAvailable}}):   {},
+	}
+	require.Len(t, fingerprints, 3)
 }
 
 // assertEveryFieldHashed proves fp reacts to every field of T: a fingerprint

--- a/internal/services/orphanscan/service.go
+++ b/internal/services/orphanscan/service.go
@@ -1286,7 +1286,7 @@ func buildFileMapFromTorrents(torrents []qbt.Torrent, filesByHash map[string]qbt
 		hasFiles := ok && len(files) > 0
 
 		if !hasFiles {
-			if isTransientTorrentStateForOrphanScan(torrent.State) {
+			if torrent.HasMetadata != nil && !*torrent.HasMetadata || isTransientTorrentStateForOrphanScan(torrent.State) {
 				if hasAbsSavePath {
 					skippedRoots[savePath] = struct{}{}
 				}

--- a/internal/services/orphanscan/service.go
+++ b/internal/services/orphanscan/service.go
@@ -1286,7 +1286,11 @@ func buildFileMapFromTorrents(torrents []qbt.Torrent, filesByHash map[string]qbt
 		hasFiles := ok && len(files) > 0
 
 		if !hasFiles {
-			if torrent.HasMetadata != nil && !*torrent.HasMetadata || isTransientTorrentStateForOrphanScan(torrent.State) {
+			if torrent.HasMetadata != nil && !*torrent.HasMetadata {
+				continue
+			}
+
+			if isTransientTorrentStateForOrphanScan(torrent.State) {
 				if hasAbsSavePath {
 					skippedRoots[savePath] = struct{}{}
 				}

--- a/internal/services/orphanscan/settling_test.go
+++ b/internal/services/orphanscan/settling_test.go
@@ -122,18 +122,25 @@ func TestBuildFileMapFromTorrents_FailsWhenStableTorrentMissingFiles(t *testing.
 	assert.Contains(t, err.Error(), "stable torrents returned no files")
 }
 
-func TestBuildFileMapFromTorrents_SkipsTorrentWithoutMetadata(t *testing.T) {
+func TestBuildFileMapFromTorrents_IgnoresTorrentWithoutMetadataAtSharedRoot(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
 	hasMetadata := false
 
-	result, err := buildFileMapFromTorrents([]qbt.Torrent{
-		{Hash: "metadata-less", SavePath: root, State: qbt.TorrentStateStoppedDl, HasMetadata: &hasMetadata},
-	}, map[string]qbt.TorrentFiles{})
+	result, err := buildFileMapFromTorrents(
+		[]qbt.Torrent{
+			{Hash: "stable", SavePath: root, State: qbt.TorrentStatePausedUp},
+			{Hash: "metadata-less", SavePath: root, State: qbt.TorrentStateStoppedDl, HasMetadata: &hasMetadata},
+		},
+		map[string]qbt.TorrentFiles{
+			"stable": {{Name: "movie.mkv", Size: 1}},
+		},
+	)
 	require.NoError(t, err)
-	assert.Empty(t, result.scanRoots)
-	assert.Equal(t, []string{filepath.Clean(root)}, result.skippedRoots)
+	assert.Equal(t, []string{filepath.Clean(root)}, result.scanRoots)
+	assert.Empty(t, result.skippedRoots)
+	assert.True(t, result.fileMap.Has(normalizePath(filepath.Join(root, "movie.mkv"))))
 }
 
 func TestBuildFileMapFromTorrents_SkipsTransientMissingRoots(t *testing.T) {

--- a/internal/services/orphanscan/settling_test.go
+++ b/internal/services/orphanscan/settling_test.go
@@ -122,6 +122,20 @@ func TestBuildFileMapFromTorrents_FailsWhenStableTorrentMissingFiles(t *testing.
 	assert.Contains(t, err.Error(), "stable torrents returned no files")
 }
 
+func TestBuildFileMapFromTorrents_SkipsTorrentWithoutMetadata(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	hasMetadata := false
+
+	result, err := buildFileMapFromTorrents([]qbt.Torrent{
+		{Hash: "metadata-less", SavePath: root, State: qbt.TorrentStateStoppedDl, HasMetadata: &hasMetadata},
+	}, map[string]qbt.TorrentFiles{})
+	require.NoError(t, err)
+	assert.Empty(t, result.scanRoots)
+	assert.Equal(t, []string{filepath.Clean(root)}, result.skippedRoots)
+}
+
 func TestBuildFileMapFromTorrents_SkipsTransientMissingRoots(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Description

- Exclude torrents explicitly reported by qBittorrent as lacking metadata when building the orphan-scan file map. This prevents their save paths from suppressing valid torrents sharing the same download root. Clients that do not provide `has_metadata` remain fail-closed.
- Add metadata availability to SSE row fingerprints so clients receive updates across `unknown`, `unavailable`, and `available` states.

Context: [discussion #2436](https://github.com/autobrr/qui/discussions/2436)  
Dependency: [go-qBittorrent PR #134](https://github.com/autobrr/go-qbittorrent/pull/134)

## How has this been tested?

Built `qui` and verified startup using an isolated SQLite data directory. Confirmed schema migrations applied and the server listened on `127.0.0.1:7476` prior to timed shutdown.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved orphan scanning for torrents that are still missing metadata.
  * Prevented incomplete torrent data from triggering unnecessary scan errors or skipped paths.
  * Ensured torrents sharing a location with metadata-incomplete torrents continue to be scanned correctly.
  * Improved live torrent updates so metadata availability changes are reflected reliably.

* **Tests**
  * Added coverage for shared scan locations and distinct metadata availability states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->