### PR TITLE
fix(torrents): require targets for unified bulk actions

### DIFF
--- a/internal/api/handlers/torrents.go
+++ b/internal/api/handlers/torrents.go
@@ -1283,10 +1283,6 @@ func parseInstanceIDsParam(raw string) ([]int, error) {
 	return normalizeInstanceIDs(instanceIDs)
 }
 
-func shouldResolveCrossInstanceHashes(instanceID int, req BulkActionRequest) bool {
-	return instanceID == allInstancesID && len(req.Hashes) > 0 && len(req.Targets) == 0
-}
-
 func appendTargetsFromCrossInstanceTorrents(
 	targetsByInstance map[int][]string,
 	seen map[int]map[string]struct{},
@@ -1376,6 +1372,12 @@ func (h *TorrentsHandler) BulkAction(w http.ResponseWriter, r *http.Request) {
 
 	if req.SelectAll && (len(req.Hashes) > 0 || len(req.Targets) > 0) {
 		RespondError(w, http.StatusBadRequest, "Cannot specify hashes/targets together with selectAll")
+		return
+	}
+
+	// A hash names a torrent, not an instance. In the unified scope only targets can.
+	if instanceID == allInstancesID && len(req.Hashes) > 0 && len(req.Targets) == 0 {
+		RespondError(w, http.StatusBadRequest, "targets is required when addressing torrents by hash in the unified scope")
 		return
 	}
 
@@ -1510,49 +1512,9 @@ func (h *TorrentsHandler) BulkAction(w http.ResponseWriter, r *http.Request) {
 			addBulkTarget(targetsByInstance, seenTargets, targetInstanceID, target.Hash)
 		}
 
-		if len(req.Hashes) > 0 {
-			// Explicit targets are authoritative in unified scope; only resolve hashes when
-			// targets are not provided (backward-compatible payloads).
-			if shouldResolveCrossInstanceHashes(instanceID, req) {
-				requestedHashes := buildExcludeHashSet(req.Hashes)
-				response, crossErr := h.syncManager.GetCrossInstanceTorrentsWithFilters(
-					r.Context(),
-					0,
-					0,
-					"",
-					"",
-					"",
-					qbittorrent.FilterOptions{},
-					req.InstanceIDs,
-				)
-				if crossErr != nil {
-					log.Error().Err(crossErr).Msg("Failed to resolve hash targets for cross-instance bulk action")
-					RespondError(w, http.StatusInternalServerError, "Failed to get torrents for bulk action")
-					return
-				}
-				if response.PartialResults {
-					log.Warn().
-						Str("action", req.Action).
-						Ints("instanceIDs", req.InstanceIDs).
-						Msg("Cross-instance hash resolution aborted due to partial results")
-					RespondError(w, http.StatusServiceUnavailable, "Unable to resolve all scoped instances for bulk action")
-					return
-				}
-
-				for _, torrent := range response.CrossInstanceTorrents {
-					normalized := normalizeHashValue(torrent.Hash)
-					if requestedHashes == nil {
-						continue
-					}
-					if _, ok := requestedHashes[normalized]; !ok {
-						continue
-					}
-					addBulkTarget(targetsByInstance, seenTargets, torrent.InstanceID, torrent.Hash)
-				}
-			} else if instanceID != allInstancesID {
-				for _, hash := range req.Hashes {
-					addBulkTarget(targetsByInstance, seenTargets, instanceID, hash)
-				}
+		if instanceID != allInstancesID {
+			for _, hash := range req.Hashes {
+				addBulkTarget(targetsByInstance, seenTargets, instanceID, hash)
 			}
 		}
 	}

--- a/internal/api/handlers/torrents_bulk_action_test.go
+++ b/internal/api/handlers/torrents_bulk_action_test.go
@@ -4,7 +4,6 @@
 package handlers
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"slices"
@@ -264,7 +263,7 @@ func TestBulkAction_UnifiedScopeTargetsReachOneInstance(t *testing.T) {
 		}))
 		t.Cleanup(srv.Close)
 
-		instance, createErr := instanceStore.Create(context.Background(), name, srv.URL, "user", "pass", nil, nil, false, nil)
+		instance, createErr := instanceStore.Create(t.Context(), name, srv.URL, "user", "pass", nil, nil, false, nil)
 		require.NoError(t, createErr)
 		instanceIDs[name] = instance.ID
 		clients[instance.ID] = newStaleCachedClient(t, srv.URL, shared)

--- a/internal/api/handlers/torrents_bulk_action_test.go
+++ b/internal/api/handlers/torrents_bulk_action_test.go
@@ -4,12 +4,20 @@
 package handlers
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"slices"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/stretchr/testify/require"
 
+	"github.com/autobrr/qui/internal/models"
 	"github.com/autobrr/qui/internal/qbittorrent"
+	"github.com/autobrr/qui/internal/testutil/testdb"
 )
 
 func TestValidateBulkActionRequest(t *testing.T) {
@@ -205,4 +213,76 @@ func TestParseInstanceIDsParam(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestBulkAction_UnifiedScopeRejectsBareHashes pins the unified-scope contract:
+// a hash names a torrent, not an instance, so hashes without targets are a 400
+// instead of a fan-out to every instance that holds the hash (issue #2527).
+func TestBulkAction_UnifiedScopeRejectsBareHashes(t *testing.T) {
+	t.Parallel()
+
+	handler := &TorrentsHandler{}
+	req := newTorrentFieldRequest(t, allInstancesID, map[string]any{
+		"action": "recheck",
+		"hashes": []string{"shared"},
+	})
+
+	rec := httptest.NewRecorder()
+	handler.BulkAction(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
+	require.Contains(t, rec.Body.String(), "targets")
+}
+
+// TestBulkAction_UnifiedScopeTargetsReachOneInstance is the mirror case: the same
+// payload with targets for one instance reaches only that instance, even though
+// the other instance holds the same hash.
+func TestBulkAction_UnifiedScopeTargetsReachOneInstance(t *testing.T) {
+	t.Parallel()
+
+	db := testdb.NewMigratedSQLite(t, "torrents-bulk-action")
+	instanceStore, err := models.NewInstanceStore(db, []byte("01234567890123456789012345678901"))
+	require.NoError(t, err)
+	clientPool, err := qbittorrent.NewClientPool(instanceStore, models.NewInstanceErrorStore(db), 60*time.Second)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = clientPool.Close() })
+
+	shared := []qbt.Torrent{{Name: "Shared", Hash: "shared", AddedOn: 1}}
+	clients := make(map[int]*qbittorrent.Client, 2)
+	instanceIDs := make(map[string]int, 2)
+	recheckHits := map[string]*atomic.Int64{"alpha": {}, "beta": {}}
+	for name, hits := range recheckHits {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/api/v2/torrents/recheck":
+				hits.Add(1)
+			case "/api/v2/sync/maindata":
+				_, _ = w.Write([]byte(`{"rid":1,"full_update":true,"torrents":{"shared":{"name":"Shared","hash":"shared","added_on":1}}}`))
+				return
+			}
+			_, _ = w.Write([]byte("Ok."))
+		}))
+		t.Cleanup(srv.Close)
+
+		instance, createErr := instanceStore.Create(context.Background(), name, srv.URL, "user", "pass", nil, nil, false, nil)
+		require.NoError(t, createErr)
+		instanceIDs[name] = instance.ID
+		clients[instance.ID] = newStaleCachedClient(t, srv.URL, shared)
+	}
+	setUnexportedField(t, clientPool, "clients", clients)
+
+	handler := NewTorrentsHandler(qbittorrent.NewSyncManager(clientPool, nil), nil, instanceStore)
+	req := newTorrentFieldRequest(t, allInstancesID, map[string]any{
+		"action":      "recheck",
+		"hashes":      []string{"shared"},
+		"targets":     []map[string]any{{"instanceId": instanceIDs["alpha"], "hash": "shared"}},
+		"instanceIds": []int{instanceIDs["alpha"], instanceIDs["beta"]},
+	})
+
+	rec := httptest.NewRecorder()
+	handler.BulkAction(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	require.EqualValues(t, 1, recheckHits["alpha"].Load())
+	require.EqualValues(t, 0, recheckHits["beta"].Load())
 }

