### PR TITLE
perf(qbittorrent): share one app info refresh across concurrent callers

### DIFF
--- a/internal/qbittorrent/app_info.go
+++ b/internal/qbittorrent/app_info.go
@@ -98,16 +98,20 @@ func (c *Client) GetAppInfo(ctx context.Context) (*AppInfo, error) {
 		ctx = context.Background()
 	}
 
-	c.appInfoMu.RLock()
-	cached := cloneAppInfo(c.appInfoCache)
-	fresh := c.appInfoCache != nil && time.Since(c.appInfoFetchedAt) < appInfoCacheTTL
-	c.appInfoMu.RUnlock()
-
+	cached, fresh := c.cachedAppInfo()
 	if fresh {
-		return cached, nil
+		return cloneAppInfo(cached), nil
 	}
 
-	info, err := c.refreshAppInfo(ctx)
+	// Concurrent stream groups all see the cache expire at once; share one
+	// refresh. Joiners share the leader's result, so the refresh must not die
+	// with the leader's context; appInfoRequestTimeout still bounds it.
+	result, err, _ := c.appInfoGroup.Do("refresh", func() (any, error) {
+		if info, fresh := c.cachedAppInfo(); fresh {
+			return info, nil
+		}
+		return c.refreshAppInfo(context.WithoutCancel(ctx))
+	})
 	if err != nil {
 		// A saturated qBittorrent WebUI times out even trivial calls. Serve the
 		// last known app info rather than failing the whole torrent stream tick;
@@ -117,14 +121,25 @@ func (c *Client) GetAppInfo(ctx context.Context) (*AppInfo, error) {
 				Err(err).
 				Int("instanceID", c.instanceID).
 				Msg("Serving stale qBittorrent app info after refresh failure")
-			return cached, nil
+			return cloneAppInfo(cached), nil
 		}
 		return nil, err
 	}
 
-	return info, nil
+	cached, _ = result.(*AppInfo)
+	return cloneAppInfo(cached), nil
 }
 
+// cachedAppInfo returns the cached app info and whether it is still within the TTL.
+func (c *Client) cachedAppInfo() (*AppInfo, bool) {
+	c.appInfoMu.RLock()
+	defer c.appInfoMu.RUnlock()
+	return c.appInfoCache, c.appInfoCache != nil && time.Since(c.appInfoFetchedAt) < appInfoCacheTTL
+}
+
+// refreshAppInfo fetches app info and stores it in the cache. Callers must not
+// mutate the returned value: it is the cached instance, shared by every caller
+// that joined the same singleflight refresh.
 func (c *Client) refreshAppInfo(ctx context.Context) (*AppInfo, error) {
 	requestCtx, cancel := context.WithTimeout(ctx, appInfoRequestTimeout)
 	defer cancel()
@@ -184,5 +199,5 @@ func (c *Client) refreshAppInfo(ctx context.Context) (*AppInfo, error) {
 	c.appInfoFetchedAt = time.Now()
 	c.appInfoMu.Unlock()
 
-	return cloneAppInfo(info), nil
+	return info, nil
 }

--- a/internal/qbittorrent/app_info_test.go
+++ b/internal/qbittorrent/app_info_test.go
@@ -6,6 +6,9 @@ package qbittorrent
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -92,36 +95,98 @@ func TestBuildProcessInfo(t *testing.T) {
 	}
 }
 
