### PR TITLE
fix(orphanscan): drop scan roots covered by ignore paths

### DIFF
--- a/documentation/docs/features/orphan-scan.md
+++ b/documentation/docs/features/orphan-scan.md
@@ -53,6 +53,8 @@ qui scans a directory only if at least one torrent points to it. If you delete a
 
 <OrphanScanDefaultIgnores />
 
+If an ignore path is a scan path, or a directory above a scan path, qui removes that scan path from the run. Use this when a save path is not available on the host that runs qui. If the ignore paths remove all scan paths, the run fails and tells you that the ignore paths cover every scan path.
+
 ## Max files per run behavior
 
 1. qui walks all scan roots during each run to keep the scan scope complete.

--- a/internal/services/orphanscan/service.go
+++ b/internal/services/orphanscan/service.go
@@ -552,6 +552,11 @@ func (s *Service) executeScan(ctx context.Context, instanceID int, runID int64) 
 	tfm := result.fileMap
 	scanRoots := result.scanRoots
 
+	// A save path that is not mounted on the qui host would otherwise fail the
+	// run on lstat, with no way for the user to exclude it (issue #2483).
+	rootsBeforeIgnore := len(scanRoots)
+	scanRoots = filterCoveredScanRoots(scanRoots, settings.IgnorePaths)
+
 	log.Info().
 		Int("files", tfm.Len()).
 		Int("roots", len(scanRoots)).
