### PR TITLE
fix(stream): prevent desync after missed baselines

### DIFF
--- a/documentation/docs/api/overview.md
+++ b/documentation/docs/api/overview.md
@@ -23,6 +23,14 @@ curl -H "X-API-Key: YOUR_API_KEY_HERE" \
   http://localhost:7476/api/instances
 ```
 
+## Torrent updates
+
+`GET /api/stream` sends torrent updates through Server-Sent Events. See `/api/docs` for subscription parameters and event examples.
+
+Keep the version from each accepted snapshot or delta. Apply a delta only when its `baseVersion` matches that version and its `minor` increases by one within the same `major`. If the versions do not match, reconnect for a full snapshot and use REST polling until it arrives.
+
+In a delta, omitted counts and preferences retain their previous values. Explicit `preferences: null` clears preferences. Omitted categories and tags mean empty collections.
+
 ## Security notes
 
 - qui shows an API key only once, at creation. Save it in a safe place.

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -60,7 +60,6 @@ var undocumentedRoutes = map[routeKey]struct{}{
 	{Method: http.MethodPut, Path: "/api/torznab/search/cache/settings"}:                            {},
 	{Method: http.MethodGet, Path: "/api/torznab/search/history"}:                                   {},
 	{Method: http.MethodGet, Path: "/api/torznab/search/recent"}:                                    {},
-	{Method: http.MethodGet, Path: "/api/stream"}:                                                   {},
 	{Method: http.MethodPost, Path: "/api/instances/{instanceId}/backups/run"}:                      {},
 	{Method: http.MethodGet, Path: "/api/instances/{instanceId}/backups/runs"}:                      {},
 	{Method: http.MethodDelete, Path: "/api/instances/{instanceId}/backups/runs"}:                   {},

--- a/internal/api/sse/delta.go
+++ b/internal/api/sse/delta.go
@@ -6,6 +6,7 @@ package sse
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/json"
 	"hash/fnv"
 	"maps"
 	"math"
@@ -32,11 +33,10 @@ import (
 //
 // There is intentionally no periodic full keyframe: a recurring full page re-send is
 // hundreds of KB and, over an HTTP/2 proxy, head-of-line-blocks every other request
-// on the shared connection each time it fires. Correctness instead rests on
-// init-seeds-baseline (the client's init equals the server baseline) plus a fresh
-// init on every reconnect; the only drift window is the sub-millisecond gap between
-// subscription registration and go-sse subscribe, which self-heals on the next
-// reconnect.
+// on the shared connection each time it fires. Instead, every frame advances an
+// explicit sequence and the complete reconstructed snapshot is retained for new
+// subscribers. Clients can therefore detect a missed delta and reconnect for an
+// exact init without periodically paying for a full page.
 //
 // The caller holds no lock; the group's single-processor invariant (the sending
 // flag) already serializes ticks, and baselineMu guards the baseline against the
@@ -58,27 +58,42 @@ func (g *subscriptionGroup) buildUpdatePayload(opts StreamOptions, resp *qbittor
 		order, changedIdx, newFP = computeRowDelta(resp.Torrents, singleRowKey, singleRowFingerprint, g.baselineFP)
 	}
 
-	forceFull := !g.baselineSeeded
+	forceFull := g.baselineSnapshot == nil
+	baseVersion := g.version
 
-	countsFP := countsFingerprint(resp.Counts)
+	// Nil edge-triggered fields mean "no update", not "clear". Reconstruct the
+	// complete snapshot represented by this frame before retaining it for joiners.
+	// Explicit JSON null remains non-nil and therefore still clears preferences.
+	snapshot := *resp
+	if g.baselineSnapshot != nil {
+		if snapshot.AppPreferences == nil {
+			snapshot.AppPreferences = g.baselineSnapshot.AppPreferences
+		}
+		if snapshot.Counts == nil {
+			snapshot.Counts = g.baselineSnapshot.Counts
+		}
+	}
 
 	// Advance the baseline before returning so the next tick diffs against this page.
 	prevOrder := g.baselineOrder
-	prevPrefs := g.baselinePrefs
-	prevCounts := g.baselineCounts
+	var prevPrefs json.RawMessage
+	var prevCounts *qbittorrent.TorrentCounts
+	if g.baselineSnapshot != nil {
+		prevPrefs = g.baselineSnapshot.AppPreferences
+		prevCounts = g.baselineSnapshot.Counts
+	}
 	g.baselineFP = newFP
 	g.baselineOrder = order
-	g.baselinePrefs = resp.AppPreferences
-	g.baselineCounts = countsFP
-	// A tick without counts (a cross-instance page where no member contributed
-	// any) must not wipe the snapshot reconcileInitWithBaseline hands to joiners.
-	if resp.Counts != nil {
-		g.baselineCountsData = resp.Counts
-	}
-	g.baselineSeeded = true
+	g.baselineSnapshot = &snapshot
+	g.version.Minor++
 
 	if forceFull {
-		return &StreamPayload{Type: streamEventUpdate, Data: resp, Meta: meta}
+		return &StreamPayload{
+			Type:    streamEventUpdate,
+			Data:    &snapshot,
+			Meta:    meta,
+			Version: new(g.version),
+		}
 	}
 
 	// Shallow-copy the response so the delta frame keeps every aggregate field but
@@ -87,14 +102,18 @@ func (g *subscriptionGroup) buildUpdatePayload(opts StreamOptions, resp *qbittor
 	deltaResp := *resp
 
 	// ~4.7 KB and edited rarely; the client keeps its cached copy when the field is absent.
-	if bytes.Equal(resp.AppPreferences, prevPrefs) {
+	if bytes.Equal(snapshot.AppPreferences, prevPrefs) {
 		deltaResp.AppPreferences = nil
+	} else {
+		deltaResp.AppPreferences = snapshot.AppPreferences
 	}
 
 	// Several KB per tick on an instance with many categories, tags and trackers,
 	// and unchanged whenever the library is; the client keeps its cached copy.
-	if countsFP == prevCounts {
+	if countsEqual(snapshot.Counts, prevCounts) {
 		deltaResp.Counts = nil
+	} else {
+		deltaResp.Counts = snapshot.Counts
 	}
 
 	if isCross {
@@ -105,7 +124,7 @@ func (g *subscriptionGroup) buildUpdatePayload(opts StreamOptions, resp *qbittor
 		deltaResp.CrossInstanceTorrents = nil
 	}
 
-	delta := &StreamDelta{}
+	delta := &StreamDelta{BaseVersion: baseVersion}
 	if !slices.Equal(order, prevOrder) {
 		// Send the order even when empty (the page drained to zero rows): a pointer
 		// keeps a present-but-empty order distinct from an absent one on the wire, so
@@ -113,42 +132,34 @@ func (g *subscriptionGroup) buildUpdatePayload(opts StreamOptions, resp *qbittor
 		delta.Order = &order
 	}
 
-	return &StreamPayload{Type: streamEventDelta, Data: &deltaResp, Delta: delta, Meta: meta}
+	return &StreamPayload{
+		Type:    streamEventDelta,
+		Data:    &deltaResp,
+		Delta:   delta,
+		Meta:    meta,
+		Version: new(g.version),
+	}
 }
 
-// reconcileInitWithBaseline makes a freshly built init snapshot and the group
-// baseline agree, in whichever direction is available.
-//
-// With no baseline yet, the snapshot seeds it, so the client's init and the server
-// baseline are identical and the very next tick is a clean delta the client applies
-// without drift.
-//
-// A later joiner to an already-seeded group must not re-seed (that would desync
-// existing subscribers), so the snapshot takes the edge-triggered fields from the
-// baseline instead. Its rows may still differ slightly from the shared baseline
-// until it reconnects.
-func (g *subscriptionGroup) reconcileInitWithBaseline(opts StreamOptions, resp *qbittorrent.TorrentResponse) {
-	if resp == nil {
-		return
-	}
-
+// buildInitPayload returns the exact complete snapshot represented by the group's
+// current baseline. The first init seeds that baseline from resp; later callers
+// ignore independently materialized rows so they cannot join halfway through a
+// delta sequence with a different page. A nil result means the group is unseeded
+// and no candidate snapshot was supplied.
+func (g *subscriptionGroup) buildInitPayload(opts StreamOptions, resp *qbittorrent.TorrentResponse, meta *StreamMeta) *StreamPayload {
 	g.baselineMu.Lock()
 	defer g.baselineMu.Unlock()
 
-	if g.baselineSeeded {
-		// Preferences are edge-triggered and there is no periodic keyframe, so an
-		// init built while the preferences cache was empty would leave this joiner
-		// without them until it reconnects. It inherits the baseline instead.
-		if resp.AppPreferences == nil {
-			resp.AppPreferences = g.baselinePrefs
+	if g.baselineSnapshot != nil {
+		return &StreamPayload{
+			Type:    streamEventInit,
+			Data:    g.baselineSnapshot,
+			Meta:    meta,
+			Version: new(g.version),
 		}
-		// Counts are edge-triggered the same way: init metas never set
-		// IncludeCounts, so without this backfill a joiner whose REST bootstrap
-		// failed would show zero sidebar counts until the library next changes.
-		if resp.Counts == nil {
-			resp.Counts = g.baselineCountsData
-		}
-		return
+	}
+	if resp == nil {
+		return nil
 	}
 
 	var (
@@ -163,10 +174,15 @@ func (g *subscriptionGroup) reconcileInitWithBaseline(opts StreamOptions, resp *
 
 	g.baselineFP = fp
 	g.baselineOrder = order
-	g.baselinePrefs = resp.AppPreferences
-	g.baselineCounts = countsFingerprint(resp.Counts)
-	g.baselineCountsData = resp.Counts
-	g.baselineSeeded = true
+	g.baselineSnapshot = resp
+	g.version.Minor++
+
+	return &StreamPayload{
+		Type:    streamEventInit,
+		Data:    g.baselineSnapshot,
+		Meta:    meta,
+		Version: new(g.version),
+	}
 }
 
 // computeRowDelta walks the freshly materialized rows in display order, producing
@@ -315,42 +331,22 @@ func crossRowFingerprint(b *fpBuf, c qbittorrent.CrossInstanceTorrentView) uint6
 	return b.sum()
 }
 
-// fpSortedMap appends a map in key order so the hash does not follow Go's
-// randomized map iteration order.
-func fpSortedMap[V any](b *fpBuf, m map[string]V, appendValue func(*fpBuf, V)) {
-	b.i64(int64(len(m)))
-	for _, k := range slices.Sorted(maps.Keys(m)) {
-		b.str(k)
-		appendValue(b, m[k])
+// countsEqual compares read-only snapshots without allocating or sorting map keys.
+func countsEqual(a, b *qbittorrent.TorrentCounts) bool {
+	if a == b {
+		return true
 	}
-}
-
-// countsFingerprint hashes the sidebar counts aggregate. Counts are several KB of
-// JSON on an instance with many categories, tags and trackers, and they only move
-// when the library does, so a tick that leaves them unchanged omits the field the
-// same way it already omits preferences. The client reuses its last same-scope
-// counts snapshot when the field is absent.
-func countsFingerprint(c *qbittorrent.TorrentCounts) uint64 {
-	if c == nil {
-		return 0
+	if a == nil || b == nil {
+		return false
 	}
-	b := make(fpBuf, 0, fpBufSize)
-	b.i64(int64(c.Total))
-	fpSortedMap(&b, c.Status, func(b *fpBuf, v int) { b.i64(int64(v)) })
-	fpSortedMap(&b, c.Categories, func(b *fpBuf, v int) { b.i64(int64(v)) })
-	fpSortedMap(&b, c.CategorySizes, func(b *fpBuf, v int64) { b.i64(v) })
-	fpSortedMap(&b, c.Tags, func(b *fpBuf, v int) { b.i64(int64(v)) })
-	fpSortedMap(&b, c.TagSizes, func(b *fpBuf, v int64) { b.i64(v) })
-	fpSortedMap(&b, c.Trackers, func(b *fpBuf, v int) { b.i64(int64(v)) })
-	fpSortedMap(&b, c.TrackerTransfers, func(b *fpBuf, v qbittorrent.TrackerTransferStats) {
-		b.i64(v.Uploaded)
-		b.i64(v.Downloaded)
-		b.i64(v.UploadedSession)
-		b.i64(v.DownloadedSession)
-		b.i64(v.TotalSize)
-		b.i64(int64(v.Count))
-	})
-	return b.sum()
+	return a.Total == b.Total &&
+		maps.Equal(a.Status, b.Status) &&
+		maps.Equal(a.Categories, b.Categories) &&
+		maps.Equal(a.CategorySizes, b.CategorySizes) &&
+		maps.Equal(a.Tags, b.Tags) &&
+		maps.Equal(a.TagSizes, b.TagSizes) &&
+		maps.Equal(a.Trackers, b.Trackers) &&
+		maps.Equal(a.TrackerTransfers, b.TrackerTransfers)
 }
 
 // subsetRows returns the rows at the given indices, preserving order.

--- a/internal/api/sse/delta_test.go
+++ b/internal/api/sse/delta_test.go
@@ -52,7 +52,7 @@ func TestBuildUpdatePayloadSeedsFullThenStreamsDeltas(t *testing.T) {
 	require.Equal(t, streamEventUpdate, full.Type)
 	require.Nil(t, full.Delta)
 	require.Len(t, full.Data.Torrents, 3)
-	require.True(t, g.baselineSeeded)
+	require.NotNil(t, g.baselineSnapshot)
 
 	// No change: an aggregate-only delta with no changed rows and no order.
 	steady := g.buildUpdatePayload(opts, singleResp(tv("a", "A"), tv("b", "B"), tv("c", "C")), &StreamMeta{})
@@ -295,68 +295,44 @@ func TestDeltaOmitsUnchangedCounts(t *testing.T) {
 	require.Equal(t, 3, changed.Data.Counts.Status["seeding"])
 }
 
-// TestInitInheritsBaselinePreferences pins the fix for a subscriber joining a group
-// whose baseline already carries preferences while its own init snapshot found the
-// preferences cache empty. Ticks only send preferences on change and there is no
-// periodic keyframe, so without the backfill that subscriber never receives them.
-func TestInitInheritsBaselinePreferences(t *testing.T) {
+// TestInitUsesExactVersionedBaseline pins continuity for late joiners. Once a
+// group has a baseline, an independently materialized candidate cannot replace or
+// diverge from it; every init identifies the exact retained frame version.
+func TestInitUsesExactVersionedBaseline(t *testing.T) {
+	counts := &qbittorrent.TorrentCounts{Status: map[string]int{"all": 1}, Total: 1}
 	prefs := json.RawMessage(`{"max_ratio":2}`)
-
-	g := &subscriptionGroup{}
-	seeded := singleResp(tv("a", "A"))
-	seeded.AppPreferences = prefs
 	opts := StreamOptions{InstanceIDs: []int{1}}
-	g.reconcileInitWithBaseline(opts, seeded)
+	g := &subscriptionGroup{version: StreamVersion{Major: 7}}
 
-	// A later init whose materialized response has no preferences at all.
-	joiner := singleResp(tv("a", "A"))
-	require.Nil(t, joiner.AppPreferences)
-	g.reconcileInitWithBaseline(opts, joiner)
-	require.Equal(t, prefs, joiner.AppPreferences, "the init must inherit the baseline preferences")
-
-	// An init that carries its own preferences keeps them untouched.
-	own := singleResp(tv("a", "A"))
-	own.AppPreferences = json.RawMessage(`{"max_ratio":9}`)
-	g.reconcileInitWithBaseline(opts, own)
-	require.JSONEq(t, `{"max_ratio":9}`, string(own.AppPreferences),
-		"an init with its own preferences must not inherit the baseline")
-}
-
-// TestInitInheritsBaselineCounts pins the counts twin of the preferences backfill:
-// init metas never set IncludeCounts, and ticks only resend counts on change with
-// no periodic keyframe, so a joiner to a seeded group whose REST bootstrap failed
-// would otherwise show zero sidebar counts until the library next changes.
-func TestInitInheritsBaselineCounts(t *testing.T) {
-	counts := &qbittorrent.TorrentCounts{Status: map[string]int{"all": 3}, Total: 3}
-
-	g := &subscriptionGroup{}
-	opts := StreamOptions{InstanceIDs: []int{1}}
 	seeded := singleResp(tv("a", "A"))
 	seeded.Counts = counts
-	g.buildUpdatePayload(opts, seeded, &StreamMeta{})
+	seeded.AppPreferences = prefs
+	first := g.buildInitPayload(opts, seeded, &StreamMeta{})
+	require.Same(t, seeded, first.Data)
+	require.Equal(t, &StreamVersion{Major: 7, Minor: 1}, first.Version)
 
-	// A later init built without counts inherits the retained snapshot.
-	joiner := singleResp(tv("a", "A"))
-	require.Nil(t, joiner.Counts)
-	g.reconcileInitWithBaseline(opts, joiner)
-	require.Equal(t, counts, joiner.Counts, "the init must inherit the baseline counts")
+	// This candidate was built later but does not represent the group's baseline.
+	joinerCandidate := singleResp(tv("a", "not-the-baseline"))
+	joinerCandidate.Counts = &qbittorrent.TorrentCounts{Total: 9}
+	joiner := g.buildInitPayload(opts, joinerCandidate, &StreamMeta{})
+	require.Same(t, seeded, joiner.Data)
+	require.Equal(t, first.Version, joiner.Version)
 
-	// A tick without counts must not wipe the retained snapshot.
-	g.buildUpdatePayload(opts, singleResp(tv("a", "A-renamed")), &StreamMeta{})
-	late := singleResp(tv("a", "A-renamed"))
-	g.reconcileInitWithBaseline(opts, late)
-	require.Equal(t, counts, late.Counts, "a counts-free tick must not clear the retained snapshot")
+	// Even an aggregate-only frame advances Minor. Its retained full snapshot keeps
+	// edge-triggered fields that were omitted from the delta on the wire.
+	delta := g.buildUpdatePayload(opts, singleResp(tv("a", "A")), &StreamMeta{})
+	require.Equal(t, StreamVersion{Major: 7, Minor: 1}, delta.Delta.BaseVersion)
+	require.Equal(t, &StreamVersion{Major: 7, Minor: 2}, delta.Version)
+	require.Empty(t, delta.Data.Torrents)
 
-	// An init that carries its own counts keeps them untouched.
-	own := singleResp(tv("a", "A-renamed"))
-	own.Counts = &qbittorrent.TorrentCounts{Status: map[string]int{"all": 9}, Total: 9}
-	g.reconcileInitWithBaseline(opts, own)
-	require.Equal(t, 9, own.Counts.Total, "an init with its own counts must not inherit the baseline")
+	late := g.buildInitPayload(opts, singleResp(tv("a", "stale")), &StreamMeta{})
+	require.Equal(t, &StreamVersion{Major: 7, Minor: 2}, late.Version)
+	require.Equal(t, "A", late.Data.Torrents[0].Name)
+	require.Equal(t, counts, late.Data.Counts)
+	require.Equal(t, prefs, late.Data.AppPreferences)
 }
 
-// TestCountsFingerprintIgnoresMapOrder guards against hashing Go's randomized map
-// iteration order, which would resend counts on every tick and defeat the dedup.
-func TestCountsFingerprintIgnoresMapOrder(t *testing.T) {
+func TestCountsEqual(t *testing.T) {
 	build := func() *qbittorrent.TorrentCounts {
 		c := &qbittorrent.TorrentCounts{
 			Status:     map[string]int{},
@@ -370,10 +346,13 @@ func TestCountsFingerprintIgnoresMapOrder(t *testing.T) {
 		return c
 	}
 
-	want := countsFingerprint(build())
+	want := build()
+	require.True(t, countsEqual(nil, nil))
+	require.False(t, countsEqual(want, nil))
+	require.False(t, countsEqual(nil, want))
+	require.True(t, countsEqual(want, want))
 	for range 3 {
-		require.Equal(t, want, countsFingerprint(build()),
-			"identical counts must hash identically regardless of map iteration order")
+		require.True(t, countsEqual(want, build()))
 	}
 }
 

--- a/internal/api/sse/fingerprint_test.go
+++ b/internal/api/sse/fingerprint_test.go
@@ -57,8 +57,7 @@ func setSampleValue(t *testing.T, f reflect.Value) {
 	case reflect.Slice:
 		f.Set(reflect.Append(f, reflect.New(f.Type().Elem()).Elem()))
 	case reflect.Map:
-		// One entry with a zero value: fpSortedMap hashes the length and key, so
-		// the entry alone must move the fingerprint.
+		// A new map key must be detected even when its value is zero.
 		m := reflect.MakeMap(f.Type())
 		m.SetMapIndex(reflect.ValueOf("x"), reflect.New(f.Type().Elem()).Elem())
 		f.Set(m)
@@ -137,24 +136,25 @@ func TestTrackerFingerprintCoversEveryField(t *testing.T) {
 	})
 }
 
-// TestCountsFingerprintCoversEveryField proves the counts fingerprint reacts to
-// every TorrentCounts field, the way the row fingerprint is already guarded.
-func TestCountsFingerprintCoversEveryField(t *testing.T) {
-	assertEveryFieldHashed(t, "add it to countsFingerprint", func(c qbittorrent.TorrentCounts) uint64 {
-		return countsFingerprint(&c)
-	})
+func TestCountsEqualCoversEveryField(t *testing.T) {
+	var base qbittorrent.TorrentCounts
+	typ := reflect.TypeFor[qbittorrent.TorrentCounts]()
+	for i := range typ.NumField() {
+		var changed qbittorrent.TorrentCounts
+		setSampleValue(t, reflect.ValueOf(&changed).Elem().Field(i))
+		require.False(t, countsEqual(&base, &changed), "%s must affect countsEqual", typ.Field(i).Name)
+	}
 }
 
-// TestTrackerTransferStatsFingerprintCoversEveryField does the same for the
-// per-domain transfer stats nested inside TorrentCounts.TrackerTransfers. The
-// map sample in the counts test only proves the map key is hashed, not the
-// struct fields of its values.
-func TestTrackerTransferStatsFingerprintCoversEveryField(t *testing.T) {
-	assertEveryFieldHashed(t, "add it to countsFingerprint's TrackerTransfers loop", func(s qbittorrent.TrackerTransferStats) uint64 {
-		return countsFingerprint(&qbittorrent.TorrentCounts{
-			TrackerTransfers: map[string]qbittorrent.TrackerTransferStats{"x": s},
-		})
-	})
+func TestCountsEqualCoversTransferFields(t *testing.T) {
+	base := &qbittorrent.TorrentCounts{TrackerTransfers: map[string]qbittorrent.TrackerTransferStats{"x": {}}}
+	typ := reflect.TypeFor[qbittorrent.TrackerTransferStats]()
+	for i := range typ.NumField() {
+		var stats qbittorrent.TrackerTransferStats
+		setSampleValue(t, reflect.ValueOf(&stats).Elem().Field(i))
+		changed := &qbittorrent.TorrentCounts{TrackerTransfers: map[string]qbittorrent.TrackerTransferStats{"x": stats}}
+		require.False(t, countsEqual(base, changed), "%s must affect countsEqual", typ.Field(i).Name)
+	}
 }
 
 func BenchmarkSingleRowFingerprint(b *testing.B) {

--- a/internal/api/sse/manager.go
+++ b/internal/api/sse/manager.go
@@ -185,9 +185,10 @@ type StreamManager struct {
 	activityUnsub   func()
 	activityCounter atomic.Uint64
 
-	counter atomic.Uint64
-	closing atomic.Bool
-	mu      sync.RWMutex
+	nextSubscriptionID uint64 // guarded by mu
+	nextStreamMajor    uint64 // guarded by mu
+	closing            atomic.Bool
+	mu                 sync.RWMutex
 
 	// Observability counters (lifetime totals).
 	eventsPublished atomic.Uint64
@@ -221,6 +222,7 @@ type subscriptionState struct {
 type subscriptionGroup struct {
 	key     string
 	options StreamOptions
+	version StreamVersion // guarded by baselineMu
 
 	mu          sync.Mutex
 	sending     bool
@@ -233,17 +235,12 @@ type subscriptionGroup struct {
 	// Delta baseline for this group's page-0 window, owned by the single tick
 	// processor (processGroup) and guarded by baselineMu against the unrelated init
 	// path. baselineFP maps each row key to its last-broadcast change fingerprint;
-	// baselineOrder is the last-broadcast key order. See buildUpdatePayload.
-	// baselinePrefs is the preferences blob this group last put on the wire, and
-	// baselineCounts the fingerprint of the sidebar counts it last sent, so a delta
-	// can drop either field while it is unchanged.
-	baselineMu         sync.Mutex
-	baselineFP         map[string]uint64
-	baselineOrder      []string
-	baselinePrefs      json.RawMessage
-	baselineCounts     uint64
-	baselineCountsData *qbittorrent.TorrentCounts // retained for the init backfill, see reconcileInitWithBaseline
-	baselineSeeded     bool
+	// baselineOrder is the last-broadcast key order, and baselineSnapshot is the
+	// complete reconstructed frame represented by version. See buildUpdatePayload.
+	baselineMu       sync.Mutex
+	baselineFP       map[string]uint64
+	baselineOrder    []string
+	baselineSnapshot *qbittorrent.TorrentResponse
 }
 
 type syncLoopState struct {
@@ -268,11 +265,21 @@ type backoffState struct {
 
 // StreamPayload is the message envelope sent to the frontend.
 type StreamPayload struct {
-	Type  string                       `json:"type"`
-	Data  *qbittorrent.TorrentResponse `json:"data,omitempty"`
-	Delta *StreamDelta                 `json:"delta,omitempty"`
-	Meta  *StreamMeta                  `json:"meta,omitempty"`
-	Err   string                       `json:"error,omitempty"`
+	Type    string                       `json:"type"`
+	Data    *qbittorrent.TorrentResponse `json:"data,omitempty"`
+	Delta   *StreamDelta                 `json:"delta,omitempty"`
+	Meta    *StreamMeta                  `json:"meta,omitempty"`
+	Version *StreamVersion               `json:"version,omitempty"`
+	Err     string                       `json:"error,omitempty"`
+}
+
+// StreamVersion is a lexicographic generation clock for one filtered stream.
+// Major changes when a subscription group is recreated; Minor advances for every
+// data frame within that group. It is not a distributed vector clock: baselineMu
+// serializes the group's sole version writer.
+type StreamVersion struct {
+	Major uint64 `json:"major"`
+	Minor uint64 `json:"minor"`
 }
 
 // StreamDelta describes how to reconcile a group's page-0 window against the
@@ -289,7 +296,8 @@ type StreamPayload struct {
 // making a full clear indistinguishable from an aggregate-only tick and leaving the
 // deleted rows on screen until the next keyframe.
 type StreamDelta struct {
-	Order *[]string `json:"order,omitempty"`
+	Order       *[]string     `json:"order,omitempty"`
+	BaseVersion StreamVersion `json:"baseVersion"`
 }
 
 // StreamMeta carries lightweight metadata about the sync update.
@@ -475,15 +483,6 @@ func (m *StreamManager) registerSubscription(opts StreamOptions, clientKey strin
 		return "", errors.New("stream manager shutting down")
 	}
 
-	id := fmt.Sprintf("qui-session-%d", m.counter.Add(1))
-	state := &subscriptionState{
-		id:        id,
-		options:   opts,
-		created:   time.Now(),
-		groupKey:  streamOptionsKey(opts),
-		clientKey: clientKey,
-	}
-
 	m.mu.Lock()
 	// Re-check under the lock: Shutdown sets closing before draining the loop maps,
 	// so without this a registration that passed the pre-lock check could repopulate
@@ -492,11 +491,22 @@ func (m *StreamManager) registerSubscription(opts StreamOptions, clientKey strin
 		m.mu.Unlock()
 		return "", errors.New("stream manager shutting down")
 	}
+	m.nextSubscriptionID++
+	id := fmt.Sprintf("qui-session-%d", m.nextSubscriptionID)
+	state := &subscriptionState{
+		id:        id,
+		options:   opts,
+		created:   time.Now(),
+		groupKey:  streamOptionsKey(opts),
+		clientKey: clientKey,
+	}
 	group, ok := m.groups[state.groupKey]
 	if !ok {
+		m.nextStreamMajor++
 		group = &subscriptionGroup{
 			key:     state.groupKey,
 			options: opts,
+			version: StreamVersion{Major: m.nextStreamMajor},
 			subs:    make(map[string]*subscriptionState),
 		}
 		m.groups[state.groupKey] = group
@@ -1122,17 +1132,9 @@ func (m *StreamManager) writeInitToSession(w http.ResponseWriter, sub *subscript
 		Timestamp:  time.Now(),
 	}
 
-	payload := m.buildGroupPayload(group, group.options, streamEventInit, meta)
+	payload := m.buildGroupInitPayload(group, group.options, meta)
 	if payload == nil || m.closing.Load() {
 		return false
-	}
-
-	// Seed the delta baseline from this init snapshot so the client's first frame and
-	// the server baseline match exactly; the next tick is then a clean delta. When the
-	// group is already seeded (a tick or an earlier joiner got there first) the
-	// snapshot instead inherits the baseline's edge-triggered fields.
-	if payload.Data != nil {
-		group.reconcileInitWithBaseline(group.options, payload.Data)
 	}
 
 	return m.writePayloadToSession(w, clonePayloadForSubscriber(payload, sub))
@@ -1373,25 +1375,31 @@ func (m *StreamManager) processGroup(group *subscriptionGroup) {
 	}
 }
 
-// buildGroupPayload materializes the current page and wraps it as a full snapshot
-// of the given event type. Used for the synchronous init write; tick updates go
-// through buildGroupUpdatePayload instead.
-func (m *StreamManager) buildGroupPayload(group *subscriptionGroup, opts StreamOptions, eventType string, meta *StreamMeta) *StreamPayload {
+// buildGroupInitPayload returns the exact snapshot represented by the group's
+// current baseline. A new group materializes one candidate and seeds from it; if a
+// tick wins while that build is in flight, the candidate is discarded in favor of
+// the tick's retained snapshot.
+func (m *StreamManager) buildGroupInitPayload(group *subscriptionGroup, opts StreamOptions, meta *StreamMeta) *StreamPayload {
 	if group == nil || m.syncManager == nil || m.closing.Load() {
 		return nil
 	}
 
 	metaCopy := cloneMeta(meta)
+	if payload := group.buildInitPayload(opts, nil, metaCopy); payload != nil {
+		return payload
+	}
+
 	response, errPayload := m.materializeGroupResponse(opts, metaCopy, group.key)
 	if errPayload != nil {
+		// A concurrent tick may have seeded the group while materialization failed.
+		// Prefer its valid retained baseline to failing a joiner unnecessarily.
+		if payload := group.buildInitPayload(opts, nil, metaCopy); payload != nil {
+			return payload
+		}
 		return errPayload
 	}
 
-	return &StreamPayload{
-		Type: eventType,
-		Data: response,
-		Meta: metaCopy,
-	}
+	return group.buildInitPayload(opts, response, metaCopy)
 }
 
 // buildGroupUpdatePayload materializes the current page and turns it into a tick

--- a/internal/api/sse/manager_delivery_test.go
+++ b/internal/api/sse/manager_delivery_test.go
@@ -146,6 +146,53 @@ func (f *fakeSyncProvider) gateTorrentBuilds() (release func()) {
 	}
 }
 
+// TestInitBuildUsesBaselinePublishedWhileMaterializing pins the initialization
+// race: if a tick advances the group while an init candidate is being built, the
+// joiner must receive the tick's exact retained snapshot and version rather than
+// the stale candidate it materialized independently.
+func TestInitBuildUsesBaselinePublishedWhileMaterializing(t *testing.T) {
+	before := singleResp(qbittorrent.TorrentView{Torrent: &qbt.Torrent{
+		Hash:     "a",
+		Progress: 0.99,
+		State:    qbt.TorrentStateDownloading,
+	}})
+	provider := &fakeSyncProvider{torrentsResponse: before}
+	manager := NewStreamManager(nil, provider, nil)
+	t.Cleanup(func() { _ = manager.Shutdown(context.Background()) })
+
+	opts := StreamOptions{InstanceID: 1, Limit: 300}
+	group := &subscriptionGroup{
+		key:     streamOptionsKey(opts),
+		options: opts,
+		version: StreamVersion{Major: 11},
+	}
+	release := provider.gateTorrentBuilds()
+	result := make(chan *StreamPayload, 1)
+	go func() {
+		result <- manager.buildGroupInitPayload(group, opts, &StreamMeta{InstanceID: 1})
+	}()
+
+	require.Eventually(t, func() bool {
+		return provider.torrentsCallCount() == 1
+	}, time.Second, time.Millisecond)
+
+	completed := singleResp(qbittorrent.TorrentView{Torrent: &qbt.Torrent{
+		Hash:     "a",
+		Progress: 1,
+		State:    qbt.TorrentStateUploading,
+	}})
+	published := group.buildUpdatePayload(opts, completed, &StreamMeta{InstanceID: 1})
+	require.Equal(t, &StreamVersion{Major: 11, Minor: 1}, published.Version)
+	release()
+
+	init := <-result
+	require.NotNil(t, init)
+	require.Equal(t, streamEventInit, init.Type)
+	require.Equal(t, published.Version, init.Version)
+	require.InDelta(t, 1, init.Data.Torrents[0].Progress, 0)
+	require.Equal(t, qbt.TorrentStateUploading, init.Data.Torrents[0].State)
+}
+
 // cloneTorrentResponse returns a shallow copy so the build path cannot mutate the
 // canned response shared across calls (buildGroupPayload sets InstanceMeta).
 func cloneTorrentResponse(resp *qbittorrent.TorrentResponse) *qbittorrent.TorrentResponse {

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -1416,6 +1416,86 @@ paths:
         '500':
           description: Failed to get cross-seed status
 
+  /api/stream:
+    get:
+      tags:
+        - Torrents
+      summary: Stream torrent updates
+      description: |
+        Subscribe to torrent views through Server-Sent Events. Each named event
+        contains a JSON payload. `meta.streamKey` identifies the requested view.
+
+        `init` and `update` contain a full snapshot in `data`. All torrent data
+        events include `version`, an object with positive integer `major` and
+        `minor` fields. `major` changes when the server recreates a stream group.
+        `minor` advances with each data update in that group.
+
+        `delta` contains changed rows and requires `delta.baseVersion`, with the
+        same fields as `version`. Apply a delta only when `baseVersion` equals
+        the last applied version, `major` is unchanged, and `minor` advances by one.
+        If any check fails, reconnect for a fresh `init` and use REST polling
+        until a valid full snapshot arrives.
+
+        `delta.order`, when present, replaces the row order and membership.
+        An empty array clears the page. Row keys are torrent hashes for a single
+        instance and `instanceId:hash` for a cross-instance view. Changed rows
+        are in `data.torrents` or `data.cross_instance_torrents`, respectively.
+        The other `data` fields follow the torrent list response.
+
+        In a delta, omitted `counts` and `preferences` retain their previous
+        values. Explicit `preferences: null` clears preferences. Omitted
+        `categories` and `tags` mean empty collections and clear previous values.
+
+        `stream-error` contains an `error` message and optional retry metadata.
+        `heartbeat` keeps the connection alive. Neither advances the data version.
+        With `activity=1`, separate `activity` events report qui background changes.
+      parameters:
+        - name: streams
+          in: query
+          description: |
+            JSON array of 1 to 64 subscriptions. Required unless `activity=1`.
+            Each entry accepts `key`, `instanceId`, `instanceIds`, `page`, `limit`,
+            `sort`, `order`, `search`, and `filters`. Use a positive `instanceId`
+            or 1 to 64 positive `instanceIds` for a cross-instance view.
+            `key` is returned as `meta.streamKey`. `page` starts at 0.
+            `limit` defaults to 300 and cannot exceed 2000. `sort` defaults to
+            `added_on` and `order` to `desc`. `filters` is a JSON object with the
+            same fields as the torrent list filters.
+          schema:
+            type: string
+          example: '[{"key":"main","instanceId":1,"page":0,"limit":300}]'
+        - name: activity
+          in: query
+          description: Set to 1 to include activity events, with or without torrent subscriptions.
+          schema:
+            type: integer
+            enum: [0, 1]
+            default: 0
+      responses:
+        '200':
+          description: Stream established
+          content:
+            text/event-stream:
+              schema:
+                type: string
+              example: |
+                event: init
+                data: {"type":"init","version":{"major":1,"minor":1},"meta":{"streamKey":"main","instanceId":1,"timestamp":"2026-09-08T12:00:00Z"},"data":{"torrents":[],"total":0}}
+
+                event: delta
+                data: {"type":"delta","version":{"major":1,"minor":2},"delta":{"baseVersion":{"major":1,"minor":1}},"meta":{"streamKey":"main","instanceId":1,"timestamp":"2026-09-08T12:00:02Z"},"data":{"torrents":[],"total":0}}
+
+        '400':
+          description: Missing or invalid subscriptions
+        '401':
+          description: Authentication required
+        '404':
+          description: Instance not found
+        '500':
+          description: Failed to prepare the stream
+        '503':
+          description: Server is shutting down
+
   /api/instances/{instanceID}/torrents:
     get:
       tags:

--- a/web/src/contexts/SyncStreamContext.test.tsx
+++ b/web/src/contexts/SyncStreamContext.test.tsx
@@ -44,7 +44,7 @@ function TestProviders({ children }: { children: ReactNode }) {
 // instance and lets each test drive open / error / event emission by hand.
 // ---------------------------------------------------------------------------
 
-type SourceEventName = "init" | "update" | "stream-error" | "heartbeat" | "activity"
+type SourceEventName = "init" | "update" | "delta" | "stream-error" | "heartbeat" | "activity"
 
 class MockEventSource {
   static readonly CONNECTING = 0
@@ -210,6 +210,7 @@ function renderSubscriber(params: StreamParams | null, enabled = true) {
 
 const DEFAULT: StreamState = {
   connected: false,
+  initialized: false,
   error: null,
   retrying: false,
   retryAttempt: 0,
@@ -351,6 +352,7 @@ describe("SyncStreamContext", () => {
         source.emitOpen()
         source.emit("update", {
           type: "update",
+          version: { major: 1, minor: 1 },
           meta: { instanceId: 1, timestamp: "now", streamKey: key },
         })
       })
@@ -360,9 +362,221 @@ describe("SyncStreamContext", () => {
       expect(controls.payloads).toHaveLength(1)
       expect(controls.payloads[0].type).toBe("update")
     })
+
+    it("coalesces recovery when a delta does not continue the accepted version", () => {
+      const { controls } = renderSubscriber(BASE_PARAMS)
+      flushConnectionQueue()
+      const source = MockEventSource.instances[0]
+      const key = createStreamKey(BASE_PARAMS)
+
+      act(() => {
+        source.emitOpen()
+        source.emit("init", {
+          type: "init",
+          version: { major: 3, minor: 4 },
+          meta: { instanceId: 1, timestamp: "now", streamKey: key },
+          data: { torrents: [], total: 0 },
+        })
+        // Frame 5 was missed. The next aggregate-only frame proves the gap even
+        // though it carries no changed rows.
+        source.emit("delta", {
+          type: "delta",
+          version: { major: 3, minor: 6 },
+          delta: { baseVersion: { major: 3, minor: 5 } },
+          meta: { instanceId: 1, timestamp: "now", streamKey: key },
+          data: { torrents: [], total: 0 },
+        })
+        // A second bad frame before the queued reconnect runs must not create a
+        // second replacement connection.
+        source.emit("delta", {
+          type: "delta",
+          version: { major: 3, minor: 7 },
+          delta: { baseVersion: { major: 3, minor: 6 } },
+          meta: { instanceId: 1, timestamp: "now", streamKey: key },
+          data: { torrents: [], total: 0 },
+        })
+      })
+
+      expect(controls.payloads).toHaveLength(1)
+      expect(controls.getState().connected).toBe(false)
+      expect(controls.getState().initialized).toBe(false)
+
+      act(() => vi.advanceTimersByTime(4000))
+      expect(source.closed).toBe(true)
+      expect(MockEventSource.instances).toHaveLength(2)
+
+      const replacement = MockEventSource.instances[1]
+      act(() => {
+        replacement.emitOpen()
+        replacement.emit("init", {
+          type: "init",
+          version: { major: 3, minor: 7 },
+          meta: { instanceId: 1, timestamp: "now", streamKey: key },
+          data: { torrents: [], total: 0 },
+        })
+      })
+
+      expect(controls.getState().initialized).toBe(true)
+      expect(controls.payloads.map(payload => payload.type)).toEqual(["init", "init"])
+    })
   })
 
   describe("reconnect backoff", () => {
+    it("preserves recovery deadlines across remounts and visibility changes", () => {
+      let state = DEFAULT
+      let remount = () => {}
+      function Subscriber() {
+        state = useSyncStream(BASE_PARAMS)
+        return null
+      }
+      function Root() {
+        const [revision, setRevision] = useState(0)
+        remount = () => setRevision(value => value + 1)
+        return <Subscriber key={revision} />
+      }
+      render(<TestProviders><Root /></TestProviders>)
+      flushConnectionQueue()
+      const key = createStreamKey(BASE_PARAMS)
+      for (const delay of [4000, 8000]) {
+        const source = MockEventSource.instances.at(-1)!
+        act(() => {
+          source.emitOpen()
+          source.emit("init", { type: "init", meta: { streamKey: key }, data: { torrents: [] } })
+        })
+        const deadline = state.nextRetryAt
+        const count = MockEventSource.instances.length
+        act(() => {
+          vi.advanceTimersByTime(1000)
+          remount()
+        })
+        flushConnectionQueue()
+        act(() => {
+          setVisibility("hidden")
+          setVisibility("visible")
+        })
+        expect(state.nextRetryAt).toBe(deadline)
+        expect(MockEventSource.instances).toHaveLength(count)
+        act(() => vi.advanceTimersByTime(delay - 1001))
+        expect(MockEventSource.instances).toHaveLength(count)
+        act(() => vi.advanceTimersByTime(1))
+        expect(MockEventSource.instances).toHaveLength(count + 1)
+      }
+    })
+
+    it("invalidates every subscription while shared recovery waits", () => {
+      const paramsB = makeParams({ instanceId: 2 })
+      let stateA = DEFAULT
+      let stateB = DEFAULT
+      function Subscribers() {
+        stateA = useSyncStream(BASE_PARAMS)
+        stateB = useSyncStream(paramsB)
+        return null
+      }
+      render(<TestProviders><Subscribers /></TestProviders>)
+      flushConnectionQueue()
+      const source = MockEventSource.instances[0]
+      act(() => {
+        source.emitOpen()
+        for (const params of [BASE_PARAMS, paramsB]) {
+          source.emit("init", {
+            type: "init", version: { major: 1, minor: 1 },
+            meta: { streamKey: createStreamKey(params) }, data: { torrents: [] },
+          })
+        }
+      })
+      expect(stateA.initialized).toBe(true)
+      expect(stateB.initialized).toBe(true)
+      act(() => source.emit("delta", {
+        type: "delta", version: { major: 1, minor: 3 },
+        delta: { baseVersion: { major: 1, minor: 2 } },
+        meta: { streamKey: createStreamKey(BASE_PARAMS) }, data: { torrents: [] },
+      }))
+      expect(source.closed).toBe(true)
+      expect(stateA.connected).toBe(false)
+      expect(stateB.connected).toBe(false)
+      expect(stateA.initialized).toBe(false)
+      expect(stateB.initialized).toBe(false)
+      expect(stateB.retryAttempt).toBe(1)
+      act(() => vi.advanceTimersByTime(4000))
+      const replacement = MockEventSource.instances.at(-1)!
+      act(() => {
+        replacement.emitOpen()
+        replacement.emit("init", {
+          type: "init", version: { major: 1, minor: 3 },
+          meta: { streamKey: createStreamKey(BASE_PARAMS) }, data: { torrents: [] },
+        })
+      })
+      expect(stateA.initialized).toBe(true)
+      expect(stateB.initialized).toBe(false)
+      expect(stateA.retryAttempt).toBe(1)
+      act(() => replacement.emit("init", {
+        type: "init", version: { major: 1, minor: 2 },
+        meta: { streamKey: createStreamKey(paramsB) }, data: { torrents: [] },
+      }))
+      expect(stateB.initialized).toBe(true)
+      expect(stateB.retryAttempt).toBe(0)
+    })
+
+    it("resets recovery using only subscriptions sent to the source", () => {
+      let state = DEFAULT
+      function Subscribers() {
+        state = useSyncStream(BASE_PARAMS)
+        useSyncStream(makeParams({ instanceId: 0 }))
+        return null
+      }
+      render(<TestProviders><Subscribers /></TestProviders>)
+      flushConnectionQueue()
+      const key = createStreamKey(BASE_PARAMS)
+      act(() => {
+        const source = MockEventSource.instances[0]
+        source.emitOpen()
+        source.emit("init", { type: "init", meta: { streamKey: key }, data: { torrents: [] } })
+      })
+      expect(state.retryAttempt).toBe(1)
+      act(() => vi.advanceTimersByTime(4000))
+      act(() => {
+        const source = MockEventSource.instances.at(-1)!
+        source.emitOpen()
+        source.emit("init", {
+          type: "init", version: { major: 1, minor: 1 },
+          meta: { streamKey: key }, data: { torrents: [] },
+        })
+      })
+      expect(state.retryAttempt).toBe(0)
+      expect(state.initialized).toBe(true)
+    })
+
+    it("backs off rejected frames across socket opens and resets after a valid baseline", () => {
+      const { controls } = renderSubscriber(BASE_PARAMS)
+      flushConnectionQueue()
+      const key = createStreamKey(BASE_PARAMS)
+
+      for (const delay of [4000, 8000, 16000, 30000]) {
+        const source = MockEventSource.instances.at(-1)!
+        act(() => {
+          source.emitOpen()
+          source.emit("init", { type: "init", meta: { streamKey: key }, data: { torrents: [] } })
+        })
+        expect(controls.getState().nextRetryAt).toBe(Date.now() + delay)
+        const count = MockEventSource.instances.length
+        act(() => vi.advanceTimersByTime(delay - 1))
+        expect(MockEventSource.instances).toHaveLength(count)
+        act(() => vi.advanceTimersByTime(1))
+        expect(MockEventSource.instances).toHaveLength(count + 1)
+      }
+
+      const source = MockEventSource.instances.at(-1)!
+      act(() => {
+        source.emitOpen()
+        source.emit("init", {
+          type: "init", version: { major: 1, minor: 1 },
+          meta: { streamKey: key }, data: { torrents: [] },
+        })
+      })
+      expect(controls.getState().retryAttempt).toBe(0)
+      expect(controls.getState().initialized).toBe(true)
+    })
+
     it("doubles the delay each attempt and caps at RETRY_MAX_DELAY_MS", () => {
       const { controls } = renderSubscriber(BASE_PARAMS)
       flushConnectionQueue()
@@ -476,7 +690,7 @@ describe("SyncStreamContext", () => {
 
       // The init finally lands; from here the normal 15s budget applies.
       act(() => {
-        source.emit("init", { type: "init", meta: { instanceId: 1, timestamp: "now", streamKey: createStreamKey(BASE_PARAMS) }, data: { torrents: [], total: 0 } })
+        source.emit("init", { type: "init", version: { major: 1, minor: 1 }, meta: { instanceId: 1, timestamp: "now", streamKey: createStreamKey(BASE_PARAMS) }, data: { torrents: [], total: 0 } })
       })
       act(() => {
         vi.advanceTimersByTime(STALE - 1)
@@ -632,6 +846,7 @@ describe("SyncStreamContext", () => {
         source.emitOpen()
         source.emit("update", {
           type: "update",
+          version: { major: 1, minor: 1 },
           meta: { instanceId: 1, timestamp: "now", streamKey: createStreamKey(BASE_PARAMS) },
         })
       })
@@ -728,6 +943,7 @@ describe("SyncStreamContext", () => {
       act(() => {
         source.emit("init", {
           type: "init",
+          version: { major: 1, minor: 1 },
           meta: { instanceId: params.instanceId, timestamp: "now", streamKey: createStreamKey(params) },
         })
       })
@@ -885,6 +1101,7 @@ describe("SyncStreamContext", () => {
         source.emitOpen()
         source.emit("update", {
           type: "update",
+          version: { major: 1, minor: 1 },
           meta: { instanceId: 1, timestamp: "now", streamKey: key },
         })
       })
@@ -894,6 +1111,75 @@ describe("SyncStreamContext", () => {
       expect(controlsB.payloads).toHaveLength(1)
       expect(controlsA.getState().connected).toBe(true)
       expect(controlsB.getState().connected).toBe(true)
+    })
+
+    it("requests one shared init when a listener remounts without a baseline", () => {
+      const controlsA: HarnessControls = { getState: () => DEFAULT, payloads: [] }
+      const controlsB: HarnessControls = { getState: () => DEFAULT, payloads: [] }
+      let setMounted: (mounted: boolean) => void = () => {}
+
+      function Subscriber({ controls }: { controls: HarnessControls }) {
+        const state = useSyncStream(makeParams(), {
+          onMessage: payload => controls.payloads.push(payload),
+        })
+        controls.getState = () => state
+        return null
+      }
+
+      function Root() {
+        const [mounted, updateMounted] = useState(true)
+        setMounted = updateMounted
+        return (
+          <TestProviders>
+            <Subscriber controls={controlsA} />
+            {mounted ? <Subscriber controls={controlsB} /> : null}
+          </TestProviders>
+        )
+      }
+
+      act(() => {
+        render(<Root />)
+      })
+      flushConnectionQueue()
+
+      const key = createStreamKey(makeParams())
+      const first = MockEventSource.instances[0]
+      act(() => {
+        first.emitOpen()
+        first.emit("init", {
+          type: "init",
+          version: { major: 4, minor: 1 },
+          meta: { instanceId: 1, timestamp: "now", streamKey: key },
+          data: { torrents: [], total: 0 },
+        })
+      })
+      expect(controlsA.payloads).toHaveLength(1)
+      expect(controlsB.payloads).toHaveLength(1)
+
+      act(() => setMounted(false))
+      act(() => setMounted(true))
+      expect(controlsA.getState().initialized).toBe(false)
+      flushConnectionQueue()
+
+      expect(first.closed).toBe(true)
+      expect(MockEventSource.instances).toHaveLength(2)
+      const replacement = MockEventSource.instances[1]
+      act(() => {
+        replacement.emitOpen()
+        replacement.emit("init", {
+          type: "init",
+          version: { major: 4, minor: 1 },
+          meta: { instanceId: 1, timestamp: "now", streamKey: key },
+          data: { torrents: [], total: 0 },
+        })
+      })
+
+      // The already-mounted listener receives the same replacement baseline; it
+      // is not left on a different sequence when the remounted listener recovers.
+      expect(controlsA.payloads.map(payload => payload.type)).toEqual(["init", "init"])
+      expect(controlsB.payloads.map(payload => payload.type)).toEqual(["init", "init"])
+      expect(controlsA.getState().initialized).toBe(true)
+      expect(controlsB.getState().initialized).toBe(true)
     })
 
     it("opens distinct EventSources for differing params", () => {

--- a/web/src/contexts/SyncStreamContext.tsx
+++ b/web/src/contexts/SyncStreamContext.tsx
@@ -5,7 +5,7 @@
 
 import { api } from "@/lib/api"
 import { invalidateAllActivity, invalidateForActivity } from "@/lib/activity-invalidation"
-import type { ActivityEvent, ActivityStreamPayload, TorrentFilters, TorrentStreamMeta, TorrentStreamPayload } from "@/types"
+import type { ActivityEvent, ActivityStreamPayload, TorrentFilters, TorrentStreamMeta, TorrentStreamPayload, TorrentStreamVersion } from "@/types"
 import { useQueryClient } from "@tanstack/react-query"
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react"
 
@@ -79,10 +79,25 @@ function normalizeInstanceIds(instanceIds?: number[]): number[] | undefined {
   return normalized.length > 0 ? normalized : undefined
 }
 
+function isStreamVersion(value: TorrentStreamVersion | undefined): value is TorrentStreamVersion {
+  return Boolean(
+    value &&
+    Number.isSafeInteger(value.major) &&
+    value.major > 0 &&
+    Number.isSafeInteger(value.minor) &&
+    value.minor > 0
+  )
+}
+
+function sameStreamVersion(a: TorrentStreamVersion | undefined, b: TorrentStreamVersion | undefined) {
+  return Boolean(a && b && a.major === b.major && a.minor === b.minor)
+}
+
 type StreamListener = (payload: TorrentStreamPayload) => void
 
 export interface StreamState {
   connected: boolean
+  initialized: boolean
   error: string | null
   lastMeta?: TorrentStreamMeta
   retrying: boolean
@@ -113,8 +128,10 @@ interface StreamEntry {
   params: StreamParams
   listeners: Set<StreamListener>
   connected: boolean
+  initialized: boolean
   error: string | null
   lastMeta?: TorrentStreamMeta
+  version?: TorrentStreamVersion
   handoffTimer?: number
   handoffPending?: boolean
   // Set once the replacement connection's socket has demonstrably opened during a
@@ -126,6 +143,7 @@ interface StreamEntry {
 }
 
 interface StreamConnection {
+  recovering?: boolean
   source?: EventSource
   handlers?: {
     payload: (event: MessageEvent | Event) => void
@@ -149,12 +167,14 @@ interface PendingConnectionUpdate {
   timer?: number
   preserveState?: boolean
   resetRetry?: boolean
+  force?: boolean
 }
 
 const SyncStreamContext = createContext<SyncStreamContextValue | null>(null)
 
 const DEFAULT_STREAM_STATE: StreamState = {
   connected: false,
+  initialized: false,
   error: null,
   retrying: false,
   retryAttempt: 0,
@@ -166,6 +186,7 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
   const stateSubscribersRef = useRef<Record<string, Set<(state: StreamState) => void>>>({})
   const connectionRef = useRef<StreamConnection>({ retryAttempt: 0 })
   const scheduleReconnectRef = useRef<() => void>(() => {})
+  const requestRecoveryRef = useRef<(key: string) => void>(() => {})
   // Re-armable handle to the live connection's stale watchdog. openConnection owns
   // resetStaleTimer (it closes over that connection's handlers); we mirror it here so
   // the visibility effect can re-arm a FRESH timer on tab refocus without reaching
@@ -214,6 +235,7 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
 
       return {
         connected: entry.connected,
+        initialized: entry.initialized,
         error: entry.error,
         lastMeta: entry.lastMeta,
         retrying: connection.retryTimer !== undefined,
@@ -290,6 +312,7 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
       connection.retryTimer = undefined
     }
     connection.retryAttempt = 0
+    connection.recovering = false
     connection.nextRetryAt = undefined
   }, [])
 
@@ -370,7 +393,7 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
   const openConnection = useCallback(
     (
       entries: StreamEntry[],
-      options: { preserveState?: boolean; resetRetry?: boolean } = {}
+      options: { preserveState?: boolean; resetRetry?: boolean; force?: boolean } = {}
     ) => {
       const normalized = buildStreamPayload(entries)
       const connection = connectionRef.current
@@ -384,6 +407,7 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
           if (entry.connected) {
             entry.connected = false
           }
+          entry.initialized = false
           clearHandoffState(entry)
           notifyStateSubscribers(entry.key)
         })
@@ -393,7 +417,13 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
 
       const signature = JSON.stringify({ streams: normalized, activity: wantActivity })
 
-      if (connection.signature === signature && connection.source) {
+      // The scheduled recovery owns the next connection attempt. It reads live
+      // subscriptions when it fires, so intervening mounts and view changes coalesce.
+      if (connection.recovering && connection.retryTimer !== undefined) {
+        return
+      }
+
+      if (!options.force && connection.signature === signature && connection.source) {
         return
       }
 
@@ -403,6 +433,7 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
       if (typeof window === "undefined" || typeof EventSource === "undefined") {
         entries.forEach(entry => {
           entry.connected = false
+          entry.initialized = false
           entry.error = STREAM_ERROR_UNSUPPORTED
           clearHandoffState(entry)
           notifyStateSubscribers(entry.key)
@@ -451,6 +482,7 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
             }
             entry.handoffPending = false
             entry.connected = false
+            entry.initialized = false
             notifyStateSubscribers(entry.key)
           }, HANDOFF_GRACE_PERIOD_MS)
           entry.handoffTimer = timer
@@ -458,6 +490,7 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
       } else {
         entries.forEach(entry => {
           entry.connected = false
+          entry.initialized = false
           clearHandoffState(entry)
           notifyStateSubscribers(entry.key)
         })
@@ -475,6 +508,7 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
             entry.error = STREAM_ERROR_DISCONNECTED
           }
           entry.connected = false
+          entry.initialized = false
           notifyStateSubscribers(entry.key)
         })
 
@@ -563,9 +597,43 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
         if (payload.type === "stream-error" && payload.error) {
           entry.error = payload.error
           entry.connected = false
-        } else {
+          entry.initialized = false
+        } else if (payload.type === "init" || payload.type === "update" || payload.type === "delta") {
+          const nextVersion = payload.version
+          const baseVersion = payload.delta?.baseVersion
+          const validFullFrame =
+            payload.type !== "delta" &&
+            isStreamVersion(nextVersion)
+          const validDeltaFrame =
+            payload.type === "delta" &&
+            isStreamVersion(nextVersion) &&
+            isStreamVersion(baseVersion) &&
+            entry.initialized &&
+            sameStreamVersion(entry.version, baseVersion) &&
+            nextVersion.major === baseVersion.major &&
+            nextVersion.minor === baseVersion.minor + 1
+
+          if (!validFullFrame && !validDeltaFrame) {
+            entry.error = null
+            entry.connected = true
+            entry.initialized = false
+            entry.version = undefined
+            clearHandoffState(entry)
+            notifyStateSubscribers(streamKey)
+            requestRecoveryRef.current(streamKey)
+            return
+          }
+
           entry.error = null
           entry.connected = true
+          entry.initialized = true
+          entry.version = nextVersion
+          if (connection.recovering && normalized.every(({ key }) => {
+            const candidate = streamsRef.current[key]
+            return !candidate || candidate.initialized
+          })) {
+            clearConnectionRetryState()
+          }
         }
 
         clearHandoffState(entry)
@@ -636,9 +704,11 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
         // reconcile even on the first successful open, not just on later reconnects.
         const openedAfterFailures = connection.retryAttempt > 0
         resetStaleTimer()
-        clearConnectionRetryState()
-        connection.retryAttempt = 0
-        connection.nextRetryAt = undefined
+        // An open socket does not prove that rejected frames have recovered.
+        // Keep the retry budget until every subscription accepts a baseline.
+        if (!connection.recovering) {
+          clearConnectionRetryState()
+        }
         if (activityCountRef.current > 0) {
           if (activityReconnectArmedRef.current || openedAfterFailures) {
             // Reconnect (or a first open that followed failures): the previous
@@ -703,7 +773,7 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
   )
 
   const ensureConnection = useCallback(
-    (options: { preserveState?: boolean; resetRetry?: boolean } = {}) => {
+    (options: { preserveState?: boolean; resetRetry?: boolean; force?: boolean } = {}) => {
       const entries = Object.values(streamsRef.current)
       if (entries.length === 0 && activityCountRef.current === 0) {
         closeConnection()
@@ -718,25 +788,28 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
   )
 
   const queueConnectionUpdate = useCallback(
-    (options: { preserveState?: boolean; resetRetry?: boolean } = {}) => {
+    (options: { preserveState?: boolean; resetRetry?: boolean; force?: boolean } = {}) => {
       const pending: PendingConnectionUpdate =
         pendingConnectionUpdateRef.current ?? {
           timer: undefined,
           preserveState: undefined,
           resetRetry: undefined,
+          force: undefined,
         }
       pending.preserveState = pending.preserveState || options.preserveState
       pending.resetRetry = pending.resetRetry || options.resetRetry
+      pending.force = pending.force || options.force
 
       if (pending.timer === undefined) {
         const schedule =
           typeof window !== "undefined"? window.setTimeout: (setTimeout as unknown as (handler: () => void, timeout: number) => number)
         pending.timer = schedule(() => {
-          const { preserveState, resetRetry } = pendingConnectionUpdateRef.current ?? {}
+          const { preserveState, resetRetry, force } = pendingConnectionUpdateRef.current ?? {}
           pendingConnectionUpdateRef.current = null
           ensureConnection({
             preserveState,
             resetRetry,
+            force,
           })
         }, 0)
       }
@@ -745,6 +818,28 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
     },
     [ensureConnection]
   )
+
+  const requestRecovery = useCallback(
+    (key: string) => {
+      if (!streamsRef.current[key]) {
+        return
+      }
+      connectionRef.current.recovering = true
+      closeConnection({ preserveRetry: true })
+      // Recovery stops the shared source, so no subscription has a live
+      // baseline during backoff, including those that accepted their last frame.
+      Object.values(streamsRef.current).forEach(entry => {
+        entry.connected = false
+        entry.initialized = false
+        entry.version = undefined
+        clearHandoffState(entry)
+      })
+      notifyAllStateSubscribers()
+      scheduleReconnectRef.current()
+    },
+    [clearHandoffState, closeConnection, notifyAllStateSubscribers]
+  )
+  requestRecoveryRef.current = requestRecovery
 
   const scheduleReconnect = useCallback(() => {
     const connection = connectionRef.current
@@ -798,6 +893,7 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
           params,
           listeners: new Set(),
           connected: options.preserveConnected ?? false,
+          initialized: false,
           error: null,
         }
         streamsRef.current[key] = entry
@@ -805,6 +901,8 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
       } else if (!isSameParams(entry.params, params)) {
         entry.params = params
         entry.error = null
+        entry.initialized = false
+        entry.version = undefined
         queueConnectionUpdate({ preserveState: true, resetRetry: true })
       } else {
         queueConnectionUpdate({ preserveState: true })
@@ -827,6 +925,8 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
         delete streamsRef.current[entry.key]
         clearHandoffState(entry)
         entry.connected = false
+        entry.initialized = false
+        entry.version = undefined
         entry.error = null
         notifyStateSubscribers(entry.key)
         queueConnectionUpdate({ preserveState: true })
@@ -843,7 +943,13 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
       options: { preserveConnected?: boolean } = {}
     ) => {
       const entry = ensureStream(params, options)
+      const needsInit = entry.connected || entry.initialized
       entry.listeners.add(listener)
+      if (needsInit) {
+        entry.initialized = false
+        entry.version = undefined
+        queueConnectionUpdate({ preserveState: true, force: true })
+      }
       notifyStateSubscribers(entry.key)
 
       return () => {
@@ -855,7 +961,7 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
         }
       }
     },
-    [ensureStream, notifyStateSubscribers, scheduleEntryRemoval]
+    [ensureStream, notifyStateSubscribers, queueConnectionUpdate, scheduleEntryRemoval]
   )
 
   const getState = useCallback(
@@ -872,6 +978,7 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
       const connection = connectionRef.current
       return {
         connected: entry.connected,
+        initialized: entry.initialized,
         error: entry.error,
         lastMeta: entry.lastMeta,
         retrying: connection.retryTimer !== undefined,
@@ -970,7 +1077,6 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
 
       if (isDisconnected) {
         // Dead/closed source: reset retry state and force an immediate reconnection.
-        clearConnectionRetryState()
         ensureConnection({ preserveState: false, resetRetry: true })
         return
       }
@@ -984,7 +1090,7 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
     return () => {
       document.removeEventListener("visibilitychange", handleVisibilityChange)
     }
-  }, [clearConnectionRetryState, ensureConnection])
+  }, [ensureConnection])
 
   useEffect(() => {
     return () => {

--- a/web/src/hooks/useTorrentsList.test.tsx
+++ b/web/src/hooks/useTorrentsList.test.tsx
@@ -84,6 +84,7 @@ const mockedUseCapabilities = vi.mocked(useInstanceCapabilities)
 
 const DISCONNECTED: StreamState = {
   connected: false,
+  initialized: false,
   error: null,
   retrying: false,
   retryAttempt: 0,
@@ -752,6 +753,70 @@ describe("useTorrentsList", () => {
     )
   })
 
+  it("keeps an in-flight pagination request alive when a stream frame arrives", async () => {
+    let pageOneSignal: AbortSignal | undefined
+    let resolvePageOne: ((response: TorrentResponse) => void) | undefined
+    const pageOneRequest = new Promise<TorrentResponse>(resolve => {
+      resolvePageOne = resolve
+    })
+
+    mockedApi.getTorrents.mockImplementation((_instanceId, params, signal) => {
+      if (params.page === 0) {
+        return Promise.resolve(makeResponse({
+          torrents: [makeTorrent({ hash: "a" })],
+          total: 2,
+          hasMore: true,
+        }))
+      }
+
+      pageOneSignal = signal
+      return pageOneRequest
+    })
+
+    const { result } = renderHook(
+      () => useTorrentsList(1, { pollingEnabled: false }),
+      { wrapper: makeWrapper() }
+    )
+
+    await flush()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600)
+    })
+    act(() => {
+      result.current.loadMore()
+    })
+    await flush()
+
+    expect(pageOneSignal).toBeInstanceOf(AbortSignal)
+    expect(result.current.isLoadingMore).toBe(true)
+
+    act(() => {
+      capturedOnMessage?.({
+        type: "init",
+        data: makeResponse({
+          torrents: [makeTorrent({ hash: "a", name: "streamed-a" })],
+          total: 2,
+          hasMore: true,
+        }),
+      })
+    })
+    await flush()
+
+    expect(pageOneSignal?.aborted).toBe(false)
+
+    act(() => {
+      resolvePageOne?.(makeResponse({
+        torrents: [makeTorrent({ hash: "b" })],
+        total: 2,
+        hasMore: false,
+      }))
+    })
+    await flush()
+
+    expect(result.current.isLoadingMore).toBe(false)
+    expect(result.current.torrents.map(torrent => torrent.hash)).toEqual(["a", "b"])
+  })
+
   it("resets pagination state and re-fetches page 0 when filters change", async () => {
     const initial = [makeTorrent({ hash: "a" }), makeTorrent({ hash: "b" })]
     const filtered = [makeTorrent({ hash: "z" })]
@@ -849,7 +914,7 @@ describe("useTorrentsList", () => {
     ]
 
     // Stream is connected: REST page-0 query should be gated off.
-    streamState = { ...DISCONNECTED, connected: true }
+    streamState = { ...DISCONNECTED, connected: true, initialized: true }
 
     const { result } = renderHook(() => useTorrentsList(1), { wrapper: makeWrapper() })
 
@@ -870,12 +935,53 @@ describe("useTorrentsList", () => {
     expect(result.current.torrents.map(t => t.hash)).toEqual(["s1", "s2"])
     expect(result.current.totalCount).toBe(2)
     expect(result.current.isStreaming).toBe(true)
-    // Connected stream disables the page-0 REST fetch entirely.
-    expect(mockedApi.getTorrents).not.toHaveBeenCalled()
+    // REST remains eligible until this listener owns a baseline. The init aborts
+    // that in-flight fallback and takes ownership without allowing it to overwrite.
+    expect(mockedApi.getTorrents).toHaveBeenCalledTimes(1)
+    expect(mockedApi.getTorrents.mock.calls[0]?.[2]?.aborted).toBe(true)
+  })
+
+  it("keeps the accepted stream cache successful and idle after cancelling REST", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    let resolveRequest!: (response: TorrentResponse) => void
+    mockedApi.getTorrents.mockReturnValue(new Promise(resolve => { resolveRequest = resolve }))
+    streamState = { ...DISCONNECTED, connected: true, initialized: true }
+    const { result } = renderHook(() => useTorrentsList(1), { wrapper: makeWrapper(queryClient) })
+    await flush()
+    const snapshot = makeResponse({ torrents: [makeTorrent({ hash: "stream" })], total: 1, hasMore: false })
+    act(() => capturedOnMessage?.({ type: "init", data: snapshot }))
+    await flush()
+    // Even an API mock that ignores abort cannot overwrite the stream's cache.
+    act(() => resolveRequest(makeResponse({ torrents: [makeTorrent({ hash: "rest" })] })))
+    await flush()
+    const query = queryClient.getQueryCache().findAll({ queryKey: ["torrents-list"] })[0]
+    expect(query.state.data).toMatchObject({ torrents: [{ hash: "stream" }] })
+    expect(query.state.status).toBe("success")
+    expect(query.state.fetchStatus).toBe("idle")
+    expect(query.state.error).toBeNull()
+    expect(result.current.torrents.map(torrent => torrent.hash)).toEqual(["stream"])
+  })
+
+  it("keeps REST enabled when a shared stream has no baseline for this listener", async () => {
+    streamState = { ...DISCONNECTED, connected: true, initialized: true }
+    mockedApi.getTorrents.mockResolvedValue(
+      makeResponse({
+        torrents: [makeTorrent({ hash: "rest" })],
+        total: 1,
+        hasMore: false,
+      })
+    )
+
+    const { result } = renderHook(() => useTorrentsList(1), { wrapper: makeWrapper() })
+    await flush()
+
+    expect(mockedApi.getTorrents).toHaveBeenCalled()
+    expect(result.current.torrents.map(torrent => torrent.hash)).toEqual(["rest"])
+    expect(result.current.isStreaming).toBe(false)
   })
 
   it("preserves last stream counts when a connected stream snapshot omits counts", async () => {
-    streamState = { ...DISCONNECTED, connected: true }
+    streamState = { ...DISCONNECTED, connected: true, initialized: true }
     const counts = makeCounts()
 
     const { result } = renderHook(() => useTorrentsList(1), { wrapper: makeWrapper() })
@@ -898,11 +1004,12 @@ describe("useTorrentsList", () => {
     await flush()
 
     expect(result.current.counts).toBe(counts)
-    expect(mockedApi.getTorrents).not.toHaveBeenCalled()
+    expect(mockedApi.getTorrents).toHaveBeenCalledTimes(1)
+    expect(mockedApi.getTorrents.mock.calls[0]?.[2]?.aborted).toBe(true)
   })
 
   it("keeps explicit zero stream counts authoritative over preserved counts", async () => {
-    streamState = { ...DISCONNECTED, connected: true }
+    streamState = { ...DISCONNECTED, connected: true, initialized: true }
     const previousCounts = makeCounts()
     const zeroCounts = makeCounts({
       status: { all: 0 },
@@ -936,7 +1043,7 @@ describe("useTorrentsList", () => {
   })
 
   it("does not preserve stream counts across filter scope changes", async () => {
-    streamState = { ...DISCONNECTED, connected: true }
+    streamState = { ...DISCONNECTED, connected: true, initialized: true }
     const counts = makeCounts()
     const downloadingFilter = { status: ["downloading"] } as TorrentFilters
 
@@ -968,7 +1075,7 @@ describe("useTorrentsList", () => {
   })
 
   it("ignores full stream frames from a previous scope after search changes", async () => {
-    streamState = { ...DISCONNECTED, connected: true }
+    streamState = { ...DISCONNECTED, connected: true, initialized: true }
 
     const { result, rerender } = renderHook(
       ({ search }: { search?: string }) => useTorrentsList(1, { pollingEnabled: false, search }),
@@ -1013,7 +1120,7 @@ describe("useTorrentsList", () => {
   })
 
   it("keeps the committed stream callback active when a scope render is abandoned", async () => {
-    streamState = { ...DISCONNECTED, connected: true }
+    streamState = { ...DISCONNECTED, connected: true, initialized: true }
     const pending = new Promise<never>(() => undefined)
     let committedList: ReturnType<typeof useTorrentsList> | undefined
 
@@ -1074,7 +1181,7 @@ describe("useTorrentsList", () => {
   })
 
   it("does not publish counts from an abandoned stream render", async () => {
-    streamState = { ...DISCONNECTED, connected: true }
+    streamState = { ...DISCONNECTED, connected: true, initialized: true }
     const committedCounts = makeCounts({ status: { all: 1 }, total: 1 })
     const abandonedCounts = makeCounts({ status: { all: 2 }, total: 2 })
     const pending = new Promise<never>(() => undefined)
@@ -1139,7 +1246,7 @@ describe("useTorrentsList", () => {
     // All-instances view with a connected stream routes through the cross-instance
     // STREAM merge branch (mergeStreamedCrossInstanceFirstPage), keyed on
     // instanceId+hash. Distinct rows that share a hash across instances stay separate.
-    streamState = { ...DISCONNECTED, connected: true }
+    streamState = { ...DISCONNECTED, connected: true, initialized: true }
 
     // page-0 stream rows: same hash "x" on two instances are two distinct rows.
     const page0Rows = [
@@ -1266,7 +1373,7 @@ describe("useTorrentsList", () => {
 
   it("does not poll page 0 once the stream is connected", async () => {
     // Connected stream gates the page-0 REST query off entirely; no poll ever fires.
-    streamState = { ...DISCONNECTED, connected: true }
+    streamState = { ...DISCONNECTED, connected: true, initialized: true }
 
     const { result } = renderHook(
       () => useTorrentsList(1, { pollingEnabled: true }),
@@ -1281,6 +1388,7 @@ describe("useTorrentsList", () => {
     })
     await flush()
     expect(result.current.torrents).toHaveLength(1)
+    const callsAfterInit = mockedApi.getTorrents.mock.calls.length
 
     // Advancing well past the poll interval must not produce any getTorrents call.
     await act(async () => {
@@ -1288,7 +1396,7 @@ describe("useTorrentsList", () => {
     })
     await flush()
 
-    expect(mockedApi.getTorrents).not.toHaveBeenCalled()
+    expect(mockedApi.getTorrents).toHaveBeenCalledTimes(callsAfterInit)
   })
 
   it("ERROR PATH: a rejected getTorrents settles loading false and keeps the list empty", async () => {

--- a/web/src/hooks/useTorrentsList.ts
+++ b/web/src/hooks/useTorrentsList.ts
@@ -345,6 +345,11 @@ export function useTorrentsList(
     }
   }, [enabled, filters, instanceId, useCrossInstanceEndpoint, isCrossSeedFiltering, streamInstanceIds, order, pageSize, search, sort])
 
+  const listQueryKey = useMemo(
+    () => ["torrents-list", instanceId, instanceIdsKey, currentPage, filters, search, sort, order, useCrossInstanceEndpoint, isCrossSeedFiltering] as const,
+    [instanceId, instanceIdsKey, currentPage, filters, search, sort, order, useCrossInstanceEndpoint, isCrossSeedFiltering]
+  )
+
   const handleStreamPayload = useCallback(
     (payload: TorrentStreamPayload) => {
       if (!payload?.data) {
@@ -387,6 +392,11 @@ export function useTorrentsList(
       } else {
         data = normalizeStreamedSnapshot(payload.data)
       }
+
+      // REST owns the list until this listener has a usable stream baseline. Once
+      // a frame arrives, abort any in-flight fallback before committing the frame
+      // so a slower REST response cannot overwrite the newer stream snapshot.
+      void queryClient.cancelQueries({ queryKey: streamQueryKey, exact: true })
 
       // Publish through the query cache FIRST and adopt its structurally-shared
       // result as the single object lineage for every sink. setQueryData applies
@@ -463,7 +473,15 @@ export function useTorrentsList(
     onMessage: handleStreamPayload,
   })
 
-  const shouldDisablePolling = Boolean(streamParams) && streamState.connected && !streamState.error
+  const hasBaselineForCurrentView =
+    lastStreamSnapshotScopeRef.current === viewScopeKey &&
+    lastFullSnapshotRef.current !== null
+  const shouldDisablePolling =
+    Boolean(streamParams) &&
+    streamState.connected &&
+    streamState.initialized &&
+    !streamState.error &&
+    hasBaselineForCurrentView
   const preferCachedQuery = currentPage === 0 && shouldDisablePolling
   // Polls the scrolled-in window while a recheck/move is in progress anywhere
   // in it; stops on its own once every row settles. Not gated on the stream:
@@ -477,9 +495,7 @@ export function useTorrentsList(
   // still connecting (e.g. behind a buffering reverse proxy that delays the init
   // event) streamState.error is null but no data is arriving, so gating on error
   // alone would disable REST entirely and the first page would never load.
-  const queryEnabled =
-    enabled &&
-    (currentPage > 0 || !streamParams || !streamState.connected || Boolean(streamState.error))
+  const queryEnabled = enabled && (currentPage > 0 || !shouldDisablePolling)
 
   // Reset state when instanceId, filters, search, or sort changes
   // Use JSON.stringify to avoid resetting on every object reference change during polling
@@ -507,11 +523,6 @@ export function useTorrentsList(
       return previous === next ? previous : next
     })
   }, [allTorrents.length, lastKnownTotal])
-
-  const listQueryKey = useMemo(
-    () => ["torrents-list", instanceId, instanceIdsKey, currentPage, filters, search, sort, order, useCrossInstanceEndpoint, isCrossSeedFiltering] as const,
-    [instanceId, instanceIdsKey, currentPage, filters, search, sort, order, useCrossInstanceEndpoint, isCrossSeedFiltering]
-  )
 
   // Query for torrents - backend handles stale-while-revalidate
   const { data, isLoading, isFetching, isPlaceholderData } = useQuery<TorrentResponse>({

--- a/web/src/lib/__tests__/cross-instance-torrents.test.ts
+++ b/web/src/lib/__tests__/cross-instance-torrents.test.ts
@@ -5,7 +5,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-import { applyStreamDelta, mergeStreamedCrossInstanceFirstPage, normalizeCrossInstanceTorrents, normalizeStreamedSnapshot, resolveStreamedCrossInstanceTorrents } from "@/lib/cross-instance-torrents"
+import { mergeStreamedCrossInstanceFirstPage, normalizeCrossInstanceTorrents, normalizeStreamedSnapshot, resolveStreamedCrossInstanceTorrents } from "@/lib/cross-instance-torrents"
 import type { CrossInstanceTorrent, Torrent, TorrentResponse } from "@/types"
 
 // A streamed cross-instance torrent as it arrives over SSE: the backend's
@@ -217,81 +217,5 @@ describe("mergeStreamedCrossInstanceFirstPage", () => {
       camel("e", 1, "alpha"), camel("f", 1, "alpha"),
     ]
     expect(mergeStreamedCrossInstanceFirstPage(prev, snapshot(0, streamed("a", 1, "alpha")))).toEqual([])
-  })
-})
-
-describe("applyStreamDelta", () => {
-  function singleBase(...hashes: string[]): TorrentResponse {
-    return {
-      torrents: hashes.map(hash => ({ hash, name: `${hash}.iso` })) as unknown as Torrent[],
-      total: hashes.length,
-    }
-  }
-
-  it("reconstructs a single-instance page from an in-place value change", () => {
-    const base = singleBase("a", "b", "c")
-    const a = base.torrents![0]
-    const payload = {
-      type: "delta" as const,
-      data: { torrents: [{ hash: "b", name: "b-new.iso" }] as unknown as Torrent[], total: 3 },
-    }
-    const { data, changed } = applyStreamDelta(base, payload, false)
-    expect(changed).toBe(true)
-    expect(data.torrents!.map(t => t.hash)).toEqual(["a", "b", "c"])
-    expect(data.torrents![0]).toBe(a) // unchanged row keeps reference
-    expect(data.torrents![1].name).toBe("b-new.iso")
-  })
-
-  it("applies a single-instance reorder + add from the order list", () => {
-    const base = singleBase("a", "b")
-    const payload = {
-      type: "delta" as const,
-      delta: { order: ["b", "d", "a"] },
-      data: { torrents: [{ hash: "d", name: "d.iso" }] as unknown as Torrent[], total: 3 },
-    }
-    const { data } = applyStreamDelta(base, payload, false)
-    expect(data.torrents!.map(t => t.hash)).toEqual(["b", "d", "a"])
-  })
-
-  it("clears the page when a delta drains it to zero rows (present empty order)", () => {
-    const base = singleBase("a", "b")
-    const payload = {
-      type: "delta" as const,
-      delta: { order: [] as string[] },
-      data: { torrents: [] as unknown as Torrent[], total: 0 },
-    }
-    const { data, changed } = applyStreamDelta(base, payload, false)
-    expect(changed).toBe(true)
-    expect(data.torrents).toEqual([])
-  })
-
-  it("passes the page through unchanged on an aggregate-only delta", () => {
-    const base = singleBase("a", "b")
-    const prevRows = base.torrents
-    const payload = { type: "delta" as const, data: { torrents: [], total: 2, stats: { downloading: 1 } } as unknown as TorrentResponse }
-    const { data, changed } = applyStreamDelta(base, payload, false)
-    expect(changed).toBe(false)
-    expect(data.torrents).toBe(prevRows) // page list referentially stable
-  })
-
-  it("reconstructs a cross-instance page and normalizes snake_case changed rows", () => {
-    const base: TorrentResponse = {
-      crossInstanceTorrents: [camel("a", 1, "alpha"), camel("a", 2, "beta")],
-      total: 2,
-    } as TorrentResponse
-    const payload = {
-      type: "delta" as const,
-      data: {
-        cross_instance_torrents: [streamed("a", 2, "beta")],
-        total: 2,
-      } as unknown as TorrentResponse,
-    }
-    const { data, changed } = applyStreamDelta(base, payload, true)
-    expect(changed).toBe(true)
-    const rows = data.crossInstanceTorrents!
-    expect(rows.map(r => `${r.instanceId}:${r.hash}`)).toEqual(["1:a", "2:a"])
-    // The changed instance-2 row is normalized to camelCase instance metadata.
-    expect(rows[1].instanceId).toBe(2)
-    expect(rows[1].instanceName).toBe("beta")
   })
 })

--- a/web/src/lib/cross-instance-torrents.test.ts
+++ b/web/src/lib/cross-instance-torrents.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { describe, expect, it } from "vitest"
+
+import { applyStreamDelta } from "@/lib/cross-instance-torrents"
+import type { Torrent, TorrentResponse } from "@/types"
+
+describe("applyStreamDelta", () => {
+  function singleBase(...hashes: string[]): TorrentResponse {
+    return {
+      torrents: hashes.map(hash => ({ hash, name: `${hash}.iso` })) as unknown as Torrent[],
+      total: hashes.length,
+    }
+  }
+
+  it("reconstructs a single-instance page from an in-place value change", () => {
+    const base = singleBase("a", "b", "c")
+    const a = base.torrents![0]
+    const payload = {
+      type: "delta" as const,
+      data: { torrents: [{ hash: "b", name: "b-new.iso" }] as unknown as Torrent[], total: 3 },
+    }
+    const { data, changed } = applyStreamDelta(base, payload, false)
+    expect(changed).toBe(true)
+    expect(data.torrents!.map(t => t.hash)).toEqual(["a", "b", "c"])
+    expect(data.torrents![0]).toBe(a) // unchanged row keeps reference
+    expect(data.torrents![1].name).toBe("b-new.iso")
+  })
+
+  it("applies a single-instance reorder + add from the order list", () => {
+    const base = singleBase("a", "b")
+    const payload = {
+      type: "delta" as const,
+      delta: { order: ["b", "d", "a"], baseVersion: { major: 1, minor: 1 } },
+      data: { torrents: [{ hash: "d", name: "d.iso" }] as unknown as Torrent[], total: 3 },
+    }
+    const { data } = applyStreamDelta(base, payload, false)
+    expect(data.torrents!.map(t => t.hash)).toEqual(["b", "d", "a"])
+  })
+
+  it("clears the page when a delta drains it to zero rows (present empty order)", () => {
+    const base = singleBase("a", "b")
+    const payload = {
+      type: "delta" as const,
+      delta: { order: [] as string[], baseVersion: { major: 1, minor: 1 } },
+      data: { torrents: [] as unknown as Torrent[], total: 0 },
+    }
+    const { data, changed } = applyStreamDelta(base, payload, false)
+    expect(changed).toBe(true)
+    expect(data.torrents).toEqual([])
+  })
+
+  it("reconstructs a cross-instance page and normalizes snake_case changed rows", () => {
+    const base: TorrentResponse = {
+      crossInstanceTorrents: [{ hash: "a", instanceId: 1, instanceName: "alpha" }, { hash: "a", instanceId: 2, instanceName: "beta" }],
+      total: 2,
+    } as TorrentResponse
+    const payload = {
+      type: "delta" as const,
+      data: {
+        cross_instance_torrents: [{ hash: "a", instance_id: 2, instance_name: "beta" }],
+        total: 2,
+      } as unknown as TorrentResponse,
+    }
+    const { data, changed } = applyStreamDelta(base, payload, true)
+    expect(changed).toBe(true)
+    const rows = data.crossInstanceTorrents!
+    expect(rows.map(r => `${r.instanceId}:${r.hash}`)).toEqual(["1:a", "2:a"])
+    // The changed instance-2 row is normalized to camelCase instance metadata.
+    expect(rows[1].instanceId).toBe(2)
+    expect(rows[1].instanceName).toBe("beta")
+  })
+})
+
+describe("applyStreamDelta", () => {
+  it("passes the page through unchanged on an aggregate-only delta", () => {
+    const torrents = ["a", "b"].map(hash => ({
+      hash,
+      name: `${hash}.iso`,
+    })) as unknown as Torrent[]
+    const base = {
+      torrents,
+      total: torrents.length,
+      counts: { status: { all: 2 }, categories: {}, tags: {}, trackers: {}, total: 2 },
+      preferences: { max_ratio: 2 },
+    } as unknown as TorrentResponse
+    const payload = {
+      type: "delta" as const,
+      data: {
+        torrents: [],
+        total: 2,
+        stats: { downloading: 1 },
+      } as unknown as TorrentResponse,
+    }
+
+    const { data, changed } = applyStreamDelta(base, payload, false)
+
+    expect(changed).toBe(false)
+    expect(data.torrents).toBe(torrents)
+    expect(data.counts).toBe(base.counts)
+    expect(data.preferences).toBe(base.preferences)
+  })
+})

--- a/web/src/lib/cross-instance-torrents.test.ts
+++ b/web/src/lib/cross-instance-torrents.test.ts
@@ -76,16 +76,19 @@ describe("applyStreamDelta", () => {
 })
 
 describe("applyStreamDelta", () => {
-  it("passes the page through unchanged on an aggregate-only delta", () => {
+  it.each([false, true])("retains only counts and preferences on an aggregate-only delta, cross-instance: %s", isCrossInstance => {
     const torrents = ["a", "b"].map(hash => ({
       hash,
       name: `${hash}.iso`,
     })) as unknown as Torrent[]
     const base = {
       torrents,
+      crossInstanceTorrents: torrents.map(torrent => ({ ...torrent, instanceId: 1, instanceName: "Field" })),
       total: torrents.length,
       counts: { status: { all: 2 }, categories: {}, tags: {}, trackers: {}, total: 2 },
       preferences: { max_ratio: 2 },
+      categories: { FieldCategory: { name: "FieldCategory", savePath: "/synthetic/" } },
+      tags: ["FieldTag"],
     } as unknown as TorrentResponse
     const payload = {
       type: "delta" as const,
@@ -96,11 +99,24 @@ describe("applyStreamDelta", () => {
       } as unknown as TorrentResponse,
     }
 
-    const { data, changed } = applyStreamDelta(base, payload, false)
+    const { data, changed } = applyStreamDelta(base, payload, isCrossInstance)
 
     expect(changed).toBe(false)
-    expect(data.torrents).toBe(torrents)
+    expect(isCrossInstance ? data.crossInstanceTorrents : data.torrents).toBe(isCrossInstance ? base.crossInstanceTorrents : torrents)
     expect(data.counts).toBe(base.counts)
     expect(data.preferences).toBe(base.preferences)
+    expect(data.categories).toBeUndefined()
+    expect(data.tags).toBeUndefined()
+  })
+
+  it.each([false, true])("preserves omitted and explicit null preferences, cross-instance: %s", isCrossInstance => {
+    const base: TorrentResponse = { torrents: [], total: 0 }
+    const payload = { type: "delta" as const, data: base }
+
+    expect(applyStreamDelta(base, payload, isCrossInstance).data).not.toHaveProperty("preferences")
+
+    const cleared = applyStreamDelta(base, { ...payload, data: { ...base, preferences: null } }, isCrossInstance).data
+    expect(cleared.preferences).toBeNull()
+    expect(applyStreamDelta(cleared, payload, isCrossInstance).data.preferences).toBeNull()
   })
 })

--- a/web/src/lib/cross-instance-torrents.ts
+++ b/web/src/lib/cross-instance-torrents.ts
@@ -142,6 +142,7 @@ export function applyStreamDelta(
 
     return {
       data: {
+        ...prev,
         ...frame,
         crossInstanceTorrents: rows,
         cross_instance_torrents: rows,
@@ -156,6 +157,7 @@ export function applyStreamDelta(
 
   return {
     data: {
+      ...prev,
       ...frame,
       torrents: rows,
     },

--- a/web/src/lib/cross-instance-torrents.ts
+++ b/web/src/lib/cross-instance-torrents.ts
@@ -131,6 +131,12 @@ export function applyStreamDelta(
 ): { data: TorrentResponse; changed: boolean } {
   const order = payload.delta?.order
   const frame = payload.data ?? ({} as TorrentResponse)
+  // Only counts and preferences use omission to mean "unchanged".
+  const snapshot = {
+    counts: prev.counts,
+    ...(prev.preferences !== undefined && { preferences: prev.preferences }),
+    ...frame,
+  }
 
   if (isCrossInstance) {
     const prevRows = prev.crossInstanceTorrents ?? []
@@ -142,8 +148,7 @@ export function applyStreamDelta(
 
     return {
       data: {
-        ...prev,
-        ...frame,
+        ...snapshot,
         crossInstanceTorrents: rows,
         cross_instance_torrents: rows,
       },
@@ -157,8 +162,7 @@ export function applyStreamDelta(
 
   return {
     data: {
-      ...prev,
-      ...frame,
+      ...snapshot,
       torrents: rows,
     },
     changed,

--- a/web/src/types/torrents.ts
+++ b/web/src/types/torrents.ts
@@ -316,6 +316,11 @@ export interface TorrentStreamMeta {
   streamKey?: string
 }
 
+export interface TorrentStreamVersion {
+  major: number
+  minor: number
+}
+
 // TorrentStreamDelta reconciles a delta frame's page-0 window against the previous
 // frame. The added/changed rows ride in the frame's `data.torrents` (or
 // `cross_instance_torrents`); `order` is the full page key sequence, present only
@@ -324,6 +329,7 @@ export interface TorrentStreamMeta {
 // cross-instance streams.
 export interface TorrentStreamDelta {
   order?: string[]
+  baseVersion: TorrentStreamVersion
 }
 
 export interface TorrentStreamPayload {
@@ -331,6 +337,7 @@ export interface TorrentStreamPayload {
   data?: TorrentResponse
   delta?: TorrentStreamDelta
   meta?: TorrentStreamMeta
+  version?: TorrentStreamVersion
   error?: string
 }
 


### PR DESCRIPTION
## Description

A newly mounted or remounted torrent view could receive its initial snapshot and then miss an update before its subscription became active. Later deltas assumed that missed update had been applied, so a completed torrent could remain shown as downloading indefinitely even while aggregate speeds continued to update.

This change makes initialization and later updates one ordered stream. Frames carry a major/minor vector clock, the backend retains the snapshot for each baseline, and the client accepts a delta only when its base matches the state it has applied. A mismatch requests a fresh snapshot and keeps REST fallback active until the stream is usable again.

Fixes: no linked issue.

## How has this been tested?

Built and started qui with an isolated SQLite database. All 94 migrations applied, the API server started successfully, and the bundled UI returned HTTP 200. Automated regression tests cover a completion published across the initialization/subscription gap and client recovery from a missed baseline.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

## AI disclosure

Yes. Roughly all code in this PR was written with OpenAI Codex using GPT-5.6-sol at high reasoning, with human direction and review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Added version tracking for live torrent updates to detect stale or out-of-order data.
  - Improved automatic recovery after invalid or out-of-sequence stream updates.
  - Preserved complete torrent snapshots when applying partial updates, including aggregate counts and preferences.
  - Improved synchronization when listeners reconnect or remount.
  - Added activity event notifications for live stream listeners.

- **Bug Fixes**
  - Prevented streamed data from being overwritten by older REST responses.
  - Kept REST fallback requests available until a complete live-stream baseline is received.
  - Improved polling behavior after successful stream initialization.

- **Documentation**
  - Documented the live torrent updates stream endpoint and versioning rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
