### PR TITLE
fix(qbittorrent): retain workflow behavior on 5.3

### DIFF
--- a/documentation/docs/advanced/compatibility.md
+++ b/documentation/docs/advanced/compatibility.md
@@ -34,6 +34,15 @@ qui detects the features that each qBittorrent instance supports and adjusts the
 Hybrid and v2 torrent creation requires a qBittorrent build that links against libtorrent v2. If a build links against libtorrent 1.x, it ignores the `format` parameter.
 :::
 
+## qBittorrent 5.3 compatibility
+
+qui supports the API changes in qBittorrent 5.3 build `55d169a94` and keeps support for older versions, including 5.2.2.
+Torrent adds keep the same skip-checking behavior after an upgrade.
+RSS rule edits retain seed mode and share-limit mode, and torrent creation dates keep the same display format.
+
+The preferences API includes the new mail-encryption and torrent-file backup fields.
+Configure these options in qBittorrent. qui does not add controls for them.
+
 ## Authentication compatibility
 
 ### API key auth with reverse-proxy Basic Auth

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/autobrr/autobrr v1.85.0
 	github.com/autobrr/go-bdinfo v0.4.3-0.20260905142019-c391e265ec72
 	github.com/autobrr/go-mediainfo v0.8.0
-	github.com/autobrr/go-qbittorrent v1.18.1-0.20260825200055-b0abc1c0134d
+	github.com/autobrr/go-qbittorrent v1.18.1-0.20260907054918-b510b62679e2
 	github.com/autobrr/go-torrent v1.1.1
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/cespare/xxhash/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/autobrr/go-bdinfo v0.4.3-0.20260905142019-c391e265ec72 h1:fQnXBwvj6HC
 github.com/autobrr/go-bdinfo v0.4.3-0.20260905142019-c391e265ec72/go.mod h1:OjpQR7TPcP7fBTo4GW1Yz1+biQG7YTo1OZH7KXX5gS0=
 github.com/autobrr/go-mediainfo v0.8.0 h1:XzsjHvBOlGx2BnwYCqwCOIJsmrFy4BJb0jgoB2qKuR0=
 github.com/autobrr/go-mediainfo v0.8.0/go.mod h1:P3LGxIPznO2TLKV/e58YgN0/ozP5pLCAncFzsdxMDcY=
-github.com/autobrr/go-qbittorrent v1.18.1-0.20260825200055-b0abc1c0134d h1:oWXjEZZrc74m0/Cbmy7Yyeim97VjFUTekotsAC6v7uU=
-github.com/autobrr/go-qbittorrent v1.18.1-0.20260825200055-b0abc1c0134d/go.mod h1:spB3GP7xDu0btv59uUdxkLPEzoT+9xpx86QpJr4DUOw=
+github.com/autobrr/go-qbittorrent v1.18.1-0.20260907054918-b510b62679e2 h1:erHPtiYUo5NSysQx+Vf0Qka3zIQkmErIfAmibG0zQkk=
+github.com/autobrr/go-qbittorrent v1.18.1-0.20260907054918-b510b62679e2/go.mod h1:spB3GP7xDu0btv59uUdxkLPEzoT+9xpx86QpJr4DUOw=
 github.com/autobrr/go-torrent v1.1.1 h1:Vc5R3QGZlmAEoEyEYqT2B9j/CX7to82GzFlHhXbphCw=
 github.com/autobrr/go-torrent v1.1.1/go.mod h1:MNqAUt4SVvZTVyVSD3iQHXgi+ARVM3Z6dY0aTvXTnvY=
 github.com/autobrr/rls v0.8.1 h1:OjoFFVGcTibGrwf6b4pfk7JHsSYrGOX7F5P/8WtS3aE=

