### PR TITLE
fix(reannounce): skip the scan when the scope cannot match

### DIFF
--- a/documentation/docs/features/reannounce.md
+++ b/documentation/docs/features/reannounce.md
@@ -41,6 +41,8 @@ Choose which torrents qui monitors:
 - **Monitor All Stalled Torrents**: qui checks every stalled torrent. If you want to ignore specific categories, tags, or trackers (such as public trackers), add **Exclude** rules.
 - **Custom filter (Monitor All disabled)**: qui checks only torrents that match your **Include** rules. **Exclude** rules still block specific items within those groups.
 
+If you disable **Monitor All** and add no **Include** rules, no torrent can match. qui then does no scan and sends no request to qBittorrent.
+
 ### Quick Retry
 
 By default, qui waits about **2 minutes** between reannounce attempts for the same torrent. This duration acts as a per-torrent cooldown between scans.

--- a/documentation/docs/features/reannounce.md
+++ b/documentation/docs/features/reannounce.md
@@ -38,7 +38,7 @@ Some slow trackers need up to 50 retries at 7s intervals (about 6 minutes) to re
 
 Choose which torrents qui monitors:
 
-- **Monitor All Stalled Torrents**: qui checks every stalled torrent. If you want to ignore specific categories, tags, or trackers (such as public trackers), add **Exclude** rules.
+- **Monitor All Stalled Torrents**: qui checks every stalled torrent. This is the default setting for new instances. If you want to ignore specific categories, tags, or trackers (such as public trackers), add **Exclude** rules.
 - **Custom filter (Monitor All disabled)**: qui checks only torrents that match your **Include** rules. **Exclude** rules still block specific items within those groups.
 
 If you disable **Monitor All** and add no **Include** rules, no torrent can match. qui then does no scan and sends no request to qBittorrent.

--- a/internal/models/instance_reannounce.go
+++ b/internal/models/instance_reannounce.go
@@ -43,6 +43,21 @@ type InstanceReannounceSettings struct {
 	UpdatedAt                 time.Time `json:"updatedAt"`
 }
 
