### PR TITLE
fix(indexers): ignore missing requested indexers

### DIFF
--- a/internal/services/jackett/service.go
+++ b/internal/services/jackett/service.go
@@ -3870,6 +3870,9 @@ func (s *Service) resolveIndexerSelection(ctx context.Context, indexerIDs []int)
 	var selected []*models.TorznabIndexer
 	for _, id := range indexerIDs {
 		indexer, err := s.indexerStore.Get(ctx, id)
+		if errors.Is(err, models.ErrTorznabIndexerNotFound) {
+			continue
+		}
 		if err != nil {
 			log.Warn().
 				Err(err).


### PR DESCRIPTION
## Description

Silently skip requested Torznab indexer IDs that no longer exist. Unexpected indexer-store failures still emit a warning.

## How has this been tested?

- Created and deleted a synthetic Torznab indexer, then searched using its stale ID.
- The search returned an empty result and emitted no missing-indexer warning.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Silently ignores requested indexers that are no longer available, preventing unnecessary warning messages.
  - Continues to report other indexer loading errors as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->