### PR TITLE
perf(torrents): answer single-hash requests from the cache index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ Repo rules for AI agents working on qui.
 
 - Stay inside requested scope. Do not implement review-suggested/extra changes without explicit user approval.
 - Treat other agent/Codex/CodeRabbit feedback as input to discuss, not automatic action.
+- A review suggestion that changes a branch lands only after you show the input that branch guarded, in a test or a trace. A simplification that reads cleaner can still drop a case the old guard handled.
 - qui is single-user self-hosted software. Prefer readable, maintainable code over paranoid guards for impossible states.
 
 ## Repo Map

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -1538,6 +1538,26 @@ func (sm *SyncManager) GetTorrentsWithFilters(ctx context.Context, instanceID in
 		hasTrackerFilters || hasExcludeStatusFilters || hasExcludeCategoryFilters || hasExcludeTagFilters || hasExcludeTrackerFilters ||
 		hasExprFilters || needsManualStatusFiltering || needsManualCategoryFiltering || needsManualTagFiltering || hasHashFilters
 
+	// One hash and nothing else set (the details panel's stream): answer from the
+	// per-hash index. A miss falls through to the scan, which does variant matching.
+	// ponytail: single hash only; a multi-hash request still scans because the
+	// library sort would have to run on the picked rows.
+	var hashLookupHit bool
+	if len(filters.Hashes) == 1 && !needsTrackerHydration {
+		rest := filters
+		rest.Hashes = nil
+		if rest.IsEmpty() {
+			getTorrent := syncManager.GetTorrent
+			if skipFreshData {
+				getTorrent = syncManager.GetTorrentUnchecked
+			}
+			if torrent, ok := lookupTorrentByExactHash(getTorrent, filters.Hashes[0]); ok {
+				filteredTorrents = []qbt.Torrent{torrent}
+				hashLookupHit = true
+			}
+		}
+	}
+
 	var trackerMap map[string][]qbt.TorrentTracker
 	var counts *TorrentCounts
 
@@ -1561,7 +1581,13 @@ func (sm *SyncManager) GetTorrentsWithFilters(ctx context.Context, instanceID in
 	subcategoriesAlwaysEnabled := client.SubcategoriesAlwaysEnabled()
 	useSubcategories := resolveUseSubcategories(supportsSubcategories, subcategoriesAlwaysEnabled, mainData, categories)
 
-	if useManualFiltering {
+	switch {
+	case hashLookupHit:
+		useManualFiltering = false
+		log.Trace().
+			Int("instanceID", instanceID).
+			Msg("Using cached hash lookup for a single-hash request")
+	case useManualFiltering:
 		// Use manual filtering - get all torrents and filter manually
 		log.Trace().
 			Int("instanceID", instanceID).
@@ -1598,7 +1624,7 @@ func (sm *SyncManager) GetTorrentsWithFilters(ctx context.Context, instanceID in
 		}
 
 		filteredTorrents = sm.applyManualFiltersWithTrackerHealth(client, filteredTorrents, filters, mainData, categories, useSubcategories, cachedHealth)
-	} else {
+	default:
 		// Use library filtering for single selections
 		log.Trace().
 			Int("instanceID", instanceID).
@@ -3313,6 +3339,22 @@ func normalizeHashes(hashes []string) normalizedHashes {
 	}
 
 	return result
+}
+
+// lookupTorrentByExactHash reads one row by its cache key. Keys are
+// case-sensitive, so the input is tried as given, lower and upper. It does not
+// match infohash_v1/v2 variants; resolveTorrentByVariantHash scans for those.
+func lookupTorrentByExactHash(get func(string) (qbt.Torrent, bool), hash string) (qbt.Torrent, bool) {
+	trimmed := strings.TrimSpace(hash)
+	if trimmed == "" {
+		return qbt.Torrent{}, false
+	}
+	for _, variant := range []string{trimmed, strings.ToLower(trimmed), strings.ToUpper(trimmed)} {
+		if torrent, ok := get(variant); ok {
+			return torrent, true
+		}
+	}
+	return qbt.Torrent{}, false
 }
 
 func matchesAnyHash(torrent qbt.Torrent, targetSet map[string]struct{}) bool {

--- a/internal/qbittorrent/sync_manager_test.go
+++ b/internal/qbittorrent/sync_manager_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"runtime"
 	"slices"
 	"strings"
 	"sync"
@@ -3350,4 +3351,111 @@ func TestGetAuthoritativeDomainToHashesMemoizesPerGeneration(t *testing.T) {
 		"a mapping write must invalidate the snapshot")
 	require.NotContains(t, third, "tracker.example.invalid",
 		"the fresh snapshot must reflect the removal")
+}
+
+// The details panel streams one torrent by hash on every sync tick. The cache
+// indexes rows by hash, so that request is a lookup, not a copy of the library
+// plus a filter pass. Not parallel: it reads process-wide allocation totals.
+func TestGetTorrentsWithFiltersSingleHashSkipsLibraryCopy(t *testing.T) {
+	const librarySize = 500
+
+	var maindata bytes.Buffer
+	maindata.WriteString(`{"rid":1,"full_update":true,"torrents":{`)
+	for i := range librarySize {
+		if i > 0 {
+			maindata.WriteByte(',')
+		}
+		fmt.Fprintf(&maindata, `"%040x": {"name":"Some.Release.Title.%d.S01E01.1080p.WEB-GRPA","infohash_v1":"%040x","state":"uploading","added_on":%d,"size":100,"progress":1,"category":"tv"}`, i+1, i, i+1, i)
+	}
+	// One hybrid torrent keyed by its v1 hash with a distinct v2 hash.
+	maindata.WriteString(`,"aa11": {"name":"Hybrid.Release.S02E03.2160p.WEB-GRPB","infohash_v1":"aa11","infohash_v2":"bb22bb22","state":"uploading","added_on":1,"size":100,"progress":1,"category":"tv"}`)
+	maindata.WriteString(`}}`)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/sync/maindata":
+			_, _ = w.Write(maindata.Bytes())
+		case "/api/v2/app/webapiVersion":
+			_, _ = w.Write([]byte("2.16.0"))
+		case "/api/v2/torrents/categories":
+			_, _ = w.Write([]byte(`{}`))
+		case "/api/v2/torrents/tags":
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	pool := setupTestPool(t)
+	defer pool.Close()
+
+	ctx := WithSkipFreshData(t.Context())
+	inst, err := pool.instanceStore.Create(ctx, "mock", srv.URL, "user", "pass", nil, nil, false, nil)
+	require.NoError(t, err)
+
+	qbtClient := qbt.NewClient(qbt.Config{Host: srv.URL, Timeout: 60})
+	client := &Client{
+		Client:      qbtClient,
+		instanceID:  inst.ID,
+		syncManager: qbtClient.NewSyncManager(qbt.DefaultSyncOptions()),
+	}
+	client.updateHealthStatus(true)
+	require.NoError(t, client.syncManager.Sync(ctx))
+
+	pool.mu.Lock()
+	pool.clients[inst.ID] = client
+	pool.mu.Unlock()
+
+	sm := NewSyncManager(pool, nil)
+
+	byHash := func(hash string) FilterOptions { return FilterOptions{Hashes: []string{hash}} }
+	byExpr := func(hash string) FilterOptions { return FilterOptions{Expr: fmt.Sprintf("Hash == %q", hash)} }
+	target := fmt.Sprintf("%040x", 7)
+
+	for _, tc := range []struct {
+		name    string
+		filters FilterOptions
+		want    string // expected name; "" means no row
+	}{
+		{"exact key", byHash(target), "Some.Release.Title.6.S01E01.1080p.WEB-GRPA"},
+		{"upper-case key", byHash(strings.ToUpper(target)), "Some.Release.Title.6.S01E01.1080p.WEB-GRPA"},
+		{"v2 variant of a hybrid torrent", byHash("BB22BB22"), "Hybrid.Release.S02E03.2160p.WEB-GRPB"},
+		{"removed torrent", byHash(fmt.Sprintf("%040x", 999999)), ""},
+		{"hash plus a status the row fails", FilterOptions{Hashes: []string{target}, Status: []string{"downloading"}}, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := sm.GetTorrentsWithFilters(ctx, inst.ID, 1, 0, "added_on", "desc", "", tc.filters)
+			require.NoError(t, err)
+			if tc.want == "" {
+				require.Equal(t, 0, resp.Total, "a miss reports total 0 so the panel drops its stale row")
+				require.Empty(t, resp.Torrents)
+			} else {
+				require.Equal(t, 1, resp.Total)
+				require.Len(t, resp.Torrents, 1)
+				require.Equal(t, tc.want, resp.Torrents[0].Name)
+			}
+			require.NotNil(t, resp.Counts)
+			require.Equal(t, librarySize+1, resp.Counts.Status["all"], "sidebar counts still cover the whole library")
+		})
+	}
+
+	// Allocation proof: the hash request must not copy the library the way the
+	// expr request does. Counts are left out, the way a stream tick without
+	// IncludeCounts leaves them out, so the runs compare only the row selection.
+	ctx = WithSkipTrackerHydration(ctx)
+	measure := func(filters FilterOptions) uint64 {
+		var before, after runtime.MemStats
+		runtime.ReadMemStats(&before)
+		for range 20 {
+			_, err := sm.GetTorrentsWithFilters(ctx, inst.ID, 1, 0, "added_on", "desc", "", filters)
+			require.NoError(t, err)
+		}
+		runtime.ReadMemStats(&after)
+		return after.TotalAlloc - before.TotalAlloc
+	}
+	exprBytes := measure(byExpr(target))
+	hashBytes := measure(byHash(target))
+	t.Logf("20 requests: expr filter %d bytes, hash filter %d bytes", exprBytes, hashBytes)
+	require.Less(t, hashBytes*10, exprBytes, "a single-hash request must allocate far less than the library scan")
 }

--- a/internal/qbittorrent/sync_manager_test.go
+++ b/internal/qbittorrent/sync_manager_test.go
@@ -3365,7 +3365,7 @@ func TestGetTorrentsWithFiltersSingleHashSkipsLibraryCopy(t *testing.T) {
 		if i > 0 {
 			maindata.WriteByte(',')
 		}
-		fmt.Fprintf(&maindata, `"%040x": {"name":"Some.Release.Title.%d.S01E01.1080p.WEB-GRPA","infohash_v1":"%040x","state":"uploading","added_on":%d,"size":100,"progress":1,"category":"tv"}`, i+1, i, i+1, i)
+		fmt.Fprintf(&maindata, `"%040x": {"name":"Some.Release.Title.%d.S01E01.1080p.WEB-GRPA","infohash_v1":"%040x","state":"uploading","added_on":%d,"size":100,"progress":1,"category":"tv"}`, i+1, i+1, i+1, i)
 	}
 	// One hybrid torrent keyed by its v1 hash with a distinct v2 hash.
 	maindata.WriteString(`,"aa11": {"name":"Hybrid.Release.S02E03.2160p.WEB-GRPB","infohash_v1":"aa11","infohash_v2":"bb22bb22","state":"uploading","added_on":1,"size":100,"progress":1,"category":"tv"}`)
@@ -3418,8 +3418,8 @@ func TestGetTorrentsWithFiltersSingleHashSkipsLibraryCopy(t *testing.T) {
 		filters FilterOptions
 		want    string // expected name; "" means no row
 	}{
-		{"exact key", byHash(target), "Some.Release.Title.6.S01E01.1080p.WEB-GRPA"},
-		{"upper-case key", byHash(strings.ToUpper(target)), "Some.Release.Title.6.S01E01.1080p.WEB-GRPA"},
+		{"exact key", byHash(target), "Some.Release.Title.7.S01E01.1080p.WEB-GRPA"},
+		{"upper-case key", byHash(strings.ToUpper(target)), "Some.Release.Title.7.S01E01.1080p.WEB-GRPA"},
 		{"v2 variant of a hybrid torrent", byHash("BB22BB22"), "Hybrid.Release.S02E03.2160p.WEB-GRPB"},
 		{"removed torrent", byHash(fmt.Sprintf("%040x", 999999)), ""},
 		{"hash plus a status the row fails", FilterOptions{Hashes: []string{target}, Status: []string{"downloading"}}, ""},

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -85,3 +85,5 @@ Coverage must compare against English for missing/extra keys, interpolation plac
 ## Torrent Details Note
 
 `web/src/components/torrents/TorrentDetailsPanel.tsx` live row state is stream-backed via `useSyncStream`; polling is fallback while stream unavailable. Content/files and Peers tabs still poll on interval, but polling is tab-scoped and visibility-gated.
+
+`useSyncStream` listeners receive raw frames. A delta for unchanged rows carries an empty `torrents` list and the previous `total`, so a handler clears its row only on `total === 0` and keeps the previous row on an empty list.

--- a/web/src/components/torrents/TorrentDetailsPanel.tsx
+++ b/web/src/components/torrents/TorrentDetailsPanel.tsx
@@ -142,7 +142,7 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
     }
 
     return {
-      expr: `Hash == "${torrent.hash}"`,
+      hashes: [torrent.hash],
       status: [],
       excludeStatus: [],
       categories: [],
@@ -174,14 +174,9 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
         return
       }
 
-      const nextTorrent = payload.data.torrents?.find(item => item.hash === torrent.hash) ?? null
-      if (!nextTorrent && payload.data.total === 0) {
-        setStreamTorrent(null)
-        return
-      }
-      if (nextTorrent) {
-        setStreamTorrent(nextTorrent)
-      }
+      // The stream is filtered to this hash with limit 1, so the row is either
+      // the first entry or gone (total 0 after removal).
+      setStreamTorrent(payload.data.torrents?.[0] ?? null)
     },
     [torrent?.hash]
   )

