### PR TITLE
fix(indexers): skip caps sync for disabled indexers

### DIFF
--- a/internal/api/handlers/jackett.go
+++ b/internal/api/handlers/jackett.go
@@ -468,7 +468,7 @@ func (h *JackettHandler) CreateIndexer(w http.ResponseWriter, r *http.Request) {
 		} else {
 			indexer = updated
 		}
-	} else if h.service != nil {
+	} else if h.service != nil && indexer.Enabled {
 		// No capabilities/categories provided, try to fetch them from the service
 		if updated, err := h.service.SyncIndexerCaps(r.Context(), indexer.ID); err != nil {
 			log.Warn().
@@ -671,7 +671,7 @@ func (h *JackettHandler) UpdateIndexer(w http.ResponseWriter, r *http.Request) {
 		} else {
 			indexer = updated
 		}
-	} else if h.service != nil {
+	} else if h.service != nil && indexer.Enabled {
 		// No capabilities/categories provided, try to fetch them from the service
 		if updated, err := h.service.SyncIndexerCaps(r.Context(), indexer.ID); err != nil {
 			log.Warn().

--- a/internal/api/handlers/jackett_disabled_caps_test.go
+++ b/internal/api/handlers/jackett_disabled_caps_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/services/jackett"
+)
+
+func TestCreateDisabledIndexerSkipsAutomaticCapsSync(t *testing.T) {
+	var capsRequests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		capsRequests.Add(1)
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	t.Cleanup(server.Close)
+
+	store := newTorznabStore(t)
+	handler := NewJackettHandler(jackett.NewService(store), store)
+	body := fmt.Sprintf(`{
+		"name": "Test Indexer",
+		"base_url": %q,
+		"indexer_id": "test-indexer",
+		"api_key": "test-key",
+		"backend": "prowlarr",
+		"enabled": false
+	}`, server.URL)
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/torznab/indexers", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	handler.CreateIndexer(resp, req)
+
+	require.Equal(t, http.StatusCreated, resp.Code, resp.Body.String())
+	require.Zero(t, capsRequests.Load(), "creating a disabled indexer must not fetch caps")
+}
+
+func TestUpdateDisabledIndexerSkipsAutomaticCapsSync(t *testing.T) {
+	var capsRequests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		capsRequests.Add(1)
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	t.Cleanup(server.Close)
+
+	store := newTorznabStore(t)
+	indexer, err := store.CreateWithIndexerID(t.Context(), "Test Indexer", server.URL, "test-indexer", "test-key", nil, nil, true, 0, 30, models.TorznabBackendProwlarr)
+	require.NoError(t, err)
+
+	handler := NewJackettHandler(jackett.NewService(store), store)
+	body := fmt.Sprintf(`{
+		"name": "Test Indexer",
+		"base_url": %q,
+		"indexer_id": "test-indexer",
+		"backend": "prowlarr",
+		"enabled": false
+	}`, server.URL)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPut, "/api/torznab/indexers/"+strconv.Itoa(indexer.ID), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("indexerID", strconv.Itoa(indexer.ID))
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	resp := httptest.NewRecorder()
+	handler.UpdateIndexer(resp, req)
+
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+	require.Zero(t, capsRequests.Load(), "updating a disabled indexer must not fetch caps")
+}


### PR DESCRIPTION
## Description

Skip automatic capability synchronization when creating or updating a disabled Torznab indexer.

Manual capability synchronization remains available, while disabled indexers no longer make unexpected backend requests when saved.

## How has this been tested?

- Started qui against a temporary SQLite database and created and updated a disabled synthetic Prowlarr indexer through the API. Both responses contained no capability-sync warnings, and the unreachable synthetic backend was not contacted.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled indexers no longer automatically synchronize capabilities during creation or updates.
  * Prevents unnecessary capability requests for disabled indexers, including when the service is unavailable or rate-limited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->