### PR TITLE
docs(config): explain UI preference persistence

### DIFF
--- a/documentation/docs/configuration/environment.md
+++ b/documentation/docs/configuration/environment.md
@@ -65,6 +65,12 @@ QUI__CUSTOM_THEMES_DIR=...  # Optional: directory for sideloaded custom theme .c
 
 `QUI__CUSTOM_THEMES_DIR` sets where [custom themes](../features/custom-themes.md) are read from. It defaults to a `themes` folder next to the config file (`/config/themes` in Docker) and is created automatically. Loading custom themes requires premium access.
 
+### UI preferences
+
+qui stores UI preferences, such as table columns, column sizes, density, filters, and theme, in the database. The browser maintains a local copy to apply these preferences before loading the database values.
+
+If these preferences reset after a restart, ensure that qui uses a persistent database. For SQLite, keep `qui.db` in persistent storage. In Docker, persist `/config` or the directory set by `QUI__DATA_DIR`.
+
 ## Database
 
 ```bash


### PR DESCRIPTION
## Description

Document how qui stores UI preferences in the database and browser cache. Add the storage checks for preferences that reset after a restart.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on database persistence requirements for retaining UI preferences across restarts, including table, filter, density, and theme settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->