--- a/web/src/components/torrents/TorrentDetailsPanel.tsx
+++ b/web/src/components/torrents/TorrentDetailsPanel.tsx
@@ -31,7 +31,7 @@ import { formatSpeedWithUnit, useSpeedUnits } from "@/lib/speedUnits"
 import { canBanPeer, getPeerDisplayAddress } from "@/lib/torrent-peer-address"
 import { getPeerFlagDetails } from "@/lib/torrent-peer-flags"
 import { getStateLabel } from "@/lib/torrent-state-utils"
-import { resolveTorrentHashes } from "@/lib/torrent-utils"
+import { resolveStreamRow, resolveTorrentHashes } from "@/lib/torrent-utils"
 import { getTrackerStatusBadge } from "@/lib/tracker-utils"
 import { cn, copyTextToClipboard, formatBytes, formatDuration } from "@/lib/utils"
 import type { SortedPeer, SortedPeersResponse, Torrent, TorrentFile, TorrentFilters, TorrentStreamPayload, TorrentTracker } from "@/types"
@@ -174,14 +174,8 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
         return
       }
 
-      // The stream is filtered to this hash with limit 1. A delta whose row did
-      // not change carries no rows but total 1, so only total 0 clears the row.
-      const nextTorrent = payload.data.torrents?.[0]
-      if (nextTorrent) {
-        setStreamTorrent(nextTorrent)
-      } else if (payload.data.total === 0) {
-        setStreamTorrent(null)
-      }
+      const data = payload.data
+      setStreamTorrent(previous => resolveStreamRow(previous, data))
     },
     [torrent?.hash]
   )

