### PR TITLE
feat(crossseed): search and match anime episodes through the episode map

### DIFF
--- a/documentation/docs/features/cross-seed/overview.md
+++ b/documentation/docs/features/cross-seed/overview.md
@@ -103,6 +103,8 @@ RSS uses the same classifier with its feed title and byte count. The [autobrr in
 
 Announce matching over alternate titles, such as an anime announced under its English or romaji name, needs a [Sonarr or Radarr integration](../search.md#sonarr-and-radarr-integrations). Without one, qui matches announces on the release name only.
 
+Sonarr also maps a single anime episode between numbering schemes. When Sonarr names exactly one episode for a release, qui reads its season, episode, and absolute number, and stores the map with the cached IDs. A search for an absolute-numbered episode (`Show - 81`) then asks ID-capable indexers for the mapped `S04E15`, and a `S04E15` announce or search result matches a local `Show - 81` file as a strict match, in both directions. The map only adds matches: when a tracker numbers the episode differently from Sonarr, qui treats the pair as an episode mismatch, as before. Season packs are not mapped. See [Season Packs](./season-packs.md#anime-absolute-numbering).
+
 If autobrr has no positive size, qui uses a narrow name-only preflight. This preflight can approve one download, but it cannot approve an add.
 
 ### Manual Match

--- a/documentation/docs/features/cross-seed/season-packs.md
+++ b/documentation/docs/features/cross-seed/season-packs.md
@@ -104,7 +104,7 @@ If Sonarr resolves the show, qui pulls its series-wide alternate titles and uses
 
 If both sides use the same absolute numbering, qui matches absolute-numbered anime episodes (for example `Show - 1140`, with no season number) against a season pack. qui keys the local episode to the pack season and uses the absolute episode number to identify it.
 
-This feature does not translate between different numbering schemes. A pack that uses `SxxExx` numbering does not match local episodes numbered with absolute numbers, and the reverse also holds. Translation between schemes requires authoritative per-episode data from a metadata provider. In practice, releases that cross-seed cleanly already share a numbering convention.
+Season-pack matching does not translate between numbering schemes. A pack that uses `SxxExx` numbering does not match local episodes numbered with absolute numbers, and the reverse also holds. Translation needs per-episode data for every file in the pack. Single episodes are different: with Sonarr linked, qui maps one episode between schemes. See [Manual Search](./overview.md#manual-search) in the overview.
 
 A `/check` call without torrent data has no file list to determine the pack's numbering scheme. The check remains optimistic and reports ready against local episodes that use the other scheme. The `/apply` endpoint verifies the real file list of the pack and acts as the authority. A false ready result from the light check costs only one wasted `.torrent` download, and qui injects nothing.
 

--- a/internal/services/crossseed/alt_pass_usable_test.go
+++ b/internal/services/crossseed/alt_pass_usable_test.go
@@ -106,7 +106,7 @@ func TestSearchResultUsable(t *testing.T) {
 			got := s.searchResultUsable(
 				namedRelease{release: &source, rawName: tt.sourceName},
 				namedRelease{release: &candidate, rawName: tt.candidateName},
-				tt.sourceSize, tt.candidateSize, nil, tt.tolerance, tt.findIndividualEpisodes,
+				tt.sourceSize, tt.candidateSize, nil, nil, tt.tolerance, tt.findIndividualEpisodes,
 			)
 			require.Equal(t, tt.want, got)
 		})
@@ -140,7 +140,7 @@ func TestIndexersWithoutUsableResults(t *testing.T) {
 	got := s.indexersWithoutUsableResults(
 		[]int{1, 2, 3}, results,
 		namedRelease{release: &source, rawName: sourceName},
-		size, nil, 5, false,
+		size, nil, nil, 5, false,
 	)
 	require.Equal(t, []int{1, 3}, got)
 
@@ -181,7 +181,7 @@ func TestHasUsableSearchResult(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, service.hasUsableSearchResult(tt.results, sourceView, size, nil, 5, false))
+			require.Equal(t, tt.want, service.hasUsableSearchResult(tt.results, sourceView, size, nil, nil, 5, false))
 		})
 	}
 }

--- a/internal/services/crossseed/announcement_match.go
+++ b/internal/services/crossseed/announcement_match.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	qbt "github.com/autobrr/go-qbittorrent"
+
+	"github.com/autobrr/qui/internal/models"
 )
 
 // announceAliasLookupTimeout bounds the ARR alias lookup on announce paths.
