### PR TITLE
fix(web): avoid canvas readback for dynamic favicon

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,7 @@
 <html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/x-icon" href="data:," />
+    <link rel="icon" type="image/x-icon" href="data:," data-dynamic-favicon="svg" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/web/src/hooks/useDynamicFavicon.ts
+++ b/web/src/hooks/useDynamicFavicon.ts
@@ -22,8 +22,6 @@ export function useDynamicFavicon() {
       canvas.height = size
       const ctx = canvas.getContext("2d")
 
-      if (!ctx) return
-
       // Get the dark mode primary color from the current theme
       const currentTheme = getThemeById(theme)
       if (!currentTheme) return
@@ -72,6 +70,15 @@ export function useDynamicFavicon() {
         </svg>
       `
 
+      if (cancelled) return
+
+      const svgLink = getDynamicFaviconLink("svg")
+      svgLink.type = "image/svg+xml"
+      svgLink.href = `data:image/svg+xml,${encodeURIComponent(svg)}`
+      document.head.appendChild(svgLink)
+
+      if (!ctx) return
+
       const img = new Image()
       img.onload = () => {
         // A theme switch superseded this load.
@@ -79,16 +86,12 @@ export function useDynamicFavicon() {
         ctx.clearRect(0, 0, size, size)
         ctx.drawImage(img, 0, 0, size, size)
 
-        const faviconUrl = canvas.toDataURL("image/png")
-
-        let link = document.querySelector<HTMLLinkElement>("link[rel*='icon']")
-        if (!link) {
-          link = document.createElement("link")
-          link.type = "image/png"
-          link.rel = "icon"
-          document.getElementsByTagName("head")[0].appendChild(link)
-        }
-        link.href = faviconUrl
+        const pngLink = getDynamicFaviconLink("png")
+        pngLink.type = "image/png"
+        pngLink.href = canvas.toDataURL("image/png")
+        pngLink.setAttribute("sizes", `${size}x${size}`)
+        document.head.insertBefore(pngLink, svgLink)
+        document.head.appendChild(svgLink)
       }
 
       img.src = `data:image/svg+xml;base64,${btoa(svg)}`
@@ -101,4 +104,14 @@ export function useDynamicFavicon() {
       clearTimeout(timeoutId)
     }
   }, [theme, variation])
+}
+
+function getDynamicFaviconLink(format: "png" | "svg"): HTMLLinkElement {
+  let link = document.querySelector<HTMLLinkElement>(`link[data-dynamic-favicon="${format}"]`)
+  if (!link) {
+    link = document.createElement("link")
+    link.rel = "icon"
+    link.dataset.dynamicFavicon = format
+  }
+  return link
 }

--- a/web/src/hooks/useDynamicFavicon.ts
+++ b/web/src/hooks/useDynamicFavicon.ts
@@ -70,8 +70,6 @@ export function useDynamicFavicon() {
         </svg>
       `
 
-      if (cancelled) return
-
       const svgLink = getDynamicFaviconLink("svg")
       svgLink.type = "image/svg+xml"
       svgLink.href = `data:image/svg+xml,${encodeURIComponent(svg)}`


### PR DESCRIPTION
## Description

Firefox intercepts canvas readback when fingerprinting resistance is enabled because it can expose details such as GPU, drivers, fonts, and rendering behavior. Because qui generates the dynamic favicon by drawing SVG into a canvas and exporting it with `toDataURL("image/png")`, Firefox will return protected canvas output and resulting in a broken favicon.

This change keeps the existing canvas-generated PNG favicon and adds a dynamic SVG favicon candidate. Firefox with strict fingerprinting protections can use the SVG favicon path, avoiding corrupted canvas readback output, while browsers without SVG favicon support still have the PNG candidate.

SVG favicon support reference (but PNG fallback should cover missing support): https://caniuse.com/link-icon-svg

## How has this been tested?

Built and run the Docker image.

Verified in Firefox with strict privacy/fingerprinting protections enabled that the browser tab icon renders correctly instead of as garbled pixels.

Verified that changing themes still updates the favicon colour.

## Screenshots (for UI changes)

**FIREFOX:**
Before - with fingerprinting disabled, does not support Canvas producing PNG:
<img width="268" height="53" alt="image" src="https://github.com/user-attachments/assets/e06ae8e7-ad1b-43ab-987c-03d28e587710" />

After - Is fixed by this change as it will use the SVG icon:
Minimal Theme:
<img width="214" height="38" alt="image" src="https://github.com/user-attachments/assets/1530fc14-6a37-4686-a81d-14c324606a54" />
autobrr Theme:
<img width="215" height="42" alt="image" src="https://github.com/user-attachments/assets/3897f945-7a2d-4815-97db-fc831a4b9433" />

**CHROME:**
Before - was working before this change:
<img width="303" height="46" alt="image" src="https://github.com/user-attachments/assets/db32861e-3f30-4f4e-bd3b-3af5792a8cc1" />

After - still working after this change:
Minimal Theme:
<img width="303" height="50" alt="image" src="https://github.com/user-attachments/assets/9a8c3c45-5dcd-43c9-bfae-d719677a06d5" />
autobrr Theme:
<img width="303" height="46" alt="image" src="https://github.com/user-attachments/assets/211d0a0f-18ee-4745-9f6a-e862ad77c98a" />


## Checklist

- [x] My PR title follows the Conventional Commits (https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

## AI disclosure

Yes. Codex was used to diagnose the Firefox canvas/fingerprint interaction and draft the small favicon implementation change. The code change is minimal and was reviewed/tested manually by a professional software developer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Improved dynamic favicon updates for faster, more reliable display.
- Preserved SVG favicon quality while continuing to support PNG rendering.
- Improved favicon handling across browsers and display contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->