### PR TITLE
fix(notifications): route Notifiarr test events

### DIFF
--- a/internal/services/notifications/notifiarr_api_test.go
+++ b/internal/services/notifications/notifiarr_api_test.go
@@ -5,6 +5,7 @@ package notifications
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -15,6 +16,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/models"
 )
 
 func TestValidateNotifiarrAPIKeySkipsNonNotifiarrAPI(t *testing.T) {
@@ -211,4 +214,65 @@ func TestBuildNotifiarrAPIDataIncludesZeroValueTorrentMetrics(t *testing.T) {
 	require.Equal(t, int64(0), *data.Torrent.NumSeeds)
 	require.NotNil(t, data.Torrent.NumLeechs)
 	require.Equal(t, int64(0), *data.Torrent.NumLeechs)
+}
+
+func TestSendTestNotifiarrAPIUsesConfiguredEventType(t *testing.T) {
+	t.Parallel()
+
+	type receivedPayload struct {
+		payload notifiarrAPIPayload
+		err     error
+	}
+	payloads := make(chan receivedPayload, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload notifiarrAPIPayload
+		err := json.NewDecoder(r.Body).Decode(&payload)
+		payloads <- receivedPayload{
+			payload: payload,
+			err:     err,
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	endpoint := server.URL + "/api/v1/notification/qui"
+	target := &models.NotificationTarget{
+		URL:        "notifiarrapi://abc123?endpoint=" + url.QueryEscape(endpoint),
+		EventTypes: []string{string(EventCrossSeedCompletionSucceeded)},
+	}
+
+	err := (&Service{}).SendTest(context.Background(), target, "Test notification", "Test message")
+	require.NoError(t, err)
+
+	select {
+	case received := <-payloads:
+		require.NoError(t, received.err)
+		payload := received.payload
+		require.Equal(t, string(EventCrossSeedCompletionSucceeded), payload.Event)
+		require.Equal(t, string(EventCrossSeedCompletionSucceeded), payload.Data.Event)
+		require.Equal(t, "Test notification", payload.Data.Subject)
+		require.Equal(t, "Test message", payload.Data.Message)
+	case <-time.After(time.Second):
+		t.Fatal("expected test notification request")
+	}
+}
+
+func TestSendTestNotifiarrAPIRequiresConfiguredEventType(t *testing.T) {
+	t.Parallel()
+
+	var hits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	endpoint := server.URL + "/api/v1/notification/qui"
+	target := &models.NotificationTarget{
+		URL: "notifiarrapi://abc123?endpoint=" + url.QueryEscape(endpoint),
+	}
+
+	err := (&Service{}).SendTest(context.Background(), target, "Test notification", "Test message")
+	require.EqualError(t, err, "notifiarr api test requires at least one event type")
+	require.Zero(t, hits.Load())
 }

--- a/internal/services/notifications/service.go
+++ b/internal/services/notifications/service.go
@@ -143,7 +143,15 @@ func (s *Service) SendTest(ctx context.Context, target *models.NotificationTarge
 		return errors.New("notification target required")
 	}
 
-	return s.send(ctx, target, Event{}, title, message)
+	event := Event{}
+	if targetScheme(target.URL) == "notifiarrapi" {
+		if len(target.EventTypes) == 0 {
+			return errors.New("notifiarr api test requires at least one event type")
+		}
+		event.Type = EventType(target.EventTypes[0])
+	}
+
+	return s.send(ctx, target, event, title, message)
 }
 
 func (s *Service) worker(ctx context.Context) {


### PR DESCRIPTION
## Description

Route native Notifiarr test notifications through the first event type configured on the target. Notifiarr accepts the generic `test` event but does not route it through qui's event-specific channel settings. This caused qui to report success without a Discord delivery.

Return an error when a native Notifiarr target has no configured event type. Other notification target types keep their current test behavior.

## How has this been tested?

Created a temporary qui configuration and sent a test notification through a local fake Notifiarr endpoint. Confirmed that the delivered event was `cross_seed_completion_succeeded`.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

No database schema change.

## AI disclosure

Yes. OpenAI Codex (GPT-5.6 Sol) produced most of the implementation and tests under human direction and review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Test notifications sent through Notifiarr now use the first configured event type consistently.
  - Notifiarr test notifications are prevented when no event type is configured, with an appropriate error reported.
  - Other notification targets continue to behave as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->