### PR TITLE
fix(jackett): let tests override the torznab request interval

### DIFF
--- a/internal/services/crossseed/search_music_query_test.go
+++ b/internal/services/crossseed/search_music_query_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	qbt "github.com/autobrr/go-qbittorrent"
 	"github.com/moistari/rls"
@@ -115,7 +116,7 @@ func TestSearchTorrentMatches_ForcedMusicBuildsMusicQuery(t *testing.T) {
 						Capabilities: []string{"search", "music-search", "audio-search"},
 						Categories:   []models.TorznabIndexerCategory{{IndexerID: 1, CategoryID: 3000, CategoryName: "Audio"}},
 					},
-				}}}),
+				}}}, jackett.WithMinRequestInterval(time.Millisecond)),
 				syncManager: &gazelleSkipHashSyncManager{
 					torrents: []qbt.Torrent{sourceTorrent},
 					filesByHash: map[string]qbt.TorrentFiles{

--- a/internal/services/crossseed/search_torznab_failure_gazelle_test.go
+++ b/internal/services/crossseed/search_torznab_failure_gazelle_test.go
@@ -104,7 +104,7 @@ func newTorznabGazelleFixture(t *testing.T, dbName, trackerURL string) (*Service
 				Capabilities: []string{"search", "music-search", "audio-search"},
 				Categories:   []models.TorznabIndexerCategory{{IndexerID: 1, CategoryID: 3000, CategoryName: "Audio"}},
 			},
-		}}}),
+		}}}, jackett.WithMinRequestInterval(time.Millisecond)),
 		syncManager: &hashFilteringSyncManager{
 			torrents: []qbt.Torrent{sourceTorrent},
 			filesByHash: map[string]qbt.TorrentFiles{

--- a/internal/services/crossseed/service_search_test.go
+++ b/internal/services/crossseed/service_search_test.go
@@ -131,7 +131,7 @@ func newFailingJackettService(err error) *jackett.Service {
 }
 
 func newJackettServiceWithIndexers(indexers []*models.TorznabIndexer) *jackett.Service {
-	return jackett.NewService(&failingEnabledIndexerStore{indexers: indexers})
+	return jackett.NewService(&failingEnabledIndexerStore{indexers: indexers}, jackett.WithMinRequestInterval(time.Millisecond))
 }
 
 func TestIsNilARRLookupServiceHandlesTypedNilARRService(t *testing.T) {

--- a/internal/services/crossseed/tag_id_primary_wiring_test.go
+++ b/internal/services/crossseed/tag_id_primary_wiring_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	mediainfo "github.com/autobrr/go-mediainfo"
 	qbt "github.com/autobrr/go-qbittorrent"
@@ -118,7 +119,7 @@ func TestTagIDPrimaryMixedModeWithTitleRescue(t *testing.T) {
 				Capabilities: []string{"search", "movie-search"},
 				Categories:   movieCategories,
 			},
-		}}}),
+		}}}, jackett.WithMinRequestInterval(time.Millisecond)),
 		syncManager: &gazelleSkipHashSyncManager{
 			torrents: []qbt.Torrent{sourceTorrent},
 			filesByHash: map[string]qbt.TorrentFiles{

--- a/internal/services/jackett/scheduler.go
+++ b/internal/services/jackett/scheduler.go
@@ -78,6 +78,12 @@ func NewRateLimiter(minInterval time.Duration) *RateLimiter {
 	}
 }
 
+func (r *RateLimiter) setMinInterval(d time.Duration) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.minInterval = d
+}
+
 func (r *RateLimiter) RecordRequestComplete(indexerID int, ts time.Time) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/internal/services/jackett/scheduler_test.go
+++ b/internal/services/jackett/scheduler_test.go
@@ -1145,3 +1145,15 @@ func TestRateLimiter_WaitForMinInterval_IgnoresCooldown(t *testing.T) {
 		t.Fatalf("WaitForMinInterval waited unexpectedly long (cooldown should be ignored)")
 	}
 }
+
+func TestWithMinRequestInterval(t *testing.T) {
+	indexer := &models.TorznabIndexer{ID: 1, Backend: models.TorznabBackendNative}
+
+	paced := NewService(nil)
+	paced.rateLimiter.RecordRequestComplete(indexer.ID, time.Now())
+	require.Greater(t, paced.rateLimiter.NextWait(indexer), time.Second, "default pacing should make the next request wait")
+
+	fast := NewService(nil, WithMinRequestInterval(time.Millisecond))
+	fast.rateLimiter.RecordRequestComplete(indexer.ID, time.Now())
+	require.LessOrEqual(t, fast.rateLimiter.NextWait(indexer), time.Millisecond)
+}

--- a/internal/services/jackett/service.go
+++ b/internal/services/jackett/service.go
@@ -466,6 +466,16 @@ func (s *Service) searchIndexersWithScheduler(ctx context.Context, indexers []*m
 	return err
 }
 
+// WithMinRequestInterval overrides the pacing between requests to one native
+// Torznab indexer. Tests use it to skip the 60 s default.
+func WithMinRequestInterval(d time.Duration) ServiceOption {
+	return func(s *Service) {
+		if d > 0 {
+			s.rateLimiter.setMinInterval(d)
+		}
+	}
+}
+
 // WithTorrentCache wires a torrent payload cache into the service.
 func WithTorrentCache(cache *models.TorznabTorrentCacheStore) ServiceOption {
 	return func(s *Service) {


### PR DESCRIPTION
## Description

The 60 s pacing added in #2462 has no override, so crossseed tests that build the real jackett service sleep 60 s on every repeat query to a native indexer. This adds a `jackett.WithMinRequestInterval` option and uses it at the four slow call sites. Production pacing is unchanged.

## How has this been tested?

Timed the four worst crossseed tests locally: 540 s before, 0.55 s after. The whole crossseed package with `-race` went from 578 s to 44 s. The new `TestWithMinRequestInterval` fails without the option (`"59.999999659s" is not less than or equal to "1ms"`) and passes with it.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable pacing for requests to individual indexers.
  - Services can now use shorter intervals between requests when supported, improving responsiveness for compatible search scenarios while retaining existing default behavior.

- **Tests**
  - Added coverage to verify both the default request pacing and custom interval settings.
  - Updated search-related test configurations to use faster request intervals for more efficient test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->