--- a/internal/api/handlers/torrents_field_test.go
+++ b/internal/api/handlers/torrents_field_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/autobrr/autobrr/pkg/ttlcache"
 	qbt "github.com/autobrr/go-qbittorrent"
 	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/require"
@@ -393,6 +394,7 @@ func newStaleCachedClient(t *testing.T, host string, torrents []qbt.Torrent) *qu
 	setUnexportedField(t, client, "isHealthy", true)
 	setUnexportedField(t, client, "lastHealthCheck", time.Now())
 	setUnexportedField(t, client, "syncManager", syncManager)
+	setUnexportedField(t, client, "optimisticUpdates", ttlcache.New(ttlcache.Options[string, *quiqbt.OptimisticTorrentUpdate]{}))
 
 	return client
 }

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -1594,7 +1594,7 @@ paths:
       tags:
         - Torrents
       summary: Bulk torrent action
-      description: Perform bulk actions on multiple torrents
+      description: Perform bulk actions on multiple torrents. In the unified scope (instanceID 0) a hash alone does not name an instance, so `targets` is required when addressing torrents by hash; bare `hashes` return 400.
       parameters:
         - $ref: '#/components/parameters/instanceID'
       requestBody:
@@ -1610,7 +1610,20 @@ paths:
                   type: array
                   items:
                     type: string
-                  description: Specific torrent hashes to target. Required unless selectAll is true.
+                  description: Specific torrent hashes to target. Required unless selectAll is true. In the unified scope, hashes without targets are rejected.
+                targets:
+                  type: array
+                  description: Explicit instance and hash pairs. Required in the unified scope when addressing torrents by hash; authoritative over hashes there.
+                  items:
+                    type: object
+                    required:
+                      - instanceId
+                      - hash
+                    properties:
+                      instanceId:
+                        type: integer
+                      hash:
+                        type: string
                 selectAll:
                   type: boolean
                   description: Apply the action to all torrents matching the provided filters.

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -6080,8 +6080,8 @@ components:
       required: true
       schema:
         type: integer
-        minimum: 1
-      description: qBittorrent instance ID
+        minimum: 0
+      description: qBittorrent instance ID. 0 is the unified scope on the endpoints that support it.
     hash:
       name: hash
       in: path

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -1610,7 +1610,7 @@ paths:
                   type: array
                   items:
                     type: string
-                  description: Specific torrent hashes to target. Required unless selectAll is true. In the unified scope, hashes without targets are rejected.
+                  description: Specific torrent hashes to target. Optional when targets is provided; the request is rejected when hashes, targets, and selectAll are all absent. In the unified scope, hashes without targets are rejected.
                 targets:
                   type: array
                   description: Explicit instance and hash pairs. Required in the unified scope when addressing torrents by hash; authoritative over hashes there.

