### PR TITLE
fix(indexers): keep activity lists in a stable order

### DIFF
--- a/internal/services/jackett/scheduler.go
+++ b/internal/services/jackett/scheduler.go
@@ -4,11 +4,14 @@
 package jackett
 
 import (
+	"cmp"
 	"container/heap"
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net/url"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -292,13 +295,9 @@ type taskItem struct {
 
 type taskHeap []*taskItem
 
-func (h taskHeap) Len() int { return len(h) }
-func (h taskHeap) Less(i, j int) bool {
-	if h[i].priority == h[j].priority {
-		return h[i].created.Before(h[j].created)
-	}
-	return h[i].priority < h[j].priority
-}
+func (h taskHeap) Len() int           { return len(h) }
+func (h taskHeap) Less(i, j int) bool { return compareTasks(h[i], h[j]) < 0 }
+
 func (h taskHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i]; h[i].index = i; h[j].index = j }
 func (h *taskHeap) Push(x any) {
 	item := x.(*taskItem)
@@ -313,6 +312,18 @@ func (h *taskHeap) Pop() any {
 	item.index = -1
 	*h = old[0 : n-1]
 	return item
+}
+
+// compareTasks orders tasks the way the scheduler dequeues them: highest
+// priority first, then oldest, with the task ID to break ties.
+func compareTasks(a, b *taskItem) int {
+	if c := cmp.Compare(a.priority, b.priority); c != 0 {
+		return c
+	}
+	if c := a.created.Compare(b.created); c != 0 {
+		return c
+	}
+	return cmp.Compare(a.task.taskID, b.task.taskID)
 }
 
 // jobState tracks completion status for a multi-indexer job.
@@ -955,9 +966,10 @@ func (s *searchScheduler) GetStatus() SchedulerStatus {
 		WorkersInUse:  len(s.workerPool),
 	}
 
-	// Collect queued tasks
-	for i := 0; i < s.taskQueue.Len(); i++ {
-		item := s.taskQueue[i]
+	// Collect queued tasks by priority and age; the heap array is not sorted.
+	queued := slices.Clone(s.taskQueue)
+	slices.SortFunc(queued, compareTasks)
+	for _, item := range queued {
 		priority := "background"
 		if item.task.meta != nil && item.task.meta.rateLimit != nil {
 			priority = string(item.task.meta.rateLimit.Priority)
@@ -973,27 +985,33 @@ func (s *searchScheduler) GetStatus() SchedulerStatus {
 		})
 	}
 
-	// Collect in-flight tasks with full details
-	for _, item := range s.inFlight {
-		if item != nil {
-			priority := "background"
-			if item.task.meta != nil && item.task.meta.rateLimit != nil {
-				priority = string(item.task.meta.rateLimit.Priority)
-			}
-			status.InFlightTasks = append(status.InFlightTasks, SchedulerTaskStatus{
-				JobID:       item.task.jobID,
-				TaskID:      item.task.taskID,
-				IndexerID:   item.task.indexer.ID,
-				IndexerName: item.task.indexer.Name,
-				Priority:    priority,
-				CreatedAt:   item.created,
-				IsRSS:       item.task.isRSS,
-			})
+	// Collect in-flight tasks with full details, oldest first.
+	inFlight := slices.Collect(maps.Values(s.inFlight))
+	slices.SortFunc(inFlight, func(a, b *taskItem) int {
+		if c := a.created.Compare(b.created); c != 0 {
+			return c
 		}
+		return cmp.Compare(a.task.taskID, b.task.taskID)
+	})
+	for _, item := range inFlight {
+		priority := "background"
+		if item.task.meta != nil && item.task.meta.rateLimit != nil {
+			priority = string(item.task.meta.rateLimit.Priority)
+		}
+		status.InFlightTasks = append(status.InFlightTasks, SchedulerTaskStatus{
+			JobID:       item.task.jobID,
+			TaskID:      item.task.taskID,
+			IndexerID:   item.task.indexer.ID,
+			IndexerName: item.task.indexer.Name,
+			Priority:    priority,
+			CreatedAt:   item.created,
+			IsRSS:       item.task.isRSS,
+		})
 	}
 
-	// Collect active jobs
-	for jobID, job := range s.jobs {
+	// Collect active jobs, lowest job ID first.
+	for _, jobID := range slices.Sorted(maps.Keys(s.jobs)) {
+		job := s.jobs[jobID]
 		status.ActiveJobs = append(status.ActiveJobs, SchedulerJobStatus{
 			JobID:          jobID,
 			TotalTasks:     job.totalTasks,

--- a/internal/services/jackett/scheduler_test.go
+++ b/internal/services/jackett/scheduler_test.go
@@ -1157,3 +1157,102 @@ func TestWithMinRequestInterval(t *testing.T) {
 	fast.rateLimiter.RecordRequestComplete(indexer.ID, time.Now())
 	require.LessOrEqual(t, fast.rateLimiter.NextWait(indexer), time.Millisecond)
 }
+
+func TestSchedulerGetStatusOrdersTasksDeterministically(t *testing.T) {
+	base := time.Now()
+	newItem := func(taskID uint64, indexerID int, priority int, age time.Duration) *taskItem {
+		return &taskItem{
+			task: workerTask{
+				jobID:   1,
+				taskID:  taskID,
+				indexer: &models.TorznabIndexer{ID: indexerID, Name: "Indexer"},
+			},
+			priority: priority,
+			created:  base.Add(age),
+		}
+	}
+
+	s := &searchScheduler{
+		inFlight:   make(map[int]*taskItem),
+		jobs:       make(map[uint64]*jobState),
+		workerPool: make(chan struct{}, 4),
+	}
+
+	// Queued: a push order whose heap array is [4 5 1 2 3 6], so the raw array
+	// cannot pass for dequeue order. Tasks 1 and 6 share a priority and a
+	// creation time, so the task ID has to break the tie.
+	queuedItems := []*taskItem{
+		newItem(1, 11, 2, time.Second),
+		newItem(2, 12, 2, 2*time.Second),
+		newItem(3, 13, 1, 3*time.Second),
+		newItem(4, 14, 0, 4*time.Second),
+		newItem(5, 15, 1, time.Second),
+		newItem(6, 16, 2, time.Second),
+	}
+	for _, item := range queuedItems {
+		heap.Push(&s.taskQueue, item)
+	}
+
+	// In-flight: two tasks share a creation time so the task ID has to break the tie.
+	for _, item := range []*taskItem{
+		newItem(20, 20, 0, 3*time.Second),
+		newItem(22, 22, 0, time.Second),
+		newItem(21, 21, 0, time.Second),
+	} {
+		s.inFlight[item.task.indexer.ID] = item
+	}
+
+	s.jobs[7] = &jobState{totalTasks: 1}
+	s.jobs[3] = &jobState{totalTasks: 1}
+	s.jobs[5] = &jobState{totalTasks: 1}
+
+	wantQueued := []uint64{4, 5, 3, 1, 6, 2}
+	wantInFlight := []uint64{21, 22, 20}
+	wantJobs := []uint64{3, 5, 7}
+
+	for range 20 {
+		status := s.GetStatus()
+
+		gotQueued := make([]uint64, 0, len(status.QueuedTasks))
+		for _, task := range status.QueuedTasks {
+			gotQueued = append(gotQueued, task.TaskID)
+		}
+		if !slices.Equal(gotQueued, wantQueued) {
+			t.Fatalf("queued order = %v, want %v", gotQueued, wantQueued)
+		}
+
+		gotInFlight := make([]uint64, 0, len(status.InFlightTasks))
+		for _, task := range status.InFlightTasks {
+			gotInFlight = append(gotInFlight, task.TaskID)
+		}
+		if !slices.Equal(gotInFlight, wantInFlight) {
+			t.Fatalf("in-flight order = %v, want %v", gotInFlight, wantInFlight)
+		}
+
+		gotJobs := make([]uint64, 0, len(status.ActiveJobs))
+		for _, job := range status.ActiveJobs {
+			gotJobs = append(gotJobs, job.JobID)
+		}
+		if !slices.Equal(gotJobs, wantJobs) {
+			t.Fatalf("active job order = %v, want %v", gotJobs, wantJobs)
+		}
+	}
+
+	// The same task set pushed in the opposite order gives a different heap
+	// array, and must still come back in the same order.
+	reversed := &searchScheduler{
+		inFlight:   make(map[int]*taskItem),
+		jobs:       make(map[uint64]*jobState),
+		workerPool: make(chan struct{}, 4),
+	}
+	for _, item := range slices.Backward(queuedItems) {
+		heap.Push(&reversed.taskQueue, item)
+	}
+	gotQueued := make([]uint64, 0, len(queuedItems))
+	for _, task := range reversed.GetStatus().QueuedTasks {
+		gotQueued = append(gotQueued, task.TaskID)
+	}
+	if !slices.Equal(gotQueued, wantQueued) {
+		t.Fatalf("queued order after reversed pushes = %v, want %v", gotQueued, wantQueued)
+	}
+}

--- a/internal/services/jackett/service.go
+++ b/internal/services/jackett/service.go
@@ -4,6 +4,7 @@
 package jackett
 
 import (
+	"cmp"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -4607,6 +4608,15 @@ func (s *Service) GetActivityStatus(ctx context.Context) (*ActivityStatus, error
 					})
 				}
 			}
+			slices.SortFunc(status.CooldownIndexers, func(a, b IndexerCooldownStatus) int {
+				if c := a.CooldownEnd.Compare(b.CooldownEnd); c != 0 {
+					return c
+				}
+				if c := cmp.Compare(a.IndexerName, b.IndexerName); c != 0 {
+					return c
+				}
+				return cmp.Compare(a.IndexerID, b.IndexerID)
+			})
 		}
 	}
 

--- a/internal/services/jackett/service_test.go
+++ b/internal/services/jackett/service_test.go
@@ -3631,3 +3631,37 @@ func TestExecuteIndexerSearchSchedulesLatencyCleanup(t *testing.T) {
 	case <-time.After(50 * time.Millisecond):
 	}
 }
+
+func TestGetActivityStatusOrdersCooldownsByEnd(t *testing.T) {
+	store := &mockTorznabIndexerStore{indexers: []*models.TorznabIndexer{
+		{ID: 1, Name: "Alpha"},
+		{ID: 2, Name: "Charlie"},
+		{ID: 3, Name: "Bravo"},
+		{ID: 4, Name: "Delta"},
+	}}
+	service := NewService(store)
+	defer service.searchScheduler.Stop()
+
+	base := time.Now().Add(time.Minute)
+	// Indexers 2 and 3 share a cooldown end, and their names sort the opposite
+	// way from their IDs, so the name tiebreak has to decide.
+	service.rateLimiter.SetCooldown(1, rateLimitScopeQuery, base.Add(3*time.Minute))
+	service.rateLimiter.SetCooldown(2, rateLimitScopeQuery, base.Add(time.Minute))
+	service.rateLimiter.SetCooldown(3, rateLimitScopeGrab, base.Add(time.Minute))
+	service.rateLimiter.SetCooldown(4, rateLimitScopeQuery, base)
+
+	want := []int{4, 3, 2, 1}
+	for range 20 {
+		status, err := service.GetActivityStatus(context.Background())
+		if err != nil {
+			t.Fatalf("GetActivityStatus() error = %v", err)
+		}
+		got := make([]int, 0, len(status.CooldownIndexers))
+		for _, cooldown := range status.CooldownIndexers {
+			got = append(got, cooldown.IndexerID)
+		}
+		if !slices.Equal(got, want) {
+			t.Fatalf("cooldown order = %v, want %v", got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Description

The Scheduler Activity panel reordered its rate-limited, running, and queued rows on every refresh, because the backend built those lists from Go maps and from the heap array. Each list now comes back in a fixed order: rate-limited indexers by cooldown end, queued tasks by priority and age, running tasks oldest first, active jobs by job ID.

The queue and the status list now share one comparator, so the displayed order cannot drift away from the order the scheduler dequeues in.

Fixes #2477

## How has this been tested?

Ran the built binary against a stub Torznab server that answers every search with 429 and a different `Retry-After` per indexer. With three indexers in cooldown, five consecutive calls to `/api/torznab/activity` returned the same list each time, sorted by cooldown end.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduler status reporting with consistent ordering for queued tasks, in-flight tasks, and active jobs.
  * Ensured cooldown statuses are displayed in a stable order based on cooldown time and indexer details.

* **Tests**
  * Added coverage confirming status results remain deterministic across repeated requests and varying insertion order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->