### PR TITLE
fix(automations): match tracker conditions against every tracker of a torrent

### DIFF
--- a/documentation/docs/features/automations.md
+++ b/documentation/docs/features/automations.md
@@ -140,6 +140,12 @@ If you configured [Tracker Customizations](./tracker-customizations.md) (Dashboa
 On qBittorrent versions before 5.1, qui cannot read the full tracker list. **Tracker** then sees only the tracker that qBittorrent reports as working. When qui finds no tracker at all, positive operators such as **is** and **contains** match nothing, and negative operators such as **is not** match every torrent.
 
 :::note
+Any tracker condition (**Tracker**, **Trackers (All)**, **Tracker status**, or **Tracker message**) makes qui read the tracker list of every torrent. qui sends one request for each instance and keeps the result for 5 minutes. Rules without a tracker condition, and rules that are turned off, send no extra request.
+
+On a large library, or on an instance whose qBittorrent Web UI is already slow, that request adds a delay to the automation run.
+:::
+
+:::note
 Older rules can use a second field named **Trackers (All)**. It now behaves the same as **Tracker**, so qui no longer offers it for new rules. Your existing rules keep working. To stop seeing it, change the condition to **Tracker**.
 :::
 

--- a/documentation/docs/features/automations.md
+++ b/documentation/docs/features/automations.md
@@ -126,15 +126,19 @@ When qui evaluates a rule, these fields use qui's current system time. Use them 
 
 | Field | Description |
 | --- | --- |
-| Tracker | Primary tracker (URL, domain, or customization display name) |
-| Trackers (All) | All tracker URLs/domains/display names for this torrent |
+| Tracker | Any tracker of the torrent (URL, domain, or customization display name) |
+| Trackers (All) | Same as **Tracker**: all tracker URLs, domains, and display names for this torrent |
 | Private | Boolean: the torrent uses a private tracker |
 | Unregistered | Boolean: the tracker reports unregistered (requires qBittorrent 5.1+) |
 | Tracker status | Per-tracker announce status. See [Tracker status values](#tracker-status-values) (requires qBittorrent 5.1+). |
 | Tracker message | Per-tracker status message. Use `nil` for an empty message (requires qBittorrent 5.1+). |
 | Comment | Torrent comment field |
 
-If you configured [Tracker Customizations](./tracker-customizations.md) (Dashboard → **Tracker Breakdown**), the **Tracker** condition can also match the display name in addition to the raw URL or domain.
+**Tracker** and **Trackers (All)** read the same list: every tracker the torrent announces to, including trackers that do not work. qui ignores the DHT, PeX, and LSD pseudo-trackers.
+
+If you configured [Tracker Customizations](./tracker-customizations.md) (Dashboard → **Tracker Breakdown**), both conditions can also match the display name in addition to the raw URL or domain. A merged tracker group matches by its group name.
+
+On qBittorrent versions before 5.1, qui cannot read the full tracker list. These two conditions then see only the tracker that qBittorrent reports as working. When qui finds no tracker at all, positive operators such as **is** and **contains** match nothing, and negative operators such as **is not** match every torrent.
 
 #### Mode fields
 
@@ -261,7 +265,7 @@ qui supports full RE2 (Go regex) syntax. Patterns are case-insensitive by defaul
 
 Field notes:
 
-- **Tracker**: qui checks the pattern against multiple candidates (raw URL, extracted domain, and the optional customization display name). If a regex is negative, it passes only when **none** of the candidates match.
+- **Tracker** and **Trackers (All)**: qui checks the pattern against multiple candidates for each tracker (raw URL, extracted domain, and the optional customization display name). If a regex is negative, it passes only when **none** of the candidates match.
 - **Tags**: If you do not use regex, qui applies string operators per tag. If you turn regex on, qui matches the pattern against the full raw tags string.
 
 The UI validates patterns and shows an error for invalid regex.
@@ -630,7 +634,7 @@ qui evaluates the move path as a **Go template** for each torrent. Use a fixed p
 - By tracker: `/data/{{.Tracker}}` (when a tracker display name is configured)
 
 :::note
-If you want `.Tracker` to use your [tracker customization](./tracker-customizations.md) display name, the rule also needs a **Tracker** condition. A tag action with **Use tracker name as tag** and **Use display name** enabled also works. Without one of those settings, `.Tracker` falls back to the tracker domain, and qui names your folders after the domain instead.
+If you want `.Tracker` to use your [tracker customization](./tracker-customizations.md) display name, the rule also needs a **Tracker** or **Trackers (All)** condition. A tag action with **Use tracker name as tag** and **Use display name** enabled also works. Without one of those settings, `.Tracker` falls back to the tracker domain, and qui names your folders after the domain instead.
 :::
 
 ### Auto management

--- a/documentation/docs/features/automations.md
+++ b/documentation/docs/features/automations.md
@@ -127,18 +127,21 @@ When qui evaluates a rule, these fields use qui's current system time. Use them 
 | Field | Description |
 | --- | --- |
 | Tracker | Any tracker of the torrent (URL, domain, or customization display name) |
-| Trackers (All) | Same as **Tracker**: all tracker URLs, domains, and display names for this torrent |
 | Private | Boolean: the torrent uses a private tracker |
 | Unregistered | Boolean: the tracker reports unregistered (requires qBittorrent 5.1+) |
 | Tracker status | Per-tracker announce status. See [Tracker status values](#tracker-status-values) (requires qBittorrent 5.1+). |
 | Tracker message | Per-tracker status message. Use `nil` for an empty message (requires qBittorrent 5.1+). |
 | Comment | Torrent comment field |
 
-**Tracker** and **Trackers (All)** read the same list: every tracker the torrent announces to, including trackers that do not work. qui ignores the DHT, PeX, and LSD pseudo-trackers.
+**Tracker** matches every tracker the torrent announces to, including trackers that do not work. qui ignores the DHT, PeX, and LSD pseudo-trackers.
 
-If you configured [Tracker Customizations](./tracker-customizations.md) (Dashboard → **Tracker Breakdown**), both conditions can also match the display name in addition to the raw URL or domain. A merged tracker group matches by its group name.
+If you configured [Tracker Customizations](./tracker-customizations.md) (Dashboard → **Tracker Breakdown**), the condition can also match the display name in addition to the raw URL or domain. A merged tracker group matches by its group name.
 
-On qBittorrent versions before 5.1, qui cannot read the full tracker list. These two conditions then see only the tracker that qBittorrent reports as working. When qui finds no tracker at all, positive operators such as **is** and **contains** match nothing, and negative operators such as **is not** match every torrent.
+On qBittorrent versions before 5.1, qui cannot read the full tracker list. **Tracker** then sees only the tracker that qBittorrent reports as working. When qui finds no tracker at all, positive operators such as **is** and **contains** match nothing, and negative operators such as **is not** match every torrent.
+
+:::note
+Older rules can use a second field named **Trackers (All)**. It now behaves the same as **Tracker**, so qui no longer offers it for new rules. Your existing rules keep working. To stop seeing it, change the condition to **Tracker**.
+:::
 
 #### Mode fields
 
@@ -265,7 +268,7 @@ qui supports full RE2 (Go regex) syntax. Patterns are case-insensitive by defaul
 
 Field notes:
 
-- **Tracker** and **Trackers (All)**: qui checks the pattern against multiple candidates for each tracker (raw URL, extracted domain, and the optional customization display name). If a regex is negative, it passes only when **none** of the candidates match.
+- **Tracker**: qui checks the pattern against multiple candidates for each tracker (raw URL, extracted domain, and the optional customization display name). If a regex is negative, it passes only when **none** of the candidates match.
 - **Tags**: If you do not use regex, qui applies string operators per tag. If you turn regex on, qui matches the pattern against the full raw tags string.
 
 The UI validates patterns and shows an error for invalid regex.
@@ -634,7 +637,7 @@ qui evaluates the move path as a **Go template** for each torrent. Use a fixed p
 - By tracker: `/data/{{.Tracker}}` (when a tracker display name is configured)
 
 :::note
-If you want `.Tracker` to use your [tracker customization](./tracker-customizations.md) display name, the rule also needs a **Tracker** or **Trackers (All)** condition. A tag action with **Use tracker name as tag** and **Use display name** enabled also works. Without one of those settings, `.Tracker` falls back to the tracker domain, and qui names your folders after the domain instead.
+If you want `.Tracker` to use your [tracker customization](./tracker-customizations.md) display name, the rule also needs a **Tracker** condition. A tag action with **Use tracker name as tag** and **Use display name** enabled also works. Without one of those settings, `.Tracker` falls back to the tracker domain, and qui names your folders after the domain instead.
 :::
 
 ### Auto management

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -3648,7 +3648,14 @@ type TorrentCounts struct {
 	Total            int                             `json:"total"`
 }
 
+// ExtractDomainFromURL calls the package-level ExtractDomainFromURL.
+func (sm *SyncManager) ExtractDomainFromURL(urlStr string) string {
+	return ExtractDomainFromURL(urlStr)
+}
+
 // ExtractDomainFromURL extracts the domain from a BitTorrent tracker URL with caching.
+// The Trackers filter sidebar and the automation tracker conditions both call it, so
+// they agree on which trackers a torrent belongs to.
 // Handles multiple formats:
 //   - Standard URLs with schemes (http, https, udp, ws, wss)
 //   - Scheme-less URLs (tracker.example.com/announce)
@@ -3658,7 +3665,7 @@ type TorrentCounts struct {
 //
 // Known limitation: IPv6 addresses with ports but without brackets (e.g., 2001:db8::1:8080)
 // may be parsed incorrectly. Standard format is [2001:db8::1]:8080.
-func (sm *SyncManager) ExtractDomainFromURL(urlStr string) string {
+func ExtractDomainFromURL(urlStr string) string {
 	urlStr = strings.TrimSpace(urlStr)
 	if urlStr == "" {
 		return ""

--- a/internal/services/automations/evaluator.go
+++ b/internal/services/automations/evaluator.go
@@ -5,8 +5,6 @@ package automations
 
 import (
 	"math"
-	"net"
-	"net/url"
 	"regexp"
 	"slices"
 	"strconv"
@@ -937,7 +935,10 @@ func trackerCandidates(trackerURL string, ctx *EvalContext) []string {
 	if qbittorrent.IsPseudoTrackerLabel(raw) {
 		return nil
 	}
-	domain := extractTrackerDomain(raw)
+	domain := qbittorrent.ExtractDomainFromURL(raw)
+	if domain == "Unknown" {
+		domain = ""
+	}
 	displayName := ""
 	if ctx != nil && ctx.TrackerDisplayNameByDomain != nil && domain != "" {
 		if name, ok := ctx.TrackerDisplayNameByDomain[strings.ToLower(domain)]; ok {
@@ -1008,57 +1009,6 @@ func compareStringCandidates(candidates []string, cond *RuleCondition) bool {
 	return slices.ContainsFunc(uniq, func(c string) bool {
 		return compareString(c, cond)
 	})
-}
-
-func extractTrackerDomain(raw string) string {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return ""
-	}
-
-	// URL parsing with scheme (http/https/udp/etc).
-	if u, err := url.Parse(raw); err == nil {
-		if h := u.Hostname(); h != "" {
-			return normalizeLower(h)
-		}
-	}
-
-	// Scheme-less input (tracker.example.com/announce).
-	if !strings.Contains(raw, "://") {
-		if u, err := url.Parse("//" + raw); err == nil {
-			if h := u.Hostname(); h != "" {
-				return normalizeLower(h)
-			}
-		}
-	}
-
-	// Manual fallback: host[:port][/path]
-	candidate := raw
-	if idx := strings.IndexAny(candidate, "/?#"); idx != -1 {
-		candidate = candidate[:idx]
-	}
-	candidate = strings.TrimPrefix(candidate, "//")
-	candidate = strings.TrimSpace(candidate)
-	if candidate == "" {
-		return ""
-	}
-
-	// Try to split host:port (IPv6 requires brackets for SplitHostPort).
-	if host, _, err := net.SplitHostPort(candidate); err == nil {
-		return normalizeLower(strings.Trim(host, "[]"))
-	}
-
-	// If it's a plain IP (including IPv6 without port), keep it.
-	if ip := net.ParseIP(candidate); ip != nil && strings.Contains(candidate, ":") {
-		return normalizeLower(candidate)
-	}
-
-	// Strip :port for hostnames/IPv4.
-	if idx := strings.Index(candidate, ":"); idx != -1 {
-		candidate = candidate[:idx]
-	}
-	candidate = strings.Trim(candidate, "[]")
-	return normalizeLowerTrim(candidate)
 }
 
 // compareTags compares tags against the condition, treating tags as a set.

--- a/internal/services/automations/evaluator.go
+++ b/internal/services/automations/evaluator.go
@@ -124,7 +124,8 @@ type EvalContext struct {
 	SameInstanceCrossSeedTagsByHash map[string][]string
 
 	// TrackerDisplayNameByDomain maps lowercase tracker domains to their display names.
-	// Used for UseTrackerAsTag with UseDisplayName option.
+	// Read by the TRACKER and TRACKERS conditions, and by UseTrackerAsTag with the
+	// UseDisplayName option.
 	TrackerDisplayNameByDomain map[string]string
 
 	// ReleaseParser caches parsed release metadata for RLS-derived fields.
@@ -411,9 +412,7 @@ func evaluateLeaf(cond *RuleCondition, torrent qbt.Torrent, ctx *EvalContext) bo
 		return compareRlsYearIfSet(torrentRlsYear(torrent, ctx), cond)
 	case FieldState:
 		return compareState(torrent, cond, ctx)
-	case FieldTracker:
-		return compareTracker(torrent.Tracker, cond, ctx)
-	case FieldTrackers:
+	case FieldTracker, FieldTrackers:
 		return compareTrackers(torrent, cond, ctx)
 	case FieldTrackerStatus:
 		return compareTrackerStatuses(torrent, cond)
@@ -821,10 +820,8 @@ func compareString(value string, cond *RuleCondition) bool {
 	}
 }
 
-func compareTracker(trackerURL string, cond *RuleCondition, ctx *EvalContext) bool {
-	return compareStringCandidates(trackerCandidates(trackerURL, ctx), cond)
-}
-
+// compareTrackers matches TRACKER and TRACKERS against every tracker the torrent
+// announces to: qBittorrent empties the primary tracker field when none work.
 func compareTrackers(torrent qbt.Torrent, cond *RuleCondition, ctx *EvalContext) bool {
 	candidates := make([]string, 0, len(torrent.Trackers)*3+3)
 	candidates = append(candidates, trackerCandidates(torrent.Tracker, ctx)...)
@@ -934,6 +931,12 @@ func compareTrackerMessage(message string, cond *RuleCondition) bool {
 func trackerCandidates(trackerURL string, ctx *EvalContext) []string {
 	// Candidates: raw URL, extracted domain, optional customization display name.
 	raw := strings.TrimSpace(trackerURL)
+	// DHT/PeX/LSD are peer-discovery mechanisms, not trackers. qBittorrent reports
+	// them both as entries and as the primary tracker, and they would otherwise match
+	// a "contains dht" query on nearly every public torrent.
+	if qbittorrent.IsPseudoTrackerLabel(raw) {
+		return nil
+	}
 	domain := extractTrackerDomain(raw)
 	displayName := ""
 	if ctx != nil && ctx.TrackerDisplayNameByDomain != nil && domain != "" {

--- a/internal/services/automations/evaluator_test.go
+++ b/internal/services/automations/evaluator_test.go
@@ -3821,3 +3821,130 @@ func TestEvaluateCondition_CrossSeedTags(t *testing.T) {
 		})
 	}
 }
+
+// TestEvaluateCondition_TrackerFields_AllTrackers covers issue #2481: TRACKER and
+// TRACKERS must match every tracker a torrent announces to, not only the tracker
+// qBittorrent currently reports as working (torrent.Tracker is empty when none work).
+func TestEvaluateCondition_TrackerFields_AllTrackers(t *testing.T) {
+	deadGroupCtx := &EvalContext{
+		TrackerDisplayNameByDomain: map[string]string{
+			"tracker.dead-one.test": "dead",
+			"tracker.dead-two.test": "dead",
+		},
+	}
+
+	// Every tracker is down, so qBittorrent leaves the primary tracker field empty.
+	allDead := qbt.Torrent{
+		Tracker: "",
+		Trackers: []qbt.TorrentTracker{
+			{Url: "** [DHT] **", Status: qbt.TrackerStatusDisabled},
+			{Url: "udp://tracker.dead-one.test:1337/announce", Status: qbt.TrackerStatusNotWorking},
+			{Url: "udp://tracker.dead-two.test:1337/announce", Status: qbt.TrackerStatusNotWorking},
+		},
+	}
+
+	// A working primary plus a second tracker on another domain.
+	multiTracker := qbt.Torrent{
+		Tracker: "https://primary.test/announce",
+		Trackers: []qbt.TorrentTracker{
+			{Url: "https://primary.test/announce", Status: qbt.TrackerStatusOK},
+			{Url: "https://secondary.test/announce", Status: qbt.TrackerStatusOK},
+		},
+	}
+
+	// qBittorrent also reports a pseudo label in the primary tracker field.
+	pseudoPrimary := qbt.Torrent{Tracker: "** [DHT] **"}
+
+	pseudoOnly := qbt.Torrent{
+		Trackers: []qbt.TorrentTracker{
+			{Url: "** [DHT] **", Status: qbt.TrackerStatusDisabled},
+			{Url: "** [PeX] **", Status: qbt.TrackerStatusDisabled},
+			{Url: "** [LSD] **", Status: qbt.TrackerStatusDisabled},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		cond     *RuleCondition
+		torrent  qbt.Torrent
+		ctx      *EvalContext
+		expected bool
+	}{
+		{
+			name:     "tracker matches customization display name when no tracker works",
+			cond:     &RuleCondition{Field: FieldTracker, Operator: OperatorEqual, Value: "dead"},
+			torrent:  allDead,
+			ctx:      deadGroupCtx,
+			expected: true,
+		},
+		{
+			name:     "trackers matches customization display name when no tracker works",
+			cond:     &RuleCondition{Field: FieldTrackers, Operator: OperatorEqual, Value: "dead"},
+			torrent:  allDead,
+			ctx:      deadGroupCtx,
+			expected: true,
+		},
+		{
+			name:     "tracker matches domain when no tracker works",
+			cond:     &RuleCondition{Field: FieldTracker, Operator: OperatorEqual, Value: "tracker.dead-two.test"},
+			torrent:  allDead,
+			expected: true,
+		},
+		{
+			name:     "tracker matches a non-primary tracker",
+			cond:     &RuleCondition{Field: FieldTracker, Operator: OperatorEqual, Value: "secondary.test"},
+			torrent:  multiTracker,
+			expected: true,
+		},
+		{
+			name:     "trackers matches a non-primary tracker",
+			cond:     &RuleCondition{Field: FieldTrackers, Operator: OperatorContains, Value: "secondary.test"},
+			torrent:  multiTracker,
+			expected: true,
+		},
+		{
+			name:     "tracker still matches the primary tracker",
+			cond:     &RuleCondition{Field: FieldTracker, Operator: OperatorEqual, Value: "primary.test"},
+			torrent:  multiTracker,
+			expected: true,
+		},
+		{
+			name:     "tracker does not match an absent domain",
+			cond:     &RuleCondition{Field: FieldTracker, Operator: OperatorEqual, Value: "elsewhere.test"},
+			torrent:  multiTracker,
+			expected: false,
+		},
+		{
+			name:     "not equal is false when a non-primary tracker matches",
+			cond:     &RuleCondition{Field: FieldTracker, Operator: OperatorNotEqual, Value: "secondary.test"},
+			torrent:  multiTracker,
+			expected: false,
+		},
+		{
+			name:     "tracker ignores DHT pseudo trackers",
+			cond:     &RuleCondition{Field: FieldTracker, Operator: OperatorContains, Value: "dht"},
+			torrent:  pseudoOnly,
+			expected: false,
+		},
+		{
+			name:     "pseudo only torrent is treated as having no tracker",
+			cond:     &RuleCondition{Field: FieldTracker, Operator: OperatorEqual, Value: ""},
+			torrent:  pseudoOnly,
+			expected: true,
+		},
+		{
+			name:     "tracker ignores a pseudo label in the primary tracker field",
+			cond:     &RuleCondition{Field: FieldTracker, Operator: OperatorContains, Value: "dht"},
+			torrent:  pseudoPrimary,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EvaluateConditionWithContext(tt.cond, tt.torrent, tt.ctx, 0); got != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, got)
+			}
+		})
+	}
+}

--- a/internal/services/automations/service.go
+++ b/internal/services/automations/service.go
@@ -5081,7 +5081,19 @@ func (s *Service) hydrateTorrentTrackersForRule(ctx context.Context, instanceID 
 	if !rulesUseTrackerEntryData([]*models.Automation{rule}) {
 		return torrents
 	}
-	return s.syncManager.HydrateTorrentTrackers(ctx, instanceID, torrents)
+
+	hydrated := s.syncManager.HydrateTorrentTrackers(ctx, instanceID, torrents)
+	// The rule needs tracker entries. When none arrive, the tracker conditions
+	// match nothing, and the reason (a failed fetch, or qBittorrent below 5.1)
+	// is otherwise only visible at trace level with no rule context.
+	if len(hydrated) > 0 && !slices.ContainsFunc(hydrated, func(t qbt.Torrent) bool { return len(t.Trackers) > 0 }) {
+		log.Debug().
+			Int("instanceID", instanceID).
+			Str("rule", rule.Name).
+			Int("torrents", len(hydrated)).
+			Msg("automations: no tracker data for any torrent, tracker conditions will not match")
+	}
+	return hydrated
 }
 
 // rulesUseCondition checks if any enabled rule uses the given field.

--- a/internal/services/automations/service.go
+++ b/internal/services/automations/service.go
@@ -2026,6 +2026,12 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 
 	if rulesUseTrackerEntryData(eligibleRules) {
 		torrents = s.syncManager.HydrateTorrentTrackers(ctx, instanceID, torrents)
+		if trackerDataMissing(torrents) {
+			log.Debug().
+				Int("instanceID", instanceID).
+				Int("torrents", len(torrents)).
+				Msg("automations: no tracker data for any torrent, tracker conditions will not match")
+		}
 	}
 
 	// Get instance for local filesystem access check
@@ -5083,10 +5089,7 @@ func (s *Service) hydrateTorrentTrackersForRule(ctx context.Context, instanceID 
 	}
 
 	hydrated := s.syncManager.HydrateTorrentTrackers(ctx, instanceID, torrents)
-	// The rule needs tracker entries. When none arrive, the tracker conditions
-	// match nothing, and the reason (a failed fetch, or qBittorrent below 5.1)
-	// is otherwise only visible at trace level with no rule context.
-	if len(hydrated) > 0 && !slices.ContainsFunc(hydrated, func(t qbt.Torrent) bool { return len(t.Trackers) > 0 }) {
+	if trackerDataMissing(hydrated) {
 		log.Debug().
 			Int("instanceID", instanceID).
 			Str("rule", rule.Name).
@@ -5094,6 +5097,12 @@ func (s *Service) hydrateTorrentTrackersForRule(ctx context.Context, instanceID 
 			Msg("automations: no tracker data for any torrent, tracker conditions will not match")
 	}
 	return hydrated
+}
+
+// trackerDataMissing reports that no torrent carries tracker entries. An empty
+// torrent list is not missing data: it says nothing about hydration.
+func trackerDataMissing(torrents []qbt.Torrent) bool {
+	return len(torrents) > 0 && !slices.ContainsFunc(torrents, func(t qbt.Torrent) bool { return len(t.Trackers) > 0 })
 }
 
 // rulesUseCondition checks if any enabled rule uses the given field.

--- a/internal/services/automations/service.go
+++ b/internal/services/automations/service.go
@@ -937,7 +937,7 @@ func (s *Service) setupPreviewTrackerDisplayNames(ctx context.Context, instanceI
 	if s == nil || s.trackerCustomizationStore == nil {
 		return
 	}
-	if !ConditionUsesField(cond, FieldTracker) {
+	if !ConditionUsesField(cond, FieldTracker) && !ConditionUsesField(cond, FieldTrackers) {
 		return
 	}
 
@@ -2169,9 +2169,9 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 		s.loadCrossSeedFiles(ctx, instanceID, buildContentPathIndex(torrents), evalCtx)
 	}
 
-	// Load tracker display names when needed by tagging OR by TRACKER conditions.
+	// Load tracker display names when needed by tagging OR by TRACKER/TRACKERS conditions.
 	// KISS: only load customizations when a rule actually references them.
-	if (rulesUseTrackerDisplayName(eligibleRules) || rulesUseCondition(eligibleRules, FieldTracker)) && s.trackerCustomizationStore != nil {
+	if (rulesUseTrackerDisplayName(eligibleRules) || rulesUseCondition(eligibleRules, FieldTracker) || rulesUseCondition(eligibleRules, FieldTrackers)) && s.trackerCustomizationStore != nil {
 		customizations, err := s.trackerCustomizationStore.List(ctx)
 		if err != nil {
 			log.Warn().Err(err).Int("instanceID", instanceID).Msg("automations: failed to load tracker customizations for display names")
@@ -2205,10 +2205,12 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 	// This must happen after skipCheck is defined so we only stamp lastRuleRun
 	// for rules that will actually process at least one torrent.
 	rulesUsed := make(map[int]struct{})
+	consideredTorrents := 0
 	for _, torrent := range torrents {
 		if skipCheck(torrent.Hash) {
 			continue
 		}
+		consideredTorrents++
 		for _, rule := range selectMatchingRules(torrent, eligibleRules, s.syncManager) {
 			rulesUsed[rule.ID] = struct{}{}
 		}
@@ -2228,37 +2230,50 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 			Int("torrents", len(torrents)).
 			Int("matchedRules", len(rulesUsed)).
 			Msg("automations: no actions to apply")
+	}
 
-		for _, rule := range eligibleRules {
-			stats := ruleStats[rule.ID]
-			if stats == nil || stats.MatchedTrackers == 0 {
-				continue
+	// Report every rule that did nothing, even when another rule acted. A rule
+	// matching zero torrents is the hardest run to diagnose, so it must not stay silent.
+	for _, rule := range eligibleRules {
+		stats := ruleStats[rule.ID]
+		if stats == nil || stats.MatchedTrackers == 0 {
+			// Stay quiet when every torrent was skipped as recently processed:
+			// the rule saw nothing, which says nothing about the rule.
+			if consideredTorrents > 0 {
+				log.Debug().
+					Int("instanceID", instanceID).
+					Int("ruleID", rule.ID).
+					Str("ruleName", rule.Name).
+					Str("trackerPattern", rule.TrackerPattern).
+					Int("consideredTorrents", consideredTorrents).
+					Msg("automations: rule matched no torrents")
 			}
-			if stats.totalApplied() > 0 {
-				continue
-			}
-
-			log.Debug().
-				Int("instanceID", instanceID).
-				Int("ruleID", rule.ID).
-				Str("ruleName", rule.Name).
-				Int("matchedTrackers", stats.MatchedTrackers).
-				Int("speedNoMatch", stats.SpeedConditionNotMet).
-				Int("shareNoMatch", stats.ShareConditionNotMet).
-				Int("pauseNoMatch", stats.PauseConditionNotMet).
-				Int("resumeNoMatch", stats.ResumeConditionNotMet).
-				Int("recheckNoMatch", stats.RecheckConditionNotMet).
-				Int("reannounceNoMatch", stats.ReannounceConditionNotMet).
-				Int("tagNoMatch", stats.TagConditionNotMet).
-				Int("tagMissingUnregisteredSet", stats.TagSkippedMissingUnregisteredSet).
-				Int("categoryNoMatchOrBlocked", stats.CategoryConditionNotMetOrBlocked).
-				Int("deleteNoMatch", stats.DeleteConditionNotMet).
-				Int("moveNoMatch", stats.MoveConditionNotMet).
-				Int("moveAlreadyAtDest", stats.MoveAlreadyAtDestination).
-				Int("moveBlockedByCrossSeed", stats.MoveBlockedByCrossSeed).
-				Int("exportToInstanceNoMatch", stats.ExportToInstanceConditionNotMet).
-				Msg("automations: rule matched trackers but applied no actions")
+			continue
 		}
+		if stats.totalApplied() > 0 {
+			continue
+		}
+
+		log.Debug().
+			Int("instanceID", instanceID).
+			Int("ruleID", rule.ID).
+			Str("ruleName", rule.Name).
+			Int("matchedTrackers", stats.MatchedTrackers).
+			Int("speedNoMatch", stats.SpeedConditionNotMet).
+			Int("shareNoMatch", stats.ShareConditionNotMet).
+			Int("pauseNoMatch", stats.PauseConditionNotMet).
+			Int("resumeNoMatch", stats.ResumeConditionNotMet).
+			Int("recheckNoMatch", stats.RecheckConditionNotMet).
+			Int("reannounceNoMatch", stats.ReannounceConditionNotMet).
+			Int("tagNoMatch", stats.TagConditionNotMet).
+			Int("tagMissingUnregisteredSet", stats.TagSkippedMissingUnregisteredSet).
+			Int("categoryNoMatchOrBlocked", stats.CategoryConditionNotMetOrBlocked).
+			Int("deleteNoMatch", stats.DeleteConditionNotMet).
+			Int("moveNoMatch", stats.MoveConditionNotMet).
+			Int("moveAlreadyAtDest", stats.MoveAlreadyAtDestination).
+			Int("moveBlockedByCrossSeed", stats.MoveBlockedByCrossSeed).
+			Int("exportToInstanceNoMatch", stats.ExportToInstanceConditionNotMet).
+			Msg("automations: rule matched trackers but applied no actions")
 	}
 
 	// Update lastRuleRun only for rules that matched at least one non-skipped torrent
@@ -5050,15 +5065,20 @@ func scoreRuleUsesField(rule models.ScoreRule, field ConditionField) bool {
 	return false
 }
 
+// rulesUseTrackerEntryData reports whether any rule needs the per-torrent tracker
+// list. Rules without a tracker condition skip hydration entirely.
 func rulesUseTrackerEntryData(rules []*models.Automation) bool {
-	return rulesUseCondition(rules, FieldTrackerStatus) || rulesUseCondition(rules, FieldTrackerMessage)
+	return rulesUseCondition(rules, FieldTracker) ||
+		rulesUseCondition(rules, FieldTrackers) ||
+		rulesUseCondition(rules, FieldTrackerStatus) ||
+		rulesUseCondition(rules, FieldTrackerMessage)
 }
 
 func (s *Service) hydrateTorrentTrackersForRule(ctx context.Context, instanceID int, torrents []qbt.Torrent, rule *models.Automation) []qbt.Torrent {
 	if s == nil || s.syncManager == nil || rule == nil {
 		return torrents
 	}
-	if !ruleUsesCondition(rule, FieldTrackerStatus) && !ruleUsesCondition(rule, FieldTrackerMessage) {
+	if !rulesUseTrackerEntryData([]*models.Automation{rule}) {
 		return torrents
 	}
 	return s.syncManager.HydrateTorrentTrackers(ctx, instanceID, torrents)

--- a/internal/services/automations/service.go
+++ b/internal/services/automations/service.go
@@ -1948,10 +1948,16 @@ func (s *Service) applyRulesForInstance(ctx context.Context, instanceID int, for
 		return nil, nil
 	}
 
-	// Pre-filter rules by interval eligibility
+	// Pre-filter rules by enablement and interval eligibility
 	now := time.Now()
 	eligibleRules := make([]*models.Automation, 0, len(rules))
 	for _, rule := range rules {
+		// A disabled rule never stamps lastRuleRun, so the interval filter below can
+		// never drop it: without this it stays eligible on every tick and pulls the
+		// data the gates further down fetch.
+		if !rule.Enabled {
+			continue
+		}
 		if !force {
 			interval := DefaultRuleInterval
 			if rule.IntervalSeconds != nil {

--- a/internal/services/automations/service_preview_test.go
+++ b/internal/services/automations/service_preview_test.go
@@ -72,17 +72,22 @@ func TestSetupPreviewTrackerDisplayNames_LoadsWhenTrackerFieldUsed(t *testing.T)
 		trackerCustomizationStore: store,
 	}
 
-	evalCtx := &EvalContext{}
-	cond := &RuleCondition{
-		Field:    FieldTracker,
-		Operator: OperatorNotEqual,
-		Value:    "BHD",
+	// Both tracker fields match display names, so both must load the map.
+	for _, field := range []ConditionField{FieldTracker, FieldTrackers} {
+		t.Run(string(field), func(t *testing.T) {
+			evalCtx := &EvalContext{}
+			cond := &RuleCondition{
+				Field:    field,
+				Operator: OperatorNotEqual,
+				Value:    "BHD",
+			}
+
+			s.setupPreviewTrackerDisplayNames(ctx, 1, cond, evalCtx)
+
+			require.NotNil(t, evalCtx.TrackerDisplayNameByDomain)
+			assert.Equal(t, "BHD", evalCtx.TrackerDisplayNameByDomain["bhd.example"])
+		})
 	}
-
-	s.setupPreviewTrackerDisplayNames(ctx, 1, cond, evalCtx)
-
-	require.NotNil(t, evalCtx.TrackerDisplayNameByDomain)
-	assert.Equal(t, "BHD", evalCtx.TrackerDisplayNameByDomain["bhd.example"])
 }
 
 func TestSetupPreviewTrackerDisplayNames_SkipsWhenTrackerFieldNotUsed(t *testing.T) {

--- a/internal/services/automations/service_test.go
+++ b/internal/services/automations/service_test.go
@@ -2667,3 +2667,26 @@ func (r *automationRecordingNotifier) Events() []notifications.Event {
 	copy(out, r.events)
 	return out
 }
+
+func TestTrackerDataMissing(t *testing.T) {
+	withTrackers := qbt.Torrent{Trackers: []qbt.TorrentTracker{{Url: "https://tracker.example/announce"}}}
+	withoutTrackers := qbt.Torrent{Tracker: "https://tracker.example/announce"}
+
+	tests := []struct {
+		name     string
+		torrents []qbt.Torrent
+		want     bool
+	}{
+		{name: "no torrents at all says nothing about hydration", torrents: nil, want: false},
+		{name: "hydration returned no tracker entries", torrents: []qbt.Torrent{withoutTrackers, withoutTrackers}, want: true},
+		{name: "one torrent with entries is enough", torrents: []qbt.Torrent{withoutTrackers, withTrackers}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := trackerDataMissing(tt.torrents); got != tt.want {
+				t.Errorf("trackerDataMissing() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/services/automations/service_test.go
+++ b/internal/services/automations/service_test.go
@@ -374,6 +374,8 @@ func TestRulesUseTrackerEntryData(t *testing.T) {
 	}
 
 	statusRule := deleteRule(&models.RuleCondition{Field: models.FieldTrackerStatus, Operator: models.OperatorEqual, Value: "error"})
+	trackerRule := deleteRule(&models.RuleCondition{Field: models.FieldTracker, Operator: models.OperatorEqual, Value: "dead"})
+	trackersRule := deleteRule(&models.RuleCondition{Field: models.FieldTrackers, Operator: models.OperatorContains, Value: "tracker.example"})
 	nestedMessageRule := deleteRule(&models.RuleCondition{
 		Operator: models.OperatorOr,
 		Conditions: []*models.RuleCondition{
@@ -389,6 +391,8 @@ func TestRulesUseTrackerEntryData(t *testing.T) {
 		want  bool
 	}{
 		{name: "status field", rules: []*models.Automation{statusRule}, want: true},
+		{name: "tracker field", rules: []*models.Automation{trackerRule}, want: true},
+		{name: "trackers field", rules: []*models.Automation{trackersRule}, want: true},
 		{name: "message field nested in group", rules: []*models.Automation{nestedMessageRule}, want: true},
 		{name: "no tracker entry fields", rules: []*models.Automation{unrelatedRule}, want: false},
 		{name: "mixed rules detect tracker field", rules: []*models.Automation{unrelatedRule, statusRule}, want: true},

--- a/web/src/components/query-builder/constants.ts
+++ b/web/src/components/query-builder/constants.ts
@@ -19,7 +19,10 @@ export const CONDITION_FIELDS = {
   CONTENT_PATH: { label: "Content Path", type: "string" as const, description: "Content location" },
   DOWNLOAD_PATH: { label: "Download Path", type: "string" as const, description: "Session download path from qBittorrent" },
   CREATED_BY: { label: "Created By", type: "string" as const, description: "Torrent creator metadata" },
-  TRACKERS: { label: "Trackers (All)", type: "string" as const, description: "All tracker URLs/domains/display names for this torrent" },
+  // Legacy alias of TRACKER, which now matches every tracker too. Kept out of
+  // FIELD_GROUPS so it is no longer offered, and kept here so saved rules that
+  // already use it still render a label, a type, and help text.
+  TRACKERS: { label: "Trackers (All)", type: "string" as const, description: "Same as Tracker: any tracker of the torrent (URL, domain, or display name)" },
   CONTENT_TYPE: { label: "Content Type", type: "string" as const, description: "Detected content type (movie, tv, music, etc) from release parsing" },
   EFFECTIVE_NAME: { label: "Effective Name", type: "string" as const, description: "Parsed item key (title/year or SxxEyy) for grouping across trackers" },
   RLS_SOURCE: { label: "Source (RLS)", type: "string" as const, description: "Parsed source (normalized: WEBDL, WEBRIP, BLURAY, etc)" },
@@ -288,7 +291,7 @@ export const FIELD_GROUPS = [
   },
   {
     label: "Tracker",
-    fields: ["TRACKER", "TRACKERS", "TRACKERS_COUNT", "PRIVATE", "IS_UNREGISTERED", "TRACKER_STATUS", "TRACKER_MESSAGE", "COMMENT"],
+    fields: ["TRACKER", "TRACKERS_COUNT", "PRIVATE", "IS_UNREGISTERED", "TRACKER_STATUS", "TRACKER_MESSAGE", "COMMENT"],
   },
   {
     label: "Cross-Seed",

--- a/web/src/components/query-builder/constants.ts
+++ b/web/src/components/query-builder/constants.ts
@@ -31,7 +31,7 @@ export const CONDITION_FIELDS = {
   RLS_GROUP: { label: "Group (RLS)", type: "string" as const, description: "Parsed release group (e.g. NTb, FLUX, FraMeSToR)" },
   RLS_YEAR: { label: "Year (RLS)", type: "integer" as const, description: "Year parsed from the torrent name (e.g. 2021). Best for movies and dated releases; most TV episodes (e.g. S14E05) have no year and never match any comparison operator (the NOT toggle inverts that, so it matches yearless releases)." },
   STATE: { label: "State", type: "state" as const, description: "Torrent status (matches sidebar filters)" },
-  TRACKER: { label: "Tracker", type: "string" as const, description: "Primary tracker (URL, domain, or display name)" },
+  TRACKER: { label: "Tracker", type: "string" as const, description: "Any tracker of the torrent (URL, domain, or display name)" },
   TRACKER_STATUS: { label: "Tracker status", type: "trackerStatus" as const, description: "Per-tracker announce status (matches if any tracker matches)" },
   TRACKER_MESSAGE: { label: "Tracker message", type: "string" as const, description: "Per-tracker status message (matches if any tracker matches). Use \"nil\" for empty." },
   COMMENT: { label: "Comment", type: "string" as const, description: "Torrent comment" },


### PR DESCRIPTION
## Description

qBittorrent reports only the first working tracker in a torrent's primary tracker field, and leaves that field empty when no tracker works. The Tracker condition compared against that field alone, so a rule keyed on a tracker customization group of dead trackers matched nothing. Tracker conditions now match every tracker the torrent announces to.

Trackers (All) did read the full list, but automations fetched that list only for Tracker status and Tracker message rules, and loaded the customization display names only for Tracker. Both conditions now trigger the fetch and the display name lookup. Rules without a tracker condition still make no extra request. Candidates also drop the DHT, PeX, and LSD pseudo-trackers wherever they occur, the primary tracker field included.

That makes the two fields identical, so the second commit removes Trackers (All) from the query builder. The field stays in the backend and in `CONDITION_FIELDS`, so rules that already use it keep working and keep their label.

A rule that matches no torrents now records that at debug level with the rule name and the instance. The related "matched trackers but applied no actions" line was only written when no rule in the whole run did anything, so it went silent as soon as a different rule acted. It now reports per rule.

Fixes #2481

## How has this been tested?

Built the binary and ran it against qBittorrent 5.2.3 with two torrents whose trackers are all unreachable `.test` hosts, and a merged customization group. Compared the same rule previews on this branch and on develop:

| Condition | develop | this branch |
| --- | --- | --- |
| Tracker is `dead` (group name) | 1 | 1 |
| Trackers (All) is `dead` | 0 | 1 |
| Tracker is `tracker.primary-x.test` | 0 | 1 |
| Trackers (All) contains `tracker.primary-x.test` | 0 | 1 |
| Tracker is `tracker.dead-two.test` | 0 | 1 |

The count a Tracker rule reported for the group equalled the count in the Trackers sidebar. Both new log lines appeared in a scheduled run and in a dry run.

One correction to the issue text, found during that run: qBittorrent 5.2.3 does not empty the primary tracker field when every tracker fails. It keeps one non-working tracker and picks an arbitrary one. A torrent with two trackers reported the second. The field is empty only when the torrent has no real trackers at all. The common failure is therefore a primary field that names the wrong tracker, which this change also fixes.

I did not open the query builder in a browser to confirm Trackers (All) is gone from the field list.

## Screenshots (for UI changes)

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tracker-based automation conditions now match any announced tracker, including non-working trackers.
  * Matching supports tracker URLs, domains, and customized display names.
  * DHT, PeX, and LSD pseudo-trackers are excluded from matching.

* **Bug Fixes**
  * Improved handling when torrents have no eligible trackers.
  * Existing `Trackers (All)` rules now behave consistently with `Tracker`.

* **Documentation**
  * Updated tracker condition descriptions, caching, delays, and legacy-field guidance.
  * Clarified that `Trackers (All)` is no longer offered for new rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->