### PR TITLE
fix(web): format timestamps with date/time preferences everywhere

### DIFF
--- a/web/src/components/cross-seed/DirScanTab.tsx
+++ b/web/src/components/cross-seed/DirScanTab.tsx
@@ -835,6 +835,7 @@ function buildSettingsFormState(settings: SettingsDialogProps["settings"]) {
 
 function SettingsDialog({ open, onOpenChange, settings, instances }: SettingsDialogProps) {
   const { t } = useTranslation("crossseed")
+  const { formatDate } = useDateTimeFormatters()
   const updateSettings = useUpdateDirScanSettings()
   const [form, setForm] = useState(() => buildSettingsFormState(settings))
 
@@ -923,8 +924,8 @@ function SettingsDialog({ open, onOpenChange, settings, instances }: SettingsDia
     }
     const days = Math.max(1, form.maxSearcheeAgeDays)
     const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
-    return cutoff.toLocaleString()
-  }, [ageFilterEnabled, form.maxSearcheeAgeDays])
+    return formatDate(cutoff)
+  }, [ageFilterEnabled, form.maxSearcheeAgeDays, formatDate])
 
   const handleSave = useCallback(() => {
     updateSettings.mutate(form, {

--- a/web/src/components/instances/preferences/OrphanScanPreviewDialog.test.tsx
+++ b/web/src/components/instances/preferences/OrphanScanPreviewDialog.test.tsx
@@ -18,14 +18,14 @@ vi.mock("@/hooks/useDateTimeFormatters", () => ({
   useDateTimeFormatters: () => ({ formatISOTimestamp: (iso: string) => `pref:${iso}` }),
 }))
 
-const files: OrphanScanFile[] = [
-  { id: 1, runId: 1, filePath: "/data/a.mkv", fileSize: 10, status: "pending", modifiedAt: "2026-01-02T03:04:05Z" },
-  { id: 2, runId: 1, filePath: "/data/b.mkv", fileSize: 20, status: "pending" },
-]
-
 // Stable singletons: a fresh object per render would retrigger the page-merge effect forever.
-const runQuery = { data: { files } }
-const confirmMutation = { isPending: false }
+const { runQuery, confirmMutation } = vi.hoisted(() => {
+  const files: OrphanScanFile[] = [
+    { id: 1, runId: 1, filePath: "/data/a.mkv", fileSize: 10, status: "pending", modifiedAt: "2026-01-02T03:04:05Z" },
+    { id: 2, runId: 1, filePath: "/data/b.mkv", fileSize: 20, status: "pending" },
+  ]
+  return { runQuery: { data: { files } }, confirmMutation: { isPending: false } }
+})
 
 vi.mock("@/hooks/useOrphanScan", () => ({
   useOrphanScanRun: () => runQuery,

--- a/web/src/components/instances/preferences/OrphanScanPreviewDialog.test.tsx
+++ b/web/src/components/instances/preferences/OrphanScanPreviewDialog.test.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { afterEach, beforeEach, expect, it, vi } from "vitest"
+import { cleanup, render } from "@testing-library/react"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import type { OrphanScanFile } from "@/types"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+// The dialog must route modifiedAt through the preference-aware formatter,
+// not the browser-locale toLocaleString().
+vi.mock("@/hooks/useDateTimeFormatters", () => ({
+  useDateTimeFormatters: () => ({ formatISOTimestamp: (iso: string) => `pref:${iso}` }),
+}))
+
+const files: OrphanScanFile[] = [
+  { id: 1, runId: 1, filePath: "/data/a.mkv", fileSize: 10, status: "pending", modifiedAt: "2026-01-02T03:04:05Z" },
+  { id: 2, runId: 1, filePath: "/data/b.mkv", fileSize: 20, status: "pending" },
+]
+
+// Stable singletons: a fresh object per render would retrigger the page-merge effect forever.
+const runQuery = { data: { files } }
+const confirmMutation = { isPending: false }
+
+vi.mock("@/hooks/useOrphanScan", () => ({
+  useOrphanScanRun: () => runQuery,
+  useConfirmOrphanScanDeletion: () => confirmMutation,
+}))
+
+import { OrphanScanPreviewDialog } from "@/components/instances/preferences/OrphanScanPreviewDialog"
+
+beforeEach(() => {
+  // Radix dialog/tooltip measure through ResizeObserver, which jsdom lacks.
+  vi.stubGlobal("ResizeObserver", class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+it("formats the Modified column with the date/time preferences", () => {
+  render(
+    <TooltipProvider>
+      <OrphanScanPreviewDialog open onOpenChange={() => {}} instanceId={1} runId={1} />
+    </TooltipProvider>
+  )
+
+  const cells = [...document.body.querySelectorAll("tbody td:nth-child(3)")].map((td) => td.textContent)
+  expect(cells).toEqual(["pref:2026-01-02T03:04:05Z", "-"])
+})

--- a/web/src/components/instances/preferences/OrphanScanPreviewDialog.tsx
+++ b/web/src/components/instances/preferences/OrphanScanPreviewDialog.tsx
@@ -6,6 +6,7 @@
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { PathCell } from "@/components/ui/path-cell"
+import { useDateTimeFormatters } from "@/hooks/useDateTimeFormatters"
 import { useConfirmOrphanScanDeletion, useOrphanScanRun } from "@/hooks/useOrphanScan"
 import { api } from "@/lib/api"
 import { type CsvColumn, downloadBlob, toCsv } from "@/lib/csv-export"
@@ -32,6 +33,7 @@ export function OrphanScanPreviewDialog({
   runId,
 }: OrphanScanPreviewDialogProps) {
   const { t } = useTranslation("instances")
+  const { formatISOTimestamp } = useDateTimeFormatters()
   const [offset, setOffset] = useState(0)
   const [files, setFiles] = useState<OrphanScanFile[]>([])
   const [isExporting, setIsExporting] = useState(false)
@@ -167,7 +169,7 @@ export function OrphanScanPreviewDialog({
                       {formatBytes(f.fileSize)}
                     </td>
                     <td className="p-2 text-right font-mono text-muted-foreground whitespace-nowrap">
-                      {f.modifiedAt ? new Date(f.modifiedAt).toLocaleString() : "-"}
+                      {f.modifiedAt ? formatISOTimestamp(f.modifiedAt) : "-"}
                     </td>
                     <td className="p-2">
                       <div className="text-xs font-mono text-muted-foreground">

--- a/web/src/components/settings/LogSettingsPanel.tsx
+++ b/web/src/components/settings/LogSettingsPanel.tsx
@@ -314,27 +314,14 @@ function parseLogLine(entry: RawLogLine): ParsedLogEntry {
   }
 }
 
-function formatTime(isoTime: string): string {
-  if (!isoTime) return ""
-  try {
-    const date = new Date(isoTime)
-    return date.toLocaleTimeString("en-US", {
-      hour12: false,
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-    })
-  } catch {
-    return ""
-  }
-}
-
 function LogEntry({
   entry,
+  formatTimeOnly,
   onSelect,
   onMute,
 }: {
   entry: ParsedLogEntry
+  formatTimeOnly: (timestamp: number, includeSeconds?: boolean) => string
   onSelect?: () => void
   onMute?: () => void
 }) {
@@ -362,7 +349,7 @@ function LogEntry({
       role={isClickable ? "button" : undefined}
       tabIndex={isClickable ? 0 : undefined}
     >
-      <span className="shrink-0 text-muted-foreground/60">{formatTime(entry.time)}</span>
+      <span className="shrink-0 text-muted-foreground/60">{entry.time ? formatTimeOnly(Date.parse(entry.time) / 1000, true) : ""}</span>
       <button
         type="button"
         onClick={onMute ? handleMute : undefined}
@@ -459,6 +446,7 @@ function LogEntryDialog({
   onOpenChange: (open: boolean) => void
 }) {
   const { t } = useTranslation("settings")
+  const { formatISOTimestamp } = useDateTimeFormatters()
   // Memoize JSON stringification and highlighting to avoid re-tokenizing on unrelated renders
   const { prettyJson, highlightedJson } = useMemo(() => {
     if (!entry) return { prettyJson: "", highlightedJson: [] as React.ReactNode[] }
@@ -505,7 +493,7 @@ function LogEntryDialog({
             )}
           </DialogTitle>
           <DialogDescription>
-            {entry?.time ? new Date(entry.time).toLocaleString() : t("logs.entryDialog.rawLine")}
+            {entry?.time ? formatISOTimestamp(entry.time) : t("logs.entryDialog.rawLine")}
           </DialogDescription>
         </DialogHeader>
         <div className="max-h-[400px] overflow-auto rounded-md border bg-muted/30 p-4">
@@ -537,6 +525,7 @@ const LOG_HARD_CAP = 10000
 
 function LiveLogViewer({ configPath }: { configPath?: string }) {
   const { t } = useTranslation("settings")
+  const { formatTimeOnly } = useDateTimeFormatters()
   const [lines, setLines] = useState<RawLogLine[]>([])
   const [autoScroll, setAutoScroll] = useState(true)
   const [isConnected, setIsConnected] = useState(false)
@@ -837,6 +826,7 @@ function LiveLogViewer({ configPath }: { configPath?: string }) {
               <LogEntry
                 key={entry.id}
                 entry={entry}
+                formatTimeOnly={formatTimeOnly}
                 onSelect={() => setSelectedEntry(entry)}
                 onMute={() => handleMuteMessage(entry.message)}
               />

--- a/web/src/components/torrents/CrossSeedDialog.tsx
+++ b/web/src/components/torrents/CrossSeedDialog.tsx
@@ -42,6 +42,7 @@ import type {
 } from "@/types"
 import { AlertTriangle, ChevronDown, ChevronRight, Copy, ExternalLink, Loader2, RefreshCw, SlidersHorizontal } from "lucide-react"
 import { memo, useCallback, useEffect, useMemo, useState } from "react"
+import { useDateTimeFormatters } from "@/hooks/useDateTimeFormatters"
 import { useTranslation } from "react-i18next"
 import { toast } from "sonner"
 
@@ -149,6 +150,7 @@ const CrossSeedDialogComponent = ({
   onForceRefresh,
 }: CrossSeedDialogProps) => {
   const { t } = useTranslation(["torrents", "settings", "crossseed"])
+  const { formatISOTimestamp } = useDateTimeFormatters()
   const excludedIndexerEntries = useMemo(() => {
     if (!sourceTorrent?.excludedIndexers) {
       return []
@@ -490,7 +492,7 @@ const CrossSeedDialogComponent = ({
                               <span className="shrink-0">{formatBytes(result.size)}</span>
                               <span className="shrink-0">{t("crossSeedDialog.seeders", { count: result.seeders })}</span>
                               {result.matchReason && <span className="min-w-0 truncate">{t("crossSeedDialog.match", { reason: result.matchReason })}</span>}
-                              <span className="shrink-0">{formatCrossSeedPublishDate(result.publishDate)}</span>
+                              <span className="shrink-0">{formatISOTimestamp(result.publishDate)}</span>
                             </div>
                           </div>
                         </div>
@@ -770,14 +772,6 @@ function groupTraceReasons(trace: CrossSeedSearchDecisionTrace): Array<{
       count,
       candidates: trace.rejectedCandidates?.filter(candidate => candidate.reason === reason) ?? [],
     }))
-}
-
-function formatCrossSeedPublishDate(value: string): string {
-  const parsed = new Date(value)
-  if (Number.isNaN(parsed.getTime())) {
-    return value
-  }
-  return parsed.toLocaleString()
 }
 
 // Maps instance status codes to user-friendly display information

--- a/web/src/components/torrents/TorrentTableColumns.tsx
+++ b/web/src/components/torrents/TorrentTableColumns.tsx
@@ -20,7 +20,7 @@ import {
   getLinuxTags,
   getLinuxTracker
 } from "@/lib/incognito"
-import { isNeverCompletedTimestamp } from "@/lib/dateTimeUtils"
+import { formatTimestamp as formatStoredTimestamp, isNeverCompletedTimestamp } from "@/lib/dateTimeUtils"
 import { formatSpeedWithUnit, type SpeedUnit } from "@/lib/speedUnits"
 import { getStateLabel } from "@/lib/torrent-state-utils"
 import {
@@ -425,7 +425,7 @@ export const createColumns = (
   },
   speedUnit: SpeedUnit = "bytes",
   trackerIcons?: Record<string, string>,
-  formatTimestamp?: (timestamp: number) => string,
+  formatTimestamp: (timestamp: number) => string = formatStoredTimestamp,
   instancePreferences?: AppPreferences | null,
   supportsTrackerHealth: boolean = true,
   showInstanceColumn: boolean = false,
@@ -853,7 +853,7 @@ export const createColumns = (
         }
 
         return (
-          <div className="overflow-hidden whitespace-nowrap text-sm">{formatTimestamp ? formatTimestamp(addedOn) : new Date(addedOn * 1000).toLocaleString()}</div>
+          <div className="overflow-hidden whitespace-nowrap text-sm">{formatTimestamp(addedOn)}</div>
         )
       },
       size: 200,
@@ -868,7 +868,7 @@ export const createColumns = (
         }
 
         return (
-          <div className="overflow-hidden whitespace-nowrap text-sm">{formatTimestamp ? formatTimestamp(completionOn) : new Date(completionOn * 1000).toLocaleString()}</div>
+          <div className="overflow-hidden whitespace-nowrap text-sm">{formatTimestamp(completionOn)}</div>
         )
       },
       size: 200,
@@ -1117,7 +1117,7 @@ export const createColumns = (
         }
 
         return (
-          <div className="overflow-hidden whitespace-nowrap text-sm">{formatTimestamp ? formatTimestamp(lastSeenComplete) : new Date(lastSeenComplete * 1000).toLocaleString()}</div>
+          <div className="overflow-hidden whitespace-nowrap text-sm">{formatTimestamp(lastSeenComplete)}</div>
         )
       },
       size: 200,
@@ -1132,7 +1132,7 @@ export const createColumns = (
         }
 
         return (
-          <div className="overflow-hidden whitespace-nowrap text-sm">{formatTimestamp ? formatTimestamp(lastActivity) : new Date(lastActivity * 1000).toLocaleString()}</div>
+          <div className="overflow-hidden whitespace-nowrap text-sm">{formatTimestamp(lastActivity)}</div>
         )
       },
       size: 200,

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -821,27 +821,6 @@ function TorznabSearchCachePanel() {
   )
 }
 
-function formatApplicationDate(value?: string): string {
-  if (!value || value.trim() === "") {
-    return "—"
-  }
-
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) {
-    return value
-  }
-
-  return date.toLocaleString(undefined, {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    timeZoneName: "short",
-  })
-}
-
 function formatRelativeDate(value: string | undefined, t: (key: string, options?: Record<string, string>) => string): string {
   if (!value || value.trim() === "") {
     return "—"
@@ -963,6 +942,7 @@ function ApplicationSection({ title, description, fields, onCopy, headerAction }
 
 function ApplicationInfoPanel() {
   const { t } = useTranslation("settings")
+  const { formatISOTimestamp, formatTimestamp } = useDateTimeFormatters()
   const appInfoQuery = useQuery({
     queryKey: ["application-info"],
     queryFn: () => api.getApplicationInfo(),
@@ -1031,14 +1011,14 @@ function ApplicationInfoPanel() {
     return { label: t("application.build.statuses.upToDate"), detail: t("application.build.statuses.upToDateDetail") }
   }, [t, info, latestVersionQuery.data, latestVersionQuery.isFetching, latestVersionQuery.isLoading])
 
-  const updateCheckedAt = latestVersionQuery.dataUpdatedAt > 0 ? formatApplicationDate(new Date(latestVersionQuery.dataUpdatedAt).toISOString()) : t("application.build.statuses.notCheckedYet")
+  const updateCheckedAt = latestVersionQuery.dataUpdatedAt > 0 ? formatTimestamp(latestVersionQuery.dataUpdatedAt / 1000) : t("application.build.statuses.notCheckedYet")
 
   const buildFields: ApplicationField[] = info ? [
     { label: t("application.build.version"), value: info.version || "—", monospace: true },
     { label: t("application.build.commit"), value: info.commitShort || info.commit || "—", copyValue: info.commit || "", monospace: true },
     {
       label: t("application.build.buildDate"),
-      value: formatApplicationDate(info.buildDate),
+      value: info.buildDate?.trim() ? formatISOTimestamp(info.buildDate) : "—",
       secondary: formatRelativeDate(info.buildDate, t),
     },
     {


### PR DESCRIPTION
## Description

Routes every user-facing timestamp that still used browser-locale `toLocaleString()` through `useDateTimeFormatters`, so the stored Date Format, Time Format, and Timezone preferences apply everywhere: orphan scan preview, log viewer rows and entry dialog, cross-seed publish dates, dirscan age cutoff preview, application build dates, and the torrent table fallback formatter.

The Settings build date drops seconds and the timezone abbreviation. The preference timezone applies, like every other timestamp in the app.

Fixes #2501

## How has this been tested?

Component test for the orphan preview column. The other sites are one-line delegations to the existing formatter. Not exercised live.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Standardized date and time displays across settings, logs, torrent tables, cross-seed dialogs, and orphan scan previews.
  - Dates and timestamps now consistently respect the application’s configured formatting preferences.
  - Settings previews and update information now use the same configured date formatting.
  - Improved handling of missing file modification dates by displaying a clear placeholder.
- **Tests**
  - Added coverage confirming preference-aware timestamp formatting in orphan scan previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->