### PR TITLE
fix(qbittorrent): key the peer fetch on the lowered hash

### DIFF
--- a/internal/qbittorrent/client.go
+++ b/internal/qbittorrent/client.go
@@ -928,6 +928,9 @@ const peerSyncFetchTimeout = 30 * time.Second
 // Callers must not mutate the returned response, it is shared by every reader that
 // joined the same fetch.
 func (c *Client) SyncPeers(ctx context.Context, hash string) (*qbt.TorrentPeersResponse, error) {
+	// The manager is keyed on the lowered hash, so the fetch must be too:
+	// otherwise two spellings of one hash share a manager but not a fetch.
+	hash = strings.ToLower(hash)
 	peerSync := c.GetOrCreatePeerSyncManager(hash)
 
 	// Joiners share the leader's result, so the fetch must not die with the

--- a/internal/qbittorrent/client_test.go
+++ b/internal/qbittorrent/client_test.go
@@ -1075,9 +1075,12 @@ func TestSyncPeersSerializesConcurrentReaders(t *testing.T) {
 	}
 
 	var wg sync.WaitGroup
-	for range 2 {
+	// One caller spells the hash in upper case. The API takes the hash straight
+	// from the URL, so both spellings reach SyncPeers, and both must land on the
+	// same fetch: a second spelling must not open a second rid on one manager.
+	for _, callerHash := range []string{hash, strings.ToUpper(hash)} {
 		wg.Go(func() {
-			_, err := client.SyncPeers(t.Context(), hash)
+			_, err := client.SyncPeers(t.Context(), callerHash)
 			require.NoError(t, err)
 		})
 	}


### PR DESCRIPTION
## Description

Follow-up to #2611. `GetOrCreatePeerSyncManager` lowercases the hash but `SyncPeers` passed the caller's spelling to the singleflight group, so two spellings of one hash shared a manager but not a fetch, read the same rid, and merged in completion order. That is the race #2611 removed for the common case. The API takes the hash straight from the URL, so both spellings reach `SyncPeers`.

## How has this been tested?

Reverted the normalization and ran the concurrency test against the unfixed code: red on 3 of 3 runs with `rid 0 was sent by 2 fetches; concurrent readers shared a rid`. Green on 3 of 3 with the fix.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved peer synchronization so uppercase and lowercase versions of the same hash share the same peer data and request handling.
  * Prevented duplicate peer fetches when the same hash is provided with different capitalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->