### PR TITLE
fix(ci): raise the triage turn cap to 80

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -151,7 +151,7 @@ jobs:
           claude_args: |
             --allowedTools "Read,Grep,Glob,Bash(gh label list:*),Bash(gh release list:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh discussion list:*),Bash(gh discussion view:*),Bash(./.github/scripts/discussion-write.sh:*),mcp__github__get_discussion,mcp__github__get_discussion_comments,mcp__github__list_discussions"
             --model claude-opus-5
-            --max-turns 40
+            --max-turns 80
             --mcp-config /tmp/mcp-config/mcp-servers.json
           settings: |
             {"env": {"GH_TOKEN": "${{ secrets.GITHUB_TOKEN }}", "DISCUSSION_WRITE_ALLOWED_OPS": "add-label,remove-label,comment,close,create-issue"}}


### PR DESCRIPTION
## Description

The first live triage run finished its work in 53 turns, then `claude-code-action` failed the job for exceeding the 40-turn cap. Raises the cap to 80. `timeout-minutes: 15` stays the real ceiling.

## How has this been tested?

Run 33276642466 on #1845: labels, comment, issue #2473 and close all landed, only the post-run turn check failed.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced automated discussion triage to support longer processing runs.
  * Preserved existing behavior for newly submitted discussions, follow-up replies, and stale requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->