### PR TITLE
fix(backups): scope run cache updates to backup queries

### DIFF
--- a/web/src/hooks/useInstanceBackups.test.tsx
+++ b/web/src/hooks/useInstanceBackups.test.tsx
@@ -39,19 +39,26 @@ afterEach(() => {
   vi.clearAllMocks()
 })
 
+type RunMutation = { mutateAsync: (payload: never) => Promise<unknown> }
+
+async function expectPrependsRun(hook: () => RunMutation, payload: unknown) {
+  mockedApi.triggerBackup.mockResolvedValue(run)
+  mockedApi.importBackupManifest.mockResolvedValue(run)
+  const { queryClient, wrapper } = makeClient()
+  const { result } = renderHook(hook, { wrapper })
+
+  await expect(result.current.mutateAsync(payload as never)).resolves.toEqual(run)
+
+  expect(queryClient.getQueryData(["instance-backups", 1, "runs", 25, 0])).toEqual({ runs: [run, existingRun], hasMore: false })
+  expect(queryClient.getQueryData(["orphan-scan", 1, "runs", null])).toBe(orphanRuns)
+}
+
 describe("backup run mutations", () => {
-  it.each([
-    ["useTriggerBackup", () => useTriggerBackup(1), {}],
-    ["useImportBackupManifest", () => useImportBackupManifest(1), new File([], "m.json")],
-  ] as const)("%s prepends the run without touching other features' runs queries", async (_name, hook, payload) => {
-    mockedApi.triggerBackup.mockResolvedValue(run)
-    mockedApi.importBackupManifest.mockResolvedValue(run)
-    const { queryClient, wrapper } = makeClient()
-    const { result } = renderHook(hook, { wrapper })
+  it("useTriggerBackup prepends the run without touching other features' runs queries", async () => {
+    await expectPrependsRun(() => useTriggerBackup(1), {})
+  })
 
-    await expect(result.current.mutateAsync(payload as never)).resolves.toEqual(run)
-
-    expect(queryClient.getQueryData(["instance-backups", 1, "runs", 25, 0])).toEqual({ runs: [run, existingRun], hasMore: false })
-    expect(queryClient.getQueryData(["orphan-scan", 1, "runs", null])).toBe(orphanRuns)
+  it("useImportBackupManifest prepends the run without touching other features' runs queries", async () => {
+    await expectPrependsRun(() => useImportBackupManifest(1), new File([], "m.json"))
   })
 })

--- a/web/src/hooks/useInstanceBackups.test.tsx
+++ b/web/src/hooks/useInstanceBackups.test.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { cleanup, renderHook } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    triggerBackup: vi.fn(),
+    importBackupManifest: vi.fn(),
+  },
+}))
+
+import { api } from "@/lib/api"
+import { useImportBackupManifest, useTriggerBackup } from "@/hooks/useInstanceBackups"
+
+const mockedApi = vi.mocked(api, true)
+
+const run = { id: 7, instanceId: 1, status: "pending" } as never
+const existingRun = { id: 3, instanceId: 1, status: "success" }
+const orphanRuns = [{ id: 9, status: "completed" }]
+
+function makeClient() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  queryClient.setQueryData(["instance-backups", 1, "runs", 25, 0], { runs: [existingRun], hasMore: false })
+  queryClient.setQueryData(["orphan-scan", 1, "runs", null], orphanRuns)
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+  return { queryClient, wrapper }
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe("backup run mutations", () => {
+  it.each([
+    ["useTriggerBackup", () => useTriggerBackup(1), {}],
+    ["useImportBackupManifest", () => useImportBackupManifest(1), new File([], "m.json")],
+  ] as const)("%s prepends the run without touching other features' runs queries", async (_name, hook, payload) => {
+    mockedApi.triggerBackup.mockResolvedValue(run)
+    mockedApi.importBackupManifest.mockResolvedValue(run)
+    const { queryClient, wrapper } = makeClient()
+    const { result } = renderHook(hook, { wrapper })
+
+    await expect(result.current.mutateAsync(payload as never)).resolves.toEqual(run)
+
+    expect(queryClient.getQueryData(["instance-backups", 1, "runs", 25, 0])).toEqual({ runs: [run, existingRun], hasMore: false })
+    expect(queryClient.getQueryData(["orphan-scan", 1, "runs", null])).toBe(orphanRuns)
+  })
+})

--- a/web/src/hooks/useInstanceBackups.ts
+++ b/web/src/hooks/useInstanceBackups.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useMutation, useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query"
 
 import { useActivityStream } from "@/contexts/SyncStreamContext"
 import { api } from "@/lib/api"
@@ -44,6 +44,24 @@ export function useUpdateBackupSettings(instanceId: number) {
   })
 }
 
+// prependRun puts a fresh run at the top of every first-page runs query for
+// the instance so the history table shows it before the refetch lands.
+function prependRun(queryClient: QueryClient, instanceId: number, run: BackupRun) {
+  queryClient.setQueriesData<BackupRunsResponse>(
+    {
+      queryKey: ["instance-backups", instanceId, "runs"],
+      predicate: (query) => !query.queryKey[4],
+    },
+    (existing) => {
+      if (!existing) {
+        return { runs: [run], hasMore: false }
+      }
+      const filtered = existing.runs.filter(item => item.id !== run.id)
+      return { ...existing, runs: [run, ...filtered] }
+    }
+  )
+}
+
 export function useTriggerBackup(instanceId: number) {
   const queryClient = useQueryClient()
 
@@ -51,28 +69,7 @@ export function useTriggerBackup(instanceId: number) {
     mutationFn: (payload: { kind?: string; requestedBy?: string } = {}) => api.triggerBackup(instanceId, payload),
     onSuccess: (run: BackupRun) => {
       queryClient.invalidateQueries({ queryKey: ["instance-backups", instanceId, "runs"] })
-      queryClient.setQueriesData<BackupRunsResponse>(
-        {
-          predicate: (query) => {
-            const key = query.queryKey
-            if (!Array.isArray(key)) {
-              return false
-            }
-            const [, keyInstanceId, section, , offset] = key
-            if (keyInstanceId !== instanceId || section !== "runs") {
-              return false
-            }
-            return offset === 0 || offset === null || offset === undefined
-          },
-        },
-        (existing) => {
-          if (!existing) {
-            return { runs: [run], hasMore: false }
-          }
-          const filtered = existing.runs.filter(item => item.id !== run.id)
-          return { ...existing, runs: [run, ...filtered] }
-        }
-      )
+      prependRun(queryClient, instanceId, run)
     },
   })
 }
@@ -164,28 +161,7 @@ export function useImportBackupManifest(instanceId: number) {
     mutationFn: (manifestFile: File) => api.importBackupManifest(instanceId, manifestFile),
     onSuccess: (run: BackupRun) => {
       queryClient.invalidateQueries({ queryKey: ["instance-backups", instanceId, "runs"] })
-      queryClient.setQueriesData<BackupRunsResponse>(
-        {
-          predicate: (query) => {
-            const key = query.queryKey
-            if (!Array.isArray(key)) {
-              return false
-            }
-            const [, keyInstanceId, section, , offset] = key
-            if (keyInstanceId !== instanceId || section !== "runs") {
-              return false
-            }
-            return offset === 0 || offset === null || offset === undefined
-          },
-        },
-        (existing) => {
-          if (!existing) {
-            return { runs: [run], hasMore: false }
-          }
-          const filtered = existing.runs.filter(item => item.id !== run.id)
-          return { ...existing, runs: [run, ...filtered] }
-        }
-      )
+      prependRun(queryClient, instanceId, run)
     },
   })
 }


### PR DESCRIPTION
## Description

Fixes `Cannot read properties of undefined (reading 'filter')` after a manual backup when the Automations page was opened earlier in the same session.

The trigger and manifest-import hooks prepend the new run into the cached runs queries with a `setQueriesData` predicate. That predicate never checked the first key element, so it also matched the orphan-scan runs query for the same instance (`["orphan-scan", id, "runs", null]`, which the Automations page mounts). That query holds a bare array, so `existing.runs` was undefined and the updater threw. The backup itself was already queued on the server, only the optimistic table update failed.

Not a 1.28 regression. The predicate dates from #559, and it became reachable in v1.12.0 when #818 mounted the orphan-scan runs query on the Automations page.

Both predicates now share one helper that prefix-matches `["instance-backups", id, "runs"]` and only touches first-page entries. Regression test seeds both queries and runs both mutations.

## How has this been tested?

Reproduced the user's exact error with the new test before the fix. Repro path confirmed by the reporter: hard refresh then backup works, Automations tab then backup fails.

Live differential on a scratch qui with a stub qBittorrent that answers login and Web API version. Same tab, same path both times: load Automations, click through to Backups in-app, Run manual backup. The develop bundle shows the `reading 'filter'` toast. This branch shows `Backup queued` and the new row. Bundle identity was checked by grepping the served chunk, since the service worker keeps the previous bundle alive across a binary swap.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Backup runs now appear immediately at the beginning of the first page after triggering a backup or importing a backup manifest.
  * Unrelated backup queries, including orphan scans, remain unchanged.

* **Tests**
  * Added coverage for updating backup run results after triggering backups and importing manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
