### PR TITLE
perf(filesmanager): skip no-op writes in torrent files cache upsert

### DIFF
--- a/internal/services/filesmanager/repository.go
+++ b/internal/services/filesmanager/repository.go
@@ -277,7 +277,12 @@ func (r *Repository) UpsertFiles(ctx context.Context, files []CachedFile) error 
 		}
 	}
 
-	// Pre-build the full query for full batches
+	// Pre-build the full query for full batches.
+	//
+	// The guard on DO UPDATE keeps unchanged rows from being rewritten: most torrents are
+	// complete and seeding, so every sync would rewrite their file rows for nothing
+	// (discussion #2374). cached_at is outside the guard and nothing reads it; freshness
+	// comes from torrent_files_sync.last_synced_at, which cacheIsFresh reads.
 	queryTemplate := `
 			INSERT INTO torrent_files_cache
 			(instance_id, torrent_hash_id, file_index, name_id, size, progress, priority,
@@ -293,6 +298,14 @@ func (r *Repository) UpsertFiles(ctx context.Context, files []CachedFile) error 
 				piece_range_end = excluded.piece_range_end,
 				availability = excluded.availability,
 				cached_at = excluded.cached_at
+			WHERE torrent_files_cache.name_id IS DISTINCT FROM excluded.name_id
+				OR torrent_files_cache.size IS DISTINCT FROM excluded.size
+				OR torrent_files_cache.progress IS DISTINCT FROM excluded.progress
+				OR torrent_files_cache.priority IS DISTINCT FROM excluded.priority
+				OR torrent_files_cache.is_seed IS DISTINCT FROM excluded.is_seed
+				OR torrent_files_cache.piece_range_start IS DISTINCT FROM excluded.piece_range_start
+				OR torrent_files_cache.piece_range_end IS DISTINCT FROM excluded.piece_range_end
+				OR torrent_files_cache.availability IS DISTINCT FROM excluded.availability
 		`
 	fullBatchQuery := dbinterface.BuildQueryWithPlaceholders(queryTemplate, 12, fileBatchSize)
 	t := time.Now()

