### PR TITLE
fix(orphanscan): protect metadata-less paths

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/andybalholm/brotli v1.2.2
 	github.com/autobrr/autobrr v1.82.1
 	github.com/autobrr/go-mediainfo v0.8.0
-	github.com/autobrr/go-qbittorrent v1.18.1-0.20260825184924-ed7e9179e725
+	github.com/autobrr/go-qbittorrent v1.18.1-0.20260825200055-b0abc1c0134d
 	github.com/autobrr/go-torrent v1.1.1-0.20260811091921-e2224c4f4e34
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/cespare/xxhash/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/autobrr/go-qbittorrent v1.17.1-0.20260815045428-fe3b4cb79f3e h1:bzRlD
 github.com/autobrr/go-qbittorrent v1.17.1-0.20260815045428-fe3b4cb79f3e/go.mod h1:9ujARiuSKZf8+NtApflTB69Wsptsp0Qk1mSVVC0tGzM=
 github.com/autobrr/go-qbittorrent v1.18.1-0.20260825184924-ed7e9179e725 h1:BFf040TbBQnE39tAIfvd0Vrd5d7Zh3PCTHy9YrUxHrw=
 github.com/autobrr/go-qbittorrent v1.18.1-0.20260825184924-ed7e9179e725/go.mod h1:spB3GP7xDu0btv59uUdxkLPEzoT+9xpx86QpJr4DUOw=
+github.com/autobrr/go-qbittorrent v1.18.1-0.20260825200055-b0abc1c0134d h1:oWXjEZZrc74m0/Cbmy7Yyeim97VjFUTekotsAC6v7uU=
+github.com/autobrr/go-qbittorrent v1.18.1-0.20260825200055-b0abc1c0134d/go.mod h1:spB3GP7xDu0btv59uUdxkLPEzoT+9xpx86QpJr4DUOw=
 github.com/autobrr/go-torrent v1.1.1-0.20260811091921-e2224c4f4e34 h1:ubxfEt1oWe2B3otV6mhHiONaeO7ydAJaveOsQyPiIz0=
 github.com/autobrr/go-torrent v1.1.1-0.20260811091921-e2224c4f4e34/go.mod h1:MNqAUt4SVvZTVyVSD3iQHXgi+ARVM3Z6dY0aTvXTnvY=
 github.com/autobrr/rls v0.8.1 h1:OjoFFVGcTibGrwf6b4pfk7JHsSYrGOX7F5P/8WtS3aE=

--- a/internal/api/sse/delta.go
+++ b/internal/api/sse/delta.go
@@ -219,9 +219,9 @@ func (b *fpBuf) bit(v bool) {
 // almost as large as a full snapshot (the root cause of the stream saturating an
 // HTTP/2 connection). The excluded fields still ride along with their current value
 // whenever a row is sent for a real change; they are just not on their own a reason
-// to resend a row. MagnetURI is also left out, for a different reason: TorrentView
-// shadows it out of the serialized payload entirely (issue #2328), so a magnet-only
-// change has nothing to update and must not resend a row.
+// to resend a row. MagnetURI and HasMetadata are also left out, for a different
+// reason: TorrentView shadows them out of the serialized payload entirely, so
+// changes to them have nothing to update and must not resend a row (issue #2328).
 // TestTorrentFingerprintCoversEveryField pins this partition, so a
 // go-qbittorrent bump that adds a field fails until the field is categorized here.
 func (b *fpBuf) torrent(t *qbt.Torrent) {
@@ -245,8 +245,6 @@ func (b *fpBuf) torrent(t *qbt.Torrent) {
 	b.bit(t.FirstLastPiecePrio)
 	b.bit(t.ForceStart)
 	b.str(t.Hash)
-	b.bit(t.HasMetadata != nil)
-	b.bit(t.HasMetadata != nil && *t.HasMetadata)
 	b.str(t.InfohashV1)
 	b.str(t.InfohashV2)
 	b.bit(t.Private)

--- a/internal/api/sse/fingerprint_test.go
+++ b/internal/api/sse/fingerprint_test.go
@@ -36,7 +36,8 @@ var volatileTorrentFields = map[string]bool{
 // TorrentView shadows them out of the serialized payload (issue #2328), so a
 // change to one has nothing to update client-side and must not resend a row.
 var payloadOmittedTorrentFields = map[string]bool{
-	"MagnetURI": true,
+	"MagnetURI":   true,
+	"HasMetadata": true,
 }
 
 // setSampleValue writes a non-zero value of the field's kind so a hashed field
@@ -103,16 +104,15 @@ func TestMagnetOnlyChangeDoesNotResendRow(t *testing.T) {
 	require.Empty(t, changed, "magnet-only change must not resend the row")
 }
 
-func TestTorrentFingerprintDistinguishesHasMetadataStates(t *testing.T) {
+func TestHasMetadataOnlyChangeDoesNotResendRow(t *testing.T) {
 	metadataUnavailable := false
 	metadataAvailable := true
+	before := []qbittorrent.TorrentView{{Torrent: &qbt.Torrent{Hash: "aaa", Name: "Alpha", HasMetadata: &metadataUnavailable}}}
+	after := []qbittorrent.TorrentView{{Torrent: &qbt.Torrent{Hash: "aaa", Name: "Alpha", HasMetadata: &metadataAvailable}}}
 
-	fingerprints := map[uint64]struct{}{
-		singleRowFingerprint(new(fpBuf), qbittorrent.TorrentView{Torrent: &qbt.Torrent{}}):                                  {},
-		singleRowFingerprint(new(fpBuf), qbittorrent.TorrentView{Torrent: &qbt.Torrent{HasMetadata: &metadataUnavailable}}): {},
-		singleRowFingerprint(new(fpBuf), qbittorrent.TorrentView{Torrent: &qbt.Torrent{HasMetadata: &metadataAvailable}}):   {},
-	}
-	require.Len(t, fingerprints, 3)
+	_, _, baseFP := computeRowDelta(before, singleRowKey, singleRowFingerprint, nil)
+	_, changed, _ := computeRowDelta(after, singleRowKey, singleRowFingerprint, baseFP)
+	require.Empty(t, changed, "has_metadata-only change must not resend the row")
 }
 
 // assertEveryFieldHashed proves fp reacts to every field of T: a fingerprint

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -187,12 +187,12 @@ const (
 // Uses pointer embedding to avoid unnecessary copies of the large qbt.Torrent struct.
 type TorrentView struct {
 	*qbt.Torrent
-	// MagnetURI shadows the promoted qbt.Torrent field so magnet_uri never
-	// reaches list/SSE JSON (issue #2328: 13% of the list payload, only the
-	// copy-magnet action reads it, and that fetches on demand). *struct{}
-	// instead of string so any promoted read fails to compile instead of
-	// silently returning ""; readers must go through .Torrent.MagnetURI.
+	// These fields shadow backend-only qbt.Torrent fields so they never reach
+	// list/SSE JSON. MagnetURI is fetched on demand (issue #2328), while
+	// HasMetadata is used only by orphan scans. *struct{} makes accidental
+	// promoted reads fail to compile; readers must go through .Torrent.
 	MagnetURI     *struct{}     `json:"magnet_uri,omitempty"`
+	HasMetadata   *struct{}     `json:"has_metadata,omitempty"`
 	TrackerHealth TrackerHealth `json:"tracker_health,omitempty"`
 }
 

--- a/internal/qbittorrent/torrent_view_json_test.go
+++ b/internal/qbittorrent/torrent_view_json_test.go
@@ -11,18 +11,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestTorrentViewJSONOmitsMagnetURI pins the shadow field on TorrentView: the
-// embedded qbt.Torrent.MagnetURI must never serialize in list/SSE rows (issue
-// #2328), while the rest of the row stays intact. Marshaling the cross-instance
-// view exercises TorrentView through its deepest embedding, covering both row
-// types in one pass.
-func TestTorrentViewJSONOmitsMagnetURI(t *testing.T) {
+// TestTorrentViewJSONOmitsInternalFields pins the shadow fields on TorrentView:
+// fields used only by the backend must never serialize in list/SSE rows. Marshaling
+// the cross-instance view exercises TorrentView through its deepest embedding,
+// covering both row types in one pass.
+func TestTorrentViewJSONOmitsInternalFields(t *testing.T) {
 	t.Parallel()
 
+	hasMetadata := false
 	torrent := &qbt.Torrent{
-		Hash:      "aaa",
-		Name:      "Alpha",
-		MagnetURI: "magnet:?xt=urn:btih:aaa",
+		Hash:        "aaa",
+		HasMetadata: &hasMetadata,
+		Name:        "Alpha",
+		MagnetURI:   "magnet:?xt=urn:btih:aaa",
 	}
 
 	data, err := json.Marshal(CrossInstanceTorrentView{
@@ -34,6 +35,7 @@ func TestTorrentViewJSONOmitsMagnetURI(t *testing.T) {
 	var decoded map[string]any
 	require.NoError(t, json.Unmarshal(data, &decoded))
 	require.NotContains(t, decoded, "magnet_uri")
+	require.NotContains(t, decoded, "has_metadata")
 	require.Equal(t, "aaa", decoded["hash"])
 	require.Equal(t, "Alpha", decoded["name"])
 }

--- a/internal/services/orphanscan/delete_test.go
+++ b/internal/services/orphanscan/delete_test.go
@@ -371,6 +371,39 @@ func TestSafeDeleteTarget_SkipsWhenTargetIsIgnored(t *testing.T) {
 	}
 }
 
+func TestDeletionIgnorePathsProtectFreshUnavailableRoots(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	metadataRoot := filepath.Join(root, "metadata-pending")
+	skippedRoot := filepath.Join(root, "checking")
+	metadataFile := filepath.Join(metadataRoot, "pending.bin")
+	skippedFile := filepath.Join(skippedRoot, "existing.bin")
+	writeOldFile(t, metadataFile)
+	writeOldFile(t, skippedFile)
+
+	ignorePaths, err := NormalizeIgnorePaths(scanIgnorePaths(nil, []string{root}, &buildFileMapResult{
+		metadataRoots: []string{metadataRoot},
+		skippedRoots:  []string{skippedRoot},
+	}))
+	if err != nil {
+		t.Fatalf("NormalizeIgnorePaths: %v", err)
+	}
+
+	for _, target := range []string{metadataFile, skippedFile} {
+		disp, err := safeDeleteTarget(root, target, NewTorrentFileMap(), ignorePaths)
+		if err != nil {
+			t.Fatalf("safeDeleteTarget(%q): %v", target, err)
+		}
+		if disp != deleteDispositionSkippedIgnored {
+			t.Fatalf("safeDeleteTarget(%q) disposition: got %v want %v", target, disp, deleteDispositionSkippedIgnored)
+		}
+		if _, err := os.Stat(target); err != nil {
+			t.Fatalf("stat protected target %q: %v", target, err)
+		}
+	}
+}
+
 func TestSafeDeleteTarget_AllowsDeleteWhenNoIgnorePaths(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/orphanscan/service.go
+++ b/internal/services/orphanscan/service.go
@@ -570,7 +570,7 @@ func (s *Service) executeScan(ctx context.Context, instanceID int, runID int64) 
 		return
 	}
 
-	allIgnorePaths := append(append([]string(nil), settings.IgnorePaths...), result.skippedRoots...)
+	allIgnorePaths := scanIgnorePaths(settings.IgnorePaths, scanRoots, result)
 
 	// Normalize ignore paths
 	ignorePaths, err := NormalizeIgnorePaths(allIgnorePaths)
@@ -851,13 +851,15 @@ func (s *Service) executeDeletion(ctx context.Context, instanceID int, runID int
 	if err != nil {
 		log.Warn().Err(err).Int("instance", instanceID).Msg("orphanscan: failed to load settings for deletion")
 	}
-	var ignorePaths []string
+	var configuredIgnorePaths []string
 	if settings != nil {
-		ignorePaths, err = NormalizeIgnorePaths(settings.IgnorePaths)
-		if err != nil {
-			log.Warn().Err(err).Int("instance", instanceID).Msg("orphanscan: invalid ignore paths during deletion, using unnormalized paths")
-			ignorePaths = settings.IgnorePaths // Fall back to unnormalized to preserve protection
-		}
+		configuredIgnorePaths = settings.IgnorePaths
+	}
+	rawIgnorePaths := scanIgnorePaths(configuredIgnorePaths, run.ScanPaths, fileMapResult)
+	ignorePaths, err := NormalizeIgnorePaths(rawIgnorePaths)
+	if err != nil {
+		log.Warn().Err(err).Int("instance", instanceID).Msg("orphanscan: invalid ignore paths during deletion, using unnormalized paths")
+		ignorePaths = rawIgnorePaths // Fall back to unnormalized to preserve protection
 	}
 
 	// Get files for deletion
@@ -1160,6 +1162,47 @@ func filterScanRootsCoveredBySkippedRoots(scanRoots, skippedRoots []string) []st
 	return filtered
 }
 
+func isSameRoot(first, second string) bool {
+	first = filepath.Clean(first)
+	second = filepath.Clean(second)
+	if first == second {
+		return true
+	}
+	if normalizePath(first) != normalizePath(second) {
+		return false
+	}
+	firstInfo, firstErr := os.Lstat(first)
+	secondInfo, secondErr := os.Lstat(second)
+	return firstErr == nil && secondErr == nil && os.SameFile(firstInfo, secondInfo)
+}
+
+func metadataIgnoreRoots(scanRoots, metadataRoots []string) []string {
+	ignored := make([]string, 0, len(metadataRoots))
+	for _, metadataRoot := range metadataRoots {
+		normalizedMetadataRoot := normalizePath(metadataRoot)
+		nested := false
+		for _, scanRoot := range scanRoots {
+			normalizedScanRoot := normalizePath(scanRoot)
+			if isSameRoot(metadataRoot, scanRoot) {
+				nested = false
+				break
+			}
+			if isPathUnderNormalized(normalizedMetadataRoot, normalizedScanRoot) {
+				nested = true
+			}
+		}
+		if nested {
+			ignored = append(ignored, filepath.Clean(metadataRoot))
+		}
+	}
+	return ignored
+}
+
+func scanIgnorePaths(configured, scanRoots []string, result *buildFileMapResult) []string {
+	ignored := append(append([]string(nil), configured...), result.skippedRoots...)
+	return append(ignored, metadataIgnoreRoots(scanRoots, result.metadataRoots)...)
+}
+
 // dedupeCaseVariantRoots drops a scan root when an earlier root differs from it
 // only by case AND both name the same directory on disk, which is what a
 // case-insensitive filesystem gives us when qBittorrent reports two spellings of
@@ -1266,16 +1309,18 @@ func actualSavePathFromContentPath(savePath, contentPath string, files qbt.Torre
 
 // buildFileMapResult contains the file map plus metadata for storage
 type buildFileMapResult struct {
-	fileMap      *TorrentFileMap
-	scanRoots    []string
-	skippedRoots []string
-	torrentCount int
+	fileMap       *TorrentFileMap
+	scanRoots     []string
+	skippedRoots  []string
+	metadataRoots []string
+	torrentCount  int
 }
 
 func buildFileMapFromTorrents(torrents []qbt.Torrent, filesByHash map[string]qbt.TorrentFiles) (*buildFileMapResult, error) {
 	tfm := NewTorrentFileMap()
 	scanRoots := make(map[string]struct{})
 	skippedRoots := make(map[string]struct{})
+	metadataRoots := make(map[string]struct{})
 	stableMissingFiles := 0
 
 	for i := range torrents {
@@ -1287,6 +1332,9 @@ func buildFileMapFromTorrents(torrents []qbt.Torrent, filesByHash map[string]qbt
 
 		if !hasFiles {
 			if torrent.HasMetadata != nil && !*torrent.HasMetadata {
+				if hasAbsSavePath {
+					metadataRoots[savePath] = struct{}{}
+				}
 				continue
 			}
 
@@ -1329,10 +1377,11 @@ func buildFileMapFromTorrents(torrents []qbt.Torrent, filesByHash map[string]qbt
 	scanRootList := dedupeCaseVariantRoots(filterScanRootsCoveredBySkippedRoots(sortedRoots(scanRoots), skippedRootList))
 
 	return &buildFileMapResult{
-		fileMap:      tfm,
-		scanRoots:    scanRootList,
-		skippedRoots: skippedRootList,
-		torrentCount: len(torrents),
+		fileMap:       tfm,
+		scanRoots:     scanRootList,
+		skippedRoots:  skippedRootList,
+		metadataRoots: sortedRoots(metadataRoots),
+		torrentCount:  len(torrents),
 	}, nil
 }
 
@@ -1459,6 +1508,7 @@ func (s *Service) buildFileMap(ctx context.Context, instanceID int) (*buildFileM
 
 		added := result.fileMap.MergeFrom(otherResult.fileMap)
 		result.skippedRoots = mergeRootLists(result.skippedRoots, otherResult.skippedRoots)
+		result.metadataRoots = mergeRootLists(result.metadataRoots, otherResult.metadataRoots)
 		result.scanRoots = filterScanRootsCoveredBySkippedRoots(result.scanRoots, result.skippedRoots)
 		log.Debug().
 			Int("instance", inst.ID).

--- a/internal/services/orphanscan/service_cross_instance_test.go
+++ b/internal/services/orphanscan/service_cross_instance_test.go
@@ -50,6 +50,8 @@ func TestBuildFileMap_CrossInstance(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
+	metadataRoot := filepath.Join(root, "incoming")
+	hasMetadata := false
 
 	svc := NewService(DefaultConfig(), nil, nil, nil, nil)
 
@@ -75,7 +77,10 @@ func TestBuildFileMap_CrossInstance(t *testing.T) {
 		case 1:
 			return []qbt.Torrent{{Hash: "A", SavePath: root, State: qbt.TorrentStatePausedUp}}, nil
 		case 2:
-			return []qbt.Torrent{{Hash: "B", SavePath: root, State: qbt.TorrentStatePausedUp}}, nil
+			return []qbt.Torrent{
+				{Hash: "B", SavePath: root, State: qbt.TorrentStatePausedUp},
+				{Hash: "C", SavePath: metadataRoot, State: qbt.TorrentStateStoppedDl, HasMetadata: &hasMetadata},
+			}, nil
 		default:
 			return nil, nil
 		}
@@ -113,6 +118,9 @@ func TestBuildFileMap_CrossInstance(t *testing.T) {
 	wantRoots := []string{filepath.Clean(root)}
 	if !slices.Equal(gotRoots, wantRoots) {
 		t.Fatalf("scanRoots mismatch: got=%v want=%v", gotRoots, wantRoots)
+	}
+	if got := metadataIgnoreRoots(result.scanRoots, result.metadataRoots); !slices.Equal(got, []string{filepath.Clean(metadataRoot)}) {
+		t.Fatalf("metadataIgnoreRoots mismatch: got=%v want=%v", got, []string{filepath.Clean(metadataRoot)})
 	}
 }
 

--- a/internal/services/orphanscan/settling_test.go
+++ b/internal/services/orphanscan/settling_test.go
@@ -4,6 +4,7 @@
 package orphanscan
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -220,6 +221,52 @@ func TestFilterScanRootsCoveredBySkippedRoots(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestMetadataIgnoreRoots(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	scanRoot := filepath.Join(base, "downloads")
+	nestedRoot := filepath.Join(scanRoot, "incoming")
+
+	got := metadataIgnoreRoots(
+		[]string{scanRoot},
+		[]string{nestedRoot, scanRoot, base, filepath.Join(base, "elsewhere")},
+	)
+	assert.Equal(t, []string{filepath.Clean(nestedRoot)}, got)
+	assert.Empty(t, metadataIgnoreRoots([]string{scanRoot, nestedRoot}, []string{nestedRoot}))
+
+	stagedFile := filepath.Join(nestedRoot, "pending.bin")
+	orphanFile := filepath.Join(scanRoot, "orphan.bin")
+	writeOldFile(t, stagedFile)
+	writeOldFile(t, orphanFile)
+
+	orphans, truncated, err := walkScanRoot(context.Background(), scanRoot, NewTorrentFileMap(), got, 0, 100)
+	require.NoError(t, err)
+	assert.False(t, truncated)
+	assert.Equal(t, []string{normalizePath(orphanFile)}, orphanPaths(orphans))
+
+	t.Run("distinct case variants", func(t *testing.T) {
+		caseRoot := filepath.Join(base, "case-sensitive")
+		upperRoot := filepath.Join(caseRoot, "Incoming")
+		lowerRoot := filepath.Join(caseRoot, "incoming")
+		require.NoError(t, os.MkdirAll(upperRoot, 0o755))
+		require.NoError(t, os.MkdirAll(lowerRoot, 0o755))
+
+		upperInfo, err := os.Lstat(upperRoot)
+		require.NoError(t, err)
+		lowerInfo, err := os.Lstat(lowerRoot)
+		require.NoError(t, err)
+		if os.SameFile(upperInfo, lowerInfo) {
+			t.Skip("filesystem is case-insensitive")
+		}
+
+		assert.Equal(t, []string{filepath.Clean(upperRoot)}, metadataIgnoreRoots(
+			[]string{caseRoot, lowerRoot},
+			[]string{upperRoot},
+		))
+	})
 }
 
 func TestBuildFileMapFromTorrents_ContentPathDivergesFromSavePath(t *testing.T) {


### PR DESCRIPTION
## Description

This pull request updates orphan scans to exclude files located under the save path of any torrent that has not yet fetched metadata. When a pending torrent's save path is located inside another torrent's scan root, qui scans the parent root while skipping the pending torrent's subdirectory.

The same exclusion applies when local qBittorrent instances use overlapping paths. Matching or parent save paths remain scannable. qui uses `has_metadata` internally to determine scan exclusions, but omits this field from torrent REST and SSE responses.

Context:

- [Discussion #2436](https://github.com/autobrr/qui/discussions/2436)
- [Original qui fix #2441](https://github.com/autobrr/qui/pull/2441)
- [Merged go-qBittorrent PR #134](https://github.com/autobrr/go-qbittorrent/pull/134)

## How has this been tested?

I compared the version before this PR (`3c9b0c65`) with this PR (`4e5061bc`) against the same qBittorrent v5.2.3 instance using the following test setup:

- A seeded torrent with `has_metadata=true`, `content_path=downloads/seeded.bin`, and save path `downloads`.
- A tracker-free magnet with `has_metadata=false`, an empty `content_path`, and save path `downloads/incoming`.
- Files located at `downloads/incoming/pending.bin` and `downloads/orphan.bin`.

Test execution:

- Before this PR, qui incorrectly listed both `incoming/pending.bin` and `orphan.bin` as deletion candidates.
- With this PR, qui protected `incoming/pending.bin` and listed only the unrelated `orphan.bin`.
- After confirming the deletion, qui removed `orphan.bin` and preserved both `seeded.bin` and `incoming/pending.bin`.
- The torrent REST response did not contain the internal `has_metadata` field.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL
