### PR TITLE
fix(qbittorrent): serialize peer fetch and merge per torrent

### DIFF
--- a/internal/qbittorrent/client.go
+++ b/internal/qbittorrent/client.go
@@ -100,6 +100,7 @@ type Client struct {
 	healthMu             sync.RWMutex
 	appInfoMu            sync.RWMutex
 	appInfoGroup         singleflight.Group
+	peerSyncGroup        singleflight.Group
 	preferencesCache     *qbt.AppPreferences
 	preferencesJSON      json.RawMessage
 	preferencesFetchedAt time.Time
@@ -499,16 +500,10 @@ func (c *Client) GetCachedServerState() *qbt.ServerState {
 // UpdateWithPeersData triggers a sync on the peer manager to keep it warm after intercepting peer data
 // This ensures our local peer state stays synchronized with the proxy client's view
 func (c *Client) UpdateWithPeersData(hash string, data *qbt.TorrentPeersResponse) {
-	// Get or create the peer sync manager for this torrent
-	peerSync := c.GetOrCreatePeerSyncManager(hash)
-
 	// Trigger a background sync to refresh the peer state
 	// We can't directly inject the data, but we can trigger a sync to keep the cache warm
 	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-
-		if err := peerSync.Sync(ctx); err != nil {
+		if _, err := c.SyncPeers(context.Background(), hash); err != nil {
 			log.Error().
 				Err(err).
 				Int("instanceID", c.instanceID).
@@ -935,6 +930,42 @@ func isStoppedOrErrorState(state qbt.TorrentState) bool {
 		state == qbt.TorrentStateStoppedUp ||
 		state == qbt.TorrentStateMissingFiles ||
 		state == qbt.TorrentStateError
+}
+
+// peerSyncFetchTimeout bounds a peer fetch that outlives the reader which started it.
+const peerSyncFetchTimeout = 30 * time.Second
+
+// SyncPeers fetches peer updates for a torrent, merges them and returns the merged
+// list. Readers of the same hash share one fetch, so the rid a request carries is
+// always the rid the previous merge produced: an older snapshot can no longer land
+// on top of a newer one and restore a peer the server already removed.
+// Callers must not mutate the returned response, it is shared by every reader that
+// joined the same fetch.
+func (c *Client) SyncPeers(ctx context.Context, hash string) (*qbt.TorrentPeersResponse, error) {
+	peerSync := c.GetOrCreatePeerSyncManager(hash)
+
+	// Joiners share the leader's result, so the fetch must not die with the
+	// leader's context; peerSyncFetchTimeout still bounds it. DoChan lets a
+	// caller whose own request went away leave without waiting for the fetch.
+	ch := c.peerSyncGroup.DoChan(hash, func() (any, error) {
+		fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), peerSyncFetchTimeout)
+		defer cancel()
+
+		if err := peerSync.Sync(fetchCtx); err != nil {
+			return nil, err
+		}
+		return peerSync.GetPeers(), nil
+	})
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case result := <-ch:
+		if result.Err != nil {
+			return nil, result.Err
+		}
+		return result.Val.(*qbt.TorrentPeersResponse), nil
+	}
 }
 
 // GetOrCreatePeerSyncManager gets or creates a PeerSyncManager for a specific torrent

--- a/internal/qbittorrent/client_test.go
+++ b/internal/qbittorrent/client_test.go
@@ -972,14 +972,18 @@ func TestSyncPeersSerializesConcurrentReaders(t *testing.T) {
 func TestSyncPeersLeavesWhenCallerGoesAway(t *testing.T) {
 	const hash = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 
+	fetchStarted := make(chan struct{})
 	release := make(chan struct{})
-	t.Cleanup(func() { close(release) })
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(fetchStarted)
 		<-release
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"rid":1,"full_update":true,"peers":{}}`))
 	}))
 	t.Cleanup(srv.Close)
+	// Cleanups run last registered first, so the handler is released before the
+	// server shuts down and waits for it.
+	t.Cleanup(func() { close(release) })
 
 	client := &Client{
 		Client:          qbt.NewClient(qbt.Config{Host: srv.URL, Timeout: 60}),
@@ -987,8 +991,20 @@ func TestSyncPeersLeavesWhenCallerGoesAway(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(t.Context())
+	errs := make(chan error, 1)
+	go func() {
+		_, err := client.SyncPeers(ctx, hash)
+		errs <- err
+	}()
+
+	// Cancel while the fetch is in flight, which is what a closed tab does.
+	<-fetchStarted
 	cancel()
 
-	_, err := client.SyncPeers(ctx, hash)
-	require.ErrorIs(t, err, context.Canceled)
+	select {
+	case err := <-errs:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("SyncPeers kept waiting for a fetch after its caller went away")
+	}
 }

--- a/internal/qbittorrent/client_test.go
+++ b/internal/qbittorrent/client_test.go
@@ -867,3 +867,128 @@ func TestHealthCheckRetriesCapabilitiesUntilLoaded(t *testing.T) {
 	require.Equal(t, "2.11.4", client.GetWebAPIVersion())
 	require.True(t, client.trackerManager().SupportsIncludeTrackers(), "the health check must apply the capability to the tracker manager")
 }
+
+// TestSyncPeersSerializesConcurrentReaders pins the ordering guarantee that the
+// race detector cannot see: every peer fetch must carry the rid the previous
+// merge produced, so an older snapshot can never merge on top of a newer one.
+func TestSyncPeersSerializesConcurrentReaders(t *testing.T) {
+	const hash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	const stalePeer = "192.0.2.9:9"
+
+	var mu sync.Mutex
+	ridsSent := make(map[string]int)
+	requests := 0
+	newestRid := int64(0)
+	secondRequest := make(chan struct{})
+
+	// served records the newest response the server produced. The merged state
+	// must end up matching it, whatever order the fetches ran in. Only the rid 1
+	// response carries the stale peer, so the rid alone says what to expect.
+	served := func(rid int64) {
+		mu.Lock()
+		defer mu.Unlock()
+		newestRid = max(newestRid, rid)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rid := r.URL.Query().Get("rid")
+
+		mu.Lock()
+		ridsSent[rid]++
+		requests++
+		first := requests == 1
+		if requests == 2 {
+			close(secondRequest)
+		}
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+
+		if first {
+			// Hold the oldest snapshot open long enough for an unserialized
+			// reader to overtake it. Nothing overtakes it once fetch and merge
+			// are serialized, so fall through on the timeout instead.
+			select {
+			case <-secondRequest:
+			case <-time.After(200 * time.Millisecond):
+			}
+			served(1)
+			_, _ = w.Write([]byte(`{"rid":1,"full_update":true,"peers":{"192.0.2.1:1":{"ip":"192.0.2.1"},"` + stalePeer + `":{"ip":"192.0.2.9"}}}`))
+			return
+		}
+
+		served(2)
+		if rid == "0" {
+			// A reader that never saw the first merge asks for a full snapshot.
+			_, _ = w.Write([]byte(`{"rid":2,"full_update":true,"peers":{"192.0.2.1:1":{"ip":"192.0.2.1"}}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"rid":2,"peers_removed":["` + stalePeer + `"]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &Client{
+		Client:          qbt.NewClient(qbt.Config{Host: srv.URL, Timeout: 60}),
+		peerSyncManager: make(map[string]*qbt.PeerSyncManager),
+	}
+
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Go(func() {
+			_, err := client.SyncPeers(t.Context(), hash)
+			require.NoError(t, err)
+		})
+	}
+	wg.Wait()
+
+	mu.Lock()
+	wantRid := newestRid
+	wantStalePeer := wantRid == 1
+	for rid, count := range ridsSent {
+		require.Equalf(t, 1, count, "rid %s was sent by %d fetches; concurrent readers shared a rid", rid, count)
+	}
+	mu.Unlock()
+
+	// The merged state must match the newest response the server produced, not
+	// whichever fetch happened to return last.
+	peers := client.GetOrCreatePeerSyncManager(hash).GetPeers()
+	require.Equal(t, wantRid, peers.Rid, "rid regressed to an older snapshot")
+	if wantStalePeer {
+		require.Contains(t, peers.Peers, stalePeer)
+	} else {
+		require.NotContains(t, peers.Peers, stalePeer, "an older snapshot restored a removed peer")
+	}
+
+	// The next reader carries the rid the last merge produced, so the server can
+	// answer with a removal and the removal sticks.
+	peers, err := client.SyncPeers(t.Context(), hash)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), peers.Rid)
+	require.NotContains(t, peers.Peers, stalePeer, "a removal from an incremental update was lost")
+}
+
+// TestSyncPeersLeavesWhenCallerGoesAway keeps a reader whose request was
+// cancelled from waiting out a slow qBittorrent.
+func TestSyncPeersLeavesWhenCallerGoesAway(t *testing.T) {
+	const hash = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		<-release
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"rid":1,"full_update":true,"peers":{}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := &Client{
+		Client:          qbt.NewClient(qbt.Config{Host: srv.URL, Timeout: 60}),
+		peerSyncManager: make(map[string]*qbt.PeerSyncManager),
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := client.SyncPeers(ctx, hash)
+	require.ErrorIs(t, err, context.Canceled)
+}

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -2990,16 +2990,14 @@ func (sm *SyncManager) GetTorrentPeers(ctx context.Context, instanceID int, hash
 		return nil, fmt.Errorf("failed to get client: %w", err)
 	}
 
-	// Get or create peer sync manager for this torrent
-	peerSync := clientWrapper.GetOrCreatePeerSyncManager(hash)
-
-	// Sync to get latest peer data
-	if err := peerSync.Sync(ctx); err != nil {
+	// Fetch and merge the latest peer data. Concurrent readers of one hash share
+	// the fetch, which keeps the merges in order.
+	peers, err := clientWrapper.SyncPeers(ctx, hash)
+	if err != nil {
 		return nil, fmt.Errorf("failed to sync torrent peers: %w", err)
 	}
 
-	// Return the current peer data (already merged with incremental updates)
-	return peerSync.GetPeers(), nil
+	return peers, nil
 }
 
 // GetTorrentPieceStates returns the download state of each piece for a torrent.


### PR DESCRIPTION
## Description

Two readers of one torrent hash sent the same rid and merged their peer responses in whichever order they finished, so an older snapshot could restore a peer the server had removed and push the stored rid backwards. Readers of a hash now share one fetch, which puts the merge inside the flight: the rid a request carries is always the rid the previous merge produced.

Fixes #2610

Merge order: last of the peer group, after #2604 and #2605. #2604 deletes `UpdateWithPeersData`, which this PR edits, and #2605 changes the type of the `peerSyncManager` map that this PR builds in its tests, so this branch needs a merge from develop after each of them lands.

## How has this been tested?

Local rig, a stub qBittorrent that holds the first peer response open and serves current truth to the second. Two concurrent reads of one hash, then one poll. The rid each fetch carries is the observable; both builds converge on the same peer list one poll later.

- develop: `["0", "0", "1"]`. Two fetches shared rid 0, both readers got the older snapshot, and the next poll sent the regressed rid 1 after the server had already served rid 2.
- this branch: `["0", "1"]`. One fetch for two readers, the next fetch carries the previous merge's rid, and the removal sticks.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved peer synchronization to prevent concurrent updates from overwriting newer peer data.
  - Ensured incremental peer additions and removals are merged consistently.
  - Peer requests now stop promptly when the requesting operation is canceled.

- **Performance**
  - Concurrent requests for the same torrent share a single peer-data fetch, reducing duplicate network requests.
  - Peer synchronization uses a bounded fetch timeout, helping prevent requests from remaining active indefinitely.
  - Unused peer synchronization resources are automatically cleaned up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
