### PR TITLE
test(qbittorrent): pin list hydration to never call torrents/trackers

### DIFF
--- a/internal/qbittorrent/client_test.go
+++ b/internal/qbittorrent/client_test.go
@@ -765,21 +765,18 @@ func TestSplitHostUserinfo(t *testing.T) {
 	}
 }
 
-// TestNewClientWithTimeoutEnablesBulkTrackerFetch pins list hydration to never
-// issue per-hash torrents/trackers requests. Two flags guard this: the client
-// capability gate in enrichTorrentsWithTrackerData, and the tracker manager's
-// include flag that picks bulk torrents/info over the per-hash fallback. The
-// sync manager is created after the first capability refresh, so a missed
-// mirror between the two used to route qBittorrent 5.1+ into the fallback.
+// TestNewClientWithTimeoutEnablesBulkTrackerFetch pins list hydration to the
+// bulk torrents/info request on qBittorrent 5.1+ and to no request at all below
+// it. The per-hash torrents/trackers fallback must never fire from qui.
 func TestNewClientWithTimeoutEnablesBulkTrackerFetch(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
-		version  string
-		wantBulk bool
+		version      string
+		bulkRequests int
 	}{
-		{version: "2.11.3", wantBulk: false},
-		{version: "2.11.4", wantBulk: true},
+		{version: "2.11.3", bulkRequests: 0}, // highest version below the gate
+		{version: "2.11.4", bulkRequests: 1}, // lowest version at the gate
 	} {
 		t.Run(tc.version, func(t *testing.T) {
 			t.Parallel()
@@ -816,26 +813,18 @@ func TestNewClientWithTimeoutEnablesBulkTrackerFetch(t *testing.T) {
 
 			client, err := NewClientWithTimeout(1, srv.URL, "user", "pass", "", nil, nil, true, time.Second, 60*time.Second)
 			require.NoError(t, err)
-			require.Equal(t, tc.wantBulk, client.trackerManager().SupportsIncludeTrackers(), "tracker manager must mirror the include capability at construction")
 
 			torrents := []qbt.Torrent{{Hash: "aaa"}, {Hash: "bbb"}, {Hash: "ccc"}}
 			enriched, _, _ := (&SyncManager{}).enrichTorrentsWithTrackerData(t.Context(), client, torrents, nil)
-			wantInfo := 0
-			if tc.wantBulk {
-				wantInfo = 1
-			}
 			for _, torrent := range enriched {
-				if tc.wantBulk {
-					require.Len(t, torrent.Trackers, 1, "hash %s should be hydrated", torrent.Hash)
-				} else {
-					require.Empty(t, torrent.Trackers, "hash %s must stay unhydrated below 5.1", torrent.Hash)
-				}
+				// One tracker per torrent when hydrated, none when the gate skips hydration.
+				require.Len(t, torrent.Trackers, tc.bulkRequests, "hash %s", torrent.Hash)
 			}
 
 			mu.Lock()
 			defer mu.Unlock()
-			require.Equal(t, wantInfo, hits["/api/v2/torrents/info"], "bulk torrents/info requests")
-			require.Zero(t, hits["/api/v2/torrents/trackers"], "list hydration must never fall back to per-hash torrents/trackers")
+			require.Equal(t, tc.bulkRequests, hits["/api/v2/torrents/info"], "bulk torrents/info requests")
+			require.Zero(t, hits["/api/v2/torrents/trackers"], "per-hash torrents/trackers requests")
 		})
 	}
 }

--- a/internal/qbittorrent/client_test.go
+++ b/internal/qbittorrent/client_test.go
@@ -765,20 +765,21 @@ func TestSplitHostUserinfo(t *testing.T) {
 	}
 }
 
