### PR TITLE
refactor(proxy): stop refetching peers qui already proxied

### DIFF
--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -407,7 +407,6 @@ func (h *Handler) Routes(r chi.Router) {
 		// Register intercepted endpoints (these use qui's sync manager or special handling)
 		pr.Post("/api/v2/auth/login", h.handleAuthLogin)
 		pr.Get("/api/v2/sync/maindata", h.handleSyncMainData)
-		pr.Get("/api/v2/sync/torrentPeers", h.handleTorrentPeers)
 		pr.Get("/api/v2/torrents/info", h.handleTorrentsInfo)
 		pr.Get("/api/v2/torrents/categories", h.handleCategories)
 		pr.Get("/api/v2/torrents/tags", h.handleTags)
@@ -1531,81 +1530,6 @@ func (h *Handler) handleTorrentTrackers(w http.ResponseWriter, r *http.Request) 
 			Err(err).
 			Int("instanceId", instanceID).
 			Msg("Failed to encode trackers response")
-	}
-}
-
-// handleTorrentPeers handles /api/v2/sync/torrentPeers requests
-func (h *Handler) handleTorrentPeers(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	instanceID := GetInstanceIDFromContext(ctx)
-	clientAPIKey := GetClientAPIKeyFromContext(ctx)
-
-	hash := r.URL.Query().Get("hash")
-
-	log.Trace().
-		Int("instanceId", instanceID).
-		Str("client", clientAPIKey.ClientName).
-		Str("hash", hash).
-		Msg("Proxying sync/torrentPeers request")
-
-	// Use a custom response writer to capture the response
-	buf := h.bufferPool.Get()
-	crwBody := buf[:0]
-	crw := &capturingResponseWriter{
-		ResponseWriter: w,
-		body:           crwBody,
-		statusCode:     http.StatusOK,
-	}
-	defer func() {
-		if buf != nil {
-			h.bufferPool.Put(buf[:cap(buf)])
-		}
-	}()
-
-	// Proxy the request
-	h.proxy.ServeHTTP(crw, r)
-
-	// Update local peer sync manager state for successful responses
-	if crw.statusCode == http.StatusOK && len(crw.body) > 0 {
-		var peersData qbt.TorrentPeersResponse
-		if err := json.Unmarshal(crw.body, &peersData); err != nil {
-			log.Error().
-				Err(err).
-				Int("instanceId", instanceID).
-				Str("hash", hash).
-				Msg("Failed to parse sync/torrentPeers response")
-			return
-		}
-
-		// Check if this is a full update (FullUpdate field or rid == 0)
-		isFullUpdate := peersData.FullUpdate || peersData.Rid == 0
-
-		if isFullUpdate {
-			client, err := h.clientPool.GetClient(ctx, instanceID)
-			if err != nil {
-				log.Error().
-					Err(err).
-					Int("instanceId", instanceID).
-					Msg("Failed to get client for peer state update")
-				return
-			}
-
-			// Update peer state using the same pattern as maindata
-			client.UpdateWithPeersData(hash, &peersData)
-
-			log.Trace().
-				Int("instanceId", instanceID).
-				Str("hash", hash).
-				Int64("rid", peersData.Rid).
-				Int("peerCount", len(peersData.Peers)).
-				Msg("Updated local peer state from full sync/torrentPeers response")
-		} else {
-			log.Trace().
-				Int("instanceId", instanceID).
-				Str("hash", hash).
-				Int64("rid", peersData.Rid).
-				Msg("Skipping incremental sync/torrentPeers update")
-		}
 	}
 }
 

--- a/internal/qbittorrent/client.go
+++ b/internal/qbittorrent/client.go
@@ -496,36 +496,6 @@ func (c *Client) GetCachedServerState() *qbt.ServerState {
 	return &stateCopy
 }
 
-// UpdateWithPeersData triggers a sync on the peer manager to keep it warm after intercepting peer data
-// This ensures our local peer state stays synchronized with the proxy client's view
-func (c *Client) UpdateWithPeersData(hash string, data *qbt.TorrentPeersResponse) {
-	// Get or create the peer sync manager for this torrent
-	peerSync := c.GetOrCreatePeerSyncManager(hash)
-
-	// Trigger a background sync to refresh the peer state
-	// We can't directly inject the data, but we can trigger a sync to keep the cache warm
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-
-		if err := peerSync.Sync(ctx); err != nil {
-			log.Error().
-				Err(err).
-				Int("instanceID", c.instanceID).
-				Str("hash", hash).
-				Msg("Failed to sync peer manager after intercepted peer data")
-			return
-		}
-
-		log.Debug().
-			Int("instanceID", c.instanceID).
-			Str("hash", hash).
-			Int("peerCount", len(data.Peers)).
-			Int64("rid", data.Rid).
-			Msg("Updated peer state with fresh data from intercepted request")
-	}()
-}
-
 func (c *Client) SupportsRenameTorrent() bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()


### PR DESCRIPTION
## Description

A proxy client's first `sync/torrentPeers` request for a torrent cost two calls to qBittorrent. This removes the second one.

`handleTorrentPeers` captured the proxied response body and, on a full update, passed it to `UpdateWithPeersData`. That method ignored the payload it was given, because the peer sync manager has no way to accept decoded data, and instead spawned a goroutine that issued another `sync/torrentPeers` request to warm qui's own manager. Nothing ever served the warmed data: `SyncManager.GetTorrentPeers` calls `Sync` on every read, so a UI request always fetches again anyway.

With the warm gone, the handler was a bare `h.proxy.ServeHTTP` call, which is what the wildcard route at the end of the group already does, so the handler and its route go too. The middleware chain is identical, since the wildcard sits inside the same `Route` block. One behaviour change: a non-GET request to that path is now proxied to qBittorrent instead of answered with 405 by chi.

The `sync/maindata` interception next to it is untouched. It still captures its body, and it routes through `HintMainDataRefresh` rather than a raw goroutine.

## How has this been tested?

Not covered by a new test: the change only deletes code, and what remains on the path is the wildcard proxy route that every non-intercepted qBittorrent endpoint already uses.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Requests to the torrent peers synchronization endpoint are now handled by the standard reverse proxy.
  - Intercepted peer data no longer triggers local peer-cache updates or background synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->