### PR TITLE
perf(reannounce): narrow tracker fetches and bound jobs

### DIFF
--- a/internal/services/reannounce/service.go
+++ b/internal/services/reannounce/service.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -36,6 +37,7 @@ type Service struct {
 	clientPool    *qbittorrent.ClientPool
 	syncManager   *qbittorrent.SyncManager
 	j             map[int]map[string]*reannounceJob
+	queues        map[int]*reannounceQueue
 	jobsMu        sync.Mutex
 	ctxMu         sync.RWMutex
 	baseCtx       context.Context
@@ -56,6 +58,11 @@ type reannounceJob struct {
 	lastRequested time.Time
 	isRunning     bool
 	lastCompleted time.Time
+}
+
+type reannounceQueue struct {
+	active  int
+	pending []func()
 }
 
 // ActivityOutcome describes a high-level outcome for a reannounce attempt.
@@ -80,6 +87,11 @@ type ActivityEvent struct {
 }
 
 const defaultHistorySize = 50
+
+const maxConcurrentJobsPerInstance = 4
+
+// Keep hash lists below common proxy URL limits, including 64-character hashes.
+const trackerFetchBatchSize = 100
 
 // MonitoredTorrentState describes the current monitoring state for a torrent.
 type MonitoredTorrentState string
@@ -133,6 +145,7 @@ func NewService(cfg Config, instanceStore *models.InstanceStore, settingsStore *
 		clientPool:        clientPool,
 		syncManager:       syncManager,
 		j:                 make(map[int]map[string]*reannounceJob),
+		queues:            make(map[int]*reannounceQueue),
 		historySucceeded:  make(map[int][]ActivityEvent),
 		historyFailed:     make(map[int][]ActivityEvent),
 		historySkipped:    make(map[int][]ActivityEvent),
@@ -240,24 +253,42 @@ func (s *Service) scanInstance(ctx context.Context, instanceID int, settings *mo
 		return
 	}
 
-	var torrents []qbt.Torrent
-
-	// For qBittorrent 5.1+ (WebAPI >= 2.11.4), fetch torrents with tracker data in one call.
-	// For older versions, use the sync manager cache (trackers fetched separately in executeJob).
-	if client.SupportsTrackerHealth() {
-		torrents, err = client.GetTorrentsCtx(ctx, qbt.TorrentFilterOptions{
-			Filter:          qbt.TorrentFilterStalled,
-			IncludeTrackers: true,
-		})
-	} else {
-		// Older qBittorrent - use cached torrents; executeJob will fetch fresh trackers
-		torrents, err = s.syncManager.GetTorrents(ctx, instanceID, qbt.TorrentFilterOptions{
-			Filter: qbt.TorrentFilterStalled,
-		})
-	}
+	torrents, err := s.syncManager.GetTorrents(ctx, instanceID, qbt.TorrentFilterOptions{
+		Filter: qbt.TorrentFilterStalled,
+	})
 	if err != nil {
-		log.Debug().Err(err).Int("instanceID", instanceID).Msg("reannounce: failed to fetch torrents")
+		log.Debug().Err(err).Int("instanceID", instanceID).Msg("reannounce: failed to fetch cached torrents")
 		return
+	}
+
+	if client.SupportsTrackerHealth() {
+		// Cached torrents can lack tracker lists. Keep possible tracker matches
+		// and apply tracker rules to the fresh response below.
+		prefilter := *settings
+		prefilter.Trackers = nil
+		prefilter.MonitorAll = settings.MonitorAll || (!settings.ExcludeTrackers && len(settings.Trackers) > 0)
+		var hashes []string
+		for _, torrent := range torrents {
+			if s.torrentMeetsCriteria(torrent, &prefilter) {
+				hashes = append(hashes, torrent.Hash)
+			}
+		}
+		if len(hashes) == 0 {
+			return
+		}
+		torrents = nil
+		for batch := range slices.Chunk(hashes, trackerFetchBatchSize) {
+			fresh, err := client.GetTorrentsCtx(ctx, qbt.TorrentFilterOptions{
+				Filter:          qbt.TorrentFilterStalled,
+				Hashes:          batch,
+				IncludeTrackers: true,
+			})
+			if err != nil {
+				log.Debug().Err(err).Int("instanceID", instanceID).Msg("reannounce: failed to fetch trackers for candidates")
+				return
+			}
+			torrents = append(torrents, fresh...)
+		}
 	}
 
 	for _, torrent := range torrents {
@@ -373,9 +404,11 @@ func (s *Service) enqueue(instanceID int, hash string, torrentName string, track
 		s.recordActivity(instanceID, hash, torrentName, trackers, ActivityOutcomeSkipped, "service not started")
 		return false
 	}
+	if baseCtx.Err() != nil {
+		return false
+	}
 
 	s.jobsMu.Lock()
-	defer s.jobsMu.Unlock()
 	instJobs, ok := s.j[instanceID]
 	if !ok {
 		instJobs = make(map[string]*reannounceJob)
@@ -394,6 +427,7 @@ func (s *Service) enqueue(instanceID int, hash string, torrentName string, track
 	debounceWindow := s.effectiveDebounceWindow(settings)
 
 	if job.isRunning {
+		s.jobsMu.Unlock()
 		return true
 	}
 
@@ -406,6 +440,7 @@ func (s *Service) enqueue(instanceID int, hash string, torrentName string, track
 				reason = "debounced during cooldown window"
 			}
 			s.recordActivity(instanceID, hash, torrentName, trackers, ActivityOutcomeSkipped, reason)
+			s.jobsMu.Unlock()
 			return true
 		}
 	}
@@ -416,23 +451,69 @@ func (s *Service) enqueue(instanceID int, hash string, torrentName string, track
 	if runner == nil {
 		runner = s.executeJob
 	}
+	queue := s.queues[instanceID]
+	if queue == nil {
+		queue = &reannounceQueue{}
+		s.queues[instanceID] = queue
+	}
+	queue.pending = append(queue.pending, func() {
+		s.jobsMu.Lock()
+		if baseCtx.Err() != nil {
+			delete(instJobs, hash)
+			if len(instJobs) == 0 {
+				delete(s.j, instanceID)
+			}
+			s.jobsMu.Unlock()
+			return
+		}
+		// Queue time must not expire the cooldown record before the job runs.
+		job.lastRequested = s.currentTime()
+		s.jobsMu.Unlock()
+		defer s.finishJob(instanceID, hash)
+		runner(baseCtx, instanceID, hash, torrentName, trackers)
+	})
+	if queue.active >= maxConcurrentJobsPerInstance {
+		s.jobsMu.Unlock()
+		return true
+	}
+	queue.active++
+	s.jobsMu.Unlock()
+
 	spawn := s.spawn
 	if spawn == nil {
 		spawn = func(fn func()) { go fn() }
 	}
 	spawn(func() {
-		runner(baseCtx, instanceID, hash, torrentName, trackers)
+		for {
+			s.jobsMu.Lock()
+			if len(queue.pending) == 0 {
+				queue.active--
+				if queue.active == 0 {
+					delete(s.queues, instanceID)
+				}
+				s.jobsMu.Unlock()
+				return
+			}
+			next := queue.pending[0]
+			queue.pending[0] = nil
+			queue.pending = queue.pending[1:]
+			s.jobsMu.Unlock()
+			next()
+		}
 	})
 	return true
 }
 
 func (s *Service) executeJob(parentCtx context.Context, instanceID int, hash string, torrentName string, initialTrackers string) {
-	defer s.finishJob(instanceID, hash)
 	ctx, cancel := context.WithTimeout(parentCtx, 5*time.Minute)
 	defer cancel()
 	settings := s.getSettings(ctx, instanceID)
 	if settings == nil {
 		settings = models.DefaultInstanceReannounceSettings(instanceID)
+	}
+	if !settings.CanMatchTorrents() {
+		s.recordActivity(instanceID, hash, torrentName, initialTrackers, ActivityOutcomeSkipped, "monitoring disabled or no matching scope")
+		return
 	}
 	client, err := s.clientPool.GetClient(ctx, instanceID)
 	if err != nil {
@@ -444,6 +525,19 @@ func (s *Service) executeJob(parentCtx context.Context, instanceID int, hash str
 	if err != nil {
 		log.Debug().Err(err).Int("instanceID", instanceID).Str("hash", hash).Msg("reannounce: failed to load trackers")
 		s.recordActivity(instanceID, hash, torrentName, initialTrackers, ActivityOutcomeFailed, fmt.Sprintf("failed to load trackers: %v", err))
+		return
+	}
+	// A queued torrent can leave the monitoring scope before a worker is free.
+	torrent, ok, err := s.syncManager.HasTorrentByAnyHash(ctx, instanceID, []string{hash})
+	if err != nil {
+		s.recordActivity(instanceID, hash, torrentName, initialTrackers, ActivityOutcomeFailed, fmt.Sprintf("failed to load torrent: %v", err))
+		return
+	}
+	if ok {
+		torrent.Trackers = trackerList
+	}
+	if !ok || !s.torrentMeetsCriteria(*torrent, settings) {
+		s.recordActivity(instanceID, hash, torrentName, initialTrackers, ActivityOutcomeSkipped, "torrent no longer matches monitoring scope")
 		return
 	}
 	if s.hasHealthyTracker(trackerList) {

--- a/internal/services/reannounce/service_test.go
+++ b/internal/services/reannounce/service_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json/v2"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -768,9 +769,9 @@ func TestServiceEnqueue_BoundsWorkersAndCancelsQueue(t *testing.T) {
 		require.Zero(t, active.Load())
 		require.Empty(t, svc.queues)
 		require.Len(t, started, 2*maxConcurrentJobsPerInstance+1, "canceled queued jobs must not run")
-		for _, jobs := range svc.j {
+		for jobs := range maps.Values(svc.j) {
 			require.NotContains(t, jobs, "HASH19", "queued jobs must not acquire a cooldown on cancellation")
-			for _, job := range jobs {
+			for job := range maps.Values(jobs) {
 				require.False(t, job.isRunning)
 			}
 		}
@@ -825,7 +826,7 @@ func TestServiceEnqueue_RechecksScopeAfterQueueWait(t *testing.T) {
 			svc.settingsCache.Replace(&models.InstanceReannounceSettings{InstanceID: instanceID, Enabled: true, MonitorAll: true})
 			var workers []func()
 			svc.spawn = func(fn func()) { workers = append(workers, fn) }
-			for hash := range torrents {
+			for hash := range maps.Keys(torrents) {
 				require.True(t, svc.enqueue(instanceID, strings.ToUpper(hash), "Synthetic seed", "tracker.test"))
 			}
 			svc.settingsCache.Replace(&models.InstanceReannounceSettings{InstanceID: instanceID, Enabled: enabled, Categories: []string{"missing"}})

--- a/internal/services/reannounce/service_test.go
+++ b/internal/services/reannounce/service_test.go
@@ -5,8 +5,14 @@ package reannounce
 
 import (
 	"context"
+	"encoding/json/v2"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	qbt "github.com/autobrr/go-qbittorrent"
@@ -14,6 +20,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/qbittorrent"
+	"github.com/autobrr/qui/internal/testutil/testdb"
 )
 
 func TestTorrentMeetsCriteria_MonitorAllAndAge(t *testing.T) {
@@ -376,15 +384,19 @@ func TestServiceEnqueue_DebouncesWhileRunning(t *testing.T) {
 	now := time.Unix(0, 0)
 	svc := newTestServiceForDebounce(time.Minute, func() time.Time { return now })
 	started := 0
+	var workers []func()
+	svc.spawn = func(fn func()) { workers = append(workers, fn) }
 	svc.runJob = func(ctx context.Context, instanceID int, hash string, torrentName string, trackers string) {
 		started++
 	}
 
 	require.True(t, svc.enqueue(1, "ABC", "Test Torrent", "tracker.example.com"))
-	require.Equal(t, 1, started, "expected first enqueue to start job")
+	require.Len(t, workers, 1)
 
 	require.True(t, svc.enqueue(1, "ABC", "Test Torrent", "tracker.example.com"))
-	require.Equal(t, 1, started, "expected duplicate enqueue while running to be debounced")
+	require.Len(t, workers, 1, "expected duplicate enqueue to use the same worker")
+	workers[0]()
+	require.Equal(t, 1, started)
 }
 
 func TestServiceEnqueue_RespectsCooldownAfterCompletion(t *testing.T) {
@@ -397,8 +409,6 @@ func TestServiceEnqueue_RespectsCooldownAfterCompletion(t *testing.T) {
 
 	require.True(t, svc.enqueue(1, "ABC", "Test Torrent", "tracker.example.com"))
 	require.Equal(t, 1, started, "expected first enqueue to start job")
-
-	svc.finishJob(1, "ABC")
 
 	now = now.Add(30 * time.Second)
 	require.True(t, svc.enqueue(1, "ABC", "Test Torrent", "tracker.example.com"))
@@ -423,8 +433,6 @@ func TestServiceEnqueue_AggressiveModeSkipsDebounce(t *testing.T) {
 	// 1. Run initial job
 	require.True(t, svc.enqueue(1, "ABC", "Test", "tracker"))
 	require.Equal(t, 1, started)
-	svc.finishJob(1, "ABC")
-
 	// 2. Advance time slightly (still inside debounce window)
 	now = now.Add(5 * time.Second)
 
@@ -451,20 +459,11 @@ func newTestServiceForDebounce(window time.Duration, now func() time.Time) *Serv
 	if now == nil {
 		now = time.Now
 	}
-	return &Service{
-		cfg: Config{
-			DebounceWindow: window,
-			ScanInterval:   time.Second,
-		},
-		j:                make(map[int]map[string]*reannounceJob),
-		now:              now,
-		spawn:            func(fn func()) { fn() },
-		historySucceeded: make(map[int][]ActivityEvent),
-		historyFailed:    make(map[int][]ActivityEvent),
-		historySkipped:   make(map[int][]ActivityEvent),
-		historyCap:       defaultHistorySize,
-		baseCtx:          context.Background(),
-	}
+	svc := NewService(Config{DebounceWindow: window, ScanInterval: time.Second}, nil, nil, nil, nil, nil)
+	svc.now = now
+	svc.spawn = func(fn func()) { fn() }
+	svc.baseCtx = context.Background()
+	return svc
 }
 
 func TestServiceRecordActivityLimit(t *testing.T) {
@@ -536,4 +535,324 @@ func TestScanInstance_SkipsFetchWhenScopeCannotMatch(t *testing.T) {
 	require.NotPanics(t, func() {
 		svc.scanInstance(context.Background(), 1, &models.InstanceReannounceSettings{Enabled: true})
 	})
+}
+
+func TestScanInstance_FetchesOnlyCandidates(t *testing.T) {
+	now := time.Now()
+	torrents := map[string]qbt.Torrent{}
+	for _, hash := range []string{"eligible", "other", "old", "young", "category", "tag", "healthy", "active"} {
+		torrents[hash] = qbt.Torrent{
+			Hash: hash, Name: "Synthetic " + hash, AddedOn: now.Unix() - 60,
+			State: qbt.TorrentStateStalledUp, Category: hash, Tags: hash,
+			Trackers: []qbt.TorrentTracker{{Url: "https://" + hash + ".test/announce", Status: qbt.TrackerStatusNotWorking}},
+		}
+	}
+	old := torrents["old"]
+	old.AddedOn = now.Unix() - 601
+	torrents["old"] = old
+	young := torrents["young"]
+	young.AddedOn = now.Unix()
+	torrents["young"] = young
+	healthy := torrents["healthy"]
+	healthy.Trackers[0].Status = qbt.TrackerStatusOK
+	torrents["healthy"] = healthy
+	active := torrents["active"]
+	active.State = qbt.TorrentStateUploading
+	torrents["active"] = active
+
+	for _, tc := range []struct {
+		name       string
+		settings   models.InstanceReannounceSettings
+		wantHashes []string
+		wantJobs   []string
+	}{
+		{
+			name: "age and exclusions",
+			settings: models.InstanceReannounceSettings{
+				MonitorAll: true, ExcludeCategories: true, Categories: []string{"category"},
+				ExcludeTags: true, Tags: []string{"tag"},
+			},
+			wantHashes: []string{"eligible", "other", "healthy"},
+			wantJobs:   []string{"ELIGIBLE", "OTHER"},
+		},
+		{
+			name:       "category or tag inclusion",
+			settings:   models.InstanceReannounceSettings{Categories: []string{"eligible"}, Tags: []string{"tag"}},
+			wantHashes: []string{"eligible", "tag"},
+			wantJobs:   []string{"ELIGIBLE", "TAG"},
+		},
+		{
+			name:       "empty candidates",
+			settings:   models.InstanceReannounceSettings{Categories: []string{"missing"}},
+			wantHashes: nil,
+			wantJobs:   nil,
+		},
+		{
+			name:       "tracker inclusion with empty cache lists",
+			settings:   models.InstanceReannounceSettings{Trackers: []string{"eligible.test"}},
+			wantHashes: []string{"eligible", "other", "category", "tag", "healthy"},
+			wantJobs:   []string{"ELIGIBLE"},
+		},
+		{
+			name: "tracker inclusion or category with tag exclusion",
+			settings: models.InstanceReannounceSettings{
+				Categories: []string{"category"}, Trackers: []string{"eligible.test", "tag.test"},
+				ExcludeTags: true, Tags: []string{"tag"},
+			},
+			wantHashes: []string{"eligible", "other", "category", "healthy"},
+			wantJobs:   []string{"ELIGIBLE", "CATEGORY"},
+		},
+		{
+			name: "tracker exclusion keeps category scope",
+			settings: models.InstanceReannounceSettings{
+				Categories: []string{"eligible", "category"}, ExcludeTrackers: true, Trackers: []string{"category.test"},
+			},
+			wantHashes: []string{"eligible", "category"},
+			wantJobs:   []string{"ELIGIBLE"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			svc, instanceID, requests := newScanTestService(t, "2.11.4", torrents)
+			svc.now = func() time.Time { return now }
+			var jobs []string
+			svc.runJob = func(_ context.Context, _ int, hash, _, _ string) { jobs = append(jobs, hash) }
+			tc.settings.Enabled = true
+			tc.settings.MaxAgeSeconds = 600
+			tc.settings.InitialWaitSeconds = 15
+			svc.scanInstance(t.Context(), instanceID, &tc.settings)
+			if len(tc.wantHashes) == 0 {
+				require.Empty(t, requests)
+			} else {
+				require.Len(t, requests, 1)
+				require.ElementsMatch(t, tc.wantHashes, <-requests)
+			}
+			require.ElementsMatch(t, tc.wantJobs, jobs)
+		})
+	}
+}
+
+func TestScanInstance_BatchesCandidates(t *testing.T) {
+	torrents := make(map[string]qbt.Torrent)
+	for i := range trackerFetchBatchSize + 1 {
+		hash := fmt.Sprintf("%064x", i)
+		torrents[hash] = qbt.Torrent{Hash: hash, Name: "Synthetic seed", State: qbt.TorrentStateStalledUp}
+	}
+	svc, instanceID, requests := newScanTestService(t, "2.11.4", torrents)
+	svc.runJob = func(context.Context, int, string, string, string) {}
+	svc.scanInstance(t.Context(), instanceID, &models.InstanceReannounceSettings{Enabled: true, MonitorAll: true})
+	require.Len(t, requests, 2)
+	first, second := <-requests, <-requests
+	require.Len(t, first, trackerFetchBatchSize)
+	require.Len(t, second, 1)
+	seen := make(map[string]bool)
+	for _, batch := range [][]string{first, second} {
+		for _, hash := range batch {
+			require.Contains(t, torrents, hash)
+			require.False(t, seen[hash], "duplicate hash in tracker requests")
+			seen[hash] = true
+		}
+	}
+	require.Len(t, seen, len(torrents))
+}
+
+func TestScanInstance_OlderClientUsesCache(t *testing.T) {
+	torrents := map[string]qbt.Torrent{"eligible": {Hash: "eligible", Name: "Synthetic seed", State: qbt.TorrentStateStalledUp}}
+	svc, instanceID, requests := newScanTestService(t, "2.10.0", torrents)
+	var jobs []string
+	svc.runJob = func(_ context.Context, _ int, hash, _, _ string) { jobs = append(jobs, hash) }
+	svc.scanInstance(t.Context(), instanceID, &models.InstanceReannounceSettings{Enabled: true, MonitorAll: true})
+	require.Empty(t, requests)
+	require.Equal(t, []string{"ELIGIBLE"}, jobs)
+}
+
+func newScanTestService(t *testing.T, version string, torrents map[string]qbt.Torrent) (*Service, int, <-chan []string) {
+	t.Helper()
+	requests := make(chan []string, len(torrents)+1)
+	cached := make(map[string]qbt.Torrent, len(torrents))
+	for hash, torrent := range torrents {
+		torrent.Trackers = nil
+		cached[hash] = torrent
+	}
+	mainData, err := json.Marshal(qbt.MainData{Rid: 1, FullUpdate: true, Torrents: cached})
+	require.NoError(t, err)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/app/webapiVersion":
+			_, _ = w.Write([]byte(version))
+		case "/api/v2/sync/maindata":
+			_, _ = w.Write(mainData)
+		case "/api/v2/torrents/info":
+			assert.Equal(t, "true", r.URL.Query().Get("includeTrackers"))
+			assert.Equal(t, "stalled", r.URL.Query().Get("filter"))
+			hashes := strings.Split(r.URL.Query().Get("hashes"), "|")
+			requests <- hashes
+			var response []qbt.Torrent
+			for _, hash := range hashes {
+				if torrent, ok := torrents[hash]; ok {
+					response = append(response, torrent)
+				}
+			}
+			assert.NoError(t, json.MarshalWrite(w, response))
+		case "/api/v2/torrents/trackers":
+			torrent := torrents[strings.ToLower(r.URL.Query().Get("hash"))]
+			assert.NoError(t, json.MarshalWrite(w, torrent.Trackers))
+		default:
+			t.Errorf("unexpected qBittorrent request: %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	db := testdb.NewMigratedSQLite(t, "reannounce-scan")
+	instances, err := models.NewInstanceStore(db, make([]byte, 32))
+	require.NoError(t, err)
+	instance, err := instances.Create(t.Context(), "Reannounce stub", server.URL, "", "", nil, nil, false, new(true))
+	require.NoError(t, err)
+	pool, err := qbittorrent.NewClientPool(instances, models.NewInstanceErrorStore(db), time.Second)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, pool.Close()) })
+	// Fill the cache before attaching qui's background tracker refresh.
+	syncCtx, cancel := context.WithCancel(t.Context())
+	_, err = pool.GetClient(syncCtx, instance.ID)
+	cancel()
+	require.NoError(t, err)
+	svc := NewService(DefaultConfig(), instances, nil, nil, pool, qbittorrent.NewSyncManager(pool, nil))
+	svc.setBaseContext(t.Context())
+	svc.spawn = func(fn func()) { fn() }
+	return svc, instance.ID, requests
+}
+
+func TestServiceEnqueue_BoundsWorkersAndCancelsQueue(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		svc := NewService(DefaultConfig(), nil, nil, nil, nil, nil)
+		svc.setBaseContext(ctx)
+		started := make(chan string, 100)
+		release := make(chan struct{})
+		var active atomic.Int32
+		var spawned atomic.Int32
+		svc.spawn = func(fn func()) { spawned.Add(1); go fn() }
+		svc.runJob = func(ctx context.Context, _ int, hash, _, _ string) {
+			active.Add(1)
+			defer active.Add(-1)
+			started <- hash
+			select {
+			case <-ctx.Done():
+			case <-release:
+			}
+		}
+		for instanceID := 1; instanceID <= 2; instanceID++ {
+			for i := range 20 {
+				require.True(t, svc.enqueue(instanceID, fmt.Sprintf("HASH%d", i), "Synthetic seed", "tracker.test"))
+			}
+		}
+		synctest.Wait()
+		require.EqualValues(t, 2*maxConcurrentJobsPerInstance, active.Load())
+		require.EqualValues(t, 2*maxConcurrentJobsPerInstance, spawned.Load())
+		require.Len(t, started, 2*maxConcurrentJobsPerInstance)
+		for instanceID := 1; instanceID <= 2; instanceID++ {
+			require.Equal(t, maxConcurrentJobsPerInstance, svc.queues[instanceID].active)
+			require.Len(t, svc.queues[instanceID].pending, 20-maxConcurrentJobsPerInstance)
+			require.True(t, svc.enqueue(instanceID, "HASH19", "Synthetic seed", "tracker.test"))
+			require.Len(t, svc.queues[instanceID].pending, 20-maxConcurrentJobsPerInstance)
+		}
+
+		release <- struct{}{}
+		synctest.Wait()
+		require.Len(t, started, 2*maxConcurrentJobsPerInstance+1)
+		require.EqualValues(t, 2*maxConcurrentJobsPerInstance, active.Load())
+		require.EqualValues(t, 2*maxConcurrentJobsPerInstance, spawned.Load())
+
+		cancel()
+		synctest.Wait()
+		require.Zero(t, active.Load())
+		require.Empty(t, svc.queues)
+		require.Len(t, started, 2*maxConcurrentJobsPerInstance+1, "canceled queued jobs must not run")
+		for _, jobs := range svc.j {
+			require.NotContains(t, jobs, "HASH19", "queued jobs must not acquire a cooldown on cancellation")
+			for _, job := range jobs {
+				require.False(t, job.isRunning)
+			}
+		}
+		require.False(t, svc.enqueue(1, "AFTER_CANCEL", "Synthetic seed", "tracker.test"))
+	})
+}
+
+func TestServiceEnqueue_CooldownStartsAfterQueueWait(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		svc := NewService(DefaultConfig(), nil, nil, nil, nil, nil)
+		svc.setBaseContext(ctx)
+		release := make(chan struct{})
+		var queuedRuns atomic.Int32
+		svc.runJob = func(ctx context.Context, _ int, hash, _, _ string) {
+			if hash == "QUEUED" {
+				queuedRuns.Add(1)
+				return
+			}
+			select {
+			case <-release:
+			case <-ctx.Done():
+			}
+		}
+		for i := range maxConcurrentJobsPerInstance {
+			require.True(t, svc.enqueue(1, fmt.Sprintf("BLOCKED%d", i), "Synthetic seed", "tracker.test"))
+		}
+		require.True(t, svc.enqueue(1, "QUEUED", "Synthetic seed", "tracker.test"))
+		synctest.Wait()
+		time.Sleep(2 * svc.cfg.DebounceWindow)
+		release <- struct{}{}
+		synctest.Wait()
+		require.EqualValues(t, 1, queuedRuns.Load())
+		require.True(t, svc.enqueue(1, "QUEUED", "Synthetic seed", "tracker.test"))
+		synctest.Wait()
+		require.EqualValues(t, 1, queuedRuns.Load(), "queue wait must not consume the completion cooldown")
+		cancel()
+	})
+}
+
+func TestServiceEnqueue_RechecksScopeAfterQueueWait(t *testing.T) {
+	for _, enabled := range []bool{false, true} {
+		t.Run(fmt.Sprintf("enabled=%t", enabled), func(t *testing.T) {
+			torrents := make(map[string]qbt.Torrent)
+			for i := range maxConcurrentJobsPerInstance + 1 {
+				hash := fmt.Sprintf("hash%d", i)
+				torrents[hash] = qbt.Torrent{Hash: hash, Name: "Synthetic seed", State: qbt.TorrentStateStalledUp}
+			}
+			svc, instanceID, _ := newScanTestService(t, "2.11.4", torrents)
+			svc.settingsCache = NewSettingsCache(nil)
+			svc.settingsCache.Replace(&models.InstanceReannounceSettings{InstanceID: instanceID, Enabled: true, MonitorAll: true})
+			var workers []func()
+			svc.spawn = func(fn func()) { workers = append(workers, fn) }
+			for hash := range torrents {
+				require.True(t, svc.enqueue(instanceID, strings.ToUpper(hash), "Synthetic seed", "tracker.test"))
+			}
+			svc.settingsCache.Replace(&models.InstanceReannounceSettings{InstanceID: instanceID, Enabled: enabled, Categories: []string{"missing"}})
+			for _, worker := range workers {
+				worker()
+			}
+			events := svc.GetActivity(instanceID, 0)
+			require.Len(t, events, len(torrents))
+			for _, event := range events {
+				require.Equal(t, ActivityOutcomeSkipped, event.Outcome)
+			}
+		})
+	}
+}
+
+func TestServiceEnqueue_RechecksScopeWithUppercaseHash(t *testing.T) {
+	hash := strings.Repeat("a", 40)
+	torrents := map[string]qbt.Torrent{hash: {
+		Hash: hash, Name: "Synthetic seed", State: qbt.TorrentStateStalledUp,
+		Trackers: []qbt.TorrentTracker{{Url: "https://tracker.test/announce", Status: qbt.TrackerStatusOK}},
+	}}
+	svc, instanceID, _ := newScanTestService(t, "2.11.4", torrents)
+	svc.settingsCache = NewSettingsCache(nil)
+	svc.settingsCache.Replace(&models.InstanceReannounceSettings{InstanceID: instanceID, Enabled: true, MonitorAll: true})
+	require.True(t, svc.enqueue(instanceID, strings.ToUpper(hash), "Synthetic seed", "tracker.test"))
+	events := svc.GetActivity(instanceID, 0)
+	require.Len(t, events, 1)
+	require.Equal(t, ActivityOutcomeSkipped, events[0].Outcome)
+	require.Equal(t, "tracker healthy", events[0].Reason, "the cached torrent must pass the scope check")
 }


### PR DESCRIPTION
## Description

Filter cached torrents before fetching tracker data and limit reannounce jobs to four per instance to reduce qBittorrent load.

Closes #2579.

## How has this been tested?

Ran the built app and the unchanged service from `b2462ea0` with `qui serve --config-dir <isolated-dir> --data-dir <isolated-dir>` against local HTTP stubs. Each measurement covered 8.5 seconds after adding a synthetic instance.

| Measurement | Before | After |
| --- | ---: | ---: |
| Mixed library: torrent entries in the tracker scan | 142 | 2 |
| Empty candidate set: tracker scan requests | 1 | 0 |
| Mass failure: peak concurrent tracker requests | 20 | 4 |
| Total qBittorrent requests, mixed library | 7 | 8 |
| Total qBittorrent requests, empty candidate set | 5 | 4 |
| Total qBittorrent requests, mass failure | 25 | 10 |

Totals include startup and background requests. Reading cached torrent state triggered one additional main-data refresh in each run. A final live run confirmed that an uppercase queued hash finds its lowercase cache entry and reaches the tracker-health check. The tests used no real clients or trackers. All test processes, listeners, helpers, and temporary data were removed.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Reannounce processing now limits concurrent jobs per instance, improving stability during busy periods.
  - Large tracker updates are processed in batches for more efficient operation.

- **Reliability**
  - Queued jobs are cancelled promptly when the service stops.
  - Jobs re-check torrent eligibility before execution, preventing actions on torrents that no longer match monitoring rules.
  - Tracker data and cached information are used more selectively based on client capabilities.
  - Reannounce cooldowns now account for time spent waiting in the queue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->