### PR TITLE
docs(automations): add example for finding duplicate releases

### DIFF
--- a/documentation/docs/features/automations.md
+++ b/documentation/docs/features/automations.md
@@ -1137,6 +1137,20 @@ Remove completed torrents and all their cross-seeded copies when they are old en
 
 When a torrent matches, qui also deletes every other torrent that points to the same downloaded files. Use this rule when you no longer need any copy of the content.
 
+### Find duplicate releases of the same title
+
+List releases that share a parsed title but come from different release groups, such as `Show.S01.1080p.WEB-DL-GROUP1` and `Show.S01.1080p.WEB-DL-GROUP2`:
+
+- Tracker: `*`
+- Condition: `Is Grouped is true` with `groupId` set to `release_item` (see [Grouping](#grouping))
+- Action: Tag "dupe" (mode: add)
+
+The **Live impact preview** lists the matches while you edit, so the rule can stay disabled if you only want to look.
+
+:::note
+Cross-seeded copies of a release are also members of these groups, because the `release_item` key ignores the release group and the tracker.
+:::
+
 ### Organize by tracker
 
 Move torrents to tracker-named categories:


### PR DESCRIPTION
## Description

Adds an example rule that lists releases with the same parsed title from different release groups, using `release_item` grouping and the `Is Grouped` condition. Came from a Discord support question that needed four separate doc sections to answer.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an automation example for finding duplicate releases with the same title across different release groups.
  * Documented tagging matching releases as duplicates.
  * Noted that the Live impact preview is available while editing rules.
  * Clarified how cross-seeded copies are included in matching results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->