### PR TITLE
fix(torrents): support qBittorrent I2P peers

### DIFF
--- a/internal/api/handlers/torrents.go
+++ b/internal/api/handlers/torrents.go
@@ -2389,8 +2389,8 @@ func (h *TorrentsHandler) GetTorrentPeers(w http.ResponseWriter, r *http.Request
 			return sortedPeers[i].UpSpeed > sortedPeers[j].UpSpeed
 		}
 
-		// Finally by IP for stable sorting
-		return sortedPeers[i].IP < sortedPeers[j].IP
+		// Finally by canonical peer address for stable sorting.
+		return sortedPeers[i].Key < sortedPeers[j].Key
 	})
 
 	// Create response with sorted peers

--- a/web/src/components/torrents/TorrentDetailsPanel.tsx
+++ b/web/src/components/torrents/TorrentDetailsPanel.tsx
@@ -26,12 +26,13 @@ import { isHardlinkManaged, useLocalCrossSeedMatches } from "@/lib/cross-seed-ut
 import { getLinuxCategory, getLinuxComment, getLinuxCreatedBy, getLinuxFileName, getLinuxHash, getLinuxIsoName, getLinuxSavePath, getLinuxTags, getLinuxTracker, useIncognitoMode } from "@/lib/incognito"
 import { renderTextWithLinks } from "@/lib/linkUtils"
 import { formatSpeedWithUnit, useSpeedUnits } from "@/lib/speedUnits"
+import { canBanPeer, getPeerDisplayAddress } from "@/lib/torrent-peer-address"
 import { getPeerFlagDetails } from "@/lib/torrent-peer-flags"
 import { getStateLabel } from "@/lib/torrent-state-utils"
 import { resolveTorrentHashes } from "@/lib/torrent-utils"
 import { getTrackerStatusBadge } from "@/lib/tracker-utils"
 import { cn, copyTextToClipboard, formatBytes, formatDuration } from "@/lib/utils"
-import type { SortedPeersResponse, Torrent, TorrentFile, TorrentFilters, TorrentStreamPayload, TorrentTracker, TorrentPeer } from "@/types"
+import type { SortedPeer, SortedPeersResponse, Torrent, TorrentFile, TorrentFilters, TorrentStreamPayload, TorrentTracker } from "@/types"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { Ban, Copy, Loader2, Trash2, UserPlus, X } from "lucide-react"
 import { memo, useCallback, useEffect, useMemo, useState } from "react"
@@ -82,7 +83,7 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
   const { formatTimestamp } = useDateTimeFormatters()
   const [showBanPeerDialog, setShowBanPeerDialog] = useState(false)
   const [peersToAdd, setPeersToAdd] = useState("")
-  const [peerToBan, setPeerToBan] = useState<TorrentPeer | null>(null)
+  const [peerToBan, setPeerToBan] = useState<SortedPeer | null>(null)
   const [isReady, setIsReady] = useState(false)
   const { data: metadata } = useInstanceMetadata(instanceId)
   const { data: capabilities } = useInstanceCapabilities(instanceId)
@@ -635,29 +636,28 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
     await queryClient.invalidateQueries({ queryKey: ["torrent-files", instanceId, torrent.hash] })
   }, [instanceId, queryClient, torrent])
 
-  // Handle copy peer IP:port
-  const handleCopyPeer = useCallback(async (peer: TorrentPeer) => {
-    const peerAddress = `${peer.ip}:${peer.port}`
+  // Handle copy peer address
+  const handleCopyPeer = useCallback(async (peer: SortedPeer) => {
+    if (incognitoMode) return
     try {
-      await copyTextToClipboard(peerAddress)
+      await copyTextToClipboard(peer.key)
       toast.success(t("detailsPanel.toast.copied", { type: t("peersTable.address") }))
     } catch (err) {
       console.error("Failed to copy to clipboard:", err)
       toast.error(t("detailsPanel.toast.copyFailed"))
     }
-  }, [t])
+  }, [incognitoMode, t])
 
   // Handle ban peer click
