### PR TITLE
fix(database): drop unused timestamp indexes on torrent_files_cache/sync

### DIFF
--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -307,8 +307,7 @@ var expectedIndexes = map[string][]string{
 	"client_api_keys":     {"idx_client_api_keys_instance_id"},
 	"instance_errors":     {"idx_instance_errors_lookup"},
 	"sessions":            {"sessions_expiry_idx"},
-	"torrent_files_cache": {"idx_torrent_files_cache_lookup", "idx_torrent_files_cache_cached_at"},
-	"torrent_files_sync":  {"idx_torrent_files_sync_last_synced"},
+	"torrent_files_cache": {"idx_torrent_files_cache_lookup"},
 	"automations":         {"idx_automations_instance"},
 	"automation_activity": {"idx_automation_activity_instance_created"},
 }

--- a/internal/database/migrations/091_drop_unused_timestamp_indexes.sql
+++ b/internal/database/migrations/091_drop_unused_timestamp_indexes.sql
@@ -1,0 +1,11 @@
+-- Migration 091: Drop unused timestamp indexes on torrent_files_cache/torrent_files_sync
+--
+-- cached_at and last_synced_at are rewritten on every upsert (once per torrent per sync
+-- cycle), but neither column is ever used in a WHERE or ORDER BY clause: cache eviction
+-- deletes by (instance_id, torrent_hash_id) identity, and the only reads of these columns
+-- are unfiltered aggregates (MIN/MAX/AVG) that a seq scan already has to do. On Postgres
+-- this indexed-but-unfiltered timestamp blocks HOT updates on every write, forcing full
+-- index maintenance for no read benefit. See discussion #2374.
+
+DROP INDEX IF EXISTS idx_torrent_files_cache_cached_at;
+DROP INDEX IF EXISTS idx_torrent_files_sync_last_synced;

--- a/internal/database/postgres_migrations/093_drop_unused_timestamp_indexes.sql
+++ b/internal/database/postgres_migrations/093_drop_unused_timestamp_indexes.sql
@@ -1,0 +1,15 @@
+-- Drop unused timestamp indexes on torrent_files_cache/torrent_files_sync (Postgres
+-- mirror of SQLite migration 091).
+--
+-- cached_at and last_synced_at are rewritten on every upsert (once per torrent per sync
+-- cycle), but neither column is ever used in a WHERE or ORDER BY clause: cache eviction
+-- deletes by (instance_id, torrent_hash_id) identity, and the only reads of these columns
+-- are unfiltered aggregates (MIN/MAX/AVG) that a seq scan already has to do anyway. With
+-- the index in place, Postgres cannot use HOT updates for these high-churn tables because
+-- the indexed timestamp changes on every write, forcing full index maintenance for no read
+-- benefit. Plain DROP INDEX (not CONCURRENTLY) is fine here: dropping is a fast metadata
+-- change and migrations already run inside a transaction, which disallows CONCURRENTLY.
+-- See discussion #2374.
+
+DROP INDEX IF EXISTS idx_torrent_files_cache_cached_at;
+DROP INDEX IF EXISTS idx_torrent_files_sync_last_synced;


### PR DESCRIPTION
## Description

`torrent_files_cache.cached_at` and `torrent_files_sync.last_synced_at` are rewritten on every upsert (once per torrent per sync cycle), but neither column is ever used in a `WHERE` or `ORDER BY` clause: cache eviction deletes by `(instance_id, torrent_hash_id)` identity, and the only reads of these columns are unfiltered aggregates (`MIN`/`MAX`/`AVG`) that already require a full scan.

Because these indexed columns are rewritten on every write, Postgres cannot use HOT (Heap-Only Tuple) updates for these high-churn tables, forcing full index maintenance for no read benefit. Dropping the indexes removes that overhead at zero cost to existing queries.

Addresses discussion #2374.

## How has this been tested?

- `go build ./...`, `go vet ./...`, `gofmt -l .` all clean
- `go test -race -count=1 ./...` passes (verified in a Go 1.27 container since no local toolchain was available)
- Updated `internal/database/db_test.go`'s schema-conformance test, which asserted these indexes existed, to reflect their removal

## Checklist

- [x] My PR title follows the Conventional Commits format (it becomes the squashed commit message)
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

## AI disclosure

This PR was written by Claude Code (Sonnet 5), based on investigation of the linked discussion and the codebase, with human review and verification (build/vet/test run in a container) before submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unused database indexes related to torrent cache and synchronization timestamps.
  * Improved database maintenance by safely applying these changes across supported database systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->