### PR TITLE
fix(crossseed): search and match absolute-numbered anime episodes

### DIFF
--- a/internal/services/crossseed/announcement_match_test.go
+++ b/internal/services/crossseed/announcement_match_test.go
@@ -544,3 +544,34 @@ func TestAnnounceAliasTitlesBoundsLookup(t *testing.T) {
 	require.True(t, spy.hasDeadline)
 	require.LessOrEqual(t, time.Until(spy.deadline), announceAliasLookupTimeout)
 }
+
+// TestClassifyWebhookAnnouncementSourceColonTitleAbsoluteEpisode: a Sonarr
+// announce keeps the series title's colon and S04E15; the file on disk cannot
+// hold a colon and carries the absolute number. Exact size admits the pair.
+func TestClassifyWebhookAnnouncementSourceColonTitleAbsoluteEpisode(t *testing.T) {
+	const (
+		sourceHash   = "colon-absolute-source"
+		sourceName   = "[KiraSubs] Re Start Isekai Life - 81 (1080p) [ABCD1234].mkv"
+		announceName = "Re:Start Isekai Life S04E15 1080p WEB-DL AAC2.0 H.264-KiraSubs"
+		size         = int64(1_449_551_462)
+	)
+	source := qbt.Torrent{Hash: sourceHash, Name: sourceName, Size: size, TotalSize: size, Progress: 1}
+	instance := &models.Instance{ID: 1, Name: "main"}
+	svc := &Service{
+		syncManager: newFakeSyncManager(instance, []qbt.Torrent{source}, map[string]qbt.TorrentFiles{
+			sourceHash: {{Name: sourceName, Size: size}},
+		}),
+		releaseCache:     NewReleaseCache(),
+		stringNormalizer: stringutils.NewDefaultNormalizer(),
+	}
+	candidate := namedRelease{release: svc.releaseCache.Parse(announceName), rawName: announceName}
+
+	got := svc.classifyWebhookAnnouncementSource(context.Background(), 1, &source, candidate, size, announcementMatchPolicy{
+		findIndividualEpisodes:   true,
+		tolerateOneSidedChecksum: true,
+	})
+
+	require.True(t, got.decision.Accepted, got.decision.RejectReason)
+	require.Equal(t, searchCandidateClassExactSizeFallback, got.decision.Class)
+	require.Contains(t, got.decision.RelaxedDifferences, "episode")
+}

--- a/internal/services/crossseed/matching_title_test.go
+++ b/internal/services/crossseed/matching_title_test.go
@@ -235,7 +235,7 @@ func TestReleasesMatch_PunctuationVariations(t *testing.T) {
 				Group:  "GROUP",
 			},
 			wantMatch:   true,
