### PR TITLE
fix(torrents): stop re-applying the search client-side in cross-seed filter mode

### DIFF
--- a/web/src/components/torrents/TorrentTableOptimized.tsx
+++ b/web/src/components/torrents/TorrentTableOptimized.tsx
@@ -424,8 +424,6 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
   const navigate = useNavigate()
 
   const {
-    globalFilter,
-    setGlobalFilter,
     effectiveSearch,
     columnFiltersExpr,
     combinedFiltersExpr,
@@ -807,7 +805,6 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
     // State management
     state: {
       sorting,
-      globalFilter,
       rowSelection,
       columnSizing,
       columnVisibility,
@@ -821,7 +818,6 @@ export const TorrentTableOptimized = memo(function TorrentTableOptimized({
       }),
     },
     onSortingChange: setSorting,
-    onGlobalFilterChange: setGlobalFilter,
     onRowSelectionChange: setRowSelection,
     onColumnSizingChange: setColumnSizing,
     onColumnVisibilityChange: setColumnVisibility,

--- a/web/src/components/torrents/table/__tests__/TorrentTableOptimized.smoke.test.tsx
+++ b/web/src/components/torrents/table/__tests__/TorrentTableOptimized.smoke.test.tsx
@@ -9,10 +9,12 @@
  *
  * It mounts the REAL component with the network/router/stream boundaries
  * mocked and a deterministic virtualizer, then asserts the behaviours most
- * likely to break while extracting seams: rows render, and the header
- * select-all toggles row selection. The external data/action hooks mocked
- * here are NOT what the decomposition refactors, so this harness stays stable
- * across the 10 PRs it guards. Real virtualized scrolling and column-filter
+ * likely to break while extracting seams: rows render, the header
+ * select-all toggles row selection, and cross-seed mode keeps the rows the
+ * backend matched for a multi-word search (#2525). The external data/action
+ * hooks mocked here are NOT what the decomposition refactors, so this harness
+ * stays stable across the 10 PRs it guards; `scenario` is the only per-test
+ * knob they read. Real virtualized scrolling and column-filter
  * UI are intentionally left to per-seam unit tests + the manual smoke per PR.
  *
  * IMPORTANT: every mocked hook returns a STABLE singleton reference. Returning
@@ -26,6 +28,9 @@ import { cleanup, fireEvent, render, within } from "@testing-library/react"
 import type { ReactNode } from "react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { makeTorrent } from "@/test/mockTorrent"
+
+// Per-test knobs read by the hoisted mocks below. Reset in beforeEach.
+const scenario = vi.hoisted(() => ({ routeSearch: "", isCrossSeedFiltering: false }))
 
 const torrents = [
   makeTorrent({ hash: "hash-aaa", name: "Alpha Release", state: "downloading", progress: 0.5 }),
@@ -48,7 +53,7 @@ vi.mock("react-i18next", async (importOriginal) => {
 
 // Router: avoid needing a real router tree.
 vi.mock("@tanstack/react-router", async (importOriginal) => {
-  const search = {}
+  const search = { get q() { return scenario.routeSearch || undefined } }
   const navigate = vi.fn()
   return {
     ...(await importOriginal<typeof import("@tanstack/react-router")>()),
@@ -154,7 +159,7 @@ vi.mock("@/hooks/useTorrentsList", () => {
         streamRetrying: false,
         streamNextRetryAt: undefined,
         streamRetryAttempt: 0,
-        isCrossSeedFiltering: false,
+        get isCrossSeedFiltering() { return scenario.isCrossSeedFiltering },
         isCrossInstanceEndpoint: false,
       }
       return result
@@ -206,6 +211,8 @@ function renderTable() {
 describe("TorrentTableOptimized smoke", () => {
   beforeEach(() => {
     localStorage.clear()
+    scenario.routeSearch = ""
+    scenario.isCrossSeedFiltering = false
   })
 
   it("renders a row for each torrent", () => {
@@ -228,5 +235,16 @@ describe("TorrentTableOptimized smoke", () => {
       (cb) => cb !== header && cb.getAttribute("aria-checked") === "true"
     )
     expect(checkedRowsAfter.length).toBeGreaterThan(0)
+  })
+
+  // Issue #2525: in cross-seed mode the table filters client-side. The search
+  // already narrowed rows on the backend (every word must appear somewhere in
+  // the name), so the table must not re-apply it as a literal substring.
+  it("keeps backend-matched rows when a multi-word search meets the cross-seed filter", () => {
+    scenario.routeSearch = "release alpha"
+    scenario.isCrossSeedFiltering = true
+    const { container } = renderTable()
+    expect(container.textContent).toContain("Alpha Release")
+    expect(container.textContent).toContain("Bravo Release")
   })
 })

--- a/web/src/components/torrents/tanstackTableFeatures.ts
+++ b/web/src/components/torrents/tanstackTableFeatures.ts
@@ -17,7 +17,6 @@ import {
   filterFn_inNumberRange,
   filterFn_includesString,
   filterFn_weakEquals,
-  globalFilteringFeature,
   rowSelectionFeature,
   rowSortingFeature,
   sortFn_alphanumeric,
@@ -44,7 +43,6 @@ export const sortableDetailsTableFeatures = tableFeatures({
 
 export const torrentTableFeatures = tableFeatures({
   columnFilteringFeature,
-  globalFilteringFeature,
   columnOrderingFeature,
   columnSizingFeature,
   columnResizingFeature,

--- a/web/src/hooks/torrent-table/__tests__/useTorrentTableFilterExpr.test.ts
+++ b/web/src/hooks/torrent-table/__tests__/useTorrentTableFilterExpr.test.ts
@@ -7,7 +7,7 @@ import { useTorrentTableFilterExpr } from "@/hooks/torrent-table/useTorrentTable
 import type { ColumnFilter } from "@/lib/column-filter-utils"
 import { makeFilters } from "@/test/mockFilters"
 import type { TorrentFilters } from "@/types"
-import { act, renderHook } from "@testing-library/react"
+import { renderHook } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 // Router search is the only external dependency that needs a provider; stub it.
@@ -30,27 +30,15 @@ beforeEach(() => {
 })
 
 describe("useTorrentTableFilterExpr — search derivation", () => {
-  it("prefers the trimmed route search over the debounced input", () => {
+  it("trims the route search into effectiveSearch", () => {
     hoisted.routeSearch = { q: "  fromRoute  " }
     const { result } = render({ instanceId: 1, columnFilters: [] })
     expect(result.current.effectiveSearch).toBe("fromRoute")
   })
 
-  it("debounces the global filter into effectiveSearch", () => {
-    vi.useFakeTimers()
-    try {
-      const { result } = render({ instanceId: 1, columnFilters: [] })
-      expect(result.current.effectiveSearch).toBe("")
-
-      act(() => result.current.setGlobalFilter("linux"))
-      // Not yet applied — debounce window hasn't elapsed.
-      expect(result.current.effectiveSearch).toBe("")
-
-      act(() => vi.advanceTimersByTime(200))
-      expect(result.current.effectiveSearch).toBe("linux")
-    } finally {
-      vi.useRealTimers()
-    }
+  it("is empty without a route search", () => {
+    const { result } = render({ instanceId: 1, columnFilters: [] })
+    expect(result.current.effectiveSearch).toBe("")
   })
 })
 

--- a/web/src/hooks/torrent-table/__tests__/useTorrentTableFilterExpr.test.ts
+++ b/web/src/hooks/torrent-table/__tests__/useTorrentTableFilterExpr.test.ts
@@ -7,8 +7,8 @@ import { useTorrentTableFilterExpr } from "@/hooks/torrent-table/useTorrentTable
 import type { ColumnFilter } from "@/lib/column-filter-utils"
 import { makeFilters } from "@/test/mockFilters"
 import type { TorrentFilters } from "@/types"
-import { renderHook } from "@testing-library/react"
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { cleanup, renderHook } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 // Router search is the only external dependency that needs a provider; stub it.
 const hoisted = vi.hoisted(() => ({ routeSearch: {} as { q?: string } }))
@@ -28,6 +28,8 @@ function render(initialProps: Props) {
 beforeEach(() => {
   hoisted.routeSearch = {}
 })
+
+afterEach(cleanup)
 
 describe("useTorrentTableFilterExpr — search derivation", () => {
   it("trims the route search into effectiveSearch", () => {

--- a/web/src/hooks/torrent-table/useTorrentTableFilterExpr.ts
+++ b/web/src/hooks/torrent-table/useTorrentTableFilterExpr.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useDebounce } from "@/hooks/useDebounce"
 import { columnFiltersToExpr, type ColumnFilter } from "@/lib/column-filter-utils"
 import type { TorrentFilters } from "@/types"
 import { useSearch } from "@tanstack/react-router"
@@ -21,8 +20,6 @@ export interface UserAction {
 }
 
 export interface TorrentTableFilterExpr {
-  globalFilter: string
-  setGlobalFilter: Dispatch<SetStateAction<string>>
   effectiveSearch: string
   columnFiltersExpr: string | null
   combinedFiltersExpr: string | null | undefined
@@ -32,9 +29,9 @@ export interface TorrentTableFilterExpr {
 }
 
 /**
- * Owns the table's search + filter-expression derivation: the debounced/route
- * search inputs, the column-filter-to-expr conversion, the cross-seed detection,
- * and the combined backend expression.
+ * Owns the table's search + filter-expression derivation: the route search
+ * (`?q=`, already debounced by the header input), the column-filter-to-expr
+ * conversion, the cross-seed detection, and the combined backend expression.
  *
  * The `combinedFiltersExpr` cross-seed early-return is load-bearing (regression
  * #1925): in cross-seed mode the column filters are applied client-side by
@@ -47,33 +44,19 @@ export function useTorrentTableFilterExpr({
   instanceId,
   columnFilters,
 }: UseTorrentTableFilterExprParams): TorrentTableFilterExpr {
-  const [globalFilter, setGlobalFilter] = useState("")
   // Track user-initiated actions to differentiate from automatic data updates
   const [lastUserAction, setLastUserAction] = useState<UserAction | null>(null)
   const previousFiltersRef = useRef(filters)
   const previousInstanceIdRef = useRef(instanceId)
 
-  // Debounce search to prevent excessive filtering (200ms delay for faster response)
-  const debouncedSearch = useDebounce(globalFilter, 200)
   const routeSearch = useSearch({ strict: false }) as { q?: string }
   const rawRouteSearch = typeof routeSearch?.q === "string" ? routeSearch.q : ""
-  const searchFromRoute = rawRouteSearch.trim()
-
-  // Use route search if present, otherwise fall back to the local debounced search
-  const effectiveSearch = (searchFromRoute || debouncedSearch).trim()
+  const effectiveSearch = rawRouteSearch.trim()
 
   // Seed with the initial effectiveSearch so a route-derived search present on
   // mount (e.g. loading a URL with ?q=) isn't mistaken for a user-initiated
   // search action and doesn't emit a spurious {type: "search"}.
   const previousSearchRef = useRef(effectiveSearch)
-
-  // Keep local input state in sync with route query so internal effects remain consistent
-  useEffect(() => {
-    if (searchFromRoute !== globalFilter) {
-      setGlobalFilter(searchFromRoute)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchFromRoute])
 
   // Convert column filters to expr format for backend
   const columnFiltersExpr = useMemo(() => columnFiltersToExpr(columnFilters), [columnFilters])
@@ -123,8 +106,6 @@ export function useTorrentTableFilterExpr({
   }, [filters, instanceId, effectiveSearch])
 
   return {
-    globalFilter,
-    setGlobalFilter,
     effectiveSearch,
     columnFiltersExpr,
     combinedFiltersExpr,


### PR DESCRIPTION
## Description

In cross-seed filter mode the desktop table filters client-side, and the TanStack global filter re-applied the search text as a literal substring match after the backend had already matched it word by word. A multi-word search left the table empty. Removes the global filtering feature and the dead local search state (the route query is the only search input, and the header already debounces it).

Fixes #2525

## How has this been tested?

On media's live Docker backend, the CI frontend showed both cross-seed matches where develop showed no rows. Search controls, sorting, and column filters worked, but unmatched searches still showed the existing filters empty-state message.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved torrent search behavior by consistently using the trimmed search query from the URL.
  * Fixed cross-seed filtering so rows matching multi-word searches remain visible.
  * Prevented duplicate client-side filtering while preserving search results.

* **Tests**
  * Expanded coverage for cross-seed filtering and multi-word searches.
  * Updated search tests for route-based queries and empty search states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->