--- a/internal/api/handlers/qbittorrent_compatibility_test.go
+++ b/internal/api/handlers/qbittorrent_compatibility_test.go
@@ -1,0 +1,147 @@
+// Copyright (c) 2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package handlers
+
+import (
+	"bytes"
+	"encoding/json/v2"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/models"
+	quiqbt "github.com/autobrr/qui/internal/qbittorrent"
+	"github.com/autobrr/qui/internal/testutil/testdb"
+)
+
+func compatibilityHandlerManager(t *testing.T, host string) (*quiqbt.SyncManager, int) {
+	t.Helper()
+	db := testdb.NewMigratedSQLite(t, "qbittorrent-compatibility")
+	store, err := models.NewInstanceStore(db, []byte("01234567890123456789012345678901"))
+	require.NoError(t, err)
+	pool, err := quiqbt.NewClientPool(store, models.NewInstanceErrorStore(db), time.Minute)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pool.Close() })
+	instance, err := store.Create(t.Context(), "Synthetic", host, "user", "pass", nil, nil, false, nil)
+	require.NoError(t, err)
+	setUnexportedField(t, pool, "clients", map[int]*quiqbt.Client{
+		instance.ID: newStaleCachedClient(t, host, nil),
+	})
+	return quiqbt.NewSyncManager(pool, nil), instance.ID
+}
+
+func TestRSSRuleEditPreservesSeedAndShareLimitsMode(t *testing.T) {
+	for _, field := range []string{"skip_checking", "seed_mode"} {
+		for _, seedMode := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s=%t", field, seedMode), func(t *testing.T) {
+				posted := make(chan string, 1)
+				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch r.URL.Path {
+					case "/api/v2/rss/rules":
+						_, _ = fmt.Fprintf(w, `{"Synthetic":{"mustContain":"Before","torrentParams":{"%s":%t,"share_limits_mode":"All"}}}`, field, seedMode)
+					case "/api/v2/rss/setRule":
+						if err := r.ParseForm(); err != nil {
+							http.Error(w, err.Error(), http.StatusBadRequest)
+							return
+						}
+						posted <- r.Form.Get("ruleDef")
+					default:
+						http.NotFound(w, r)
+					}
+				}))
+				t.Cleanup(srv.Close)
+				sm, id := compatibilityHandlerManager(t, srv.URL)
+				router := chi.NewRouter()
+				router.Route("/api/instances/{instanceID}/rss", NewRSSHandler(sm).Routes)
+				path := fmt.Sprintf("/api/instances/%d/rss/rules", id)
+				rec := httptest.NewRecorder()
+				router.ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, path, nil))
+				require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+				require.Contains(t, rec.Body.String(), fmt.Sprintf(`"seed_mode":%t`, seedMode))
+				require.Contains(t, rec.Body.String(), `"share_limits_mode":"All"`)
+
+				var rules qbt.RSSRules
+				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rules))
+				rule := rules["Synthetic"]
+				rule.MustContain = "After"
+				body, err := json.Marshal(SetRuleRequest{Name: "Synthetic", Rule: rule})
+				require.NoError(t, err)
+				rec = httptest.NewRecorder()
+				router.ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodPost, path, bytes.NewReader(body)))
+				require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+				select {
+				case raw := <-posted:
+					require.Contains(t, raw, `"mustContain":"After"`)
+					require.Contains(t, raw, fmt.Sprintf(`"seed_mode":%t`, seedMode))
+					require.Contains(t, raw, fmt.Sprintf(`"skip_checking":%t`, seedMode))
+					require.Contains(t, raw, `"share_limits_mode":"All"`)
+				default:
+					t.Fatal("RSS edit did not reach qBittorrent")
+				}
+			})
+		}
+	}
+}
+
+func TestTorrentCreationHandlerPreservesDateStrings(t *testing.T) {
+	const date = "2026-01-01T00:00:00Z"
+	for _, upstreamDate := range []string{`"` + date + `"`, "1767225600"} {
+		t.Run(upstreamDate, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/v2/app/webapiVersion":
+					_, _ = w.Write([]byte("2.16.0"))
+				case "/api/v2/torrentcreator/status":
+					_, _ = fmt.Fprintf(w, `[{"taskID":"synthetic","status":"Finished","timeAdded":%s,"timeStarted":%s,"timeFinished":%s}]`, upstreamDate, upstreamDate, upstreamDate)
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			t.Cleanup(srv.Close)
+			sm, id := compatibilityHandlerManager(t, srv.URL)
+			router := chi.NewRouter()
+			router.Get("/api/instances/{instanceID}/torrent-creator/status", NewTorrentsHandler(sm, nil, nil).GetTorrentCreationStatus)
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, fmt.Sprintf("/api/instances/%d/torrent-creator/status", id), nil))
+			require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+			for _, field := range []string{"timeAdded", "timeStarted", "timeFinished"} {
+				require.Contains(t, rec.Body.String(), fmt.Sprintf(`"%s":%q`, field, date))
+			}
+		})
+	}
+}
+
+func TestPreferencesHandlerCarriesCompatibilityFields(t *testing.T) {
+	const preferences = `{"mail_notification_encryption_type":"STARTTLS","remove_torrent_file_backup":true,"torrent_files_backup_enabled":true,"torrent_files_backup_dir":"backup","torrent_files_finished_backup_dir_enabled":true,"torrent_files_finished_backup_dir":"finished","mail_notification_ssl_enabled":true,"export_dir":"legacy","export_dir_fin":"legacy-finished"}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/app/preferences" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(preferences))
+	}))
+	t.Cleanup(srv.Close)
+	sm, id := compatibilityHandlerManager(t, srv.URL)
+	router := chi.NewRouter()
+	router.Get("/api/instances/{instanceID}/preferences", NewPreferencesHandler(sm).GetPreferences)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, fmt.Sprintf("/api/instances/%d/preferences", id), nil))
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	var want, got qbt.AppPreferences
+	require.NoError(t, json.Unmarshal([]byte(preferences), &want))
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Equal(t, want, got)
+	require.Equal(t, "STARTTLS", got.MailNotificationEncryptionType)
+	require.True(t, got.TorrentFilesBackupEnabled)
+	require.True(t, got.RemoveTorrentFileBackup)
+	require.Equal(t, "backup", got.TorrentFilesBackupDir)
+	require.True(t, got.TorrentFilesFinishedBackupDirEnabled)
+	require.Equal(t, "finished", got.TorrentFilesFinishedBackupDir)
+}

--- a/internal/api/handlers/qbittorrent_compatibility_test.go
+++ b/internal/api/handlers/qbittorrent_compatibility_test.go
@@ -45,7 +45,7 @@ func TestRSSRuleEditPreservesSeedAndShareLimitsMode(t *testing.T) {
 				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					switch r.URL.Path {
 					case "/api/v2/rss/rules":
-						_, _ = fmt.Fprintf(w, `{"Synthetic":{"mustContain":"Before","torrentParams":{"%s":%t,"share_limits_mode":"All"}}}`, field, seedMode)
+						_, _ = fmt.Fprintf(w, `{"Synthetic":{"mustContain":"Before","torrentParams":{"%s":%t,"share_limits_mode":"MatchAll"}}}`, field, seedMode)
 					case "/api/v2/rss/setRule":
 						if err := r.ParseForm(); err != nil {
 							http.Error(w, err.Error(), http.StatusBadRequest)
@@ -65,7 +65,7 @@ func TestRSSRuleEditPreservesSeedAndShareLimitsMode(t *testing.T) {
 				router.ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, path, nil))
 				require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
 				require.Contains(t, rec.Body.String(), fmt.Sprintf(`"seed_mode":%t`, seedMode))
-				require.Contains(t, rec.Body.String(), `"share_limits_mode":"All"`)
+				require.Contains(t, rec.Body.String(), `"share_limits_mode":"MatchAll"`)
 
 				var rules qbt.RSSRules
 				require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rules))
@@ -81,7 +81,7 @@ func TestRSSRuleEditPreservesSeedAndShareLimitsMode(t *testing.T) {
 					require.Contains(t, raw, `"mustContain":"After"`)
 					require.Contains(t, raw, fmt.Sprintf(`"seed_mode":%t`, seedMode))
 					require.Contains(t, raw, fmt.Sprintf(`"skip_checking":%t`, seedMode))
-					require.Contains(t, raw, `"share_limits_mode":"All"`)
+					require.Contains(t, raw, `"share_limits_mode":"MatchAll"`)
 				default:
 					t.Fatal("RSS edit did not reach qBittorrent")
 				}

--- a/internal/qbittorrent/preferences_test.go
+++ b/internal/qbittorrent/preferences_test.go
@@ -5,6 +5,10 @@ package qbittorrent
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -43,4 +47,35 @@ func TestGetAppPreferencesReturnsErrorWhenNoCacheAndRefreshFails(t *testing.T) {
 	prefs, err := c.GetAppPreferences(ctx)
 	require.Error(t, err)
 	require.Nil(t, prefs)
+}
+
+func TestCachedPreferencesPreserveCompatibilityFields(t *testing.T) {
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/app/preferences" {
+			http.NotFound(w, r)
+			return
+		}
+		hits.Add(1)
+		_, _ = w.Write([]byte(`{"mail_notification_encryption_type":"SMTPS","torrent_files_backup_enabled":true,"torrent_files_backup_dir":"backup","export_dir":"legacy","mail_notification_ssl_enabled":true}`))
+	}))
+	defer srv.Close()
+	client := &Client{Client: qbt.NewClient(qbt.Config{Host: srv.URL})}
+	prefs, err := client.GetAppPreferences(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "SMTPS", prefs.MailNotificationEncryptionType)
+	require.True(t, prefs.TorrentFilesBackupEnabled)
+	prefs.TorrentFilesBackupDir = "changed"
+
+	cached, err := client.GetAppPreferences(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, "backup", cached.TorrentFilesBackupDir)
+	require.Equal(t, int64(1), hits.Load())
+	raw, err := client.cachedAppPreferencesJSON()
+	require.NoError(t, err)
+	var decoded qbt.AppPreferences
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	require.Equal(t, *cached, decoded)
+	require.Equal(t, "legacy", decoded.ExportDir)
+	require.True(t, decoded.MailNotificationSslEnabled)
 }

--- a/internal/qbittorrent/sync_manager_test.go
+++ b/internal/qbittorrent/sync_manager_test.go
@@ -12,6 +12,7 @@ import (
 	"maps"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"reflect"
 	"runtime"
 	"slices"
@@ -3458,4 +3459,65 @@ func TestGetTorrentsWithFiltersSingleHashSkipsLibraryCopy(t *testing.T) {
 	hashBytes := measure(byHash(target))
 	t.Logf("20 requests: expr filter %d bytes, hash filter %d bytes", exprBytes, hashBytes)
 	require.Less(t, hashBytes*10, exprBytes, "a single-hash request must allocate far less than the library scan")
+}
+
+// Cross-seed retries a failed seed-mode add after it removes skip_checking.
+// Exercise the same map through the real SyncManager and library HTTP client.
+func TestAddTorrentSeedModeRetryRequiresChecking(t *testing.T) {
+	adds := make(chan url.Values, 2)
+	var syncs atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/torrents/add":
+			if err := r.ParseMultipartForm(1 << 20); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			defer func() { _ = r.MultipartForm.RemoveAll() }()
+			adds <- r.PostForm
+			if r.PostForm.Get("seedMode") == "true" {
+				http.Error(w, "synthetic seed-mode failure", http.StatusUnsupportedMediaType)
+				return
+			}
+			_, _ = w.Write([]byte("Ok."))
+		case "/api/v2/sync/maindata":
+			syncs.Add(1)
+			_, _ = w.Write([]byte(`{"rid":1,"full_update":true,"torrents":{}}`))
+		case "/api/v2/app/webapiVersion":
+			_, _ = w.Write([]byte("2.16.0"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	pool := setupTestPool(t)
+	defer pool.Close()
+	instance, err := pool.instanceStore.Create(t.Context(), "Synthetic", srv.URL, "user", "pass", nil, nil, false, nil)
+	require.NoError(t, err)
+	qbtClient := qbt.NewClient(qbt.Config{Host: srv.URL})
+	client := &Client{Client: qbtClient, instanceID: instance.ID, syncManager: qbtClient.NewSyncManager(qbt.DefaultSyncOptions())}
+	client.updateHealthStatus(true)
+	pool.clients[instance.ID] = client
+	sm := NewSyncManager(pool, nil)
+	options := map[string]string{"skip_checking": "true", "paused": "true"}
+	_, err = sm.AddTorrent(t.Context(), instance.ID, []byte("synthetic torrent"), options)
+	require.Error(t, err)
+	first := <-adds
+	require.Equal(t, "true", first.Get("skip_checking"))
+	require.Equal(t, "true", first.Get("seedMode"))
+	require.Equal(t, map[string]string{"skip_checking": "true", "paused": "true"}, options)
+
+	delete(options, "skip_checking")
+	_, err = sm.AddTorrent(t.Context(), instance.ID, []byte("synthetic torrent"), options)
+	require.NoError(t, err)
+	retry := <-adds
+	require.NotContains(t, retry, "seedMode")
+	require.NotContains(t, retry, "skip_checking")
+	require.Equal(t, "true", retry.Get("paused"))
+	require.Eventually(t, func() bool {
+		sm.syncDebounceMu.Lock()
+		defer sm.syncDebounceMu.Unlock()
+		return len(sm.debouncedSyncTimers) == 0
+	}, 5*time.Second, 10*time.Millisecond)
+	require.GreaterOrEqual(t, syncs.Load(), int64(2))
 }

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -2690,10 +2690,13 @@ paths:
                       type: string
                     timeAdded:
                       type: string
+                      description: Date string. Numeric upstream timestamps become UTC RFC3339 strings.
                     timeStarted:
                       type: string
+                      description: Date string. Omitted when the task has no timeStarted value.
                     timeFinished:
                       type: string
+                      description: Date string. Omitted when the task has no timeFinished value.
                     progress:
                       type: number
                     errorMessage:
@@ -2963,8 +2966,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                description: qBittorrent preferences object with various settings
+                $ref: '#/components/schemas/QBittorrentPreferences'
     patch:
       tags:
         - Instances
@@ -2977,11 +2979,14 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              description: Partial preferences object with settings to update
+              $ref: '#/components/schemas/QBittorrentPreferences'
       responses:
         '200':
           description: Preferences updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QBittorrentPreferences'
 
   /api/instances/{instanceID}/alternative-speed-limits:
     get:
@@ -9554,6 +9559,34 @@ components:
           nullable: true
           description: Legacy field
 
+    QBittorrentPreferences:
+      type: object
+      additionalProperties: true
+      description: qBittorrent preferences. Available fields depend on the server version.
+      properties:
+        mail_notification_encryption_type:
+          type: string
+          description: Mail encryption in qBittorrent 5.3. Values include None, STARTTLS, and SMTPS.
+        mail_notification_ssl_enabled:
+          type: boolean
+          description: Legacy mail encryption field.
+        remove_torrent_file_backup:
+          type: boolean
+        torrent_files_backup_enabled:
+          type: boolean
+        torrent_files_backup_dir:
+          type: string
+        torrent_files_finished_backup_dir_enabled:
+          type: boolean
+        torrent_files_finished_backup_dir:
+          type: string
+        export_dir:
+          type: string
+          description: Legacy torrent-file backup directory.
+        export_dir_fin:
+          type: string
+          description: Legacy finished torrent-file backup directory.
+
     RSSRuleTorrentParams:
       type: object
       properties:
@@ -9573,6 +9606,10 @@ components:
           type: string
         skip_checking:
           type: boolean
+          description: Legacy alias for seed_mode. qui returns matching values for both fields.
+        seed_mode:
+          type: boolean
+          description: Skip the initial hash check. Takes precedence over skip_checking when both are supplied.
         upload_limit:
           type: integer
         download_limit:
@@ -9582,6 +9619,8 @@ components:
         inactive_seeding_time_limit:
           type: integer
         share_limit_action:
+          type: string
+        share_limits_mode:
           type: string
         ratio_limit:
           type: number

--- a/web/src/pages/RSSPage.test.tsx
+++ b/web/src/pages/RSSPage.test.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
+import { TooltipProvider } from "@/components/ui/tooltip"
 import { ArticlesPanel, EditRuleDialog } from "@/pages/RSSPage"
 import type { RSSArticle, RSSAutoDownloadRule } from "@/types"
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
@@ -82,19 +83,21 @@ describe("EditRuleDialog", () => {
       affectedFeeds: [],
       ignoreDays: 0,
       smartFilter: false,
-      torrentParams: { seed_mode: seedMode, skip_checking: seedMode, share_limits_mode: "All" },
+      torrentParams: { seed_mode: seedMode, skip_checking: seedMode, share_limits_mode: "MatchAll" },
     }
     render(
-      <EditRuleDialog
-        instanceId={1}
-        open
-        onOpenChange={() => {}}
-        ruleName="Synthetic"
-        rule={rule}
-        feedsData={{}}
-        categories={{}}
-        tags={[]}
-      />
+      <TooltipProvider>
+        <EditRuleDialog
+          instanceId={1}
+          open
+          onOpenChange={() => {}}
+          ruleName="Synthetic"
+          rule={rule}
+          feedsData={{}}
+          categories={{}}
+          tags={[]}
+        />
+      </TooltipProvider>
     )
 
     fireEvent.change(screen.getByLabelText("ruleForm.mustContain"), { target: { value: "After" } })
@@ -104,7 +107,7 @@ describe("EditRuleDialog", () => {
       name: "Synthetic",
       rule: expect.objectContaining({
         mustContain: "After",
-        torrentParams: expect.objectContaining({ seed_mode: seedMode, skip_checking: seedMode, share_limits_mode: "All" }),
+        torrentParams: expect.objectContaining({ seed_mode: seedMode, skip_checking: seedMode, share_limits_mode: "MatchAll" }),
       }),
     }))
   })

--- a/web/src/pages/RSSPage.test.tsx
+++ b/web/src/pages/RSSPage.test.tsx
@@ -3,13 +3,14 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { ArticlesPanel } from "@/pages/RSSPage"
-import type { RSSArticle } from "@/types"
-import { cleanup, render, screen } from "@testing-library/react"
+import { ArticlesPanel, EditRuleDialog } from "@/pages/RSSPage"
+import type { RSSArticle, RSSAutoDownloadRule } from "@/types"
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 const mocks = vi.hoisted(() => ({
   markAsRead: vi.fn(),
+  setRule: { mutateAsync: vi.fn().mockResolvedValue(undefined), isPending: false },
   virtualizer: {
     getTotalSize: () => 156,
     getVirtualItems: () => [
@@ -32,13 +33,17 @@ vi.mock("@/hooks/useDateTimeFormatters", () => ({
 vi.mock("@/hooks/useRSS", async (importOriginal) => ({
   ...await importOriginal<typeof import("@/hooks/useRSS")>(),
   useMarkRSSAsRead: () => ({ mutateAsync: mocks.markAsRead }),
+  useSetRSSRule: () => mocks.setRule,
 }))
 
 vi.mock("@tanstack/react-virtual", () => ({
   useVirtualizer: () => mocks.virtualizer,
 }))
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
 
 describe("ArticlesPanel", () => {
   it("mounts only virtual rows for a synthetic 1,000-article feed", () => {
@@ -62,5 +67,45 @@ describe("ArticlesPanel", () => {
     expect(document.querySelectorAll("[data-index]")).toHaveLength(3)
     expect(screen.queryByText("Article 0")).not.toBeNull()
     expect(screen.queryByText("Article 999")).toBeNull()
+  })
+})
+
+
+describe("EditRuleDialog", () => {
+  it.each([false, true])("retains seed_mode=%s and share_limits_mode on an unrelated edit", async (seedMode) => {
+    const rule: RSSAutoDownloadRule = {
+      enabled: true,
+      priority: 0,
+      useRegex: false,
+      mustContain: "Before",
+      mustNotContain: "",
+      affectedFeeds: [],
+      ignoreDays: 0,
+      smartFilter: false,
+      torrentParams: { seed_mode: seedMode, skip_checking: seedMode, share_limits_mode: "All" },
+    }
+    render(
+      <EditRuleDialog
+        instanceId={1}
+        open
+        onOpenChange={() => {}}
+        ruleName="Synthetic"
+        rule={rule}
+        feedsData={{}}
+        categories={{}}
+        tags={[]}
+      />
+    )
+
+    fireEvent.change(screen.getByLabelText("ruleForm.mustContain"), { target: { value: "After" } })
+    fireEvent.click(screen.getByRole("button", { name: "editRuleDialog.saveChanges" }))
+
+    await waitFor(() => expect(mocks.setRule.mutateAsync).toHaveBeenCalledWith({
+      name: "Synthetic",
+      rule: expect.objectContaining({
+        mustContain: "After",
+        torrentParams: expect.objectContaining({ seed_mode: seedMode, skip_checking: seedMode, share_limits_mode: "All" }),
+      }),
+    }))
   })
 })

--- a/web/src/pages/RSSPage.tsx
+++ b/web/src/pages/RSSPage.tsx
@@ -2142,7 +2142,7 @@ interface EditRuleDialogProps {
   tags: string[]
 }
 
-function EditRuleDialog({
+export function EditRuleDialog({
   instanceId,
   open,
   onOpenChange,

--- a/web/src/types/app.ts
+++ b/web/src/types/app.ts
@@ -228,6 +228,11 @@ export interface AppPreferences {
   dont_count_slow_torrents: boolean
   export_dir: string
   export_dir_fin: string
+  remove_torrent_file_backup?: boolean
+  torrent_files_backup_enabled?: boolean
+  torrent_files_backup_dir?: string
+  torrent_files_finished_backup_dir_enabled?: boolean
+  torrent_files_finished_backup_dir?: string
   idn_support_enabled: boolean
   locale: string
   performance_warning: boolean
@@ -263,6 +268,7 @@ export interface AppPreferences {
   mail_notification_sender: string
   mail_notification_smtp: string
   mail_notification_ssl_enabled: boolean
+  mail_notification_encryption_type?: string
   mail_notification_username: string
 
   // Scan directories (structured as empty object in go-qbittorrent)

--- a/web/src/types/rss.ts
+++ b/web/src/types/rss.ts
@@ -44,11 +44,13 @@ export interface RSSRuleTorrentParams {
   content_layout?: string
   operating_mode?: string
   skip_checking?: boolean
+  seed_mode?: boolean
   upload_limit?: number
   download_limit?: number
   seeding_time_limit?: number
   inactive_seeding_time_limit?: number
   share_limit_action?: string
+  share_limits_mode?: string
   ratio_limit?: number
   stopped?: boolean
   stop_condition?: string


### PR DESCRIPTION
## Description

Keeps torrent adds, RSS rules, creation dates, and preferences compatible with qBittorrent 5.3 and older servers.

Depends on https://github.com/autobrr/go-qbittorrent/pull/141. Pins its available revision `b510b62679e2`; keep this PR in draft until the library change is ready.

Closes #2598.

## How has this been tested?

Ran the built qui binary against isolated, tracker-free qBittorrent 5.2.2 and 5.3 build `55d169a94`. With same-sized synthetic files containing different data, skip-checking adds reached `stoppedUP` at 100%; re-adds with checking reached `stoppedDL` at 0% on both versions. RSS edits retained true and false seed mode, and 5.3 retained `MatchAll`, including an edit through the browser. Creation-task dialogs displayed both legacy dates and converted Unix timestamps. Preference responses retained the old and new fields.

The forced cross-seed failure/retry uses the local HTTP regression fixture. Restore, directory scan, automation, cross-seed, and season-pack workflows were traced to common add normalization but were not run live end to end.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL
