### PR TITLE
refactor(backend): remove unused APIs and helpers

### DIFF
--- a/internal/api/handlers/health.go
+++ b/internal/api/handlers/health.go
@@ -6,7 +6,6 @@ package handlers
 import (
 	"encoding/json"
 	"net/http"
-	"time"
 )
 
 type HealthHandler struct {
@@ -26,83 +25,13 @@ func (h *HealthHandler) HandleHealth(w http.ResponseWriter, r *http.Request) {
 func (h *HealthHandler) HandleReady(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
-	// Check if service is ready to serve traffic
-	if h.isReady() {
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ready"})
-	} else {
-		w.WriteHeader(http.StatusServiceUnavailable)
-		_ = json.NewEncoder(w).Encode(map[string]string{"status": "not ready"})
-	}
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ready"})
 }
 
 func (h *HealthHandler) HandleLiveness(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
-	// Check if service is alive (should restart if this fails)
-	if h.isAlive() {
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(map[string]string{"status": "alive"})
-	} else {
-		w.WriteHeader(http.StatusServiceUnavailable)
-		_ = json.NewEncoder(w).Encode(map[string]string{"status": "dead"})
-	}
-}
-
-// Helper methods for actual health checking
-// func (h *HealthHandler) checkOverallHealth() HealthResponse {
-//	checks := make(map[string]CheckResult)
-//	overallStatus := "ok"
-//
-//	// Example: Database check
-//	if h.db != nil {
-//		if err := h.db.Ping(); err != nil {
-//			checks["database"] = CheckResult{Status: "fail", Error: err.Error()}
-//			overallStatus = "fail"
-//		} else {
-//			checks["database"] = CheckResult{Status: "ok"}
-//		}
-//	}
-//
-//	// Example: External service check
-//	if h.externalService != nil {
-//		if err := h.checkExternalService(); err != nil {
-//			checks["external_service"] = CheckResult{Status: "fail", Error: err.Error()}
-//			overallStatus = "fail"
-//		} else {
-//			checks["external_service"] = CheckResult{Status: "ok"}
-//		}
-//	}
-//
-//	return HealthResponse{
-//		Status:    overallStatus,
-//		Checks:    checks,
-//		Timestamp: time.Now().UTC(),
-//	}
-//}
-
-func (h *HealthHandler) isReady() bool {
-	// Check if all dependencies are available and service can handle requests
-	// if h.db != nil && h.db.Ping() != nil {
-	//	return false
-	//}
-	// Add other readiness checks
-	return true
-}
-
-func (h *HealthHandler) isAlive() bool {
-	// Basic liveness check - service is running and responsive
-	// This should rarely return false unless there's a deadlock or similar
-	return true
-}
-
-type HealthResponse struct {
-	Status    string                 `json:"status"`
-	Checks    map[string]CheckResult `json:"checks,omitempty"`
-	Timestamp time.Time              `json:"timestamp"`
-}
-
-type CheckResult struct {
-	Status string `json:"status"`
-	Error  string `json:"error,omitempty"`
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "alive"})
 }

