### PR TITLE
fix(settings): preserve latest cross-tab write

### DIFF
--- a/web/src/lib/__tests__/client-settings.test.ts
+++ b/web/src/lib/__tests__/client-settings.test.ts
@@ -158,6 +158,23 @@ describe("push queue", () => {
     expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({ "qui-test-bool": "false" })
   })
 
+  it("replays a newer cross-tab value after an older PUT finishes", async () => {
+    let resolvePut: (value: unknown) => void = () => {}
+    fetchMock.mockReturnValueOnce(new Promise((resolve) => { resolvePut = resolve }))
+    seedAndMarkReady({})
+    writeRaw("qui-test-bool", "true")
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({ "qui-test-bool": "true" })
+
+    // Another tab writes the shared cache while this tab's older PUT is slow.
+    localStorage.setItem("qui-test-bool", "false")
+    resolvePut({ ok: true, status: 200 })
+    await vi.runAllTimersAsync()
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({ "qui-test-bool": "false" })
+  })
+
   // REGRESSION: a flush whose timer fired during an in-flight PUT was
   // swallowed; if that PUT then failed, the newer write stalled until the
   // next write or tab-hide.

--- a/web/src/lib/client-settings.ts
+++ b/web/src/lib/client-settings.ts
@@ -149,8 +149,8 @@ function scheduleFlush(): void {
 }
 
 let flushInFlight = false
-// A timer or tab-hide flush that fired while a PUT was in flight; replayed
-// once the PUT settles so the write it carried is not stalled.
+// A flush needed after the current PUT, either requested while in flight or
+// after another tab replaces a batch value.
 let flushRequestedInFlight = false
 
 async function flushPending(): Promise<void> {
@@ -174,10 +174,14 @@ async function flushPending(): Promise<void> {
       keepalive: true,
     })
     if (!response.ok) throw new Error(`HTTP ${response.status}`)
-    // Drop what this PUT delivered. Entries replaced mid-flight stay queued;
-    // their own scheduleFlush timer (or the replay below) picks them up.
+    // Drop what this PUT delivered. Entries replaced in this tab stay queued;
+    // a newer value from another tab is copied from the shared localStorage.
     for (const [key, raw] of Object.entries(batch)) {
-      if (pending.get(key) === raw) pending.delete(key)
+      const latest = readRaw(key)
+      if (latest !== null && latest !== raw) {
+        pending.set(key, latest)
+        flushRequestedInFlight = true
+      } else if (pending.get(key) === raw) pending.delete(key)
     }
     persistPending()
   } catch (error) {


### PR DESCRIPTION
## Description

Prevent an older client-settings PUT from overwriting a newer choice made in another tab.

After a successful PUT, the queue compares each delivered value with shared localStorage. If another tab changed the value while the request was in flight, the current tab keeps the newer value queued and sends a follow-up PUT.

## How has this been tested?

Ran the built app with an isolated SQLite database. Opened two logged-in tabs, toggled the synced sidebar preference in each direction, confirmed both tabs updated, and confirmed the database stored the second tab choice.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where newer cross-tab settings changes could be lost while an earlier update was still being saved.
  * Ensured the latest settings are automatically submitted after the in-progress update completes.

* **Tests**
  * Added regression coverage for preserving and replaying newer settings updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->