-			description: "colon should be stripped - 'City: Downtown' matches 'City Downtown'",
+			description: "colon should read as a space - 'City: Downtown' matches 'City Downtown'",
 		},
 		{
 			name: "hyphen vs space TV",

--- a/internal/services/jackett/service.go
+++ b/internal/services/jackett/service.go
@@ -3038,7 +3038,12 @@ func (s *Service) buildSearchParams(req *TorznabSearchRequest, searchMode string
 			Msg("Adding season parameter to torznab search")
 	}
 
-	if req.Episode != nil {
+	// Torznab ep counts within a season. An absolute-numbered anime episode has
+	// no season, and HDBits filters its TVDb search on the bare number and
+	// returns nothing. ponytail: the ID search returns the newest page and the
+	// matcher picks the episode; map absolute to season/episode via Sonarr if
+	// old episodes of long-running shows fall off that page.
+	if req.Episode != nil && req.Season != nil && *req.Season > 0 {
 		params.Set("ep", strconv.Itoa(*req.Episode))
 		log.Debug().
 			Str("search_mode", mode).

--- a/internal/services/jackett/service_test.go
+++ b/internal/services/jackett/service_test.go
@@ -1091,6 +1091,20 @@ func TestBuildSearchParams(t *testing.T) {
 			},
 		},
 		{
+			name: "seasonless absolute episode omits ep",
+			req: &TorznabSearchRequest{
+				Query:   "Re Start Isekai Life",
+				TVDbID:  "305089",
+				Episode: new(81),
+			},
+			searchMode: "tvsearch",
+			expected: map[string]string{
+				"t":      "tvsearch",
+				"q":      "Re Start Isekai Life",
+				"tvdbid": "305089",
+			},
+		},
+		{
 			name: "movie request",
 			req: &TorznabSearchRequest{
 				Query:  "The Matrix",

--- a/pkg/stringutils/unicode.go
+++ b/pkg/stringutils/unicode.go
@@ -106,8 +106,10 @@ func normalized(s string) string {
 	s = strings.ReplaceAll(s, "\u02bc", "") // Modifier letter apostrophe
 	s = strings.ReplaceAll(s, "`", "")      // Backtick
 
-	// Remove colons - "csi: miami" → "csi miami"
-	s = strings.ReplaceAll(s, ":", "")
+	// Colons become spaces - "csi: miami" → "csi miami", "re:zero" → "re zero".
+	// A file name cannot hold a colon, so on-disk names space it while an
+	// arr-built announce name keeps it. Trade: "re:zero" no longer folds to "rezero".
+	s = strings.ReplaceAll(s, ":", " ")
 
 	// Remove exclamation and question marks - scene naming drops them,
 	// so "Overtake!" announces as "Overtake.S01..."
@@ -150,7 +152,8 @@ func NormalizeUnicode(s string) string {
 //   - Unicode normalization (removes diacritics, decomposes ligatures)
 //   - Lowercase
 //   - Strip apostrophes (including Unicode variants)
-//   - Strip colons, exclamation and question marks
+//   - Convert colons to spaces
+//   - Strip exclamation and question marks
 //   - Convert commas to spaces
 //   - Convert ampersand to "and"
 //   - Convert hyphens to spaces

--- a/pkg/stringutils/unicode_test.go
+++ b/pkg/stringutils/unicode_test.go
@@ -103,6 +103,7 @@ func TestNormalizeForMatching(t *testing.T) {
 		// Colon handling
 		{"colon", "CSI: Miami", "csi miami"},
 		{"colon with space", "City: Downtown", "city downtown"},
+		{"colon without space", "Re:Start Isekai Life", "re start isekai life"},
 		{"comma", "Signal, Bloom", "signal bloom"},
 		{"comma without space", "Signal,Bloom", "signal bloom"},
 
@@ -186,6 +187,18 @@ func TestNormalizeForMatching_RealWorldPairs(t *testing.T) {
 			"csi colon",
 			"CSI: Miami S01",
 			"CSI Miami S01",
+		},
+		{
+			// A file name cannot hold a colon, so the on-disk name spaces it.
+			"colon without space vs on-disk name",
+			"Re:Start Isekai Life S04E15",
+			"Re Start Isekai Life S04E15",
+		},
+		{
+			// Sonarr series title versus a tracker's spelling of the same title.
+			"sonarr colon space comma vs tracker colon hyphens",
+			"Re: START, Isekai Life Again",
+			"Re:START -Isekai Life Again-",
 		},
 		{
 			"comma title separator",


### PR DESCRIPTION
## Description

Fixes two rejections that hid every cross-seed for an absolute-numbered anime episode.

Torznab `ep` counts within a season, and qui sent it without one for absolute-numbered names such as `[Group] Title - 81`. Prowlarr and Jackett already drop a seasonless episode from text searches, but Prowlarr's HDBits definition forwards it into the TVDb filter, and HDBits returns nothing. The search now omits `ep` unless a season is set, so HDBits gets a plain TVDb search and the matcher picks the episode.

Title matching stripped colons, so `Re:Zero` folded to `rezero` while the on-disk name, which cannot hold a colon, folded to `re zero`. A Sonarr-built announce and Sonarr alias titles never matched the local file or a tracker's spelling. A colon now reads as a space, the same as a hyphen or comma. Trade-off: `Re:Zero` no longer folds together with `ReZero`. Once the titles agree, the existing exact-size tier admits the absolute-numbered file against its `S04E15` counterpart.

## How has this been tested?

Reproduced the HDBits request against an httptest indexer carrying Prowlarr's HDBits caps, and reproduced both title rejections with the source name, the BeyondHD result name, and the Sonarr alias list from the user's debug logs. All three pass after the change.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved title matching for series names containing colons, including cases where local filenames cannot preserve the punctuation.
  * Improved matching for seasonless, absolute-numbered episodes.
  * Updated episode searches to better support absolute episode numbering without a season value.

* **Tests**
  * Added coverage for colon normalization, punctuation variations, and absolute episode matching scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->