### PR TITLE
feat(torrents): sort the Content tab by name, size, progress, or priority

### DIFF
--- a/documentation/docs/features/torrent-management.md
+++ b/documentation/docs/features/torrent-management.md
@@ -90,6 +90,12 @@ Up to 10 torrents download as individual files. Larger selections download as on
 
 If some torrents fail to export, the archive still downloads. An `export-errors.txt` file inside the archive lists the failures.
 
+## Content tab sorting
+
+The **Content** tab of the details panel shows the files of a torrent as a folder tree. Click a column header (**Name**, **Progress**, **Size**, or **Priority**) to sort the rows by that column. Click the same header again to reverse the direction. The narrow layout shows the same four choices as a row of buttons above the file list.
+
+Folders always stay above files. A folder sorts by the total of its files. The **Priority** column appears only when the instance supports per-file priority. The sort resets to **Name** when you reload the page.
+
 ## MediaInfo
 
 The **Content** tab of the details panel offers a **MediaInfo** action on each file. It analyzes the file on disk and opens a dialog with two tabs: **Summary** and **Raw JSON**. **Copy Summary** and **Copy JSON** copy the report to the clipboard.

--- a/web/src/components/torrents/TorrentDetailsPanel.tsx
+++ b/web/src/components/torrents/TorrentDetailsPanel.tsx
@@ -23,6 +23,7 @@ import { usePersistedTabState } from "@/hooks/usePersistedTabState"
 import { scheduleTorrentListRefetches } from "@/hooks/useTorrentActions"
 import { api } from "@/lib/api"
 import { isHardlinkManaged, useLocalCrossSeedMatches } from "@/lib/cross-seed-utils"
+import { DEFAULT_FILE_SORT } from "@/lib/file-tree"
 import { getLinuxCategory, getLinuxComment, getLinuxCreatedBy, getLinuxFileName, getLinuxHash, getLinuxIsoName, getLinuxSavePath, getLinuxTags, getLinuxTracker, useIncognitoMode } from "@/lib/incognito"
 import { renderTextWithLinks } from "@/lib/linkUtils"
 import { formatSpeedWithUnit, useSpeedUnits } from "@/lib/speedUnits"
@@ -41,7 +42,7 @@ import { toast } from "sonner"
 import { CrossSeedTable, GeneralTabHorizontal, PeersTable, TorrentFileTable, TrackerContextMenu, TrackersTable, WebSeedsTable } from "./details"
 import { EditTrackerDialog, RenameTorrentFileDialog, RenameTorrentFolderDialog } from "./TorrentDialogs"
 import { TorrentFileMediaInfoDialog } from "./TorrentFileMediaInfoDialog"
-import { TorrentFileTree } from "./TorrentFileTree"
+import { TorrentFileSortBar, TorrentFileTree } from "./TorrentFileTree"
 
 interface TorrentDetailsPanelProps {
   instanceId: number;
@@ -93,6 +94,7 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
   const displayName = incognitoMode ? getLinuxIsoName(torrent?.hash ?? "") : torrent?.name
   const incognitoHash = incognitoMode && torrent?.hash ? getLinuxHash(torrent.hash) : undefined
   const [pendingFileIndices, setPendingFileIndices] = useState<Set<number>>(() => new Set())
+  const [fileSort, setFileSort] = useState(DEFAULT_FILE_SORT)
   const supportsFilePriority = capabilities?.supportsFilePriority ?? false
   const { data: instances } = useQuery({ queryKey: ["instances"], queryFn: () => api.getInstances(), staleTime: 60000 })
   const hasLocalFilesystemAccess = instances?.find(i => i.id === instanceId)?.hasLocalFilesystemAccess ?? false
@@ -1674,11 +1676,13 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
                     )}
                   </div>
                 </div>
+                <TorrentFileSortBar sort={fileSort} supportsFilePriority={supportsFilePriority} onSortChange={setFileSort} />
                 <ScrollArea className="flex-1 min-h-0 w-full [&>[data-slot=scroll-area-viewport]]:!overflow-x-hidden">
                   <div className="p-4 sm:p-6 pb-8">
                     <TorrentFileTree
                       key={torrent.hash}
                       files={files}
+                      sort={fileSort}
                       supportsFilePriority={supportsFilePriority}
                       pendingFileIndices={pendingFileIndices}
                       incognitoMode={incognitoMode}

