### PR TITLE
fix(crossseed): align webhook notifications with apply outcomes

### DIFF
--- a/documentation/docs/features/notifications.md
+++ b/documentation/docs/features/notifications.md
@@ -38,8 +38,8 @@ Notes:
 | `cross_seed_search_failed` | Seeded search run fails or is canceled (summary). |
 | `cross_seed_completion_succeeded` | Completion search run completes (summary counts and samples). |
 | `cross_seed_completion_failed` | Completion search run fails. |
-| `cross_seed_webhook_succeeded` | Webhook check run completes (summary counts and samples). |
-| `cross_seed_webhook_failed` | Webhook check run fails. |
+| `cross_seed_webhook_succeeded` | Webhook apply adds one or more torrents. No-op checks and applies do not notify. |
+| `cross_seed_webhook_failed` | Webhook check or apply fails. |
 | `automations_actions_applied` | Automation rules applied actions (summary counts and samples; only when actions occur). |
 | `automations_run_failed` | Automation rules failed to run for an instance (system error). |
 

--- a/internal/services/crossseed/autobrr_apply_test.go
+++ b/internal/services/crossseed/autobrr_apply_test.go
@@ -191,6 +191,83 @@ func TestAutobrrApplyNotifiesWhenTorrentDataIsEmpty(t *testing.T) {
 	require.Contains(t, events[0].ErrorMessage, "torrentData is required")
 }
 
