### PR TITLE
refactor(api): drop the dead full_update field from the peers response

### DIFF
--- a/internal/api/handlers/torrents.go
+++ b/internal/api/handlers/torrents.go
@@ -93,6 +93,11 @@ type SortedPeer struct {
 // SortedPeersResponse wraps the peers response with sorted peers
 type SortedPeersResponse struct {
 	*qbt.TorrentPeersResponse
+	// FullUpdate shadows the promoted qbt field so it never reaches the JSON:
+	// MergePeers never copies it into the cached response, so the endpoint has
+	// only ever sent false. *struct{} makes accidental promoted reads fail to
+	// compile.
+	FullUpdate  *struct{}    `json:"full_update,omitempty"`
 	SortedPeers []SortedPeer `json:"sorted_peers,omitempty"`
 }
 

--- a/internal/api/handlers/torrents_test.go
+++ b/internal/api/handlers/torrents_test.go
@@ -4,9 +4,13 @@
 package handlers
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 	"unicode/utf8"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/stretchr/testify/require"
 
 	"github.com/autobrr/qui/pkg/torrentname"
 )
@@ -100,4 +104,23 @@ func TestValidateTorrentFilePath(t *testing.T) {
 			t.Fatalf("%s: expected nil error, got %v", tt.name, err)
 		}
 	}
+}
+
+// TestSortedPeersResponseOmitsFullUpdate pins the shadow field on the peers
+// response: MergePeers never copies FullUpdate into the cached struct, so the
+// endpoint has only ever sent false and must now send nothing.
+func TestSortedPeersResponseOmitsFullUpdate(t *testing.T) {
+	t.Parallel()
+
+	data, err := json.Marshal(SortedPeersResponse{
+		TorrentPeersResponse: &qbt.TorrentPeersResponse{Rid: 7, FullUpdate: true},
+		SortedPeers:          []SortedPeer{{Key: "192.0.2.1:1"}},
+	})
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.NotContains(t, decoded, "full_update")
+	require.EqualValues(t, 7, decoded["rid"])
+	require.Contains(t, decoded, "sorted_peers")
 }

--- a/web/src/types/torrents.ts
+++ b/web/src/types/torrents.ts
@@ -415,7 +415,6 @@ export interface TorrentPeersResponse {
   peers?: Record<string, TorrentPeer>
   peers_removed?: string[]
   rid: number
-  full_update: boolean
   show_flags?: boolean
 }
 


### PR DESCRIPTION
## Description

The `full_update` key on `GET /api/instances/{id}/torrents/{hash}/peers` has always been `false`, so this removes it.

`PeerSyncManager` keeps one `TorrentPeersResponse` per torrent and merges each qBittorrent answer into it. `MergePeers` copies `Peers`, `PeersRemoved`, `Rid` and `ShowFlags`, but never `FullUpdate`, and it only reads the incoming flag to pick a branch. The cached struct therefore keeps its zero value for the life of the manager, and `GetPeers` hands that constant to the handler. Nothing reads it: no Go code, no test, no OpenAPI schema, and no frontend code, where the type declared the field but never used it.

The field lives in the go-qbittorrent struct that `SortedPeersResponse` embeds, so qui hides it with a `*struct{}` shadow, the same way `TorrentView` hides `magnet_uri` and `has_metadata`. The qBittorrent-compatible proxy is untouched. It decodes upstream bodies itself and still reads the real flag to decide whether to warm its cache.

Merge order: independent of #2604, #2605 and #2611. It touches different files and can land at any point.

## How has this been tested?

The endpoint's JSON shape is fully determined by the struct tags, and the new test pins it, so CI covers this change.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Torrent peer responses no longer expose the internal `full_update` field.
  * Existing peer data, including request identifiers and sorted peer details, remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
