### PR TITLE
fix(web): resolve dynamic imports relative to chunk for base_url deployments

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -126,11 +126,11 @@ export default defineConfig(() => ({
   ],
   experimental: {
     // The Go handler rewrites the absolute /assets/ paths in index.html for
-    // base-URL deployments, but never rewrites CSS content, so CSS url()
-    // assets (large flag icons) 404 under a subpath. Emit CSS urls relative
-    // to the stylesheet; they resolve correctly for any base. HTML keeps the
-    // absolute paths the handler rewrite depends on.
-    renderBuiltUrl: (_filename, { hostType }) => hostType === "css" ? { relative: true } : undefined,
+    // base-URL deployments, but never rewrites JS/CSS content. Emit asset
+    // urls relative to the requesting file so dynamic imports and CSS url()
+    // resolve correctly for any base. HTML keeps the absolute paths the
+    // handler rewrite depends on.
+    renderBuiltUrl: (_filename, { hostType }) => hostType === "html" ? undefined : { relative: true },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Description

FIxes #2276 which broke rendering of all flags when using subpaths.

Dynamically imported JS/CSS chunks (route splits, flag-icons CSS) are fetched from `/assets/...` instead of `/<base_url>/assets/...` when qui is deployed under a sub-path, causing 404s.

Vite bakes absolute `/assets/...` paths into the compiled JS bundle's `__vite__mapDeps`. The Go handler rewrites `index.html` but cannot rewrite minified JS content. Flipping `renderBuiltUrl` to emit relative paths for JS/CSS (keeping only HTML absolute for the Go handler) makes dynamic imports resolve correctly from any base.

## How has this been tested?

- Deployed with `base_url = "/qui/"` and confirmed all route chunks and flag-icons CSS load from `/qui/assets/...`

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

## AI disclosure

Yes, Anthropic Claude Opus 5 was used to investigate the root cause and produce the one-line fix. ~100% AI-assisted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed asset linking so CSS and JavaScript resources load correctly from relative paths.
  * Preserved absolute URLs for HTML pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->