### PR TITLE
fix(logging): lower routine search events to debug

### DIFF
--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -3888,14 +3888,14 @@ func (s *Service) executeAutomationRun(ctx context.Context, run *models.CrossSee
 	return run, runErr
 }
 
-// sizeMismatchLogLevel returns warn for the first size-mismatch rejection of a
+// sizeMismatchLogLevel returns debug for the first size-mismatch rejection of a
 // (source, matched) pair and trace for repeats: RSS retries the same doomed
 // pair every run until it leaves the feed. In-memory and unbounded on purpose.
 func (s *Service) sizeMismatchLogLevel(sourceHash, matchedHash string) zerolog.Level {
 	if _, seen := s.sizeMismatchWarned.LoadOrStore(sourceHash+"|"+matchedHash, struct{}{}); seen {
 		return zerolog.TraceLevel
 	}
-	return zerolog.WarnLevel
+	return zerolog.DebugLevel
 }
 
 func isSkippedCrossSeedResultStatus(status string) bool {

--- a/internal/services/crossseed/size_mismatch_log_test.go
+++ b/internal/services/crossseed/size_mismatch_log_test.go
@@ -15,10 +15,10 @@ func TestSizeMismatchLogLevel(t *testing.T) {
 
 	s := &Service{}
 
-	require.Equal(t, zerolog.WarnLevel, s.sizeMismatchLogLevel("src-a", "match-1"), "first rejection of a pair warns")
+	require.Equal(t, zerolog.DebugLevel, s.sizeMismatchLogLevel("src-a", "match-1"), "first rejection of a pair logs at debug")
 	require.Equal(t, zerolog.TraceLevel, s.sizeMismatchLogLevel("src-a", "match-1"), "repeat of the same pair drops to trace")
 	require.Equal(t, zerolog.TraceLevel, s.sizeMismatchLogLevel("src-a", "match-1"), "further repeats stay trace")
 
-	require.Equal(t, zerolog.WarnLevel, s.sizeMismatchLogLevel("src-a", "match-2"), "same source against another local copy warns")
-	require.Equal(t, zerolog.WarnLevel, s.sizeMismatchLogLevel("src-b", "match-1"), "different source against the same local copy warns")
+	require.Equal(t, zerolog.DebugLevel, s.sizeMismatchLogLevel("src-a", "match-2"), "same source against another local copy logs at debug")
+	require.Equal(t, zerolog.DebugLevel, s.sizeMismatchLogLevel("src-b", "match-1"), "different source against the same local copy logs at debug")
 }

--- a/internal/services/jackett/service.go
+++ b/internal/services/jackett/service.go
@@ -947,7 +947,7 @@ func (s *Service) Recent(ctx context.Context, limit, offset int, indexerIDs []in
 			JobID:   jobID,
 		}
 		if partial {
-			log.Warn().
+			log.Debug().
 				Int("indexers_requested", len(indexersToSearch)).
 				Int("results_collected", len(searchResults)).
 				Dur("timeout", searchTimeout).

--- a/internal/services/jackett/service_test.go
+++ b/internal/services/jackett/service_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"maps"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +17,9 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 
 	"github.com/autobrr/qui/internal/models"
 	"github.com/autobrr/qui/internal/pkg/timeouts"
@@ -3336,6 +3340,15 @@ func TestRecentSurfacesTotalIndexerFailure(t *testing.T) {
 // TestRecentPartialCoverageMarksPartial verifies Recent flags incomplete indexer
 // coverage as partial even when no error is returned.
 func TestRecentPartialCoverageMarksPartial(t *testing.T) {
+	originalLogger := log.Logger
+	partialLogLevel := zerolog.NoLevel
+	log.Logger = zerolog.New(io.Discard).Level(zerolog.TraceLevel).Hook(zerolog.HookFunc(func(_ *zerolog.Event, level zerolog.Level, msg string) {
+		if msg == "Recent search returning partial results" {
+			partialLogLevel = level
+		}
+	}))
+	t.Cleanup(func() { log.Logger = originalLogger })
+
 	store := &mockTorznabIndexerStore{
 		indexers: []*models.TorznabIndexer{
 			{ID: 1, Name: "IndexerOne", Enabled: true},
@@ -3378,6 +3391,10 @@ func TestRecentPartialCoverageMarksPartial(t *testing.T) {
 		t.Fatalf("expected partial success, got error %v", err)
 	case <-time.After(2 * time.Second):
 		t.Fatal("Recent never invoked its callback")
+	}
+
+	if partialLogLevel != zerolog.DebugLevel {
+		t.Fatalf("partial search log level = %s, want debug", partialLogLevel)
 	}
 }
 


### PR DESCRIPTION
## Description

Lower routine partial recent-search and cross-seed size-mismatch rejection messages from warn to debug. Repeated size-mismatch pairs remain at trace.

This keeps warning logs focused on failures that need operator attention.

## How has this been tested?

- Built and started qui against a temporary SQLite database, then confirmed `/health` returned `{"status":"ok"}`.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced the visibility of expected partial-result and size-mismatch messages by logging them at debug level.
  * Repeated size-mismatch rejections continue to use trace-level logging.

* **Tests**
  * Updated logging coverage to verify the revised log levels for initial and repeated events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->