@@ -25,6 +27,9 @@ type announcementMatchPolicy struct {
 	// attach to the candidate side only, so they can never widen the identity
 	// of an unrelated source torrent.
 	candidateTitles []string
+	// episodeMap is the Sonarr triple for the announced release, resolved with
+	// the alias titles.
+	episodeMap *models.EpisodeMap
 	// tolerateOneSidedChecksum lets the advisory webhook check pass a candidate
 	// whose only strict failure is a CRC tag on one side. IRC announce sizes are
 	// rounded, so the check cannot reach the exact-size checksum relaxation that
@@ -96,15 +101,16 @@ func (s *Service) classifyWebhookAnnouncementSource(
 	return announcementCandidateDecision{decision: decision, replayable: true}
 }
 
-// announceAliasTitles resolves ARR alternate titles for an announced release.
-// Callers run it once per announce, outside the per-torrent scan loops.
-func (s *Service) announceAliasTitles(ctx context.Context, announcedName, contentType string) []string {
+// announceAliasTitles resolves ARR alternate titles and the episode map for an
+// announced release. Callers run it once per announce, outside the per-torrent
+// scan loops.
+func (s *Service) announceAliasTitles(ctx context.Context, announcedName, contentType string) ([]string, *models.EpisodeMap) {
 	ctx, cancel := context.WithTimeout(ctx, announceAliasLookupTimeout)
 	defer cancel()
 	if arrResult, _ := s.lookupARRExternalIDs(ctx, announcedName, contentType); arrResult != nil {
-		return arrResult.Titles
+		return arrResult.Titles, arrResult.EpisodeMap
 	}
-	return nil
+	return nil, nil
 }
 
 func (s *Service) announcementRawSearchInput(source *qbt.Torrent, candidate namedRelease, candidateSize int64, policy announcementMatchPolicy) searchCandidateInput {
@@ -115,6 +121,7 @@ func (s *Service) announcementRawSearchInput(source *qbt.Torrent, candidate name
 		SourceSize:             searchSourceSize(source),
 		CandidateSize:          candidateSize,
 		CandidateTitles:        policy.candidateTitles,
+		EpisodeMap:             policy.episodeMap,
 		TolerancePercent:       defaultSizeMismatchTolerancePercent,
 		FindIndividualEpisodes: policy.findIndividualEpisodes,
 		RescueTitleMismatches:  policy.rescueTitleMismatches,

--- a/internal/services/crossseed/episode_map_match_test.go
+++ b/internal/services/crossseed/episode_map_match_test.go
@@ -113,6 +113,9 @@ func TestClassifySearchCandidateEpisodeMap(t *testing.T) {
 		{name: "no map is an episode mismatch", sourceName: episodeMapAbsoluteNoCRCName, candidateName: episodeMapSeasonedName, candidateSize: episodeMapSize + 500, wantReason: episodeMismatchReason},
 		{name: "tracker disagreement is an episode mismatch", sourceName: episodeMapAbsoluteNoCRCName, candidateName: episodeMapOffByOneName, candidateSize: episodeMapSize + 500, episodeMap: episodeMapS04E15, wantReason: episodeMismatchReason},
 		{name: "tracker disagreement passes the exact-size tier", sourceName: episodeMapAbsoluteNoCRCName, candidateName: episodeMapOffByOneName, candidateSize: episodeMapSize, episodeMap: episodeMapS04E15, wantAccepted: true, wantClass: searchCandidateClassExactSizeFallback},
+		// A special maps to season 0; without the guard the seasonless "- 15" would
+		// pose as the seasoned side and "- 81" would be rewritten onto it.
+		{name: "season-zero map never equates two seasonless episodes", sourceName: episodeMapAbsoluteNoCRCName, candidateName: "[KiraSubs] Azure Compass - 15 (1080p).mkv", candidateSize: episodeMapSize + 500, episodeMap: &models.EpisodeMap{Season: 0, Episode: 15, Absolute: 81}, wantReason: episodeMismatchReason},
 	}
 
 	for _, tt := range tests {

--- a/internal/services/crossseed/episode_map_match_test.go
+++ b/internal/services/crossseed/episode_map_match_test.go
@@ -1,0 +1,194 @@
+// Copyright (c) 2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package crossseed
+
+import (
+	"context"
+	"testing"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/moistari/rls"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/pkg/stringutils"
+)
+
+const (
+	episodeMapAbsoluteName = "[KiraSubs] Azure Compass - 81 (1080p) [ABCD1234].mkv"
+	// The search classifier has no one-sided checksum tolerance below exact
+	// size, so the search fixture drops the CRC to isolate the map rule.
+	episodeMapAbsoluteNoCRCName = "[KiraSubs] Azure Compass - 81 (1080p).mkv"
+	episodeMapSeasonedName      = "Azure Compass S04E15 1080p WEB-DL AAC2.0 H.264-KiraSubs"
+	episodeMapOffByOneName      = "Azure Compass S04E16 1080p WEB-DL AAC2.0 H.264-KiraSubs"
+	episodeMapSize              = int64(1_449_551_462)
+)
+
+var episodeMapS04E15 = &models.EpisodeMap{Season: 4, Episode: 15, Absolute: 81}
+
+// TestClassifyWebhookAnnouncementSourceEpisodeMap: the webhook check sees a
+// rounded announce size, so only a strict match can report ready. The Sonarr
+// episode map makes a mixed-scheme pair strict in both directions; without a
+// map, or when the tracker numbers the episode differently from Sonarr, the
+// exact-size tier still decides.
+func TestClassifyWebhookAnnouncementSourceEpisodeMap(t *testing.T) {
+	tests := []struct {
+		name          string
+		sourceName    string
+		announceName  string
+		announceSize  int64
+		episodeMap    *models.EpisodeMap
+		wantAccepted  bool
+		wantClass     searchCandidateClass
+		wantReason    string
+		wantMapReason bool
+	}{
+		{name: "seasoned announce against absolute local", sourceName: episodeMapAbsoluteName, announceName: episodeMapSeasonedName, announceSize: episodeMapSize + 500, episodeMap: episodeMapS04E15, wantAccepted: true, wantClass: searchCandidateClassStrict, wantMapReason: true},
+		{name: "absolute announce against seasoned local", sourceName: episodeMapSeasonedName, announceName: episodeMapAbsoluteName, announceSize: episodeMapSize + 500, episodeMap: episodeMapS04E15, wantAccepted: true, wantClass: searchCandidateClassStrict, wantMapReason: true},
+		{name: "no map keeps the rejection", sourceName: episodeMapAbsoluteName, announceName: episodeMapSeasonedName, announceSize: episodeMapSize + 500, wantReason: episodeMismatchReason},
+		{name: "tracker disagrees with the map at a rounded size", sourceName: episodeMapAbsoluteName, announceName: episodeMapOffByOneName, announceSize: episodeMapSize + 500, episodeMap: episodeMapS04E15, wantReason: episodeMismatchReason},
+		{name: "tracker disagrees with the map at a byte-equal size", sourceName: episodeMapAbsoluteName, announceName: episodeMapOffByOneName, announceSize: episodeMapSize, episodeMap: episodeMapS04E15, wantAccepted: true, wantClass: searchCandidateClassExactSizeFallback},
+		{name: "same-scheme pair ignores the map", sourceName: episodeMapSeasonedName, announceName: episodeMapSeasonedName, announceSize: episodeMapSize + 500, episodeMap: episodeMapS04E15, wantAccepted: true, wantClass: searchCandidateClassStrict},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const sourceHash = "episode-map-source"
+			source := qbt.Torrent{Hash: sourceHash, Name: tt.sourceName, Size: episodeMapSize, TotalSize: episodeMapSize, Progress: 1}
+			instance := &models.Instance{ID: 1, Name: "main"}
+			svc := &Service{
+				syncManager: newFakeSyncManager(instance, []qbt.Torrent{source}, map[string]qbt.TorrentFiles{
+					sourceHash: {{Name: tt.sourceName, Size: episodeMapSize}},
+				}),
+				releaseCache:     NewReleaseCache(),
+				stringNormalizer: stringutils.NewDefaultNormalizer(),
+			}
+			candidate := namedRelease{release: svc.releaseCache.Parse(tt.announceName), rawName: tt.announceName}
+
+			got := svc.classifyWebhookAnnouncementSource(context.Background(), 1, &source, candidate, tt.announceSize, announcementMatchPolicy{
+				findIndividualEpisodes:   true,
+				skipRecheck:              true,
+				episodeMap:               tt.episodeMap,
+				tolerateOneSidedChecksum: true,
+			})
+
+			require.Equal(t, tt.wantAccepted, got.decision.Accepted, got.decision.RejectReason)
+			if !tt.wantAccepted {
+				require.Equal(t, tt.wantReason, got.decision.RejectReason)
+				return
+			}
+			require.Equal(t, tt.wantClass, got.decision.Class)
+			if tt.wantMapReason {
+				require.Contains(t, got.decision.MatchReason, "mapped episode 81 = S04E15")
+				require.False(t, searchDecisionRequiresVerification(got.decision.provenance()),
+					"a mapped strict match needs no verification, so skip recheck accepts it")
+				require.Equal(t, tt.episodeMap, got.decision.provenance().EpisodeMap)
+			} else {
+				require.NotContains(t, got.decision.MatchReason, "mapped episode")
+			}
+		})
+	}
+}
+
+// TestClassifySearchCandidateEpisodeMap: a search result named S04E15 matches
+// the local absolute-numbered file strictly through the map, without a
+// byte-equal size. Without a map the pair is an episode mismatch, and a tracker
+// that disagrees with Sonarr passes only through the exact-size tier.
+func TestClassifySearchCandidateEpisodeMap(t *testing.T) {
+	service := &Service{stringNormalizer: stringutils.NewDefaultNormalizer()}
+
+	tests := []struct {
+		name          string
+		sourceName    string
+		candidateName string
+		candidateSize int64
+		episodeMap    *models.EpisodeMap
+		wantAccepted  bool
+		wantClass     searchCandidateClass
+		wantReason    string
+	}{
+		{name: "mapped pair is strict", sourceName: episodeMapAbsoluteNoCRCName, candidateName: episodeMapSeasonedName, candidateSize: episodeMapSize + 500, episodeMap: episodeMapS04E15, wantAccepted: true, wantClass: searchCandidateClassStrict},
+		{name: "mapped pair in reverse is strict", sourceName: episodeMapSeasonedName, candidateName: episodeMapAbsoluteNoCRCName, candidateSize: episodeMapSize + 500, episodeMap: episodeMapS04E15, wantAccepted: true, wantClass: searchCandidateClassStrict},
+		{name: "no map is an episode mismatch", sourceName: episodeMapAbsoluteNoCRCName, candidateName: episodeMapSeasonedName, candidateSize: episodeMapSize + 500, wantReason: episodeMismatchReason},
+		{name: "tracker disagreement is an episode mismatch", sourceName: episodeMapAbsoluteNoCRCName, candidateName: episodeMapOffByOneName, candidateSize: episodeMapSize + 500, episodeMap: episodeMapS04E15, wantReason: episodeMismatchReason},
+		{name: "tracker disagreement passes the exact-size tier", sourceName: episodeMapAbsoluteNoCRCName, candidateName: episodeMapOffByOneName, candidateSize: episodeMapSize, episodeMap: episodeMapS04E15, wantAccepted: true, wantClass: searchCandidateClassExactSizeFallback},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := rls.ParseString(tt.sourceName)
+			candidate := rls.ParseString(tt.candidateName)
+
+			decision := service.classifySearchCandidate(searchCandidateInput{
+				Source:                 namedRelease{release: &source, rawName: tt.sourceName},
+				Candidate:              namedRelease{release: &candidate, rawName: tt.candidateName},
+				EpisodeMap:             tt.episodeMap,
+				SourceSize:             episodeMapSize,
+				CandidateSize:          tt.candidateSize,
+				TolerancePercent:       5,
+				FindIndividualEpisodes: true,
+			})
+
+			require.Equal(t, tt.wantAccepted, decision.Accepted, decision.RejectReason)
+			if !tt.wantAccepted {
+				require.Equal(t, tt.wantReason, decision.RejectReason)
+				return
+			}
+			require.Equal(t, tt.wantClass, decision.Class)
+			if tt.wantClass == searchCandidateClassStrict {
+				require.Contains(t, decision.MatchReason, "mapped episode 81 = S04E15")
+			} else {
+				require.Contains(t, decision.RelaxedDifferences, "episode")
+			}
+		})
+	}
+}
+
+// TestFindCandidatesEpisodeMapReachesFileValidation: apply re-parses both
+// names, and the local file still carries the other numbering scheme, so the
+// name-derived episode keys never line up. A mapped search decision must let
+// the pair through to file-level size matching, in both directions.
+func TestFindCandidatesEpisodeMapReachesFileValidation(t *testing.T) {
+	tests := []struct {
+		name         string
+		existingName string
+		targetName   string
+	}{
+		{name: "seasoned target against absolute local", existingName: episodeMapAbsoluteNoCRCName, targetName: episodeMapSeasonedName},
+		{name: "absolute target against seasoned local", existingName: episodeMapSeasonedName, targetName: episodeMapAbsoluteNoCRCName},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const (
+				instanceID = 1
+				sourceHash = "existing"
+			)
+			instance := &models.Instance{ID: instanceID, Name: "main"}
+			existing := qbt.Torrent{Hash: sourceHash, Name: tt.existingName, Size: episodeMapSize, TotalSize: episodeMapSize, Progress: 1}
+			files := map[string]qbt.TorrentFiles{sourceHash: {{Name: tt.existingName, Size: episodeMapSize}}}
+			svc := &Service{
+				instanceStore:    &fakeInstanceStore{instances: map[int]*models.Instance{instanceID: instance}},
+				syncManager:      newFakeSyncManager(instance, []qbt.Torrent{existing}, files),
+				releaseCache:     NewReleaseCache(),
+				stringNormalizer: stringutils.NewDefaultNormalizer(),
+			}
+
+			response, err := svc.FindCandidates(context.Background(), &FindCandidatesRequest{
+				TorrentName:            tt.targetName,
+				TargetInstanceIDs:      []int{instanceID},
+				FindIndividualEpisodes: true,
+				SearchDecision: searchDecisionProvenance{
+					Class:            searchCandidateClassStrict,
+					SourceInstanceID: instanceID,
+					SourceHash:       sourceHash,
+					EpisodeMap:       episodeMapS04E15,
+				},
+			})
+			require.NoError(t, err)
+			require.Len(t, response.Candidates, 1, "a mapped pair must survive the name-derived match gate")
+			require.Equal(t, sourceHash, response.Candidates[0].Torrents[0].Hash)
+		})
+	}
+}

