### PR TITLE
fix(docker): honor configured non-root user

### DIFF
--- a/distrib/docker/Dockerfile
+++ b/distrib/docker/Dockerfile
@@ -90,6 +90,9 @@ VOLUME /config
 COPY --from=go-builder /app/qui /usr/local/bin/
 COPY distrib/docker/entrypoint.sh /entrypoint.sh
 
+# Verify Compose user mode still works when shared PUID/PGID variables are present.
+RUN PUID=99 PGID=100 su-exec 99:100 /entrypoint.sh --version
+
 EXPOSE 7476
 
 # Health check

--- a/distrib/docker/ci.Dockerfile
+++ b/distrib/docker/ci.Dockerfile
@@ -80,6 +80,9 @@ VOLUME /config
 COPY --from=go-builder /app/qui /usr/local/bin/
 COPY distrib/docker/entrypoint.sh /entrypoint.sh
 
+# Verify Compose user mode still works when shared PUID/PGID variables are present.
+RUN PUID=99 PGID=100 su-exec 99:100 /entrypoint.sh --version
+
 EXPOSE 7476
 
 # Health check

--- a/distrib/docker/entrypoint.sh
+++ b/distrib/docker/entrypoint.sh
@@ -4,6 +4,11 @@ set -e
 # UMASK is handled by the qui binary itself (applyUmask in cmd/qui),
 # so the entrypoint does not touch it.
 
+# Docker's user setting has already dropped privileges, so run qui directly.
+if [ "$(id -u)" -ne 0 ]; then
+    exec /usr/local/bin/qui "$@"
+fi
+
 # Fail fast if only one of PUID/PGID is set
 if { [ -n "$PUID" ] && [ -z "$PGID" ]; } || { [ -z "$PUID" ] && [ -n "$PGID" ]; }; then
     echo >&2 "ERROR: PUID and PGID must be set together"


### PR DESCRIPTION
## Description

Existing Compose stacks can set Docker's `user:` option while inheriting `PUID` and `PGID` from a shared environment anchor. PUID/PGID support made the entrypoint attempt root-only user setup after Docker had already dropped privileges, so those containers stopped at startup with `adduser: permission denied (are you root?)`.

Honor Docker's configured user by launching qui directly when the entrypoint is already non-root. Root-started containers keep the existing PUID/PGID user creation, ownership repair, and privilege drop. Both Docker builds now run the affected combination as a regression check.

The issue in a nutshell: two condoms sounds good on paper, but causes friction in production

## How has this been tested?

- Reproduced the failure in the pre-fix image with UID 99, GID 100, and matching PUID/PGID values.
- Built both Docker image definitions with the regression check.
- Started the rebuilt image with `--user 99:100`, `PUID=99`, and `PGID=100`; confirmed it stayed on UID 99/GID 100 and `/health` returned `{"status":"ok"}`.
- Confirmed root-started PUID/PGID mode still reaches qui after its setup path.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container startup when running as a non-root user.
  * Preserved existing UID/GID configuration and permission handling for root-based execution.
  * Added validation to ensure version checks work with Compose-style user settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->