### PR TITLE
fix(web): dismiss path autocomplete on outside pointer interaction

### DIFF
--- a/web/src/components/instances/preferences/WorkflowDialog.tsx
+++ b/web/src/components/instances/preferences/WorkflowDialog.tsx
@@ -772,6 +772,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
     highlightedIndex: freeSpaceHighlightedIndex,
     showSuggestions: showFreeSpaceSuggestions,
     inputRef: freeSpacePathInputRef,
+    listRef: freeSpaceListRef,
   } = usePathAutocomplete(handleFreeSpacePathSelect, instanceId)
 
   // Container and position for autocomplete dropdown portal (inside dialog, outside scroll)
@@ -3915,6 +3916,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
                         </div>
                         {dropdownRect && dropdownContainerRef.current && createPortal(
                           <div
+                            ref={freeSpaceListRef}
                             className="absolute rounded-md border bg-popover text-popover-foreground shadow-md pointer-events-auto"
                             style={{
                               top: dropdownRect.top,

--- a/web/src/components/torrents/AddTorrentDialog.tsx
+++ b/web/src/components/torrents/AddTorrentDialog.tsx
@@ -643,6 +643,7 @@ export function AddTorrentDialog({ instanceId, open: controlledOpen, onOpenChang
     highlightedIndex: saveHighlightedIndex,
     showSuggestions: showSaveSuggestions,
     inputRef: savePathInputRef,
+    listRef: savePathListRef,
   } = usePathAutocomplete(setSavePath, instanceId);
 
   const {
@@ -653,6 +654,7 @@ export function AddTorrentDialog({ instanceId, open: controlledOpen, onOpenChang
     highlightedIndex: tempHighlightedIndex,
     showSuggestions: showTempSuggestions,
     inputRef: tempPathInputRef,
+    listRef: tempPathListRef,
   } = usePathAutocomplete(setTempPath, instanceId);
 
   const onDrop = useCallback((acceptedFiles: File[]) => {
@@ -1368,7 +1370,7 @@ export function AddTorrentDialog({ instanceId, open: controlledOpen, onOpenChang
 
                                 {supportsPathAutocomplete && showSaveSuggestions && saveSuggestions.length > 0 && (
                                   <div className="relative">
-                                    <div className="absolute z-50 mt-1 left-0 right-0 rounded-md border bg-popover text-popover-foreground shadow-md">
+                                    <div ref={savePathListRef} className="absolute z-50 mt-1 left-0 right-0 rounded-md border bg-popover text-popover-foreground shadow-md">
                                       <div className="max-h-55 overflow-y-auto py-1">
                                         {saveSuggestions.map((entry, idx) => (
                                           <button
@@ -1443,7 +1445,7 @@ export function AddTorrentDialog({ instanceId, open: controlledOpen, onOpenChang
 
                                           {supportsPathAutocomplete && showTempSuggestions && tempSuggestions.length > 0 && (
                                             <div className="relative">
-                                              <div className="absolute z-50 mt-1 left-0 right-0 rounded-md border bg-popover text-popover-foreground shadow-md">
+                                              <div ref={tempPathListRef} className="absolute z-50 mt-1 left-0 right-0 rounded-md border bg-popover text-popover-foreground shadow-md">
                                                 <div className="max-h-55 overflow-y-auto py-1">
                                                   {tempSuggestions.map((entry, idx) => (
                                                     <button

--- a/web/src/components/torrents/TorrentCreatorDialog.tsx
+++ b/web/src/components/torrents/TorrentCreatorDialog.tsx
@@ -63,14 +63,15 @@ interface PathSuggestionsProps {
   suggestions: string[]
   highlightedIndex: number
   onSelect: (entry: string) => void
+  listRef: React.RefObject<HTMLDivElement | null>
 }
 
-function PathSuggestions({ suggestions, highlightedIndex, onSelect }: PathSuggestionsProps): React.ReactNode {
+function PathSuggestions({ suggestions, highlightedIndex, onSelect, listRef }: PathSuggestionsProps): React.ReactNode {
   if (suggestions.length === 0) return null
 
   return (
     <div className="relative">
-      <div className="absolute z-50 mt-1 left-0 right-0 rounded-md border bg-popover text-popover-foreground shadow-md">
+      <div ref={listRef} className="absolute z-50 mt-1 left-0 right-0 rounded-md border bg-popover text-popover-foreground shadow-md">
         <div className="max-h-55 overflow-y-auto py-1">
           {suggestions.map((entry, idx) => (
             <button
@@ -189,6 +190,7 @@ export function TorrentCreatorDialog({ instanceId, open, onOpenChange }: Torrent
     highlightedIndex: sourcePathHighlightedIndex,
     showSuggestions: showSourcePathSuggestions,
     inputRef: sourcePathInputRef,
+    listRef: sourcePathListRef,
   } = usePathAutocomplete(setSourcePath, instanceId)
 
   const {
@@ -199,6 +201,7 @@ export function TorrentCreatorDialog({ instanceId, open, onOpenChange }: Torrent
     highlightedIndex: torrentFilePathHighlightedIndex,
     showSuggestions: showTorrentFilePathSuggestions,
     inputRef: torrentFilePathInputRef,
+    listRef: torrentFilePathListRef,
   } = usePathAutocomplete(setTorrentFilePath, instanceId)
 
   useEffect(() => {
@@ -273,6 +276,7 @@ export function TorrentCreatorDialog({ instanceId, open, onOpenChange }: Torrent
                       suggestions={sourcePathSuggestions}
                       highlightedIndex={sourcePathHighlightedIndex}
                       onSelect={handleSourcePathSelect}
+                      listRef={sourcePathListRef}
                     />
                   )}
 
@@ -529,6 +533,7 @@ export function TorrentCreatorDialog({ instanceId, open, onOpenChange }: Torrent
                           suggestions={torrentFilePathSuggestions}
                           highlightedIndex={torrentFilePathHighlightedIndex}
                           onSelect={handleTorrentFilePathSelect}
+                          listRef={torrentFilePathListRef}
                         />
                       )}
 

--- a/web/src/components/torrents/TorrentDialogs.tsx
+++ b/web/src/components/torrents/TorrentDialogs.tsx
@@ -529,6 +529,7 @@ export const SetLocationDialog = memo(function SetLocationDialog({
     highlightedIndex,
     showSuggestions,
     inputRef: autocompleteInputRef,
+    listRef: suggestionListRef,
   } = usePathAutocomplete(setLocation, instanceId)
 
   const inputRef = useRef<HTMLInputElement>(null)
@@ -601,7 +602,7 @@ export const SetLocationDialog = memo(function SetLocationDialog({
             />
             {supportsPathAutocomplete && showSuggestions && suggestions.length > 0 && (
               <div className="relative">
-                <div className="absolute z-50 mt-1 left-0 right-0 rounded-md border bg-popover text-popover-foreground shadow-md">
+                <div ref={suggestionListRef} className="absolute z-50 mt-1 left-0 right-0 rounded-md border bg-popover text-popover-foreground shadow-md">
                   <div className="max-h-55 overflow-y-auto py-1">
                     {suggestions.map((entry, idx) => (
                       <button

--- a/web/src/hooks/usePathAutocomplete.test.tsx
+++ b/web/src/hooks/usePathAutocomplete.test.tsx
@@ -29,7 +29,10 @@ function pointerDown(target: EventTarget) {
 }
 
 describe("usePathAutocomplete outside dismissal", () => {
-  afterEach(cleanup)
+  afterEach(() => {
+    cleanup()
+    document.body.replaceChildren()
+  })
 
   it("dismisses on a pointer interaction outside the input and list, keeps the value", () => {
     const onSelect = vi.fn()

--- a/web/src/hooks/usePathAutocomplete.test.tsx
+++ b/web/src/hooks/usePathAutocomplete.test.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { act, cleanup, renderHook } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { usePathAutocomplete } from "./usePathAutocomplete"
+
+vi.mock("./useDirectoryContent", () => {
+  const directory = { data: ["/data/alpha", "/data/alps"] }
+  return { useDirectoryContent: () => directory }
+})
+
+function mountRefs(result: { current: ReturnType<typeof usePathAutocomplete> }) {
+  const input = document.createElement("input")
+  const list = document.createElement("div")
+  document.body.append(input, list)
+  result.current.inputRef.current = input
+  result.current.listRef.current = list
+  return { input, list }
+}
+
+function pointerDown(target: EventTarget) {
+  act(() => {
+    target.dispatchEvent(new Event("pointerdown", { bubbles: true }))
+  })
+}
+
+describe("usePathAutocomplete outside dismissal", () => {
+  afterEach(cleanup)
+
+  it("dismisses on a pointer interaction outside the input and list, keeps the value", () => {
+    const onSelect = vi.fn()
+    const { result } = renderHook(() => usePathAutocomplete(onSelect, 1))
+    mountRefs(result)
+
+    act(() => result.current.handleInputChange("/data/al"))
+    expect(result.current.showSuggestions).toBe(true)
+
+    pointerDown(document.body)
+    expect(result.current.showSuggestions).toBe(false)
+    expect(result.current.inputValue).toBe("/data/al")
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it("keeps the list open for pointer interactions inside the input or the list", () => {
+    const { result } = renderHook(() => usePathAutocomplete(vi.fn(), 1))
+    const { input, list } = mountRefs(result)
+    const scrollBox = document.createElement("div")
+    list.append(scrollBox)
+
+    act(() => result.current.handleInputChange("/data/al"))
+    pointerDown(scrollBox)
+    expect(result.current.showSuggestions).toBe(true)
+    pointerDown(input)
+    expect(result.current.showSuggestions).toBe(true)
+  })
+
+  it("reopens on typing after an outside dismissal", () => {
+    const { result } = renderHook(() => usePathAutocomplete(vi.fn(), 1))
+    mountRefs(result)
+
+    act(() => result.current.handleInputChange("/data/al"))
+    pointerDown(document.body)
+    expect(result.current.showSuggestions).toBe(false)
+
+    act(() => result.current.handleInputChange("/data/alp"))
+    expect(result.current.showSuggestions).toBe(true)
+  })
+})

--- a/web/src/hooks/usePathAutocomplete.ts
+++ b/web/src/hooks/usePathAutocomplete.ts
@@ -16,6 +16,7 @@ export function usePathAutocomplete(
   const [highlightedIndex, setHighlightedIndex] = useState<number>(-1);
   const [dismissed, setDismissed] = useState(false);
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const listRef = useRef<HTMLDivElement | null>(null);
   const skipHighlightResetRef = useRef(false);
 
   const getParentPath = useCallback((path: string) => {
@@ -164,6 +165,20 @@ export function usePathAutocomplete(
     !(suggestions.length === 1 && suggestions[0] === inputValue) &&
     !(inputValue.endsWith("/") && suggestions.some((s) => s === inputValue));
 
+  // Dismiss on any pointer interaction outside the input and the list. Blur
+  // cannot do this because the suggestion buttons prevent it. A pointerdown on
+  // the list itself (for example its scrollbar) keeps it open.
+  useEffect(() => {
+    if (!showSuggestions) return;
+    const onPointerDown = (e: Event) => {
+      const target = e.target as Node;
+      if (inputRef.current?.contains(target) || listRef.current?.contains(target)) return;
+      setDismissed(true);
+    };
+    document.addEventListener("pointerdown", onPointerDown, true);
+    return () => document.removeEventListener("pointerdown", onPointerDown, true);
+  }, [showSuggestions]);
+
   return {
     suggestions,
     inputValue,
@@ -174,5 +189,6 @@ export function usePathAutocomplete(
     highlightedIndex,
     showSuggestions,
     inputRef,
+    listRef,
   };
 }


### PR DESCRIPTION
## Description

The path autocomplete list stayed open until Escape. Only the Set Location dialog wired the hook's blur handler, and nothing listened for a pointer interaction outside the list, so the overlay covered the controls under it. The hook now owns dismissal: a `pointerdown` outside the input and the list closes it, for every field that uses `usePathAutocomplete`. Typing, ArrowUp, ArrowDown and Escape work as before, and a click on a suggestion still drills into the chosen directory.

Fixes #2484

## How has this been tested?

Ran the built binary against a stub qBittorrent with a canned directory listing. In Add Torrent, Advanced, typed a partial path so the list covered the temp path toggle, clicked outside: list closed, typed value stayed, toggle clickable. Typed again: list reopened. Clicked a suggestion: list showed the subdirectories.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path autocomplete behavior by dismissing suggestions when users click or tap outside the input and suggestion list.
  * Preserved suggestions for interactions within the input or list, while allowing typing to reopen them.

* **Tests**
  * Added coverage for outside dismissal, internal interactions, and reopening suggestions through typing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->