--- a/internal/services/crossseed/episode_map_search_test.go
+++ b/internal/services/crossseed/episode_map_search_test.go
@@ -36,8 +36,12 @@ func TestEpisodeMapSearchSendsSeasonedPairOnIDPath(t *testing.T) {
 	for _, tt := range []struct {
 		name       string
 		episodeMap *models.EpisodeMap
+		query      string
+		capsless   bool
 	}{
 		{name: "with map", episodeMap: episodeMapS04E15},
+		{name: "with map and a caller-supplied query", episodeMap: episodeMapS04E15, query: "Azure Compass"},
+		{name: "with map and an indexer without cached caps", episodeMap: episodeMapS04E15, capsless: true},
 		{name: "without map"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -62,6 +66,11 @@ func TestEpisodeMapSearchSendsSeasonedPairOnIDPath(t *testing.T) {
 
 			ctx := context.Background()
 			instance := &models.Instance{ID: 1, Name: "Test"}
+			// An indexer whose caps were never fetched prunes nothing and keeps every ID.
+			idCapableCaps := []string{"search", "tv-search", "tv-search-tvdbid", "tv-search-season", "tv-search-ep"}
+			if tt.capsless {
+				idCapableCaps = nil
+			}
 
 			sourceTorrent := qbt.Torrent{Hash: sourceHash, Name: sourceName, Progress: 1, Size: episodeMapSize, TotalSize: episodeMapSize, Tracker: "https://example.invalid/announce"}
 			tvCategories := []models.TorznabIndexerCategory{{IndexerID: 1, CategoryID: 5000, CategoryName: "TV"}, {IndexerID: 1, CategoryID: 5070, CategoryName: "TV/Anime"}}
@@ -72,7 +81,7 @@ func TestEpisodeMapSearchSendsSeasonedPairOnIDPath(t *testing.T) {
 					EpisodeMap: tt.episodeMap,
 				}},
 				jackettService: jackett.NewService(&gettableIndexerStore{failingEnabledIndexerStore{indexers: []*models.TorznabIndexer{
-					{ID: 1, Name: "ID Capable Indexer", Enabled: true, BaseURL: idCapable.URL, Backend: models.TorznabBackendNative, Capabilities: []string{"search", "tv-search", "tv-search-tvdbid", "tv-search-season", "tv-search-ep"}, Categories: tvCategories},
+					{ID: 1, Name: "ID Capable Indexer", Enabled: true, BaseURL: idCapable.URL, Backend: models.TorznabBackendNative, Capabilities: idCapableCaps, Categories: tvCategories},
 					{ID: 2, Name: "Text Indexer", Enabled: true, BaseURL: text.URL, Backend: models.TorznabBackendNative, Capabilities: []string{"search", "tv-search"}, Categories: tvCategories},
 				}}}, jackett.WithMinRequestInterval(time.Millisecond)),
 				syncManager: &gazelleSkipHashSyncManager{
@@ -86,7 +95,7 @@ func TestEpisodeMapSearchSendsSeasonedPairOnIDPath(t *testing.T) {
 				},
 			}
 
-			_, _, _, err := svc.searchTorrentMatches(ctx, instance.ID, sourceHash, TorrentSearchOptions{IndexerIDs: []int{1, 2}}, nil)
+			_, _, _, err := svc.searchTorrentMatches(ctx, instance.ID, sourceHash, TorrentSearchOptions{IndexerIDs: []int{1, 2}, Query: tt.query}, nil)
 			require.NoError(t, err)
 
 			mu.Lock()

--- a/internal/services/crossseed/episode_map_search_test.go
+++ b/internal/services/crossseed/episode_map_search_test.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package crossseed
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/services/arr"
+	"github.com/autobrr/qui/internal/services/jackett"
+	"github.com/autobrr/qui/pkg/stringutils"
+)
+
+// TestEpisodeMapSearchSendsSeasonedPairOnIDPath drives the search for an
+// absolute-numbered source through two recording Torznab servers. With a map,
+// the ID-capable indexer receives the mapped season and episode next to the
+// TVDb ID and no title query; the text indexer receives the title alone with
+// no season or episode, and the title retry passes stay unchanged. Without a
+// map the ID-capable indexer receives the ID alone.
+func TestEpisodeMapSearchSendsSeasonedPairOnIDPath(t *testing.T) {
+	const (
+		sourceHash = "9b3f0d8e5a1c4b7e2f6d0a9c8b7e6f5d4c3b2a10"
+		sourceName = "[KiraSubs] Azure Compass - 81 (1080p) [ABCD1234].mkv"
+	)
+
+	for _, tt := range []struct {
+		name       string
+		episodeMap *models.EpisodeMap
+	}{
+		{name: "with map", episodeMap: episodeMapS04E15},
+		{name: "without map"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var mu sync.Mutex
+			var idCapableRequests, textRequests []url.Values
+			newRecorder := func(requests *[]url.Values) *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					q := r.URL.Query()
+					if q.Get("t") != "caps" {
+						mu.Lock()
+						*requests = append(*requests, q)
+						mu.Unlock()
+					}
+					w.Header().Set("Content-Type", "application/rss+xml")
+					_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"><channel></channel></rss>`))
+				}))
+			}
+			idCapable := newRecorder(&idCapableRequests)
+			t.Cleanup(idCapable.Close)
+			text := newRecorder(&textRequests)
+			t.Cleanup(text.Close)
+
+			ctx := context.Background()
+			instance := &models.Instance{ID: 1, Name: "Test"}
+
+			sourceTorrent := qbt.Torrent{Hash: sourceHash, Name: sourceName, Progress: 1, Size: episodeMapSize, TotalSize: episodeMapSize, Tracker: "https://example.invalid/announce"}
+			tvCategories := []models.TorznabIndexerCategory{{IndexerID: 1, CategoryID: 5000, CategoryName: "TV"}, {IndexerID: 1, CategoryID: 5070, CategoryName: "TV/Anime"}}
+			svc := &Service{
+				instanceStore: &fakeInstanceStore{instances: map[int]*models.Instance{instance.ID: instance}},
+				arrService: &spyARRLookupService{result: &arr.ExternalIDsResult{
+					IDs:        &models.ExternalIDs{TVDbID: 424242},
+					EpisodeMap: tt.episodeMap,
+				}},
+				jackettService: jackett.NewService(&gettableIndexerStore{failingEnabledIndexerStore{indexers: []*models.TorznabIndexer{
+					{ID: 1, Name: "ID Capable Indexer", Enabled: true, BaseURL: idCapable.URL, Backend: models.TorznabBackendNative, Capabilities: []string{"search", "tv-search", "tv-search-tvdbid", "tv-search-season", "tv-search-ep"}, Categories: tvCategories},
+					{ID: 2, Name: "Text Indexer", Enabled: true, BaseURL: text.URL, Backend: models.TorznabBackendNative, Capabilities: []string{"search", "tv-search"}, Categories: tvCategories},
+				}}}, jackett.WithMinRequestInterval(time.Millisecond)),
+				syncManager: &gazelleSkipHashSyncManager{
+					torrents:    []qbt.Torrent{sourceTorrent},
+					filesByHash: map[string]qbt.TorrentFiles{sourceHash: {{Name: sourceName, Size: episodeMapSize, Progress: 1}}},
+				},
+				releaseCache:     NewReleaseCache(),
+				stringNormalizer: stringutils.NewDefaultNormalizer(),
+				automationSettingsLoader: func(context.Context) (*models.CrossSeedAutomationSettings, error) {
+					return models.DefaultCrossSeedAutomationSettings(), nil
+				},
+			}
+
+			_, _, _, err := svc.searchTorrentMatches(ctx, instance.ID, sourceHash, TorrentSearchOptions{IndexerIDs: []int{1, 2}}, nil)
+			require.NoError(t, err)
+
+			mu.Lock()
+			defer mu.Unlock()
+
+			var idQueries int
+			for _, p := range idCapableRequests {
+				if p.Get("tvdbid") == "" {
+					// Title retry pass: text mode, no mapped pair.
+					require.NotEmpty(t, p.Get("q"))
+					require.Empty(t, p.Get("season"), "a title retry must not carry the mapped season")
+					require.Empty(t, p.Get("ep"), "a title retry must not carry the mapped episode")
+					continue
+				}
+				idQueries++
+				require.Empty(t, p.Get("q"), "an ID query must not carry a title query")
+				if tt.episodeMap == nil {
+					require.Empty(t, p.Get("season"), "without a map the ID path sends the ID alone")
+					require.Empty(t, p.Get("ep"), "without a map the ID path sends the ID alone")
+					continue
+				}
+				require.Equal(t, "4", p.Get("season"), "the ID path must carry the mapped season")
+				require.Equal(t, "15", p.Get("ep"), "the ID path must carry the mapped episode")
+			}
+			require.Positive(t, idQueries, "ID-capable indexer must search by ID")
+
+			require.NotEmpty(t, textRequests)
+			for _, p := range textRequests {
+				require.NotEmpty(t, p.Get("q"), "text indexer must search by title")
+				require.Empty(t, p.Get("tvdbid"), "text indexer must never receive an ID param")
+				require.Empty(t, p.Get("season"), "text indexer must keep the title-only query")
+				require.Empty(t, p.Get("ep"), "text indexer must keep the title-only query")
+			}
+		})
+	}
+}