--- a/internal/services/filesmanager/repository_upsert_guard_test.go
+++ b/internal/services/filesmanager/repository_upsert_guard_test.go
@@ -1,0 +1,254 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package filesmanager
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/database"
+	"github.com/autobrr/qui/internal/testutil/testdb"
+)
+
+// The upsert guard is SQL, and the two engines differ on null comparison and
+// numeric affinity, so every case below runs against both. The Postgres half
+// skips unless QUI_TEST_POSTGRES_DSN is set.
+func forEachBackend(t *testing.T, run func(ctx context.Context, t *testing.T, db *database.DB)) {
+	t.Helper()
+
+	backends := []struct {
+		name string
+		open func(t *testing.T) *database.DB
+	}{
+		{"sqlite", func(t *testing.T) *database.DB { return testdb.NewMigratedSQLite(t, "filesmanager-guard") }},
+		{"postgres", func(t *testing.T) *database.DB { return testdb.NewMigratedPostgres(t, "filesmanager-guard") }},
+	}
+
+	for _, backend := range backends {
+		t.Run(backend.name, func(t *testing.T) {
+			t.Parallel()
+
+			db := backend.open(t)
+			ctx := context.Background()
+			seedInstance(ctx, t, db)
+			run(ctx, t, db)
+		})
+	}
+}
+
+// seedInstance creates the instance row the cache rows point at.
+func seedInstance(ctx context.Context, t *testing.T, db *database.DB) {
+	t.Helper()
+
+	var nameID, hostID, usernameID int64
+	require.NoError(t, db.QueryRowContext(ctx, "INSERT INTO string_pool (value) VALUES (?) RETURNING id", "instance-name").Scan(&nameID))
+	require.NoError(t, db.QueryRowContext(ctx, "INSERT INTO string_pool (value) VALUES (?) RETURNING id", "instance-host").Scan(&hostID))
+	require.NoError(t, db.QueryRowContext(ctx, "INSERT INTO string_pool (value) VALUES (?) RETURNING id", "instance-username").Scan(&usernameID))
+
+	_, err := db.ExecContext(ctx, "INSERT INTO instances (id, name_id, host_id, username_id, password_encrypted) VALUES (?, ?, ?, ?, ?)", 1, nameID, hostID, usernameID, "enc")
+	require.NoError(t, err)
+}
+
+// sentinel is far enough in the past that a real write can never land on it.
+var sentinel = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// markCachedAt stamps every cached file row with the sentinel so a later upsert
+// that actually writes is visible: the row moves off the sentinel.
+func markCachedAt(ctx context.Context, t *testing.T, db *database.DB) {
+	t.Helper()
+	_, err := db.ExecContext(ctx, `UPDATE torrent_files_cache SET cached_at = ?`, sentinel)
+	require.NoError(t, err)
+}
+
+// countAtSentinel reports how many rows still carry the sentinel, i.e. how many
+// rows the last upsert left untouched.
+func countAtSentinel(ctx context.Context, t *testing.T, db *database.DB) int {
+	t.Helper()
+	var n int
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT COUNT(*) FROM torrent_files_cache WHERE cached_at = ?`, sentinel).Scan(&n))
+	return n
+}
+
+func baseFile() CachedFile {
+	return CachedFile{
+		InstanceID:      1,
+		TorrentHash:     "guard-hash",
+		FileIndex:       0,
+		Name:            "season.pack/episode.mkv",
+		Size:            1 << 30,
+		Progress:        1.0,
+		Priority:        1,
+		IsSeed:          new(true),
+		PieceRangeStart: 0,
+		PieceRangeEnd:   511,
+		Availability:    1.0,
+	}
+}
+
+// A complete, seeding torrent re-synced with identical data must produce no row
+// writes at all. This is the case that dominates a steady-state library.
+func TestUpsertFilesSkipsUnchangedRows(t *testing.T) {
+	t.Parallel()
+
+	forEachBackend(t, func(ctx context.Context, t *testing.T, db *database.DB) {
+		repo := NewRepository(db)
+
+		files := []CachedFile{baseFile()}
+		require.NoError(t, repo.UpsertFiles(ctx, files))
+
+		markCachedAt(ctx, t, db)
+		require.NoError(t, repo.UpsertFiles(ctx, files))
+		require.Equal(t, 1, countAtSentinel(ctx, t, db), "unchanged row should not have been rewritten")
+	})
+}
+
+// Each guarded column must still let a real change through on its own.
+func TestUpsertFilesWritesChangedRows(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mutate func(*CachedFile)
+	}{
+		{"name", func(f *CachedFile) { f.Name = "season.pack/episode.renamed.mkv" }},
+		{"size", func(f *CachedFile) { f.Size = 1<<30 + 1 }},
+		{"progress", func(f *CachedFile) { f.Progress = 0.5 }},
+		{"priority", func(f *CachedFile) { f.Priority = 7 }},
+		{"is_seed", func(f *CachedFile) { f.IsSeed = new(false) }},
+		{"piece_range_start", func(f *CachedFile) { f.PieceRangeStart = 1 }},
+		{"piece_range_end", func(f *CachedFile) { f.PieceRangeEnd = 512 }},
+		{"availability", func(f *CachedFile) { f.Availability = 0.25 }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			forEachBackend(t, func(ctx context.Context, t *testing.T, db *database.DB) {
+				repo := NewRepository(db)
+
+				require.NoError(t, repo.UpsertFiles(ctx, []CachedFile{baseFile()}))
+				markCachedAt(ctx, t, db)
+
+				changed := baseFile()
+				tt.mutate(&changed)
+				require.NoError(t, repo.UpsertFiles(ctx, []CachedFile{changed}))
+
+				require.Zero(t, countAtSentinel(ctx, t, db), "changed %s should have been written", tt.name)
+
+				stored, err := repo.GetFiles(ctx, 1, "guard-hash")
+				require.NoError(t, err)
+				require.Len(t, stored, 1)
+				require.Equal(t, changed.Name, stored[0].Name)
+				require.Equal(t, changed.Size, stored[0].Size)
+				require.InDelta(t, changed.Progress, stored[0].Progress, 1e-9)
+				require.Equal(t, changed.Priority, stored[0].Priority)
+				require.Equal(t, changed.IsSeed, stored[0].IsSeed)
+				require.Equal(t, changed.PieceRangeStart, stored[0].PieceRangeStart)
+				require.Equal(t, changed.PieceRangeEnd, stored[0].PieceRangeEnd)
+				require.InDelta(t, changed.Availability, stored[0].Availability, 1e-9)
+			})
+		})
+	}
+}
+
+// is_seed is nullable, so the guard must be null-safe. A plain `<>` would yield
+// NULL for these comparisons and silently drop the change.
+func TestUpsertFilesGuardIsNullSafe(t *testing.T) {
+	t.Parallel()
+
+	t.Run("null stays null", func(t *testing.T) {
+		t.Parallel()
+
+		forEachBackend(t, func(ctx context.Context, t *testing.T, db *database.DB) {
+			repo := NewRepository(db)
+
+			nullSeed := baseFile()
+			nullSeed.IsSeed = nil
+			require.NoError(t, repo.UpsertFiles(ctx, []CachedFile{nullSeed}))
+
+			markCachedAt(ctx, t, db)
+			require.NoError(t, repo.UpsertFiles(ctx, []CachedFile{nullSeed}))
+			require.Equal(t, 1, countAtSentinel(ctx, t, db), "null-to-null should not have been rewritten")
+		})
+	})
+
+	t.Run("null to value", func(t *testing.T) {
+		t.Parallel()
+
+		forEachBackend(t, func(ctx context.Context, t *testing.T, db *database.DB) {
+			repo := NewRepository(db)
+
+			nullSeed := baseFile()
+			nullSeed.IsSeed = nil
+			require.NoError(t, repo.UpsertFiles(ctx, []CachedFile{nullSeed}))
+			markCachedAt(ctx, t, db)
+
+			require.NoError(t, repo.UpsertFiles(ctx, []CachedFile{baseFile()}))
+			require.Zero(t, countAtSentinel(ctx, t, db), "null-to-value should have been written")
+
+			stored, err := repo.GetFiles(ctx, 1, "guard-hash")
+			require.NoError(t, err)
+			require.Len(t, stored, 1)
+			require.Equal(t, new(true), stored[0].IsSeed)
+		})
+	})
+
+	t.Run("value to null", func(t *testing.T) {
+		t.Parallel()
+
+		forEachBackend(t, func(ctx context.Context, t *testing.T, db *database.DB) {
+			repo := NewRepository(db)
+
+			require.NoError(t, repo.UpsertFiles(ctx, []CachedFile{baseFile()}))
+			markCachedAt(ctx, t, db)
+
+			nullSeed := baseFile()
+			nullSeed.IsSeed = nil
+			require.NoError(t, repo.UpsertFiles(ctx, []CachedFile{nullSeed}))
+			require.Zero(t, countAtSentinel(ctx, t, db), "value-to-null should have been written")
+
+			stored, err := repo.GetFiles(ctx, 1, "guard-hash")
+			require.NoError(t, err)
+			require.Len(t, stored, 1)
+			require.Nil(t, stored[0].IsSeed)
+		})
+	})
+}
+
+// A sync sweep touches many torrents at once; only the rows that actually moved
+// should be written, and only within the batch that contains them.
+func TestUpsertFilesGuardIsPerRowAcrossBatches(t *testing.T) {
+	t.Parallel()
+
+	forEachBackend(t, func(ctx context.Context, t *testing.T, db *database.DB) {
+		repo := NewRepository(db)
+
+		// Span more than one batch so the guard is exercised on a full-batch query
+		// and on the partial trailing one.
+		const total = fileBatchSize*2 + 5
+		files := make([]CachedFile, total)
+		for i := range files {
+			f := baseFile()
+			f.FileIndex = i
+			files[i] = f
+		}
+		require.NoError(t, repo.UpsertFiles(ctx, files))
+
+		markCachedAt(ctx, t, db)
+
+		// Move one file in each batch: first, one past the batch boundary, and last.
+		changed := make([]CachedFile, total)
+		copy(changed, files)
+		for _, i := range []int{0, fileBatchSize, total - 1} {
+			changed[i].Progress = 0.5
+		}
+		require.NoError(t, repo.UpsertFiles(ctx, changed))
+
+		require.Equal(t, total-3, countAtSentinel(ctx, t, db), "only the three changed rows should have been written")
+	})
+}


### PR DESCRIPTION
## Question for maintainers

**Is anything meant to read `torrent_files_cache.cached_at` as a freshness indicator?**

With the guard, unchanged rows stop refreshing it, so it becomes "when this row's data last changed" rather than "when we last verified it".

I traced it and found nothing reading it: `CachedFile.CachedAt` is scanned in `getFiles`/`GetFilesBatch` and then never used, the struct has no JSON tags, `convertCachedFiles` drops it, and no query filters, orders, or aggregates on the column. The "when we last verified" meaning already lives in a different column, `torrent_files_sync.last_synced_at`, which this PR leaves untouched.

So this looks safe. But if `cached_at` is intended for something not yet wired up, say so and I will move it outside the guard, or update it through a cheaper path.

## Description

The `DO UPDATE` on `torrent_files_cache` has no `WHERE` clause, so every sync rewrites every row whether or not anything changed. Most torrents are complete and seeding, which makes their file rows static (`progress`, `size`, `priority`, `is_seed`, `piece_range_*`, `availability`, `name_id` all fixed), so the bulk of those writes store values identical to what is already there.

#2455 dropped the indexes that were blocking HOT updates and made each write cheap, but it did not stop the writes. This adds a null-safe change guard so no-op rows produce no write at all.

`IS DISTINCT FROM` is needed rather than `<>` because `is_seed` and the `piece_range` columns are nullable: `<>` yields NULL when either side is NULL, so a null-to-value change would be silently dropped.

Follows up on discussion #2374.

Overlaps with #2590, which attacks the same waste from the other end: that PR cuts how many sync sweeps happen at all, this one makes each remaining sweep write only what changed. They are independent, and I have not measured the two together.

### What is deliberately not changed

**`torrent_files_sync` is left alone**, though it has the same shape. Its `last_synced_at` is the input to the 5 minute TTL in `cacheIsFresh`. Guarding that upsert would stop the timestamp advancing for stable torrents, so `cacheIsFresh` would return false forever and every read would become a cache miss, increasing both database writes and qBittorrent API calls. `torrent_progress` is also hardcoded to `0.0` ("Not tracking progress anymore") and `file_count` rarely moves, so the guard would fire on nearly every row.

No schema change, no migration, no API change, no user-visible behaviour change.

## How has this been tested?

CI covers the added tests. Two things CI does not do:

**Measured effect**, on Postgres 18.6, 500 torrents x 20 files, driven through `Service.CacheFilesBatch` and read from `pg_stat_user_tables.n_tup_upd`:

| sweep | before | after |
| --- | --- | --- |
| identical re-sync of 10,000 rows | 10,000 row updates | **0** |
| one file's progress changed | 10,000 row updates | **1** |

**`IS DISTINCT FROM` on SQLite.** `modernc.org/sqlite v1.56.0` bundles SQLite 3.53.3, past the 3.39 floor. Confirmed a guarded upsert through the driver: no-op reports 0 rows affected, a real change reports 1. One spelling works for both backends, so the shared query template needs no dialect branch.

The added tests run against SQLite and Postgres both, and I checked they fail with the guard removed rather than passing vacuously. They cover: unchanged rows producing no write, each of the eight guarded columns individually still letting a change through, null-safety in all three directions (null to null, null to value, value to null), and per-row behaviour across batch boundaries.

The batch `Exec` result is discarded, so nothing depends on the affected-row count that the guard changes.

Not done: no end-to-end run against a live qBittorrent. The measurement above exercises the real service and repository path against real Postgres, but not the UI or a real client.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL — no schema change

## AI disclosure

Written with Claude Code (Opus 5). The SQL guard and the tests are AI-written, then reviewed and cut back by me. The investigation behind it (tracing `cached_at` readers, the `torrent_files_sync` TTL finding that ruled out the second half of the original proposal, and the Postgres measurements) was also AI-run, and the numbers above come from runs I can reproduce.
