### PR TITLE
fix(search): rerun recent searches with their restored indexer selection

### DIFF
--- a/web/src/lib/search-derived-params.test.ts
+++ b/web/src/lib/search-derived-params.test.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { describe, expect, it } from "vitest"
+
+import { resolveSuggestionIndexerIds } from "./search-derived-params"
+
+describe("resolveSuggestionIndexerIds", () => {
+  it("keeps only the saved ids that are still enabled", () => {
+    expect(resolveSuggestionIndexerIds([3, 1, 7], [1, 2, 3])).toEqual(new Set([3, 1]))
+  })
+
+  it("returns null when no saved ids are given", () => {
+    expect(resolveSuggestionIndexerIds([], [1, 2])).toBeNull()
+    expect(resolveSuggestionIndexerIds(null, [1, 2])).toBeNull()
+    expect(resolveSuggestionIndexerIds(undefined, [1, 2])).toBeNull()
+  })
+
+  it("returns null when saved and enabled ids do not overlap", () => {
+    expect(resolveSuggestionIndexerIds([4, 5], [1, 2, 3])).toBeNull()
+    expect(resolveSuggestionIndexerIds([1, 2], [])).toBeNull()
+  })
+})

--- a/web/src/lib/search-derived-params.ts
+++ b/web/src/lib/search-derived-params.ts
@@ -100,3 +100,13 @@ export function getSearchTypeLabel(type: SearchType, t: TFunction): string {
   const key = SEARCH_TYPE_KEYS[type]
   return key ? t(key.label) : t("searchTypes.auto.label")
 }
+
+/**
+ * Filter a recent search's saved indexer ids down to the ones still enabled.
+ * Returns null when nothing usable remains, so callers keep their current selection.
+ */
+export function resolveSuggestionIndexerIds(savedIds: number[] | null | undefined, enabledIds: number[]): Set<number> | null {
+  const enabled = new Set(enabledIds)
+  const filtered = savedIds?.filter(id => enabled.has(id)) ?? []
+  return filtered.length ? new Set(filtered) : null
+}

--- a/web/src/pages/Search.tsx
+++ b/web/src/pages/Search.tsx
@@ -23,7 +23,7 @@ import { useInstances } from "@/hooks/useInstances"
 import { api } from "@/lib/api"
 import type { ColumnFilter } from "@/lib/column-filter-utils"
 import { filterSearchResult } from "@/lib/column-filter-utils"
-import { getCategoriesForSearchType, getSearchTypeLabel, getSearchTypeOptions, inferSearchTypeFromCategories, type SearchType } from "@/lib/search-derived-params"
+import { getCategoriesForSearchType, getSearchTypeLabel, getSearchTypeOptions, inferSearchTypeFromCategories, resolveSuggestionIndexerIds, type SearchType } from "@/lib/search-derived-params"
 import { extractImdbId, extractTvdbId } from "@/lib/search-id-parsing"
 import { cn, formatBytes } from "@/lib/utils"
 import type { TorznabIndexer, TorznabRecentSearch, TorznabSearchRequest, TorznabSearchResponse, TorznabSearchResult } from "@/types"
@@ -393,8 +393,9 @@ export function Search() {
     }
   }
 
