### PR TITLE
docs: add Disc report glossary terms and ADR 0003

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -21,3 +21,9 @@ qui manages torrent-client state and workflows for a self-hosted installation.
 - **Manual match**: A cross-seed apply where the user chooses the target torrent. Candidate discovery and the category and content-type gates are bypassed; the recheck is the arbiter of a wrong pick. _Avoid_: forced match, pinned match.
 - **Numbering scheme**: How a TV release names its episode: seasoned (`S04E15`) or absolute (`- 81`, no season). A pair of releases that use the same scheme compare episode numbers directly. _Avoid_: anime numbering, episode format.
 - **Episode map**: The Sonarr-sourced triple (season, episode, absolute) for one release name. It lets one seasoned and one absolute release count as the same episode. Exists only when Sonarr names exactly one episode and that episode has an absolute number; otherwise there is no map and the pair falls back to size evidence. _Avoid_: Sonarr mapping, episode translation, absolute lookup.
+
+## Disc reports
+
+- **Disc**: A Blu-ray as one unit: the folder that holds `BDMV`, or one `.iso`. The unit a BDInfo scan reads. One torrent can hold several Discs. _Avoid_: Blu-ray folder, disc torrent.
+- **Disc scan**: One queued or running BDInfo job on one Disc. _Avoid_: BDInfo job, bdinfo run.
+- **Disc report**: The cached BDInfo text for one Disc on one instance. _Avoid_: disc info, BDInfo output.

--- a/docs/adr/0003-disc-reports-live-in-the-database.md
+++ b/docs/adr/0003-disc-reports-live-in-the-database.md
@@ -1,0 +1,20 @@
+---
+status: accepted
+date: 2026-09-05
+---
+
+# Disc reports live in the database
+
+A Disc scan reads a whole Blu-ray at disk speed, so one Disc report can cost twenty minutes and qui must keep it. qui stores the report text in the Disc scan row, keyed on the instance and the resolved on-disk path of the Disc. Seeding folders stay untouched and read-only mounts work.
+
+## Considered options
+
+- **`.bdinfo` file beside the Disc**, as the BDInfo CLI does. Rejected: it writes into content qBittorrent seeds, fails on read-only mounts, and leaves the report behind when the torrent is removed.
+- **Key the cache on inode or content hash** so hardlinked copies at two paths share one report. Rejected: two scans of a hardlinked Disc is a rare cost, and inode identity needs per-platform code.
+- **Key the cache on path alone**, shared across instances. Rejected: two instances on different hosts can hold different discs at the same path once remote filesystem access exists.
+
+## Consequences
+
+- Discs are treated as immutable. No automatic invalidation; the user rescans.
+- Rows are kept when the torrent is deleted. Cleanup is a later problem if anyone hits it.
+- The scan runs where the bytes are. Only the one `bdinfo.Run` call knows the disc is local, so remote support (#1917) replaces that call, by exec of a user-installed `bdinfo` or by an SFTP-backed go-bdinfo filesystem, rather than adding a read primitive to `fsops.Backend`. Until it exists, a scan on a remote instance fails with a visible error.


### PR DESCRIPTION
## Description

Adds the Disc, Disc scan, and Disc report glossary terms and ADR 0003 (Disc reports live in the database) from the grilling behind #2567, so the tickets for that feature can start from a shared vocabulary in any worktree.

Related to #2567

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added glossary definitions for discs, disc scans, and disc reports.
  - Documented the decision to store disc reports in the database, including caching behavior and retention considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->