### PR TITLE
perf(proxy): remove duplicate peer fetch

### DIFF
--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -1548,65 +1548,7 @@ func (h *Handler) handleTorrentPeers(w http.ResponseWriter, r *http.Request) {
 		Str("hash", hash).
 		Msg("Proxying sync/torrentPeers request")
 
-	// Use a custom response writer to capture the response
-	buf := h.bufferPool.Get()
-	crwBody := buf[:0]
-	crw := &capturingResponseWriter{
-		ResponseWriter: w,
-		body:           crwBody,
-		statusCode:     http.StatusOK,
-	}
-	defer func() {
-		if buf != nil {
-			h.bufferPool.Put(buf[:cap(buf)])
-		}
-	}()
-
-	// Proxy the request
-	h.proxy.ServeHTTP(crw, r)
-
-	// Update local peer sync manager state for successful responses
-	if crw.statusCode == http.StatusOK && len(crw.body) > 0 {
-		var peersData qbt.TorrentPeersResponse
-		if err := json.Unmarshal(crw.body, &peersData); err != nil {
-			log.Error().
-				Err(err).
-				Int("instanceId", instanceID).
-				Str("hash", hash).
-				Msg("Failed to parse sync/torrentPeers response")
-			return
-		}
-
-		// Check if this is a full update (FullUpdate field or rid == 0)
-		isFullUpdate := peersData.FullUpdate || peersData.Rid == 0
-
-		if isFullUpdate {
-			client, err := h.clientPool.GetClient(ctx, instanceID)
-			if err != nil {
-				log.Error().
-					Err(err).
-					Int("instanceId", instanceID).
-					Msg("Failed to get client for peer state update")
-				return
-			}
-
-			// Update peer state using the same pattern as maindata
-			client.UpdateWithPeersData(hash, &peersData)
-
-			log.Trace().
-				Int("instanceId", instanceID).
-				Str("hash", hash).
-				Int64("rid", peersData.Rid).
-				Int("peerCount", len(peersData.Peers)).
-				Msg("Updated local peer state from full sync/torrentPeers response")
-		} else {
-			log.Trace().
-				Int("instanceId", instanceID).
-				Str("hash", hash).
-				Int64("rid", peersData.Rid).
-				Msg("Skipping incremental sync/torrentPeers update")
-		}
-	}
+	h.proxy.ServeHTTP(w, r)
 }
 
 // handleTorrentFiles handles /api/v2/torrents/files requests

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -407,7 +407,6 @@ func (h *Handler) Routes(r chi.Router) {
 		// Register intercepted endpoints (these use qui's sync manager or special handling)
 		pr.Post("/api/v2/auth/login", h.handleAuthLogin)
 		pr.Get("/api/v2/sync/maindata", h.handleSyncMainData)
-		pr.Get("/api/v2/sync/torrentPeers", h.handleTorrentPeers)
 		pr.Get("/api/v2/torrents/info", h.handleTorrentsInfo)
 		pr.Get("/api/v2/torrents/categories", h.handleCategories)
 		pr.Get("/api/v2/torrents/tags", h.handleTags)
@@ -1532,23 +1531,6 @@ func (h *Handler) handleTorrentTrackers(w http.ResponseWriter, r *http.Request) 
 			Int("instanceId", instanceID).
 			Msg("Failed to encode trackers response")
 	}
-}
-
-// handleTorrentPeers handles /api/v2/sync/torrentPeers requests
-func (h *Handler) handleTorrentPeers(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	instanceID := GetInstanceIDFromContext(ctx)
-	clientAPIKey := GetClientAPIKeyFromContext(ctx)
-
-	hash := r.URL.Query().Get("hash")
-
-	log.Trace().
-		Int("instanceId", instanceID).
-		Str("client", clientAPIKey.ClientName).
-		Str("hash", hash).
-		Msg("Proxying sync/torrentPeers request")
-
-	h.proxy.ServeHTTP(w, r)
 }
 
 // handleTorrentFiles handles /api/v2/torrents/files requests

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -193,7 +193,7 @@ func TestHandleSyncMainDataCapturesBodyWithoutLeadingZeros(t *testing.T) {
 	require.Equal(t, payload, rec.Body.Bytes())
 }
 