+// CanMatchTorrents reports whether any torrent can match these settings: the
+// feature is on, and the scope is either MonitorAll or at least one inclusion
+// list. A scope that matches nothing lets callers skip the client fetch.
+func (s *InstanceReannounceSettings) CanMatchTorrents() bool {
+	if s == nil || !s.Enabled {
+		return false
+	}
+	if s.MonitorAll {
+		return true
+	}
+	return (len(s.Categories) > 0 && !s.ExcludeCategories) ||
+		(len(s.Tags) > 0 && !s.ExcludeTags) ||
+		(len(s.Trackers) > 0 && !s.ExcludeTrackers)
+}
+
 // InstanceReannounceStore manages persistence for InstanceReannounceSettings.
 type InstanceReannounceStore struct {
 	db dbinterface.Querier
@@ -63,7 +78,7 @@ func DefaultInstanceReannounceSettings(instanceID int) *InstanceReannounceSettin
 		MaxAgeSeconds:             defaultMaxAgeSeconds,
 		MaxRetries:                defaultMaxRetries,
 		Aggressive:                false,
-		MonitorAll:                false,
+		MonitorAll:                true,
 		ExcludeCategories:         false,
 		Categories:                []string{},
 		ExcludeTags:               false,

--- a/internal/models/instance_reannounce_test.go
+++ b/internal/models/instance_reannounce_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package models_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/autobrr/qui/internal/models"
+)
+
+func TestCanMatchTorrents(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings *models.InstanceReannounceSettings
+		want     bool
+	}{
+		{name: "Nil", settings: nil, want: false},
+		{name: "Disabled", settings: &models.InstanceReannounceSettings{MonitorAll: true}, want: false},
+		{name: "Empty scope", settings: &models.InstanceReannounceSettings{Enabled: true}, want: false},
+		{name: "Exclusions only", settings: &models.InstanceReannounceSettings{
+			Enabled:           true,
+			ExcludeCategories: true,
+			Categories:        []string{"tv"},
+		}, want: false},
+		{name: "MonitorAll", settings: &models.InstanceReannounceSettings{Enabled: true, MonitorAll: true}, want: true},
+		{name: "Category include", settings: &models.InstanceReannounceSettings{Enabled: true, Categories: []string{"tv"}}, want: true},
+		{name: "Tag include", settings: &models.InstanceReannounceSettings{Enabled: true, Tags: []string{"tagA"}}, want: true},
+		{name: "Tracker include", settings: &models.InstanceReannounceSettings{Enabled: true, Trackers: []string{"tracker.example.com"}}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.settings.CanMatchTorrents())
+		})
+	}
+}

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -563,8 +563,7 @@ func (h *Handler) monitoringEnabled(instanceID int) bool {
 	if h.reannounceCache == nil {
 		return false
 	}
-	settings := h.reannounceCache.Get(instanceID)
-	return settings != nil && settings.Enabled
+	return h.reannounceCache.Get(instanceID).CanMatchTorrents()
 }
 
 func restoreBody(r *http.Request, body []byte) {

--- a/internal/services/reannounce/service.go
+++ b/internal/services/reannounce/service.go
@@ -175,7 +175,7 @@ func (s *Service) RequestReannounce(ctx context.Context, instanceID int, hashes 
 		return nil
 	}
 	settings := s.getSettings(ctx, instanceID)
-	if settings == nil || !settings.Enabled {
+	if !settings.CanMatchTorrents() {
 		return nil
 	}
 	upperHashes := normalizeHashes(hashes)
@@ -225,15 +225,15 @@ func (s *Service) scanInstances(ctx context.Context) {
 		if instance == nil || !instance.IsActive {
 			continue
 		}
-		settings := s.getSettings(ctx, instance.ID)
-		if settings == nil || !settings.Enabled {
-			continue
-		}
-		s.scanInstance(ctx, instance.ID, settings)
+		s.scanInstance(ctx, instance.ID, s.getSettings(ctx, instance.ID))
 	}
 }
 
 func (s *Service) scanInstance(ctx context.Context, instanceID int, settings *models.InstanceReannounceSettings) {
+	if !settings.CanMatchTorrents() {
+		return
+	}
+
 	client, err := s.clientPool.GetClient(ctx, instanceID)
 	if err != nil {
 		log.Debug().Err(err).Int("instanceID", instanceID).Msg("reannounce: client unavailable for scan")
@@ -287,7 +287,7 @@ func (s *Service) GetMonitoredTorrents(ctx context.Context, instanceID int) []Mo
 	}
 
 	settings := s.getSettings(ctx, instanceID)
-	if settings == nil || !settings.Enabled {
+	if !settings.CanMatchTorrents() {
 		return nil
 	}
 
@@ -563,7 +563,7 @@ func (s *Service) torrentMeetsCriteria(torrent qbt.Torrent, settings *models.Ins
 // category/tag/tracker filters) WITHOUT checking the initial wait period. Used by
 // GetMonitoredTorrents to show new torrents that are still in their initial wait.
 func (s *Service) torrentMatchesFilters(torrent qbt.Torrent, settings *models.InstanceReannounceSettings) bool {
-	if settings == nil || !settings.Enabled {
+	if !settings.CanMatchTorrents() {
 		return false
 	}
 
@@ -615,30 +615,8 @@ func (s *Service) torrentMatchesFilters(torrent qbt.Torrent, settings *models.In
 		return true
 	}
 
-	// 3. Check inclusions
-	// If no inclusions are defined, we shouldn't match anything (unless MonitorAll is true, handled above).
-	// However, existing tests imply that empty inclusion lists act as "wildcard" if we don't check for emptiness.
-	// But the new logic is specific: you must match AT LEAST one inclusion criteria if MonitorAll is false.
-	// Let's check if any inclusion criteria is actually set.
-
-	hasInclusionCriteria := (len(settings.Categories) > 0 && !settings.ExcludeCategories) ||
-		(len(settings.Tags) > 0 && !settings.ExcludeTags) ||
-		(len(settings.Trackers) > 0 && !settings.ExcludeTrackers)
-
-	if !hasInclusionCriteria {
-		// If MonitorAll is false and no inclusion criteria are provided, we match nothing.
-		// Wait, if I have "Exclude Category TV" and MonitorAll=False, does it mean "Include Everything EXCEPT TV"?
-		// If MonitorAll is false, the UI says "Monitor specific ...".
-		// If I set "Exclude Category TV", then MonitorAll=False, do I want to monitor everything else?
-		// The UI implies "Monitor scope" switch toggles between "All" and "Specific".
-		// If "Specific", you must provide positive criteria.
-		// BUT, now we have exclusions.
-		// If I want to "Monitor All EXCEPT TV", I should enable MonitorAll and add Exclude TV.
-		// If I disable MonitorAll, I am in "Allowlist" mode (plus local blocklists).
-		// So if MonitorAll=False, I MUST match an Allowlist entry.
-		return false
-	}
-
+	// 3. Check inclusions. CanMatchTorrents above guarantees at least one
+	// inclusion list is set, so a torrent must match one of them.
 	if !settings.ExcludeCategories && len(settings.Categories) > 0 {
 		for _, category := range settings.Categories {
 			if strings.EqualFold(category, torrent.Category) {
@@ -669,8 +647,7 @@ func (s *Service) torrentMatchesFilters(torrent qbt.Torrent, settings *models.In
 		}
 	}
 
-	// If MonitorAll is false, we require at least one positive inclusion criterion to match.
-	// Since we haven't returned true by now, no inclusion criteria were matched.
+	// No inclusion entry matched.
 	return false
 }
 

--- a/internal/services/reannounce/service_test.go
+++ b/internal/services/reannounce/service_test.go
@@ -526,3 +526,41 @@ func TestServiceRecordActivityLimit(t *testing.T) {
 	}
 	require.Equal(t, 4, failedCount)
 }
+
+func TestCanMatchTorrents(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings *models.InstanceReannounceSettings
+		want     bool
+	}{
+		{name: "Nil", settings: nil, want: false},
+		{name: "Disabled", settings: &models.InstanceReannounceSettings{MonitorAll: true}, want: false},
+		{name: "Empty scope", settings: &models.InstanceReannounceSettings{Enabled: true}, want: false},
+		{name: "Exclusions only", settings: &models.InstanceReannounceSettings{
+			Enabled:           true,
+			ExcludeCategories: true,
+			Categories:        []string{"tv"},
+		}, want: false},
+		{name: "MonitorAll", settings: &models.InstanceReannounceSettings{Enabled: true, MonitorAll: true}, want: true},
+		{name: "Category include", settings: &models.InstanceReannounceSettings{Enabled: true, Categories: []string{"tv"}}, want: true},
+		{name: "Tag include", settings: &models.InstanceReannounceSettings{Enabled: true, Tags: []string{"tagA"}}, want: true},
+		{name: "Tracker include", settings: &models.InstanceReannounceSettings{Enabled: true, Trackers: []string{"tracker.example.com"}}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.settings.CanMatchTorrents())
+		})
+	}
+}
+
+// A scope that cannot match any torrent must not reach the client. The service
+// here has no client pool, so a fetch attempt would panic: returning cleanly
+// proves the scan short-circuited before the request.
+func TestScanInstance_SkipsFetchWhenScopeCannotMatch(t *testing.T) {
+	svc := &Service{}
+
+	require.NotPanics(t, func() {
+		svc.scanInstance(context.Background(), 1, &models.InstanceReannounceSettings{Enabled: true})
+	})
+}

--- a/internal/services/reannounce/service_test.go
+++ b/internal/services/reannounce/service_test.go
@@ -527,33 +527,6 @@ func TestServiceRecordActivityLimit(t *testing.T) {
 	require.Equal(t, 4, failedCount)
 }
 
-func TestCanMatchTorrents(t *testing.T) {
-	tests := []struct {
-		name     string
-		settings *models.InstanceReannounceSettings
-		want     bool
-	}{
-		{name: "Nil", settings: nil, want: false},
-		{name: "Disabled", settings: &models.InstanceReannounceSettings{MonitorAll: true}, want: false},
-		{name: "Empty scope", settings: &models.InstanceReannounceSettings{Enabled: true}, want: false},
-		{name: "Exclusions only", settings: &models.InstanceReannounceSettings{
-			Enabled:           true,
-			ExcludeCategories: true,
-			Categories:        []string{"tv"},
-		}, want: false},
-		{name: "MonitorAll", settings: &models.InstanceReannounceSettings{Enabled: true, MonitorAll: true}, want: true},
-		{name: "Category include", settings: &models.InstanceReannounceSettings{Enabled: true, Categories: []string{"tv"}}, want: true},
-		{name: "Tag include", settings: &models.InstanceReannounceSettings{Enabled: true, Tags: []string{"tagA"}}, want: true},
-		{name: "Tracker include", settings: &models.InstanceReannounceSettings{Enabled: true, Trackers: []string{"tracker.example.com"}}, want: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, tt.settings.CanMatchTorrents())
-		})
-	}
-}
-
 // A scope that cannot match any torrent must not reach the client. The service
 // here has no client pool, so a fetch attempt would panic: returning cleanly
 // proves the scan short-circuited before the request.

--- a/web/src/components/instances/preferences/TrackerReannounceForm.tsx
+++ b/web/src/components/instances/preferences/TrackerReannounceForm.tsx
@@ -25,6 +25,7 @@ import { useInstanceTrackers } from "@/hooks/useInstanceTrackers"
 import { buildTrackerCustomizationMaps, useTrackerCustomizations } from "@/hooks/useTrackerCustomizations"
 import { useTrackerIcons } from "@/hooks/useTrackerIcons"
 import { api } from "@/lib/api"
+import { DEFAULT_REANNOUNCE_SETTINGS } from "@/lib/instance-validation"
 import { pickTrackerIconDomain } from "@/lib/tracker-icons"
 import { cn, copyTextToClipboard, formatErrorReason, normalizeTrackerDomains } from "@/lib/utils"
 import { REANNOUNCE_CONSTRAINTS, type InstanceFormData, type InstanceReannounceActivity, type InstanceReannounceSettings } from "@/types"
@@ -42,22 +43,6 @@ interface TrackerReannounceFormProps {
   variant?: "card" | "embedded"
   /** Form ID for external submit button. When provided, the internal submit button is hidden. */
   formId?: string
-}
-
-const DEFAULT_SETTINGS: InstanceReannounceSettings = {
-  enabled: false,
-  initialWaitSeconds: 15,
-  reannounceIntervalSeconds: 7,
-  maxAgeSeconds: 600,
-  maxRetries: 50,
-  aggressive: false,
-  monitorAll: false,
-  excludeCategories: false,
-  categories: [],
-  excludeTags: false,
-  tags: [],
-  excludeTrackers: false,
-  trackers: [],
 }
 
 const GLOBAL_SCAN_INTERVAL_SECONDS = 7
@@ -292,7 +277,7 @@ export function TrackerReannounceForm({ instanceId, onInstanceChange, onSuccess,
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     const sanitized = sanitizeSettings(settings)
-    const wasEnabled = instance?.reannounceSettings?.enabled ?? DEFAULT_SETTINGS.enabled
+    const wasEnabled = instance?.reannounceSettings?.enabled ?? DEFAULT_REANNOUNCE_SETTINGS.enabled
 
     if (!wasEnabled && sanitized.enabled) {
       setPendingEnableSettings(sanitized)
@@ -909,7 +894,7 @@ function NumberField({ id, label, description, tooltip, value, min, max, onChang
 
 function cloneSettings(settings?: InstanceReannounceSettings): InstanceReannounceSettings {
   if (!settings) {
-    return { ...DEFAULT_SETTINGS }
+    return { ...DEFAULT_REANNOUNCE_SETTINGS }
   }
   return {
     enabled: settings.enabled,
@@ -938,10 +923,10 @@ function sanitizeSettings(settings: InstanceReannounceSettings): InstanceReannou
 
   return {
     enabled: settings.enabled,
-    initialWaitSeconds: clamp(settings.initialWaitSeconds, DEFAULT_SETTINGS.initialWaitSeconds, REANNOUNCE_CONSTRAINTS.MIN_INITIAL_WAIT),
-    reannounceIntervalSeconds: clamp(settings.reannounceIntervalSeconds, DEFAULT_SETTINGS.reannounceIntervalSeconds, REANNOUNCE_CONSTRAINTS.MIN_INTERVAL),
-    maxAgeSeconds: clamp(settings.maxAgeSeconds, DEFAULT_SETTINGS.maxAgeSeconds, REANNOUNCE_CONSTRAINTS.MIN_MAX_AGE),
-    maxRetries: clamp(settings.maxRetries, DEFAULT_SETTINGS.maxRetries, REANNOUNCE_CONSTRAINTS.MIN_MAX_RETRIES, REANNOUNCE_CONSTRAINTS.MAX_MAX_RETRIES),
+    initialWaitSeconds: clamp(settings.initialWaitSeconds, DEFAULT_REANNOUNCE_SETTINGS.initialWaitSeconds, REANNOUNCE_CONSTRAINTS.MIN_INITIAL_WAIT),
+    reannounceIntervalSeconds: clamp(settings.reannounceIntervalSeconds, DEFAULT_REANNOUNCE_SETTINGS.reannounceIntervalSeconds, REANNOUNCE_CONSTRAINTS.MIN_INTERVAL),
+    maxAgeSeconds: clamp(settings.maxAgeSeconds, DEFAULT_REANNOUNCE_SETTINGS.maxAgeSeconds, REANNOUNCE_CONSTRAINTS.MIN_MAX_AGE),
+    maxRetries: clamp(settings.maxRetries, DEFAULT_REANNOUNCE_SETTINGS.maxRetries, REANNOUNCE_CONSTRAINTS.MIN_MAX_RETRIES, REANNOUNCE_CONSTRAINTS.MAX_MAX_RETRIES),
     monitorAll: settings.monitorAll,
     excludeCategories: settings.excludeCategories,
     categories: normalizeList(settings.categories),

--- a/web/src/lib/instance-validation.ts
+++ b/web/src/lib/instance-validation.ts
@@ -13,7 +13,7 @@ export const DEFAULT_REANNOUNCE_SETTINGS: InstanceReannounceSettings = {
   maxAgeSeconds: 600,
   maxRetries: 50,
   aggressive: false,
-  monitorAll: false,
+  monitorAll: true,
   excludeCategories: false,
   categories: [],
   excludeTags: false,


### PR DESCRIPTION
## Description

The reannounce scan fetched every stalled torrent with tracker data every 7 seconds even when the configured scope could never match a torrent, and that empty scope was the default a user got by flipping the enable switch. The fetch now runs only when the scope can match, and the `monitorAll` default in the model and the web form matches the migration default of 1.

Fixes #2490

## How has this been tested?

Ran the built binary against a throwaway qBittorrent 5.2.3 container, with a request log between qui and the client:

- Enabled, `monitorAll` off, no include rules, 35 s: 0 `torrents/info?filter=stalled&includeTrackers=true` requests.
- `monitorAll` on, 35 s: 5 requests, one per 7 s tick.
- `monitorAll` off with one include category, 25 s: 4 requests.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reannounce monitoring now defaults to monitoring all torrents for new configurations.
  * Monitoring automatically recognizes whether the current scope can match any torrents.
* **Bug Fixes**
  * Prevented unnecessary scans and requests when monitoring is enabled without any possible matching criteria.
  * Improved handling of empty, disabled, or exclusions-only monitoring scopes.
* **Documentation**
  * Clarified that no scans or qBittorrent requests occur when Monitor All is disabled and no Include rules are configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->