--- a/web/src/components/torrents/TorrentFileTree.test.tsx
+++ b/web/src/components/torrents/TorrentFileTree.test.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { cleanup, fireEvent, render } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { TorrentFileSortBar } from "./TorrentFileTree"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+afterEach(cleanup)
+
+describe("TorrentFileSortBar", () => {
+  it("renders one button per column and toggles direction on the active one", () => {
+    const onSortChange = vi.fn()
+    const { getAllByRole, getByText } = render(
+      <TorrentFileSortBar sort={{ column: "size", direction: "asc" }} supportsFilePriority onSortChange={onSortChange} />
+    )
+    expect(getAllByRole("button").map(b => b.textContent)).toEqual([
+      "fileTable.headers.name",
+      "fileTable.headers.progress",
+      "fileTable.headers.size",
+      "filePriority.header",
+    ])
+
+    fireEvent.click(getByText("fileTable.headers.size"))
+    expect(onSortChange).toHaveBeenLastCalledWith({ column: "size", direction: "desc" })
+
+    fireEvent.click(getByText("fileTable.headers.name"))
+    expect(onSortChange).toHaveBeenLastCalledWith({ column: "name", direction: "asc" })
+  })
+
+  it("hides the priority button when the instance lacks per-file priority", () => {
+    const { queryByText } = render(
+      <TorrentFileSortBar sort={{ column: "name", direction: "asc" }} supportsFilePriority={false} onSortChange={() => {}} />
+    )
+    expect(queryByText("filePriority.header")).toBeNull()
+  })
+})

--- a/web/src/components/torrents/TorrentFileTree.test.tsx
+++ b/web/src/components/torrents/TorrentFileTree.test.tsx
@@ -26,6 +26,11 @@ describe("TorrentFileSortBar", () => {
       "filePriority.header",
     ])
 
+    const sizeButton = getByText("fileTable.headers.size").closest("button")!
+    expect(sizeButton.getAttribute("aria-pressed")).toBe("true")
+    expect(sizeButton.getAttribute("aria-label")).toBe("fileTable.headers.size, sort.ascending")
+    expect(getByText("fileTable.headers.name").closest("button")!.getAttribute("aria-pressed")).toBe("false")
+
     fireEvent.click(getByText("fileTable.headers.size"))
     expect(onSortChange).toHaveBeenLastCalledWith({ column: "size", direction: "desc" })
 