-  const handleBanPeerClick = useCallback((peer: TorrentPeer) => {
+  const handleBanPeerClick = useCallback((peer: SortedPeer) => {
     setPeerToBan(peer)
     setShowBanPeerDialog(true)
   }, [])
 
   // Handle ban peer confirmation
   const handleBanPeerConfirm = useCallback(() => {
-    if (peerToBan) {
-      const peerAddress = `${peerToBan.ip}:${peerToBan.port}`
-      banPeerMutation.mutate(peerAddress)
+    if (peerToBan && canBanPeer(peerToBan)) {
+      banPeerMutation.mutate(peerToBan.key)
     }
   }, [peerToBan, banPeerMutation])
 
@@ -1403,7 +1403,7 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
                                   <div className="flex items-start justify-between gap-3">
                                     <div className="flex-1 space-y-1">
                                       <div className="flex items-center gap-2 flex-wrap">
-                                        <span className="font-mono text-sm cursor-context-menu">{peer.ip}:{peer.port}</span>
+                                        <span className="font-mono text-sm cursor-context-menu">{getPeerDisplayAddress(peer, incognitoMode)}</span>
                                         {peer.country_code && (
                                           <span
                                             className={`fi fi-${peer.country_code.toLowerCase()} rounded text-sm`}
@@ -1517,18 +1517,23 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
                               <ContextMenuContent>
                                 <ContextMenuItem
                                   onClick={() => handleCopyPeer(peer)}
+                                  disabled={incognitoMode}
                                 >
                                   <Copy className="h-4 w-4 mr-2" />
                                   {t("detailsPanel.actions.copyIpPort")}
                                 </ContextMenuItem>
-                                <ContextMenuSeparator />
-                                <ContextMenuItem
-                                  onClick={() => handleBanPeerClick(peer)}
-                                  className="text-destructive focus:text-destructive"
-                                >
-                                  <Ban className="h-4 w-4 mr-2" />
-                                  {t("detailsPanel.actions.banPeerPermanently")}
-                                </ContextMenuItem>
+                                {canBanPeer(peer) && (
+                                  <>
+                                    <ContextMenuSeparator />
+                                    <ContextMenuItem
+                                      onClick={() => handleBanPeerClick(peer)}
+                                      className="text-destructive focus:text-destructive"
+                                    >
+                                      <Ban className="h-4 w-4 mr-2" />
+                                      {t("detailsPanel.actions.banPeerPermanently")}
+                                    </ContextMenuItem>
+                                  </>
+                                )}
                               </ContextMenuContent>
                             </ContextMenu>
                           )
@@ -2003,7 +2008,7 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
             <div className="space-y-2 text-sm">
               <div>
                 <span className="text-muted-foreground">{t("detailsPanel.banPeerPermanent.ipAddress")}</span>
-                <span className="ml-2 font-mono">{peerToBan.ip}:{peerToBan.port}</span>
+                <span className="ml-2 font-mono">{getPeerDisplayAddress(peerToBan, incognitoMode)}</span>
               </div>
               {peerToBan.client && (
                 <div>

--- a/web/src/components/torrents/TorrentDetailsPanel.tsx
+++ b/web/src/components/torrents/TorrentDetailsPanel.tsx
@@ -1403,7 +1403,7 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
                                   <div className="flex items-start justify-between gap-3">
                                     <div className="flex-1 space-y-1">
                                       <div className="flex items-center gap-2 flex-wrap">
-                                        <span className="font-mono text-sm cursor-context-menu">{getPeerDisplayAddress(peer, incognitoMode)}</span>
+                                        <span className="font-mono text-sm break-all cursor-context-menu">{getPeerDisplayAddress(peer, incognitoMode)}</span>
                                         {peer.country_code && (
                                           <span
                                             className={`fi fi-${peer.country_code.toLowerCase()} rounded text-sm`}

--- a/web/src/components/torrents/TorrentDetailsPanel.tsx
+++ b/web/src/components/torrents/TorrentDetailsPanel.tsx
@@ -641,7 +641,7 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
     if (incognitoMode) return
     try {
       await copyTextToClipboard(peer.key)
-      toast.success(t("detailsPanel.toast.copied", { type: t("peersTable.address") }))
+      toast.success(t("peersTable.toast.ipCopied"))
     } catch (err) {
       console.error("Failed to copy to clipboard:", err)
       toast.error(t("detailsPanel.toast.copyFailed"))

--- a/web/src/components/torrents/details/PeersTable.tsx
+++ b/web/src/components/torrents/details/PeersTable.tsx
@@ -7,10 +7,11 @@ import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuSeparator,
 import { Progress } from "@/components/ui/progress"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { canBanPeer, getPeerDisplayAddress } from "@/lib/torrent-peer-address"
 import { getPeerFlagDetails } from "@/lib/torrent-peer-flags"
 import { cn, copyTextToClipboard, formatBytes } from "@/lib/utils"
 import { formatSpeedWithUnit, type SpeedUnit } from "@/lib/speedUnits"
-import type { SortedPeer, TorrentPeer } from "@/types"
+import type { SortedPeer } from "@/types"
 import {
   createColumnHelper,
   flexRender,
@@ -31,7 +32,7 @@ interface PeersTableProps {
   speedUnit: SpeedUnit
   showFlags: boolean
   incognitoMode: boolean
-  onBanPeer?: (peer: TorrentPeer) => void
+  onBanPeer?: (peer: SortedPeer) => void
 }
 
 const columnHelper = createColumnHelper<typeof sortableDetailsTableFeatures, SortedPeer>()
@@ -76,18 +77,14 @@ export const PeersTable = memo(function PeersTable({
       size: 30,
       enableSorting: false,
     }),
-    columnHelper.accessor((row) => `${row.ip}:${row.port}`, {
+    columnHelper.accessor((row) => row.key, {
       id: "address",
       header: t("peersTable.address"),
-      cell: (info) => {
-        const displayIp = incognitoMode ? "192.168.x.x" : ( info.row.original.ip.match(/:/) ? `[${info.row.original.ip}]` : info.row.original.ip )
-        const displayPort = incognitoMode ? "xxxxx" : info.row.original.port
-        return (
-          <span className="font-mono text-xs">
-            {displayIp}:{displayPort}
-          </span>
-        )
-      },
+      cell: (info) => (
+        <span className="font-mono text-xs">
+          {getPeerDisplayAddress(info.row.original, incognitoMode)}
+        </span>
+      ),
       size: 150,
     }),
     columnHelper.accessor("client", {
@@ -199,9 +196,9 @@ export const PeersTable = memo(function PeersTable({
     onSortingChange: setSorting,
   })
 
-  const handleCopyIp = (peer: SortedPeer) => {
+  const handleCopyAddress = (peer: SortedPeer) => {
     if (incognitoMode) return
-    copyTextToClipboard(`${peer.ip}`)
+    copyTextToClipboard(peer.key)
     toast.success(t("peersTable.toast.ipCopied"))
   }
 
@@ -267,13 +264,13 @@ export const PeersTable = memo(function PeersTable({
                 </ContextMenuTrigger>
                 <ContextMenuContent>
                   <ContextMenuItem
-                    onClick={() => handleCopyIp(row.original)}
+                    onClick={() => handleCopyAddress(row.original)}
                     disabled={incognitoMode}
                   >
                     <Copy className="h-3.5 w-3.5 mr-2" />
                     {t("peersTable.copyIpAddress")}
                   </ContextMenuItem>
-                  {onBanPeer && (
+                  {onBanPeer && canBanPeer(row.original) && (
                     <>
                       <ContextMenuSeparator />
                       <ContextMenuItem

--- a/web/src/i18n/locales/cs/torrents.json
+++ b/web/src/i18n/locales/cs/torrents.json
@@ -1134,7 +1134,7 @@
       "unknownClient": "Neznámý klient"
     },
     "actions": {
-      "copyIpPort": "Kopírovat IP:port",
+      "copyIpPort": "Kopírovat adresu",
       "banPeerPermanently": "Permanentně zakázat peer",
       "selectAll": "Všechny",
       "selectNone": "Žádné"
@@ -1208,7 +1208,7 @@
     "editTrackerUrl": "Upravit URL trackeru"
   },
   "peersTable": {
-    "address": "IP:Port",
+    "address": "IP/adresa",
     "client": "Klient",
     "flags": "Vlajky",
     "progress": "Postup",
@@ -1217,11 +1217,11 @@
     "downloaded": "Stáhnuto",
     "uploaded": "Odesláno",
     "relevance": "Relevance",
-    "copyIpAddress": "Kopírovat IP adresu",
+    "copyIpAddress": "Kopírovat adresu",
     "banPeer": "Zakázat peer",
     "noPeersConnected": "Žádné peerové připojení",
     "toast": {
-      "ipCopied": "IP adresa zkopírována do schránky"
+      "ipCopied": "Adresa zkopírována do schránky"
     }
   },
   "routes": {

--- a/web/src/i18n/locales/de/torrents.json
+++ b/web/src/i18n/locales/de/torrents.json
@@ -1134,7 +1134,7 @@
       "unknownClient": "Unbekannter Client"
     },
     "actions": {
-      "copyIpPort": "IP:Port kopieren",
+      "copyIpPort": "Adresse kopieren",
       "banPeerPermanently": "Peer dauerhaft sperren",
       "selectAll": "Alle",
       "selectNone": "Keine"
@@ -1208,7 +1208,7 @@
     "editTrackerUrl": "Tracker-URL bearbeiten"
   },
   "peersTable": {
-    "address": "IP:Port",
+    "address": "IP/Adresse",
     "client": "Client",
     "flags": "Flags",
     "progress": "Fortschritt",
@@ -1217,11 +1217,11 @@
     "downloaded": "Heruntergeladen",
     "uploaded": "Hochgeladen",
     "relevance": "Relevanz",
-    "copyIpAddress": "IP-Adresse kopieren",
+    "copyIpAddress": "Adresse kopieren",
     "banPeer": "Peer sperren",
     "noPeersConnected": "Keine Peers verbunden",
     "toast": {
-      "ipCopied": "IP-Adresse in die Zwischenablage kopiert"
+      "ipCopied": "Adresse in die Zwischenablage kopiert"
     }
   },
   "routes": {

--- a/web/src/i18n/locales/en/torrents.json
+++ b/web/src/i18n/locales/en/torrents.json
@@ -1134,7 +1134,7 @@
       "unknownClient": "Unknown client"
     },
     "actions": {
-      "copyIpPort": "Copy IP:port",
+      "copyIpPort": "Copy address",
       "banPeerPermanently": "Ban peer permanently",
       "selectAll": "All",
       "selectNone": "None"
@@ -1208,7 +1208,7 @@
     "editTrackerUrl": "Edit Tracker URL"
   },
   "peersTable": {
-    "address": "IP:Port",
+    "address": "IP/Address",
     "client": "Client",
     "flags": "Flags",
     "progress": "Progress",
@@ -1217,11 +1217,11 @@
     "downloaded": "Downloaded",
     "uploaded": "Uploaded",
     "relevance": "Relevance",
-    "copyIpAddress": "Copy IP Address",
+    "copyIpAddress": "Copy address",
     "banPeer": "Ban Peer",
     "noPeersConnected": "No peers connected",
     "toast": {
-      "ipCopied": "IP address copied to clipboard"
+      "ipCopied": "Address copied to clipboard"
     }
   },
   "routes": {

--- a/web/src/i18n/locales/fr/torrents.json
+++ b/web/src/i18n/locales/fr/torrents.json
@@ -1134,7 +1134,7 @@
       "unknownClient": "Client inconnu"
     },
     "actions": {
-      "copyIpPort": "Copier IP:port",
+      "copyIpPort": "Copier l’adresse",
       "banPeerPermanently": "Bannir définitivement",
       "selectAll": "Tout",
       "selectNone": "Aucun"
@@ -1208,7 +1208,7 @@
     "editTrackerUrl": "Modifier l'URL du Tracker"
   },
   "peersTable": {
-    "address": "IP:Port",
+    "address": "IP/Adresse",
     "client": "Client",
     "flags": "Drapeaux",
     "progress": "Progression",
@@ -1217,11 +1217,11 @@
     "downloaded": "Téléchargé",
     "uploaded": "Envoyé",
     "relevance": "Pertinence",
-    "copyIpAddress": "Copier l'adresse IP",
+    "copyIpAddress": "Copier l’adresse",
     "banPeer": "Bannir le pair",
     "noPeersConnected": "Aucun pair connecté",
     "toast": {
-      "ipCopied": "Adresse IP copiée dans le presse-papiers"
+      "ipCopied": "Adresse copiée dans le presse-papiers"
     }
   },
   "routes": {

--- a/web/src/i18n/locales/it/torrents.json
+++ b/web/src/i18n/locales/it/torrents.json
@@ -1134,7 +1134,7 @@
       "unknownClient": "Client sconosciuto"
     },
     "actions": {
-      "copyIpPort": "Copia IP:porta",
+      "copyIpPort": "Copia indirizzo",
       "banPeerPermanently": "Banna peer permanentemente",
       "selectAll": "Tutti",
       "selectNone": "Nessuno"
@@ -1208,7 +1208,7 @@
     "editTrackerUrl": "Modifica URL del tracker"
   },
   "peersTable": {
-    "address": "IP:Porta",
+    "address": "IP/Indirizzo",
     "client": "Client",
     "flags": "Flag",
     "progress": "Avanzamento",
@@ -1217,11 +1217,11 @@
     "downloaded": "Scaricato",
     "uploaded": "Caricato",
     "relevance": "Rilevanza",
-    "copyIpAddress": "Copia indirizzo IP",
+    "copyIpAddress": "Copia indirizzo",
     "banPeer": "Banna peer",
     "noPeersConnected": "Nessun peer connesso",
     "toast": {
-      "ipCopied": "Indirizzo IP copiato negli appunti"
+      "ipCopied": "Indirizzo copiato negli appunti"
     }
   },
   "routes": {

--- a/web/src/i18n/locales/ko/torrents.json
+++ b/web/src/i18n/locales/ko/torrents.json
@@ -1075,7 +1075,7 @@
       "unknownClient": "알 수 없는 클라이언트"
     },
     "actions": {
-      "copyIpPort": "IP:port 복사",
+      "copyIpPort": "주소 복사",
       "banPeerPermanently": "피어 영구 차단",
       "selectAll": "전체",
       "selectNone": "없음"
@@ -1149,7 +1149,7 @@
     "editTrackerUrl": "트래커 URL 편집"
   },
   "peersTable": {
-    "address": "IP:포트",
+    "address": "IP/주소",
     "client": "클라이언트",
     "flags": "플래그",
     "progress": "진행률",
@@ -1158,11 +1158,11 @@
     "downloaded": "다운로드됨",
     "uploaded": "업로드됨",
     "relevance": "관련성",
-    "copyIpAddress": "IP 주소 복사",
+    "copyIpAddress": "주소 복사",
     "banPeer": "피어 차단",
     "noPeersConnected": "연결된 피어 없음",
     "toast": {
-      "ipCopied": "IP 주소가 클립보드에 복사되었습니다"
+      "ipCopied": "주소가 클립보드에 복사되었습니다"
     }
   },
   "routes": {

--- a/web/src/i18n/locales/pt-BR/torrents.json
+++ b/web/src/i18n/locales/pt-BR/torrents.json
@@ -1134,7 +1134,7 @@
       "unknownClient": "Cliente desconhecido"
     },
     "actions": {
-      "copyIpPort": "Copiar IP:porta",
+      "copyIpPort": "Copiar endereço",
       "banPeerPermanently": "Banir peer permanentemente",
       "selectAll": "Todos",
       "selectNone": "Nenhum"
@@ -1208,7 +1208,7 @@
     "editTrackerUrl": "Editar URL do Tracker"
   },
   "peersTable": {
-    "address": "IP:Porta",
+    "address": "IP/Endereço",
     "client": "Cliente",
     "flags": "Bandeiras (Flags)",
     "progress": "Progresso",
@@ -1217,11 +1217,11 @@
     "downloaded": "Baixado",
     "uploaded": "Enviado",
     "relevance": "Relevância",
-    "copyIpAddress": "Copiar IP",
+    "copyIpAddress": "Copiar endereço",
     "banPeer": "Banir Peer",
     "noPeersConnected": "Nenhum peer conectado",
     "toast": {
-      "ipCopied": "Endereço IP copiado para a área de transferência"
+      "ipCopied": "Endereço copiado para a área de transferência"
     }
   },
   "routes": {

--- a/web/src/i18n/locales/uk/torrents.json
+++ b/web/src/i18n/locales/uk/torrents.json
@@ -1252,7 +1252,7 @@
       "unknownClient": "Невідомий клієнт"
     },
     "actions": {
-      "copyIpPort": "Скопіюйте IP:порт",
+      "copyIpPort": "Копіювати адресу",
       "banPeerPermanently": "Заблокувати піра назавжди",
       "selectAll": "Усі",
       "selectNone": "Жодного"
@@ -1326,7 +1326,7 @@
     "editTrackerUrl": "Редагувати URL трекера"
   },
   "peersTable": {
-    "address": "IP:Порт",
+    "address": "IP/Адреса",
     "client": "Клієнт",
     "flags": "Прапори",
     "progress": "Прогрес",
@@ -1335,11 +1335,11 @@
     "downloaded": "Завантажено",
     "uploaded": "Вивантажено",
     "relevance": "Актуальність",
-    "copyIpAddress": "Скопіюйте адресу IP",
+    "copyIpAddress": "Копіювати адресу",
     "banPeer": "Заблокувати піра",
     "noPeersConnected": "Немає підключених пірів",
     "toast": {
-      "ipCopied": "Адресу IP скопійовано в буфер обміну"
+      "ipCopied": "Адресу скопійовано в буфер обміну"
     }
   },
   "routes": {

--- a/web/src/i18n/locales/zh-CN/torrents.json
+++ b/web/src/i18n/locales/zh-CN/torrents.json
@@ -1075,7 +1075,7 @@
       "unknownClient": "未知客户端"
     },
     "actions": {
-      "copyIpPort": "复制 IP:端口",
+      "copyIpPort": "复制地址",
       "banPeerPermanently": "永久封禁节点",
       "selectAll": "全部",
       "selectNone": "无"
@@ -1149,7 +1149,7 @@
     "editTrackerUrl": "编辑 Tracker URL"
   },
   "peersTable": {
-    "address": "IP:端口",
+    "address": "IP/地址",
     "client": "客户端",
     "flags": "标志",
     "progress": "进度",
@@ -1158,11 +1158,11 @@
     "downloaded": "已下载",
     "uploaded": "已上传",
     "relevance": "相关性",
-    "copyIpAddress": "复制 IP 地址",
+    "copyIpAddress": "复制地址",
     "banPeer": "封禁节点",
     "noPeersConnected": "无已连接节点",
     "toast": {
-      "ipCopied": "IP 地址已复制到剪贴板"
+      "ipCopied": "地址已复制到剪贴板"
     }
   },
   "routes": {

--- a/web/src/i18n/locales/zh-TW/torrents.json
+++ b/web/src/i18n/locales/zh-TW/torrents.json
@@ -1075,7 +1075,7 @@
       "unknownClient": "未知用戶端"
     },
     "actions": {
-      "copyIpPort": "複製 IP:連接埠",
+      "copyIpPort": "複製位址",
       "banPeerPermanently": "永久封鎖節點",
       "selectAll": "全部",
       "selectNone": "無"
@@ -1149,7 +1149,7 @@
     "editTrackerUrl": "編輯 Tracker URL"
   },
   "peersTable": {
-    "address": "IP:連接埠",
+    "address": "IP/位址",
     "client": "用戶端",
     "flags": "標誌",
     "progress": "進度",
@@ -1158,11 +1158,11 @@
     "downloaded": "已下載",
     "uploaded": "已上傳",
     "relevance": "相關性",
-    "copyIpAddress": "複製 IP 位址",
+    "copyIpAddress": "複製位址",
     "banPeer": "封鎖節點",
     "noPeersConnected": "無已連線節點",
     "toast": {
-      "ipCopied": "IP 位址已複製到剪貼簿"
+      "ipCopied": "位址已複製到剪貼簿"
     }
   },
   "routes": {

--- a/web/src/lib/torrent-peer-address.test.ts
+++ b/web/src/lib/torrent-peer-address.test.ts
@@ -1,0 +1,24 @@
+import type { SortedPeer } from "@/types"
+import { describe, expect, it } from "vitest"
+import { canBanPeer, getPeerDisplayAddress } from "./torrent-peer-address"
+
+const peer = (value: Partial<SortedPeer> & Pick<SortedPeer, "key">): SortedPeer => ({
+  progress: 0,
+  ...value,
+})
+
+describe("torrent peer addresses", () => {
+  it.each([
+    { name: "IPv4", value: peer({ key: "198.51.100.7:6881", ip: "198.51.100.7", port: 6881 }), bannable: true },
+    { name: "IPv6", value: peer({ key: "[2001:db8::7]:6881", ip: "2001:db8::7", port: 6881 }), bannable: true },
+    { name: "I2P", value: peer({ key: "exampledestination.b32.i2p" }), bannable: false },
+  ])("uses the canonical $name key", ({ value, bannable }) => {
+    expect(getPeerDisplayAddress(value, false)).toBe(value.key)
+    expect(canBanPeer(value)).toBe(bannable)
+  })
+
+  it("masks every address kind in incognito mode", () => {
+    const value = peer({ key: "exampledestination.b32.i2p" })
+    expect(getPeerDisplayAddress(value, true)).toBe("192.168.x.x:xxxxx")
+  })
+})

--- a/web/src/lib/torrent-peer-address.ts
+++ b/web/src/lib/torrent-peer-address.ts
@@ -1,0 +1,9 @@
+import type { SortedPeer, TorrentPeer } from "@/types"
+
+export function getPeerDisplayAddress(peer: SortedPeer, incognitoMode: boolean): string {
+  return incognitoMode ? "192.168.x.x:xxxxx" : peer.key
+}
+
+export function canBanPeer(peer: TorrentPeer): boolean {
+  return peer.ip !== undefined && peer.port !== undefined
+}

--- a/web/src/types/torrents.ts
+++ b/web/src/types/torrents.ts
@@ -388,8 +388,8 @@ export interface TransferInfo {
 }
 
 export interface TorrentPeer {
-  ip: string
-  port: number
+  ip?: string
+  port?: number
   connection?: string
   flags?: string
   flags_desc?: string


### PR DESCRIPTION
## Description

qBittorrent 5.2 includes I2P peers in `sync/torrentPeers` without `ip` or `port`. qui treated both fields as required, which crashed the desktop peer table and rendered `:` in the compact view.

Use qBittorrent's peer-map key as the canonical address for sorting, display, copy, and supported ban requests. IP fields are now optional, I2P peers no longer expose an unsupported ban action, and incognito mode masks every peer address.

Related to [discussion #2039](https://github.com/autobrr/qui/discussions/2039).

## How has this been tested?

Tested the production build against a protocol-faithful local qBittorrent WebAPI stub with synthetic IPv4 and IPv6 peers. Verified desktop and mobile display, incremental peer polling, clipboard output, canonical IPv6 ban payloads, incognito masking, and copy prevention. Chromium reported no page or console errors.

A live I2P peer was not available. The qBittorrent 5.2 I2P response shape is covered by the focused frontend regression test.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Peer addresses now support IPv4, IPv6, and I2P formats.
  * Incognito mode masks peer addresses and disables copying.
  * Ban actions appear only for eligible peers.
  * Peer address copying uses the displayed canonical address.

* **Improvements**
  * Long peer addresses now wrap correctly in the peers list.
  * Peer ordering is more consistent when addresses otherwise match.
  * Torrent peer labels and messages now use “address” terminology across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->