-func TestGetAppInfoServesStaleCacheWhenRefreshFails(t *testing.T) {
+// newAppInfoStub serves the app info endpoints and counts hits per path. A
+// non-2xx versionStatus makes the version call fail without retries.
+func newAppInfoStub(t *testing.T, versionStatus int) (*Client, func(path string) int) {
+	t.Helper()
+
+	var mu sync.Mutex
+	hits := map[string]int{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		hits[r.URL.Path]++
+		mu.Unlock()
+		switch r.URL.Path {
+		case "/api/v2/app/version":
+			time.Sleep(50 * time.Millisecond) // widen the window so callers overlap
+			w.WriteHeader(versionStatus)
+			_, _ = w.Write([]byte("v5.1.0"))
+		case "/api/v2/app/webapiVersion":
+			_, _ = w.Write([]byte("2.11.4"))
+		case "/api/v2/app/buildInfo":
+			_, _ = w.Write([]byte(`{"qt":"6.7.2","libtorrent":"2.0.10","boost":"1.86","openssl":"3.3","zlib":"1.3","bitness":64}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
 	c := &Client{
-		Client:     qbt.NewClient(qbt.Config{Host: "http://127.0.0.1:0"}),
+		Client:     qbt.NewClient(qbt.Config{Host: srv.URL, Timeout: 60}),
 		instanceID: 1,
 	}
+	hitCount := func(path string) int {
+		mu.Lock()
+		defer mu.Unlock()
+		return hits[path]
+	}
+	return c, hitCount
+}
+
+type appInfoResult struct {
+	info *AppInfo
+	err  error
+}
+
+// callGetAppInfoConcurrently runs n overlapping GetAppInfo calls and returns every result.
+func callGetAppInfoConcurrently(ctx context.Context, c *Client, n int) []appInfoResult {
+	results := make([]appInfoResult, n)
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Go(func() {
+			results[i].info, results[i].err = c.GetAppInfo(ctx)
+		})
+	}
+	wg.Wait()
+	return results
+}
+
+func TestGetAppInfoSharesOneRefreshAcrossConcurrentCallers(t *testing.T) {
+	c, hitCount := newAppInfoStub(t, http.StatusOK)
 	c.appInfoCache = &AppInfo{Version: "4.6.7", WebAPIVersion: "2.11.4"}
 	c.appInfoFetchedAt = time.Now().Add(-2 * appInfoCacheTTL) // force the cache stale
 
-	// A canceled context makes the refresh fail immediately, standing in for a
-	// saturated qBittorrent WebUI that times out every request.
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	for _, r := range callGetAppInfoConcurrently(t.Context(), c, 8) {
+		require.NoError(t, r.err)
+		require.NotNil(t, r.info)
+		require.Equal(t, "v5.1.0", r.info.Version)
+		require.Equal(t, "2.11.4", r.info.WebAPIVersion)
+	}
+	require.Equal(t, 1, hitCount("/api/v2/app/version"))
+	require.Equal(t, 1, hitCount("/api/v2/app/webapiVersion"))
+	require.Equal(t, 1, hitCount("/api/v2/app/buildInfo"))
+	require.Equal(t, 0, hitCount("/api/v2/app/processInfo"), "2.11.4 predates process info")
+}
 
-	info, err := c.GetAppInfo(ctx)
-	require.NoError(t, err)
-	require.NotNil(t, info)
-	require.Equal(t, "4.6.7", info.Version)
-	require.Equal(t, "2.11.4", info.WebAPIVersion)
+func TestGetAppInfoServesStaleCacheWhenRefreshFails(t *testing.T) {
+	c, hitCount := newAppInfoStub(t, http.StatusInternalServerError)
+	c.appInfoCache = &AppInfo{Version: "4.6.7", WebAPIVersion: "2.11.4"}
+	c.appInfoFetchedAt = time.Now().Add(-2 * appInfoCacheTTL) // force the cache stale
+
+	for _, r := range callGetAppInfoConcurrently(t.Context(), c, 8) {
+		require.NoError(t, r.err)
+		require.NotNil(t, r.info)
+		require.Equal(t, "4.6.7", r.info.Version)
+		require.Equal(t, "2.11.4", r.info.WebAPIVersion)
+	}
+	require.Equal(t, 1, hitCount("/api/v2/app/version"))
+	require.Equal(t, 0, hitCount("/api/v2/app/webapiVersion"), "refresh stops at the first failure")
 }
 
 func TestGetAppInfoReturnsErrorWhenNoCacheAndRefreshFails(t *testing.T) {
-	c := &Client{
-		Client:     qbt.NewClient(qbt.Config{Host: "http://127.0.0.1:0"}),
-		instanceID: 1,
-	}
+	c, _ := newAppInfoStub(t, http.StatusInternalServerError)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	info, err := c.GetAppInfo(ctx)
+	info, err := c.GetAppInfo(t.Context())
 	require.Error(t, err)
 	require.Nil(t, info)
 }

--- a/internal/qbittorrent/client.go
+++ b/internal/qbittorrent/client.go
@@ -21,6 +21,7 @@ import (
 	"github.com/avast/retry-go"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
+	"golang.org/x/sync/singleflight"
 )
 
 var (
@@ -98,6 +99,7 @@ type Client struct {
 	serverStateMu        sync.RWMutex
 	healthMu             sync.RWMutex
 	appInfoMu            sync.RWMutex
+	appInfoGroup         singleflight.Group
 	preferencesCache     *qbt.AppPreferences
 	preferencesJSON      json.RawMessage
 	preferencesFetchedAt time.Time


### PR DESCRIPTION
## Description

Shares one app info refresh per client with `singleflight`, so an expired cache no longer makes every stream group fetch version, Web API version, build info, and process info on its own. The refresh runs under `context.WithoutCancel` so one caller's disconnect does not fail the joiners. Stale cache is still served after a failed refresh.

Fixes #2582

## How has this been tested?

CI covers it: a local HTTP stub with eight concurrent callers counts one hit per endpoint on both the success and the failure path.

Live on media (instance 1, 6052 torrents) with a request sniffer in the qBittorrent path and six SSE streams open on the instance with distinct sort and limit, so six stream groups race each 5-minute cache expiry. Develop: 10 `app/version` and 10 `app/buildInfo` requests in 11.8 minutes. pr-2593: 2 of each in 11.9 minutes, one per expiry, and no app info error in the log.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved application information loading by sharing concurrent refresh requests, reducing duplicate network calls.

* **Reliability**
  * Continued serving cached application information when a refresh fails.
  * Refresh operations now remain bounded by request timeouts without being interrupted by the initiating caller’s cancellation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
