### PR TITLE
fix(jackett): schedule opportunistic cleanup of torznab indexer latency

### DIFF
--- a/internal/services/crossseed/service_search_test.go
+++ b/internal/services/crossseed/service_search_test.go
@@ -118,6 +118,10 @@ func (s *failingEnabledIndexerStore) RecordLatency(context.Context, int, string,
 	return nil
 }
 
+func (s *failingEnabledIndexerStore) CleanupOldLatency(context.Context, time.Duration) (int64, error) {
+	return 0, nil
+}
+
 func (s *failingEnabledIndexerStore) RecordError(context.Context, int, string, string) error {
 	return nil
 }

--- a/internal/services/dirscan/service_indexer_probe_test.go
+++ b/internal/services/dirscan/service_indexer_probe_test.go
@@ -64,6 +64,10 @@ func (s *failingDirScanIndexerStore) RecordLatency(context.Context, int, string,
 	return nil
 }
 
+func (s *failingDirScanIndexerStore) CleanupOldLatency(context.Context, time.Duration) (int64, error) {
+	return 0, nil
+}
+
 func (s *failingDirScanIndexerStore) RecordError(context.Context, int, string, string) error {
 	return nil
 }

--- a/internal/services/jackett/service.go
+++ b/internal/services/jackett/service.go
@@ -43,6 +43,7 @@ type IndexerStore interface {
 	SetCategories(ctx context.Context, indexerID int, categories []models.TorznabIndexerCategory) error
 	SetLimits(ctx context.Context, indexerID, limitDefault, limitMax int) error
 	RecordLatency(ctx context.Context, indexerID int, operationType string, latencyMs int, success bool) error
+	CleanupOldLatency(ctx context.Context, olderThan time.Duration) (int64, error)
 	RecordError(ctx context.Context, indexerID int, errorMessage, errorCode string) error
 	ListRateLimitCooldowns(ctx context.Context) ([]models.TorznabIndexerCooldown, error)
 	UpsertRateLimitCooldown(ctx context.Context, indexerID int, resumeAt time.Time, cooldown time.Duration, reason string) error
@@ -89,6 +90,8 @@ type Service struct {
 	nextSearchCacheCleanup  time.Time
 	torrentCacheCleanupMu   sync.Mutex
 	nextTorrentCacheCleanup time.Time
+	latencyCleanupMu        sync.Mutex
+	nextLatencyCleanup      time.Time
 
 	// searchHistory provides in-memory search history tracking
 	searchHistory *SearchHistoryBuffer
@@ -114,6 +117,8 @@ const (
 
 	searchCacheCleanupInterval  = 6 * time.Hour
 	torrentCacheCleanupInterval = 6 * time.Hour
+	latencyCleanupInterval      = 6 * time.Hour
+	latencyRetention            = 14 * 24 * time.Hour
 
 	searchCacheScopeCrossSeed = "cross_seed"
 	searchCacheScopeGeneral   = "general"
@@ -1673,6 +1678,31 @@ func (s *Service) maybeScheduleTorrentCacheCleanup() {
 	}()
 }
 
+func (s *Service) maybeScheduleLatencyCleanup() {
+	if s == nil || s.indexerStore == nil {
+		return
+	}
+
+	s.latencyCleanupMu.Lock()
+	if time.Now().Before(s.nextLatencyCleanup) {
+		s.latencyCleanupMu.Unlock()
+		return
+	}
+	s.nextLatencyCleanup = time.Now().Add(latencyCleanupInterval)
+	s.latencyCleanupMu.Unlock()
+
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		if deleted, err := s.indexerStore.CleanupOldLatency(ctx, latencyRetention); err != nil {
+			log.Debug().Err(err).Msg("Failed to cleanup torznab indexer latency")
+		} else if deleted > 0 {
+			log.Debug().Int64("deleted", deleted).Msg("Cleaned up torznab indexer latency records")
+		}
+	}()
+}
+
 // FlushSearchCache removes all cached search responses.
 func (s *Service) FlushSearchCache(ctx context.Context) (int64, error) {
 	if !s.shouldUseSearchCache() {
@@ -2075,6 +2105,7 @@ func (s *Service) executeIndexerSearch(ctx context.Context, idx *models.TorznabI
 	if recErr := s.indexerStore.RecordLatency(ctx, idx.ID, "search", latencyMs, err == nil); recErr != nil {
 		log.Debug().Err(recErr).Int("indexer_id", idx.ID).Msg("Failed to record torznab latency")
 	}
+	s.maybeScheduleLatencyCleanup()
 
 	if opts.logSearchActivity {
 		log.Debug().

--- a/internal/services/jackett/service_test.go
+++ b/internal/services/jackett/service_test.go
@@ -1966,7 +1966,7 @@ type mockTorznabIndexerStore struct {
 	getCalls            []int
 	apiKeyErrors        map[int]error
 	apiKeyCalls         []int
-	latencyCleanupCalls int
+	latencyCleanupCalls chan time.Duration
 }
 
 func (m *mockTorznabIndexerStore) Get(ctx context.Context, id int) (*models.TorznabIndexer, error) {
@@ -2055,10 +2055,9 @@ func (m *mockTorznabIndexerStore) RecordLatency(ctx context.Context, indexerID i
 }
 
 func (m *mockTorznabIndexerStore) CleanupOldLatency(ctx context.Context, olderThan time.Duration) (int64, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	m.latencyCleanupCalls++
+	if m.latencyCleanupCalls != nil {
+		m.latencyCleanupCalls <- olderThan
+	}
 	return 0, nil
 }
 
@@ -3648,38 +3647,42 @@ func TestApplyIndexerRestrictionsKeepsContentTypeRouting(t *testing.T) {
 	}
 }
 
-// Regression test for discussion #2376: CleanupOldLatency existed but nothing
-// ever called it, so torznab_indexer_latency grew without bound. This checks
-// that a search's latency record now opportunistically triggers cleanup, and
-// that the interval gate prevents it from running on every single search.
-func TestMaybeScheduleLatencyCleanupTriggersAndDebounces(t *testing.T) {
-	store := &mockTorznabIndexerStore{}
+func TestExecuteIndexerSearchSchedulesLatencyCleanup(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/rss+xml")
+		if _, err := w.Write([]byte(`<rss version="2.0"><channel><title>Test</title></channel></rss>`)); err != nil {
+			t.Errorf("write RSS response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	cleanupCalls := make(chan time.Duration, 1)
+	store := &mockTorznabIndexerStore{latencyCleanupCalls: cleanupCalls}
 	service := NewService(store)
-
-	service.maybeScheduleLatencyCleanup()
-
-	deadline := time.After(2 * time.Second)
-	for {
-		store.mu.Lock()
-		calls := store.latencyCleanupCalls
-		store.mu.Unlock()
-		if calls == 1 {
-			break
-		}
-		select {
-		case <-deadline:
-			t.Fatalf("expected CleanupOldLatency to be called once, got %d", calls)
-		case <-time.After(10 * time.Millisecond):
-		}
+	indexer := &models.TorznabIndexer{
+		ID:      1,
+		BaseURL: server.URL,
+		Backend: models.TorznabBackendNative,
 	}
 
-	// A second call within latencyCleanupInterval should be debounced.
-	service.maybeScheduleLatencyCleanup()
-	time.Sleep(50 * time.Millisecond)
+	result := service.executeIndexerSearch(context.Background(), indexer, nil, nil, indexerExecOptions{})
+	if result.err != nil {
+		t.Fatalf("executeIndexerSearch() error = %v", result.err)
+	}
 
-	store.mu.Lock()
-	defer store.mu.Unlock()
-	if store.latencyCleanupCalls != 1 {
-		t.Fatalf("expected CleanupOldLatency to still be called once (debounced), got %d", store.latencyCleanupCalls)
+	select {
+	case olderThan := <-cleanupCalls:
+		if olderThan != 14*24*time.Hour {
+			t.Fatalf("CleanupOldLatency() olderThan = %v, want 14 days", olderThan)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected search to schedule latency cleanup")
+	}
+
+	service.maybeScheduleLatencyCleanup()
+	select {
+	case <-cleanupCalls:
+		t.Fatal("expected latency cleanup to be interval-gated")
+	case <-time.After(50 * time.Millisecond):
 	}
 }

--- a/internal/services/jackett/service_test.go
+++ b/internal/services/jackett/service_test.go
@@ -1955,17 +1955,18 @@ func TestGetConfiguredTrackerDomains_ProwlarrResolvesRealDomain(t *testing.T) {
 //
 // Mock store for testing
 type mockTorznabIndexerStore struct {
-	mu                 sync.Mutex
-	indexers           []*models.TorznabIndexer
-	capabilities       map[int][]string // indexerID -> capabilities
-	cooldowns          map[int]models.TorznabIndexerCooldown
-	upsertCooldowns    []int
-	deleteCooldowns    []int
-	panicOnListEnabled bool
-	listEnabledCalls   int
-	getCalls           []int
-	apiKeyErrors       map[int]error
-	apiKeyCalls        []int
+	mu                  sync.Mutex
+	indexers            []*models.TorznabIndexer
+	capabilities        map[int][]string // indexerID -> capabilities
+	cooldowns           map[int]models.TorznabIndexerCooldown
+	upsertCooldowns     []int
+	deleteCooldowns     []int
+	panicOnListEnabled  bool
+	listEnabledCalls    int
+	getCalls            []int
+	apiKeyErrors        map[int]error
+	apiKeyCalls         []int
+	latencyCleanupCalls int
 }
 
 func (m *mockTorznabIndexerStore) Get(ctx context.Context, id int) (*models.TorznabIndexer, error) {
@@ -2051,6 +2052,14 @@ func (m *mockTorznabIndexerStore) SetLimits(ctx context.Context, indexerID, limi
 
 func (m *mockTorznabIndexerStore) RecordLatency(ctx context.Context, indexerID int, operationType string, latencyMs int, success bool) error {
 	return nil
+}
+
+func (m *mockTorznabIndexerStore) CleanupOldLatency(ctx context.Context, olderThan time.Duration) (int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.latencyCleanupCalls++
+	return 0, nil
 }
 
 func (m *mockTorznabIndexerStore) RecordError(ctx context.Context, indexerID int, errorMessage, errorCode string) error {
@@ -3636,5 +3645,41 @@ func TestApplyIndexerRestrictionsKeepsContentTypeRouting(t *testing.T) {
 				t.Fatalf("rateLimited = true, want false")
 			}
 		})
+	}
+}
+
+// Regression test for discussion #2376: CleanupOldLatency existed but nothing
+// ever called it, so torznab_indexer_latency grew without bound. This checks
+// that a search's latency record now opportunistically triggers cleanup, and
+// that the interval gate prevents it from running on every single search.
+func TestMaybeScheduleLatencyCleanupTriggersAndDebounces(t *testing.T) {
+	store := &mockTorznabIndexerStore{}
+	service := NewService(store)
+
+	service.maybeScheduleLatencyCleanup()
+
+	deadline := time.After(2 * time.Second)
+	for {
+		store.mu.Lock()
+		calls := store.latencyCleanupCalls
+		store.mu.Unlock()
+		if calls == 1 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("expected CleanupOldLatency to be called once, got %d", calls)
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	// A second call within latencyCleanupInterval should be debounced.
+	service.maybeScheduleLatencyCleanup()
+	time.Sleep(50 * time.Millisecond)
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if store.latencyCleanupCalls != 1 {
+		t.Fatalf("expected CleanupOldLatency to still be called once (debounced), got %d", store.latencyCleanupCalls)
 	}
 }


### PR DESCRIPTION
## Description

`CleanupOldLatency` existed on `TorznabIndexerStore` and was exercised by two unit tests, but had no production caller — `RecordLatency` inserts one row per Torznab search with no corresponding cleanup, so `torznab_indexer_latency` grew without bound.

This wires `CleanupOldLatency` up using the exact interval-gated, opportunistic-cleanup pattern this service already uses for its search cache (`maybeScheduleSearchCacheCleanup`) and torrent cache (`maybeScheduleTorrentCacheCleanup`): a mutex-guarded "next cleanup" timestamp, checked and advanced synchronously, with the actual delete running in a background goroutine. It's triggered after each recorded search latency, gated to once per 6 hours (matching the existing caches' interval), retaining the last 14 days — double the 7-day window `torznab_indexer_latency_stats` needs for its rolling stats.

Addresses discussion #2376.

## How has this been tested?

- `go build ./...`, `go vet ./...`, `gofmt -l .` all clean
- `go test -race -count=1 ./...` passes (verified in a Go 1.27 container since no local toolchain was available)
- Added `TestMaybeScheduleLatencyCleanupTriggersAndDebounces`, asserting the cleanup fires once and is debounced on a second call within the interval
- Added `CleanupOldLatency` to the `IndexerStore` interface, which required updating three test doubles (`mockTorznabIndexerStore`, `failingDirScanIndexerStore`, `failingEnabledIndexerStore`) to keep them compiling against the interface

## Checklist

- [x] My PR title follows the Conventional Commits format (it becomes the squashed commit message)
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL (n/a — no schema change in this PR)

## AI disclosure

This PR was written by Claude Code (Sonnet 5), based on investigation of the linked discussion and the codebase, with human review and verification (build/vet/test run in a container) before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup of outdated indexer latency records.
  * Cleanup runs periodically in the background, removing records older than 14 days.
  * Cleanup is scheduled after searches and limited to prevent unnecessary repeated work.

* **Bug Fixes**
  * Improved maintenance of latency data to keep performance information current.
  * Reduced redundant cleanup activity while preserving regular data housekeeping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->