### PR TITLE
refactor(filesmanager): remove unused cache paths and chunk helpers

### DIFF
--- a/internal/services/filesmanager/repository.go
+++ b/internal/services/filesmanager/repository.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -47,11 +48,6 @@ func NewRepository(db dbinterface.Querier) *Repository {
 	return &Repository{db: db}
 }
 
-// GetFiles retrieves all cached files for a torrent
-func (r *Repository) GetFiles(ctx context.Context, instanceID int, hash string) ([]CachedFile, error) {
-	return r.getFiles(ctx, r.db, instanceID, hash)
-}
-
 // GetFilesBatch retrieves cached files for multiple torrents at once.
 func (r *Repository) GetFilesBatch(ctx context.Context, instanceID int, hashes []string) (map[string][]CachedFile, error) {
 	cleaned := dedupeHashes(hashes)
@@ -60,7 +56,7 @@ func (r *Repository) GetFilesBatch(ctx context.Context, instanceID int, hashes [
 	}
 
 	results := make(map[string][]CachedFile, len(cleaned))
-	for _, batch := range chunkHashes(cleaned, maxBatchItems) {
+	for batch := range slices.Chunk(cleaned, maxBatchItems) {
 		args := make([]any, 0, len(batch)+1)
 		args = append(args, instanceID)
 		for _, h := range batch {
@@ -118,65 +114,6 @@ func (r *Repository) GetFilesBatch(ctx context.Context, instanceID int, hashes [
 	}
 
 	return results, nil
-}
-
-// GetFilesTx retrieves all cached files for a torrent within a transaction
-func (r *Repository) GetFilesTx(ctx context.Context, tx dbinterface.TxQuerier, instanceID int, hash string) ([]CachedFile, error) {
-	return r.getFiles(ctx, tx, instanceID, hash)
-}
-
-// getFiles is the internal implementation that works with any querier (db or tx)
-func (r *Repository) getFiles(ctx context.Context, q querier, instanceID int, hash string) ([]CachedFile, error) {
-	query := `
-		SELECT id, instance_id, torrent_hash, file_index, name, size, progress,
-		       priority, is_seed, piece_range_start, piece_range_end, availability, cached_at
-		FROM torrent_files_cache_view
-		WHERE instance_id = ? AND torrent_hash = ?
-		ORDER BY file_index ASC
-	`
-
-	rows, err := q.QueryContext(ctx, query, instanceID, hash)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	var files []CachedFile
-	for rows.Next() {
-		var f CachedFile
-		var isSeed sql.NullInt64
-		err := rows.Scan(
-			&f.ID,
-			&f.InstanceID,
-			&f.TorrentHash,
-			&f.FileIndex,
-			&f.Name,
-			&f.Size,
-			&f.Progress,
-			&f.Priority,
-			&isSeed,
-			&f.PieceRangeStart,
-			&f.PieceRangeEnd,
-			&f.Availability,
-			&f.CachedAt,
-		)
-		if err != nil {
-			return nil, err
-		}
-
-		f.IsSeed = decodeNullableBoolFromInt(isSeed)
-
-		files = append(files, f)
-	}
-
-	return files, rows.Err()
-}
-
-// querier interface for methods that accept db or tx
-type querier interface {
-	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
-	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
-	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
 }
 
 // UpsertFiles inserts or updates cached file information.
@@ -361,8 +298,6 @@ func (r *Repository) UpsertFiles(ctx context.Context, files []CachedFile) error 
 
 // DeleteFiles removes all cached files for a torrent.
 // Returns nil if successful or if no cache existed for the given torrent.
-// To distinguish between "deleted" vs "nothing to delete", check the logs or
-// use GetFiles before calling this method.
 func (r *Repository) DeleteFiles(ctx context.Context, instanceID int, hash string) error {
 	// Start a transaction
 	tx, err := r.db.BeginTx(ctx, nil)
@@ -419,11 +354,6 @@ func decodeNullableBoolFromInt(value sql.NullInt64) *bool {
 	return &result
 }
 
-// GetSyncInfo retrieves sync metadata for a torrent
-func (r *Repository) GetSyncInfo(ctx context.Context, instanceID int, hash string) (*SyncInfo, error) {
-	return r.getSyncInfo(ctx, r.db, instanceID, hash)
-}
-
 // GetSyncInfoBatch retrieves sync metadata for multiple torrents in a single query.
 func (r *Repository) GetSyncInfoBatch(ctx context.Context, instanceID int, hashes []string) (map[string]*SyncInfo, error) {
 	cleaned := dedupeHashes(hashes)
@@ -432,7 +362,7 @@ func (r *Repository) GetSyncInfoBatch(ctx context.Context, instanceID int, hashe
 	}
 
 	results := make(map[string]*SyncInfo, len(cleaned))
-	for _, batch := range chunkHashes(cleaned, maxBatchItems) {
+	for batch := range slices.Chunk(cleaned, maxBatchItems) {
 		args := make([]any, 0, len(batch)+1)
 		args = append(args, instanceID)
 		for _, h := range batch {
@@ -475,74 +405,6 @@ func (r *Repository) GetSyncInfoBatch(ctx context.Context, instanceID int, hashe
 	}
 
 	return results, nil
-}
-
-// GetSyncInfoTx retrieves sync metadata for a torrent within a transaction
-func (r *Repository) GetSyncInfoTx(ctx context.Context, tx dbinterface.TxQuerier, instanceID int, hash string) (*SyncInfo, error) {
-	return r.getSyncInfo(ctx, tx, instanceID, hash)
-}
-
-// getSyncInfo is the internal implementation that works with any querier (db or tx)
-func (r *Repository) getSyncInfo(ctx context.Context, q querier, instanceID int, hash string) (*SyncInfo, error) {
-	query := `
-		SELECT instance_id, torrent_hash, last_synced_at, torrent_progress, file_count
-		FROM torrent_files_sync_view
-		WHERE instance_id = ? AND torrent_hash = ?
-	`
-
-	var info SyncInfo
-	err := q.QueryRowContext(ctx, query, instanceID, hash).Scan(
-		&info.InstanceID,
-		&info.TorrentHash,
-		&info.LastSyncedAt,
-		&info.TorrentProgress,
-		&info.FileCount,
-	)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return &info, nil
-}
-
-// UpsertSyncInfo inserts or updates sync metadata
-func (r *Repository) UpsertSyncInfo(ctx context.Context, info SyncInfo) error {
-	// Start a transaction
-	tx, err := r.db.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	// Intern the torrent hash
-	ids, err := dbinterface.InternStrings(ctx, tx, info.TorrentHash)
-	if err != nil {
-		return fmt.Errorf("failed to intern torrent_hash: %w", err)
-	}
-	hashID := ids[0]
-
-	_, err = tx.ExecContext(ctx, `
-		INSERT INTO torrent_files_sync
-		(instance_id, torrent_hash_id, last_synced_at, torrent_progress, file_count)
-		VALUES (?, ?, ?, ?, ?)
-		ON CONFLICT(instance_id, torrent_hash_id) DO UPDATE SET
-			last_synced_at = excluded.last_synced_at,
-			torrent_progress = excluded.torrent_progress,
-			file_count = excluded.file_count
-	`,
-		info.InstanceID,
-		hashID,
-		info.LastSyncedAt,
-		info.TorrentProgress,
-		info.FileCount,
-	)
-
-	if err != nil {
-		return err
-	}
-
-	return tx.Commit()
 }
 
 // UpsertSyncInfoBatch inserts or updates sync metadata for multiple torrents
@@ -670,7 +532,7 @@ func (r *Repository) DeleteTorrentCache(ctx context.Context, instanceID int, has
 	}
 
 	// Delete files for all valid hashes
-	for _, batch := range chunkInts(validHashIDs, maxBatchItems) {
+	for batch := range slices.Chunk(validHashIDs, maxBatchItems) {
 		args := make([]any, 0, len(batch)+1)
 		args = append(args, instanceID)
 		for _, id := range batch {
@@ -684,7 +546,7 @@ func (r *Repository) DeleteTorrentCache(ctx context.Context, instanceID int, has
 	}
 
 	// Delete sync info for all valid hashes
-	for _, batch := range chunkInts(validHashIDs, maxBatchItems) {
+	for batch := range slices.Chunk(validHashIDs, maxBatchItems) {
 		args := make([]any, 0, len(batch)+1)
 		args = append(args, instanceID)
 		for _, id := range batch {
@@ -881,30 +743,6 @@ func dedupeHashes(hashes []string) []string {
 		unique = append(unique, h)
 	}
 	return unique
-}
-
-func chunkHashes(hashes []string, size int) [][]string {
-	if size <= 0 || len(hashes) == 0 {
-		return nil
-	}
-	var chunks [][]string
-	for start := 0; start < len(hashes); start += size {
-		end := min(start+size, len(hashes))
-		chunks = append(chunks, hashes[start:end])
-	}
-	return chunks
-}
-
-func chunkInts(ints []int64, size int) [][]int64 {
-	if size <= 0 || len(ints) == 0 {
-		return nil
-	}
-	var chunks [][]int64
-	for start := 0; start < len(ints); start += size {
-		end := min(start+size, len(ints))
-		chunks = append(chunks, ints[start:end])
-	}
-	return chunks
 }
 
 func buildPlaceholders(count int) string {

--- a/internal/services/filesmanager/repository_upsert_guard_test.go
+++ b/internal/services/filesmanager/repository_upsert_guard_test.go
@@ -140,8 +140,9 @@ func TestUpsertFilesWritesChangedRows(t *testing.T) {
 
 				require.Zero(t, countAtSentinel(ctx, t, db), "changed %s should have been written", tt.name)
 
-				stored, err := repo.GetFiles(ctx, 1, "guard-hash")
+				batch, err := repo.GetFilesBatch(ctx, 1, []string{"guard-hash"})
 				require.NoError(t, err)
+				stored := batch["guard-hash"]
 				require.Len(t, stored, 1)
 				require.Equal(t, changed.Name, stored[0].Name)
 				require.Equal(t, changed.Size, stored[0].Size)
@@ -191,8 +192,9 @@ func TestUpsertFilesGuardIsNullSafe(t *testing.T) {
 			require.NoError(t, repo.UpsertFiles(ctx, []CachedFile{baseFile()}))
 			require.Zero(t, countAtSentinel(ctx, t, db), "null-to-value should have been written")
 
-			stored, err := repo.GetFiles(ctx, 1, "guard-hash")
+			batch, err := repo.GetFilesBatch(ctx, 1, []string{"guard-hash"})
 			require.NoError(t, err)
+			stored := batch["guard-hash"]
 			require.Len(t, stored, 1)
 			require.Equal(t, new(true), stored[0].IsSeed)
 		})
@@ -212,8 +214,9 @@ func TestUpsertFilesGuardIsNullSafe(t *testing.T) {
 			require.NoError(t, repo.UpsertFiles(ctx, []CachedFile{nullSeed}))
 			require.Zero(t, countAtSentinel(ctx, t, db), "value-to-null should have been written")
 
-			stored, err := repo.GetFiles(ctx, 1, "guard-hash")
+			batch, err := repo.GetFilesBatch(ctx, 1, []string{"guard-hash"})
 			require.NoError(t, err)
+			stored := batch["guard-hash"]
 			require.Len(t, stored, 1)
 			require.Nil(t, stored[0].IsSeed)
 		})

--- a/internal/services/filesmanager/service.go
+++ b/internal/services/filesmanager/service.go
@@ -29,14 +29,12 @@ type TorrentHashProvider interface {
 
 // Service manages cached torrent file information
 type Service struct {
-	db   dbinterface.Querier
 	repo *Repository
 }
 
 // NewService creates a new files manager service
 func NewService(db dbinterface.Querier) *Service {
 	return &Service{
-		db:   db,
 		repo: NewRepository(db),
 	}
 }

--- a/internal/services/filesmanager/service_test.go
+++ b/internal/services/filesmanager/service_test.go
@@ -5,6 +5,7 @@ package filesmanager
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -101,6 +102,54 @@ func TestCacheFilesBatch_MaintainsHashAlignment(t *testing.T) {
 			require.Equalf(t, names[hash], cached[0].Name, "attempt %d hash %s", attempt, hash)
 		}
 	}
+}
+
+func TestCacheFilesBatchAcrossQueryBatches(t *testing.T) {
+	t.Parallel()
+
+	forEachBackend(t, func(ctx context.Context, t *testing.T, db *database.DB) {
+		svc := NewService(db)
+		hashes := make([]string, 801)
+		files := make(map[string]qbt.TorrentFiles, len(hashes))
+		for i := range hashes {
+			hashes[i] = fmt.Sprintf("batch-hash-%d", i)
+			files[hashes[i]] = qbt.TorrentFiles{{Name: fmt.Sprintf("example-%d.mkv", i), Size: int64(i + 1)}}
+		}
+		require.NoError(t, svc.CacheFilesBatch(ctx, 1, files))
+
+		for _, empty := range [][]string{nil, {}, {"", " "}} {
+			cached, err := svc.repo.GetFilesBatch(ctx, 1, empty)
+			require.NoError(t, err)
+			require.Empty(t, cached)
+			info, err := svc.repo.GetSyncInfoBatch(ctx, 1, empty)
+			require.NoError(t, err)
+			require.Empty(t, info)
+			require.NoError(t, svc.repo.DeleteTorrentCache(ctx, 1, empty))
+		}
+
+		cached, missing, err := svc.GetCachedFilesBatch(ctx, 1, append(hashes, hashes[0], " ", "absent"), 0)
+		require.NoError(t, err)
+		require.Equal(t, []string{"absent"}, missing)
+		require.Len(t, cached, len(hashes))
+		for _, hash := range hashes {
+			require.Len(t, cached[hash], 1)
+			require.Equal(t, files[hash][0].Name, cached[hash][0].Name)
+			require.Equal(t, files[hash][0].Size, cached[hash][0].Size)
+		}
+
+		require.NoError(t, svc.CacheFiles(ctx, 1, "keep", qbt.TorrentFiles{{Name: "keep.mkv", Size: 1}}))
+		require.NoError(t, svc.repo.DeleteTorrentCache(ctx, 1, hashes))
+		cachedFiles, err := svc.repo.GetFilesBatch(ctx, 1, hashes)
+		require.NoError(t, err)
+		require.Empty(t, cachedFiles)
+		info, err := svc.repo.GetSyncInfoBatch(ctx, 1, hashes)
+		require.NoError(t, err)
+		require.Empty(t, info)
+		kept, err := svc.GetCachedFiles(ctx, 1, "keep")
+		require.NoError(t, err)
+		require.Len(t, kept, 1)
+		require.Equal(t, "keep.mkv", kept[0].Name)
+	})
 }
 
 func TestGetCachedFilesBatch_MaxAgeServesAgedRows(t *testing.T) {


### PR DESCRIPTION
## Description

Removes unused file-cache methods and service state, and uses `slices.Chunk` for the four live batch loops.

Closes #2620

Claim validation completed before implementation against `a5f6a44d`:

- Finding 8: confirmed cleanup with stale caller evidence. The seven methods have no production callers. `GetFiles` has three callers in [the SQL guard tests](https://github.com/autobrr/qui/blob/a5f6a44df332ab66f31499b003b9dd7823835251/internal/services/filesmanager/repository_upsert_guard_test.go#L143). Those reads now use `GetFilesBatch` and retain all assertions. The private interface and stale comment have no remaining use. Live service methods stay.
- Finding 24: partly resolved. Logging state is already absent. [`Service.db`](https://github.com/autobrr/qui/blob/a5f6a44df332ab66f31499b003b9dd7823835251/internal/services/filesmanager/service.go#L31) is assigned but never read. `Repository.db`, freshness checks, and synchronization stay.
- Finding 32: confirmed. The four callers at repository.go:63,435,673,687 pass the constant 800. Neither implementation yields a batch for empty input. For 801 items, both yield batches of 800 and 1. Each query retains at most 801 parameters. The removed nonpositive-size guard has no reachable caller. A new regression covers cache storage, reads, and deletion across this boundary on SQLite and PostgreSQL.

No user documentation changes are needed because behavior and configuration stay the same.

## How has this been tested?

Started the built binary with `./qui serve --config-dir <temporary-directory> --data-dir <temporary-directory>` and a loopback qBittorrent stub. Created a synthetic instance through `POST /api/instances`. Two file reads returned `example.mkv` with one upstream request. A read with `?refresh=true` made request 2. SQLite contained one file row and one sync row. The app process group stopped, both listeners closed, logs stayed quiet for six seconds, and all temporary files were removed.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * File-cache and synchronization operations now process records in batches, supporting larger requests more efficiently.
  * Cache deletion and lookup operations handle large sets of items more consistently.

* **Reliability**
  * Improved handling of empty or whitespace-only hash lists.
  * Added coverage for large batch operations, missing hashes, null-safe updates, and preserving unrelated cached entries during deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->