--- a/web/src/components/torrents/TorrentDetailsPanel.tsx
+++ b/web/src/components/torrents/TorrentDetailsPanel.tsx
@@ -174,9 +174,14 @@ export const TorrentDetailsPanel = memo(function TorrentDetailsPanel({ instanceI
         return
       }
 
-      // The stream is filtered to this hash with limit 1, so the row is either
-      // the first entry or gone (total 0 after removal).
-      setStreamTorrent(payload.data.torrents?.[0] ?? null)
+      // The stream is filtered to this hash with limit 1. A delta whose row did
+      // not change carries no rows but total 1, so only total 0 clears the row.
+      const nextTorrent = payload.data.torrents?.[0]
+      if (nextTorrent) {
+        setStreamTorrent(nextTorrent)
+      } else if (payload.data.total === 0) {
+        setStreamTorrent(null)
+      }
     },
     [torrent?.hash]
   )

--- a/web/src/lib/torrent-utils.test.ts
+++ b/web/src/lib/torrent-utils.test.ts
@@ -28,11 +28,12 @@ describe("getToggleSelectionState", () => {
 })
 
 describe("resolveStreamRow", () => {
-  const previous = { hash: "aa11", name: "Hybrid.Release.S02E03.2160p.WEB-GRPB" } as Torrent
+  // The panel selected the hybrid torrent by its v2 hash; the server keys the row by v1.
+  const previous = { hash: "bb22bb22", name: "Hybrid.Release.S02E03.2160p.WEB-GRPB" } as Torrent
+  const v1Row = { ...previous, hash: "aa11" }
   const cases: Array<{ name: string; data: { torrents: Torrent[]; total: number }; want: Torrent | null }> = [
     { name: "a changed row replaces the previous one", data: { torrents: [{ ...previous, progress: 1 }], total: 1 }, want: { ...previous, progress: 1 } },
-    // The panel asked for the v2 hash; the server answered with the v1-keyed row.
-    { name: "a row keyed by another hash still lands", data: { torrents: [{ ...previous, hash: "aa11" }], total: 1 }, want: previous },
+    { name: "a row keyed by another hash still lands", data: { torrents: [v1Row], total: 1 }, want: v1Row },
     { name: "an unchanged delta keeps the previous row", data: { torrents: [], total: 1 }, want: previous },
     { name: "a removed torrent drops the row", data: { torrents: [], total: 0 }, want: null },
   ]

--- a/web/src/lib/torrent-utils.test.ts
+++ b/web/src/lib/torrent-utils.test.ts
@@ -4,7 +4,8 @@
  */
 
 import { describe, expect, it } from "vitest"
-import { getToggleSelectionState } from "./torrent-utils"
+import type { Torrent } from "@/types"
+import { getToggleSelectionState, resolveStreamRow } from "./torrent-utils"
 
 describe("getToggleSelectionState", () => {
   const cases: Array<{ name: string; values: boolean[]; stateUnknown: boolean; allEnabled: boolean; mixed: boolean }> = [
@@ -22,6 +23,23 @@ describe("getToggleSelectionState", () => {
   for (const { name, values, stateUnknown, allEnabled, mixed } of cases) {
     it(name, () => {
       expect(getToggleSelectionState(values, stateUnknown)).toEqual({ allEnabled, mixed })
+    })
+  }
+})
+
+describe("resolveStreamRow", () => {
+  const previous = { hash: "aa11", name: "Hybrid.Release.S02E03.2160p.WEB-GRPB" } as Torrent
+  const cases: Array<{ name: string; data: { torrents: Torrent[]; total: number }; want: Torrent | null }> = [
+    { name: "a changed row replaces the previous one", data: { torrents: [{ ...previous, progress: 1 }], total: 1 }, want: { ...previous, progress: 1 } },
+    // The panel asked for the v2 hash; the server answered with the v1-keyed row.
+    { name: "a row keyed by another hash still lands", data: { torrents: [{ ...previous, hash: "aa11" }], total: 1 }, want: previous },
+    { name: "an unchanged delta keeps the previous row", data: { torrents: [], total: 1 }, want: previous },
+    { name: "a removed torrent drops the row", data: { torrents: [], total: 0 }, want: null },
+  ]
+
+  for (const { name, data, want } of cases) {
+    it(name, () => {
+      expect(resolveStreamRow(previous, data)).toEqual(want)
     })
   }
 })

--- a/web/src/lib/torrent-utils.ts
+++ b/web/src/lib/torrent-utils.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import type { Torrent } from "@/types"
+import type { Torrent, TorrentResponse } from "@/types"
 
 type HashSource = {
   hash?: string | null
@@ -211,4 +211,19 @@ export function getToggleSelectionState(values: boolean[], stateUnknown: boolean
     allEnabled: values.length > 0 && values.every(Boolean),
     mixed: stateUnknown || values.some(value => value !== values[0]),
   }
+}
+
+/**
+ * Pick the details panel's live row from one stream frame. The stream is
+ * filtered to one hash with limit 1, so the row is whatever the server picked,
+ * not a row whose `hash` equals the requested one: a hybrid torrent looked up by
+ * its v2 infohash comes back keyed by v1. A delta whose row did not change
+ * carries no rows and the previous total, so only total 0 drops the row.
+ */
+export function resolveStreamRow(previous: Torrent | null, data: Pick<TorrentResponse, "torrents" | "total">): Torrent | null {
+  const next = data.torrents?.[0]
+  if (next) {
+    return next
+  }
+  return data.total === 0 ? null : previous
 }

--- a/web/src/types/torrents.ts
+++ b/web/src/types/torrents.ts
@@ -207,6 +207,7 @@ export interface TorrentCounts {
  * Tracker filters use the same normalized domain keys as TorrentCounts.trackers.
  */
 export interface TorrentFilters {
+  hashes?: string[]
   status: string[]
   excludeStatus: string[]
   categories: string[]


### PR DESCRIPTION
## Description

Answers a torrent request whose only filter is one hash through the sync manager's per-hash index instead of cloning the whole library and filtering it. The details panel and its fallback poll send `filters.hashes` instead of a `Hash == "..."` expr. A miss falls through to the manual scan, so infohash variants still match and a removed torrent still reports total 0. Multi-hash requests still scan.

Fixes #2581

## How has this been tested?

Local rig: stub qBittorrent with a per-path request counter and 2000 synthetic torrents, this branch and develop in the same session. A 60 s details stream logged 38 hash lookups on this branch against 38 manual-filter passes on develop. qBittorrent request counts were the same on both builds (maindata +32 against +31, torrentcreator/status +6 against +6), as expected for a cache read. In the browser the stream URL carries `filters.hashes` with no expr and the panel renders the selected row.

The new test measures allocations on a 500-torrent library, 20 requests, counts excluded: 20.8 MB on the expr path, 257 KB on the hash path.

Both cases the hash path leaves to the scan were run on the same rig with a hybrid torrent in the stub: a request by the v2 infohash (lower and upper case, REST and stream) returns the v1-keyed row through the manual scan, and the REST request with a cold counts cache returns the row from the index plus whole-library counts. They still copy the library once each, as expected.

Removal, live on the rig with the stub qBittorrent (300 rows): a hash-filtered stream opened from the browser tab carried the row with a rising upspeed on every delta (hash lookup hits in the log), then `total: 0` with no rows on every delta after the torrent was deleted through the bulk-action API. The panel then keeps the prop row and its stream misses the index on each tick, which is a full scan every 2 s until the panel closes. That is what develop does with the expr filter too, and is not changed here.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for filtering torrent lists by specific torrent hashes.
  - Torrent detail views now receive targeted live updates for the selected torrent.

- **Bug Fixes**
  - Improved single-torrent lookups, including uppercase and alternate hash formats.
  - Preserved correct filtering for removed torrents and status-based conditions.
  - Sidebar torrent counts continue to reflect the complete library while targeted results load efficiently.
  - Live torrent details remain stable when updates contain no changed data and clear correctly when a torrent is removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