+func TestAutobrrApplyNotifiesForLinkModeResults(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		status    string
+		success   bool
+		eventType notifications.EventType
+		added     int
+		failed    int
+	}{
+		{name: "hardlink added", status: "added_hardlink", success: true, eventType: notifications.EventCrossSeedWebhookSucceeded, added: 1},
+		{name: "reflink added", status: "added_reflink", success: true, eventType: notifications.EventCrossSeedWebhookSucceeded, added: 1},
+		{name: "hardlink failed", status: "hardlink_error", eventType: notifications.EventCrossSeedWebhookFailed, failed: 1},
+		{name: "reflink failed", status: "reflink_error", eventType: notifications.EventCrossSeedWebhookFailed, failed: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			notifier := &recordingNotifier{}
+			service := &Service{
+				notifier: notifier,
+				crossSeedInvoker: func(context.Context, *CrossSeedRequest) (*CrossSeedResponse, error) {
+					return &CrossSeedResponse{
+						Success: tt.success,
+						Results: []InstanceCrossSeedResult{{
+							InstanceID: 1, InstanceName: "Primary", Success: tt.success, Status: tt.status, Message: "synthetic result",
+						}},
+					}, nil
+				},
+			}
+
+			response, err := service.AutobrrApply(context.Background(), &AutobrrApplyRequest{TorrentData: "ZGF0YQ=="})
+			require.NoError(t, err)
+			require.Equal(t, tt.success, response.Success)
+
+			events := notifier.Events()
+			require.Len(t, events, 1)
+			require.Equal(t, tt.eventType, events[0].Type)
+			require.NotNil(t, events[0].CrossSeed)
+			require.Equal(t, tt.added, events[0].CrossSeed.Added)
+			require.Equal(t, tt.failed, events[0].CrossSeed.Failed)
+		})
+	}
+}
+
+func TestAutobrrApplyNotificationSamplesAreUniqueAndLimited(t *testing.T) {
+	t.Parallel()
+
+	notifier := &recordingNotifier{}
+	names := []string{"Primary", "", "Archive", "Primary", "Backup", "Overflow"}
+	results := make([]InstanceCrossSeedResult, 0, len(names))
+	for id, name := range names {
+		results = append(results, InstanceCrossSeedResult{
+			InstanceID: id + 1, InstanceName: name, Success: true, Status: "added",
+		})
+	}
+	service := &Service{
+		notifier: notifier,
+		crossSeedInvoker: func(context.Context, *CrossSeedRequest) (*CrossSeedResponse, error) {
+			return &CrossSeedResponse{Success: true, Results: results}, nil
+		},
+	}
+
+	response, err := service.AutobrrApply(context.Background(), &AutobrrApplyRequest{TorrentData: "ZGF0YQ=="})
+	require.NoError(t, err)
+	require.True(t, response.Success)
+
+	events := notifier.Events()
+	require.Len(t, events, 1)
+	require.Equal(t, []string{"Primary", "Archive", "Backup"}, events[0].CrossSeed.Samples)
+	require.Contains(t, events[0].Message, "Instances: Primary; Archive; Backup")
+	require.NotContains(t, events[0].Message, "Overflow")
+}
+
 func TestAutobrrApplyDefaultsToAutomationSetting(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/crossseed/autobrr_apply_test.go
+++ b/internal/services/crossseed/autobrr_apply_test.go
@@ -156,6 +156,35 @@ func TestAutobrrApplyNotifiesWhenAddFails(t *testing.T) {
 	require.Equal(t, 1, events[0].CrossSeed.Failed)
 }
 
+func TestAutobrrApplyNotifiesWhenApplyPartiallyFails(t *testing.T) {
+	t.Parallel()
+
+	notifier := &recordingNotifier{}
+	service := &Service{
+		notifier: notifier,
+		crossSeedInvoker: func(context.Context, *CrossSeedRequest) (*CrossSeedResponse, error) {
+			return &CrossSeedResponse{
+				Success: true,
+				Results: []InstanceCrossSeedResult{
+					{InstanceID: 1, InstanceName: "primary", Success: true, Status: "added"},
+					{InstanceID: 2, InstanceName: "archive", Status: "error", Message: "synthetic add failure"},
+				},
+			}, errors.New("synthetic add failure")
+		},
+	}
+
+	response, err := service.AutobrrApply(context.Background(), &AutobrrApplyRequest{TorrentData: "ZGF0YQ=="})
+	require.NoError(t, err)
+	require.True(t, response.Success)
+
+	events := notifier.Events()
+	require.Len(t, events, 1)
+	require.Equal(t, notifications.EventCrossSeedWebhookFailed, events[0].Type)
+	require.Equal(t, 1, events[0].CrossSeed.Added)
+	require.Equal(t, 1, events[0].CrossSeed.Failed)
+	require.Contains(t, events[0].ErrorMessage, "synthetic add failure")
+}
+
 func TestAutobrrApplyNotifiesWhenProcessingFails(t *testing.T) {
 	t.Parallel()
 
@@ -189,6 +218,25 @@ func TestAutobrrApplyNotifiesWhenTorrentDataIsEmpty(t *testing.T) {
 	require.Len(t, events, 1)
 	require.Equal(t, notifications.EventCrossSeedWebhookFailed, events[0].Type)
 	require.Contains(t, events[0].ErrorMessage, "torrentData is required")
+}
+
+func TestAutobrrApplyNotifiesWhenInstanceIDsAreInvalid(t *testing.T) {
+	t.Parallel()
+
+	notifier := &recordingNotifier{}
+	service := &Service{notifier: notifier}
+
+	response, err := service.AutobrrApply(context.Background(), &AutobrrApplyRequest{
+		TorrentData: "ZGF0YQ==",
+		InstanceIDs: []int{0, -1},
+	})
+	require.ErrorIs(t, err, ErrInvalidRequest)
+	require.Nil(t, response)
+
+	events := notifier.Events()
+	require.Len(t, events, 1)
+	require.Equal(t, notifications.EventCrossSeedWebhookFailed, events[0].Type)
+	require.Contains(t, events[0].ErrorMessage, "instanceIds must contain at least one positive integer")
 }
 
 func TestAutobrrApplyNotifiesForLinkModeResults(t *testing.T) {

--- a/internal/services/crossseed/autobrr_apply_test.go
+++ b/internal/services/crossseed/autobrr_apply_test.go
@@ -14,8 +14,166 @@ import (
 
 	"github.com/autobrr/qui/internal/models"
 	internalqb "github.com/autobrr/qui/internal/qbittorrent"
+	"github.com/autobrr/qui/internal/services/notifications"
 	"github.com/autobrr/qui/pkg/stringutils"
 )
+
+func TestAutobrrApplyNotifiesAfterAddingTorrent(t *testing.T) {
+	t.Parallel()
+
+	const (
+		instanceID = 1
+		name       = "Harbor.Signal.2026.1080p.WEB-DL.H.264-LUMA"
+		sourceHash = "source-hash"
+		size       = int64(2_000_000)
+	)
+	fileName := name + ".mkv"
+	torrentData := createNamedFileTestTorrent(t, name, fileName, size)
+	instance := &models.Instance{ID: instanceID, Name: "primary", IsActive: true}
+	source := qbt.Torrent{
+		Hash: sourceHash, Name: name, Size: size, TotalSize: size, Progress: 1, SavePath: "/downloads",
+	}
+	notifier := &recordingNotifier{}
+	service := &Service{
+		instanceStore: &fakeInstanceStore{instances: map[int]*models.Instance{instanceID: instance}},
+		syncManager: &applyFakeSyncManager{newFakeSyncManager(instance, []qbt.Torrent{source}, map[string]qbt.TorrentFiles{
+			sourceHash: {{Name: fileName, Size: size}},
+		})},
+		releaseCache:     NewReleaseCache(),
+		stringNormalizer: stringutils.NewDefaultNormalizer(),
+		notifier:         notifier,
+		automationSettingsLoader: func(context.Context) (*models.CrossSeedAutomationSettings, error) {
+			settings := models.DefaultCrossSeedAutomationSettings()
+			settings.SkipPieceBoundarySafetyCheck = true
+			return settings, nil
+		},
+	}
+
+	response, err := service.AutobrrApply(context.Background(), &AutobrrApplyRequest{
+		TorrentData: base64.StdEncoding.EncodeToString(torrentData),
+		InstanceIDs: []int{instanceID},
+	})
+	require.NoError(t, err)
+	require.True(t, response.Success, "apply rejected the torrent: %+v", response.Results)
+
+	events := notifier.Events()
+	require.Len(t, events, 1)
+	require.Equal(t, notifications.EventCrossSeedWebhookSucceeded, events[0].Type)
+	require.NotNil(t, events[0].CrossSeed)
+	require.Equal(t, 1, events[0].CrossSeed.Added)
+}
+
+func TestAutobrrApplyDoesNotNotifyWhenTorrentExists(t *testing.T) {
+	t.Parallel()
+
+	const (
+		instanceID = 1
+		name       = "Silent.Harbor.2026.1080p.WEB-DL.H.264-LUMA"
+		size       = int64(2_000_000)
+	)
+	fileName := name + ".mkv"
+	torrentData := createNamedFileTestTorrent(t, name, fileName, size)
+	metadata, err := ParseTorrentMetadataWithInfo(torrentData)
+	require.NoError(t, err)
+	instance := &models.Instance{ID: instanceID, Name: "primary", IsActive: true}
+	source := qbt.Torrent{
+		Hash: metadata.HashV1, Name: name, Size: size, TotalSize: size, Progress: 1, SavePath: "/downloads",
+	}
+	notifier := &recordingNotifier{}
+	service := &Service{
+		instanceStore: &fakeInstanceStore{instances: map[int]*models.Instance{instanceID: instance}},
+		syncManager: &applyFakeSyncManager{newFakeSyncManager(instance, []qbt.Torrent{source}, map[string]qbt.TorrentFiles{
+			metadata.HashV1: {{Name: fileName, Size: size}},
+		})},
+		releaseCache:     NewReleaseCache(),
+		stringNormalizer: stringutils.NewDefaultNormalizer(),
+		notifier:         notifier,
+	}
+
+	response, err := service.AutobrrApply(context.Background(), &AutobrrApplyRequest{
+		TorrentData: base64.StdEncoding.EncodeToString(torrentData),
+		InstanceIDs: []int{instanceID},
+	})
+	require.NoError(t, err)
+	require.False(t, response.Success)
+	require.Len(t, response.Results, 1)
+	require.Equal(t, "exists", response.Results[0].Status)
+	require.Empty(t, notifier.Events())
+}
+
+type failingAutobrrApplySyncManager struct {
+	*applyFakeSyncManager
+}
+
+func (f *failingAutobrrApplySyncManager) AddTorrent(context.Context, int, []byte, map[string]string) (*qbt.TorrentAddResponse, error) {
+	return nil, errors.New("synthetic add failure")
+}
+
+func TestAutobrrApplyNotifiesWhenAddFails(t *testing.T) {
+	t.Parallel()
+
+	const (
+		instanceID = 1
+		name       = "Broken.Harbor.2026.1080p.WEB-DL.H.264-LUMA"
+		sourceHash = "source-hash"
+		size       = int64(2_000_000)
+	)
+	fileName := name + ".mkv"
+	torrentData := createNamedFileTestTorrent(t, name, fileName, size)
+	instance := &models.Instance{ID: instanceID, Name: "primary", IsActive: true}
+	source := qbt.Torrent{
+		Hash: sourceHash, Name: name, Size: size, TotalSize: size, Progress: 1, SavePath: "/downloads",
+	}
+	notifier := &recordingNotifier{}
+	service := &Service{
+		instanceStore: &fakeInstanceStore{instances: map[int]*models.Instance{instanceID: instance}},
+		syncManager: &failingAutobrrApplySyncManager{&applyFakeSyncManager{newFakeSyncManager(instance, []qbt.Torrent{source}, map[string]qbt.TorrentFiles{
+			sourceHash: {{Name: fileName, Size: size}},
+		})}},
+		releaseCache:     NewReleaseCache(),
+		stringNormalizer: stringutils.NewDefaultNormalizer(),
+		notifier:         notifier,
+		automationSettingsLoader: func(context.Context) (*models.CrossSeedAutomationSettings, error) {
+			settings := models.DefaultCrossSeedAutomationSettings()
+			settings.SkipPieceBoundarySafetyCheck = true
+			return settings, nil
+		},
+	}
+
+	response, err := service.AutobrrApply(context.Background(), &AutobrrApplyRequest{
+		TorrentData: base64.StdEncoding.EncodeToString(torrentData),
+		InstanceIDs: []int{instanceID},
+	})
+	require.NoError(t, err)
+	require.False(t, response.Success)
+	require.Len(t, response.Results, 1)
+	require.Equal(t, "error", response.Results[0].Status)
+
+	events := notifier.Events()
+	require.Len(t, events, 1)
+	require.Equal(t, notifications.EventCrossSeedWebhookFailed, events[0].Type)
+	require.NotNil(t, events[0].CrossSeed)
+	require.Equal(t, 1, events[0].CrossSeed.Failed)
+}
+
+func TestAutobrrApplyNotifiesWhenProcessingFails(t *testing.T) {
+	t.Parallel()
+
+	notifier := &recordingNotifier{}
+	service := &Service{notifier: notifier}
+
+	response, err := service.AutobrrApply(context.Background(), &AutobrrApplyRequest{
+		TorrentData: base64.StdEncoding.EncodeToString([]byte("not a torrent")),
+		TorrentName: "Invalid.Harbor.2026.1080p.WEB-DL.H.264-LUMA",
+	})
+	require.Error(t, err)
+	require.Nil(t, response)
+
+	events := notifier.Events()
+	require.Len(t, events, 1)
+	require.Equal(t, notifications.EventCrossSeedWebhookFailed, events[0].Type)
+	require.NotEmpty(t, events[0].ErrorMessage)
+}
 
 func TestAutobrrApplyDefaultsToAutomationSetting(t *testing.T) {
 	t.Parallel()

--- a/internal/services/crossseed/autobrr_apply_test.go
+++ b/internal/services/crossseed/autobrr_apply_test.go
@@ -175,6 +175,22 @@ func TestAutobrrApplyNotifiesWhenProcessingFails(t *testing.T) {
 	require.NotEmpty(t, events[0].ErrorMessage)
 }
 
+func TestAutobrrApplyNotifiesWhenTorrentDataIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	notifier := &recordingNotifier{}
+	service := &Service{notifier: notifier}
+
+	response, err := service.AutobrrApply(context.Background(), &AutobrrApplyRequest{})
+	require.ErrorIs(t, err, ErrInvalidRequest)
+	require.Nil(t, response)
+
+	events := notifier.Events()
+	require.Len(t, events, 1)
+	require.Equal(t, notifications.EventCrossSeedWebhookFailed, events[0].Type)
+	require.Contains(t, events[0].ErrorMessage, "torrentData is required")
+}
+
 func TestAutobrrApplyDefaultsToAutomationSetting(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/crossseed/crossseed_test.go
+++ b/internal/services/crossseed/crossseed_test.go
@@ -1387,7 +1387,7 @@ func TestCheckWebhook_AutobrrPayload(t *testing.T) {
 	}
 }
 
-func TestCheckWebhook_NotificationRequiresCompleteMatch(t *testing.T) {
+func TestCheckWebhook_DoesNotNotifySuccessfulChecks(t *testing.T) {
 	t.Parallel()
 
 	instance := &models.Instance{
@@ -1401,22 +1401,19 @@ func TestCheckWebhook_NotificationRequiresCompleteMatch(t *testing.T) {
 	}
 
 	tests := []struct {
-		name              string
-		progress          float64
-		wantCanCrossSeed  bool
-		wantNotificationN int
+		name             string
+		progress         float64
+		wantCanCrossSeed bool
 	}{
 		{
-			name:              "pending-only match does not notify",
-			progress:          0.5,
-			wantCanCrossSeed:  false,
-			wantNotificationN: 0,
+			name:             "pending-only match",
+			progress:         0.5,
+			wantCanCrossSeed: false,
 		},
 		{
-			name:              "complete match notifies once",
-			progress:          1.0,
-			wantCanCrossSeed:  true,
-			wantNotificationN: 1,
+			name:             "complete match",
+			progress:         1.0,
+			wantCanCrossSeed: true,
 		},
 	}
 
@@ -1441,10 +1438,7 @@ func TestCheckWebhook_NotificationRequiresCompleteMatch(t *testing.T) {
 			assert.Equal(t, "download", resp.Recommendation)
 
 			events := notifier.Events()
-			assert.Len(t, events, tt.wantNotificationN)
-			if tt.wantNotificationN > 0 {
-				assert.Equal(t, notifications.EventCrossSeedWebhookSucceeded, events[0].Type)
-			}
+			assert.Empty(t, events)
 		})
 	}
 }

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -5164,7 +5164,9 @@ func (s *Service) AutobrrApply(ctx context.Context, req *AutobrrApplyRequest) (*
 	}
 	targetInstanceIDs := normalizeInstanceIDs(req.InstanceIDs)
 	if len(req.InstanceIDs) > 0 && len(targetInstanceIDs) == 0 {
-		return nil, fmt.Errorf("%w: instanceIds must contain at least one positive integer", ErrInvalidRequest)
+		err := fmt.Errorf("%w: instanceIds must contain at least one positive integer", ErrInvalidRequest)
+		s.notifyWebhookApply(ctx, req, nil, err, startedAt)
+		return nil, err
 	}
 
 	settings, settingsErr := s.GetAutomationSettings(ctx)
@@ -12758,11 +12760,12 @@ func (s *Service) notifyWebhookApply(ctx context.Context, req *AutobrrApplyReque
 
 	eventType := notifications.EventCrossSeedWebhookSucceeded
 	errorMessage := ""
-	if len(addedResults) == 0 {
+	if len(failedResults) > 0 || runErr != nil {
 		eventType = notifications.EventCrossSeedWebhookFailed
 		if runErr != nil {
 			errorMessage = strings.TrimSpace(runErr.Error())
-		} else {
+		}
+		if errorMessage == "" && len(failedResults) > 0 {
 			errorMessage = strings.TrimSpace(failedResults[0].Message)
 		}
 		if errorMessage == "" {

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -12776,11 +12776,11 @@ func (s *Service) notifyWebhookApply(ctx context.Context, req *AutobrrApplyReque
 		failedResults = make([]InstanceCrossSeedResult, 0, len(resp.Results))
 		for _, result := range resp.Results {
 			switch result.Status {
-			case "added":
+			case "added", "added_hardlink", "added_reflink":
 				if result.Success {
 					addedResults = append(addedResults, result)
 				}
-			case "error", "no_save_path", "invalid_content_path", "pause_failed", "alignment_failed":
+			case "error", "no_save_path", "invalid_content_path", "pause_failed", "alignment_failed", "hardlink_error", "reflink_error":
 				failedResults = append(failedResults, result)
 			}
 		}
@@ -12809,13 +12809,22 @@ func (s *Service) notifyWebhookApply(ctx context.Context, req *AutobrrApplyReque
 	results := make([]InstanceCrossSeedResult, 0, len(addedResults)+len(failedResults))
 	results = append(results, addedResults...)
 	results = append(results, failedResults...)
-	samples := make([]string, 0, len(results))
+	const maxSamples = 3
+	samples := make([]string, 0, min(maxSamples, len(results)))
+	seenSamples := make(map[string]struct{}, min(maxSamples, len(results)))
 	for _, result := range results {
 		if instanceName := strings.TrimSpace(result.InstanceName); instanceName != "" {
+			if _, ok := seenSamples[instanceName]; ok {
+				continue
+			}
+			seenSamples[instanceName] = struct{}{}
 			samples = append(samples, instanceName)
+			if len(samples) == maxSamples {
+				break
+			}
 		}
 	}
-	if sampleText := formatSamplesForMessage(samples, 3); sampleText != "" {
+	if sampleText := formatSamplesForMessage(samples, maxSamples); sampleText != "" {
 		lines = append(lines, "Instances: "+sampleText)
 	}
 

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -5225,6 +5225,7 @@ func (s *Service) invokeSeasonPackApply(ctx context.Context, req *SeasonPackAppl
 
 // AutobrrApply adds a torrent provided by autobrr to the specified instance using cross-seed logic.
 func (s *Service) AutobrrApply(ctx context.Context, req *AutobrrApplyRequest) (*CrossSeedResponse, error) {
+	startedAt := time.Now().UTC()
 	if req == nil {
 		return nil, fmt.Errorf("%w: request is required", ErrInvalidRequest)
 	}
@@ -5310,6 +5311,7 @@ func (s *Service) AutobrrApply(ctx context.Context, req *AutobrrApplyRequest) (*
 	}
 	if err != nil {
 		if resp == nil || !resp.Success {
+			s.notifyWebhookApply(ctx, req, resp, err, startedAt)
 			return nil, err
 		}
 		log.Warn().Err(err).Msg("AutobrrApply completed with partial instance errors")
@@ -5331,6 +5333,8 @@ func (s *Service) AutobrrApply(ctx context.Context, req *AutobrrApplyRequest) (*
 			Str("message", r.Message).
 			Msg("AutobrrApply instance result")
 	}
+
+	s.notifyWebhookApply(ctx, req, resp, err, startedAt)
 
 	return resp, nil
 }
@@ -12759,87 +12763,93 @@ func formatSamplesForMessage(samples []string, maxCount int) string {
 	return out
 }
 
-func collectWebhookMatchSamples(matches []WebhookCheckMatch, limit int) []string {
-	if len(matches) == 0 {
-		return nil
-	}
-
-	capHint := 64
-	if limit > 0 {
-		capHint = min(limit, len(matches))
-	} else {
-		capHint = min(capHint, len(matches))
-	}
-	seen := make(map[string]struct{}, capHint)
-	samples := make([]string, 0, capHint)
-	for _, match := range matches {
-		label := strings.TrimSpace(match.TorrentName)
-		if label == "" {
-			label = strings.TrimSpace(match.TorrentHash)
-		}
-		if label == "" {
-			continue
-		}
-		if strings.TrimSpace(match.InstanceName) != "" {
-			label = fmt.Sprintf("%s @ %s", label, strings.TrimSpace(match.InstanceName))
-		}
-		if _, ok := seen[label]; ok {
-			continue
-		}
-		seen[label] = struct{}{}
-		samples = append(samples, label)
-		if limit > 0 && len(samples) >= limit {
-			break
-		}
-	}
-	return samples
-}
-
-func (s *Service) notifyWebhookCheck(ctx context.Context, req *WebhookCheckRequest, matches []WebhookCheckMatch, recommendation string, startedAt time.Time) {
-	if s == nil || s.notifier == nil || req == nil || len(matches) == 0 {
+func (s *Service) notifyWebhookApply(ctx context.Context, req *AutobrrApplyRequest, resp *CrossSeedResponse, runErr error, startedAt time.Time) {
+	if s == nil || s.notifier == nil || req == nil {
 		return
 	}
 
-	completeCount := 0
-	pendingCount := 0
-	for _, match := range matches {
-		if match.Progress >= 1.0 {
-			completeCount++
-		} else {
-			pendingCount++
+	var addedResults, failedResults []InstanceCrossSeedResult
+	if resp != nil {
+		addedResults = make([]InstanceCrossSeedResult, 0, len(resp.Results))
+		failedResults = make([]InstanceCrossSeedResult, 0, len(resp.Results))
+		for _, result := range resp.Results {
+			switch result.Status {
+			case "added":
+				if result.Success {
+					addedResults = append(addedResults, result)
+				}
+			case "error", "no_save_path", "invalid_content_path", "pause_failed", "alignment_failed":
+				failedResults = append(failedResults, result)
+			}
 		}
 	}
-	if completeCount == 0 {
+	if len(addedResults) == 0 && len(failedResults) == 0 && runErr == nil {
 		return
 	}
 
-	lines := []string{
-		"Torrent: " + strings.TrimSpace(req.TorrentName),
-		fmt.Sprintf("Matches: %d", len(matches)),
-		fmt.Sprintf("Complete matches: %d", completeCount),
-		fmt.Sprintf("Pending matches: %d", pendingCount),
+	torrentName := strings.TrimSpace(req.TorrentName)
+	if torrentName == "" && resp != nil && resp.TorrentInfo != nil {
+		torrentName = strings.TrimSpace(resp.TorrentInfo.Name)
 	}
-	if strings.TrimSpace(recommendation) != "" {
-		lines = append(lines, "Recommendation: "+strings.TrimSpace(recommendation))
+	failedCount := len(failedResults)
+	if failedCount == 0 && runErr != nil {
+		failedCount = 1
 	}
-	samples := collectWebhookMatchSamples(matches, 0)
+	lines := make([]string, 0, 3)
+	if torrentName != "" {
+		lines = append(lines, "Torrent: "+torrentName)
+	}
+	lines = append(lines, fmt.Sprintf("Added: %d", len(addedResults)))
+	if failedCount > 0 {
+		lines = append(lines, fmt.Sprintf("Failed: %d", failedCount))
+	}
+
+	results := make([]InstanceCrossSeedResult, 0, len(addedResults)+len(failedResults))
+	results = append(results, addedResults...)
+	results = append(results, failedResults...)
+	samples := make([]string, 0, len(results))
+	for _, result := range results {
+		if instanceName := strings.TrimSpace(result.InstanceName); instanceName != "" {
+			samples = append(samples, instanceName)
+		}
+	}
 	if sampleText := formatSamplesForMessage(samples, 3); sampleText != "" {
-		lines = append(lines, "Samples: "+sampleText)
+		lines = append(lines, "Instances: "+sampleText)
+	}
+
+	eventType := notifications.EventCrossSeedWebhookSucceeded
+	errorMessage := ""
+	if len(addedResults) == 0 {
+		eventType = notifications.EventCrossSeedWebhookFailed
+		if runErr != nil {
+			errorMessage = strings.TrimSpace(runErr.Error())
+		} else {
+			errorMessage = strings.TrimSpace(failedResults[0].Message)
+		}
+		if errorMessage == "" {
+			errorMessage = "cross-seed webhook apply failed"
+		}
+		lines = append(lines, "Error: "+errorMessage)
 	}
 
 	completedAt := time.Now().UTC()
 	s.notifier.Notify(ctx, notifications.Event{
-		Type:         notifications.EventCrossSeedWebhookSucceeded,
+		Type:         eventType,
 		InstanceName: "Cross-seed webhook",
 		Message:      strings.Join(lines, "\n"),
-		TorrentName:  strings.TrimSpace(req.TorrentName),
+		TorrentName:  torrentName,
 		CrossSeed: &notifications.CrossSeedEventData{
-			Matches:        len(matches),
-			Complete:       completeCount,
-			Pending:        pendingCount,
-			Recommendation: strings.TrimSpace(recommendation),
-			Samples:        samples,
+			Added:   len(addedResults),
+			Failed:  failedCount,
+			Samples: samples,
 		},
+		ErrorMessage: errorMessage,
+		ErrorMessages: func() []string {
+			if errorMessage == "" {
+				return nil
+			}
+			return []string{errorMessage}
+		}(),
 		StartedAt:   &startedAt,
 		CompletedAt: &completedAt,
 	})
@@ -14046,8 +14056,6 @@ func (s *Service) CheckWebhook(ctx context.Context, req *WebhookCheckRequest) (*
 		Bool("canCrossSeed", canCrossSeed).
 		Str("recommendation", recommendation).
 		Msg("Webhook check completed")
-
-	s.notifyWebhookCheck(ctx, req, matches, recommendation, startedAt)
 
 	return &WebhookCheckResponse{
 		CanCrossSeed:   canCrossSeed,

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -5230,7 +5230,9 @@ func (s *Service) AutobrrApply(ctx context.Context, req *AutobrrApplyRequest) (*
 		return nil, fmt.Errorf("%w: request is required", ErrInvalidRequest)
 	}
 	if strings.TrimSpace(req.TorrentData) == "" {
-		return nil, fmt.Errorf("%w: torrentData is required", ErrInvalidRequest)
+		err := fmt.Errorf("%w: torrentData is required", ErrInvalidRequest)
+		s.notifyWebhookApply(ctx, req, nil, err, startedAt)
+		return nil, err
 	}
 	targetInstanceIDs := normalizeInstanceIDs(req.InstanceIDs)
 	if len(req.InstanceIDs) > 0 && len(targetInstanceIDs) == 0 {

--- a/internal/services/notifications/service.go
+++ b/internal/services/notifications/service.go
@@ -413,10 +413,10 @@ func (s *Service) formatEvent(ctx context.Context, event Event, humanReadableMet
 		title := "Cross-seed completion search failed"
 		return formatCustomEvent(instanceLabel, title, event.Title, customMessage)
 	case EventCrossSeedWebhookSucceeded:
-		title := "Cross-seed webhook check completed"
+		title := "Cross-seed webhook torrent added"
 		return formatCustomEvent(instanceLabel, title, event.Title, customMessage)
 	case EventCrossSeedWebhookFailed:
-		title := "Cross-seed webhook check failed"
+		title := "Cross-seed webhook failed"
 		return formatCustomEvent(instanceLabel, title, event.Title, customMessage)
 	case EventAutomationsActionsApplied:
 		title := "Automations actions applied"

--- a/internal/services/notifications/types.go
+++ b/internal/services/notifications/types.go
@@ -52,8 +52,8 @@ var eventDefinitions = []EventDefinition{
 	{Type: EventCrossSeedSearchFailed, Label: "Cross-seed seeded search failed", Description: "A seeded search run fails or is canceled."},
 	{Type: EventCrossSeedCompletionSucceeded, Label: "Cross-seed completion search completed", Description: "A completion search run completes (summary counts and samples)."},
 	{Type: EventCrossSeedCompletionFailed, Label: "Cross-seed completion search failed", Description: "A completion search run fails."},
-	{Type: EventCrossSeedWebhookSucceeded, Label: "Cross-seed webhook check completed", Description: "A webhook check run completes (summary counts and samples)."},
-	{Type: EventCrossSeedWebhookFailed, Label: "Cross-seed webhook check failed", Description: "A webhook check run fails."},
+	{Type: EventCrossSeedWebhookSucceeded, Label: "Cross-seed webhook torrent added", Description: "A webhook apply adds one or more torrents."},
+	{Type: EventCrossSeedWebhookFailed, Label: "Cross-seed webhook failed", Description: "A webhook check or apply fails."},
 	{Type: EventAutomationsActionsApplied, Label: "Automations actions applied", Description: "Automation rules applied actions (summary counts and samples; only when actions occur)."},
 	{Type: EventAutomationsRunFailed, Label: "Automations run failed", Description: "Automation rules failed to run for an instance (system error)."},
 }

--- a/scripts/notifiarr-test-events.go
+++ b/scripts/notifiarr-test-events.go
@@ -545,21 +545,15 @@ func buildFixtures() []fixture {
 				InstanceName: "Cross-seed webhook",
 				TorrentName:  "Example.Show.S01E01",
 				CrossSeed: &notifications.CrossSeedEventData{
-					Matches:        3,
-					Complete:       2,
-					Pending:        1,
-					Recommendation: "keep current torrent",
-					Samples:        []string{"Example.Show.S01E01.1080p", "Example.Show.S01E01.2160p"},
+					Added:   2,
+					Samples: []string{"Primary", "Archive"},
 				},
 				StartedAt:   webhookStart,
 				CompletedAt: webhookEnd,
 				Message: strings.Join([]string{
 					"Torrent: Example.Show.S01E01",
-					"Matches: 3",
-					"Complete matches: 2",
-					"Pending matches: 1",
-					"Recommendation: keep current torrent",
-					"Samples: Example.Show.S01E01.1080p; Example.Show.S01E01.2160p",
+					"Added: 2",
+					"Instances: Primary; Archive",
 				}, "\n"),
 			},
 		},
@@ -751,10 +745,10 @@ func formatEvent(event notifications.Event) (string, string) {
 		title := "Cross-seed completion search failed"
 		return formatCustomEvent(instanceLabel, title, event.Title, customMessage)
 	case notifications.EventCrossSeedWebhookSucceeded:
-		title := "Cross-seed webhook check completed"
+		title := "Cross-seed webhook torrent added"
 		return formatCustomEvent(instanceLabel, title, event.Title, customMessage)
 	case notifications.EventCrossSeedWebhookFailed:
-		title := "Cross-seed webhook check failed"
+		title := "Cross-seed webhook failed"
 		return formatCustomEvent(instanceLabel, title, event.Title, customMessage)
 	case notifications.EventAutomationsActionsApplied:
 		title := "Automations actions applied"


### PR DESCRIPTION
## Description

Cross-seed webhook checks sent success notifications before an apply action occurred. This caused notifications for checks that found a match even when the later apply did not add a torrent.

This change moves success notifications to the apply path. A successful notification now means that qui added a torrent. Existing-torrent and other no-op results stay silent. Check and apply errors still send failure notifications. The existing event keys remain unchanged.

The notification documentation and Notifiarr test event now describe the new behavior.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] This change does not modify the database schema, so migrations are not required

## AI disclosure

Yes. OpenAI GPT-5.6 Sol wrote most of the code under maintainer direction. The maintainer reviewed the behavior and requested the final change.

## Tests

- Started an isolated qui server with a temporary SQLite database and loopback-only access.
- Confirmed that `/health` returned `{"status":"ok"}`.
- Confirmed that an empty `/api/cross-seed/apply` request returned HTTP 400 with the required validation error.
- Confirmed through the service notifier seam that empty torrent data emits one failure notification.
- Confirmed that the notification event API returned the updated success and failure descriptions.
- Confirmed that the Notifiarr dry-run event reports added torrents and target instances.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cross-seed webhook notifications now report success only when torrents are added.
  * Successful checks and attempts involving existing torrents no longer send notifications.
  * Failed checks and applications now generate failure notifications, including validation and torrent-addition failures.
  * Notifications include added and failed counts with up to three representative instance names.

* **Documentation**
  * Updated notification descriptions and event titles to reflect revised success and failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->