### PR TITLE
fix(mobile): keep torrent actions sheet and limit dialogs inside the viewport

### DIFF
--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -2305,13 +2305,13 @@ export function TorrentCardsMobile({
 
       {/* More actions sheet */}
       <Sheet open={showActionsSheet} onOpenChange={setShowActionsSheet}>
-        <SheetContent side="bottom" className="max-h-[85dvh] overflow-y-auto pb-8">
+        <SheetContent side="bottom" className="max-h-[85dvh] pb-8">
           <SheetHeader>
             <SheetTitle>
               {isAllSelected? t("mobileCards.actionsForAll", { count: effectiveSelectionCount }): t("mobileCards.actionsForCount", { count: effectiveSelectionCount })}
             </SheetTitle>
           </SheetHeader>
-          <div className="grid gap-2 py-4 px-4">
+          <div className="grid gap-2 py-4 px-4 min-h-0 overflow-y-auto">
             {(() => {
               const { allEnabled: allForceStarted, mixed: forceStartMixed } = getToggleSelectionState(getSelectedTorrents.map(t => t.force_start), stateUnknownForSelection)
 

--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -2305,7 +2305,7 @@ export function TorrentCardsMobile({
 
       {/* More actions sheet */}
       <Sheet open={showActionsSheet} onOpenChange={setShowActionsSheet}>
-        <SheetContent side="bottom" className="h-auto pb-8">
+        <SheetContent side="bottom" className="max-h-[85dvh] overflow-y-auto pb-8">
           <SheetHeader>
             <SheetTitle>
               {isAllSelected? t("mobileCards.actionsForAll", { count: effectiveSelectionCount }): t("mobileCards.actionsForCount", { count: effectiveSelectionCount })}

--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -59,10 +59,14 @@ import { useNavigate, useSearch } from "@tanstack/react-router"
 import { navigateWithSearch } from "@/lib/router-search"
 import { useVirtualizer } from "@tanstack/react-virtual"
 import {
+  ArrowDown,
+  ArrowUp,
   ArrowUpDown,
   Blocks,
   CheckCircle2,
   ChevronDown,
+  ChevronsDown,
+  ChevronsUp,
   ChevronUp,
   Clock,
   Download,
@@ -2433,38 +2437,43 @@ export function TorrentCardsMobile({
                 {t("contextMenu.searchCrossSeeds")}
               </Button>
             )}
-            <Button
-              variant="outline"
-              onClick={() => handleBulkAction(TORRENT_ACTIONS.INCREASE_PRIORITY)}
-              className="justify-start"
-            >
-              <ChevronUp className="mr-2 h-4 w-4" />
-              {t("managementBar.increasePriority")}
-            </Button>
-            <Button
-              variant="outline"
-              onClick={() => handleBulkAction(TORRENT_ACTIONS.DECREASE_PRIORITY)}
-              className="justify-start"
-            >
-              <ChevronDown className="mr-2 h-4 w-4" />
-              {t("managementBar.decreasePriority")}
-            </Button>
-            <Button
-              variant="outline"
-              onClick={() => handleBulkAction(TORRENT_ACTIONS.TOP_PRIORITY)}
-              className="justify-start"
-            >
-              <ChevronUp className="mr-2 h-4 w-4" />
-              {t("managementBar.topPriority")}
-            </Button>
-            <Button
-              variant="outline"
-              onClick={() => handleBulkAction(TORRENT_ACTIONS.BOTTOM_PRIORITY)}
-              className="justify-start"
-            >
-              <ChevronDown className="mr-2 h-4 w-4" />
-              {t("managementBar.bottomPriority")}
-            </Button>
+            <div className="flex items-center gap-2">
+              <span className="flex-1 truncate text-sm text-muted-foreground">
+                {t("managementBar.queuePriority")}
+              </span>
+              <Button
+                variant="outline"
+                className="h-11 w-11"
+                aria-label={t("managementBar.topPriority")}
+                onClick={() => handleBulkAction(TORRENT_ACTIONS.TOP_PRIORITY)}
+              >
+                <ChevronsUp className="h-4 w-4" />
+              </Button>
+              <Button
+                variant="outline"
+                className="h-11 w-11"
+                aria-label={t("managementBar.increasePriority")}
+                onClick={() => handleBulkAction(TORRENT_ACTIONS.INCREASE_PRIORITY)}
+              >
+                <ArrowUp className="h-4 w-4" />
+              </Button>
+              <Button
+                variant="outline"
+                className="h-11 w-11"
+                aria-label={t("managementBar.decreasePriority")}
+                onClick={() => handleBulkAction(TORRENT_ACTIONS.DECREASE_PRIORITY)}
+              >
+                <ArrowDown className="h-4 w-4" />
+              </Button>
+              <Button
+                variant="outline"
+                className="h-11 w-11"
+                aria-label={t("managementBar.bottomPriority")}
+                onClick={() => handleBulkAction(TORRENT_ACTIONS.BOTTOM_PRIORITY)}
+              >
+                <ChevronsDown className="h-4 w-4" />
+              </Button>
+            </div>
             {(() => {
               const { allEnabled, mixed } = getToggleSelectionState(getSelectedTorrents.map(t => t.auto_tmm), stateUnknownForSelection)
 

--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -59,14 +59,10 @@ import { useNavigate, useSearch } from "@tanstack/react-router"
 import { navigateWithSearch } from "@/lib/router-search"
 import { useVirtualizer } from "@tanstack/react-virtual"
 import {
-  ArrowDown,
-  ArrowUp,
   ArrowUpDown,
   Blocks,
   CheckCircle2,
   ChevronDown,
-  ChevronsDown,
-  ChevronsUp,
   ChevronUp,
   Clock,
   Download,
@@ -2437,43 +2433,38 @@ export function TorrentCardsMobile({
                 {t("contextMenu.searchCrossSeeds")}
               </Button>
             )}
-            <div className="flex items-center gap-2">
-              <span className="flex-1 truncate text-sm text-muted-foreground">
-                {t("managementBar.queuePriority")}
-              </span>
-              <Button
-                variant="outline"
-                className="h-11 w-11"
-                aria-label={t("managementBar.topPriority")}
-                onClick={() => handleBulkAction(TORRENT_ACTIONS.TOP_PRIORITY)}
-              >
-                <ChevronsUp className="h-4 w-4" />
-              </Button>
-              <Button
-                variant="outline"
-                className="h-11 w-11"
-                aria-label={t("managementBar.increasePriority")}
-                onClick={() => handleBulkAction(TORRENT_ACTIONS.INCREASE_PRIORITY)}
-              >
-                <ArrowUp className="h-4 w-4" />
-              </Button>
-              <Button
-                variant="outline"
-                className="h-11 w-11"
-                aria-label={t("managementBar.decreasePriority")}
-                onClick={() => handleBulkAction(TORRENT_ACTIONS.DECREASE_PRIORITY)}
-              >
-                <ArrowDown className="h-4 w-4" />
-              </Button>
-              <Button
-                variant="outline"
-                className="h-11 w-11"
-                aria-label={t("managementBar.bottomPriority")}
-                onClick={() => handleBulkAction(TORRENT_ACTIONS.BOTTOM_PRIORITY)}
-              >
-                <ChevronsDown className="h-4 w-4" />
-              </Button>
-            </div>
+            <Button
+              variant="outline"
+              onClick={() => handleBulkAction(TORRENT_ACTIONS.INCREASE_PRIORITY)}
+              className="justify-start"
+            >
+              <ChevronUp className="mr-2 h-4 w-4" />
+              {t("managementBar.increasePriority")}
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => handleBulkAction(TORRENT_ACTIONS.DECREASE_PRIORITY)}
+              className="justify-start"
+            >
+              <ChevronDown className="mr-2 h-4 w-4" />
+              {t("managementBar.decreasePriority")}
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => handleBulkAction(TORRENT_ACTIONS.TOP_PRIORITY)}
+              className="justify-start"
+            >
+              <ChevronUp className="mr-2 h-4 w-4" />
+              {t("managementBar.topPriority")}
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => handleBulkAction(TORRENT_ACTIONS.BOTTOM_PRIORITY)}
+              className="justify-start"
+            >
+              <ChevronDown className="mr-2 h-4 w-4" />
+              {t("managementBar.bottomPriority")}
+            </Button>
             {(() => {
               const { allEnabled, mixed } = getToggleSelectionState(getSelectedTorrents.map(t => t.auto_tmm), stateUnknownForSelection)
 

--- a/web/src/components/torrents/TorrentDialogs.tsx
+++ b/web/src/components/torrents/TorrentDialogs.tsx
@@ -1962,7 +1962,7 @@ export const ShareLimitDialog = memo(function ShareLimitDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md">
+      <DialogContent className="max-w-md max-h-[85dvh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>{t("dialogs.shareLimit.title", { count: hashCount })}</DialogTitle>
           <DialogDescription>
@@ -2308,7 +2308,7 @@ export const SpeedLimitsDialog = memo(function SpeedLimitsDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md">
+      <DialogContent className="max-w-md max-h-[85dvh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>{t("dialogs.speedLimits.title", { count: hashCount })}</DialogTitle>
           <DialogDescription>


### PR DESCRIPTION
## Description

Fixes two mobile overflow bugs reported on short screens (folding phone outer display, landscape):

- The torrent actions bottom sheet grew past the viewport, which pushed the header and close button off-screen and left no way to scroll or dismiss it. The sheet is now capped at 85% of the viewport height; the header with the title and close button stays pinned, and only the action list scrolls.
- The Set Share Limits and Set Speed Limits dialogs overflowed the visible area when the on-screen keyboard was open, with no way to scroll to the buttons. Both are now capped at 85% of the viewport height and scroll, the same pattern the other large dialogs use.

## How has this been tested?

Not run on a device. Reporters with short viewports should confirm both surfaces.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Improved mobile torrent action sheets with a capped height and internal scrolling for easier access on smaller screens.
  - Restored labeled queue-priority buttons for clearer controls.
  - Updated sharing and speed-limit dialogs to remain within the viewport and scroll internally when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->