### PR TITLE
fix(crossseed): use ARR alternate titles for announce matching

### DIFF
--- a/documentation/docs/features/cross-seed/overview.md
+++ b/documentation/docs/features/cross-seed/overview.md
@@ -101,6 +101,8 @@ qui still checks the downloaded torrent metadata, files, layout, and piece bound
 
 RSS uses the same classifier with its feed title and byte count. The [autobrr integration](./autobrr.md) uses passive announcement data during `/check`.
 
+Announce matching over alternate titles, such as an anime announced under its English or romaji name, needs a [Sonarr or Radarr integration](../search.md#sonarr-and-radarr-integrations). Without one, qui matches announces on the release name only.
+
 If autobrr has no positive size, qui uses a narrow name-only preflight. This preflight can approve one download, but it cannot approve an add.
 
 ### Season Pack Assembly

--- a/internal/services/arr/service.go
+++ b/internal/services/arr/service.go
@@ -288,7 +288,10 @@ func (s *Service) lookupExternalIDsFromParse(ctx context.Context, titleHash, tit
 	}
 
 	if cacheNegative {
-		if err := s.cacheStore.Set(ctx, titleHash, string(contentType), nil, nil, true, s.negativeTTL); err != nil {
+		// Detach from the request context: a lookup that finishes near a
+		// caller's deadline must still cache, or the caller repeats the HTTP
+		// round trips on its next request.
+		if err := s.cacheStore.Set(context.WithoutCancel(ctx), titleHash, string(contentType), nil, nil, true, s.negativeTTL); err != nil {
 			log.Warn().Err(err).Msg("[ARR-LOOKUP] Failed to cache negative result")
 		}
 	}
@@ -309,7 +312,8 @@ func (s *Service) lookupExternalIDsFromParse(ctx context.Context, titleHash, tit
 func (s *Service) cacheAndBuildResult(ctx context.Context, titleHash, title string, contentType ContentType, instance *models.ArrInstance, result *ExternalIDsLookupResult, source string) *ExternalIDsResult {
 	instanceID := instance.ID
 	titles := append([]string{}, result.Titles...)
-	if err := s.cacheStore.SetWithTitles(ctx, titleHash, string(contentType), &instanceID, result.IDs, titles, false, s.positiveTTL); err != nil {
+	// Detach from the request context: see the negative-cache write above.
+	if err := s.cacheStore.SetWithTitles(context.WithoutCancel(ctx), titleHash, string(contentType), &instanceID, result.IDs, titles, false, s.positiveTTL); err != nil {
 		log.Warn().Err(err).Msg("[ARR-LOOKUP] Failed to cache positive result")
 	}
 

--- a/internal/services/arr/service.go
+++ b/internal/services/arr/service.go
@@ -23,6 +23,10 @@ const (
 	// Long TTL because external IDs (IMDb, TMDb, TVDb, TVMaze) are immutable
 	DefaultPositiveCacheTTL = 30 * 24 * time.Hour // 30 days
 
+	// cacheWriteTimeout bounds detached cache writes so a wedged SQLite writer
+	// cannot hold them forever; writerMu is not context-aware while blocked.
+	cacheWriteTimeout = 5 * time.Second
+
 	// DefaultNegativeCacheTTL is the default TTL for negative cache entries (no IDs found)
 	// Short TTL because content may be added to *arr instances later
 	DefaultNegativeCacheTTL = 1 * time.Hour
@@ -288,10 +292,9 @@ func (s *Service) lookupExternalIDsFromParse(ctx context.Context, titleHash, tit
 	}
 
 	if cacheNegative {
-		// Detach from the request context: a lookup that finishes near a
-		// caller's deadline must still cache, or the caller repeats the HTTP
-		// round trips on its next request.
-		if err := s.cacheStore.Set(context.WithoutCancel(ctx), titleHash, string(contentType), nil, nil, true, s.negativeTTL); err != nil {
+		writeCtx, cancel := detachedCacheWriteContext(ctx)
+		defer cancel()
+		if err := s.cacheStore.Set(writeCtx, titleHash, string(contentType), nil, nil, true, s.negativeTTL); err != nil {
 			log.Warn().Err(err).Msg("[ARR-LOOKUP] Failed to cache negative result")
 		}
 	}
@@ -312,8 +315,9 @@ func (s *Service) lookupExternalIDsFromParse(ctx context.Context, titleHash, tit
 func (s *Service) cacheAndBuildResult(ctx context.Context, titleHash, title string, contentType ContentType, instance *models.ArrInstance, result *ExternalIDsLookupResult, source string) *ExternalIDsResult {
 	instanceID := instance.ID
 	titles := append([]string{}, result.Titles...)
-	// Detach from the request context: see the negative-cache write above.
-	if err := s.cacheStore.SetWithTitles(context.WithoutCancel(ctx), titleHash, string(contentType), &instanceID, result.IDs, titles, false, s.positiveTTL); err != nil {
+	writeCtx, cancel := detachedCacheWriteContext(ctx)
+	defer cancel()
+	if err := s.cacheStore.SetWithTitles(writeCtx, titleHash, string(contentType), &instanceID, result.IDs, titles, false, s.positiveTTL); err != nil {
 		log.Warn().Err(err).Msg("[ARR-LOOKUP] Failed to cache positive result")
 	}
 
@@ -646,4 +650,11 @@ func (s *Service) maybeScheduleCacheCleanup() {
 			log.Debug().Int64("deleted", deleted).Msg("[ARR-LOOKUP] Cleaned up expired cache entries")
 		}
 	}()
+}
+
+// detachedCacheWriteContext survives the caller's cancellation, so a lookup
+// that finishes near the caller's deadline still caches, while its own
+// timeout keeps the write from blocking forever on the serialized writer.
+func detachedCacheWriteContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), cacheWriteTimeout)
 }

--- a/internal/services/arr/service_test.go
+++ b/internal/services/arr/service_test.go
@@ -626,3 +626,30 @@ func TestDefaultTTL_Values(t *testing.T) {
 	assert.Equal(t, 30*24*time.Hour, DefaultPositiveCacheTTL)
 	assert.Equal(t, 1*time.Hour, DefaultNegativeCacheTTL)
 }
+
+// TestCacheWritesSurviveCallerCancellation catches a cache write bound to the
+// request context: an announce-path lookup that finishes near its deadline
+// would then succeed but fail to cache, so the apply-time repeat of the same
+// title pays the ARR round trips again.
+func TestCacheWritesSurviveCallerCancellation(t *testing.T) {
+	service, cacheStore := newArrLookupTestService(t, models.ArrInstanceTypeSonarr, http.NotFoundHandler())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	const title = "Sousou no Frieren S02E10 1080p WEB-DL AAC2.0 H.264-KiraSubs"
+	titleHash := models.ComputeTitleHash(title)
+	instance := &models.ArrInstance{ID: 1}
+	lookupResult := &ExternalIDsLookupResult{
+		IDs:    &models.ExternalIDs{TVDbID: 424536},
+		Titles: []string{"Frieren: Beyond Journey's End", "Sousou no Frieren"},
+	}
+
+	result := service.cacheAndBuildResult(ctx, titleHash, title, ContentTypeTV, instance, lookupResult, "parse")
+	require.NotNil(t, result)
+
+	entry, err := cacheStore.Get(context.Background(), titleHash, string(ContentTypeTV))
+	require.NoError(t, err)
+	require.NotNil(t, entry)
+	require.Equal(t, []string{"Frieren: Beyond Journey's End", "Sousou no Frieren"}, entry.Titles)
+}

--- a/internal/services/crossseed/announcement_match.go
+++ b/internal/services/crossseed/announcement_match.go
@@ -14,6 +14,10 @@ type announcementMatchPolicy struct {
 	rescueTitleMismatches  bool
 	allowUnknownSize       bool
 	skipRecheck            bool
+	// candidateTitles are ARR alternate titles for the announced release. They
+	// attach to the candidate side only, so they can never widen the identity
+	// of an unrelated source torrent.
+	candidateTitles []string
 }
 
 type announcementCandidateDecision struct {
@@ -73,6 +77,15 @@ func (s *Service) classifyWebhookAnnouncementSource(
 	return announcementCandidateDecision{decision: decision, replayable: true}
 }
 
+// announceAliasTitles resolves ARR alternate titles for an announced release.
+// Callers run it once per announce, outside the per-torrent scan loops.
+func (s *Service) announceAliasTitles(ctx context.Context, announcedName, contentType string) []string {
+	if arrResult, _ := s.lookupARRExternalIDs(ctx, announcedName, contentType); arrResult != nil {
+		return arrResult.Titles
+	}
+	return nil
+}
+
 func (s *Service) announcementRawSearchInput(source *qbt.Torrent, candidate namedRelease, candidateSize int64, policy announcementMatchPolicy) searchCandidateInput {
 	parsedSource := s.releaseCache.Parse(source.Name)
 	return searchCandidateInput{
@@ -80,6 +93,7 @@ func (s *Service) announcementRawSearchInput(source *qbt.Torrent, candidate name
 		Candidate:              candidate,
 		SourceSize:             searchSourceSize(source),
 		CandidateSize:          candidateSize,
+		CandidateTitles:        policy.candidateTitles,
 		TolerancePercent:       defaultSizeMismatchTolerancePercent,
 		FindIndividualEpisodes: policy.findIndividualEpisodes,
 		RescueTitleMismatches:  policy.rescueTitleMismatches,

--- a/internal/services/crossseed/announcement_match.go
+++ b/internal/services/crossseed/announcement_match.go
@@ -25,6 +25,12 @@ type announcementMatchPolicy struct {
 	// attach to the candidate side only, so they can never widen the identity
 	// of an unrelated source torrent.
 	candidateTitles []string
+	// tolerateOneSidedChecksum lets the advisory webhook check pass a candidate
+	// whose only strict failure is a CRC tag on one side. IRC announce sizes are
+	// rounded, so the check cannot reach the exact-size checksum relaxation that
+	// apply gets from the real torrent bytes. A false positive here costs one
+	// torrent download; apply re-validates and stays authoritative.
+	tolerateOneSidedChecksum bool
 }
 
 type announcementCandidateDecision struct {
@@ -75,7 +81,13 @@ func (s *Service) classifyWebhookAnnouncementSource(
 		return s.classifyAnnouncementSource(ctx, instanceID, source, candidate, candidateSize, policy)
 	}
 
-	decision := s.classifySearchCandidate(s.announcementRawSearchInput(source, candidate, candidateSize, policy))
+	input := s.announcementRawSearchInput(source, candidate, candidateSize, policy)
+	decision := s.classifySearchCandidate(input)
+	if policy.tolerateOneSidedChecksum && decision.RejectReason == checksumMismatchReason &&
+		s.hasOneSidedChecksum(input.Source.release, input.Candidate.release) {
+		relaxed, _ := s.withRelaxedDifferenceNeutralized(input, "checksum")
+		decision = s.classifySearchCandidate(relaxed)
+	}
 	if decision.Accepted && decision.Class != searchCandidateClassStrict {
 		decision.Accepted = false
 		decision.Class = searchCandidateClassRejected

--- a/internal/services/crossseed/announcement_match.go
+++ b/internal/services/crossseed/announcement_match.go
@@ -5,9 +5,16 @@ package crossseed
 
 import (
 	"context"
+	"time"
 
 	qbt "github.com/autobrr/go-qbittorrent"
 )
+
+// announceAliasLookupTimeout bounds the ARR alias lookup on announce paths.
+// Announce checks answer autobrr inside its webhook timeout, so a hung ARR
+// instance must degrade the check to name-only matching, not stall it for the
+// full per-instance HTTP timeouts. Search paths keep their own patience.
+const announceAliasLookupTimeout = 5 * time.Second
 
 type announcementMatchPolicy struct {
 	findIndividualEpisodes bool
@@ -80,6 +87,8 @@ func (s *Service) classifyWebhookAnnouncementSource(
 // announceAliasTitles resolves ARR alternate titles for an announced release.
 // Callers run it once per announce, outside the per-torrent scan loops.
 func (s *Service) announceAliasTitles(ctx context.Context, announcedName, contentType string) []string {
+	ctx, cancel := context.WithTimeout(ctx, announceAliasLookupTimeout)
+	defer cancel()
 	if arrResult, _ := s.lookupARRExternalIDs(ctx, announcedName, contentType); arrResult != nil {
 		return arrResult.Titles
 	}

--- a/internal/services/crossseed/announcement_match_test.go
+++ b/internal/services/crossseed/announcement_match_test.go
@@ -342,6 +342,77 @@ func TestClassifyWebhookAnnouncementSourceCandidateTitles(t *testing.T) {
 	}
 }
 
+// TestClassifyWebhookAnnouncementSourceToleratesOneSidedChecksum protects the
+// advisory check's checksum tolerance: IRC announce sizes are rounded, so a
+// CRC tag on only the local file name must not veto a within-tolerance check
+// when everything else matches strictly. Apply omits the policy flag and keeps
+// demanding strict, because it classifies real torrent bytes.
+func TestClassifyWebhookAnnouncementSourceToleratesOneSidedChecksum(t *testing.T) {
+	const (
+		sourceName   = "[KiraSubs] Frieren S2 - 10 (1080p) [ABCD1234].mkv"
+		announceName = "Frieren: Beyond Journey's End S02E10 1080p CR WEB-DL AAC 2.0 H.264-KiraSubs"
+		size         = int64(1_468_228_504)
+		roundedSize  = int64(1_471_026_298) // 1.37 GiB: what the IRC announce advertises
+	)
+	aliasTitles := []string{"Frieren: Beyond Journey's End", "Sousou no Frieren", "Frieren"}
+
+	svc := &Service{
+		releaseCache:     NewReleaseCache(),
+		stringNormalizer: stringutils.NewDefaultNormalizer(),
+	}
+	source := qbt.Torrent{Name: sourceName, Size: size, TotalSize: size, Progress: 1}
+
+	tests := []struct {
+		name          string
+		candidateName string
+		candidateSize int64
+		tolerate      bool
+		wantAccepted  bool
+	}{
+		{
+			name:          "one-sided checksum within tolerance tolerated",
+			candidateName: announceName, candidateSize: roundedSize,
+			tolerate: true, wantAccepted: true,
+		},
+		{
+			name:          "apply policy still rejects one-sided checksum",
+			candidateName: announceName, candidateSize: roundedSize,
+		},
+		{
+			name:          "conflicting checksums stay rejected",
+			candidateName: "[KiraSubs] Frieren S2 - 10 (1080p) [DEADBEEF].mkv", candidateSize: roundedSize,
+			tolerate: true,
+		},
+		{
+			name:          "other strict failures stay rejected",
+			candidateName: "Frieren: Beyond Journey's End S02E10 720p CR WEB-DL AAC 2.0 H.264-KiraSubs", candidateSize: roundedSize,
+			tolerate: true,
+		},
+		{
+			name:          "out-of-tolerance size stays rejected",
+			candidateName: announceName, candidateSize: size * 2,
+			tolerate: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			candidate := namedRelease{release: svc.releaseCache.Parse(tt.candidateName), rawName: tt.candidateName}
+
+			got := svc.classifyWebhookAnnouncementSource(context.Background(), 1, &source, candidate, tt.candidateSize, announcementMatchPolicy{
+				candidateTitles:          aliasTitles,
+				tolerateOneSidedChecksum: tt.tolerate,
+			})
+
+			require.Equal(t, tt.wantAccepted, got.decision.Accepted, got.decision.RejectReason)
+			require.True(t, got.replayable)
+			if tt.wantAccepted {
+				require.Equal(t, searchCandidateClassStrict, got.decision.Class)
+			}
+		})
+	}
+}
+
 // TestUnknownSizePreflightDecisionAllowlist catches a future classifier
 // relaxation becoming an unknown-size download recommendation by default.
 func TestUnknownSizePreflightDecisionAllowlist(t *testing.T) {

--- a/internal/services/crossseed/announcement_match_test.go
+++ b/internal/services/crossseed/announcement_match_test.go
@@ -4,6 +4,7 @@
 package crossseed
 
 import (
+	"cmp"
 	"context"
 	"testing"
 
@@ -249,6 +250,95 @@ func TestClassifyWebhookAnnouncementSourceNonexactRequiresStrictMatch(t *testing
 
 	require.False(t, got.decision.Accepted)
 	require.True(t, got.replayable)
+}
+
+// TestClassifyWebhookAnnouncementSourceCandidateTitles protects the announce
+// classifier's ARR alias handling: alias titles attach to the announced
+// candidate only, recover exact-size and unknown-size matches that plain title
+// overlap rejects, and never widen an unrelated source torrent. Names follow
+// the scrubbed repro from issue #2492.
+func TestClassifyWebhookAnnouncementSourceCandidateTitles(t *testing.T) {
+	const (
+		instanceID = 1
+		sourceHash = "alias-announce-source"
+		sourceName = "[KiraSubs] Frieren S2 - 10 (1080p) [ABCD1234].mkv"
+		size       = int64(1_500_000_000)
+
+		englishAnnounce = "Frieren: Beyond Journey's End S02E10 1080p CR WEB-DL AAC 2.0 H.264-KiraSubs"
+		romajiAnnounce  = "Sousou no Frieren S02E10 1080p WEB-DL AAC2.0 H.264-KiraSubs"
+		bracketAnnounce = "[KiraSubs] Frieren: Beyond Journey's End Season 2 - 10 [2026][Web][MKV][h264][1080p][AAC 2.0][Softsubs (KiraSubs)]"
+	)
+	aliasTitles := []string{"Frieren: Beyond Journey's End", "Sousou no Frieren", "Frieren"}
+
+	tests := []struct {
+		name            string
+		sourceName      string // empty means the seeded Frieren source
+		candidateName   string
+		candidateSize   int64
+		candidateTitles []string
+		wantAccepted    bool
+	}{
+		{
+			name:          "english title exact size with aliases",
+			candidateName: englishAnnounce, candidateSize: size,
+			candidateTitles: aliasTitles, wantAccepted: true,
+		},
+		{
+			name:          "english title exact size without aliases",
+			candidateName: englishAnnounce, candidateSize: size,
+		},
+		{
+			name:          "romaji title exact size with aliases",
+			candidateName: romajiAnnounce, candidateSize: size,
+			candidateTitles: aliasTitles, wantAccepted: true,
+		},
+		{
+			name:          "romaji title exact size without aliases",
+			candidateName: romajiAnnounce, candidateSize: size,
+		},
+		{
+			name:          "bracket title unknown size with aliases",
+			candidateName: bracketAnnounce, candidateSize: 0,
+			candidateTitles: aliasTitles, wantAccepted: true,
+		},
+		{
+			name:          "bracket title unknown size without aliases",
+			candidateName: bracketAnnounce, candidateSize: 0,
+		},
+		{
+			name:          "aliases never widen an unrelated source torrent",
+			sourceName:    "[KiraSubs] Different Voyage S2 - 10 (1080p) [ABCD1234].mkv",
+			candidateName: englishAnnounce, candidateSize: size,
+			candidateTitles: aliasTitles,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name := cmp.Or(tt.sourceName, sourceName)
+			source := qbt.Torrent{Hash: sourceHash, Name: name, Size: size, TotalSize: size, Progress: 1}
+			instance := &models.Instance{ID: instanceID, Name: "main"}
+			svc := &Service{
+				syncManager: newFakeSyncManager(instance, []qbt.Torrent{source}, map[string]qbt.TorrentFiles{
+					sourceHash: {{Name: name, Size: size}},
+				}),
+				releaseCache:     NewReleaseCache(),
+				stringNormalizer: stringutils.NewDefaultNormalizer(),
+			}
+			candidate := namedRelease{release: svc.releaseCache.Parse(tt.candidateName), rawName: tt.candidateName}
+
+			got := svc.classifyWebhookAnnouncementSource(context.Background(), instanceID, &source, candidate, tt.candidateSize, announcementMatchPolicy{
+				allowUnknownSize: tt.candidateSize == 0,
+				candidateTitles:  tt.candidateTitles,
+			})
+
+			require.Equal(t, tt.wantAccepted, got.decision.Accepted, got.decision.RejectReason)
+			if tt.wantAccepted {
+				require.Equal(t, searchCandidateClassExactSizeFallback, got.decision.Class)
+				require.Contains(t, got.decision.RelaxedDifferences, "checksum")
+			}
+		})
+	}
 }
 
 // TestUnknownSizePreflightDecisionAllowlist catches a future classifier

--- a/internal/services/crossseed/announcement_match_test.go
+++ b/internal/services/crossseed/announcement_match_test.go
@@ -7,6 +7,7 @@ import (
 	"cmp"
 	"context"
 	"testing"
+	"time"
 
 	qbt "github.com/autobrr/go-qbittorrent"
 	"github.com/stretchr/testify/require"
@@ -456,4 +457,19 @@ func TestClassifyAnnouncementSourceAvoidsUnnecessaryFileLookups(t *testing.T) {
 			require.Equal(t, tt.wantLookups, sync.lookups)
 		})
 	}
+}
+
+// TestAnnounceAliasTitlesBoundsLookup catches an announce-path alias lookup
+// without a deadline: a hung ARR instance would then stall every announce
+// check for the full per-instance HTTP timeouts.
+func TestAnnounceAliasTitlesBoundsLookup(t *testing.T) {
+	t.Parallel()
+
+	spy := &spyARRLookupService{}
+	svc := &Service{arrService: spy}
+
+	svc.announceAliasTitles(context.Background(), "Sousou no Frieren S02E10 1080p WEB-DL AAC2.0 H.264-KiraSubs", "tv")
+
+	require.True(t, spy.hasDeadline)
+	require.LessOrEqual(t, time.Until(spy.deadline), announceAliasLookupTimeout)
 }

--- a/internal/services/crossseed/autobrr_apply_test.go
+++ b/internal/services/crossseed/autobrr_apply_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/autobrr/qui/internal/models"
 	internalqb "github.com/autobrr/qui/internal/qbittorrent"
+	"github.com/autobrr/qui/internal/services/arr"
 	"github.com/autobrr/qui/internal/services/notifications"
 	"github.com/autobrr/qui/pkg/stringutils"
 )
@@ -810,6 +811,76 @@ func TestAutobrrApplyNonexactAnnouncementCheapGate(t *testing.T) {
 			} else {
 				require.True(t, response.Success)
 			}
+		})
+	}
+}
+
+// TestAutobrrApplyUsesARRAlternateTitles catches an apply path that loses the
+// announce's ARR alias titles between the webhook check and injection: the
+// bound decision must carry them into the CrossSeed revalidation, with exactly
+// one ARR lookup for the whole request.
+func TestAutobrrApplyUsesARRAlternateTitles(t *testing.T) {
+	t.Parallel()
+
+	const (
+		sourceName     = "[KiraSubs] Frieren S2 - 10 (1080p) [ABCD1234].mkv"
+		announcedName  = "Frieren: Beyond Journey's End S02E10 1080p CR WEB-DL AAC 2.0 H.264-KiraSubs"
+		downloadedName = "Sousou no Frieren S02E10 1080p WEB-DL AAC2.0 H.264-KiraSubs"
+	)
+	aliasTitles := []string{"Frieren: Beyond Journey's End", "Sousou no Frieren", "Frieren"}
+
+	torrentData := createTestTorrent(t, downloadedName, []string{"payload.mkv"}, 256*1024)
+	meta, err := ParseTorrentMetadataWithInfo(torrentData)
+	require.NoError(t, err)
+	var torrentSize int64
+	for _, file := range meta.Files {
+		torrentSize += file.Size
+	}
+
+	instance := &models.Instance{ID: 47, Name: "primary", IsActive: true}
+
+	tests := []struct {
+		name        string
+		spy         *spyARRLookupService
+		wantMatched bool
+	}{
+		{
+			name:        "aliases carry from announce match into apply revalidation",
+			spy:         &spyARRLookupService{result: &arr.ExternalIDsResult{Titles: aliasTitles, TitlesKnown: true}},
+			wantMatched: true,
+		},
+		{name: "no arr service still rejects the alias announce"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := qbt.Torrent{Hash: "frieren-library", Name: sourceName, Size: torrentSize, TotalSize: torrentSize, Progress: 1}
+			service := &Service{
+				instanceStore:    &fakeInstanceStore{instances: map[int]*models.Instance{instance.ID: instance}},
+				syncManager:      newFakeSyncManager(instance, []qbt.Torrent{source}, map[string]qbt.TorrentFiles{source.Hash: meta.Files}),
+				releaseCache:     NewReleaseCache(),
+				stringNormalizer: stringutils.NewDefaultNormalizer(),
+				automationSettingsLoader: func(context.Context) (*models.CrossSeedAutomationSettings, error) {
+					return &models.CrossSeedAutomationSettings{}, nil
+				},
+			}
+			if tt.spy != nil {
+				service.arrService = tt.spy
+			}
+
+			response, err := service.AutobrrApply(context.Background(), &AutobrrApplyRequest{
+				TorrentData: base64.StdEncoding.EncodeToString(torrentData),
+				TorrentName: announcedName,
+				InstanceIDs: []int{instance.ID},
+			})
+			require.NoError(t, err)
+			if !tt.wantMatched {
+				require.Empty(t, response.Results)
+				return
+			}
+			require.Equal(t, 1, tt.spy.calls)
+			require.Len(t, response.Results, 1)
+			require.NotEqual(t, "no_match", response.Results[0].Status)
 		})
 	}
 }

--- a/internal/services/crossseed/autobrr_exact_size_test.go
+++ b/internal/services/crossseed/autobrr_exact_size_test.go
@@ -5,12 +5,14 @@ package crossseed
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	qbt "github.com/autobrr/go-qbittorrent"
 	"github.com/stretchr/testify/require"
 
 	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/services/arr"
 	"github.com/autobrr/qui/pkg/stringutils"
 )
 
@@ -163,6 +165,75 @@ func TestCheckWebhookUnknownSizePreflight(t *testing.T) {
 			if tt.wantMatch {
 				require.Len(t, response.Matches, 1)
 				require.Equal(t, "metadata", response.Matches[0].MatchType)
+			} else {
+				require.Empty(t, response.Matches)
+			}
+		})
+	}
+}
+
+// TestCheckWebhookARRAlternateTitles catches a webhook check that ignores ARR
+// alternate titles the search path already uses, and a check that repeats the
+// ARR lookup for every scanned torrent instead of once per request.
+func TestCheckWebhookARRAlternateTitles(t *testing.T) {
+	t.Parallel()
+
+	const (
+		sourceName   = "[KiraSubs] Frieren S2 - 10 (1080p) [ABCD1234].mkv"
+		announceName = "Sousou no Frieren S02E10 1080p WEB-DL AAC2.0 H.264-KiraSubs"
+		size         = int64(1_500_000_000)
+	)
+	aliasResult := &arr.ExternalIDsResult{
+		Titles:      []string{"Frieren: Beyond Journey's End", "Sousou no Frieren", "Frieren"},
+		TitlesKnown: true,
+	}
+	instance := &models.Instance{ID: 14, Name: "primary", IsActive: true}
+
+	tests := []struct {
+		name      string
+		spy       *spyARRLookupService
+		wantMatch bool
+		wantCalls int
+	}{
+		{name: "aliases recover the match with one lookup", spy: &spyARRLookupService{result: aliasResult}, wantMatch: true, wantCalls: 1},
+		{name: "no arr service keeps rejecting", spy: nil},
+		{name: "lookup error keeps rejecting", spy: &spyARRLookupService{err: errors.New("arr down")}, wantCalls: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := qbt.Torrent{Hash: "frieren-source", Name: sourceName, Size: size, TotalSize: size, Progress: 1}
+			unrelated := qbt.Torrent{Hash: "unrelated-source", Name: "Quiet.Signal.2025.1080p.WEB-DL.H.264-LUMA", Size: size, TotalSize: size, Progress: 1}
+			service := &Service{
+				instanceStore: &fakeInstanceStore{instances: map[int]*models.Instance{instance.ID: instance}},
+				syncManager: newFakeSyncManager(instance, []qbt.Torrent{source, unrelated}, map[string]qbt.TorrentFiles{
+					source.Hash:    {{Name: source.Name, Size: size}},
+					unrelated.Hash: {{Name: unrelated.Name + ".mkv", Size: size}},
+				}),
+				releaseCache:     NewReleaseCache(),
+				stringNormalizer: stringutils.NewDefaultNormalizer(),
+				automationSettingsLoader: func(context.Context) (*models.CrossSeedAutomationSettings, error) {
+					return &models.CrossSeedAutomationSettings{}, nil
+				},
+			}
+			if tt.spy != nil {
+				service.arrService = tt.spy
+			}
+
+			response, err := service.CheckWebhook(context.Background(), &WebhookCheckRequest{
+				InstanceIDs: []int{instance.ID},
+				TorrentName: announceName,
+				Size:        uint64(size),
+			})
+			require.NoError(t, err)
+			require.Equal(t, tt.wantMatch, response.CanCrossSeed)
+			if tt.spy != nil {
+				require.Equal(t, tt.wantCalls, tt.spy.calls)
+				require.Equal(t, announceName, tt.spy.title)
+			}
+			if tt.wantMatch {
+				require.Len(t, response.Matches, 1)
+				require.Equal(t, "exact", response.Matches[0].MatchType)
 			} else {
 				require.Empty(t, response.Matches)
 			}

--- a/internal/services/crossseed/matching.go
+++ b/internal/services/crossseed/matching.go
@@ -327,12 +327,6 @@ func (s *Service) normalizedReleaseTitles(release *rls.Release, rawName string) 
 	return titles
 }
 
-func addNormalizedTitles(titles map[string]struct{}, extraTitles []string) {
-	for _, title := range extraTitles {
-		addNormalizedTitle(titles, title)
-	}
-}
-
 // normalizedTitleSetContainsAny reports whether any extra title normalizes to
 // an entry of the set. It never mutates the set.
 func normalizedTitleSetContainsAny(titles map[string]struct{}, extraTitles []string) bool {

--- a/internal/services/crossseed/matching.go
+++ b/internal/services/crossseed/matching.go
@@ -199,8 +199,6 @@ func (s *Service) validateTitleArtistAndDates(source, candidate *rls.Release, so
 	// "Bob's Burgers" vs "Bobs.Burgers" (apostrophes lost in dot notation).
 	sourceTitles := s.normalizedReleaseTitles(source, sourceName)
 	candidateTitles := s.normalizedReleaseTitles(candidate, candidateName)
-	addNormalizedTitles(sourceTitles, sourceExtraTitles)
-	addNormalizedTitles(candidateTitles, candidateExtraTitles)
 	if len(sourceTitles) == 0 || len(candidateTitles) == 0 {
 		return false, "empty normalized title"
 	}
@@ -212,7 +210,14 @@ func (s *Service) validateTitleArtistAndDates(source, candidate *rls.Release, so
 	// This still avoids false positives between related-but-distinct TV franchises
 	// (e.g. "FBI" vs "FBI Most Wanted") because overlap is checked on full normalized
 	// title entries, not arbitrary substrings.
-	if !normalizedTitleSetsOverlap(sourceTitles, candidateTitles) {
+	//
+	// Extra titles (ARR aliases) are loop-invariant across a scan while this
+	// function runs once per scanned torrent, and Sonarr alias lists are uncapped.
+	// Probe them against the other side's set instead of inserting them, so the
+	// per-pair maps stay small and never regrow per torrent.
+	if !normalizedTitleSetsOverlap(sourceTitles, candidateTitles) &&
+		!normalizedTitleSetContainsAny(sourceTitles, candidateExtraTitles) &&
+		!normalizedTitleSetContainsAny(candidateTitles, sourceExtraTitles) {
 		// Title mismatches are expected for most candidates - don't log to avoid noise
 		return false, titleMismatchReason
 	}
@@ -326,6 +331,17 @@ func addNormalizedTitles(titles map[string]struct{}, extraTitles []string) {
 	for _, title := range extraTitles {
 		addNormalizedTitle(titles, title)
 	}
+}
+
+// normalizedTitleSetContainsAny reports whether any extra title normalizes to
+// an entry of the set. It never mutates the set.
+func normalizedTitleSetContainsAny(titles map[string]struct{}, extraTitles []string) bool {
+	for _, title := range extraTitles {
+		if _, exists := titles[stringutils.NormalizeForMatching(title)]; exists {
+			return true
+		}
+	}
+	return false
 }
 
 func releaseTitle(release *rls.Release) string {

--- a/internal/services/crossseed/rss_exact_size_test.go
+++ b/internal/services/crossseed/rss_exact_size_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/services/arr"
 	"github.com/autobrr/qui/internal/services/jackett"
 	"github.com/autobrr/qui/pkg/stringutils"
 )
@@ -872,4 +873,71 @@ func TestMergeCrossSeedResponsesPreservesAggregateSuccess(t *testing.T) {
 
 	require.True(t, destination.Success)
 	require.True(t, destination.titleRescueUsed)
+}
+
+// TestFindRSSAnnouncementMatchesARRAlternateTitles catches an RSS fallback that
+// ignores ARR alternate titles the webhook and autobrr paths already use, and
+// an eager lookup that touches ARR for feed items with no byte-size collision.
+func TestFindRSSAnnouncementMatchesARRAlternateTitles(t *testing.T) {
+	t.Parallel()
+
+	const (
+		instanceID   = 17
+		sourceName   = "[KiraSubs] Frieren S2 - 10 (1080p) [ABCD1234].mkv"
+		announceName = "Sousou no Frieren S02E10 1080p WEB-DL AAC2.0 H.264-KiraSubs"
+		size         = int64(1_500_000_000)
+	)
+	aliasResult := &arr.ExternalIDsResult{
+		Titles:      []string{"Frieren: Beyond Journey's End", "Sousou no Frieren", "Frieren"},
+		TitlesKnown: true,
+	}
+
+	tests := []struct {
+		name       string
+		spy        *spyARRLookupService
+		sourceSize int64
+		wantMatch  bool
+		wantCalls  int
+	}{
+		{name: "aliases recover the match with one lookup", spy: &spyARRLookupService{result: aliasResult}, sourceSize: size, wantMatch: true, wantCalls: 1},
+		{name: "no size collision skips the lookup", spy: &spyARRLookupService{result: aliasResult}, sourceSize: size + 1},
+		{name: "no arr service keeps rejecting", sourceSize: size},
+		{name: "lookup error keeps rejecting", spy: &spyARRLookupService{err: errors.New("arr down")}, sourceSize: size, wantCalls: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := qbt.Torrent{Hash: "frieren-source", Name: sourceName, TotalSize: tt.sourceSize, Progress: 1}
+			unrelated := qbt.Torrent{Hash: "unrelated-source", Name: "Quiet.Signal.2025.1080p.WEB-DL.H.264-LUMA", TotalSize: tt.sourceSize, Progress: 1}
+			instance := &models.Instance{ID: instanceID, Name: "main"}
+			service := &Service{
+				instanceStore: &fakeInstanceStore{instances: map[int]*models.Instance{instanceID: instance}},
+				syncManager: newFakeSyncManager(instance, []qbt.Torrent{source, unrelated}, map[string]qbt.TorrentFiles{
+					source.Hash:    {{Name: source.Name, Size: tt.sourceSize}},
+					unrelated.Hash: {{Name: unrelated.Name + ".mkv", Size: tt.sourceSize}},
+				}),
+				releaseCache:     NewReleaseCache(),
+				stringNormalizer: stringutils.NewDefaultNormalizer(),
+			}
+			if tt.spy != nil {
+				service.arrService = tt.spy
+			}
+
+			matches, err := service.findRSSAnnouncementMatches(context.Background(), jackett.SearchResult{Title: announceName, Size: size}, &models.CrossSeedAutomationSettings{
+				TargetInstanceIDs: []int{instanceID},
+			}, nil)
+			require.NoError(t, err)
+			if tt.spy != nil {
+				require.Equal(t, tt.wantCalls, tt.spy.calls)
+			}
+			if tt.wantMatch {
+				require.Len(t, matches, 1)
+				// The decision must carry the aliases so the apply-time
+				// revalidation inside CrossSeed accepts the same pair.
+				require.Equal(t, aliasResult.Titles, matches[0].decision.CandidateTitles)
+			} else {
+				require.Empty(t, matches)
+			}
+		})
+	}
 }

--- a/internal/services/crossseed/search_candidate_match.go
+++ b/internal/services/crossseed/search_candidate_match.go
@@ -69,6 +69,7 @@ type searchCandidateDecision struct {
 	SearchCandidateName   string
 	GroupFallbackIdentity string
 	SourceTitles          []string
+	CandidateTitles       []string
 	RejectReason          string
 	StrictMismatchReason  string
 	RelaxedDifferences    []string
@@ -93,6 +94,7 @@ type searchDecisionProvenance struct {
 	RelaxedDifferences    []string
 	GroupFallbackIdentity string
 	SourceTitles          []string
+	CandidateTitles       []string
 }
 
 func (decision searchCandidateDecision) provenance() searchDecisionProvenance {
@@ -104,12 +106,14 @@ func (decision searchCandidateDecision) provenance() searchDecisionProvenance {
 		RelaxedDifferences:    slices.Clone(decision.RelaxedDifferences),
 		GroupFallbackIdentity: decision.GroupFallbackIdentity,
 		SourceTitles:          slices.Clone(decision.SourceTitles),
+		CandidateTitles:       slices.Clone(decision.CandidateTitles),
 	}
 }
 
 func (provenance searchDecisionProvenance) clone() searchDecisionProvenance {
 	provenance.RelaxedDifferences = slices.Clone(provenance.RelaxedDifferences)
 	provenance.SourceTitles = slices.Clone(provenance.SourceTitles)
+	provenance.CandidateTitles = slices.Clone(provenance.CandidateTitles)
 	return provenance
 }
 
@@ -275,6 +279,7 @@ func (s *Service) classifySearchCandidate(input searchCandidateInput) searchCand
 	decision.Accepted = true
 	decision.Class = class
 	decision.SourceTitles = slices.Clone(input.SourceTitles)
+	decision.CandidateTitles = slices.Clone(input.CandidateTitles)
 	decision.Score, decision.MatchReason = evaluateReleaseMatch(input.Source.release, input.Candidate.release)
 	if decision.Score <= 0 {
 		decision.Score = 1

--- a/internal/services/crossseed/search_candidate_match_test.go
+++ b/internal/services/crossseed/search_candidate_match_test.go
@@ -2328,6 +2328,65 @@ func TestCrossSeedRevalidatesARRSourceTitles(t *testing.T) {
 	require.Contains(t, aliased.Results[0].Message, "torrent properties")
 }
 
+// TestCrossSeedRevalidatesARRCandidateTitles mirrors the SourceTitles
+// revalidation above for announce-origin aliases: CandidateTitles describe the
+// incoming (target) release, so apply widens the target side with them, still
+// bound to the decision's source torrent.
+func TestCrossSeedRevalidatesARRCandidateTitles(t *testing.T) {
+	const (
+		instanceID   = 1
+		targetName   = "Money.Heist.S01E01.1080p.NF.WEB-DL.DDP5.1.H.264-NTb"
+		existingName = "La.Casa.De.Papel.S01E01.1080p.NF.WEB-DL.DDP5.1.H.264-NTb"
+		existingHash = "existing"
+	)
+	torrentData := createTestTorrent(t, targetName, []string{"payload.mkv"}, 256*1024)
+	meta, err := ParseTorrentMetadataWithInfo(torrentData)
+	require.NoError(t, err)
+	var torrentSize int64
+	for _, file := range meta.Files {
+		torrentSize += file.Size
+	}
+
+	instance := &models.Instance{ID: instanceID, Name: "main"}
+	existing := qbt.Torrent{
+		Hash:     existingHash,
+		Name:     existingName,
+		Size:     torrentSize,
+		Progress: 1,
+	}
+	service := &Service{
+		instanceStore:    &fakeInstanceStore{instances: map[int]*models.Instance{instanceID: instance}},
+		syncManager:      newFakeSyncManager(instance, []qbt.Torrent{existing}, map[string]qbt.TorrentFiles{existingHash: meta.Files}),
+		releaseCache:     NewReleaseCache(),
+		stringNormalizer: stringutils.NewDefaultNormalizer(),
+	}
+
+	apply := func(candidateTitles []string, sourceHash string) *CrossSeedResponse {
+		response, applyErr := service.CrossSeed(context.Background(), &CrossSeedRequest{
+			TorrentData:       base64.StdEncoding.EncodeToString(torrentData),
+			TargetInstanceIDs: []int{instanceID},
+			SearchDecision: searchDecisionProvenance{
+				Class:            searchCandidateClassStrict,
+				SourceInstanceID: instanceID,
+				SourceHash:       sourceHash,
+				CandidateTitles:  candidateTitles,
+			},
+		})
+		require.NoError(t, applyErr)
+		require.Len(t, response.Results, 1)
+		return response
+	}
+
+	require.Equal(t, "no_match", apply(nil, existingHash).Results[0].Status)
+	require.Equal(t, "no_match", apply([]string{"Unrelated Show"}, existingHash).Results[0].Status)
+	// The aliases stay bound to the decision's source torrent.
+	require.Equal(t, "no_match", apply([]string{"La Casa de Papel"}, "different-hash").Results[0].Status)
+
+	aliased := apply([]string{"La Casa de Papel"}, existingHash)
+	require.NotEqual(t, "no_match", aliased.Results[0].Status)
+	require.Contains(t, aliased.Results[0].Message, "torrent properties")
+}
+
 func TestARRAliasSurvivesSearchToManualAndAutomatedApply(t *testing.T) {
 	const (
 		instanceID    = 1

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -4334,6 +4334,11 @@ func (s *Service) findRSSAnnouncementMatches(ctx context.Context, result jackett
 	}
 
 	candidate := namedRelease{release: s.releaseCache.Parse(result.Title), rawName: result.Title}
+	// Resolve ARR aliases only when a torrent survives the exact-size gate
+	// below, so feed items with no byte-size collision never touch ARR.
+	aliasTitles := sync.OnceValue(func() []string {
+		return s.announceAliasTitles(ctx, result.Title, DetermineContentType(candidate.release).ContentType)
+	})
 	snapshots := (*automationSnapshots)(nil)
 	if autoCtx != nil {
 		snapshots = autoCtx.snapshots
@@ -4370,6 +4375,7 @@ func (s *Service) findRSSAnnouncementMatches(ctx context.Context, result jackett
 				findIndividualEpisodes: settings.FindIndividualEpisodes,
 				rescueTitleMismatches:  settings.RescueTitleMismatches && !settings.SkipRecheck,
 				allowUnknownSize:       false,
+				candidateTitles:        aliasTitles(),
 			})
 			if !decision.replayable || !decision.decision.Accepted {
 				continue

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -13970,11 +13970,12 @@ func (s *Service) CheckWebhook(ctx context.Context, req *WebhookCheckRequest) (*
 				}
 			}
 			decision := s.classifyWebhookAnnouncementSource(ctx, instance.ID, torrent, announcedCandidate, int64(req.Size), announcementMatchPolicy{
-				findIndividualEpisodes: findIndividualEpisodes,
-				rescueTitleMismatches:  settings.RescueTitleMismatches && !settings.SkipRecheck,
-				allowUnknownSize:       req.Size == 0,
-				skipRecheck:            settings.SkipRecheck,
-				candidateTitles:        aliasTitles,
+				findIndividualEpisodes:   findIndividualEpisodes,
+				rescueTitleMismatches:    settings.RescueTitleMismatches && !settings.SkipRecheck,
+				allowUnknownSize:         req.Size == 0,
+				skipRecheck:              settings.SkipRecheck,
+				candidateTitles:          aliasTitles,
+				tolerateOneSidedChecksum: true,
 			})
 			if !decision.decision.Accepted || decision.replayable != (req.Size > 0) {
 				continue

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -4760,12 +4760,17 @@ func (s *Service) findCandidates(ctx context.Context, req *FindCandidatesRequest
 			// for the specific torrent whose qBittorrent size supplied the search
 			// evidence. File matching and later safety checks still run.
 			var candidateAliasTitles []string
+			var targetAliasTitles []string
 			if isSearchSource {
 				candidateAliasTitles = searchDecision.SourceTitles
+				// Announce-origin decisions resolve aliases for the incoming
+				// release, which is the target side here.
+				targetAliasTitles = searchDecision.CandidateTitles
 			}
 			fallbackInput := searchCandidateInput{
 				Source:                 targetSide,
 				Candidate:              sourceSide,
+				SourceTitles:           targetAliasTitles,
 				CandidateTitles:        candidateAliasTitles,
 				FindIndividualEpisodes: req.FindIndividualEpisodes,
 			}
@@ -4773,11 +4778,14 @@ func (s *Service) findCandidates(ctx context.Context, req *FindCandidatesRequest
 				(searchDecision.Class == searchCandidateClassExactSizeFallback ||
 					searchDecision.StrictChecksumReplay)
 			if replaysExactDecision {
+				// The listing title and info.name can differ by exactly the
+				// resolved alias, so both alias sets count; only one is ever
+				// non-empty per decision origin.
 				if ok, _ := s.searchCandidateMetadataConsistent(
 					searchDecision.SearchCandidateName,
 					targetSide,
 					searchDecision.RelaxedDifferences,
-					searchDecision.SourceTitles,
+					slices.Concat(searchDecision.SourceTitles, searchDecision.CandidateTitles),
 					req.FindIndividualEpisodes,
 				); !ok {
 					continue
@@ -5328,6 +5336,7 @@ func (s *Service) applyAutobrrAnnouncement(ctx context.Context, announcedName st
 
 func (s *Service) findAutobrrAnnouncementMatches(ctx context.Context, announcedName string, actualSize int64, instances []*models.Instance, request *CrossSeedRequest, settings *models.CrossSeedAutomationSettings) []boundAnnouncementMatch {
 	candidate := namedRelease{release: s.releaseCache.Parse(announcedName), rawName: announcedName}
+	aliasTitles := s.announceAliasTitles(ctx, announcedName, DetermineContentType(candidate.release).ContentType)
 	matches := make([]boundAnnouncementMatch, 0, len(instances))
 	for _, instance := range instances {
 		torrents, err := s.syncManager.GetCachedInstanceTorrents(ctx, instance.ID)
@@ -5356,6 +5365,7 @@ func (s *Service) findAutobrrAnnouncementMatches(ctx context.Context, announcedN
 				rescueTitleMismatches:  settings != nil && settings.RescueTitleMismatches && !request.SkipRecheck,
 				allowUnknownSize:       false,
 				skipRecheck:            request.SkipRecheck,
+				candidateTitles:        aliasTitles,
 			})
 			if !decision.replayable || !decision.decision.Accepted {
 				continue
@@ -13865,6 +13875,8 @@ func (s *Service) CheckWebhook(ctx context.Context, req *WebhookCheckRequest) (*
 	// Describe the parsed content type for easier debugging and tuning.
 	contentInfo := DetermineContentType(incomingRelease)
 
+	aliasTitles := s.announceAliasTitles(ctx, req.TorrentName, contentInfo.ContentType)
+
 	log.Debug().
 		Str("source", "cross-seed.webhook").
 		Ints("requestedInstanceIds", requestedInstanceIDs).
@@ -13956,6 +13968,7 @@ func (s *Service) CheckWebhook(ctx context.Context, req *WebhookCheckRequest) (*
 				rescueTitleMismatches:  settings.RescueTitleMismatches && !settings.SkipRecheck,
 				allowUnknownSize:       req.Size == 0,
 				skipRecheck:            settings.SkipRecheck,
+				candidateTitles:        aliasTitles,
 			})
 			if !decision.decision.Accepted || decision.replayable != (req.Size > 0) {
 				continue

--- a/internal/services/crossseed/service_search_test.go
+++ b/internal/services/crossseed/service_search_test.go
@@ -35,12 +35,12 @@ type spyARRLookupService struct {
 	result       *arr.ExternalIDsResult
 	seasonResult *arr.SeasonEpisodeTotalResult
 	err          error
-	called       bool
+	calls        int
 	seasonCalls  int
 }
 
 func (s *spyARRLookupService) LookupExternalIDs(_ context.Context, title string, contentType arr.ContentType) (*arr.ExternalIDsResult, error) {
-	s.called = true
+	s.calls++
 	s.title = title
 	s.contentType = contentType
 	return s.result, s.err
@@ -159,7 +159,7 @@ func TestLookupARRExternalIDsNoInstancesIsNotDegraded(t *testing.T) {
 
 	got, degraded := svc.lookupARRExternalIDs(context.Background(), "Inception.2010", "movie")
 
-	require.True(t, spy.called)
+	require.Equal(t, 1, spy.calls)
 	require.Nil(t, got)
 	require.Empty(t, degraded)
 }
@@ -280,7 +280,7 @@ func TestLookupARRExternalIDsMapsContentType(t *testing.T) {
 
 			got, degraded := svc.lookupARRExternalIDs(context.Background(), "Inception.2010", tt.contentType)
 
-			require.Equal(t, tt.wantCalled, spy.called)
+			require.Equal(t, tt.wantCalled, spy.calls > 0)
 			require.Equal(t, tt.wantDegraded, degraded)
 			if !tt.wantCalled {
 				require.Nil(t, got)

--- a/internal/services/crossseed/service_search_test.go
+++ b/internal/services/crossseed/service_search_test.go
@@ -37,12 +37,15 @@ type spyARRLookupService struct {
 	err          error
 	calls        int
 	seasonCalls  int
+	deadline     time.Time
+	hasDeadline  bool
 }
 
-func (s *spyARRLookupService) LookupExternalIDs(_ context.Context, title string, contentType arr.ContentType) (*arr.ExternalIDsResult, error) {
+func (s *spyARRLookupService) LookupExternalIDs(ctx context.Context, title string, contentType arr.ContentType) (*arr.ExternalIDsResult, error) {
 	s.calls++
 	s.title = title
 	s.contentType = contentType
+	s.deadline, s.hasDeadline = ctx.Deadline()
 	return s.result, s.err
 }
 


### PR DESCRIPTION
## Description

The announce paths (webhook, autobrr, RSS) did not resolve ARR alternate titles, so an announce that names seeded content under an alias (anime English vs romaji title) was rejected with a title mismatch even at exact size, and size-0 announces failed the unknown-size preflight the same way.

This resolves the aliases once per announce, attaches them to the candidate side of the classifier input, carries them through the decision provenance, and consumes them in the apply-time revalidation so an accepted announce also survives injection. The RSS fallback resolves the aliases lazily, only after a torrent passes its exact-size prefilter, so feed scans do not send lookups to the ARR instances for items with no size collision. The aliases describe the incoming announce, so they never widen the identity of an unrelated source torrent. Without a Sonarr/Radarr integration behavior does not change. The announce-path lookup has a 5 second deadline, so a hung ARR instance degrades the check to name-only matching instead of stalling it, and alias titles are probed against the normalized title sets instead of inserted into them, so the per-torrent maps do not regrow on alias-heavy shows.

Field testing surfaced a follow-on gate: once the title passed via aliases, an announce could still fail the webhook check on a CRC tag that only the local file name carries, because IRC announce sizes are rounded and a non-exact size demanded a full strict match. The check now tolerates a one-sided checksum within the size tolerance. This is advisory only: a false positive costs one torrent download, and apply still validates against the real torrent bytes.

Fixes #2492

## How has this been tested?

Unit tests cover the check, the preflight, the lookup count, the end-to-end apply injection, and the one-sided checksum tolerance; each failed before the fix. The checksum case reproduces a field report: a rounded 1.37 GiB announce size against a seeded file whose name carries a CRC tag, rejected before, accepted now, with conflicting CRCs and out-of-tolerance sizes still rejected.

Field test: the PR image ran overnight on a live instance with Sonarr connected and real announce traffic. Webhook checks resolved ARR alias titles through the new path from the first minutes on, RSS automation runs completed with zero failures, and the instance stayed healthy with no errors, restarts, or rollback. The RSS alias fallback did not fire naturally, since no feed item size-collided with a seeded torrent under an alias overnight; that path is covered by the unit tests.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved cross-seed matching for releases announced under alternate titles, such as English or romaji names.
  * Supports alternate-title matching for RSS, autobrr, and webhook announcements when a Sonarr or Radarr integration is available.
  * Preserves and revalidates alternate-title matches during subsequent checks.

* **Documentation**
  * Clarified that announce matching uses the release name only without a Sonarr or Radarr integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
