### PR TITLE
perf(qbittorrent): expire unused peer sync managers

### DIFF
--- a/internal/qbittorrent/client.go
+++ b/internal/qbittorrent/client.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"math"
 	"net/url"
 	"slices"
@@ -64,6 +65,14 @@ func splitHostUserinfo(host string) (cleanHost, user, pass string) {
 // fetch failure against a real qBittorrent.
 var errInvalidWebAPIVersion = errors.New("invalid qBittorrent WebAPI version")
 
+const peerSyncIdleTimeout = 5 * time.Minute
+
+type peerSyncEntry struct {
+	manager  *qbt.PeerSyncManager
+	lastUsed time.Time
+	timer    *time.Timer
+}
+
 type Client struct {
 	*qbt.Client
 	instanceID                 int
@@ -88,7 +97,7 @@ type Client struct {
 	lastHealthCheck            time.Time
 	isHealthy                  bool
 	syncManager                *qbt.SyncManager
-	peerSyncManager            map[string]*qbt.PeerSyncManager // Map of torrent hash to PeerSyncManager
+	peerSyncManager            map[string]*peerSyncEntry
 	// optimisticUpdates stores temporary optimistic state changes for this instance
 	optimisticUpdates    *ttlcache.Cache[string, *OptimisticTorrentUpdate]
 	trackerExclusions    map[string]map[string]struct{} // Domains to hide hashes from until fresh sync arrives
@@ -179,7 +188,7 @@ func NewClientWithTimeout(instanceID int, instanceHost, username, password, apiK
 		optimisticUpdates: ttlcache.New(ttlcache.Options[string, *OptimisticTorrentUpdate]{}.
 			SetDefaultTTL(30 * time.Second)), // Updates expire after 30 seconds
 		trackerExclusions: make(map[string]map[string]struct{}),
-		peerSyncManager:   make(map[string]*qbt.PeerSyncManager),
+		peerSyncManager:   make(map[string]*peerSyncEntry),
 		completionState:   make(map[string]bool),
 		addedState:        make(map[string]struct{}),
 	}
@@ -207,6 +216,7 @@ func NewClientWithTimeout(instanceID int, instanceHost, username, password, apiK
 
 	// Set up health check callbacks
 	syncOpts.OnUpdate = func(data *qbt.MainData) {
+		client.prunePeerSyncManagers(data)
 		client.countsGen.Add(1)
 		client.updateHealthStatus(true)
 		client.updateServerState(data)
@@ -939,21 +949,46 @@ func isStoppedOrErrorState(state qbt.TorrentState) bool {
 
 // GetOrCreatePeerSyncManager gets or creates a PeerSyncManager for a specific torrent
 func (c *Client) GetOrCreatePeerSyncManager(hash string) *qbt.PeerSyncManager {
+	hash = strings.ToLower(hash)
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	// Check if we already have a sync manager for this torrent
-	if peerSync, exists := c.peerSyncManager[hash]; exists {
-		return peerSync
+	if entry, exists := c.peerSyncManager[hash]; exists {
+		entry.lastUsed = time.Now()
+		entry.timer.Reset(peerSyncIdleTimeout)
+		return entry.manager
 	}
 
-	// Create a new peer sync manager for this torrent
 	peerSyncOpts := qbt.DefaultPeerSyncOptions()
 	peerSyncOpts.AutoSync = false // We'll sync manually when requested
-	peerSync := c.NewPeerSyncManager(hash, peerSyncOpts)
-	c.peerSyncManager[hash] = peerSync
+	entry := &peerSyncEntry{
+		manager:  c.NewPeerSyncManager(hash, peerSyncOpts),
+		lastUsed: time.Now(),
+	}
+	entry.timer = time.AfterFunc(peerSyncIdleTimeout, func() {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		// A callback queued before Reset must not remove a renewed or replaced entry.
+		if c.peerSyncManager[hash] == entry && time.Since(entry.lastUsed) >= peerSyncIdleTimeout {
+			delete(c.peerSyncManager, hash)
+		}
+	})
+	c.peerSyncManager[hash] = entry
 
-	return peerSync
+	return entry.manager
+}
+
+func (c *Client) prunePeerSyncManagers(data *qbt.MainData) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// OnUpdate supplies the complete merged torrent map, including after a delta.
+	maps.DeleteFunc(c.peerSyncManager, func(hash string, entry *peerSyncEntry) bool {
+		if _, exists := data.Torrents[hash]; exists {
+			return false
+		}
+		entry.timer.Stop()
+		return true
+	})
 }
 
 // applyOptimisticCacheUpdate applies optimistic updates for the given hashes and action

--- a/internal/qbittorrent/client_test.go
+++ b/internal/qbittorrent/client_test.go
@@ -8,18 +8,114 @@ import (
 	"encoding/json/v2"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	qbt "github.com/autobrr/go-qbittorrent"
 	"github.com/avast/retry-go"
 	"github.com/stretchr/testify/require"
 )
+
+type peerSyncTestTransport func(*http.Request) (*http.Response, error)
+
+func (f peerSyncTestTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func TestPeerSyncManagerIdleExpiry(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		const activeHash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		const idleHash = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+		qbtClient := qbt.NewClient(qbt.Config{Host: "http://example.invalid"}).WithHTTPClient(&http.Client{
+			Transport: peerSyncTestTransport(func(r *http.Request) (*http.Response, error) {
+				require.Equal(t, "/api/v2/sync/torrentPeers", r.URL.Path)
+				body := `{"rid":1,"full_update":true,"peers":{"192.0.2.1:1":{"ip":"192.0.2.1","dl_speed":10}}}`
+				if r.URL.Query().Get("rid") == "1" {
+					body = `{"rid":2,"peers":{"192.0.2.1:1":{"dl_speed":20}}}`
+				} else {
+					require.Equal(t, "0", r.URL.Query().Get("rid"))
+				}
+				return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}, nil
+			}),
+		})
+		client := &Client{Client: qbtClient, peerSyncManager: make(map[string]*peerSyncEntry)}
+		active := client.GetOrCreatePeerSyncManager(activeHash)
+		idle := client.GetOrCreatePeerSyncManager(idleHash)
+		require.NoError(t, active.Sync(t.Context()))
+		require.NoError(t, idle.Sync(t.Context()))
+
+		time.Sleep(4 * time.Minute)
+		require.Same(t, active, client.GetOrCreatePeerSyncManager(strings.ToUpper(activeHash)))
+		require.NoError(t, active.Sync(t.Context()))
+		require.Equal(t, int64(2), active.GetPeers().Rid)
+		require.Equal(t, "192.0.2.1", active.GetPeers().Peers["192.0.2.1:1"].IP)
+		require.EqualValues(t, 20, active.GetPeers().Peers["192.0.2.1:1"].DownSpeed)
+
+		time.Sleep(2 * time.Minute)
+		synctest.Wait()
+		require.NotContains(t, client.peerSyncManager, idleHash, "idle entries expire without another lookup")
+		require.Contains(t, client.peerSyncManager, activeHash, "reads renew the idle timeout")
+		require.Equal(t, int64(1), idle.GetPeers().Rid, "eviction preserves data held by an existing reader")
+		replacement := client.GetOrCreatePeerSyncManager(idleHash)
+		require.NotSame(t, idle, replacement)
+		require.NoError(t, replacement.Sync(t.Context()))
+		require.Equal(t, int64(1), replacement.GetPeers().Rid, "a reopened torrent starts with a full sync")
+
+		time.Sleep(6 * time.Minute)
+		synctest.Wait()
+		require.Empty(t, client.peerSyncManager)
+	})
+}
+
+func TestPeerSyncManagerTorrentRemoval(t *testing.T) {
+	const activeHash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	const removedHash = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	var phase atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/auth/login":
+			_, _ = io.WriteString(w, "Ok.")
+		case "/api/v2/app/webapiVersion":
+			_, _ = io.WriteString(w, "2.16.0")
+		case "/api/v2/sync/maindata":
+			switch phase.Load() {
+			case 0:
+				_, _ = fmt.Fprintf(w, `{"rid":1,"full_update":true,"torrents":{%q:{},%q:{}}}`, activeHash, removedHash)
+			case 1:
+				_, _ = fmt.Fprintf(w, `{"rid":2,"torrents_removed":[%q]}`, removedHash)
+			default:
+				_, _ = io.WriteString(w, `{"rid":3,"full_update":true,"torrents":{}}`)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	client, err := NewClientWithTimeout(1, srv.URL, "", "", "", nil, nil, false, time.Second, time.Second)
+	require.NoError(t, err)
+	defer client.optimisticUpdates.Close()
+	require.NoError(t, client.GetSyncManager().Sync(t.Context()))
+	active := client.GetOrCreatePeerSyncManager(activeHash)
+	removed := client.GetOrCreatePeerSyncManager(strings.ToUpper(removedHash))
+	t.Cleanup(func() { client.prunePeerSyncManagers(&qbt.MainData{}) })
+
+	phase.Store(1)
+	require.NoError(t, client.GetSyncManager().Sync(t.Context()))
+	require.NotContains(t, client.peerSyncManager, removedHash)
+	require.Same(t, active, client.GetOrCreatePeerSyncManager(activeHash), "an unchanged torrent survives a delta")
+	require.NotSame(t, removed, client.GetOrCreatePeerSyncManager(removedHash))
+
+	phase.Store(2)
+	require.NoError(t, client.GetSyncManager().Sync(t.Context()))
+	require.Empty(t, client.peerSyncManager, "a full refresh removes absent torrents")
+}
 
 // mockSyncEventSink is a test helper that records calls to HandleMainData and HandleSyncError.
 type mockSyncEventSink struct {


### PR DESCRIPTION
## Description

Expire peer sync managers after five idle minutes and remove them when torrents disappear to release cached peer data.

Closes #2583

Merge order: after #2604 and before #2611. This PR changes the type of the `peerSyncManager` map, and #2611 builds the old type in its tests, so that branch needs a merge from develop after this one lands.

## How has this been tested?

Ran `./qui serve` with a temporary database and a local qBittorrent stub. After 310 seconds, the idle torrent used RID 0 while active reads kept incremental peer data. A torrent removal also reset its next peer request to RID 0. All test processes, listeners, and temporary files were removed.

Also field-tested on the production media server against the `pr-2605` image (revision `4fbf97b3`), with a packet sniffer in the qBittorrent network namespace reading the outgoing `rid` parameter. qui's peers API always reports `full_update: false`, because `MergePeers` never copies the flag, so the request `rid` is the only usable observable.

After a 402 second idle gap, the `develop` control sent `sync/torrentPeers?hash=734abc77...&rid=3` and kept its manager. The same gap on this build sent `rid=0`. A torrent polled every two minutes for six minutes kept its incremental stream (`rid=0,1,2,3`), so each read resets the timer. On the empty test instance, a synthetic magnet deleted and re-added 25 seconds later sent `rid=0`, where `develop` continued at `rid=2`. That gap is far below the idle timeout, so the maindata prune is the only cause. No errors appeared in the log, and the host was restored to `develop`.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