--- a/internal/api/handlers/health_test.go
+++ b/internal/api/handlers/health_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealthResponses(t *testing.T) {
+	t.Parallel()
+
+	handler := NewHealthHandler()
+	for _, tt := range []struct {
+		path   string
+		handle http.HandlerFunc
+		status string
+	}{
+		{"/health", handler.HandleHealth, "ok"},
+		{"/healthz/readiness", handler.HandleReady, "ready"},
+		{"/healthz/liveness", handler.HandleLiveness, "alive"},
+	} {
+		t.Run(tt.path, func(t *testing.T) {
+			response := httptest.NewRecorder()
+			tt.handle(response, httptest.NewRequest(http.MethodGet, tt.path, nil))
+			require.Equal(t, http.StatusOK, response.Code)
+			require.Equal(t, "application/json", response.Header().Get("Content-Type"))
+			require.JSONEq(t, `{"status":"`+tt.status+`"}`, response.Body.String())
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -764,16 +764,11 @@ func baseLogWriter(version string) io.Writer {
 	return os.Stderr
 }
 
-// DefaultLogWriter returns the base log writer for the provided version.
-func DefaultLogWriter(version string) io.Writer {
-	return baseLogWriter(version)
-}
-
 // InitDefaultLogger configures zerolog with the default writer for this version.
 // This is used by CLI entry points before a configuration file is loaded.
 func InitDefaultLogger(version string) {
 	zerolog.TimeFieldFormat = time.RFC3339
-	log.Logger = log.Logger.Output(DefaultLogWriter(version))
+	log.Logger = log.Logger.Output(baseLogWriter(version))
 }
 
 func isDevBuild(version string) bool {

--- a/internal/logstream/writer.go
+++ b/internal/logstream/writer.go
@@ -91,8 +91,3 @@ func (sw *SwitchableWriter) Swap(newWriter io.Writer, newCloser io.Closer) io.Cl
 	}
 	return nil
 }
-
-// GetHub returns the Hub associated with this writer.
-func (sw *SwitchableWriter) GetHub() *Hub {
-	return sw.hub
-}

--- a/internal/logstream/writer_test.go
+++ b/internal/logstream/writer_test.go
@@ -214,12 +214,3 @@ func TestSwitchableWriter_NilHub(t *testing.T) {
 		t.Errorf("expected 'test\\n', got %q", buf.String())
 	}
 }
-
-func TestSwitchableWriter_GetHub(t *testing.T) {
-	hub := NewHub(100)
-	sw := NewSwitchableWriter(&bytes.Buffer{}, hub)
-
-	if sw.GetHub() != hub {
-		t.Error("GetHub returned different hub")
-	}
-}

--- a/internal/metrics/collector/torrent.go
+++ b/internal/metrics/collector/torrent.go
@@ -6,6 +6,7 @@ package collector
 import (
 	"context"
 	"maps"
+	"strconv"
 	"strings"
 	"time"
 
@@ -190,7 +191,7 @@ func (c *TorrentCollector) Collect(ch chan<- prometheus.Metric) {
 	log.Debug().Int("instances", len(instances)).Msg("Collecting metrics for instances")
 
 	for _, instance := range instances {
-		instanceIDStr := instance.IDString()
+		instanceIDStr := strconv.Itoa(instance.ID)
 		instanceName := instance.Name
 
 		connected := 0.0

--- a/internal/metrics/manager_test.go
+++ b/internal/metrics/manager_test.go
@@ -113,17 +113,6 @@ func TestTorrentCollector_CollectWithNilDependencies(t *testing.T) {
 	assert.Equal(t, 0, metricCount, "Should collect 0 metrics with nil dependencies")
 }
 
-func TestInstanceInfo_IDString(t *testing.T) {
-	// Test the IDString method optimization
-	instance := &qbittorrent.InstanceInfo{
-		ID:   123,
-		Name: "test",
-	}
-
-	result := instance.IDString()
-	assert.Equal(t, "123", result, "Should convert ID to string correctly")
-}
-
 func BenchmarkTorrentCollector_Describe(b *testing.B) {
 	collector := collector.NewTorrentCollector(nil, nil, nil)
 	descChan := make(chan *prometheus.Desc, 20)
@@ -147,16 +136,5 @@ func BenchmarkTorrentCollector_CollectWithNilDeps(b *testing.B) {
 		for len(metricChan) > 0 {
 			<-metricChan
 		}
-	}
-}
-
-func BenchmarkInstanceInfo_IDString(b *testing.B) {
-	instance := &qbittorrent.InstanceInfo{
-		ID:   123456,
-		Name: "benchmark-instance",
-	}
-
-	for b.Loop() {
-		_ = instance.IDString()
 	}
 }

--- a/internal/metrics/server.go
+++ b/internal/metrics/server.go
@@ -51,7 +51,7 @@ func NewMetricsServer(manager *MetricsManager, host string, port int, basicAuthU
 
 	// Add basic auth if configured
 	if authConfigured {
-		router.Use(BasicAuth("metrics", s.basicAuthUsers))
+		router.Use(middleware.BasicAuth("metrics", s.basicAuthUsers))
 	}
 
 	// Create metrics handler
@@ -86,9 +86,4 @@ func (s *Server) ListenAndServe() error {
 		Msg("Starting Prometheus metrics server")
 
 	return s.server.ListenAndServe()
-}
-
-// BasicAuth middleware for metrics endpoint (matches autobrr implementation)
-func BasicAuth(realm string, users map[string]string) func(http.Handler) http.Handler {
-	return middleware.BasicAuth(realm, users)
 }

--- a/internal/models/arr_id_cache.go
+++ b/internal/models/arr_id_cache.go
@@ -157,8 +157,8 @@ func (s *ArrIDCacheStore) Set(ctx context.Context, titleHash, contentType string
 // same title can race, and a slower no-ID result must not hide freshly resolved
 // IDs for the negative TTL (#2300). Positive writes always win.
 func (s *ArrIDCacheStore) SetWithTitles(ctx context.Context, titleHash, contentType string, arrInstanceID *int, ids *ExternalIDs, titles []string, episodeMap *EpisodeMap, episodeMapKnown, isNegative bool, ttl time.Duration) error {
-	// Store expires_at in UTC so the bound-UTC comparisons in Get/CleanupExpired/
-	// CountValid are timezone-independent. Without .UTC() the value carries the
+	// Store expires_at in UTC so the comparisons in Get and CleanupExpired
+	// do not depend on the process timezone. Without .UTC() the value carries the
 	// process-local offset and the cache silently misses in non-UTC zones (#1961).
 	now := time.Now().UTC()
 	expiresAt := now.Add(ttl)
@@ -225,30 +225,6 @@ func (s *ArrIDCacheStore) SetWithTitles(ctx context.Context, titleHash, contentT
 	return nil
 }
 
-// Delete removes a specific cache entry
-func (s *ArrIDCacheStore) Delete(ctx context.Context, titleHash, contentType string) error {
-	query := `DELETE FROM arr_id_cache WHERE title_hash = ? AND content_type = ?`
-
-	_, err := s.db.ExecContext(ctx, query, titleHash, contentType)
-	if err != nil {
-		return fmt.Errorf("failed to delete arr id cache entry: %w", err)
-	}
-
-	return nil
-}
-
-// DeleteByArrInstance removes all cache entries for a specific ARR instance
-func (s *ArrIDCacheStore) DeleteByArrInstance(ctx context.Context, arrInstanceID int) error {
-	query := `DELETE FROM arr_id_cache WHERE arr_instance_id = ?`
-
-	_, err := s.db.ExecContext(ctx, query, arrInstanceID)
-	if err != nil {
-		return fmt.Errorf("failed to delete arr id cache entries for instance: %w", err)
-	}
-
-	return nil
-}
-
 // CleanupExpired removes all expired cache entries
 func (s *ArrIDCacheStore) CleanupExpired(ctx context.Context) (int64, error) {
 	// Compare against a bound UTC time rather than CURRENT_TIMESTAMP; see Get (#1961).
@@ -265,25 +241,4 @@ func (s *ArrIDCacheStore) CleanupExpired(ctx context.Context) (int64, error) {
 	}
 
 	return rowsAffected, nil
-}
-
-// Count returns the total number of cache entries
-func (s *ArrIDCacheStore) Count(ctx context.Context) (int64, error) {
-	var count int64
-	err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM arr_id_cache").Scan(&count)
-	if err != nil {
-		return 0, fmt.Errorf("failed to count arr id cache entries: %w", err)
-	}
-	return count, nil
-}
-
-// CountValid returns the number of non-expired cache entries
-func (s *ArrIDCacheStore) CountValid(ctx context.Context) (int64, error) {
-	// Compare against a bound UTC time rather than CURRENT_TIMESTAMP; see Get (#1961).
-	var count int64
-	err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM arr_id_cache WHERE expires_at > ?", time.Now().UTC()).Scan(&count)
-	if err != nil {
-		return 0, fmt.Errorf("failed to count valid arr id cache entries: %w", err)
-	}
-	return count, nil
 }

--- a/internal/models/arr_id_cache_test.go
+++ b/internal/models/arr_id_cache_test.go
@@ -51,14 +51,12 @@ func TestArrIDCacheStore_GetReturnsLiveEntryInNonUTCTimezone(t *testing.T) {
 	require.False(t, entry.IsNegative)
 }
 
-// TestArrIDCacheStore_ExpiryHelpersRespectNonUTCTimezone confirms the same UTC
-// normalization holds for the expiry-counting and cleanup helpers: a live entry
-// counts as valid and survives cleanup, while an already-expired entry is excluded
-// and removed — regardless of the process timezone.
+// TestArrIDCacheStore_ExpiryHelpersRespectNonUTCTimezone covers expiry and cleanup
+// outside UTC. Get excludes expired entries, and cleanup removes only those entries.
 func TestArrIDCacheStore_ExpiryHelpersRespectNonUTCTimezone(t *testing.T) {
 	forceNonUTCLocal(t)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	db := testdb.NewMigratedSQLite(t, "arr-id-cache-nonutc-expiry")
 	store := models.NewArrIDCacheStore(db)
 
@@ -69,17 +67,13 @@ func TestArrIDCacheStore_ExpiryHelpersRespectNonUTCTimezone(t *testing.T) {
 	_, err := store.Get(ctx, "stale", "movie")
 	require.ErrorIs(t, err, sql.ErrNoRows)
 
-	valid, err := store.CountValid(ctx)
-	require.NoError(t, err)
-	require.Equal(t, int64(1), valid)
-
 	removed, err := store.CleanupExpired(ctx)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), removed)
 
-	total, err := store.Count(ctx)
+	removed, err = store.CleanupExpired(ctx)
 	require.NoError(t, err)
-	require.Equal(t, int64(1), total)
+	require.Zero(t, removed)
 
 	// The live entry is the survivor and is still retrievable.
 	entry, err := store.Get(ctx, "live", "tv")
@@ -153,8 +147,7 @@ func TestArrIDCacheStore_NegativeWriteDoesNotClobberLivePositive(t *testing.T) {
 		require.NoError(t, store.Set(ctx, "expired", "movie", nil, ids, false, -time.Minute))
 		require.NoError(t, store.Set(ctx, "expired", "movie", nil, nil, true, time.Hour))
 
-		// Get filters expired rows, so read the row state via CountValid semantics:
-		// the negative entry must be the live one.
+		// The negative entry must replace the expired positive entry.
 		entry, err := store.Get(ctx, "expired", "movie")
 		require.NoError(t, err)
 		require.True(t, entry.IsNegative)

--- a/internal/models/dirscan.go
+++ b/internal/models/dirscan.go
@@ -874,22 +874,6 @@ func scanRunsFromRows(rows *sql.Rows) ([]*DirScanRun, error) {
 	return runs, nil
 }
 
-// HasActiveRun checks if there's an active run for a directory.
-func (s *DirScanStore) HasActiveRun(ctx context.Context, directoryID int) (bool, error) {
-	row := s.db.QueryRowContext(ctx, `
-		SELECT COUNT(*)
-		FROM dir_scan_runs
-		WHERE directory_id = ?
-		  AND status IN ('queued', 'scanning', 'searching', 'injecting')
-	`, directoryID)
-
-	var count int
-	if err := row.Scan(&count); err != nil {
-		return false, fmt.Errorf("scan active run count: %w", err)
-	}
-	return count > 0, nil
-}
-
 // GetActiveRun returns the active run for a directory, if any.
 func (s *DirScanStore) GetActiveRun(ctx context.Context, directoryID int) (*DirScanRun, error) {
 	row := s.db.QueryRowContext(ctx, `

--- a/internal/models/dirscan_run_status_test.go
+++ b/internal/models/dirscan_run_status_test.go
@@ -23,7 +23,7 @@ func setupDirScanTestDB(t *testing.T) *database.DB {
 }
 
 func TestDirScanStore_CreateRunIfNoActive_CreatesQueuedRun(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	db := setupDirScanTestDB(t)
 
 	instanceStore, err := models.NewInstanceStore(db, []byte("01234567890123456789012345678901"))
@@ -49,10 +49,6 @@ func TestDirScanStore_CreateRunIfNoActive_CreatesQueuedRun(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, run)
 	require.Equal(t, models.DirScanRunStatusQueued, run.Status)
-
-	active, err := store.HasActiveRun(ctx, dir.ID)
-	require.NoError(t, err)
-	require.True(t, active)
 
 	activeRun, err := store.GetActiveRun(ctx, dir.ID)
 	require.NoError(t, err)

--- a/internal/qbittorrent/metrics.go
+++ b/internal/qbittorrent/metrics.go
@@ -5,7 +5,6 @@ package qbittorrent
 
 import (
 	"context"
-	"strconv"
 
 	"github.com/rs/zerolog/log"
 )
@@ -14,10 +13,6 @@ type InstanceInfo struct {
 	ID       int
 	Name     string
 	IsActive bool
-}
-
-func (i *InstanceInfo) IDString() string {
-	return strconv.Itoa(i.ID)
 }
 
 func (cp *ClientPool) GetAllInstances(ctx context.Context) []*InstanceInfo {

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -156,10 +156,6 @@ func postAddFileFetchRetry(ctx context.Context) bool {
 	return ok && value
 }
 
-func withoutCancelPreservingDeadline(ctx context.Context) (context.Context, context.CancelFunc) {
-	return context.WithoutCancel(ctx), func() {}
-}
-
 // CacheMetadata describes whether torrent response data came from a recent
 // qBittorrent sync or from the last retained cache snapshot.
 type CacheMetadata struct {
@@ -2447,9 +2443,7 @@ func (sm *SyncManager) BulkAction(ctx context.Context, instanceID int, hashes []
 	postAddRetry := postAddBulkActionRetry(ctx)
 	retryCtx := ctx
 	if postAddRetry {
-		var retryCancel context.CancelFunc
-		retryCtx, retryCancel = withoutCancelPreservingDeadline(ctx)
-		defer retryCancel()
+		retryCtx = context.WithoutCancel(ctx)
 	}
 
 	// If not all found, try variant resolution with full torrent map.

--- a/internal/qbittorrent/sync_manager_test.go
+++ b/internal/qbittorrent/sync_manager_test.go
@@ -911,48 +911,16 @@ func TestNormalizeHashes(t *testing.T) {
 func TestBulkActionRetryAttempts(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	require.Equal(t, bulkActionSyncRetryAttempts, bulkActionRetryAttempts(ctx, 0, 1))
 	require.Equal(t, bulkActionSyncRetryAttempts, bulkActionRetryAttempts(ctx, 1, 2))
 	require.Equal(t, bulkActionAddRetryAttempts, bulkActionRetryAttempts(WithPostAddBulkActionRetry(ctx), 0, 1))
 	require.Equal(t, bulkActionAddRetryAttempts, bulkActionRetryAttempts(WithPostAddBulkActionRetry(ctx), 1, 2))
 	require.Equal(t, bulkActionSyncRetryAttempts, bulkActionRetryAttempts(WithPostAddBulkActionRetry(ctx), 2, 2))
-	retryCtx, cancelRetry := withoutCancelPreservingDeadline(WithPostAddBulkActionRetry(ctx))
-	defer cancelRetry()
+	retryCtx := context.WithoutCancel(WithPostAddBulkActionRetry(ctx))
 	require.Equal(t, bulkActionAddRetryAttempts, bulkActionRetryAttempts(retryCtx, 1, 2))
 	require.Equal(t, 0, bulkActionRetryAttempts(ctx, 0, 0))
-}
-
-func TestWithoutCancelPreservingDeadlineDetachesDeadlineAndKeepsRetryValue(t *testing.T) {
-	t.Parallel()
-
-	deadline := time.Now().Add(time.Hour)
-	parentCtx, cancelParent := context.WithDeadline(WithPostAddBulkActionRetry(context.Background()), deadline)
-	cancelParent()
-
-	retryCtx, cancelRetry := withoutCancelPreservingDeadline(parentCtx)
-	defer cancelRetry()
-
-	_, ok := retryCtx.Deadline()
-	require.False(t, ok)
-	require.NoError(t, retryCtx.Err())
-	require.True(t, postAddBulkActionRetry(retryCtx))
-}
-
-func TestWithoutCancelPreservingDeadlineDropsExpiredDeadline(t *testing.T) {
-	t.Parallel()
-
-	deadline := time.Now().Add(-time.Nanosecond)
-	parentCtx, cancelParent := context.WithDeadline(context.Background(), deadline)
-	defer cancelParent()
-
-	retryCtx, cancelRetry := withoutCancelPreservingDeadline(parentCtx)
-	defer cancelRetry()
-
-	_, ok := retryCtx.Deadline()
-	require.False(t, ok)
-	require.NoError(t, retryCtx.Err())
 }
 
 func TestBulkActionSyncRetryStopsAfterAttemptLimit(t *testing.T) {
@@ -1052,12 +1020,11 @@ func TestBulkActionSyncRetryStopsAfterAttemptLimitOnSyncFailure(t *testing.T) {
 func TestBulkActionSyncRetryKeepsCriticalBudgetWithDecoupledContext(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
 	syncer := &bulkActionRetrySyncer{}
-	retryCtx, cancelRetry := withoutCancelPreservingDeadline(ctx)
-	defer cancelRetry()
+	retryCtx := context.WithoutCancel(ctx)
 	resolved, variants := bulkActionSyncRetry(
 		retryCtx,
 		syncer,

--- a/internal/services/arr/service.go
+++ b/internal/services/arr/service.go
@@ -90,18 +90,6 @@ func NewService(instanceStore *models.ArrInstanceStore, cacheStore *models.ArrID
 	}
 }
 
-// WithPositiveTTL sets the TTL for positive cache entries
-func (s *Service) WithPositiveTTL(ttl time.Duration) *Service {
-	s.positiveTTL = ttl
-	return s
-}
-
-// WithNegativeTTL sets the TTL for negative cache entries
-func (s *Service) WithNegativeTTL(ttl time.Duration) *Service {
-	s.negativeTTL = ttl
-	return s
-}
-
 // LookupExternalIDs queries ARR instances for external IDs based on content type.
 // It checks the cache first, then queries ARR instances in priority order.
 func (s *Service) LookupExternalIDs(ctx context.Context, title string, contentType ContentType) (*ExternalIDsResult, error) {
@@ -609,11 +597,6 @@ func (s *Service) getArrTypeForContent(contentType ContentType) models.ArrInstan
 	default:
 		return ""
 	}
-}
-
-// CleanupExpiredCache removes expired cache entries
-func (s *Service) CleanupExpiredCache(ctx context.Context) (int64, error) {
-	return s.cacheStore.CleanupExpired(ctx)
 }
 
 // DebugResolveResult contains detailed debug information about an ID resolution

--- a/internal/services/arr/service_test.go
+++ b/internal/services/arr/service_test.go
@@ -506,35 +506,6 @@ func TestNewService(t *testing.T) {
 	assert.Equal(t, DefaultNegativeCacheTTL, s.negativeTTL)
 }
 
-func TestService_WithPositiveTTL(t *testing.T) {
-	s := NewService(nil, nil)
-	customTTL := 30 * time.Minute
-
-	result := s.WithPositiveTTL(customTTL)
-
-	assert.Same(t, s, result, "should return same service for chaining")
-	assert.Equal(t, customTTL, s.positiveTTL)
-}
-
-func TestService_WithNegativeTTL(t *testing.T) {
-	s := NewService(nil, nil)
-	customTTL := 15 * time.Minute
-
-	result := s.WithNegativeTTL(customTTL)
-
-	assert.Same(t, s, result, "should return same service for chaining")
-	assert.Equal(t, customTTL, s.negativeTTL)
-}
-
-func TestService_TTLChaining(t *testing.T) {
-	s := NewService(nil, nil).
-		WithPositiveTTL(4 * time.Hour).
-		WithNegativeTTL(30 * time.Minute)
-
-	assert.Equal(t, 4*time.Hour, s.positiveTTL)
-	assert.Equal(t, 30*time.Minute, s.negativeTTL)
-}
-
 func TestContentType_Constants(t *testing.T) {
 	// Verify content type constant values
 	assert.Equal(t, ContentTypeMovie, ContentType("movie"))

--- a/internal/services/automations/hardlink_index.go
+++ b/internal/services/automations/hardlink_index.go
@@ -912,37 +912,6 @@ func (idx *HardlinkIndex) GetHardlinkCopies(triggerHash string) []string {
 	return copies
 }
 
-// GetHardlinkScope returns the hardlink scope for a torrent (none, torrents_only, outside_qbittorrent, both).
-// Returns empty string if the scope is unknown (torrent not in index, files inaccessible, etc.).
-func (idx *HardlinkIndex) GetHardlinkScope(hash string) string {
-	if idx == nil {
-		return ""
-	}
-	if scope, ok := idx.ScopeByHash[hash]; ok {
-		return scope
-	}
-	return ""
-}
-
-// GetHardlinkCrossScope returns the cross-instance hardlink scope for a torrent.
-// Returns empty string if cross-scope has not been computed or is unknown.
-// Safe for concurrent use; acquires crossScopeMu internally.
-func (idx *HardlinkIndex) GetHardlinkCrossScope(hash string) string {
-	if idx == nil {
-		return ""
-	}
-	idx.crossScopeMu.Lock()
-	scopeMap := idx.CrossScopeByHash
-	idx.crossScopeMu.Unlock()
-	if scopeMap == nil {
-		return ""
-	}
-	if scope, ok := scopeMap[hash]; ok {
-		return scope
-	}
-	return ""
-}
-
 // augmentCrossInstanceScope runs Phase 2 of the hardlink index: scanning files from other
 // instances to determine whether "outside" hardlinks point to other qBittorrent instances
 // or to truly external paths (media libraries, import dirs, etc.).

--- a/internal/services/automations/hardlink_index_test.go
+++ b/internal/services/automations/hardlink_index_test.go
@@ -727,7 +727,7 @@ func TestGetHardlinkIndex_CanceledFinalScanIsNotCached(t *testing.T) {
 	rig.service.GetHardlinkIndex(scanCtx, rig.instanceID, torrents)
 	require.ErrorIs(t, scanCtx.Err(), context.Canceled)
 
-	require.Equal(t, HardlinkScopeNone, rig.service.GetHardlinkIndex(t.Context(), rig.instanceID, torrents).GetHardlinkScope(hash))
+	require.Equal(t, HardlinkScopeNone, rig.service.GetHardlinkIndex(t.Context(), rig.instanceID, torrents).ScopeByHash[hash])
 }
 
 // hardlinkIndexRig is a Service wired to a stub qBittorrent over HTTP, a real
@@ -908,7 +908,7 @@ func TestGetHardlinkIndex_ExpiredRebuildReadsCachedFileLists(t *testing.T) {
 
 	index := rig.service.GetHardlinkIndex(t.Context(), rig.instanceID, torrents)
 	require.Equal(t, int32(2), fileRequests.Load())
-	require.Equal(t, HardlinkScopeNone, index.GetHardlinkScope(hashA))
+	require.Equal(t, HardlinkScopeNone, index.ScopeByHash[hashA])
 
 	// A link appears outside the torrent set, the index ages past its TTL, and the
 	// files cache ages past its freshness window but not past the index's bound:
@@ -921,7 +921,7 @@ func TestGetHardlinkIndex_ExpiredRebuildReadsCachedFileLists(t *testing.T) {
 
 	index = rig.service.GetHardlinkIndex(t.Context(), rig.instanceID, torrents)
 	require.Equal(t, int32(2), fileRequests.Load())
-	require.Equal(t, HardlinkScopeOutsideQBitTorrent, index.GetHardlinkScope(hashA))
+	require.Equal(t, HardlinkScopeOutsideQBitTorrent, index.ScopeByHash[hashA])
 
 	// A torrent with no cached row is still fetched on an expired rebuild.
 	expireHardlinkIndex(t, rig.instanceID)
@@ -929,7 +929,7 @@ func TestGetHardlinkIndex_ExpiredRebuildReadsCachedFileLists(t *testing.T) {
 
 	index = rig.service.GetHardlinkIndex(t.Context(), rig.instanceID, torrents)
 	require.Equal(t, int32(3), fileRequests.Load())
-	require.Equal(t, HardlinkScopeNone, index.GetHardlinkScope(hashC))
+	require.Equal(t, HardlinkScopeNone, index.ScopeByHash[hashC])
 
 	// An incremental update re-reads the torrents that share files with the new
 	// one. Their lists are cached too, so only the new torrent is fetched.
@@ -940,8 +940,8 @@ func TestGetHardlinkIndex_ExpiredRebuildReadsCachedFileLists(t *testing.T) {
 
 	index = rig.service.GetHardlinkIndex(t.Context(), rig.instanceID, torrents)
 	require.Equal(t, int32(4), fileRequests.Load())
-	require.Equal(t, HardlinkScopeBoth, index.GetHardlinkScope(hashA))
-	require.Equal(t, HardlinkScopeBoth, index.GetHardlinkScope(hashD))
+	require.Equal(t, HardlinkScopeBoth, index.ScopeByHash[hashA])
+	require.Equal(t, HardlinkScopeBoth, index.ScopeByHash[hashD])
 }
 
 func TestGetHardlinkIndex_StaleCachedNameLeavesScopeUnknown(t *testing.T) {
@@ -964,7 +964,7 @@ func TestGetHardlinkIndex_StaleCachedNameLeavesScopeUnknown(t *testing.T) {
 
 	index := rig.service.GetHardlinkIndex(t.Context(), rig.instanceID, torrents)
 	require.Equal(t, int32(2), fileRequests.Load())
-	require.Equal(t, HardlinkScopeNone, index.GetHardlinkScope(hashA))
+	require.Equal(t, HardlinkScopeNone, index.ScopeByHash[hashA])
 
 	// The file is renamed in qBittorrent's own WebUI: the disk and qBittorrent
 	// agree on the new name, the cached row still holds the old one. The expired
@@ -978,8 +978,8 @@ func TestGetHardlinkIndex_StaleCachedNameLeavesScopeUnknown(t *testing.T) {
 
 	index = rig.service.GetHardlinkIndex(t.Context(), rig.instanceID, torrents)
 	require.Equal(t, int32(2), fileRequests.Load())
-	require.Empty(t, index.GetHardlinkScope(hashA))
-	require.Equal(t, HardlinkScopeNone, index.GetHardlinkScope(hashB))
+	require.Empty(t, index.ScopeByHash[hashA])
+	require.Equal(t, HardlinkScopeNone, index.ScopeByHash[hashB])
 
 	// Once the rows age past the bound, the next rebuild refetches and recovers.
 	expireHardlinkIndex(t, rig.instanceID)
@@ -988,7 +988,7 @@ func TestGetHardlinkIndex_StaleCachedNameLeavesScopeUnknown(t *testing.T) {
 
 	index = rig.service.GetHardlinkIndex(t.Context(), rig.instanceID, torrents)
 	require.Equal(t, int32(4), fileRequests.Load())
-	require.Equal(t, HardlinkScopeNone, index.GetHardlinkScope(hashA))
+	require.Equal(t, HardlinkScopeNone, index.ScopeByHash[hashA])
 }
 
 func expireHardlinkIndex(t *testing.T, instanceID int) {

--- a/internal/services/automations/service.go
+++ b/internal/services/automations/service.go
@@ -4689,15 +4689,6 @@ func cachedTorrentFilesFetcher(filesByHash map[string]qbt.TorrentFiles) torrentF
 	}
 }
 
-// isContentPathAmbiguous returns true if the ContentPath cannot reliably identify
-// files unique to this torrent. This happens when ContentPath == SavePath, meaning
-// the torrent uses the SavePath directly (common for shared download directories).
-func isContentPathAmbiguous(t qbt.Torrent) bool {
-	contentPath := normalizePath(t.ContentPath)
-	savePath := normalizePath(t.SavePath)
-	return contentPath == savePath
-}
-
 // findCrossSeedGroup returns all torrents (including the target) that share
 // the same normalized ContentPath. Returns nil if ContentPath is empty.
 func findCrossSeedGroup(target qbt.Torrent, idx contentPathIndex) []qbt.Torrent {

--- a/internal/services/automations/service_test.go
+++ b/internal/services/automations/service_test.go
@@ -1153,67 +1153,6 @@ func TestCategoryConditionNotMet(t *testing.T) {
 }
 
 // -----------------------------------------------------------------------------
-// isContentPathAmbiguous tests
-// -----------------------------------------------------------------------------
-
-func TestIsContentPathAmbiguous(t *testing.T) {
-	tests := []struct {
-		scenario    string
-		contentPath string
-		savePath    string
-		want        bool
-	}{
-		{
-			scenario:    "ContentPath != SavePath => unambiguous",
-			contentPath: "/downloads/torrent/My.Movie.2024",
-			savePath:    "/downloads/torrent",
-			want:        false,
-		},
-		{
-			scenario:    "ContentPath == SavePath => ambiguous (shared dir)",
-			contentPath: "/downloads/shared",
-			savePath:    "/downloads/shared",
-			want:        true,
-		},
-		{
-			scenario:    "ContentPath subfolder of SavePath => unambiguous",
-			contentPath: "/Downloads/torrent/My.Movie",
-			savePath:    "/downloads/torrent",
-			want:        false,
-		},
-		{
-			scenario:    "ContentPath == SavePath (case-insensitive) => ambiguous",
-			contentPath: "/Downloads/Shared",
-			savePath:    "/downloads/shared",
-			want:        true,
-		},
-		{
-			scenario:    "ContentPath == SavePath (trailing slash diff) => ambiguous",
-			contentPath: "/downloads/shared/",
-			savePath:    "/downloads/shared",
-			want:        true,
-		},
-		{
-			scenario:    "ContentPath is specific file/folder under SavePath => unambiguous",
-			contentPath: "/downloads/movies/MyMovie",
-			savePath:    "/downloads/movies",
-			want:        false,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.scenario, func(t *testing.T) {
-			torrent := qbt.Torrent{
-				ContentPath: tc.contentPath,
-				SavePath:    tc.savePath,
-			}
-			got := isContentPathAmbiguous(torrent)
-			assert.Equal(t, tc.want, got)
-		})
-	}
-}
-
-// -----------------------------------------------------------------------------
 // crossSeedGroupMembers tests
 // -----------------------------------------------------------------------------
 

--- a/internal/services/dirscan/cancel_scan_test.go
+++ b/internal/services/dirscan/cancel_scan_test.go
@@ -25,7 +25,7 @@ func setupDirScanServiceTestDB(t *testing.T) *database.DB {
 func TestService_CancelScan_QueuedRunBumpsLastScanAt(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	db := setupDirScanServiceTestDB(t)
 
 	instanceStore, err := models.NewInstanceStore(db, []byte("01234567890123456789012345678901"))
@@ -63,9 +63,9 @@ func TestService_CancelScan_QueuedRunBumpsLastScanAt(t *testing.T) {
 	require.WithinDuration(t, time.Now(), *updatedDir.LastScanAt, 5*time.Second)
 	require.False(t, svc.isDueForScan(updatedDir), "directory should not be immediately due after queued cancel")
 
-	active, err := store.HasActiveRun(ctx, dir.ID)
+	activeRun, err := store.GetActiveRun(ctx, dir.ID)
 	require.NoError(t, err)
-	require.False(t, active)
+	require.Nil(t, activeRun)
 }
 
 func TestService_Start_PrunesLegacyRunHistory(t *testing.T) {


### PR DESCRIPTION
## Description

Remove unused backend APIs and redundant helpers while preserving health responses, cache expiry, retry budgets, and automation behavior.

Closes #2621.

The caller audit confirmed the listed removals. The hardlink getter now had ten test calls, so all ten assertions use `ScopeByHash`. Live logger entry points, path checks, and synchronization remain.

## How has this been tested?

Ran the built app with a temporary database and loopback listeners. All three health routes returned their expected 200 responses. Metrics rejected missing and wrong credentials and accepted a password containing a colon. In UTC-06:00, synthetic ARR rows produced live hits, expired misses, and negative hits through `/api/arr/resolve`. All test processes, listeners, and files were removed.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Health, readiness, and liveness endpoints now consistently return successful HTTP responses with clear JSON status values.
  - Improved consistency in metrics labeling for monitored instances.

- **Maintenance**
  - Simplified internal service behavior and removed obsolete interfaces without changing supported end-user workflows.
  - Updated automated coverage for health responses, cache expiration, scan status, and retry handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->