### PR TITLE
fix(ci): triage follow-ups and the ADR for the Claude subscription

### DIFF
--- a/.github/scripts/discussion-write.sh
+++ b/.github/scripts/discussion-write.sh
@@ -139,6 +139,15 @@ case "$cmd" in
     op_allowed create-issue || die "create-issue is not permitted here (allowed: $ALLOWED_OPS)"
     [[ $# -eq 2 ]] || die "create-issue requires a title and a body argument"
     [[ -n "$1" && -n "$2" ]] || die "create-issue title and body must not be empty"
+    # A re-run on an already promoted discussion reuses its issue.
+    # ponytail: issue search is eventually consistent, so this is a backstop; the
+    # playbook's closed/label check is the real guard.
+    existing=$(gh issue list --state all --search "\"From discussion #$NUMBER\" in:body" --json url --jq '.[0].url // empty')
+    if [[ -n "$existing" ]]; then
+      echo "Issue already exists for discussion #$NUMBER: $existing" >&2
+      echo "$existing"
+      exit 0
+    fi
     gh issue create --title "$1" --label ready-for-agent \
       --body "$2"$'\n\n'"From discussion #$NUMBER"
     ;;

--- a/.github/scripts/discussion-write.sh
+++ b/.github/scripts/discussion-write.sh
@@ -142,7 +142,7 @@ case "$cmd" in
     # A re-run on an already promoted discussion reuses its issue.
     # ponytail: issue search is eventually consistent, so this is a backstop; the
     # playbook's closed/label check is the real guard.
-    existing=$(gh issue list --state all --search "\"From discussion #$NUMBER\" in:body" --json url --jq '.[0].url // empty')
+    existing=$(gh issue list --state all --search "\"From discussion #$NUMBER\" in:body author:app/github-actions" --json url --jq '.[0].url // empty')
     if [[ -n "$existing" ]]; then
       echo "Issue already exists for discussion #$NUMBER: $existing" >&2
       echo "$existing"

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -10,9 +10,9 @@ on:
   workflow_dispatch:
     inputs:
       discussion_number:
-        description: 'Discussion number to triage'
-        required: true
-        type: number
+        description: 'Discussion number to triage. Leave empty to run the sweep.'
+        required: false
+        type: string
 
 jobs:
   # Workaround: claude-code-action doesn't support 'discussion' events directly.
@@ -44,7 +44,7 @@ jobs:
   # untriaged discussions and closes needs-info discussions nobody answered.
   sweep:
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && !inputs.discussion_number)
     permissions:
       actions: write
       discussions: write
@@ -86,7 +86,12 @@ jobs:
   triage-discussion:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && inputs.discussion_number
+    # One run per discussion at a time: a creation event and the sweep can
+    # dispatch the same number, so the second run queues and then stops early
+    # because the playbook sees the discussion already triaged.
+    concurrency:
+      group: triage-discussion-${{ inputs.discussion_number }}
     permissions:
       contents: read
       discussions: write
@@ -151,7 +156,6 @@ jobs:
           claude_args: |
             --allowedTools "Read,Grep,Glob,Bash(gh label list:*),Bash(gh release list:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh discussion list:*),Bash(gh discussion view:*),Bash(./.github/scripts/discussion-write.sh:*),mcp__github__get_discussion,mcp__github__get_discussion_comments,mcp__github__list_discussions"
             --model claude-opus-5
-            --max-turns 80
             --mcp-config /tmp/mcp-config/mcp-servers.json
           settings: |
             {"env": {"GH_TOKEN": "${{ secrets.GITHUB_TOKEN }}", "DISCUSSION_WRITE_ALLOWED_OPS": "add-label,remove-label,comment,close,create-issue"}}

--- a/docs/adr/0001-discussion-triage-runs-on-the-claude-subscription.md
+++ b/docs/adr/0001-discussion-triage-runs-on-the-claude-subscription.md
@@ -1,0 +1,17 @@
+---
+status: accepted
+date: 2026-08-29
+---
+
+# Discussion triage runs on claude-code-action with the Claude subscription
+
+The triage workflow (`.github/workflows/triage.yml`) runs `anthropics/claude-code-action` with a subscription OAuth token, so every triage run is covered by the Claude subscription that is already paid for. The playbook, the write helper, the labels, and the sweep are model-agnostic; only the action step and its MCP setup name Claude.
+
+## Considered options
+
+- **`openai/codex-action`**: rejected. Its only auth input is `openai-api-key`, which the action feeds through a Responses API proxy. There is no ChatGPT subscription login, so each triage run would bill per token on the OpenAI API, on top of any ChatGPT plan. Checked against the README on 2026-08-29.
+- **`claude-code-action` with `anthropic_api_key`**: not taken. Same action, per-token billing.
+
+## Consequences
+
+If the Claude subscription ends, the workflow keeps running on `anthropic_api_key` with per-token cost, and the sweep pace in `triage.yml` must drop before the cron fires again. A port to Codex rewrites the action step, the MCP setup step, and the tool allowlist as a permission profile, at API cost either way.

--- a/docs/adr/0001-discussion-triage-runs-on-the-claude-subscription.md
+++ b/docs/adr/0001-discussion-triage-runs-on-the-claude-subscription.md
@@ -14,4 +14,4 @@ The triage workflow (`.github/workflows/triage.yml`) runs `anthropics/claude-cod
 
 ## Consequences
 
-If the Claude subscription ends, the workflow keeps running on `anthropic_api_key` with per-token cost, and the sweep pace in `triage.yml` must drop before the cron fires again. A port to Codex rewrites the action step, the MCP setup step, and the tool allowlist as a permission profile, at API cost either way.
+If the Claude subscription ends, the workflow stops until the action step is switched to `anthropic_api_key`, and the sweep pace in `triage.yml` must drop before the cron fires again. A port to Codex rewrites the action step, the MCP setup step, and the tool allowlist as a permission profile, at API cost either way.

--- a/docs/agents/triage.md
+++ b/docs/agents/triage.md
@@ -36,7 +36,7 @@ Only a local session writes `.out-of-scope/`, when a human rejects a request on 
 
 ## Steps
 
-1. Read the discussion, its comments, and its labels. If a comment holds prior triage notes, read them first. Do not ask a question that those notes already answer.
+1. Read the discussion, its comments, and its labels. If the discussion is closed, stop and report that it was triaged before. If it carries `needs-info`, `ready-for-agent`, `ready-for-human`, or `wontfix`, and the discussion author has not commented after the last triage comment, stop and report the same. If a comment holds prior triage notes, read them first. Do not ask a question that those notes already answer.
 2. Read `CONTEXT.md` and `docs/architecture.md` for the area that the discussion names.
 3. Search for the same request in open and closed discussions and in open issues. Search by the domain concept, not by the words of the reporter.
 4. Read every file in `.out-of-scope/`. Compare by concept, not by keyword.


### PR DESCRIPTION
## Description

Follow-ups to #2472. `gh workflow run triage.yml` with no input runs the sweep by hand. A concurrency group keyed on the discussion number queues a second run on the same discussion, and the playbook stops early on a discussion that was triaged before, so a creation event and the sweep cannot both promote it. `create-issue` reuses an existing issue for the discussion. The turn cap is removed; `timeout-minutes: 15` is the only ceiling.

Adds `docs/adr/0001` recording why triage runs on `claude-code-action` with the subscription token and why `openai/codex-action` was rejected (API-key auth only).

## How has this been tested?

The issue lookup was run against the live repo: finds #2473 for discussion #1845, empty for a made-up number. The workflow expressions were checked with actionlint in review. The bare `gh workflow run triage.yml` sweep runs once after merge.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Manual triage runs can process a specific discussion or sweep the outstanding backlog.
  - Triage runs are serialized per discussion to prevent conflicting updates.
  - Re-running promotion workflows no longer creates duplicate issues.

- **Bug Fixes**
  - Improved handling of closed or terminal-state discussions.
  - Triage avoids redundant follow-up when prior notes resolve a question.

- **Documentation**
  - Updated triage guidance and clarified operational requirements and subscription limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->