### PR TITLE
fix(crossseed): resume fast verification rechecks that finish between polls

### DIFF
--- a/internal/services/crossseed/recheck_resume_test.go
+++ b/internal/services/crossseed/recheck_resume_test.go
@@ -878,85 +878,64 @@ func TestProcessPendingTitleRescueMonitorWaitsForFullProgress(t *testing.T) {
 	require.Empty(t, sync.bulkActions)
 }
 
-func TestProcessPendingRecheckResumeResumesFastVerificationRecheck(t *testing.T) {
+func TestProcessPendingRecheckResumeFastVerificationRecheck(t *testing.T) {
 	t.Parallel()
 
 	// A 100%-overlap recheck can finish between polls, so checking is never observed.
-	// Before the minimum elapsed time the entry keeps waiting; after it, a settled 100%
-	// must auto-resume instead of waiting out the absolute timeout (issue #2554).
+	// The entry must wait out the minimum elapsed time, resume a settled 100% after it,
+	// then reach the confirm-and-drop exit rather than the absolute timeout (issue #2554).
 	sync := &recheckResumeSyncManager{}
 	service := &Service{
 		syncManager:      sync,
 		recheckResumeCtx: context.Background(),
 	}
 	budget := int64(0)
-	settled := qbt.Torrent{
-		Hash:       "hash1",
-		Progress:   1,
-		AmountLeft: 0,
-		State:      qbt.TorrentStatePausedUp,
+	newPending := func(addedAt time.Time) *pendingResume {
+		return &pendingResume{
+			instanceID:           1,
+			hash:                 "hash1",
+			budgetBytes:          &budget,
+			verificationRequired: true,
+			addedAt:              addedAt,
+		}
 	}
+	settled := qbt.Torrent{Hash: "hash1", Progress: 1, AmountLeft: 0, State: qbt.TorrentStatePausedUp}
+	elapsedAgo := time.Now().Add(-2 * recheckFastCompleteMinElapsed)
 
 	// Too soon after queuing: the recheck may not have run, so stay paused.
-	tooSoon := &pendingResume{
-		instanceID:           1,
-		hash:                 "hash1",
-		budgetBytes:          &budget,
-		verificationRequired: true,
-		addedAt:              time.Now(),
-	}
-	keep := service.processPendingRecheckResume(1, "hash1", tooSoon, settled)
-	require.True(t, keep)
+	tooSoon := newPending(time.Now())
+	require.True(t, service.processPendingRecheckResume(1, "hash1", tooSoon, settled))
 	require.Zero(t, tooSoon.resumeAttempts, "a 100% result before the minimum elapsed time must not resume")
 	require.Empty(t, sync.bulkActions)
 
-	// Enough time has passed for the recheck to have run: resume after stable polls.
-	elapsed := &pendingResume{
-		instanceID:           1,
-		hash:                 "hash1",
-		budgetBytes:          &budget,
-		verificationRequired: true,
-		addedAt:              time.Now().Add(-2 * recheckFastCompleteMinElapsed),
-	}
-	keep = service.processPendingRecheckResume(1, "hash1", elapsed, settled)
-	require.True(t, keep)
+	// Below 100% after the elapsed gate: still fails closed, no resume.
+	belowFull := newPending(elapsedAgo)
+	underFull := settled
+	underFull.Progress = 0.99
+	require.True(t, service.processPendingRecheckResume(1, "hash1", belowFull, underFull))
+	require.Zero(t, belowFull.resumeAttempts, "an unverified sub-100% torrent stays queued, not resumed")
+	require.Empty(t, sync.bulkActions)
+
+	// Settled 100% after the elapsed gate: resume after the stable polls.
+	elapsed := newPending(elapsedAgo)
+	require.True(t, service.processPendingRecheckResume(1, "hash1", elapsed, settled))
 	require.Zero(t, elapsed.resumeAttempts, "the unobserved-checking path still waits for stable polls")
 
-	keep = service.processPendingRecheckResume(1, "hash1", elapsed, settled)
-	require.True(t, keep, "the worker keeps the entry until resume is confirmed")
+	require.True(t, service.processPendingRecheckResume(1, "hash1", elapsed, settled),
+		"the worker keeps the entry until resume is confirmed")
 	require.Equal(t, 1, elapsed.resumeAttempts, "a settled 100% after the minimum elapsed time resumes")
+	require.True(t, elapsed.awaitingResumeConfirmation)
 	require.Equal(t, []string{"resume:hash1"}, sync.bulkActions)
-}
 
-func TestProcessPendingRecheckResumeFastPathStaysClosedBelowFull(t *testing.T) {
-	t.Parallel()
-
-	// The fast-recheck fallback only trusts a 100% result. Below 100% with no checking
-	// observed it must still fail closed, even after the minimum elapsed time (no
-	// regression on the safety property, issue #2554).
-	sync := &recheckResumeSyncManager{}
-	service := &Service{
-		syncManager:      sync,
-		recheckResumeCtx: context.Background(),
-	}
-	budget := int64(0)
-	pending := &pendingResume{
-		instanceID:           1,
-		hash:                 "hash1",
-		budgetBytes:          &budget,
-		verificationRequired: true,
-		addedAt:              time.Now().Add(-2 * recheckFastCompleteMinElapsed),
-	}
-
-	keep := service.processPendingRecheckResume(1, "hash1", pending, qbt.Torrent{
-		Hash:       "hash1",
-		Progress:   0.99,
-		AmountLeft: 0,
-		State:      qbt.TorrentStatePausedUp,
-	})
-	require.True(t, keep, "an unverified sub-100% torrent stays queued, not resumed")
-	require.Zero(t, pending.resumeAttempts)
-	require.Empty(t, sync.bulkActions)
+	// The torrent is now running: the worker must confirm the resume and drop the entry,
+	// not poll it for the full timeout and mislog it as left paused.
+	running := settled
+	running.State = qbt.TorrentStateUploading
+	require.True(t, service.processPendingRecheckResume(1, "hash1", elapsed, running),
+		"kept for one running poll while the resume is confirmed")
+	require.False(t, service.processPendingRecheckResume(1, "hash1", elapsed, running),
+		"a stable running state confirms the resume and drops the entry")
+	require.Equal(t, []string{"resume:hash1"}, sync.bulkActions, "no duplicate resume once running")
 }
 
 func TestProcessPendingRecheckResumeForgivenessRetriesAfterNegativeVerdict(t *testing.T) {

--- a/internal/services/crossseed/recheck_resume_test.go
+++ b/internal/services/crossseed/recheck_resume_test.go
@@ -878,6 +878,87 @@ func TestProcessPendingTitleRescueMonitorWaitsForFullProgress(t *testing.T) {
 	require.Empty(t, sync.bulkActions)
 }
 
+func TestProcessPendingRecheckResumeResumesFastVerificationRecheck(t *testing.T) {
+	t.Parallel()
+
+	// A 100%-overlap recheck can finish between polls, so checking is never observed.
+	// Before the minimum elapsed time the entry keeps waiting; after it, a settled 100%
+	// must auto-resume instead of waiting out the absolute timeout (issue #2554).
+	sync := &recheckResumeSyncManager{}
+	service := &Service{
+		syncManager:      sync,
+		recheckResumeCtx: context.Background(),
+	}
+	budget := int64(0)
+	settled := qbt.Torrent{
+		Hash:       "hash1",
+		Progress:   1,
+		AmountLeft: 0,
+		State:      qbt.TorrentStatePausedUp,
+	}
+
+	// Too soon after queuing: the recheck may not have run, so stay paused.
+	tooSoon := &pendingResume{
+		instanceID:           1,
+		hash:                 "hash1",
+		budgetBytes:          &budget,
+		verificationRequired: true,
+		addedAt:              time.Now(),
+	}
+	keep := service.processPendingRecheckResume(1, "hash1", tooSoon, settled)
+	require.True(t, keep)
+	require.Zero(t, tooSoon.resumeAttempts, "a 100% result before the minimum elapsed time must not resume")
+	require.Empty(t, sync.bulkActions)
+
+	// Enough time has passed for the recheck to have run: resume after stable polls.
+	elapsed := &pendingResume{
+		instanceID:           1,
+		hash:                 "hash1",
+		budgetBytes:          &budget,
+		verificationRequired: true,
+		addedAt:              time.Now().Add(-2 * recheckFastCompleteMinElapsed),
+	}
+	keep = service.processPendingRecheckResume(1, "hash1", elapsed, settled)
+	require.True(t, keep)
+	require.Zero(t, elapsed.resumeAttempts, "the unobserved-checking path still waits for stable polls")
+
+	keep = service.processPendingRecheckResume(1, "hash1", elapsed, settled)
+	require.True(t, keep, "the worker keeps the entry until resume is confirmed")
+	require.Equal(t, 1, elapsed.resumeAttempts, "a settled 100% after the minimum elapsed time resumes")
+	require.Equal(t, []string{"resume:hash1"}, sync.bulkActions)
+}
+
+func TestProcessPendingRecheckResumeFastPathStaysClosedBelowFull(t *testing.T) {
+	t.Parallel()
+
+	// The fast-recheck fallback only trusts a 100% result. Below 100% with no checking
+	// observed it must still fail closed, even after the minimum elapsed time (no
+	// regression on the safety property, issue #2554).
+	sync := &recheckResumeSyncManager{}
+	service := &Service{
+		syncManager:      sync,
+		recheckResumeCtx: context.Background(),
+	}
+	budget := int64(0)
+	pending := &pendingResume{
+		instanceID:           1,
+		hash:                 "hash1",
+		budgetBytes:          &budget,
+		verificationRequired: true,
+		addedAt:              time.Now().Add(-2 * recheckFastCompleteMinElapsed),
+	}
+
+	keep := service.processPendingRecheckResume(1, "hash1", pending, qbt.Torrent{
+		Hash:       "hash1",
+		Progress:   0.99,
+		AmountLeft: 0,
+		State:      qbt.TorrentStatePausedUp,
+	})
+	require.True(t, keep, "an unverified sub-100% torrent stays queued, not resumed")
+	require.Zero(t, pending.resumeAttempts)
+	require.Empty(t, sync.bulkActions)
+}
+
 func TestProcessPendingRecheckResumeForgivenessRetriesAfterNegativeVerdict(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/crossseed/recheck_resume_test.go
+++ b/internal/services/crossseed/recheck_resume_test.go
@@ -411,6 +411,127 @@ func TestProcessPendingRecheckResumeConfirmationStates(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Legitimate fast recheck: a 100%-overlap recheck finishes between polls,
+			// so the only checking state ever observed is the normal forced-recheck
+			// startup (checkingResumeData), with no prior piece check. That must not
+			// be mistaken for a restart interruption: once the fast-complete delay
+			// has passed, a settled 100% has to resume and then confirm-and-drop.
+			// Regression for the case that stayed paused for the full timeout.
+			name: "fast resume when only resume-data validation is observed",
+			initial: pendingResume{
+				instanceID:           1,
+				hash:                 "hash1",
+				threshold:            1.0,
+				addedAt:              now.Add(-2 * recheckFastCompleteMinElapsed),
+				verificationRequired: true,
+			},
+			steps: []resumeStep{
+				{
+					torrent: qbt.Torrent{
+						Hash:       "hash1",
+						Progress:   1.0,
+						AmountLeft: 0,
+						State:      qbt.TorrentStateCheckingResumeData,
+					},
+					keep: true,
+				},
+				{
+					torrent: qbt.Torrent{
+						Hash:       "hash1",
+						Progress:   1.0,
+						AmountLeft: 0,
+						State:      qbt.TorrentStatePausedUp,
+					},
+					keep: true,
+				},
+				{
+					torrent: qbt.Torrent{
+						Hash:       "hash1",
+						Progress:   1.0,
+						AmountLeft: 0,
+						State:      qbt.TorrentStatePausedUp,
+					},
+					keep:                       true,
+					awaitingResumeConfirmation: true,
+					resumeAttempts:             1,
+					bulkActions:                []string{"resume:hash1"},
+				},
+				{
+					torrent: qbt.Torrent{
+						Hash:     "hash1",
+						Progress: 1.0,
+						State:    qbt.TorrentStateUploading,
+					},
+					keep:                       true,
+					awaitingResumeConfirmation: true,
+					resumeAttempts:             1,
+					bulkActions:                []string{"resume:hash1"},
+				},
+				{
+					torrent: qbt.Torrent{
+						Hash:     "hash1",
+						Progress: 1.0,
+						State:    qbt.TorrentStateUploading,
+					},
+					keep:                       false,
+					awaitingResumeConfirmation: true,
+					resumeAttempts:             1,
+					bulkActions:                []string{"resume:hash1"},
+				},
+			},
+		},
+		{
+			// Restart protection: a checkingResumeData poll that follows an observed
+			// piece check is a genuine qBittorrent restart. Even after the
+			// fast-complete delay, a later settled 100% must stay paused because the
+			// interrupted check no longer proves the recheck ran.
+			name: "interrupted piece check stays paused after fast-complete delay",
+			initial: pendingResume{
+				instanceID:           1,
+				hash:                 "hash1",
+				threshold:            1.0,
+				addedAt:              now.Add(-2 * recheckFastCompleteMinElapsed),
+				verificationRequired: true,
+			},
+			steps: []resumeStep{
+				{
+					torrent: qbt.Torrent{
+						Hash:     "hash1",
+						Progress: 0.5,
+						State:    qbt.TorrentStateCheckingUp,
+					},
+					keep: true,
+				},
+				{
+					torrent: qbt.Torrent{
+						Hash:       "hash1",
+						Progress:   1.0,
+						AmountLeft: 0,
+						State:      qbt.TorrentStateCheckingResumeData,
+					},
+					keep: true,
+				},
+				{
+					torrent: qbt.Torrent{
+						Hash:       "hash1",
+						Progress:   1.0,
+						AmountLeft: 0,
+						State:      qbt.TorrentStatePausedUp,
+					},
+					keep: true,
+				},
+				{
+					torrent: qbt.Torrent{
+						Hash:       "hash1",
+						Progress:   1.0,
+						AmountLeft: 0,
+						State:      qbt.TorrentStatePausedUp,
+					},
+					keep: true,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/services/crossseed/recheck_resume_test.go
+++ b/internal/services/crossseed/recheck_resume_test.go
@@ -938,6 +938,55 @@ func TestProcessPendingRecheckResumeFastVerificationRecheck(t *testing.T) {
 	require.Equal(t, []string{"resume:hash1"}, sync.bulkActions, "no duplicate resume once running")
 }
 
+func TestProcessPendingRecheckResumeInterruptedVerification(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name                       string
+		awaitingResumeConfirmation bool
+	}{
+		{name: "waiting for verification"},
+		{name: "waiting for resume confirmation", awaitingResumeConfirmation: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sync := &recheckResumeSyncManager{}
+			service := &Service{syncManager: sync}
+			pending := &pendingResume{
+				instanceID:                 1,
+				hash:                       "hash1",
+				budgetBytes:                new(int64),
+				verificationRequired:       true,
+				addedAt:                    time.Now().Add(-2 * recheckFastCompleteMinElapsed),
+				awaitingResumeConfirmation: tt.awaitingResumeConfirmation,
+			}
+			checking := qbt.Torrent{Hash: "hash1", Progress: 0.5, State: qbt.TorrentStateCheckingUp}
+			require.True(t, service.processPendingRecheckResume(1, "hash1", pending, checking))
+			require.True(t, pending.sawChecking)
+
+			// A restart invalidates the piece check and any pending resume confirmation.
+			restarted := qbt.Torrent{Hash: "hash1", Progress: 1, AmountLeft: 0, State: qbt.TorrentStateCheckingResumeData}
+			require.True(t, service.processPendingRecheckResume(1, "hash1", pending, restarted))
+			require.False(t, pending.sawChecking)
+			require.False(t, pending.awaitingResumeConfirmation)
+
+			// The old queue timestamp must not permit resume from saved completion data.
+			settled := restarted
+			settled.State = qbt.TorrentStatePausedUp
+			for range recheckResumeStablePolls {
+				require.True(t, service.processPendingRecheckResume(1, "hash1", pending, settled))
+			}
+			require.Empty(t, sync.bulkActions)
+
+			// A new observed piece check can still permit resume after completion.
+			require.True(t, service.processPendingRecheckResume(1, "hash1", pending, checking))
+			require.True(t, service.processPendingRecheckResume(1, "hash1", pending, settled))
+			require.Equal(t, []string{"resume:hash1"}, sync.bulkActions)
+		})
+	}
+}
+
 func TestProcessPendingRecheckResumeForgivenessRetriesAfterNegativeVerdict(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -287,7 +287,11 @@ const (
 	recheckAPITimeout                     = 30 * time.Second
 	maxRecheckResumeAttempts              = 3
 	recheckResumeStablePolls              = 2
-	maxMissingFilesResumeAttempts         = 3
+	// recheckFastCompleteMinElapsed is how long after queuing a verification-required
+	// entry may resume on a settled 100% that never showed a checking state: long enough
+	// that the recheck qui issued is treated as having run (#2554), short of the 60m timeout.
+	recheckFastCompleteMinElapsed = 30 * time.Second
+	maxMissingFilesResumeAttempts = 3
 	// Forgiveness ceiling for byte-budget auto-resume: even when every missing
 	// file is an irrelevant sidecar, never auto-resume above this much missing data.
 	irrelevantResumeForgivenessCapBytes   = int64(200) << 20
@@ -6760,7 +6764,17 @@ func (s *Service) processPendingRecheckResume(instanceID int, hash string, req *
 		req.forgivenessGranted = false
 	}
 	if req.verificationRequired && !req.sawChecking {
-		return true
+		// A fast (100%-overlap) recheck can finish between polls, so checking is never
+		// observed and this would wait out recheckAbsoluteTimeout. After the heuristic
+		// delay, treat a settled 100% as verified and fall through to the normal resume
+		// path (still gated by recheckResumeStablePolls); monitorOnly never resumes.
+		fastRecheckComplete := !req.monitorOnly &&
+			isPausedOrStopped(state) &&
+			torrent.Progress >= 1 && torrent.AmountLeft <= 0 &&
+			time.Since(req.addedAt) >= recheckFastCompleteMinElapsed
+		if !fastRecheckComplete {
+			return true
+		}
 	}
 	if req.monitorOnly {
 		if isChecking {

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -287,11 +287,12 @@ const (
 	recheckAPITimeout                     = 30 * time.Second
 	maxRecheckResumeAttempts              = 3
 	recheckResumeStablePolls              = 2
+	maxMissingFilesResumeAttempts         = 3
 	// recheckFastCompleteMinElapsed is how long after queuing a verification-required
 	// entry may resume on a settled 100% that never showed a checking state: long enough
-	// that the recheck qui issued is treated as having run (#2554), short of the 60m timeout.
+	// that the recheck qui issued is treated as having run (#2554), well short of
+	// recheckAbsoluteTimeout.
 	recheckFastCompleteMinElapsed = 30 * time.Second
-	maxMissingFilesResumeAttempts = 3
 	// Forgiveness ceiling for byte-budget auto-resume: even when every missing
 	// file is an irrelevant sidecar, never auto-resume above this much missing data.
 	irrelevantResumeForgivenessCapBytes   = int64(200) << 20
@@ -487,8 +488,9 @@ type pendingResume struct {
 	monitorOnly bool
 	// verificationRequired marks an ambiguous search match that must not trust
 	// qBittorrent's optimistic pre-check completion state. The WebUI API exposes
-	// no recheck generation, so the worker must first observe checking, then a
-	// 100% result. A transition missed between polls fails closed and stays paused.
+	// no recheck generation, so the worker observes checking, then a 100% result.
+	// A checking transition missed between polls falls back to a settled 100% once
+	// recheckFastCompleteMinElapsed has passed since queuing; below that it stays paused.
 	verificationRequired bool
 	// threshold is the verified-progress fraction required to resume.
 	// Used by the season-pack flow, whose gate is "linked bytes verified".
@@ -6763,15 +6765,15 @@ func (s *Service) processPendingRecheckResume(instanceID int, hash string, req *
 		// saw; the verdict must be re-earned from post-check file progress.
 		req.forgivenessGranted = false
 	}
-	if req.verificationRequired && !req.sawChecking {
+	if req.verificationRequired && !req.sawChecking && !req.awaitingResumeConfirmation {
 		// A fast (100%-overlap) recheck can finish between polls, so checking is never
 		// observed and this would wait out recheckAbsoluteTimeout. After the heuristic
 		// delay, treat a settled 100% as verified and fall through to the normal resume
-		// path (still gated by recheckResumeStablePolls); monitorOnly never resumes.
-		fastRecheckComplete := !req.monitorOnly &&
-			isPausedOrStopped(state) &&
-			torrent.Progress >= 1 && torrent.AmountLeft <= 0 &&
-			time.Since(req.addedAt) >= recheckFastCompleteMinElapsed
+		// path (still gated by recheckResumeStablePolls); monitorOnly never resumes. Once
+		// resume is issued, awaitingResumeConfirmation takes over so the entry is
+		// confirmed and dropped rather than waiting out the timeout while it runs.
+		fastRecheckComplete := !req.monitorOnly && isPausedOrStopped(state) &&
+			satisfied() && time.Since(req.addedAt) >= recheckFastCompleteMinElapsed
 		if !fastRecheckComplete {
 			return true
 		}

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -513,8 +513,10 @@ type pendingResume struct {
 	resumeAttempts             int
 	awaitingResumeConfirmation bool
 	sawChecking                bool
-	readyPolls                 int
-	resumeConfirmedPolls       int
+	// recheckInterrupted disables the timed fallback after resume-data validation.
+	recheckInterrupted   bool
+	readyPolls           int
+	resumeConfirmedPolls int
 }
 
 type cachedTorrentSearchResults struct {
@@ -6758,6 +6760,8 @@ func (s *Service) processPendingRecheckResume(instanceID int, hash string, req *
 			req.sawChecking = true
 		} else if req.verificationRequired {
 			req.sawChecking = false
+			req.recheckInterrupted = true
+			req.awaitingResumeConfirmation = false
 		}
 		req.readyPolls = 0
 		req.resumeConfirmedPolls = 0
@@ -6772,7 +6776,7 @@ func (s *Service) processPendingRecheckResume(instanceID int, hash string, req *
 		// path (still gated by recheckResumeStablePolls); monitorOnly never resumes. Once
 		// resume is issued, awaitingResumeConfirmation takes over so the entry is
 		// confirmed and dropped rather than waiting out the timeout while it runs.
-		fastRecheckComplete := !req.monitorOnly && isPausedOrStopped(state) &&
+		fastRecheckComplete := !req.monitorOnly && !req.recheckInterrupted && isPausedOrStopped(state) &&
 			satisfied() && time.Since(req.addedAt) >= recheckFastCompleteMinElapsed
 		if !fastRecheckComplete {
 			return true

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -6752,13 +6752,19 @@ func (s *Service) processPendingRecheckResume(instanceID int, hash string, req *
 		state == qbt.TorrentStateCheckingDl
 	isChecking := isPieceChecking || state == qbt.TorrentStateCheckingResumeData
 	if isChecking {
-		// checkingResumeData validates qBittorrent's saved state during startup.
-		// It keeps this worker waiting, but it does not prove that a requested
-		// piece hash check ran. It also breaks continuity with any piece-check
-		// state observed before qBittorrent restarted.
 		if isPieceChecking {
 			req.sawChecking = true
-		} else if req.verificationRequired {
+		} else if req.verificationRequired && req.sawChecking {
+			// checkingResumeData validates qBittorrent's saved state during startup.
+			// Seeing it after we already observed a piece hash check means qBittorrent
+			// restarted and re-validated: that breaks continuity with the check we saw,
+			// so the earlier progress no longer proves the requested recheck ran. Block
+			// the fast resume and re-earn confirmation from a fresh piece check.
+			//
+			// A checkingResumeData poll with no prior piece check is just normal
+			// forced-recheck startup, which every recheck passes through before hashing.
+			// A fast (100%-overlap) recheck can still finish between polls, so this must
+			// not set recheckInterrupted or the fast path below could never fire.
 			req.sawChecking = false
 			req.recheckInterrupted = true
 			req.awaitingResumeConfirmation = false


### PR DESCRIPTION
## Description

A manual cross-seed match is queued with `verificationRequired`, and the recheck resume worker only sets `sawChecking` when a poll observes `checkingUp`/`checkingDl`. A 100%-overlap recheck can finish in under the 3s `recheckPollInterval`, so the checking state is never observed, the guard in `processPendingRecheckResume` keeps returning "keep waiting", and the torrent sits paused until the 60-minute `recheckAbsoluteTimeout` ("Verification recheck transition was not observed, torrent left paused for manual review"). It is never resumed.

This narrows that guard. A non-monitor verification entry that is settled at 100% (progress >= 1, amountLeft <= 0, in a paused/stopped state) once `recheckFastCompleteMinElapsed` has passed since queuing falls through to the existing resume path, which still requires `recheckResumeStablePolls` stable polls before it acts. `monitorOnly` still never resumes, and a sub-100% result still fails closed.

Against the acceptance criteria: a fast-recheck 100% resumes; sub-100% with no checking still fails closed; `monitorOnly` is unaffected; the `relaxed_structure_recheck_test.go` tests still pass; and a new test covers the fast-recheck scenario.

Two things worth your call:

- The elapsed threshold. I used `recheckFastCompleteMinElapsed = 30s`. The brief asks for "a reasonable minimum elapsed time", and the value is a judgment about how long a recheck qui issued needs to have run. qBittorrent reports an optimistic 100% before a recheck runs, so this delay is what separates "recheck completed fast" from "recheck has not started". If a torrent can sit paused at an optimistic 100% for longer than this on your setups (a long recheck queue), a larger value is safer. Happy to change it, or to key it off a different signal if you have one.
- I could not field-test this against a live qBittorrent (no instance with a fast-recheck cross-seed scenario on hand). The closest check is the unit tests, which drive `processPendingRecheckResume` through the exact poll sequence.

Fixes #2554

## How has this been tested?

`go test -race -count=1` on `internal/services/crossseed` (the new tests plus the existing verification and recheck tests pass), `go build`, `go vet`, `gofmt`, and `golangci-lint` on the package. The season-pack link tests (`TestApplySeasonPackWebhook_*`) fail in my sandbox because it has no reflink/hardlink support; they fail identically on an unmodified checkout, so they are environmental and unrelated to this change.

## Checklist

- [x] My PR title follows the Conventional Commits format (it becomes the squashed commit message)
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL (not applicable, no schema change)

## AI disclosure

Yes. This was written by an AI coding agent (Anthropic Claude, Opus 4.8) working from the ready-for-agent brief: it traced the recheck state machine against the source, wrote the change and the tests, and verified them locally (build, vet, gofmt, golangci-lint, go test -race). Essentially the whole diff is AI-authored and then verified as above before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic resumption after fast verification while preserving stability and timing checks.
  * Prevented interrupted verification states from triggering resumption or retaining outdated confirmations after a restart.
  * Ensured incomplete, ambiguous, or unsettled verification states do not resume prematurely.
  * Allowed eligible paused or stopped items to resume after fresh verification, confirmation, and the required waiting interval.
  * Kept items paused when verification remains in progress, even after the fast-completion interval elapses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->