-func TestHandleTorrentPeersPassesThroughWithoutCacheWarming(t *testing.T) {
+func TestProxyTorrentPeersPassesThroughWithoutCacheWarming(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
 		status int
@@ -231,7 +231,7 @@ func TestHandleTorrentPeersPassesThroughWithoutCacheWarming(t *testing.T) {
 			req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/proxy/test-key/api/v2/sync/torrentPeers?hash=abc123&rid=6", nil)
 			rec := httptest.NewRecorder()
 
-			handler.handleTorrentPeers(rec, req)
+			handler.ServeHTTP(rec, req)
 
 			require.Equal(t, int64(1), requests.Load())
 			require.Equal(t, tc.status, rec.Code)

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -193,6 +193,55 @@ func TestHandleSyncMainDataCapturesBodyWithoutLeadingZeros(t *testing.T) {
 	require.Equal(t, payload, rec.Body.Bytes())
 }
 
+func TestHandleTorrentPeersPassesThroughWithoutCacheWarming(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{"full update", http.StatusOK, `{"rid":7,"full_update":true,"peers":{"127.0.0.1:6881":{"client":"test"}}}`},
+		{"zero rid", http.StatusOK, `{"rid":0,"peers":{}}`},
+		{"incremental update", http.StatusOK, `{"rid":8,"full_update":false,"peers_removed":["127.0.0.1:6881"]}`},
+		{"upstream error", http.StatusNotFound, "torrent not found"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var requests atomic.Int64
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests.Add(1)
+				if r.Method != http.MethodGet || r.URL.Path != "/api/v2/sync/torrentPeers" || r.URL.RawQuery != "hash=abc123&rid=6" {
+					t.Errorf("unexpected upstream request: %s %s", r.Method, r.URL)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("X-Peer-Response", "unchanged")
+				w.WriteHeader(tc.status)
+				_, _ = io.WriteString(w, tc.body)
+			}))
+			defer upstream.Close()
+
+			// A full response must not access the client pool to start another fetch.
+			handler := NewHandler(nil, nil, nil, nil, nil, nil, "/")
+			instanceURL, err := url.Parse(upstream.URL)
+			require.NoError(t, err)
+			routeCtx := chi.NewRouteContext()
+			routeCtx.URLParams.Add("api-key", "test-key")
+			ctx := context.WithValue(t.Context(), chi.RouteCtxKey, routeCtx)
+			ctx = context.WithValue(ctx, ClientAPIKeyContextKey, &models.ClientAPIKey{ClientName: "test", InstanceID: 1})
+			ctx = context.WithValue(ctx, InstanceIDContextKey, 1)
+			ctx = context.WithValue(ctx, proxyContextKey, &proxyContext{instanceID: 1, instanceURL: instanceURL, httpClient: upstream.Client()})
+			req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/proxy/test-key/api/v2/sync/torrentPeers?hash=abc123&rid=6", nil)
+			rec := httptest.NewRecorder()
+
+			handler.handleTorrentPeers(rec, req)
+
+			require.Equal(t, int64(1), requests.Load())
+			require.Equal(t, tc.status, rec.Code)
+			require.Equal(t, tc.body, rec.Body.String())
+			require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+			require.Equal(t, "unchanged", rec.Header().Get("X-Peer-Response"))
+		})
+	}
+}
+
 func TestHandler_ProxyUsesInstanceHTTPClientTransport(t *testing.T) {
 	t.Helper()
 

--- a/internal/qbittorrent/client.go
+++ b/internal/qbittorrent/client.go
@@ -496,36 +496,6 @@ func (c *Client) GetCachedServerState() *qbt.ServerState {
 	return &stateCopy
 }
 
-// UpdateWithPeersData triggers a sync on the peer manager to keep it warm after intercepting peer data
-// This ensures our local peer state stays synchronized with the proxy client's view
-func (c *Client) UpdateWithPeersData(hash string, data *qbt.TorrentPeersResponse) {
-	// Get or create the peer sync manager for this torrent
-	peerSync := c.GetOrCreatePeerSyncManager(hash)
-
-	// Trigger a background sync to refresh the peer state
-	// We can't directly inject the data, but we can trigger a sync to keep the cache warm
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-
-		if err := peerSync.Sync(ctx); err != nil {
-			log.Error().
-				Err(err).
-				Int("instanceID", c.instanceID).
-				Str("hash", hash).
-				Msg("Failed to sync peer manager after intercepted peer data")
-			return
-		}
-
-		log.Debug().
-			Int("instanceID", c.instanceID).
-			Str("hash", hash).
-			Int("peerCount", len(data.Peers)).
-			Int64("rid", data.Rid).
-			Msg("Updated peer state with fresh data from intercepted request")
-	}()
-}
-
 func (c *Client) SupportsRenameTorrent() bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/internal/qbittorrent/client_test.go