@@ -574,6 +579,10 @@ func (s *Service) executeScan(ctx context.Context, instanceID int, runID int64) 
 
 	if len(scanRoots) == 0 {
 		log.Warn().Msg("orphanscan: no scan roots found")
+		if rootsBeforeIgnore > 0 {
+			s.failRun(ctx, runID, instanceID, "no scan roots left: ignore paths cover every scan path")
+			return
+		}
 		if len(result.skippedRoots) > 0 {
 			s.failRun(ctx, runID, instanceID, "no scan roots available: qBittorrent still has transitional torrents with unavailable file lists")
 			return
@@ -1167,12 +1176,12 @@ func isSameOrDescendantPath(path, base string) bool {
 	return nPath == nBase || isPathUnderNormalized(nPath, nBase)
 }
 
-func filterScanRootsCoveredBySkippedRoots(scanRoots, skippedRoots []string) []string {
+func filterCoveredScanRoots(scanRoots, covers []string) []string {
 	filtered := make([]string, 0, len(scanRoots))
 	for _, root := range scanRoots {
 		covered := false
-		for _, skippedRoot := range skippedRoots {
-			if isSameOrDescendantPath(root, skippedRoot) {
+		for _, cover := range covers {
+			if isSameOrDescendantPath(root, cover) {
 				covered = true
 				break
 			}
@@ -1400,7 +1409,7 @@ func buildFileMapFromTorrents(torrents []qbt.Torrent, filesByHash map[string]qbt
 	}
 
 	skippedRootList := sortedRoots(skippedRoots)
-	scanRootList := filterScanRootsCoveredBySkippedRoots(sortedRoots(scanRoots), skippedRootList)
+	scanRootList := filterCoveredScanRoots(sortedRoots(scanRoots), skippedRootList)
 
 	return &buildFileMapResult{
 		fileMap:       tfm,
@@ -1540,7 +1549,7 @@ func (s *Service) buildFileMap(ctx context.Context, instanceID int, backend fsop
 		added := result.fileMap.MergeFrom(otherResult.fileMap)
 		result.skippedRoots = mergeRootLists(result.skippedRoots, otherResult.skippedRoots)
 		result.metadataRoots = mergeRootLists(result.metadataRoots, otherResult.metadataRoots)
-		result.scanRoots = filterScanRootsCoveredBySkippedRoots(result.scanRoots, result.skippedRoots)
+		result.scanRoots = filterCoveredScanRoots(result.scanRoots, result.skippedRoots)
 		log.Debug().
 			Int("instance", inst.ID).
 			Int("filesAdded", added).

--- a/internal/services/orphanscan/service_scan_ignore_test.go
+++ b/internal/services/orphanscan/service_scan_ignore_test.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package orphanscan
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/fsops"
+	"github.com/autobrr/qui/internal/fsops/local"
+	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/testutil/testdb"
+)
+
+type stubInstanceGetter struct{}
+
+func (stubInstanceGetter) Get(_ context.Context, id int) (*models.Instance, error) {
+	return &models.Instance{ID: id, Name: "test", IsActive: true, HasLocalFilesystemAccess: true}, nil
+}
+
+// newScanTestService wires a service that scans one instance holding two
+// torrents: one in an existing save path, one in a save path that does not
+// exist on this host (issue #2483).
+func newScanTestService(t *testing.T) (*Service, *models.OrphanScanStore, string, string) {
+	t.Helper()
+
+	base := t.TempDir()
+	presentRoot := filepath.Join(base, "library")
+	missingRoot := filepath.Join(base, "staging", "movies")
+	require.NoError(t, os.MkdirAll(presentRoot, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(presentRoot, "owned.mkv"), []byte("x"), 0o600))
+
+	db := testdb.NewMigratedSQLite(t, "orphanscan-ignore-roots")
+	instanceStore, err := models.NewInstanceStore(db, []byte("01234567890123456789012345678901"))
+	require.NoError(t, err)
+	instance, err := instanceStore.Create(t.Context(), "test", "http://127.0.0.1:8080", "user", "pass", nil, nil, false, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, instance.ID)
+
+	store := models.NewOrphanScanStore(db)
+
+	svc := NewService(DefaultConfig(), nil, store, nil, nil, fsops.NewPool(stubInstanceGetter{}, local.NewBackend()))
+	svc.getClientProvider = func(_ context.Context, _ int) (healthChecker, error) {
+		return stubHealthChecker{healthy: true, lastSync: time.Now().Add(-time.Minute)}, nil
+	}
+	svc.listInstancesProvider = func(_ context.Context) ([]*models.Instance, error) {
+		return []*models.Instance{{ID: 1, Name: "test", IsActive: true, HasLocalFilesystemAccess: true}}, nil
+	}
+	svc.getAllTorrentsProvider = func(_ context.Context, _ int) ([]qbt.Torrent, error) {
+		return []qbt.Torrent{
+			{Hash: "present", SavePath: presentRoot, State: qbt.TorrentStatePausedUp},
+			{Hash: "missing", SavePath: missingRoot, State: qbt.TorrentStatePausedUp},
+		}, nil
+	}
+	svc.getTorrentFilesBatchProvider = func(_ context.Context, _ int, _ []string) (map[string]qbt.TorrentFiles, error) {
+		return map[string]qbt.TorrentFiles{
+			"present": {{Name: "owned.mkv", Size: 1}},
+			"missing": {{Name: "unreachable.mkv", Size: 1}},
+		}, nil
+	}
+
+	return svc, store, presentRoot, missingRoot
+}
+
+func setIgnorePaths(t *testing.T, store *models.OrphanScanStore, ignorePaths []string) {
+	t.Helper()
+
+	defaults := DefaultSettings()
+	_, err := store.UpsertSettings(t.Context(), &models.OrphanScanSettings{
+		InstanceID:          1,
+		Enabled:             true,
+		GracePeriodMinutes:  0,
+		IgnorePaths:         ignorePaths,
+		ScanIntervalHours:   defaults.ScanIntervalHours,
+		PreviewSort:         defaults.PreviewSort,
+		MaxFilesPerRun:      defaults.MaxFilesPerRun,
+		AutoCleanupMaxFiles: defaults.AutoCleanupMaxFiles,
+	})
+	require.NoError(t, err)
+}
+
+func runScanForTest(t *testing.T, svc *Service, store *models.OrphanScanStore) *models.OrphanScanRun {
+	t.Helper()
+
+	ctx := t.Context()
+	runID, err := store.CreateRunIfNoActive(ctx, 1, "manual")
+	require.NoError(t, err)
+	svc.executeScan(ctx, 1, runID)
+
+	run, err := store.GetRun(ctx, runID)
+	require.NoError(t, err)
+	require.NotNil(t, run)
+	return run
+}
+
+// An unreachable save path fails the whole run today. Ignoring that path must
+// drop the scan root instead of walking it (issue #2483).
+func TestExecuteScan_IgnorePathDropsUnreachableScanRoot(t *testing.T) {
+	t.Parallel()
+
+	svc, store, presentRoot, missingRoot := newScanTestService(t)
+
+	failed := runScanForTest(t, svc, store)
+	assert.Equal(t, "failed", failed.Status)
+	assert.Contains(t, failed.ErrorMessage, missingRoot)
+
+	setIgnorePaths(t, store, []string{missingRoot})
+	run := runScanForTest(t, svc, store)
+	assert.Equal(t, "completed", run.Status)
+	assert.Empty(t, run.ErrorMessage)
+	assert.Equal(t, []string{filepath.Clean(presentRoot)}, run.ScanPaths)
+}
+
+// Ignoring a parent of every save path leaves nothing to walk, and the run must
+// say so instead of reporting that no torrent has an absolute save path.
+func TestExecuteScan_IgnorePathsCoverEveryScanRoot(t *testing.T) {
+	t.Parallel()
+
+	svc, store, presentRoot, _ := newScanTestService(t)
+	setIgnorePaths(t, store, []string{filepath.Dir(presentRoot)})
+
+	run := runScanForTest(t, svc, store)
+	assert.Equal(t, "failed", run.Status)
+	assert.Equal(t, "no scan roots left: ignore paths cover every scan path", run.ErrorMessage)
+}

--- a/internal/services/orphanscan/settling_test.go
+++ b/internal/services/orphanscan/settling_test.go
@@ -206,31 +206,53 @@ func TestBuildFileMapFromTorrents_SkipsSharedRootWhenTransientTorrentHasNoFiles(
 	assert.True(t, result.fileMap.Has(normalizePath(filepath.Join(root, "movie.mkv"))))
 }
 
-func TestFilterScanRootsCoveredBySkippedRoots(t *testing.T) {
+func TestFilterCoveredScanRoots(t *testing.T) {
 	t.Parallel()
 
-	root := filepath.Join(t.TempDir(), "library")
+	base := t.TempDir()
+	root := filepath.Join(base, "library")
 	child := filepath.Join(root, "transient")
 	descendant := filepath.Join(child, "nested")
 	sibling := filepath.Join(root, "stable")
+	staging := filepath.Join(base, "staging")
+	staging2 := filepath.Join(base, "staging2")
+	stagingUpper := filepath.Join(base, "Staging")
 
 	tests := []struct {
-		name         string
-		scanRoots    []string
-		skippedRoots []string
-		want         []string
+		name      string
+		scanRoots []string
+		covers    []string
+		want      []string
 	}{
 		{
-			name:         "keeps parent root when skipped root is child",
-			scanRoots:    []string{root, sibling},
-			skippedRoots: []string{child},
-			want:         []string{filepath.Clean(root), filepath.Clean(sibling)},
+			name:      "keeps parent root when cover is child",
+			scanRoots: []string{root, sibling},
+			covers:    []string{child},
+			want:      []string{filepath.Clean(root), filepath.Clean(sibling)},
 		},
 		{
-			name:         "drops descendant root covered by skipped ancestor",
-			scanRoots:    []string{descendant, sibling},
-			skippedRoots: []string{child},
-			want:         []string{filepath.Clean(sibling)},
+			name:      "drops descendant root covered by ancestor",
+			scanRoots: []string{descendant, sibling},
+			covers:    []string{child},
+			want:      []string{filepath.Clean(sibling)},
+		},
+		{
+			name:      "drops root equal to cover",
+			scanRoots: []string{staging, sibling},
+			covers:    []string{staging},
+			want:      []string{filepath.Clean(sibling)},
+		},
+		{
+			name:      "keeps root that only shares a string prefix",
+			scanRoots: []string{staging2},
+			covers:    []string{staging},
+			want:      []string{filepath.Clean(staging2)},
+		},
+		{
+			name:      "drops root spelled with different case",
+			scanRoots: []string{stagingUpper, sibling},
+			covers:    []string{staging},
+			want:      []string{filepath.Clean(sibling)},
 		},
 	}
 
@@ -238,7 +260,7 @@ func TestFilterScanRootsCoveredBySkippedRoots(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := filterScanRootsCoveredBySkippedRoots(tt.scanRoots, tt.skippedRoots)
+			got := filterCoveredScanRoots(tt.scanRoots, tt.covers)
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
## Description

Orphan scan walked every scan root it derived from torrent save paths, even a root the user had listed in ignore paths. A save path that is not mounted on the qui host failed the walk on lstat, and there was no way to exclude it. Scan roots are now filtered against the ignore paths before the run records its scan paths and before the walk. An ignore path below a root still only skips that subtree.

Fixes #2483

## How has this been tested?

Ran the built binary against a throwaway qBittorrent container with one save path present on the host and one visible only inside the container:

- no ignore paths: the run reports `walk /data/staging/movies: no such file or directory`
- ignore that path, or its parent: the root is dropped, no walk error, and the recorded scan paths hold only the reachable root
- ignore `/data/staging2`: the root is still walked, so a shared prefix does not drop it
- ignore a directory below the reachable root: the root is still walked and only that subtree is skipped
- ignore paths that cover every root: the run fails with `no scan roots left: ignore paths cover every scan path`

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Orphan scans now exclude scan paths covered by configured ignore paths.
  * Added a clear error when ignore paths exclude all available scan roots.

* **Bug Fixes**
  * Improved filtering for parent paths, exact matches, case variations, and similar-looking paths.

* **Documentation**
  * Documented how ignored paths affect orphan scans and failure conditions.

* **Tests**
  * Added coverage for reachable, unreachable, and fully excluded scan paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->