--- a/internal/services/crossseed/search_candidate_match.go
+++ b/internal/services/crossseed/search_candidate_match.go
@@ -340,7 +340,10 @@ func (s *Service) classifySearchCandidate(input searchCandidateInput) searchCand
 // names the equality for the decision trace.
 func applyEpisodeMap(input searchCandidateInput) (searchCandidateInput, string) {
 	episodeMap := input.EpisodeMap
-	if episodeMap == nil || episodeMap.Absolute <= 0 || input.Source.release == nil || input.Candidate.release == nil {
+	// A special maps to season 0, which would let a seasonless episode pose as
+	// the seasoned side; only a positive triple names two distinct schemes.
+	if episodeMap == nil || episodeMap.Season <= 0 || episodeMap.Episode <= 0 || episodeMap.Absolute <= 0 ||
+		input.Source.release == nil || input.Candidate.release == nil {
 		return input, ""
 	}
 	seasonless := func(r *rls.Release) bool { return r.Series == 0 && r.Episode == episodeMap.Absolute }

--- a/internal/services/crossseed/search_candidate_match.go
+++ b/internal/services/crossseed/search_candidate_match.go
@@ -4,6 +4,7 @@
 package crossseed
 
 import (
+	"fmt"
 	"maps"
 	"slices"
 	"strconv"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/moistari/rls"
 
+	"github.com/autobrr/qui/internal/models"
 	"github.com/autobrr/qui/pkg/releases"
 )
 
@@ -44,10 +46,14 @@ const (
 // searchCandidateInput contains the two release views and size evidence used by
 // search classification, alternate-query checks, and apply-time decision replay.
 type searchCandidateInput struct {
-	Source                 namedRelease
-	Candidate              namedRelease
-	SourceTitles           []string
-	CandidateTitles        []string
+	Source          namedRelease
+	Candidate       namedRelease
+	SourceTitles    []string
+	CandidateTitles []string
+	// EpisodeMap is the Sonarr triple for the release qui looked up (the search
+	// source or the announce). It equates a seasonless episode with its seasoned
+	// counterpart on the other side; see applyEpisodeMap.
+	EpisodeMap             *models.EpisodeMap
 	SourceSize             int64
 	CandidateSize          int64
 	TolerancePercent       float64
@@ -70,6 +76,7 @@ type searchCandidateDecision struct {
 	GroupFallbackIdentity string
 	SourceTitles          []string
 	CandidateTitles       []string
+	EpisodeMap            *models.EpisodeMap
 	RejectReason          string
 	StrictMismatchReason  string
 	RelaxedDifferences    []string
@@ -95,6 +102,7 @@ type searchDecisionProvenance struct {
 	GroupFallbackIdentity string
 	SourceTitles          []string
 	CandidateTitles       []string
+	EpisodeMap            *models.EpisodeMap
 }
 
 func (decision searchCandidateDecision) provenance() searchDecisionProvenance {
@@ -107,6 +115,7 @@ func (decision searchCandidateDecision) provenance() searchDecisionProvenance {
 		GroupFallbackIdentity: decision.GroupFallbackIdentity,
 		SourceTitles:          slices.Clone(decision.SourceTitles),
 		CandidateTitles:       slices.Clone(decision.CandidateTitles),
+		EpisodeMap:            decision.EpisodeMap,
 	}
 }
 
@@ -155,6 +164,7 @@ const (
 // Apply later uses the private decision provenance to replay the release
 // prefilter; normal torrent-file validation remains authoritative.
 func (s *Service) classifySearchCandidate(input searchCandidateInput) searchCandidateDecision {
+	input, mappedEpisode := applyEpisodeMap(input)
 	decision := searchCandidateDecision{
 		Class:               searchCandidateClassRejected,
 		SizeEvidence:        classifySearchSizeEvidence(input.SourceSize, input.CandidateSize),
@@ -280,11 +290,11 @@ func (s *Service) classifySearchCandidate(input searchCandidateInput) searchCand
 	decision.Class = class
 	decision.SourceTitles = slices.Clone(input.SourceTitles)
 	decision.CandidateTitles = slices.Clone(input.CandidateTitles)
+	decision.EpisodeMap = input.EpisodeMap
 	decision.Score, decision.MatchReason = evaluateReleaseMatch(input.Source.release, input.Candidate.release)
 	if decision.Score <= 0 {
 		decision.Score = 1
 	}
-
 	switch class {
 	case searchCandidateClassTitleRescue:
 		decision.MatchReason = "Title rescue · full check required"
@@ -314,8 +324,41 @@ func (s *Service) classifySearchCandidate(input searchCandidateInput) searchCand
 		}
 	case searchCandidateClassRejected:
 	}
+	if mappedEpisode != "" {
+		decision.MatchReason = mappedEpisode + "; " + decision.MatchReason
+	}
 
 	return decision
+}
+
+// applyEpisodeMap rewrites the seasonless side of a mixed-scheme pair to the
+// mapped season and episode when the map equates the two: the seasonless side
+// carries the map's absolute number and the seasoned side carries its season
+// and episode. The strict matcher then sees a same-scheme pair. Any other pair
+// is left alone, so same-scheme pairs and a tracker that numbers the episode
+// differently from Sonarr keep today's episode mismatch. The returned reason
+// names the equality for the decision trace.
+func applyEpisodeMap(input searchCandidateInput) (searchCandidateInput, string) {
+	episodeMap := input.EpisodeMap
+	if episodeMap == nil || episodeMap.Absolute <= 0 || input.Source.release == nil || input.Candidate.release == nil {
+		return input, ""
+	}
+	seasonless := func(r *rls.Release) bool { return r.Series == 0 && r.Episode == episodeMap.Absolute }
+	seasoned := func(r *rls.Release) bool { return r.Series == episodeMap.Season && r.Episode == episodeMap.Episode }
+	var side *namedRelease
+	switch {
+	case seasonless(input.Source.release) && seasoned(input.Candidate.release):
+		side = &input.Source
+	case seasonless(input.Candidate.release) && seasoned(input.Source.release):
+		side = &input.Candidate
+	default:
+		return input, ""
+	}
+	mapped := *side.release
+	mapped.Series = episodeMap.Season
+	mapped.Episode = episodeMap.Episode
+	side.release = &mapped
+	return input, fmt.Sprintf("mapped episode %d = S%02dE%02d", episodeMap.Absolute, episodeMap.Season, episodeMap.Episode)
 }
 
 func (s *Service) hasOneSidedChecksum(source, candidate *rls.Release) bool {
@@ -521,6 +564,7 @@ func (s *Service) searchCandidateMetadataConsistent(
 	actual namedRelease,
 	allowedDifferences []string,
 	actualTitles []string,
+	episodeMap *models.EpisodeMap,
 	findIndividualEpisodes bool,
 ) (bool, string) {
 	if advertisedName == "" || actual.release == nil {
@@ -560,8 +604,10 @@ func (s *Service) searchCandidateMetadataConsistent(
 			tagOrigin: actual.tagOrigin,
 		},
 		CandidateTitles:        slices.Clone(actualTitles),
+		EpisodeMap:             episodeMap,
 		FindIndividualEpisodes: findIndividualEpisodes,
 	}
+	input, _ = applyEpisodeMap(input)
 	matches, mismatchReason := s.releasesMatchWithReasonAndNamesAndTitles(
 		input.Source.release,
 		input.Candidate.release,

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -4336,7 +4336,7 @@ func (s *Service) findRSSAnnouncementMatches(ctx context.Context, result jackett
 	candidate := namedRelease{release: s.releaseCache.Parse(result.Title), rawName: result.Title}
 	// Resolve ARR aliases only when a torrent survives the exact-size gate
 	// below, so feed items with no byte-size collision never touch ARR.
-	aliasTitles := sync.OnceValue(func() []string {
+	aliasLookup := sync.OnceValues(func() ([]string, *models.EpisodeMap) {
 		return s.announceAliasTitles(ctx, result.Title, DetermineContentType(candidate.release).ContentType)
 	})
 	snapshots := (*automationSnapshots)(nil)
@@ -4371,11 +4371,13 @@ func (s *Service) findRSSAnnouncementMatches(ctx context.Context, result jackett
 				continue
 			}
 
+			aliasTitles, episodeMap := aliasLookup()
 			decision := s.classifyAnnouncementSource(ctx, snapshot.instance.ID, torrent, candidate, result.Size, announcementMatchPolicy{
 				findIndividualEpisodes: settings.FindIndividualEpisodes,
 				rescueTitleMismatches:  settings.RescueTitleMismatches && !settings.SkipRecheck,
 				allowUnknownSize:       false,
-				candidateTitles:        aliasTitles(),
+				candidateTitles:        aliasTitles,
+				episodeMap:             episodeMap,
 			})
 			if !decision.replayable || !decision.decision.Accepted {
 				continue
@@ -4710,8 +4712,9 @@ func (s *Service) findCandidates(ctx context.Context, req *FindCandidatesRequest
 
 		// getMatchTypeFromTitle builds season and episode keys from the existing
 		// torrent's file names. Record only the bound source whose accepted apply-time
-		// mismatch actually changed that structure; another stored hard cause must
-		// not grant this bypass by itself.
+		// mismatch actually changed that structure, or whose episode map equated two
+		// numbering schemes; another stored hard cause must not grant this bypass by
+		// itself.
 		structureRelaxedHash := ""
 
 		// Pre-filter torrents before loading files to reduce downstream work
@@ -4771,18 +4774,26 @@ func (s *Service) findCandidates(ctx context.Context, req *FindCandidatesRequest
 			// evidence. File matching and later safety checks still run.
 			var candidateAliasTitles []string
 			var targetAliasTitles []string
+			var episodeMap *models.EpisodeMap
 			if isSearchSource {
 				candidateAliasTitles = searchDecision.SourceTitles
 				// Announce-origin decisions resolve aliases for the incoming
 				// release, which is the target side here.
 				targetAliasTitles = searchDecision.CandidateTitles
+				episodeMap = searchDecision.EpisodeMap
 			}
-			fallbackInput := searchCandidateInput{
+			fallbackInput, mappedEpisode := applyEpisodeMap(searchCandidateInput{
 				Source:                 targetSide,
 				Candidate:              sourceSide,
 				SourceTitles:           targetAliasTitles,
 				CandidateTitles:        candidateAliasTitles,
+				EpisodeMap:             episodeMap,
 				FindIndividualEpisodes: req.FindIndividualEpisodes,
+			})
+			if mappedEpisode != "" {
+				// The file names still carry the other scheme, so the name-derived
+				// episode keys cannot line up; file sizes decide at apply.
+				structureRelaxedHash = hashKey
 			}
 			replaysExactDecision := isSearchSource &&
 				(searchDecision.Class == searchCandidateClassExactSizeFallback ||
@@ -4796,6 +4807,7 @@ func (s *Service) findCandidates(ctx context.Context, req *FindCandidatesRequest
 					targetSide,
 					searchDecision.RelaxedDifferences,
 					slices.Concat(searchDecision.SourceTitles, searchDecision.CandidateTitles),
+					searchDecision.EpisodeMap,
 					req.FindIndividualEpisodes,
 				); !ok {
 					continue
@@ -5354,7 +5366,7 @@ func (s *Service) applyAutobrrAnnouncement(ctx context.Context, announcedName st
 
 func (s *Service) findAutobrrAnnouncementMatches(ctx context.Context, announcedName string, actualSize int64, instances []*models.Instance, request *CrossSeedRequest, settings *models.CrossSeedAutomationSettings) []boundAnnouncementMatch {
 	candidate := namedRelease{release: s.releaseCache.Parse(announcedName), rawName: announcedName}
-	aliasTitles := s.announceAliasTitles(ctx, announcedName, DetermineContentType(candidate.release).ContentType)
+	aliasTitles, episodeMap := s.announceAliasTitles(ctx, announcedName, DetermineContentType(candidate.release).ContentType)
 	matches := make([]boundAnnouncementMatch, 0, len(instances))
 	for _, instance := range instances {
 		torrents, err := s.syncManager.GetCachedInstanceTorrents(ctx, instance.ID)
@@ -5384,6 +5396,7 @@ func (s *Service) findAutobrrAnnouncementMatches(ctx context.Context, announcedN
 				allowUnknownSize:       false,
 				skipRecheck:            request.SkipRecheck,
 				candidateTitles:        aliasTitles,
+				episodeMap:             episodeMap,
 			})
 			if !decision.replayable || !decision.decision.Accepted {
 				continue
@@ -8581,11 +8594,12 @@ func searchSourceSize(t *qbt.Torrent) int64 {
 // searchResultUsable reports whether the shared search classifier accepts a
 // primary-pass result. Keeping this a boolean projection prevents alternate-query
 // scheduling from drifting from the main result loop.
-func (s *Service) searchResultUsable(source, candidate namedRelease, sourceSize, candidateSize int64, arrTitles []string, tolerancePercent float64, findIndividualEpisodes bool) bool {
+func (s *Service) searchResultUsable(source, candidate namedRelease, sourceSize, candidateSize int64, arrTitles []string, episodeMap *models.EpisodeMap, tolerancePercent float64, findIndividualEpisodes bool) bool {
 	return s.classifySearchCandidate(searchCandidateInput{
 		Source:                 source,
 		Candidate:              candidate,
 		SourceTitles:           arrTitles,
+		EpisodeMap:             episodeMap,
 		SourceSize:             sourceSize,
 		CandidateSize:          candidateSize,
 		TolerancePercent:       tolerancePercent,
@@ -8599,11 +8613,11 @@ func (s *Service) searchResultUsable(source, candidate namedRelease, sourceSize,
 // filtering is still re-queried by the targeted retry passes, so a candidate
 // it carries under another title, spelling, or ID can surface instead of
 // being permanently suppressed.
-func (s *Service) indexersWithoutUsableResults(requestedIDs []int, results []jackett.SearchResult, source namedRelease, sourceSize int64, arrTitles []string, tolerancePercent float64, findIndividualEpisodes bool) []int {
+func (s *Service) indexersWithoutUsableResults(requestedIDs []int, results []jackett.SearchResult, source namedRelease, sourceSize int64, arrTitles []string, episodeMap *models.EpisodeMap, tolerancePercent float64, findIndividualEpisodes bool) []int {
 	usable := make([]jackett.SearchResult, 0, len(results))
 	for _, r := range results {
 		candidate := s.parseReleaseName(r.Title)
-		if s.searchResultUsable(source, namedRelease{release: candidate, rawName: r.Title}, sourceSize, r.Size, arrTitles, tolerancePercent, findIndividualEpisodes) {
+		if s.searchResultUsable(source, namedRelease{release: candidate, rawName: r.Title}, sourceSize, r.Size, arrTitles, episodeMap, tolerancePercent, findIndividualEpisodes) {
 			usable = append(usable, r)
 		}
 	}
@@ -8614,10 +8628,10 @@ func (s *Service) indexersWithoutUsableResults(requestedIDs []int, results []jac
 // size filtering. The retry ladder gates on this rather than on the raw result
 // count: hits that were all rejected leave the search just as empty as no hits
 // at all, so the retry that could still find the match has to run.
-func (s *Service) hasUsableSearchResult(results []jackett.SearchResult, source namedRelease, sourceSize int64, arrTitles []string, tolerancePercent float64, findIndividualEpisodes bool) bool {
+func (s *Service) hasUsableSearchResult(results []jackett.SearchResult, source namedRelease, sourceSize int64, arrTitles []string, episodeMap *models.EpisodeMap, tolerancePercent float64, findIndividualEpisodes bool) bool {
 	for _, result := range results {
 		candidate := s.parseReleaseName(result.Title)
-		if s.searchResultUsable(source, namedRelease{release: candidate, rawName: result.Title}, sourceSize, result.Size, arrTitles, tolerancePercent, findIndividualEpisodes) {
+		if s.searchResultUsable(source, namedRelease{release: candidate, rawName: result.Title}, sourceSize, result.Size, arrTitles, episodeMap, tolerancePercent, findIndividualEpisodes) {
 			return true
 		}
 	}
@@ -8632,6 +8646,7 @@ func clearSearchRequestIDs(req *jackett.TorznabSearchRequest) {
 	req.TVDbID = ""
 	req.TMDbID = 0
 	req.TVMazeID = 0
+	req.EpisodeMap = nil
 	req.OmitQueryForIDs = false
 }
 
@@ -9082,12 +9097,14 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 	// ARR-driven ID lookup for enhanced Torznab searching
 	var externalIDs *models.ExternalIDs
 	var arrTitles []string
+	var episodeMap *models.EpisodeMap
 	arrResult, queryDegraded := s.lookupARRExternalIDs(ctx, sourceTorrent.Name, contentInfo.ContentType)
 	if arrResult != nil {
 		if arrResult.IDs != nil && !arrResult.IDs.IsEmpty() {
 			externalIDs = arrResult.IDs
 		}
 		arrTitles = arrResult.Titles
+		episodeMap = arrResult.EpisodeMap
 	}
 
 	// When the arr path yields no ID, fall back to the external ID embedded in
@@ -9131,6 +9148,12 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 			searchReq.TVMazeID = externalIDs.TVMazeID
 		}
 		searchReq.OmitQueryForIDs = true // Cross-seed: omit q when IDs present
+		// An absolute-numbered source has an episode but no season, and Torznab
+		// ep counts within a season. The map gives ID-capable indexers the
+		// seasoned pair; text indexers keep the title-only query.
+		if seasonPtr == nil && episodePtr != nil && episodeMap != nil && episodeMap.Absolute == *episodePtr {
+			searchReq.EpisodeMap = episodeMap
+		}
 	}
 
 	if seasonPtr != nil {
@@ -9311,7 +9334,7 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 	// the first fallback to drop. This pass stays gated on the whole search:
 	// dropping the year fires on nearly every movie and has low per-indexer
 	// value, unlike the targeted passes below.
-	if !s.hasUsableSearchResult(searchResults, searchSource, searchSourceSize(sourceTorrent), arrTitles, tolerancePercent, opts.FindIndividualEpisodes) && searchReq.Year > 0 {
+	if !s.hasUsableSearchResult(searchResults, searchSource, searchSourceSize(sourceTorrent), arrTitles, episodeMap, tolerancePercent, opts.FindIndividualEpisodes) && searchReq.Year > 0 {
 		log.Debug().
 			Str("torrentName", sourceTorrent.Name).
 			Int("year", searchReq.Year).
@@ -9348,7 +9371,7 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 	// passes below.
 	if tagSourcedIDs {
 		idCapIndexerIDs := s.jackettService.IndexerIDsWithIDSearchCaps(waitCtx, searchReq)
-		rescueIndexerIDs := intersectInts(idCapIndexerIDs, s.indexersWithoutUsableResults(searchReq.IndexerIDs, searchResults, searchSource, searchSourceSize(sourceTorrent), arrTitles, tolerancePercent, opts.FindIndividualEpisodes))
+		rescueIndexerIDs := intersectInts(idCapIndexerIDs, s.indexersWithoutUsableResults(searchReq.IndexerIDs, searchResults, searchSource, searchSourceSize(sourceTorrent), arrTitles, episodeMap, tolerancePercent, opts.FindIndividualEpisodes))
 		if len(rescueIndexerIDs) > 0 {
 			log.Debug().
 				Str("torrentName", sourceTorrent.Name).
@@ -9392,7 +9415,7 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 	// the file, not a resolver, and the retry request drops them.
 	if !searchReq.OmitQueryForIDs || tagSourcedIDs {
 		if altTitle, ok := AlternateTitleQuery(searchReq.Query, searchRelease, arrTitles, sourceTorrent.Name); ok {
-			altTitleIndexerIDs := s.indexersWithoutUsableResults(searchReq.IndexerIDs, searchResults, searchSource, searchSourceSize(sourceTorrent), arrTitles, tolerancePercent, opts.FindIndividualEpisodes)
+			altTitleIndexerIDs := s.indexersWithoutUsableResults(searchReq.IndexerIDs, searchResults, searchSource, searchSourceSize(sourceTorrent), arrTitles, episodeMap, tolerancePercent, opts.FindIndividualEpisodes)
 			if len(altTitleIndexerIDs) > 0 {
 				log.Debug().
 					Str("torrentName", sourceTorrent.Name).
@@ -9438,7 +9461,7 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 	// primary keeps its title passes (see the alternate-title pass above).
 	if !opts.DisableTorznab && (!searchReq.OmitQueryForIDs || tagSourcedIDs) {
 		if altQuery, ok := alternateConnectorQuery(searchReq.Query); ok {
-			altIndexerIDs := s.indexersWithoutUsableResults(searchReq.IndexerIDs, searchResults, searchSource, searchSourceSize(sourceTorrent), arrTitles, tolerancePercent, opts.FindIndividualEpisodes)
+			altIndexerIDs := s.indexersWithoutUsableResults(searchReq.IndexerIDs, searchResults, searchSource, searchSourceSize(sourceTorrent), arrTitles, episodeMap, tolerancePercent, opts.FindIndividualEpisodes)
 			if len(altIndexerIDs) > 0 {
 				altReq := *searchReq
 				clearSearchRequestIDs(&altReq)
@@ -9515,6 +9538,7 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 			Source:                 searchSource,
 			Candidate:              namedRelease{release: candidateRelease, rawName: res.Title},
 			SourceTitles:           arrTitles,
+			EpisodeMap:             episodeMap,
 			SourceSize:             sourceSizeForSearch,
 			CandidateSize:          res.Size,
 			TolerancePercent:       tolerancePercent,
@@ -13931,7 +13955,7 @@ func (s *Service) CheckWebhook(ctx context.Context, req *WebhookCheckRequest) (*
 	// Describe the parsed content type for easier debugging and tuning.
 	contentInfo := DetermineContentType(incomingRelease)
 
-	aliasTitles := s.announceAliasTitles(ctx, req.TorrentName, contentInfo.ContentType)
+	aliasTitles, episodeMap := s.announceAliasTitles(ctx, req.TorrentName, contentInfo.ContentType)
 
 	log.Debug().
 		Str("source", "cross-seed.webhook").
@@ -14025,6 +14049,7 @@ func (s *Service) CheckWebhook(ctx context.Context, req *WebhookCheckRequest) (*
 				allowUnknownSize:         req.Size == 0,
 				skipRecheck:              settings.SkipRecheck,
 				candidateTitles:          aliasTitles,
+				episodeMap:               episodeMap,
 				tolerateOneSidedChecksum: true,
 			})
 			if !decision.decision.Accepted || decision.replayable != (req.Size > 0) {

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -9150,8 +9150,10 @@ func (s *Service) searchTorrentMatches(ctx context.Context, instanceID int, hash
 		searchReq.OmitQueryForIDs = true // Cross-seed: omit q when IDs present
 		// An absolute-numbered source has an episode but no season, and Torznab
 		// ep counts within a season. The map gives ID-capable indexers the
-		// seasoned pair; text indexers keep the title-only query.
-		if seasonPtr == nil && episodePtr != nil && episodeMap != nil && episodeMap.Absolute == *episodePtr {
+		// seasoned pair; text indexers keep the title-only query. Keyed on the
+		// parsed release, not the safe-query pointers, so a caller-supplied
+		// query still carries the map.
+		if searchRelease.Series == 0 && searchRelease.Episode > 0 && episodeMap != nil && episodeMap.Absolute == searchRelease.Episode {
 			searchReq.EpisodeMap = episodeMap
 		}
 	}

--- a/internal/services/jackett/models.go
+++ b/internal/services/jackett/models.go
@@ -6,6 +6,8 @@ package jackett
 import (
 	"slices"
 	"time"
+
+	"github.com/autobrr/qui/internal/models"
 )
 
 // TorznabSearchRequest represents a general Torznab search request
@@ -30,6 +32,11 @@ type TorznabSearchRequest struct {
 	Season *int `json:"season,omitempty"`
 	// Episode for TV shows (optional)
 	Episode *int `json:"episode,omitempty"`
+	// EpisodeMap carries the Sonarr season and episode for an absolute-numbered
+	// source. It reaches only the indexers that keep an ID parameter; text
+	// indexers keep the seasonless query, because a Cardigann text search folds
+	// SxxExx into keywords and hides absolute-numbered listings.
+	EpisodeMap *models.EpisodeMap `json:"-"`
 	// Artist for music searches (optional)
 	Artist string `json:"artist,omitempty"`
 	// Album for music searches (optional)

--- a/internal/services/jackett/service.go
+++ b/internal/services/jackett/service.go
@@ -2551,7 +2551,12 @@ func (s *Service) IndexerIDsWithIDSearchCaps(ctx context.Context, req *TorznabSe
 }
 
 func (s *Service) applyCapabilitySpecificParams(idx *models.TorznabIndexer, meta *searchContext, params map[string]string) {
-	if meta == nil || len(idx.Capabilities) == 0 || len(params) == 0 {
+	if meta == nil || len(params) == 0 {
+		return
+	}
+	if len(idx.Capabilities) == 0 {
+		// Unknown caps prune nothing, so every ID the request carries survives.
+		applyEpisodeMapParams(meta, params, hasTorznabIDParams(params))
 		return
 	}
 
@@ -2617,10 +2622,7 @@ func (s *Service) applyCapabilitySpecificParams(idx *models.TorznabIndexer, meta
 			Msg("Pruned unsupported ID parameters for indexer")
 	}
 
-	if hasIDsAfterPruning && meta.episodeMap != nil {
-		params["season"] = strconv.Itoa(meta.episodeMap.Season)
-		params["ep"] = strconv.Itoa(meta.episodeMap.Episode)
-	}
+	applyEpisodeMapParams(meta, params, hasIDsAfterPruning)
 
 	// If we had IDs but they were all pruned, restore q param for this indexer
 	if !hadIDs || hasIDsAfterPruning {
@@ -2643,6 +2645,16 @@ func (s *Service) applyCapabilitySpecificParams(idx *models.TorznabIndexer, meta
 			Str("query", restoredQuery).
 			Msg("Restored q parameter after all ID params were pruned for indexer")
 	}
+}
+
+// applyEpisodeMapParams adds the Sonarr-mapped season and ep for an indexer
+// that keeps an ID parameter. Text fallbacks never receive them.
+func applyEpisodeMapParams(meta *searchContext, params map[string]string, keepsIDs bool) {
+	if !keepsIDs || meta.episodeMap == nil {
+		return
+	}
+	params["season"] = strconv.Itoa(meta.episodeMap.Season)
+	params["ep"] = strconv.Itoa(meta.episodeMap.Episode)
 }
 
 // applyProwlarrWorkaround applies Prowlarr-specific query workarounds to search parameters.

--- a/internal/services/jackett/service.go
+++ b/internal/services/jackett/service.go
@@ -167,6 +167,8 @@ type searchContext struct {
 	// ID-driven movie or TV search. The category filter is dropped with it, but only
 	// for indexers that keep at least one usable ID.
 	omitCategoriesForIDs bool
+	// episodeMap adds season and ep for indexers that keep an ID parameter.
+	episodeMap *models.EpisodeMap
 }
 
 type searchPriorityKey struct{}
@@ -220,23 +222,24 @@ type searchCacheSignature struct {
 }
 
 type searchCacheKeyPayload struct {
-	SchemaVersion int         `json:"schema_version"`
-	Scope         string      `json:"scope"`
-	Query         string      `json:"query"`
-	Categories    []int       `json:"categories,omitempty"`
-	IndexerIDs    []int       `json:"indexer_ids,omitempty"`
-	Limit         int         `json:"limit,omitempty"`
-	IMDbID        string      `json:"imdb_id,omitempty"`
-	TVDbID        string      `json:"tvdb_id,omitempty"`
-	TMDbID        int         `json:"tmdb_id,omitempty"`
-	TVMazeID      int         `json:"tvmaze_id,omitempty"`
-	Year          int         `json:"year,omitempty"`
-	Season        *int        `json:"season,omitempty"`
-	Episode       *int        `json:"episode,omitempty"`
-	Artist        string      `json:"artist,omitempty"`
-	Album         string      `json:"album,omitempty"`
-	SearchMode    string      `json:"search_mode,omitempty"`
-	ContentType   contentType `json:"content_type"`
+	SchemaVersion int                `json:"schema_version"`
+	Scope         string             `json:"scope"`
+	Query         string             `json:"query"`
+	Categories    []int              `json:"categories,omitempty"`
+	IndexerIDs    []int              `json:"indexer_ids,omitempty"`
+	Limit         int                `json:"limit,omitempty"`
+	IMDbID        string             `json:"imdb_id,omitempty"`
+	TVDbID        string             `json:"tvdb_id,omitempty"`
+	TMDbID        int                `json:"tmdb_id,omitempty"`
+	TVMazeID      int                `json:"tvmaze_id,omitempty"`
+	Year          int                `json:"year,omitempty"`
+	Season        *int               `json:"season,omitempty"`
+	Episode       *int               `json:"episode,omitempty"`
+	EpisodeMap    *models.EpisodeMap `json:"episode_map,omitempty"`
+	Artist        string             `json:"artist,omitempty"`
+	Album         string             `json:"album,omitempty"`
+	SearchMode    string             `json:"search_mode,omitempty"`
+	ContentType   contentType        `json:"content_type"`
 }
 
 // TorrentDownloadRequest captures the metadata required to download (and cache) a torrent payload.
@@ -671,6 +674,7 @@ func (s *Service) performSearch(ctx context.Context, req *TorznabSearchRequest, 
 		originalQuery:           req.Query,
 
 		omitCategoriesForIDs: req.OmitQueryForIDs && !params.Has("q"),
+		episodeMap:           req.EpisodeMap,
 	}, RateLimitPriorityInteractive)
 
 	cacheEnabled := s.shouldUseSearchCache()
@@ -1204,6 +1208,7 @@ func (s *Service) buildSearchCacheSignature(scope string, req *TorznabSearchRequ
 		Year:          req.Year,
 		Season:        req.Season,
 		Episode:       req.Episode,
+		EpisodeMap:    req.EpisodeMap,
 		Artist:        strings.TrimSpace(req.Artist),
 		Album:         strings.TrimSpace(req.Album),
 		SearchMode:    searchMode,
@@ -2612,6 +2617,11 @@ func (s *Service) applyCapabilitySpecificParams(idx *models.TorznabIndexer, meta
 			Msg("Pruned unsupported ID parameters for indexer")
 	}
 
+	if hasIDsAfterPruning && meta.episodeMap != nil {
+		params["season"] = strconv.Itoa(meta.episodeMap.Season)
+		params["ep"] = strconv.Itoa(meta.episodeMap.Episode)
+	}
+
 	// If we had IDs but they were all pruned, restore q param for this indexer
 	if !hadIDs || hasIDsAfterPruning {
 		return
@@ -3040,9 +3050,8 @@ func (s *Service) buildSearchParams(req *TorznabSearchRequest, searchMode string
 
 	// Torznab ep counts within a season. An absolute-numbered anime episode has
 	// no season, and HDBits filters its TVDb search on the bare number and
-	// returns nothing. ponytail: the ID search returns the newest page and the
-	// matcher picks the episode; map absolute to season/episode via Sonarr if
-	// old episodes of long-running shows fall off that page.
+	// returns nothing. applyCapabilitySpecificParams adds the Sonarr-mapped pair
+	// for indexers that keep an ID.
 	if req.Episode != nil && req.Season != nil && *req.Season > 0 {
 		params.Set("ep", strconv.Itoa(*req.Episode))
 		log.Debug().


### PR DESCRIPTION
## Description

Adds the episode map consumers so an absolute-numbered anime episode (`Show - 81`) and its seasoned counterpart (`S04E15`) count as the same episode. The search sends the mapped season and episode to indexers that keep an ID parameter; text indexers and the title retry passes keep the title-only query. The matcher treats a mapped pair as a strict match in both directions, so the webhook check reports ready at a rounded announce size and a search result no longer needs a byte-equal size. No map, same-scheme pairs, and a tracker that numbers the episode differently from Sonarr behave as before.

The map rides the search decision provenance, and a mapped pair reaches file-level size matching at apply, because the file names still carry the other scheme and the name-derived episode keys cannot line up.

Fixes #2536

## How has this been tested?

Ran live on media with the `pr-2541` image (revision 8bca18c2) against the real Prowlarr and Sonarr, read-only. For an absolute-numbered One Piece episode in the library, Sonarr mapped it to S23E19, and Prowlarr history shows `season=23&ep=19` beside `tvdbid` for HDBits, BTN, Aither, LST, seedpool, Luminarr, Nebulance and BeyondHD; AnimeBytes and NorBits kept the title-only query. A webhook check for `One Piece S23E19 1080p WEB-DL AAC2.0 H.264-SubsPlease` at a rounded size returned `canCrossSeed: true` against that absolute-numbered torrent only; `S23E20` matched the next absolute episode only, and a different group stayed skip. The same announce on develop (`fd4d5b34`, producer without consumer) returned false.

Not exercised live: the search-side accept with the `mapped episode` reason (the only seasoned same-group listing came from an indexer the instance's content filter excludes for anime), the apply path, and a natural autobrr announce.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved cross-seed matching for anime episodes using absolute and season/episode numbering.
  * Searches can use Sonarr’s episode mapping with compatible indexers to improve discovery across numbering formats.
  * Mapped episodes can pass matching checks and continue through file validation when numbering differs.

* **Documentation**
  * Clarified how individual anime episodes are mapped between numbering schemes.
  * Clarified that season packs are not translated between numbering schemes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