+++ b/internal/qbittorrent/client_test.go
@@ -75,6 +75,52 @@ func (m *mockSyncEventSink) getTrackerHealthUpdates() []int {
 	return append([]int(nil), m.trackerHealthUpdates...)
 }
 
+func TestGetTorrentPeersSyncsAndMergesWithoutProxyWarmup(t *testing.T) {
+	var requests atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/sync/torrentPeers" || r.URL.Query().Get("hash") != "abc123" {
+			t.Errorf("unexpected request: %s", r.URL)
+			http.NotFound(w, r)
+			return
+		}
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("rid") {
+		case "0":
+			_, _ = w.Write([]byte(`{"rid":1,"full_update":true,"peers":{"keep":{"client":"test","dl_speed":10},"remove":{"client":"test"}}}`))
+		case "1":
+			_, _ = w.Write([]byte(`{"rid":2,"full_update":false,"peers":{"keep":{"dl_speed":20},"add":{"client":"new"}},"peers_removed":["remove"]}`))
+		default:
+			t.Errorf("unexpected rid: %s", r.URL.Query().Get("rid"))
+			http.Error(w, "unexpected rid", http.StatusBadRequest)
+		}
+	}))
+	defer srv.Close()
+
+	client := &Client{
+		Client:          qbt.NewClient(qbt.Config{Host: srv.URL, APIKey: "test-key"}),
+		isHealthy:       true,
+		peerSyncManager: make(map[string]*qbt.PeerSyncManager),
+	}
+	sm := &SyncManager{clientPool: &ClientPool{clients: map[int]*Client{1: client}}}
+
+	full, err := sm.GetTorrentPeers(t.Context(), 1, "abc123")
+	require.NoError(t, err)
+	require.Equal(t, int64(1), full.Rid)
+	require.Len(t, full.Peers, 2)
+	require.Contains(t, full.Peers, "remove")
+
+	merged, err := sm.GetTorrentPeers(t.Context(), 1, "abc123")
+	require.NoError(t, err)
+	require.Equal(t, int64(2), merged.Rid)
+	require.Len(t, merged.Peers, 2)
+	require.NotContains(t, merged.Peers, "remove")
+	require.Equal(t, "new", merged.Peers["add"].Client)
+	require.Equal(t, "test", merged.Peers["keep"].Client)
+	require.Equal(t, int64(20), merged.Peers["keep"].DownSpeed)
+	require.Equal(t, int64(2), requests.Load())
+}
+
 func TestClientUpdateServerStateDoesNotBlockOnClientMutex(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Description

Removes the extra peer request after a full proxy response to reduce upstream requests and response parsing.

Without that warming the handler only forwarded to the proxy, so it and its route go too: the wildcard route at the end of the same group already covers the path with the same middleware. A non-GET request to it now reaches qBittorrent instead of chi's 405, and the endpoint is GET-only.

Closes #2580

Merge order: this PR lands first in the peer group, then #2605, then #2611. #2611 edits `UpdateWithPeersData`, which this PR deletes, so that branch needs a merge from develop after this one lands.

## How has this been tested?

Ran the built app against a local HTTP stub. A full proxy response made one upstream peer request and preserved the response body and header. The UI API fetched and merged a full response and an incremental update. Removed the test processes, listeners, and temporary files after the run.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Torrent peer responses now pass through unchanged, preserving response status, headers, content type, and body.
  * Peer information is synchronized on demand, with incremental updates correctly merging new and changed peers while removing peers no longer present.
  * Improved handling of full updates, incremental requests, zero request identifiers, and upstream errors.

* **Tests**
  * Added coverage for response passthrough and peer synchronization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