--- a/web/src/components/torrents/TorrentFileTree.tsx
+++ b/web/src/components/torrents/TorrentFileTree.tsx
@@ -87,20 +87,25 @@ export function TorrentFileSortBar({
   const { t } = useTranslation("torrents")
   return (
     <div className="flex flex-wrap gap-1 px-4 sm:px-6 py-1.5 border-b">
-      {SORT_COLUMNS.filter(({ column }) => supportsFilePriority || column !== "priority").map(({ column, labelKey }) => (
-        <button
-          key={column}
-          type="button"
-          className={cn(
-            "flex-1 h-9 flex items-center justify-center gap-1 rounded-md text-xs font-medium",
-            sort.column === column ? "bg-muted text-foreground" : "text-muted-foreground hover:bg-muted/50"
-          )}
-          onClick={() => onSortChange(toggleFileSort(sort, column))}
-        >
-          <span className="truncate">{t(labelKey)}</span>
-          {sort.column === column && <SortIcon sorted={sort.direction} />}
-        </button>
-      ))}
+      {SORT_COLUMNS.filter(({ column }) => supportsFilePriority || column !== "priority").map(({ column, labelKey }) => {
+        const active = sort.column === column
+        return (
+          <button
+            key={column}
+            type="button"
+            className={cn(
+              "flex-1 h-9 flex items-center justify-center gap-1 rounded-md text-xs font-medium",
+              active ? "bg-muted text-foreground" : "text-muted-foreground hover:bg-muted/50"
+            )}
+            aria-pressed={active}
+            aria-label={active ? `${t(labelKey)}, ${t(`sort.${sort.direction === "asc" ? "ascending" : "descending"}`)}` : undefined}
+            onClick={() => onSortChange(toggleFileSort(sort, column))}
+          >
+            <span className="truncate">{t(labelKey)}</span>
+            {active && <SortIcon sorted={sort.direction} />}
+          </button>
+        )
+      })}
     </div>
   )
 }

--- a/web/src/components/torrents/TorrentFileTree.tsx
+++ b/web/src/components/torrents/TorrentFileTree.tsx
@@ -6,10 +6,11 @@
 import { FilePrioritySelect } from "@/components/torrents/FilePrioritySelect"
 import { Checkbox } from "@/components/ui/checkbox"
 import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from "@/components/ui/context-menu"
+import { SortIcon } from "@/components/ui/sort-icon"
 import { useFileRangeSelection } from "@/hooks/useFileRangeSelection"
-import { FILE_PRIORITY, foldFolderPriority, normalizeFilePriority, type FolderPriority } from "@/lib/file-priority"
+import { buildFileTree, sortFileTree, toggleFileSort, type FileSort, type FileSortColumn, type FileTreeNode } from "@/lib/file-tree"
 import { reconcileExpandedFolders } from "@/lib/file-tree-expansion"
-import { getLinuxFileName, getLinuxSavePath } from "@/lib/incognito"
+import { getLinuxSavePath } from "@/lib/incognito"
 import { cn, copyTextToClipboard, formatBytes, joinPath } from "@/lib/utils"
 import type { TorrentFile } from "@/types"
 import { useVirtualizer } from "@tanstack/react-virtual"
@@ -20,6 +21,7 @@ import { toast } from "sonner"
 
 interface TorrentFileTreeProps {
   files: TorrentFile[]
+  sort: FileSort
   supportsFilePriority: boolean
   pendingFileIndices: Set<number>
   incognitoMode: boolean
@@ -36,133 +38,11 @@ interface TorrentFileTreeProps {
   onShowMediaInfo?: (file: TorrentFile) => void
 }
 
-interface FileTreeNode {
-  id: string
-  name: string
-  kind: "file" | "folder"
-  file?: TorrentFile
-  children?: FileTreeNode[]
-  totalSize: number
-  totalProgress: number
-  selectedCount: number
-  totalCount: number
-  priority: FolderPriority
-}
-
 interface FlatRow {
   node: FileTreeNode
   depth: number
   isExpanded: boolean
   hasChildren: boolean
-}
-
-function buildFileTree(
-  files: TorrentFile[],
-  incognitoMode: boolean,
-  torrentHash: string
-): { nodes: FileTreeNode[]; allFolderIds: string[] } {
-  const nodeMap = new Map<string, FileTreeNode>()
-  const roots: FileTreeNode[] = []
-  const allFolderIds: string[] = []
-
-  // Sort files by name for consistent ordering
-  const sortedFiles = [...files].sort((a, b) => a.name.localeCompare(b.name))
-
-  for (const file of sortedFiles) {
-    const segments = file.name.split("/").filter(Boolean)
-    let parentPath = ""
-
-    for (let i = 0; i < segments.length; i++) {
-      const segment = segments[i]
-      const currentPath = parentPath ? `${parentPath}/${segment}` : segment
-      const isLeaf = i === segments.length - 1
-
-      let node = nodeMap.get(currentPath)
-
-      if (!node) {
-        const displayName = incognitoMode && isLeaf? getLinuxFileName(torrentHash, file.index).split("/").pop() || segment: segment
-
-        node = {
-          id: currentPath,
-          name: displayName,
-          kind: isLeaf ? "file" : "folder",
-          file: isLeaf ? file : undefined,
-          children: isLeaf ? undefined : [],
-          totalSize: isLeaf ? file.size : 0,
-          totalProgress: isLeaf ? file.progress * file.size : 0,
-          selectedCount: isLeaf && file.priority !== 0 ? 1 : 0,
-          totalCount: isLeaf ? 1 : 0,
-          priority: isLeaf ? normalizeFilePriority(file.priority) : FILE_PRIORITY.normal,
-        }
-        nodeMap.set(currentPath, node)
-
-        if (!isLeaf) {
-          allFolderIds.push(currentPath)
-        }
-
-        if (parentPath) {
-          const parentNode = nodeMap.get(parentPath)
-          if (parentNode && parentNode.children) {
-            parentNode.children.push(node)
-          }
-        } else {
-          roots.push(node)
-        }
-      }
-
-      parentPath = currentPath
-    }
-  }
-
-  // Calculate aggregates bottom-up
-  function calculateAggregates(node: FileTreeNode): void {
-    if (node.kind === "folder" && node.children) {
-      let totalSize = 0
-      let totalProgress = 0
-      let selectedCount = 0
-      let totalCount = 0
-      let priority: FolderPriority | undefined
-
-      for (const child of node.children) {
-        calculateAggregates(child)
-        totalSize += child.totalSize
-        totalProgress += child.totalProgress
-        selectedCount += child.selectedCount
-        totalCount += child.totalCount
-        priority = priority === undefined ? child.priority : foldFolderPriority(priority, child.priority)
-      }
-
-      node.totalSize = totalSize
-      node.totalProgress = totalProgress
-      node.selectedCount = selectedCount
-      node.totalCount = totalCount
-      if (priority !== undefined) {
-        node.priority = priority
-      }
-
-      // Sort children: folders first, then files, both alphabetically
-      node.children.sort((a, b) => {
-        if (a.kind !== b.kind) {
-          return a.kind === "folder" ? -1 : 1
-        }
-        return a.name.localeCompare(b.name)
-      })
-    }
-  }
-
-  for (const root of roots) {
-    calculateAggregates(root)
-  }
-
-  // Sort roots: folders first, then files
-  roots.sort((a, b) => {
-    if (a.kind !== b.kind) {
-      return a.kind === "folder" ? -1 : 1
-    }
-    return a.name.localeCompare(b.name)
-  })
-
-  return { nodes: roots, allFolderIds }
 }
 
 function flattenTree(
@@ -186,8 +66,48 @@ function flattenTree(
   return rows
 }
 
+const SORT_COLUMNS: { column: FileSortColumn; labelKey: string }[] = [
+  { column: "name", labelKey: "fileTable.headers.name" },
+  { column: "progress", labelKey: "fileTable.headers.progress" },
+  { column: "size", labelKey: "fileTable.headers.size" },
+  { column: "priority", labelKey: "filePriority.header" },
+]
+
+// Sort control for the vertical layout, which has no header row to click.
+// Rendered by the details panel above the ScrollArea that holds the tree.
+export function TorrentFileSortBar({
+  sort,
+  supportsFilePriority,
+  onSortChange,
+}: {
+  sort: FileSort
+  supportsFilePriority: boolean
+  onSortChange: (sort: FileSort) => void
+}) {
+  const { t } = useTranslation("torrents")
+  return (
+    <div className="flex flex-wrap gap-1 px-4 sm:px-6 py-1.5 border-b">
+      {SORT_COLUMNS.filter(({ column }) => supportsFilePriority || column !== "priority").map(({ column, labelKey }) => (
+        <button
+          key={column}
+          type="button"
+          className={cn(
+            "flex-1 h-9 flex items-center justify-center gap-1 rounded-md text-xs font-medium",
+            sort.column === column ? "bg-muted text-foreground" : "text-muted-foreground hover:bg-muted/50"
+          )}
+          onClick={() => onSortChange(toggleFileSort(sort, column))}
+        >
+          <span className="truncate">{t(labelKey)}</span>
+          {sort.column === column && <SortIcon sorted={sort.direction} />}
+        </button>
+      ))}
+    </div>
+  )
+}
+
 export const TorrentFileTree = memo(function TorrentFileTree({
   files,
+  sort,
   supportsFilePriority,
   pendingFileIndices,
   incognitoMode,
@@ -206,23 +126,24 @@ export const TorrentFileTree = memo(function TorrentFileTree({
   const { t } = useTranslation("torrents")
   const scrollContainerRef = useRef<HTMLDivElement>(null)
 
-  const { nodes, allFolderIds } = useMemo(
+  const { nodes: unsortedNodes, folderIds } = useMemo(
     () => buildFileTree(files, incognitoMode, torrentHash),
     [files, incognitoMode, torrentHash]
   )
+  const nodes = useMemo(() => sortFileTree(unsortedNodes, sort), [unsortedNodes, sort])
 
   // Start with all folders expanded
   const [expandedFolders, setExpandedFolders] = useState<Set<string>>(
-    () => new Set(allFolderIds)
+    () => new Set(folderIds)
   )
-  const [knownFolderIds, setKnownFolderIds] = useState(allFolderIds)
+  const [knownFolderIds, setKnownFolderIds] = useState(folderIds)
 
   // Keep expandedFolders in sync when folder paths change (e.g., after rename);
   // render-time adjustment so the reconciled tree commits in one pass
-  if (knownFolderIds !== allFolderIds) {
-    setKnownFolderIds(allFolderIds)
+  if (knownFolderIds !== folderIds) {
+    setKnownFolderIds(folderIds)
     setExpandedFolders(
-      reconcileExpandedFolders(expandedFolders, new Set(knownFolderIds), new Set(allFolderIds))
+      reconcileExpandedFolders(expandedFolders, knownFolderIds, folderIds)
     )
   }
 

--- a/web/src/components/torrents/details/TorrentFileTable.tsx
+++ b/web/src/components/torrents/details/TorrentFileTable.tsx
@@ -199,16 +199,21 @@ export const TorrentFileTable = memo(function TorrentFileTable({
     resetKey: torrentHash,
   })
 
-  const sortHeader = (column: FileSortColumn, label: string, className: string) => (
-    <button
-      type="button"
-      className={cn("flex items-center gap-1 px-2 py-1.5 font-medium text-muted-foreground select-none hover:bg-muted/50", className)}
-      onClick={() => setSort(prev => toggleFileSort(prev, column))}
-    >
-      {label}
-      <SortIcon sorted={sort.column === column ? sort.direction : false} />
-    </button>
-  )
+  const sortHeader = (column: FileSortColumn, label: string, className: string) => {
+    const active = sort.column === column
+    return (
+      <button
+        type="button"
+        className={cn("flex items-center gap-1 px-2 py-1.5 font-medium text-muted-foreground select-none hover:bg-muted/50", className)}
+        aria-pressed={active}
+        aria-label={active ? `${label}, ${t(`sort.${sort.direction === "asc" ? "ascending" : "descending"}`)}` : undefined}
+        onClick={() => setSort(prev => toggleFileSort(prev, column))}
+      >
+        {label}
+        <SortIcon sorted={active ? sort.direction : false} />
+      </button>
+    )
+  }
 
   if (loading && !files) {
     return (

--- a/web/src/components/torrents/details/TorrentFileTable.tsx
+++ b/web/src/components/torrents/details/TorrentFileTable.tsx
@@ -8,11 +8,13 @@ import { Checkbox } from "@/components/ui/checkbox"
 import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from "@/components/ui/context-menu"
 import { Input } from "@/components/ui/input"
 import { Progress } from "@/components/ui/progress"
+import { SortIcon } from "@/components/ui/sort-icon"
 import { TruncatedText } from "@/components/ui/truncated-text"
 import { useFileRangeSelection } from "@/hooks/useFileRangeSelection"
-import { FILE_PRIORITY, foldFolderPriority, normalizeFilePriority, type FilePriorityValue, type FolderPriority } from "@/lib/file-priority"
+import type { FilePriorityValue } from "@/lib/file-priority"
+import { buildFileTree, DEFAULT_FILE_SORT, sortFileTree, toggleFileSort, type FileSortColumn, type FileTreeNode } from "@/lib/file-tree"
 import { reconcileExpandedFolders } from "@/lib/file-tree-expansion"
-import { getLinuxFileName, getLinuxFolderName, getLinuxSavePath } from "@/lib/incognito"
+import { getLinuxSavePath } from "@/lib/incognito"
 import { cn, copyTextToClipboard, formatBytes, joinPath } from "@/lib/utils"
 import type { TorrentFile } from "@/types"
 import { useVirtualizer } from "@tanstack/react-virtual"
@@ -40,134 +42,12 @@ interface TorrentFileTableProps {
   onShowMediaInfo?: (file: TorrentFile) => void
 }
 
-interface FileTreeNode {
-  id: string
-  name: string
-  kind: "file" | "folder"
-  file?: TorrentFile
-  children?: FileTreeNode[]
-  totalSize: number
-  totalProgress: number
-  selectedCount: number
-  totalCount: number
-  priority: FolderPriority
-}
-
 interface FlatRow {
   node: FileTreeNode
   depth: number
   isExpanded: boolean
   hasChildren: boolean
   isVisible: boolean
-}
-
-function buildFileTree(
-  files: TorrentFile[],
-  incognitoMode: boolean,
-  torrentHash: string
-): FileTreeNode[] {
-  const nodeMap = new Map<string, FileTreeNode>()
-  const roots: FileTreeNode[] = []
-
-  const sortedFiles = [...files].sort((a, b) => a.name.localeCompare(b.name))
-
-  for (const file of sortedFiles) {
-    const segments = file.name.split("/").filter(Boolean)
-    let parentPath = ""
-
-    for (let i = 0; i < segments.length; i++) {
-      const segment = segments[i]
-      const currentPath = parentPath ? `${parentPath}/${segment}` : segment
-      const isLeaf = i === segments.length - 1
-
-      let node = nodeMap.get(currentPath)
-
-      if (!node) {
-        let displayName: string
-        if (incognitoMode) {
-          if (isLeaf) {
-            displayName = getLinuxFileName(torrentHash, file.index).split("/").pop() || segment
-          } else {
-            displayName = getLinuxFolderName(torrentHash, i)
-          }
-        } else {
-          displayName = segment
-        }
-
-        node = {
-          id: currentPath,
-          name: displayName,
-          kind: isLeaf ? "file" : "folder",
-          file: isLeaf ? file : undefined,
-          children: isLeaf ? undefined : [],
-          totalSize: isLeaf ? file.size : 0,
-          totalProgress: isLeaf ? file.progress * file.size : 0,
-          selectedCount: isLeaf && file.priority !== 0 ? 1 : 0,
-          totalCount: isLeaf ? 1 : 0,
-          priority: isLeaf ? normalizeFilePriority(file.priority) : FILE_PRIORITY.normal,
-        }
-        nodeMap.set(currentPath, node)
-
-        if (parentPath) {
-          const parentNode = nodeMap.get(parentPath)
-          if (parentNode && parentNode.children) {
-            parentNode.children.push(node)
-          }
-        } else {
-          roots.push(node)
-        }
-      }
-
-      parentPath = currentPath
-    }
-  }
-
-  // Calculate aggregates bottom-up
-  function calculateAggregates(node: FileTreeNode): void {
-    if (node.kind === "folder" && node.children) {
-      node.children.forEach(calculateAggregates)
-      node.totalSize = node.children.reduce((sum, child) => sum + child.totalSize, 0)
-      node.totalProgress = node.children.reduce((sum, child) => sum + child.totalProgress, 0)
-      node.selectedCount = node.children.reduce((sum, child) => sum + child.selectedCount, 0)
-      node.totalCount = node.children.reduce((sum, child) => sum + child.totalCount, 0)
-      if (node.children.length > 0) {
-        node.priority = node.children.map(child => child.priority).reduce(foldFolderPriority)
-      }
-    }
-  }
-
-  roots.forEach(calculateAggregates)
-
-  // Sort nodes: folders first, then alphabetically within each type (natural sort)
-  function sortNodes(nodes: FileTreeNode[]): void {
-    nodes.sort((a, b) => {
-      // Folders before files
-      if (a.kind === "folder" && b.kind === "file") return -1
-      if (a.kind === "file" && b.kind === "folder") return 1
-      // Alphabetical within same type (natural sort)
-      return a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: "base" })
-    })
-    for (const node of nodes) {
-      if (node.children) sortNodes(node.children)
-    }
-  }
-  sortNodes(roots)
-
-  return roots
-}
-
-function collectFolderIds(nodes: FileTreeNode[]): Set<string> {
-  const ids = new Set<string>()
-  function walk(current: FileTreeNode[]) {
-    for (const node of current) {
-      if (node.kind === "folder") {
-        ids.add(node.id)
-        if (node.children) walk(node.children)
-      }
-    }
-  }
-  walk(nodes)
-  return ids
 }
 
 function flattenTree(
@@ -221,13 +101,14 @@ export const TorrentFileTable = memo(function TorrentFileTable({
   const { t } = useTranslation("torrents")
   const [expandedFolders, setExpandedFolders] = useState<Set<string>>(() => new Set())
   const [searchQuery, setSearchQuery] = useState("")
+  const [sort, setSort] = useState(DEFAULT_FILE_SORT)
   const scrollContainerRef = useRef<HTMLDivElement>(null)
 
-  const tree = useMemo(
-    () => (files ? buildFileTree(files, incognitoMode, torrentHash) : []),
+  const { nodes, folderIds } = useMemo(
+    () => buildFileTree(files ?? [], incognitoMode, torrentHash),
     [files, incognitoMode, torrentHash]
   )
-  const folderIds = useMemo(() => collectFolderIds(tree), [tree])
+  const tree = useMemo(() => sortFileTree(nodes, sort), [nodes, sort])
 
   // Expand all folders by default when tree is first built for a new torrent,
   // then keep the expanded set keyed to current paths (renames change node ids);
@@ -318,6 +199,17 @@ export const TorrentFileTable = memo(function TorrentFileTable({
     resetKey: torrentHash,
   })
 
+  const sortHeader = (column: FileSortColumn, label: string, className: string) => (
+    <button
+      type="button"
+      className={cn("flex items-center gap-1 px-2 py-1.5 font-medium text-muted-foreground select-none hover:bg-muted/50", className)}
+      onClick={() => setSort(prev => toggleFileSort(prev, column))}
+    >
+      {label}
+      <SortIcon sorted={sort.column === column ? sort.direction : false} />
+    </button>
+  )
+
   if (loading && !files) {
     return (
       <div className="flex items-center justify-center h-full">
@@ -384,12 +276,10 @@ export const TorrentFileTable = memo(function TorrentFileTable({
             {supportsFilePriority && (
               <div className="w-8 px-2 py-1.5 text-left shrink-0"></div>
             )}
-            <div className="flex-1 px-2 py-1.5 text-left font-medium text-muted-foreground">{t("fileTable.headers.name")}</div>
-            <div className="w-28 px-2 py-1.5 text-left font-medium text-muted-foreground shrink-0">{t("fileTable.headers.progress")}</div>
-            <div className="w-24 px-2 py-1.5 text-right font-medium text-muted-foreground shrink-0">{t("fileTable.headers.size")}</div>
-            {supportsFilePriority && (
-              <div className="w-36 px-2 py-1.5 text-left font-medium text-muted-foreground shrink-0">{t("filePriority.header")}</div>
-            )}
+            {sortHeader("name", t("fileTable.headers.name"), "flex-1")}
+            {sortHeader("progress", t("fileTable.headers.progress"), "w-28 shrink-0")}
+            {sortHeader("size", t("fileTable.headers.size"), "w-24 shrink-0 justify-end")}
+            {supportsFilePriority && sortHeader("priority", t("filePriority.header"), "w-36 shrink-0")}
           </div>
           {/* Virtualized body */}
           <div

--- a/web/src/lib/file-tree.test.ts
+++ b/web/src/lib/file-tree.test.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import type { TorrentFile } from "@/types"
+import { describe, expect, it } from "vitest"
+import { buildFileTree, DEFAULT_FILE_SORT, sortFileTree, type FileSort } from "./file-tree"
+
+function file(index: number, name: string, size: number, progress = 0, priority = 1): TorrentFile {
+  return { index, name, size, progress, priority, is_seed: false, piece_range: [0, 0], availability: 1 }
+}
+
+const files = [
+  file(0, "b.mkv", 300, 0.5, 1),
+  file(1, "a.mkv", 100, 1, 7),
+  file(2, "c10.mkv", 200, 0, 0),
+  file(3, "c2.mkv", 50, 0, 6),
+  file(4, "Sub/z.srt", 10, 1, 1),
+  file(5, "Sub/y.srt", 20, 0, 1),
+  file(6, "Big/x.bin", 1000, 0.25, 6),
+]
+
+function names(nodes: ReturnType<typeof buildFileTree>["nodes"]): string[] {
+  return nodes.map(n => n.name)
+}
+
+function sorted(sort: FileSort, incognito = false) {
+  return sortFileTree(buildFileTree(files, incognito, "hash").nodes, sort)
+}
+
+describe("buildFileTree", () => {
+  it("collects folder ids", () => {
+    expect(buildFileTree(files, false, "hash").folderIds).toEqual(new Set(["Big", "Sub"]))
+  })
+
+  it("aggregates folder size, progress and priority", () => {
+    const { nodes } = buildFileTree(files, false, "hash")
+    const sub = nodes.find(n => n.id === "Sub")!
+    expect(sub.totalSize).toBe(30)
+    expect(sub.totalProgress).toBe(10)
+    expect(sub.priority).toBe(1)
+    expect(sub.totalCount).toBe(2)
+    expect(new Set(sub.children?.map(n => n.id))).toEqual(new Set(["Sub/y.srt", "Sub/z.srt"]))
+  })
+
+  it("substitutes display names in incognito mode", () => {
+    const { nodes } = buildFileTree(files, true, "hash")
+    expect(nodes.some(n => n.name === "a.mkv" || n.name === "Sub")).toBe(false)
+  })
+})
+
+describe("sortFileTree", () => {
+  it("default order is folders first, then natural name ascending", () => {
+    const { nodes } = buildFileTree(files, false, "hash")
+    const out = sortFileTree(nodes, DEFAULT_FILE_SORT)
+    expect(names(out)).toEqual(["Big", "Sub", "a.mkv", "b.mkv", "c2.mkv", "c10.mkv"])
+    expect(out.find(n => n.id === "Sub")?.children?.map(n => n.id)).toEqual(["Sub/y.srt", "Sub/z.srt"])
+    expect(out).not.toBe(nodes)
+  })
+
+  it("name sort under incognito orders by the displayed names", () => {
+    const fileNames = names(sorted({ column: "name", direction: "asc" }, true).filter(n => n.kind === "file"))
+    expect(fileNames).toEqual([...fileNames].sort((a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" })))
+  })
+
+  it("keeps folders above files and reverses inside each group on desc", () => {
+    expect(names(sorted({ column: "name", direction: "desc" }))).toEqual(["Sub", "Big", "c10.mkv", "c2.mkv", "b.mkv", "a.mkv"])
+  })
+
+  it("sorts by size using folder aggregates", () => {
+    expect(names(sorted({ column: "size", direction: "asc" }))).toEqual(["Sub", "Big", "c2.mkv", "a.mkv", "c10.mkv", "b.mkv"])
+    expect(names(sorted({ column: "size", direction: "desc" }))).toEqual(["Big", "Sub", "b.mkv", "c10.mkv", "a.mkv", "c2.mkv"])
+  })
+
+  it("sorts by progress ratio, ties broken by name asc", () => {
+    // Sub 1/3, Big 1/4; files: a 1, b 0.5, c2 0, c10 0
+    expect(names(sorted({ column: "progress", direction: "desc" }))).toEqual(["Sub", "Big", "a.mkv", "b.mkv", "c2.mkv", "c10.mkv"])
+    expect(names(sorted({ column: "progress", direction: "asc" }))).toEqual(["Big", "Sub", "c2.mkv", "c10.mkv", "b.mkv", "a.mkv"])
+  })
+
+  it("sorts by numeric priority, mixed folders count as normal", () => {
+    const mixed = [...files, file(7, "Big/w.bin", 1, 0, 0)]
+    const out = sortFileTree(buildFileTree(mixed, false, "hash").nodes, { column: "priority", direction: "desc" })
+    // Big is mixed (6 + 0) -> 1, Sub is 1: tie -> name asc
+    expect(names(out)).toEqual(["Big", "Sub", "a.mkv", "c2.mkv", "b.mkv", "c10.mkv"])
+  })
+
+  it("sorts children recursively", () => {
+    const out = sorted({ column: "size", direction: "desc" })
+    const sub = out.find(n => n.id === "Sub")!
+    expect(sub.children?.map(n => n.id)).toEqual(["Sub/y.srt", "Sub/z.srt"])
+    const asc = sorted({ column: "size", direction: "asc" }).find(n => n.id === "Sub")!
+    expect(asc.children?.map(n => n.id)).toEqual(["Sub/z.srt", "Sub/y.srt"])
+  })
+})

--- a/web/src/lib/file-tree.ts
+++ b/web/src/lib/file-tree.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { FILE_PRIORITY, foldFolderPriority, normalizeFilePriority, type FolderPriority } from "@/lib/file-priority"
+import { getLinuxFileName, getLinuxFolderName } from "@/lib/incognito"
+import type { TorrentFile } from "@/types"
+
+export interface FileTreeNode {
+  id: string
+  name: string
+  kind: "file" | "folder"
+  file?: TorrentFile
+  children?: FileTreeNode[]
+  totalSize: number
+  totalProgress: number
+  selectedCount: number
+  totalCount: number
+  priority: FolderPriority
+}
+
+export type FileSortColumn = "name" | "size" | "progress" | "priority"
+
+export interface FileSort {
+  column: FileSortColumn
+  direction: "asc" | "desc"
+}
+
+// Name ascending is the order the tree had before headers became clickable.
+export const DEFAULT_FILE_SORT: FileSort = { column: "name", direction: "asc" }
+
+export function toggleFileSort(current: FileSort, column: FileSortColumn): FileSort {
+  if (current.column !== column) return { column, direction: "asc" }
+  return { column, direction: current.direction === "asc" ? "desc" : "asc" }
+}
+
+function compareName(a: FileTreeNode, b: FileTreeNode): number {
+  return a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: "base" })
+}
+
+function sortKey(node: FileTreeNode, column: FileSortColumn): number {
+  switch (column) {
+    case "size":
+      return node.totalSize
+    case "progress":
+      return node.totalSize > 0 ? node.totalProgress / node.totalSize : 0
+    case "priority":
+      return node.priority === "mixed" ? FILE_PRIORITY.normal : node.priority
+    default:
+      return 0
+  }
+}
+
+// Folders always sort above files. Inside each group the active column applies,
+// then name ascending breaks ties.
+function compareNodes(a: FileTreeNode, b: FileTreeNode, sort: FileSort): number {
+  if (a.kind !== b.kind) return a.kind === "folder" ? -1 : 1
+  const sign = sort.direction === "asc" ? 1 : -1
+  const primary = sort.column === "name" ? compareName(a, b) : sortKey(a, sort.column) - sortKey(b, sort.column)
+  return primary !== 0 ? sign * primary : compareName(a, b)
+}
+
+// Returns a new tree with every level reordered; the input nodes are not mutated.
+export function sortFileTree(nodes: FileTreeNode[], sort: FileSort): FileTreeNode[] {
+  return nodes
+    .map(node => (node.children ? { ...node, children: sortFileTree(node.children, sort) } : node))
+    .sort((a, b) => compareNodes(a, b, sort))
+}
+
+// Builds the folder tree for the Content tab with subtree aggregates on every
+// folder node. Nodes come back in file order; callers run sortFileTree.
+export function buildFileTree(
+  files: TorrentFile[],
+  incognitoMode: boolean,
+  torrentHash: string
+): { nodes: FileTreeNode[]; folderIds: Set<string> } {
+  const nodeMap = new Map<string, FileTreeNode>()
+  const roots: FileTreeNode[] = []
+  const folderIds = new Set<string>()
+
+  for (const file of files) {
+    const segments = file.name.split("/").filter(Boolean)
+    let parentPath = ""
+
+    for (let i = 0; i < segments.length; i++) {
+      const segment = segments[i]
+      const currentPath = parentPath ? `${parentPath}/${segment}` : segment
+      const isLeaf = i === segments.length - 1
+
+      if (!nodeMap.has(currentPath)) {
+        let displayName = segment
+        if (incognitoMode) {
+          displayName = isLeaf? getLinuxFileName(torrentHash, file.index).split("/").pop() || segment: getLinuxFolderName(torrentHash, i)
+        }
+
+        const node: FileTreeNode = {
+          id: currentPath,
+          name: displayName,
+          kind: isLeaf ? "file" : "folder",
+          file: isLeaf ? file : undefined,
+          children: isLeaf ? undefined : [],
+          totalSize: isLeaf ? file.size : 0,
+          totalProgress: isLeaf ? file.progress * file.size : 0,
+          selectedCount: isLeaf && file.priority !== 0 ? 1 : 0,
+          totalCount: isLeaf ? 1 : 0,
+          priority: isLeaf ? normalizeFilePriority(file.priority) : FILE_PRIORITY.normal,
+        }
+        nodeMap.set(currentPath, node)
+        if (!isLeaf) folderIds.add(currentPath)
+
+        if (parentPath) {
+          nodeMap.get(parentPath)?.children?.push(node)
+        } else {
+          roots.push(node)
+        }
+      }
+
+      parentPath = currentPath
+    }
+  }
+
+  function aggregate(node: FileTreeNode): void {
+    if (!node.children) return
+    node.children.forEach(aggregate)
+    node.totalSize = node.children.reduce((sum, child) => sum + child.totalSize, 0)
+    node.totalProgress = node.children.reduce((sum, child) => sum + child.totalProgress, 0)
+    node.selectedCount = node.children.reduce((sum, child) => sum + child.selectedCount, 0)
+    node.totalCount = node.children.reduce((sum, child) => sum + child.totalCount, 0)
+    if (node.children.length > 0) {
+      node.priority = node.children.map(child => child.priority).reduce(foldFolderPriority)
+    }
+  }
+  roots.forEach(aggregate)
+
+  return { nodes: roots, folderIds }
+}


### PR DESCRIPTION
## Description

Adds sortable columns to the torrent Content tab. Click a header (name, progress, size, priority) to sort, click again to reverse. The vertical layout gets a row of sort buttons above the file list because it has no header row. Folders stay above files and sort on their subtree totals.

Both file tree builders move into one shared module with the sort comparator. Merging them changes two things in the vertical tree: folder names under incognito now use the substitute names the wide table already used, and the default order uses natural number sorting.

Closes #2546

## How has this been tested?

Local rig with a stub qBittorrent and a 7-file synthetic torrent, driven in Chrome: size, progress, priority and name sorts produce the expected order in both layouts, a collapsed folder stays collapsed across a sort change, and the sort survives a file poll refresh. The vertical layout was then checked on a phone against the pr-2547 image on a real library.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added sorting controls to the torrent **Content** tab.
  - Sort files and folders by **Name**, **Progress**, **Size**, or **Priority**.
  - Select a column to sort ascending, or select it again to reverse the order.
  - Folders remain above files, with folder totals used for sorting.
  - Sorting controls adapt to narrow layouts, and **Priority** appears when supported.
  - Sorting resets to **Name** order after a page reload.

- **Documentation**
  - Added guidance covering Content tab sorting behavior and available options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