-// TestNewClientWithTimeoutEnablesBulkTrackerFetch pins the tracker manager to
-// the include-trackers capability at construction. The sync manager is created
-// after the first capability refresh, so the flag has to be applied to it.
+// TestNewClientWithTimeoutEnablesBulkTrackerFetch pins list hydration to never
+// issue per-hash torrents/trackers requests. Two flags guard this: the client
+// capability gate in enrichTorrentsWithTrackerData, and the tracker manager's
+// include flag that picks bulk torrents/info over the per-hash fallback. The
+// sync manager is created after the first capability refresh, so a missed
+// mirror between the two used to route qBittorrent 5.1+ into the fallback.
 func TestNewClientWithTimeoutEnablesBulkTrackerFetch(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
-		version      string
-		wantBulk     bool
-		wantInfo     int
-		wantTrackers int
+		version  string
+		wantBulk bool
 	}{
-		{version: "2.11.3", wantBulk: false, wantInfo: 0, wantTrackers: 3},
-		{version: "2.11.4", wantBulk: true, wantInfo: 1, wantTrackers: 0},
+		{version: "2.11.3", wantBulk: false},
+		{version: "2.11.4", wantBulk: true},
 	} {
 		t.Run(tc.version, func(t *testing.T) {
 			t.Parallel()
@@ -807,8 +808,6 @@ func TestNewClientWithTimeoutEnablesBulkTrackerFetch(t *testing.T) {
 						out = append(out, qbt.Torrent{Hash: hash, Trackers: []qbt.TorrentTracker{{Url: "https://tracker.example.invalid/announce", Status: 2}}})
 					}
 					_ = json.MarshalWrite(w, out)
-				case "/api/v2/torrents/trackers":
-					_, _ = w.Write([]byte(`[{"url":"https://tracker.example.invalid/announce","status":2}]`))
 				default:
 					http.NotFound(w, r)
 				}
@@ -820,16 +819,23 @@ func TestNewClientWithTimeoutEnablesBulkTrackerFetch(t *testing.T) {
 			require.Equal(t, tc.wantBulk, client.trackerManager().SupportsIncludeTrackers(), "tracker manager must mirror the include capability at construction")
 
 			torrents := []qbt.Torrent{{Hash: "aaa"}, {Hash: "bbb"}, {Hash: "ccc"}}
-			enriched, _, _, err := client.hydrateTorrentsWithTrackers(t.Context(), torrents)
-			require.NoError(t, err)
+			enriched, _, _ := (&SyncManager{}).enrichTorrentsWithTrackerData(t.Context(), client, torrents, nil)
+			wantInfo := 0
+			if tc.wantBulk {
+				wantInfo = 1
+			}
 			for _, torrent := range enriched {
-				require.Len(t, torrent.Trackers, 1, "hash %s should be hydrated", torrent.Hash)
+				if tc.wantBulk {
+					require.Len(t, torrent.Trackers, 1, "hash %s should be hydrated", torrent.Hash)
+				} else {
+					require.Empty(t, torrent.Trackers, "hash %s must stay unhydrated below 5.1", torrent.Hash)
+				}
 			}
 
 			mu.Lock()
 			defer mu.Unlock()
-			require.Equal(t, tc.wantInfo, hits["/api/v2/torrents/info"], "bulk torrents/info requests")
-			require.Equal(t, tc.wantTrackers, hits["/api/v2/torrents/trackers"], "per-hash torrents/trackers requests")
+			require.Equal(t, wantInfo, hits["/api/v2/torrents/info"], "bulk torrents/info requests")
+			require.Zero(t, hits["/api/v2/torrents/trackers"], "list hydration must never fall back to per-hash torrents/trackers")
 		})
 	}
 }

--- a/internal/qbittorrent/client_test.go
+++ b/internal/qbittorrent/client_test.go
@@ -816,15 +816,15 @@ func TestNewClientWithTimeoutEnablesBulkTrackerFetch(t *testing.T) {
 
 			torrents := []qbt.Torrent{{Hash: "aaa"}, {Hash: "bbb"}, {Hash: "ccc"}}
 			enriched, _, _ := (&SyncManager{}).enrichTorrentsWithTrackerData(t.Context(), client, torrents, nil)
+
+			mu.Lock()
+			defer mu.Unlock()
+			require.Zero(t, hits["/api/v2/torrents/trackers"], "list hydration must never use per-hash torrents/trackers; use torrents/info?includeTrackers on 5.1+ and skip hydration below it")
+			require.Equal(t, tc.bulkRequests, hits["/api/v2/torrents/info"], "bulk torrents/info requests")
 			for _, torrent := range enriched {
 				// One tracker per torrent when hydrated, none when the gate skips hydration.
 				require.Len(t, torrent.Trackers, tc.bulkRequests, "hash %s", torrent.Hash)
 			}
-
-			mu.Lock()
-			defer mu.Unlock()
-			require.Equal(t, tc.bulkRequests, hits["/api/v2/torrents/info"], "bulk torrents/info requests")
-			require.Zero(t, hits["/api/v2/torrents/trackers"], "per-hash torrents/trackers requests")
 		})
 	}
 }


### PR DESCRIPTION
## Description

Retargets the bulk tracker test from #2584 at the sync manager gate. It drove the go-qbittorrent tracker manager directly, so its pre-5.1 row asserted three per-hash `torrents/trackers` calls that qui never makes. The test now drives `enrichTorrentsWithTrackerData` and asserts zero per-hash calls on both versions, so a capability gate regression fails the 2.11.3 row and a flag mirror regression like #2584 fails the 2.11.4 row.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated tracker data-loading coverage across supported qBittorrent versions.
  * Verified bulk tracker information is requested only when supported.
  * Confirmed list hydration does not issue individual tracker requests.
  * Added validation that enriched torrents contain the expected tracker data for each version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->