### PR TITLE
docs(cross-seed): say a manual match takes one target torrent

### DIFF
--- a/documentation/docs/features/cross-seed/overview.md
+++ b/documentation/docs/features/cross-seed/overview.md
@@ -126,6 +126,8 @@ Two entry points open the same flow:
 
 qui ranks torrents from the same instance by file-size overlap with the uploaded file. You can also pick any other torrent. A pick with no file overlap shows a warning, but you can proceed.
 
+You select one target torrent, not several. To cross-seed a season pack against the episodes that you seed, use [Season Pack Assembly](#season-pack-assembly), which is automatic. A manual match of a pack against one episode pairs the data of that episode only. The other episodes stay unlinked, and the recheck leaves the torrent paused.
+
 A manual selection bypasses candidate discovery and the category and content-type gates. Link mode per instance settings and tag and category treatment stay the same as the automatic pipeline. Every manual match runs a full recheck before it seeds; you cannot skip it, and it decides a wrong pick. A failed recheck leaves the torrent paused for manual review.
 
 The dialog prefills the category from the target torrent and the tags from the cross-seed tag settings. You can edit both. If **Use Custom Category** is on, every cross-seed goes to that one category. The dialog then shows the category and locks it. The save path shows the effective destination and is read-only. With **By Tracker** directory organization, the tracker folder comes from the announce URL in the uploaded file. The tracker does not need a configured indexer.

--- a/documentation/docs/features/cross-seed/overview.md
+++ b/documentation/docs/features/cross-seed/overview.md
@@ -134,7 +134,7 @@ The dialog prefills the category from the target torrent and the tags from the c
 
 ### Season Pack Assembly
 
-qui can assemble season-pack torrents from individual episodes you already seed. When autobrr announces a season pack, qui checks your qBittorrent instances for matching episodes. RSS automation, a cross-seed apply, and Library Scan can also start this flow when you seed only episodes of a pack. qui links the episodes that exist locally. When coverage passes the configured threshold (default 75%), qui adds the pack and qBittorrent downloads the remainder after a recheck. When available, Sonarr, TVDB, and TVMaze improve the threshold decision. This feature requires local filesystem access and hardlink or reflink mode. See [Season Packs](./season-packs.md) for setup.
+qui can assemble season-pack torrents from individual episodes you already seed. To use automatic assembly, first enable **Assemble season packs automatically** in the settings; it is disabled by default. When autobrr announces a season pack, qui checks your qBittorrent instances for matching episodes. RSS automation, a cross-seed apply, and Library Scan can also start this flow when you seed only episodes of a pack. qui links the episodes that exist locally. When coverage passes the configured threshold (default 75%), qui adds the pack and qBittorrent downloads the remainder after a recheck. When available, Sonarr, TVDB, and TVMaze improve the threshold decision. This feature requires local filesystem access and hardlink or reflink mode. See [Season Packs](./season-packs.md) for setup.
 
 ## Blocklist
 


### PR DESCRIPTION
## Description

The Manual Match section implied a single target but never said it. A user tried to manually match a season pack against the episodes they seed, found the dialog accepts one pick, and had no sentence in the docs to confirm that was expected. Adds the singular and points season packs at the automatic assembly flow.

## How has this been tested?

Read against the code: `ManualCrossSeedDialog.tsx` holds the selection as `selectedHash: string | null`, the API takes a single `TargetHash`, and `findManualTargetCandidate` resolves exactly one torrent. The paused outcome comes from the zero download budget on the verification resume.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that manual matching targets exactly one torrent.
  - Explained that cross-seeding a season pack against multiple seeded episodes requires Season Pack Assembly.
  - Noted that matching a pack to one episode leaves other episodes unlinked and pauses the recheck.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->