### PR TITLE
fix(crossseed): stop rewriting the search run results blob on every candidate

### DIFF
--- a/internal/models/crossseed.go
+++ b/internal/models/crossseed.go
@@ -1472,26 +1472,27 @@ func (s *CrossSeedStore) CreateSearchRun(ctx context.Context, run *CrossSeedSear
 	return s.GetSearchRun(ctx, insertedID)
 }
 
-// UpdateSearchRun updates persisted metadata for a search run.
-func (s *CrossSeedStore) UpdateSearchRun(ctx context.Context, run *CrossSeedSearchRun) (*CrossSeedSearchRun, error) {
+// UpdateSearchRun persists the full row of a search run, results blob included.
+// UpdateSearchRunProgress is the cheap per-candidate write.
+func (s *CrossSeedStore) UpdateSearchRun(ctx context.Context, run *CrossSeedSearchRun) error {
 	if run == nil {
-		return nil, errors.New("run cannot be nil")
+		return errors.New("run cannot be nil")
 	}
 	if run.ID == 0 {
-		return nil, errors.New("run ID cannot be zero")
+		return errors.New("run ID cannot be zero")
 	}
 
 	resultsJSON, err := encodeSearchResults(run.Results)
 	if err != nil {
-		return nil, fmt.Errorf("encode results: %w", err)
+		return fmt.Errorf("encode results: %w", err)
 	}
 	filtersJSON, err := encodeSearchFilters(run.Filters)
 	if err != nil {
-		return nil, fmt.Errorf("encode filters: %w", err)
+		return fmt.Errorf("encode filters: %w", err)
 	}
 	indexersJSON, err := encodeIntSlice(run.IndexerIDs)
 	if err != nil {
-		return nil, fmt.Errorf("encode indexers: %w", err)
+		return fmt.Errorf("encode indexers: %w", err)
 	}
 
 	const query = `
@@ -1537,10 +1538,40 @@ func (s *CrossSeedStore) UpdateSearchRun(ctx context.Context, run *CrossSeedSear
 		resultsJSON,
 		run.ID,
 	); err != nil {
-		return nil, fmt.Errorf("update search run: %w", err)
+		return fmt.Errorf("update search run: %w", err)
 	}
 
-	return s.GetSearchRun(ctx, run.ID)
+	return nil
+}
+
+// UpdateSearchRunProgress writes the live counters of a search run and leaves
+// results_json alone. The hot per-candidate path uses it so the bytes written
+// per candidate stay constant; UpdateSearchRun persists the full row.
+func (s *CrossSeedStore) UpdateSearchRunProgress(ctx context.Context, run *CrossSeedSearchRun) error {
+	const query = `
+		UPDATE cross_seed_search_runs SET
+			status = ?,
+			total_torrents = ?,
+			processed = ?,
+			torrents_added = ?,
+			torrents_failed = ?,
+			torrents_skipped = ?
+		WHERE id = ?
+	`
+
+	if _, err := s.db.ExecContext(ctx, query,
+		run.Status,
+		run.TotalTorrents,
+		run.Processed,
+		run.TorrentsAdded,
+		run.TorrentsFailed,
+		run.TorrentsSkipped,
+		run.ID,
+	); err != nil {
+		return fmt.Errorf("update search run progress: %w", err)
+	}
+
+	return nil
 }
 
 // GetSearchRun loads a specific search run by ID.

--- a/internal/models/crossseed_test.go
+++ b/internal/models/crossseed_test.go
@@ -197,7 +197,8 @@ func TestCrossSeedStore_SearchRunResultSerializationUsesStatus(t *testing.T) {
 		ProcessedAt:  now,
 	}}
 
-	updated, err := store.UpdateSearchRun(ctx, run)
+	require.NoError(t, store.UpdateSearchRun(ctx, run))
+	updated, err := store.GetSearchRun(ctx, run.ID)
 	require.NoError(t, err)
 	require.Len(t, updated.Results, 1)
 	assert.Equal(t, models.CrossSeedSearchResultStatusAdded, updated.Results[0].Status)

--- a/internal/services/crossseed/search_run_partial_failure_test.go
+++ b/internal/services/crossseed/search_run_partial_failure_test.go
@@ -246,3 +246,54 @@ func TestSearchRunLoop_AllCandidatesFailedMarksRunFailed(t *testing.T) {
 	require.NotNil(t, errorMessage)
 	require.Contains(t, *errorMessage, "all 1 searched candidates failed")
 }
+
+// The per-candidate write must not grow with the run: counters land on every
+// persist, the results blob only every searchResultsFlushEvery entries and on
+// finalize (#2572).
+func TestPersistSearchRun_FlushesResultsEveryN(t *testing.T) {
+	ctx := t.Context()
+	db := testdb.NewMigratedSQLite(t, "search-run-flush")
+	store, err := models.NewCrossSeedStore(db, make([]byte, 32))
+	require.NoError(t, err)
+	instanceStore, err := models.NewInstanceStore(db, []byte("01234567890123456789012345678901"))
+	require.NoError(t, err)
+	instance, err := instanceStore.Create(ctx, "Test", "http://localhost:8080", "user", "pass", nil, nil, false, nil)
+	require.NoError(t, err)
+	run, err := store.CreateSearchRun(ctx, &models.CrossSeedSearchRun{
+		InstanceID: instance.ID,
+		Status:     models.CrossSeedSearchRunStatusRunning,
+		StartedAt:  time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	svc := &Service{automationStore: store}
+	state := &searchRunState{run: run}
+	svc.searchState = state
+
+	storedRun := func() *models.CrossSeedSearchRun {
+		stored, err := store.GetSearchRun(ctx, run.ID)
+		require.NoError(t, err)
+		return stored
+	}
+	skipped := models.CrossSeedSearchResult{TorrentHash: "hash", Status: models.CrossSeedSearchResultStatusSkipped, ProcessedAt: time.Now().UTC()}
+
+	for range searchResultsFlushEvery - 1 {
+		state.run.Processed++
+		svc.appendSearchResult(state, skipped)
+		svc.persistSearchRun(state)
+	}
+	stored := storedRun()
+	require.Equal(t, searchResultsFlushEvery-1, stored.Processed, "counters persist on every candidate")
+	require.Empty(t, stored.Results, "results blob stays untouched below the flush threshold")
+
+	svc.appendSearchResult(state, skipped)
+	svc.persistSearchRun(state)
+	require.Len(t, storedRun().Results, searchResultsFlushEvery, "results blob flushed at the threshold")
+
+	svc.appendSearchResult(state, skipped)
+	svc.persistSearchRun(state)
+	require.Len(t, storedRun().Results, searchResultsFlushEvery, "next candidate goes back to a counters-only write")
+
+	svc.finalizeSearchRun(state, false)
+	require.Len(t, storedRun().Results, searchResultsFlushEvery+1, "finalize writes the full row")
+}

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -1696,6 +1696,9 @@ type searchRunState struct {
 
 	currentCandidate *SearchCandidateStatus
 	recentResults    []models.CrossSeedSearchResult
+	// persistedResults counts the run.Results entries already written to
+	// results_json; see persistSearchRun.
+	persistedResults int
 	nextWake         time.Time
 	lastError        error
 	// lastCandidateErr remembers the most recent candidate-scoped failure so a
@@ -2849,7 +2852,7 @@ func (s *Service) updateAutomationRunWithRetry(ctx context.Context, run *models.
 }
 
 // updateSearchRunWithRetry attempts to update the search run in the database with retries
-func (s *Service) updateSearchRunWithRetry(ctx context.Context, run *models.CrossSeedSearchRun) (*models.CrossSeedSearchRun, error) {
+func (s *Service) updateSearchRunWithRetry(ctx context.Context, run *models.CrossSeedSearchRun) error {
 	const maxRetries = 3
 	var lastErr error
 
@@ -2858,9 +2861,9 @@ func (s *Service) updateSearchRunWithRetry(ctx context.Context, run *models.Cros
 			time.Sleep(time.Duration(attempt) * 100 * time.Millisecond)
 		}
 
-		updated, err := s.automationStore.UpdateSearchRun(ctx, run)
+		err := s.automationStore.UpdateSearchRun(ctx, run)
 		if err == nil {
-			return updated, nil
+			return nil
 		}
 
 		lastErr = err
@@ -2868,7 +2871,7 @@ func (s *Service) updateSearchRunWithRetry(ctx context.Context, run *models.Cros
 	}
 
 	log.Error().Err(lastErr).Int64("runID", run.ID).Msg("Failed to update search run after retries")
-	return run, lastErr
+	return lastErr
 }
 
 // GetAutomationStatus returns scheduler information for the API.
@@ -10778,14 +10781,7 @@ func (s *Service) finalizeSearchRun(state *searchRunState, canceled bool) {
 	}
 	s.searchMu.Unlock()
 
-	if updated, err := s.updateSearchRunWithRetry(context.Background(), state.run); err == nil {
-		s.searchMu.Lock()
-		if s.searchState == state {
-			state.run = updated
-			s.searchState.run = updated
-		}
-		s.searchMu.Unlock()
-	} else {
+	if err := s.updateSearchRunWithRetry(context.Background(), state.run); err != nil {
 		log.Warn().Err(err).Msg("failed to persist search run state")
 	}
 
@@ -12973,17 +12969,33 @@ func (s *Service) notifyWebhookCheckFailure(ctx context.Context, req *WebhookChe
 	})
 }
 
+// searchResultsFlushEvery bounds how many result entries a killed process can
+// lose: the results blob is rewritten once this many new entries have
+// accumulated, and on finalize. Counters are written on every call.
+// ponytail: each flush still rewrites the whole blob, so a run costs
+// O(n²/25) bytes; move results to their own table if that ever bites.
+const searchResultsFlushEvery = 25
+
 func (s *Service) persistSearchRun(state *searchRunState) {
-	updated, err := s.automationStore.UpdateSearchRun(context.Background(), state.run)
-	if err != nil {
-		log.Debug().Err(err).Msg("failed to persist search run progress")
+	ctx := context.Background()
+	s.searchMu.Lock()
+	resultCount := len(state.run.Results)
+	s.searchMu.Unlock()
+
+	if resultCount-state.persistedResults >= searchResultsFlushEvery {
+		if err := s.automationStore.UpdateSearchRun(ctx, state.run); err != nil {
+			log.Debug().Err(err).Msg("failed to persist search run results")
+			return
+		}
+		s.searchMu.Lock()
+		state.persistedResults = resultCount
+		s.searchMu.Unlock()
 		return
 	}
-	s.searchMu.Lock()
-	if s.searchState == state {
-		state.run = updated
+
+	if err := s.automationStore.UpdateSearchRunProgress(ctx, state.run); err != nil {
+		log.Debug().Err(err).Msg("failed to persist search run progress")
 	}
-	s.searchMu.Unlock()
 }
 
 func (s *Service) setCurrentCandidate(state *searchRunState, torrent *qbt.Torrent) {


### PR DESCRIPTION
## Description

Writes only status and counters on each search candidate, and the results blob every 25 new entries plus once on finalize, so a long run stops paying O(n²) JSON and SQL for its result history. `UpdateSearchRun` no longer re-reads the row after the write.

Live sampling on a real instance showed `results_json` rewritten after every candidate and growing ~270 bytes per entry; a completed 1283-candidate run would have pushed ~222 MB through JSON and SQL to persist a ~350 KB blob.

Each flush still rewrites the whole blob, so a run is O(n²/25) rather than linear. A results table would make it linear and needs two migrations; a comment marks that upgrade path.

Fixes #2572

## How has this been tested?

Live on a production instance with the `pr-2574` image, sampling `processed` against `length(results_json)` every 2 s during a Gazelle-only seeded search of 473 candidates. The blob stayed at 2 bytes while `processed` climbed 1 to 24, was written once at 25 (6749 bytes, 25 entries), stayed flat through 27, and finalize wrote all 28 entries on cancel. The progress endpoint kept reporting the live count throughout. Same sampling on the previous build grew the blob after every candidate.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL
