### PR TITLE
docs(agents): require PR documentation review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,8 @@ Frontend-specific rules live in `web/AGENTS.md`. Read that file before editing `
 ## Commits / PRs
 
 - Keep Superpowers workflow files local and untracked; never add or commit `docs/superpowers/`.
+- Before you open a PR or add commits to one, review the complete PR diff for documentation needs. If the diff needs Docusaurus documentation, update `documentation/docs/` in the same PR. State in the final report whether you updated the documentation or why no update was needed.
+- When available, use the `simple-english`, `unslop`, and `stop-slop` skills for documentation prose.
 - Conventional commits: `feat(scope):`, `fix(scope):`, etc.
 - Keep commits focused; split backend/frontend when practical. If a feature spans schema, backend service, and web UI, stack PRs: schema + models, then service logic, then UI.
 - Before each commit, review the diff for over-engineering. If the ponytail plugin (<https://github.com/DietrichGebert/ponytail>) is installed, use its `ponytail:ponytail-review` skill. If it is not, do a trim pass: remove speculative config, unused states, single-caller layers, and duplicate helpers.


### PR DESCRIPTION
## Description

Require contributors and agents to review the complete PR diff for Docusaurus documentation needs before they open or update a PR.

Use the preferred prose skills when they are available.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidance to require reviewing documentation needs when preparing pull requests.
  * Added instructions to update documentation alongside related changes when necessary.
  * Recommended using available writing-quality skills to produce clear, concise documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->