--- a/web/src/components/torrents/TorrentCardsMobile.tsx
+++ b/web/src/components/torrents/TorrentCardsMobile.tsx
@@ -1828,14 +1828,14 @@ export function TorrentCardsMobile({
     const deleteActionTargets = torrentToDelete? buildTorrentActionTargets([torrentToDelete], instanceId): (isAllSelected ? undefined : selectedActionTargets)
 
     const crossSeedTagHashesToBlock = deleteCrossSeeds ? getTorrentHashesWithTag(crossSeedWarning.affectedTorrents, "cross-seed") : []
+    const crossSeedDeleteTargets = [
+      ...(deleteActionTargets ?? []),
+      ...buildTorrentActionTargets(crossSeedWarning.affectedTorrents, instanceId),
+    ]
 
     if (shouldBlockCrossSeeds) {
       const taggedHashes = getTorrentHashesWithTag(deleteTorrents, "cross-seed")
-      const blocklistTargets = [
-        ...(deleteActionTargets ?? []),
-        ...buildTorrentActionTargets(crossSeedWarning.affectedTorrents, instanceId),
-      ]
-      await blockCrossSeedHashes([...taggedHashes, ...crossSeedTagHashesToBlock], blocklistTargets)
+      await blockCrossSeedHashes([...taggedHashes, ...crossSeedTagHashesToBlock], crossSeedDeleteTargets)
     }
 
     let hashes: string[]
@@ -1886,7 +1886,7 @@ export function TorrentCardsMobile({
       {
         clientHashes: visibleHashesToDelete,
         totalSelected: totalToDelete,
-        actionTargets: deleteActionTargets,
+        actionTargets: deleteCrossSeeds && deleteActionTargets ? crossSeedDeleteTargets : deleteActionTargets,
         excludeTargets: !torrentToDelete && isAllSelected? buildTorrentActionTargets(excludedTorrents, instanceId): undefined,
       }
     )

--- a/web/src/components/torrents/TorrentContextMenu.tsx
+++ b/web/src/components/torrents/TorrentContextMenu.tsx
@@ -72,8 +72,8 @@ export interface TorrentContextMenuProps {
   onPrepareCreateCategory: (hashes: string[], torrents?: Torrent[]) => void
   onPrepareShareLimit: (hashes: string[], torrents?: Torrent[]) => void
   onPrepareSpeedLimits: (hashes: string[], torrents?: Torrent[]) => void
-  onPrepareRecheck: (hashes: string[], count?: number) => void
-  onPrepareReannounce: (hashes: string[], count?: number) => void
+  onPrepareRecheck: (hashes: string[], count?: number, torrents?: Torrent[]) => void
+  onPrepareReannounce: (hashes: string[], count?: number, torrents?: Torrent[]) => void
   onPrepareLocation: (hashes: string[], torrents?: Torrent[], count?: number) => void
   onPrepareTmm?: (hashes: string[], count: number, enable: boolean) => void
   onPrepareRenameTorrent: (hashes: string[], torrents?: Torrent[]) => void
@@ -452,14 +452,14 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
               {t("contextMenu.pause")} {count > 1 ? `(${count})` : ""}
             </ContextMenuItem>
             <ContextMenuItem
-              onClick={() => onPrepareRecheck(hashes, count)}
+              onClick={() => onPrepareRecheck(hashes, count, torrents)}
               disabled={isPending}
             >
               <CheckCircle className="mr-2 h-4 w-4" />
               {t("contextMenu.forceRecheck")} {count > 1 ? `(${count})` : ""}
             </ContextMenuItem>
             <ContextMenuItem
-              onClick={() => onPrepareReannounce(hashes, count)}
+              onClick={() => onPrepareReannounce(hashes, count, torrents)}
               disabled={isPending}
             >
               <Radio className="mr-2 h-4 w-4" />

--- a/web/src/components/torrents/TorrentContextMenu.tsx
+++ b/web/src/components/torrents/TorrentContextMenu.tsx
@@ -75,7 +75,7 @@ export interface TorrentContextMenuProps {
   onPrepareRecheck: (hashes: string[], count?: number, torrents?: Torrent[]) => void
   onPrepareReannounce: (hashes: string[], count?: number, torrents?: Torrent[]) => void
   onPrepareLocation: (hashes: string[], torrents?: Torrent[], count?: number) => void
-  onPrepareTmm?: (hashes: string[], count: number, enable: boolean) => void
+  onPrepareTmm?: (hashes: string[], count: number, enable: boolean, torrents?: Torrent[]) => void
   onPrepareRenameTorrent: (hashes: string[], torrents?: Torrent[]) => void
   availableCategories?: Record<string, Category>
   onSetCategory?: (category: string, hashes: string[], targets?: Array<{ instanceId: number; hash: string }>) => void
@@ -360,11 +360,11 @@ export const TorrentContextMenu = memo(function TorrentContextMenu({
 
   const handleTmmToggle = useCallback((enable: boolean) => {
     if (onPrepareTmm) {
-      onPrepareTmm(hashes, count, enable)
+      onPrepareTmm(hashes, count, enable, torrents)
     } else {
       onAction(TORRENT_ACTIONS.TOGGLE_AUTO_TMM, hashes, { enable, targets: actionTargets })
     }
-  }, [onPrepareTmm, onAction, hashes, count, actionTargets])
+  }, [onPrepareTmm, onAction, hashes, count, torrents, actionTargets])
 
   const handleLocationClick = useCallback(() => {
     onPrepareLocation(hashes, torrents, count)

--- a/web/src/components/torrents/TorrentManagementBar.tsx
+++ b/web/src/components/torrents/TorrentManagementBar.tsx
@@ -276,21 +276,26 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
   }, [handleAction, actionHashes, actionOptions])
 
   const handleDeleteWrapper = useCallback(async () => {
+    const crossSeedDeleteTargets = [
+      ...actionTargets,
+      ...buildTorrentActionTargets(crossSeedAffectedTorrents, actionInstanceId),
+    ]
     if (shouldBlockCrossSeeds) {
       const taggedHashes = getTorrentHashesWithTag(selectedTorrents, "cross-seed")
       const crossSeedHashes = supportsCrossSeedDeleteTools && deleteCrossSeeds ? getTorrentHashesWithTag(crossSeedAffectedTorrents, "cross-seed") : []
-      const blocklistTargets = [
-        ...actionTargets,
-        ...buildTorrentActionTargets(crossSeedAffectedTorrents, actionInstanceId),
-      ]
-      await blockCrossSeedHashes([...taggedHashes, ...crossSeedHashes], blocklistTargets)
+      await blockCrossSeedHashes([...taggedHashes, ...crossSeedHashes], crossSeedDeleteTargets)
     }
 
     // Include cross-seed hashes if user opted to delete them
     const hashesToDelete = supportsCrossSeedDeleteTools && deleteCrossSeeds ? [...selectedHashes, ...crossSeedAffectedTorrents.map(t => t.hash)] : selectedHashes
 
     // Update count to include cross-seeds for accurate toast message
-    const deleteClientMeta = supportsCrossSeedDeleteTools && deleteCrossSeeds ? { clientHashes: hashesToDelete, totalSelected: hashesToDelete.length } : clientMeta
+    const deleteClientMeta = supportsCrossSeedDeleteTools && deleteCrossSeeds ? {
+      ...clientMeta,
+      clientHashes: hashesToDelete,
+      totalSelected: hashesToDelete.length,
+      actionTargets: requestTargets && crossSeedDeleteTargets,
+    } : clientMeta
 
     await handleDelete(
       hashesToDelete,
@@ -311,6 +316,7 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
     filters,
     handleDelete,
     isAllSelected,
+    requestTargets,
     search,
     selectedHashes,
     selectedTorrents,

--- a/web/src/components/torrents/TorrentManagementBar.tsx
+++ b/web/src/components/torrents/TorrentManagementBar.tsx
@@ -235,55 +235,10 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
     () => buildTorrentActionTargets(selectedTorrents, actionInstanceId),
     [selectedTorrents, actionInstanceId]
   )
-  const selectedRequestTargets = useMemo(() => {
-    const seen = new Set<string>()
-    const targets: Array<{ instanceId: number; hash: string }> = []
-
-    for (const selectedHash of selectedHashes) {
-      const trimmed = selectedHash.trim()
-      if (!trimmed) {
-        continue
-      }
-
-      const separatorIndex = trimmed.indexOf(":")
-      const target = separatorIndex > 0? {
-        instanceId: Number(trimmed.slice(0, separatorIndex)),
-        hash: trimmed.slice(separatorIndex + 1),
-      }: {
-        instanceId: actionInstanceId,
-        hash: trimmed,
-      }
-
-      if (target.instanceId <= 0 || !target.hash) {
-        continue
-      }
-
-      const dedupeKey = `${target.instanceId}:${target.hash.toLowerCase()}`
-      if (seen.has(dedupeKey)) {
-        continue
-      }
-
-      seen.add(dedupeKey)
-      targets.push(target)
-    }
-
-    return targets
-  }, [actionInstanceId, selectedHashes])
-  const selectedRequestHashes = useMemo(
-    () => Array.from(new Set(selectedHashes.map((selectedHash) => {
-      const trimmed = selectedHash.trim()
-      if (!trimmed) {
-        return ""
-      }
-
-      const separatorIndex = trimmed.indexOf(":")
-      return separatorIndex > 0 ? trimmed.slice(separatorIndex + 1) : trimmed
-    }).filter(Boolean))),
-    [selectedHashes]
-  )
+  const requestTargets = isAllSelected ? undefined : actionTargets
   const actionOptions = useMemo(() => ({
     instanceIds,
-    targets: isAllSelected || selectedRequestTargets.length !== selectedRequestHashes.length ? undefined : selectedRequestTargets,
+    targets: requestTargets,
     selectAll: isAllSelected,
     filters: isAllSelected ? filters : undefined,
     search: isAllSelected ? search : undefined,
@@ -291,14 +246,14 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
     excludeTargets: isAllSelected ? excludeTargets : undefined,
     clientHashes: selectedHashes,
     clientCount: selectionCount,
-  }), [instanceIds, isAllSelected, selectedRequestTargets, selectedRequestHashes.length, filters, search, excludeHashes, excludeTargets, selectedHashes, selectionCount])
+  }), [instanceIds, isAllSelected, requestTargets, filters, search, excludeHashes, excludeTargets, selectedHashes, selectionCount])
 
   const clientMeta = useMemo(() => ({
     clientHashes: selectedHashes,
     totalSelected: selectionCount,
-    actionTargets: isAllSelected || selectedRequestTargets.length !== selectedRequestHashes.length ? undefined : selectedRequestTargets,
+    actionTargets: requestTargets,
     excludeTargets,
-  }), [selectedHashes, selectionCount, isAllSelected, selectedRequestTargets, selectedRequestHashes.length, excludeTargets])
+  }), [selectedHashes, selectionCount, requestTargets, excludeTargets])
 
   const deleteDialogTotalSize = useMemo(() => {
     if (totalSelectionSize > 0) {
@@ -366,14 +321,14 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
   const handleTagsWrapper = useCallback((plan: Parameters<typeof handleUpdateTags>[0]) => {
     handleUpdateTags(
       plan,
-      selectedRequestHashes,
+      selectedHashes,
       isAllSelected,
       filters,
       search,
       excludeHashes,
       clientMeta
     )
-  }, [handleUpdateTags, selectedRequestHashes, isAllSelected, filters, search, excludeHashes, clientMeta])
+  }, [handleUpdateTags, selectedHashes, isAllSelected, filters, search, excludeHashes, clientMeta])
 
   const handleSetCategoryWrapper = useCallback((category: string) => {
     handleSetCategory(
@@ -794,8 +749,8 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
         selectionRequest={{
           instanceId: metadataInstanceId,
           instanceIds,
-          hashes: !isAllSelected ? selectedRequestHashes : undefined,
-          targets: !isAllSelected && selectedRequestTargets.length === selectedRequestHashes.length ? selectedRequestTargets : undefined,
+          hashes: !isAllSelected ? selectedHashes : undefined,
+          targets: requestTargets,
           selectAll: isAllSelected,
           filters: isAllSelected ? filters : undefined,
           search: isAllSelected ? search : undefined,

--- a/web/src/components/torrents/TorrentManagementBar.tsx
+++ b/web/src/components/torrents/TorrentManagementBar.tsx
@@ -294,7 +294,7 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
       ...clientMeta,
       clientHashes: hashesToDelete,
       totalSelected: hashesToDelete.length,
-      actionTargets: requestTargets && crossSeedDeleteTargets,
+      actionTargets: isAllSelected ? undefined : crossSeedDeleteTargets,
     } : clientMeta
 
     await handleDelete(
@@ -316,7 +316,6 @@ export const TorrentManagementBar = memo(function TorrentManagementBar({
     filters,
     handleDelete,
     isAllSelected,
-    requestTargets,
     search,
     selectedHashes,
     selectedTorrents,

--- a/web/src/hooks/torrent-table/useBulkActionWrappers.ts
+++ b/web/src/hooks/torrent-table/useBulkActionWrappers.ts
@@ -180,21 +180,26 @@ export function useBulkActionWrappers({
 
   const handleDeleteWrapper = useCallback(async () => {
     const crossSeedHashes = deleteCrossSeeds ? getTorrentHashesWithTag(crossSeedWarning.affectedTorrents, "cross-seed") : []
+    const crossSeedDeleteTargets = [
+      ...(contextClientMeta.actionTargets ?? []),
+      ...buildTorrentActionTargets(crossSeedWarning.affectedTorrents, instanceId),
+    ]
 
     if (shouldBlockCrossSeeds) {
       const taggedHashes = getTorrentHashesWithTag(contextTorrents, "cross-seed")
-      const blocklistTargets = [
-        ...(contextClientMeta.actionTargets ?? []),
-        ...buildTorrentActionTargets(crossSeedWarning.affectedTorrents, instanceId),
-      ]
-      await blockCrossSeedHashes([...taggedHashes, ...crossSeedHashes], blocklistTargets)
+      await blockCrossSeedHashes([...taggedHashes, ...crossSeedHashes], crossSeedDeleteTargets)
     }
 
     // Include cross-seed hashes if user opted to delete them
     const hashesToDelete = deleteCrossSeeds? [...contextHashes, ...crossSeedWarning.affectedTorrents.map(t => t.hash)]: contextHashes
 
     // Update count to include cross-seeds for accurate toast message
-    const deleteClientMeta = deleteCrossSeeds? { clientHashes: hashesToDelete, totalSelected: hashesToDelete.length }: contextClientMeta
+    const deleteClientMeta = deleteCrossSeeds ? {
+      ...contextClientMeta,
+      clientHashes: hashesToDelete,
+      totalSelected: hashesToDelete.length,
+      actionTargets: isAllSelected ? undefined : crossSeedDeleteTargets,
+    } : contextClientMeta
 
     await handleDelete(
       hashesToDelete,

--- a/web/src/hooks/useTorrentActions.test.tsx
+++ b/web/src/hooks/useTorrentActions.test.tsx
@@ -493,6 +493,38 @@ describe("useTorrentActions - prepare helpers", () => {
     expect(mockedApi.bulkAction.mock.calls[0][1].action).toBe("recheck")
   })
 
+  it("prepareRecheckAction pins the single-torrent recheck to its instance so the unified view does not fan out by hash", async () => {
+    const { result } = renderActions({ instanceIds: [3, 4, 5] })
+    const torrent = { ...makeTorrent({ hash: "shared" }), instanceId: 3 }
+
+    await act(async () => {
+      result.current.prepareRecheckAction(["shared"], 1, [torrent])
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(mockedApi.bulkAction).toHaveBeenCalledTimes(1)
+    expect(mockedApi.bulkAction.mock.calls[0][1]).toMatchObject({
+      action: "recheck",
+      hashes: ["shared"],
+      targets: [{ instanceId: 3, hash: "shared" }],
+    })
+  })
+
+  it("prepareRecheckAction stores the torrents in contextTorrents for the confirm dialog", async () => {
+    const { result } = renderActions({ instanceIds: [3, 4, 5] })
+    const torrents = [
+      { ...makeTorrent({ hash: "a" }), instanceId: 3 },
+      { ...makeTorrent({ hash: "b" }), instanceId: 4 },
+    ]
+
+    act(() => {
+      result.current.prepareRecheckAction(["a", "b"], 2, torrents)
+    })
+    expect(result.current.showRecheckDialog).toBe(true)
+    expect(result.current.contextTorrents).toEqual(torrents)
+  })
+
   it("handleSetSpeedLimits issues only one bulkAction when the download limit is negative", async () => {
     const { result } = renderActions()
 

--- a/web/src/hooks/useTorrentActions.test.tsx
+++ b/web/src/hooks/useTorrentActions.test.tsx
@@ -37,6 +37,7 @@ vi.mock("react-i18next", () => ({
 import { api } from "@/lib/api"
 import { toast } from "sonner"
 import { resetPendingListRefetchesForTests, scheduleTorrentListRefetches, useTorrentActions } from "@/hooks/useTorrentActions"
+import { buildTorrentActionTargets } from "@/lib/torrent-action-targets"
 import { makeTorrent } from "@/test/mockTorrent"
 import type { TorrentFilters } from "@/types"
 
@@ -525,7 +526,7 @@ describe("useTorrentActions - prepare helpers", () => {
     expect(result.current.contextTorrents).toEqual(torrents)
   })
 
-  it("prepareTmmAction stores the torrents so the confirm dialog can pin targets in the unified view", () => {
+  it("prepareTmmAction stores the torrents so the confirm dialog can pin targets in the unified view", async () => {
     const { result } = renderActions({ instanceIds: [3, 4, 5] })
     const torrents = [{ ...makeTorrent({ hash: "shared" }), instanceId: 3 }]
 
@@ -534,6 +535,19 @@ describe("useTorrentActions - prepare helpers", () => {
     })
     expect(result.current.showTmmDialog).toBe(true)
     expect(result.current.contextTorrents).toEqual(torrents)
+
+    await act(async () => {
+      result.current.handleTmmConfirm(["shared"], false, undefined, undefined, undefined, {
+        actionTargets: buildTorrentActionTargets(result.current.contextTorrents, 0),
+      })
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(mockedApi.bulkAction).toHaveBeenCalledTimes(1)
+    expect(mockedApi.bulkAction.mock.calls[0][1]).toMatchObject({
+      action: "toggleAutoTMM",
+      enable: true,
+      targets: [{ instanceId: 3, hash: "shared" }],
+    })
   })
 
   it("handleSetSpeedLimits issues only one bulkAction when the download limit is negative", async () => {

--- a/web/src/hooks/useTorrentActions.test.tsx
+++ b/web/src/hooks/useTorrentActions.test.tsx
@@ -525,6 +525,17 @@ describe("useTorrentActions - prepare helpers", () => {
     expect(result.current.contextTorrents).toEqual(torrents)
   })
 
+  it("prepareTmmAction stores the torrents so the confirm dialog can pin targets in the unified view", () => {
+    const { result } = renderActions({ instanceIds: [3, 4, 5] })
+    const torrents = [{ ...makeTorrent({ hash: "shared" }), instanceId: 3 }]
+
+    act(() => {
+      result.current.prepareTmmAction(["shared"], 1, true, torrents)
+    })
+    expect(result.current.showTmmDialog).toBe(true)
+    expect(result.current.contextTorrents).toEqual(torrents)
+  })
+
   it("handleSetSpeedLimits issues only one bulkAction when the download limit is negative", async () => {
     const { result } = renderActions()
 

--- a/web/src/hooks/useTorrentActions.ts
+++ b/web/src/hooks/useTorrentActions.ts
@@ -7,6 +7,7 @@ import { usePersistedDeleteFiles } from "@/hooks/usePersistedDeleteFiles"
 import { usePersistedCrossSeedBlocklist } from "@/hooks/usePersistedCrossSeedBlocklist"
 import { api } from "@/lib/api"
 import type { TagUpdatePlan } from "@/lib/tag-editor"
+import { buildTorrentActionTargets } from "@/lib/torrent-action-targets"
 import type { Torrent, TorrentFilters } from "@/types"
 import { useMutation, useQueryClient, type QueryClient } from "@tanstack/react-query"
 import { useCallback, useState } from "react"
@@ -768,6 +769,7 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
     })
     setShowRecheckDialog(false)
     setContextHashes([])
+    setContextTorrents([])
   }, [mutation, instanceIds])
 
   const handleReannounce = useCallback(async (
@@ -796,6 +798,7 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
     })
     setShowReannounceDialog(false)
     setContextHashes([])
+    setContextTorrents([])
   }, [mutation, instanceIds])
 
   const handleSetLocation = useCallback(async (
@@ -908,25 +911,28 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
     setShowCreateCategoryDialog(true)
   }, [])
 
-  const prepareRecheckAction = useCallback((hashes: string[], count?: number) => {
+  // Bare hashes fan out across every instance in the unified view, so single-row acts carry explicit targets.
+  const prepareRecheckAction = useCallback((hashes: string[], count?: number, torrents?: Torrent[]) => {
     const actualCount = count || hashes.length
     setContextHashes(hashes)
+    if (torrents) setContextTorrents(torrents)
     if (actualCount > 1) {
       setShowRecheckDialog(true)
     } else {
-      handleAction("recheck", hashes)
+      handleAction("recheck", hashes, torrents ? { targets: buildTorrentActionTargets(torrents, instanceId) } : undefined)
     }
-  }, [handleAction])
+  }, [handleAction, instanceId])
 
-  const prepareReannounceAction = useCallback((hashes: string[], count?: number) => {
+  const prepareReannounceAction = useCallback((hashes: string[], count?: number, torrents?: Torrent[]) => {
     const actualCount = count || hashes.length
     setContextHashes(hashes)
+    if (torrents) setContextTorrents(torrents)
     if (actualCount > 1) {
       setShowReannounceDialog(true)
     } else {
-      handleAction("reannounce", hashes)
+      handleAction("reannounce", hashes, torrents ? { targets: buildTorrentActionTargets(torrents, instanceId) } : undefined)
     }
-  }, [handleAction])
+  }, [handleAction, instanceId])
 
   const prepareLocationAction = useCallback((hashes: string[], torrents?: Torrent[]) => {
     setContextHashes(hashes)

--- a/web/src/hooks/useTorrentActions.ts
+++ b/web/src/hooks/useTorrentActions.ts
@@ -266,7 +266,9 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
         }
         const optimisticRemoveCount = variables.clientCount ?? hashesToRemove.length
         // Cross-seeded copies share a hash, so a targeted delete removes only the addressed rows.
-        const targetKeys = variables.targets?.length ? new Set(variables.targets.map((t) => `${t.instanceId}:${t.hash}`)) : undefined
+        const targetKey = (t: { instanceId: number; hash: string }) => `${t.instanceId}:${t.hash}`
+        const targetKeys = variables.targets?.length ? new Set(variables.targets.map(targetKey)) : undefined
+        const excludedKeys = new Set(variables.excludeTargets?.map(targetKey))
 
         queries.forEach((query) => {
           queryClient.setQueryData(query.queryKey, (oldData: {
@@ -277,10 +279,11 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
             if (!oldData) return oldData
             return {
               ...oldData,
-              torrents: oldData.torrents?.filter((t: Torrent) => targetKeys
-                ? !targetKeys.has(`${getTorrentTargetInstanceId(t, instanceId)}:${t.hash}`)
-                : !hashesToRemove.includes(t.hash)
-              ) || [],
+              torrents: oldData.torrents?.filter((t: Torrent) => {
+                const key = `${getTorrentTargetInstanceId(t, instanceId)}:${t.hash}`
+                if (excludedKeys.has(key)) return true
+                return targetKeys ? !targetKeys.has(key) : !hashesToRemove.includes(t.hash)
+              }) || [],
               total: Math.max(0, (oldData.total || 0) - optimisticRemoveCount),
               totalCount: Math.max(0, (oldData.totalCount || oldData.total || 0) - optimisticRemoveCount),
             }

--- a/web/src/hooks/useTorrentActions.ts
+++ b/web/src/hooks/useTorrentActions.ts
@@ -7,7 +7,7 @@ import { usePersistedDeleteFiles } from "@/hooks/usePersistedDeleteFiles"
 import { usePersistedCrossSeedBlocklist } from "@/hooks/usePersistedCrossSeedBlocklist"
 import { api } from "@/lib/api"
 import type { TagUpdatePlan } from "@/lib/tag-editor"
-import { buildTorrentActionTargets } from "@/lib/torrent-action-targets"
+import { buildTorrentActionTargets, getTorrentTargetInstanceId } from "@/lib/torrent-action-targets"
 import type { Torrent, TorrentFilters } from "@/types"
 import { useMutation, useQueryClient, type QueryClient } from "@tanstack/react-query"
 import { useCallback, useState } from "react"
@@ -265,6 +265,8 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
           hashesToRemove = variables.clientHashes
         }
         const optimisticRemoveCount = variables.clientCount ?? hashesToRemove.length
+        // Cross-seeded copies share a hash, so a targeted delete removes only the addressed rows.
+        const targetKeys = variables.targets?.length ? new Set(variables.targets.map((t) => `${t.instanceId}:${t.hash}`)) : undefined
 
         queries.forEach((query) => {
           queryClient.setQueryData(query.queryKey, (oldData: {
@@ -275,8 +277,9 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
             if (!oldData) return oldData
             return {
               ...oldData,
-              torrents: oldData.torrents?.filter((t: Torrent) =>
-                !hashesToRemove.includes(t.hash)
+              torrents: oldData.torrents?.filter((t: Torrent) => targetKeys
+                ? !targetKeys.has(`${getTorrentTargetInstanceId(t, instanceId)}:${t.hash}`)
+                : !hashesToRemove.includes(t.hash)
               ) || [],
               total: Math.max(0, (oldData.total || 0) - optimisticRemoveCount),
               totalCount: Math.max(0, (oldData.totalCount || oldData.total || 0) - optimisticRemoveCount),

--- a/web/src/hooks/useTorrentActions.ts
+++ b/web/src/hooks/useTorrentActions.ts
@@ -877,7 +877,7 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
 
   const prepareDeleteAction = useCallback((hashes: string[], torrents?: Torrent[]) => {
     setContextHashes(hashes)
-    if (torrents) setContextTorrents(torrents)
+    setContextTorrents(torrents ?? [])
     setDeleteCrossSeeds(false) // Reset on open to avoid stale state from previous dialog
     setShowDeleteDialog(true)
   }, [])
@@ -889,25 +889,25 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
 
   const prepareTagsAction = useCallback((hashes: string[], torrents?: Torrent[]) => {
     setContextHashes(hashes)
-    if (torrents) setContextTorrents(torrents)
+    setContextTorrents(torrents ?? [])
     setShowTagsDialog(true)
   }, [])
 
   const prepareCommentAction = useCallback((hashes: string[], torrents?: Torrent[]) => {
     setContextHashes(hashes)
-    if (torrents) setContextTorrents(torrents)
+    setContextTorrents(torrents ?? [])
     setShowCommentDialog(true)
   }, [])
 
   const prepareCategoryAction = useCallback((hashes: string[], torrents?: Torrent[]) => {
     setContextHashes(hashes)
-    if (torrents) setContextTorrents(torrents)
+    setContextTorrents(torrents ?? [])
     setShowCategoryDialog(true)
   }, [])
 
   const prepareCreateCategoryAction = useCallback((hashes: string[], torrents?: Torrent[]) => {
     setContextHashes(hashes)
-    if (torrents) setContextTorrents(torrents)
+    setContextTorrents(torrents ?? [])
     setShowCreateCategoryDialog(true)
   }, [])
 
@@ -915,7 +915,7 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
   const prepareRecheckAction = useCallback((hashes: string[], count?: number, torrents?: Torrent[]) => {
     const actualCount = count || hashes.length
     setContextHashes(hashes)
-    if (torrents) setContextTorrents(torrents)
+    setContextTorrents(torrents ?? [])
     if (actualCount > 1) {
       setShowRecheckDialog(true)
     } else {
@@ -926,7 +926,7 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
   const prepareReannounceAction = useCallback((hashes: string[], count?: number, torrents?: Torrent[]) => {
     const actualCount = count || hashes.length
     setContextHashes(hashes)
-    if (torrents) setContextTorrents(torrents)
+    setContextTorrents(torrents ?? [])
     if (actualCount > 1) {
       setShowReannounceDialog(true)
     } else {
@@ -936,12 +936,13 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
 
   const prepareLocationAction = useCallback((hashes: string[], torrents?: Torrent[]) => {
     setContextHashes(hashes)
-    if (torrents) setContextTorrents(torrents)
+    setContextTorrents(torrents ?? [])
     setShowLocationWarningDialog(true)
   }, [])
 
-  const prepareTmmAction = useCallback((hashes: string[], _count?: number, enable?: boolean) => {
+  const prepareTmmAction = useCallback((hashes: string[], _count?: number, enable?: boolean, torrents?: Torrent[]) => {
     setContextHashes(hashes)
+    setContextTorrents(torrents ?? [])
     setPendingTmmEnable(enable ?? false)
     setShowTmmDialog(true)
   }, [])
@@ -981,34 +982,34 @@ export function useTorrentActions({ instanceId, instanceIds, onActionComplete }:
 
   const prepareShareLimitAction = useCallback((hashes: string[], torrents?: Torrent[]) => {
     setContextHashes(hashes)
-    if (torrents) setContextTorrents(torrents)
+    setContextTorrents(torrents ?? [])
     setShowShareLimitDialog(true)
   }, [])
 
   const prepareSpeedLimitAction = useCallback((hashes: string[], torrents?: Torrent[]) => {
     setContextHashes(hashes)
-    if (torrents) setContextTorrents(torrents)
+    setContextTorrents(torrents ?? [])
     setShowSpeedLimitDialog(true)
   }, [])
 
   const prepareRenameTorrentAction = useCallback((hashes: string[], torrents?: Torrent[]) => {
     if (hashes.length === 0) return
     setContextHashes(hashes)
-    if (torrents) setContextTorrents(torrents)
+    setContextTorrents(torrents ?? [])
     setShowRenameTorrentDialog(true)
   }, [])
 
   const prepareRenameFileAction = useCallback((hashes: string[], torrents?: Torrent[]) => {
     if (hashes.length === 0) return
     setContextHashes(hashes)
-    if (torrents) setContextTorrents(torrents)
+    setContextTorrents(torrents ?? [])
     setShowRenameFileDialog(true)
   }, [])
 
   const prepareRenameFolderAction = useCallback((hashes: string[], torrents?: Torrent[]) => {
     if (hashes.length === 0) return
     setContextHashes(hashes)
-    if (torrents) setContextTorrents(torrents)
+    setContextTorrents(torrents ?? [])
     setShowRenameFolderDialog(true)
   }, [])
 


### PR DESCRIPTION
## Description

A hash names a torrent, not an instance. In the unified scope `BulkAction` resolved bare hashes on every instance that held them, so one row's action ran on every cross-seeded copy. The handler now returns 400 for hashes without `targets` and the resolver is gone. `appendTargetsFromCrossInstanceTorrents` stays because the selectAll path still uses it.

Two frontend paths still sent bare hashes on the unified route. The selection bar built targets from `instanceId:hash` composites nothing sends and dropped them all at instance 0, so every bar action fanned out. The context-menu TMM toggle never stored the row, so its confirm dialog had no targets. Both now send targets built from the selected rows.

Stacked on #2528.

Fixes #2527

## How has this been tested?

Built binary with two stub qBittorrent servers sharing one hash, both added to a local qui with auth disabled. In the unified view: selection-bar pause on the alpha row logged `torrents/stop` on alpha only, context-menu force recheck on the beta row logged `torrents/recheck` on beta only, context-menu Enable TMM with confirm on the alpha row logged `setAutoManagement` on alpha only. Before the frontend fix the bar action produced the new 400 toast, which is the old fan-out made visible. Delete with "also delete cross-seeds" ticked from the table context menu and from the selection bar each logged one `torrents/delete` with both hashes on the row's instance only. The mobile sheet got the same change but was not run on a device.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Unified torrent bulk actions now require explicit instance-and-torrent targets when needed.
  - Bare hash selections in unified view are rejected with a clear validation error.
  - Actions apply only to the selected instance and torrent, preventing unintended changes elsewhere.
  - Torrent deletion and management actions now preserve selected torrent context more reliably, including cross-seed operations.
  - Targeted deletion no longer removes matching torrents from other instances unintentionally.

- **Documentation**
  - Updated API documentation to describe unified scope support and instance ID `0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->