### PR TITLE
fix(torrents): send instance targets for recheck and reannounce in the unified view

### DIFF
--- a/web/src/components/torrents/TorrentContextMenu.tsx
+++ b/web/src/components/torrents/TorrentContextMenu.tsx
@@ -72,8 +72,8 @@ export interface TorrentContextMenuProps {
   onPrepareCreateCategory: (hashes: string[], torrents?: Torrent[]) => void
   onPrepareShareLimit: (hashes: string[], torrents?: Torrent[]) => void
   onPrepareSpeedLimits: (hashes: string[], torrents?: Torrent[]) => void
-  onPrepareRecheck: (hashes: string[], count?: number) => void
-  onPrepareReannounce: (hashes: string[], count?: number) => void
+  onPrepareRecheck: (hashes: string[], count?: number, torrents?: Torrent[]) => void
+  onPrepareReannounce: (hashes: string[], count?: number, torrents?: Torrent[]) => void
   onPrepareLocation: (hashes: string[], torrents?: Torrent[], count?: number) => void
   onPrepareTmm?: (hashes: string[], count: number, enable: boolean) => void
   onPrepareRenameTorrent: (hashes: string[], torrents?: Torrent[]) => void
@@ -452,14 +452,14 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
               {t("contextMenu.pause")} {count > 1 ? `(${count})` : ""}
             </ContextMenuItem>
             <ContextMenuItem
-              onClick={() => onPrepareRecheck(hashes, count)}
+              onClick={() => onPrepareRecheck(hashes, count, torrents)}
               disabled={isPending}
             >
               <CheckCircle className="mr-2 h-4 w-4" />
               {t("contextMenu.forceRecheck")} {count > 1 ? `(${count})` : ""}
             </ContextMenuItem>
             <ContextMenuItem
-              onClick={() => onPrepareReannounce(hashes, count)}
+              onClick={() => onPrepareReannounce(hashes, count, torrents)}
               disabled={isPending}
             >
               <Radio className="mr-2 h-4 w-4" />

--- a/web/src/hooks/useTorrentActions.test.tsx
+++ b/web/src/hooks/useTorrentActions.test.tsx
@@ -493,6 +493,38 @@ describe("useTorrentActions - prepare helpers", () => {
     expect(mockedApi.bulkAction.mock.calls[0][1].action).toBe("recheck")
   })
 
+  it("prepareRecheckAction pins the single-torrent recheck to its instance so the unified view does not fan out by hash", async () => {
+    const { result } = renderActions({ instanceIds: [3, 4, 5] })
+    const torrent = { ...makeTorrent({ hash: "shared" }), instanceId: 3 }
+
+    await act(async () => {
+      result.current.prepareRecheckAction(["shared"], 1, [torrent])
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(mockedApi.bulkAction).toHaveBeenCalledTimes(1)
+    expect(mockedApi.bulkAction.mock.calls[0][1]).toMatchObject({
+      action: "recheck",
+      hashes: ["shared"],
+      targets: [{ instanceId: 3, hash: "shared" }],
+    })
+  })
+
+  it("prepareRecheckAction stores the torrents in contextTorrents for the confirm dialog", async () => {
+    const { result } = renderActions({ instanceIds: [3, 4, 5] })
+    const torrents = [
+      { ...makeTorrent({ hash: "a" }), instanceId: 3 },
+      { ...makeTorrent({ hash: "b" }), instanceId: 4 },
+    ]
+
+    act(() => {
+      result.current.prepareRecheckAction(["a", "b"], 2, torrents)
+    })
+    expect(result.current.showRecheckDialog).toBe(true)
+    expect(result.current.contextTorrents).toEqual(torrents)
+  })
+
   it("handleSetSpeedLimits issues only one bulkAction when the download limit is negative", async () => {
     const { result } = renderActions()
 

--- a/web/src/hooks/useTorrentActions.ts
+++ b/web/src/hooks/useTorrentActions.ts
@@ -7,6 +7,7 @@ import { usePersistedDeleteFiles } from "@/hooks/usePersistedDeleteFiles"
 import { usePersistedCrossSeedBlocklist } from "@/hooks/usePersistedCrossSeedBlocklist"
 import { api } from "@/lib/api"
 import type { TagUpdatePlan } from "@/lib/tag-editor"
+import { buildTorrentActionTargets } from "@/lib/torrent-action-targets"
 import type { Torrent, TorrentFilters } from "@/types"
 import { useMutation, useQueryClient, type QueryClient } from "@tanstack/react-query"
 import { useCallback, useState } from "react"
@@ -768,6 +769,7 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
     })
     setShowRecheckDialog(false)
     setContextHashes([])
+    setContextTorrents([])
   }, [mutation, instanceIds])
 
   const handleReannounce = useCallback(async (
@@ -796,6 +798,7 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
     })
     setShowReannounceDialog(false)
     setContextHashes([])
+    setContextTorrents([])
   }, [mutation, instanceIds])
 
   const handleSetLocation = useCallback(async (
@@ -908,25 +911,28 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
     setShowCreateCategoryDialog(true)
   }, [])
 
-  const prepareRecheckAction = useCallback((hashes: string[], count?: number) => {
+  // Bare hashes fan out across every instance in the unified view, so single-row acts carry explicit targets.
+  const prepareRecheckAction = useCallback((hashes: string[], count?: number, torrents?: Torrent[]) => {
     const actualCount = count || hashes.length
     setContextHashes(hashes)
+    if (torrents) setContextTorrents(torrents)
     if (actualCount > 1) {
       setShowRecheckDialog(true)
     } else {
-      handleAction("recheck", hashes)
+      handleAction("recheck", hashes, torrents ? { targets: buildTorrentActionTargets(torrents, instanceId) } : undefined)
     }
-  }, [handleAction])
+  }, [handleAction, instanceId])
 
-  const prepareReannounceAction = useCallback((hashes: string[], count?: number) => {
+  const prepareReannounceAction = useCallback((hashes: string[], count?: number, torrents?: Torrent[]) => {
     const actualCount = count || hashes.length
     setContextHashes(hashes)
+    if (torrents) setContextTorrents(torrents)
     if (actualCount > 1) {
       setShowReannounceDialog(true)
     } else {
-      handleAction("reannounce", hashes)
+      handleAction("reannounce", hashes, torrents ? { targets: buildTorrentActionTargets(torrents, instanceId) } : undefined)
     }
-  }, [handleAction])
+  }, [handleAction, instanceId])
 
   const prepareLocationAction = useCallback((hashes: string[], torrents?: Torrent[]) => {
     setContextHashes(hashes)


### PR DESCRIPTION
## Description

Force recheck and Reannounce from the unified table context menu sent bare hashes with no instance targets, so the backend resolved the hash on every instance and rechecked a cross-seeded torrent on all clients at once. `prepareRecheckAction` and `prepareReannounceAction` now take the row torrents, send `targets` on the single-row path, and keep them for the confirm dialog on the multi-row path. Every other row action already went through `runAction`, which builds targets.

Related: #2527 (backend should reject bare hashes in the unified scope instead of fanning out).

## How has this been tested?

Two stub qBittorrent servers sharing one hash, both added to a local qui. The old payload (hashes only) logged `torrents/recheck` on both stubs; the new payload with `targets` logged it on one. The click path in the built UI is not verified, only the payload shape through the hook test.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Force Recheck and Reannounce now target the selected torrent instance correctly, preventing actions from being applied to unintended instances.
  - Multi-torrent actions retain the selected torrents while the confirmation dialog is open.
  - Action context is cleared after successful completion to prevent stale selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->