### PR TITLE
docs(backups): state what a snapshot does not contain

### DIFF
--- a/documentation/docs/features/backups.md
+++ b/documentation/docs/features/backups.md
@@ -12,7 +12,7 @@ If you manage multiple instances, the Backups page provides **Save changes to al
 
 ## Counters and limits that a snapshot does not contain
 
-A snapshot does not store upload totals, ratio, or seed time. It also does not store share limits, speed limits, or the download path. A restore adds a missing torrent through the qBittorrent API, and the API cannot set those counters. Torrents that a restore adds start at zero. Torrents that already exist on the instance keep their counters. A restore does not change the ratio and the seed time on the tracker, because the tracker keeps its own counts. To keep the counters in qBittorrent, make a backup of the qBittorrent data directory, which holds the fastresume files in `BT_backup`.
+A snapshot does not store upload totals, ratio, or seed time. It also does not store share limits or speed limits. A restore adds a missing torrent through the qBittorrent API, and the API cannot set those counters. Torrents that a restore adds start at zero. Torrents that already exist on the instance keep their counters. A restore does not change the ratio and the seed time on the tracker, because the tracker keeps its own counts. To keep the counters in qBittorrent, make a backup of the qBittorrent data directory, which holds the fastresume files in `BT_backup`.
 
 ## Backup storage
 

--- a/documentation/docs/features/backups.md
+++ b/documentation/docs/features/backups.md
@@ -6,9 +6,13 @@ description: Schedule and restore qBittorrent instance backups.
 
 # Backups and restore
 
-qui creates scheduled and manual snapshots of a qBittorrent instance. Each snapshot includes the torrent archive, tags, categories with their save paths, and cached `.torrent` blobs. You can restore the original state from a snapshot at any time.
+qui creates scheduled and manual snapshots of a qBittorrent instance. Each snapshot includes the torrent archive, tags, categories with their save paths, and cached `.torrent` blobs. You can restore the torrents, categories, and tags from a snapshot at any time.
 
 If you manage multiple instances, the Backups page provides **Save changes to all instances**. This action copies the current backup schedule and settings to every compatible instance in one step.
+
+## Counters and limits that a snapshot does not contain
+
+A snapshot does not store upload totals, ratio, or seed time. It also does not store share limits, speed limits, or the download path. A restore adds a missing torrent through the qBittorrent API, and the API cannot set those counters. Torrents that a restore adds start at zero. Torrents that already exist on the instance keep their counters. A restore does not change the ratio and the seed time on the tracker, because the tracker keeps its own counts. To keep the counters in qBittorrent, make a backup of the qBittorrent data directory, which holds the fastresume files in `BT_backup`.
 
 ## Backup storage
 


### PR DESCRIPTION
## Description

Adds a section to the backups page that says a snapshot does not store upload totals, ratio, seed time, share limits, speed limits, or the download path, and that only torrents a restore adds start at zero. Softens "restore the original state" in the intro. A Discord user asked exactly this and the page could not answer it.

## How has this been tested?

Checked the claim against `internal/backups/restore_execute.go` (the add call passes paused, stopped, skip_checking, category, tags, and save path only) and against the qBittorrent WebUI `addAction`, which has no field for accumulated totals.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that snapshots can restore torrents, categories, and tags.
  * Added details about counters and limits not included in snapshots, including upload totals, ratios, seed time, share limits, and speed limits.
  * Documented that restored torrents start with zero counters, existing torrents retain their counters, and tracker-side counters are unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->