### PR TITLE
fix(releases): keep S23E19.Episode.1174 names as one episode

### DIFF
--- a/pkg/releases/parser.go
+++ b/pkg/releases/parser.go
@@ -112,16 +112,28 @@ func IsEpisodeRange(release *rls.Release) bool {
 	if release == nil {
 		return false
 	}
-	// Count distinct episodes, not entries: a file path names the same episode
-	// twice ("Show.S11E11-GRP/Show.S11E11-GRP.mkv") and that is still one episode.
-	// Only tags in the SxxEyy scheme count: "S23E19.Episode.1174" names one
-	// episode under two schemes, and rls lists both numbers as series tags.
-	// The %o verb is the tag's original capture (see rls.Tag.Format).
-	first := [2]int{-1, -1}
+	// Once a tag in the SxxEyy scheme is present, only those tags count:
+	// "S23E19.Episode.1174" names one episode under two schemes, and rls lists
+	// both numbers as series tags. An absolute-only name such as
+	// "Show - 01 - 12" keeps all its tags. The %o verb is the tag's original
+	// capture (see rls.Tag.Format).
+	var tags, scheme []rls.Tag
 	for _, tag := range release.Tags() {
-		if !tag.Is(rls.TagTypeSeries) || !seasonEpisodeScheme.MatchString(fmt.Sprintf("%o", tag)) {
+		if !tag.Is(rls.TagTypeSeries) {
 			continue
 		}
+		tags = append(tags, tag)
+		if seasonEpisodeScheme.MatchString(fmt.Sprintf("%o", tag)) {
+			scheme = append(scheme, tag)
+		}
+	}
+	if len(scheme) > 0 {
+		tags = scheme
+	}
+	// Count distinct episodes, not entries: a file path names the same episode
+	// twice ("Show.S11E11-GRP/Show.S11E11-GRP.mkv") and that is still one episode.
+	first := [2]int{-1, -1}
+	for _, tag := range tags {
 		series, _ := tag.Series()
 		for _, episode := range tag.Episodes() {
 			switch cur := [2]int{series, episode}; {

--- a/pkg/releases/parser.go
+++ b/pkg/releases/parser.go
@@ -4,8 +4,8 @@
 package releases
 
 import (
+	"fmt"
 	"regexp"
-	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -114,14 +114,30 @@ func IsEpisodeRange(release *rls.Release) bool {
 	}
 	// Count distinct episodes, not entries: a file path names the same episode
 	// twice ("Show.S11E11-GRP/Show.S11E11-GRP.mkv") and that is still one episode.
-	episodes := release.SeriesEpisodes()
-	if len(episodes) < 2 {
-		return false
+	// Only tags in the SxxEyy scheme count: "S23E19.Episode.1174" names one
+	// episode under two schemes, and rls lists both numbers as series tags.
+	// The %o verb is the tag's original capture (see rls.Tag.Format).
+	first := [2]int{-1, -1}
+	for _, tag := range release.Tags() {
+		if !tag.Is(rls.TagTypeSeries) || !seasonEpisodeScheme.MatchString(fmt.Sprintf("%o", tag)) {
+			continue
+		}
+		series, _ := tag.Series()
+		for _, episode := range tag.Episodes() {
+			switch cur := [2]int{series, episode}; {
+			case first[0] < 0:
+				first = cur
+			case cur != first:
+				return true
+			}
+		}
 	}
-	return slices.ContainsFunc(episodes, func(e []int) bool {
-		return !slices.Equal(e, episodes[0])
-	})
+	return false
 }
+
+// seasonEpisodeScheme matches the original capture of a series tag written as
+// S01E05, S01E05E06, 1x05, or a bare E06 continuation, and not as "Episode 6".
+var seasonEpisodeScheme = regexp.MustCompile(`(?i)^(?:[se]|\d+x)\d`)
 
 func enrichReleaseHDR(rawName string, release *rls.Release) {
 	if release == nil {

--- a/pkg/releases/parser_test.go
+++ b/pkg/releases/parser_test.go
@@ -227,4 +227,6 @@ func TestIsEpisodeRange(t *testing.T) {
 	require.True(t, IsEpisodeRange(parser.Parse("Show.Name.S01E05.E06.1080p.WEB-GRP")))
 	require.True(t, IsEpisodeRange(parser.Parse("Show.Name.1x05.1x06.1080p.WEB-GRP")))
 	require.True(t, IsEpisodeRange(parser.Parse("Show.Name.S01E01E02-GRP/Show.Name.Episode.1-2.mkv")))
+	// An absolute-only batch has no SxxEyy tag, so every tag counts.
+	require.True(t, IsEpisodeRange(parser.Parse("[Grp] Show Name - 01 - 12 [1080p]")))
 }

--- a/pkg/releases/parser_test.go
+++ b/pkg/releases/parser_test.go
@@ -216,4 +216,15 @@ func TestIsEpisodeRange(t *testing.T) {
 	// A path naming the same episode twice is one episode, not a range.
 	require.False(t, IsEpisodeRange(parser.Parse("Show.Name.S11E11.1080p.WEB-GRP/Show.Name.S11E11.1080p.WEB-GRP.mkv")))
 	require.False(t, IsEpisodeRange(nil))
+	// One episode named under two schemes (SxxEyy plus an absolute "Episode N")
+	// is not a range, even though rls lists both numbers in SeriesEpisodes.
+	release := parser.Parse("Sea.Voyage.S23E19.Episode.1174.1080p.CR.WEB-DL.DDP2.0.H.264-Grp.mkv")
+	require.False(t, IsEpisodeRange(release))
+	require.Equal(t, 19, release.Episode)
+	require.Equal(t, rls.Episode, release.Type)
+	// A bare E continuation, an NxNN pair, or a pack folder with an
+	// "Episode N" file name is still a range.
+	require.True(t, IsEpisodeRange(parser.Parse("Show.Name.S01E05.E06.1080p.WEB-GRP")))
+	require.True(t, IsEpisodeRange(parser.Parse("Show.Name.1x05.1x06.1080p.WEB-GRP")))
+	require.True(t, IsEpisodeRange(parser.Parse("Show.Name.S01E01E02-GRP/Show.Name.Episode.1-2.mkv")))
 }


### PR DESCRIPTION
## Description

A release that names one episode under two schemes, SxxEyy plus an absolute `Episode N`, was read as an episode range and so as a season pack. `IsEpisodeRange` now counts only series tags written in the SxxEyy or NxNN scheme. Real ranges (`S01E05E06`, `S00E02-E05`, `1x05.1x06`) and pack folders with `Episode N` file names stay packs.

Fixes #2542

## How has this been tested?

Live on the media server with the `pr-2543` image. A manual cross-seed search from an absolute-numbered `- 1174` source torrent, cache bypassed, before and after the swap. On `develop`, the `S23E19.Episode.1174` listing from two indexers was rejected with `season pack versus episode mismatch`. On this build the same listing passes the pack gate and the mapped episode gate and stops on `site mismatch`, which is the right terminal reason for a different release group. Real season packs in the same result set still reject as packs.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved episode-range detection for season-and-episode tags, including formats such as `S01E05`, `S01E05E06`, `1x05`, and bare `E06`.
  * Prevented duplicate path entries from inflating episode counts.
  * Corrected handling of episodes identified by both season/episode tags and absolute numbering.
  * Improved recognition of ranges in pack folders, continuation formats, and batches using only absolute episode numbers.
  * Prevented “Episode 6” identifiers from being misclassified as ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