-  const validateSearchInputs = useCallback((overrideQuery?: string) => {
+  const validateSearchInputs = useCallback((overrideQuery?: string, overrideIndexers?: Set<number> | null) => {
     const normalizedQuery = (overrideQuery ?? query).trim()
+    const activeIndexers = overrideIndexers ?? selectedIndexers
 
     // Allow search with either query or advanced parameters
     if (!normalizedQuery && !hasAdvancedParams) {
@@ -402,7 +403,7 @@ export function Search() {
       return false
     }
 
-    if (selectedIndexers.size === 0) {
+    if (activeIndexers.size === 0) {
       toast.error(t("toast.selectIndexer"))
       return false
     }
@@ -431,7 +432,8 @@ export function Search() {
       bypassCache = false,
       queryOverride,
       searchTypeOverride,
-    }: { bypassCache?: boolean; queryOverride?: string; searchTypeOverride?: SearchType } = {}) => {
+      indexerIdsOverride,
+    }: { bypassCache?: boolean; queryOverride?: string; searchTypeOverride?: SearchType; indexerIdsOverride?: Set<number> | null } = {}) => {
       const reqId = ++latestReqIdRef.current
       const searchQuery = (queryOverride ?? query).trim()
       const targetSearchType = searchTypeOverride ?? searchType
@@ -446,7 +448,7 @@ export function Search() {
       try {
         const payload: TorznabSearchRequest = {
           query: searchQuery,
-          indexer_ids: Array.from(selectedIndexers),
+          indexer_ids: Array.from(indexerIdsOverride ?? selectedIndexers),
         }
 
         const derivedCategories = getCategoriesForSearchType(targetSearchType)
@@ -673,19 +675,6 @@ export function Search() {
     setInstanceMenuOpen(false)
   }, [persistSelectedInstanceId, setInstanceMenuOpen])
 
-  const applyIndexerSelectionFromSuggestion = useCallback((indexerIds: number[]) => {
-    if (!indexerIds || indexerIds.length === 0 || indexers.length === 0) {
-      return
-    }
-
-    const enabled = new Set(indexers.map(idx => idx.id))
-    const filtered = indexerIds.filter(id => enabled.has(id))
-    if (filtered.length === 0) {
-      return
-    }
-    setSelectedIndexers(new Set(filtered))
-  }, [indexers])
-
   const toggleIndexer = (id: number) => {
     setSelectedIndexers(prev => {
       const newSelected = new Set(prev)
@@ -908,14 +897,19 @@ export function Search() {
     setQuery(search.query)
     const derivedType = inferSearchTypeFromCategories(search.categories) ?? "auto"
     setSearchType(derivedType)
-    applyIndexerSelectionFromSuggestion(search.indexerIds)
+    // setSelectedIndexers only applies on the next render, so the restored ids
+    // must also flow into validation and the request directly.
+    const restoredIndexerIds = resolveSuggestionIndexerIds(search.indexerIds, indexers.map(idx => idx.id))
+    if (restoredIndexerIds) {
+      setSelectedIndexers(restoredIndexerIds)
+    }
     const normalized = search.query.trim()
-    if (!validateSearchInputs(normalized)) {
+    if (!validateSearchInputs(normalized, restoredIndexerIds)) {
       return
     }
     closeSuggestions()
-    void runSearch({ queryOverride: normalized, searchTypeOverride: derivedType })
-  }, [applyIndexerSelectionFromSuggestion, closeSuggestions, runSearch, validateSearchInputs])
+    void runSearch({ queryOverride: normalized, searchTypeOverride: derivedType, indexerIdsOverride: restoredIndexerIds })
+  }, [closeSuggestions, indexers, runSearch, validateSearchInputs])
 
   const handleDownload = useCallback((result: TorznabSearchResult) => {
     window.open(result.downloadUrl, "_blank", "noopener,noreferrer")


### PR DESCRIPTION
## Description

Clicking a recent-search suggestion queued the restored indexer ids with `setSelectedIndexers` and then validated and ran the search in the same tick, so both still read the previous selection. The request queried the wrong indexers (all enabled ones in the default state), or validation rejected it when none were selected. The restored ids now flow through `validateSearchInputs` and `runSearch` directly, mirroring the existing `queryOverride` pattern, with the same fallback as before when the saved ids are empty or all disabled.

## How has this been tested?

Unit tests cover the id filtering and fallback, and a mutated helper made them fail as expected. I have no local instance with indexers and search history, so the live suggestion click is not exercised: click a recent search whose saved indexers differ from the current selection and confirm the results come from the saved set.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Restored search suggestions now correctly retain only currently enabled indexers.
  - Invalid or unavailable saved indexer selections are safely ignored.
  - Search requests now use the validated restored indexer selection consistently.
- **Tests**
  - Added coverage for filtering enabled indexers, handling missing saved selections, and resolving non-overlapping IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->