### PR TITLE
refactor(crossseed): remove inactive auto-resume policy flag

### DIFF
--- a/internal/services/crossseed/add_policy.go
+++ b/internal/services/crossseed/add_policy.go
@@ -20,11 +20,6 @@ type AddPolicy struct {
 	// regardless of user's StartPaused setting.
 	ForcePaused bool
 
-	// ForceSkipAutoResume prevents any auto-resume logic from running,
-	// including both immediate resume for perfect matches and queued
-	// recheck-resume for alignment/extras cases.
-	ForceSkipAutoResume bool
-
 	// DiscLayout indicates this is a disc-based media torrent (Blu-ray/DVD).
 	// When true, ForcePaused is set and auto-resume is only allowed after
 	// a full recheck reaches 100%.
@@ -41,10 +36,9 @@ func PolicyForSourceFiles(sourceFiles qbt.TorrentFiles) AddPolicy {
 	isDisc, marker := isDiscLayoutTorrent(sourceFiles)
 	if isDisc {
 		return AddPolicy{
-			ForcePaused:         true,
-			ForceSkipAutoResume: false,
-			DiscLayout:          true,
-			DiscMarker:          marker,
+			ForcePaused: true,
+			DiscLayout:  true,
+			DiscMarker:  marker,
 		}
 	}
 	return AddPolicy{}
@@ -95,12 +89,6 @@ func (p AddPolicy) ApplyToAddOptions(options map[string]string) {
 		options["paused"] = "true"
 		options["stopped"] = "true"
 	}
-}
-
-// ShouldSkipAutoResume returns true if auto-resume should be skipped for this torrent.
-// This includes both immediate resume (perfect match) and queued recheck-resume.
-func (p AddPolicy) ShouldSkipAutoResume() bool {
-	return p.ForceSkipAutoResume
 }
 
 // StatusSuffix returns a message suffix for result status when policy constraints applied.

--- a/internal/services/crossseed/add_policy_test.go
+++ b/internal/services/crossseed/add_policy_test.go
@@ -149,12 +149,11 @@ func TestIsDiscLayoutTorrent(t *testing.T) {
 
 func TestPolicyForSourceFiles(t *testing.T) {
 	tests := []struct {
-		name                    string
-		files                   qbt.TorrentFiles
-		wantDiscLayout          bool
-		wantForcePaused         bool
-		wantForceSkipAutoResume bool
-		wantDiscMarker          string
+		name            string
+		files           qbt.TorrentFiles
+		wantDiscLayout  bool
+		wantForcePaused bool
+		wantDiscMarker  string
 	}{
 		{
 			name: "disc layout forces paused",
@@ -179,7 +178,6 @@ func TestPolicyForSourceFiles(t *testing.T) {
 
 			assert.Equal(t, tt.wantDiscLayout, policy.DiscLayout)
 			assert.Equal(t, tt.wantForcePaused, policy.ForcePaused)
-			assert.Equal(t, tt.wantForceSkipAutoResume, policy.ForceSkipAutoResume)
 			assert.Equal(t, tt.wantDiscMarker, policy.DiscMarker)
 		})
 	}
@@ -217,30 +215,6 @@ func TestAddPolicy_ApplyToAddOptions(t *testing.T) {
 
 			assert.Equal(t, tt.wantPaused, options["paused"])
 			assert.Equal(t, tt.wantStopped, options["stopped"])
-		})
-	}
-}
-
-func TestAddPolicy_ShouldSkipAutoResume(t *testing.T) {
-	tests := []struct {
-		name   string
-		policy AddPolicy
-		want   bool
-	}{
-		{
-			name:   "ForceSkipAutoResume true",
-			policy: AddPolicy{ForceSkipAutoResume: true},
-			want:   true,
-		},
-		{
-			name:   "ForceSkipAutoResume false",
-			policy: AddPolicy{ForceSkipAutoResume: false},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, tt.policy.ShouldSkipAutoResume())
 		})
 	}
 }
@@ -285,12 +259,11 @@ func TestAddPolicy_StatusSuffix(t *testing.T) {
 // This proves that disc layout torrents cannot be added "running" regardless of mode.
 func TestPolicyFlow_DiscLayoutForcesPaused(t *testing.T) {
 	tests := []struct {
-		name         string
-		files        qbt.TorrentFiles
-		initialOpts  map[string]string
-		wantPaused   string
-		wantStopped  string
-		wantSkipAuto bool
+		name        string
+		files       qbt.TorrentFiles
+		initialOpts map[string]string
+		wantPaused  string
+		wantStopped string
 	}{
 		{
 			name: "BDMV disc overrides paused=false",
@@ -298,40 +271,36 @@ func TestPolicyFlow_DiscLayoutForcesPaused(t *testing.T) {
 				{Name: "Movie/BDMV/index.bdmv"},
 				{Name: "Movie/BDMV/STREAM/00000.m2ts"},
 			},
-			initialOpts:  map[string]string{"paused": "false", "stopped": "false"},
-			wantPaused:   "true",
-			wantStopped:  "true",
-			wantSkipAuto: false,
+			initialOpts: map[string]string{"paused": "false", "stopped": "false"},
+			wantPaused:  "true",
+			wantStopped: "true",
 		},
 		{
 			name: "VIDEO_TS disc overrides paused=false",
 			files: qbt.TorrentFiles{
 				{Name: "DVD/VIDEO_TS/VIDEO_TS.VOB"},
 			},
-			initialOpts:  map[string]string{"paused": "false", "stopped": "false"},
-			wantPaused:   "true",
-			wantStopped:  "true",
-			wantSkipAuto: false,
+			initialOpts: map[string]string{"paused": "false", "stopped": "false"},
+			wantPaused:  "true",
+			wantStopped: "true",
 		},
 		{
 			name: "non-disc preserves paused=false",
 			files: qbt.TorrentFiles{
 				{Name: "Movie.2024.1080p.BluRay.x264-GROUP.mkv"},
 			},
-			initialOpts:  map[string]string{"paused": "false", "stopped": "false"},
-			wantPaused:   "false",
-			wantStopped:  "false",
-			wantSkipAuto: false,
+			initialOpts: map[string]string{"paused": "false", "stopped": "false"},
+			wantPaused:  "false",
+			wantStopped: "false",
 		},
 		{
 			name: "non-disc preserves paused=true",
 			files: qbt.TorrentFiles{
 				{Name: "Movie.2024.1080p.BluRay.x264-GROUP.mkv"},
 			},
-			initialOpts:  map[string]string{"paused": "true", "stopped": "true"},
-			wantPaused:   "true",
-			wantStopped:  "true",
-			wantSkipAuto: false,
+			initialOpts: map[string]string{"paused": "true", "stopped": "true"},
+			wantPaused:  "true",
+			wantStopped: "true",
 		},
 	}
 
@@ -345,7 +314,6 @@ func TestPolicyFlow_DiscLayoutForcesPaused(t *testing.T) {
 
 			assert.Equal(t, tt.wantPaused, opts["paused"], "paused option mismatch")
 			assert.Equal(t, tt.wantStopped, opts["stopped"], "stopped option mismatch")
-			assert.Equal(t, tt.wantSkipAuto, policy.ShouldSkipAutoResume(), "ShouldSkipAutoResume mismatch")
 		})
 	}
 }

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -6362,13 +6362,6 @@ func (s *Service) processCrossSeedCandidate(
 				Str("torrentHash", torrentHash).
 				Msg("Failed to trigger recheck after add, skipping auto-resume")
 			result.Message += " - recheck failed, manual intervention required"
-		} else if addPolicy.ShouldSkipAutoResume() {
-			result.Message += s.titleRescueMonitorSuffix(candidate.titleRescue, candidate.InstanceID, activeHash)
-			log.Debug().
-				Int("instanceID", candidate.InstanceID).
-				Str("torrentHash", torrentHash).
-				Msg("Skipping auto-resume per add policy (recheck triggered)")
-			result.Message += addPolicy.StatusSuffix()
 		} else if req.SkipAutoResume {
 			result.Message += s.titleRescueMonitorSuffix(candidate.titleRescue, candidate.InstanceID, activeHash)
 			// User requested to skip auto-resume - leave paused after recheck
@@ -6400,13 +6393,7 @@ func (s *Service) processCrossSeedCandidate(
 		}
 	} else if startPaused && alignmentSucceeded {
 		// Perfect match: skip_checking=true, no alignment needed, torrent is at 100%
-		if addPolicy.ShouldSkipAutoResume() {
-			log.Debug().
-				Int("instanceID", candidate.InstanceID).
-				Str("torrentHash", torrentHash).
-				Msg("Skipping auto-resume for perfect match per add policy")
-			result.Message += addPolicy.StatusSuffix()
-		} else if req.SkipAutoResume {
+		if req.SkipAutoResume {
 			// User requested to skip auto-resume - leave paused
 			log.Debug().
 				Int("instanceID", candidate.InstanceID).
@@ -6425,9 +6412,6 @@ func (s *Service) processCrossSeedCandidate(
 				result.Message += " - auto-resume failed, manual resume required"
 			}
 		}
-	} else if !startPaused && addPolicy.ShouldSkipAutoResume() {
-		// User wanted auto-start, but policy forces paused
-		result.Message += addPolicy.StatusSuffix()
 	}
 	result.Success = true
 	result.Status = "added"
@@ -15098,13 +15082,6 @@ func (s *Service) processHardlinkMode(
 					Str("torrentHash", torrentHash).
 					Msg("[CROSSSEED] Hardlink mode: failed to trigger recheck after add")
 				statusMsg += " - recheck failed, manual intervention required"
-			case addPolicy.ShouldSkipAutoResume():
-				statusMsg += s.titleRescueMonitorSuffix(candidate.titleRescue, candidate.InstanceID, torrentHash)
-				log.Debug().
-					Int("instanceID", candidate.InstanceID).
-					Str("torrentHash", torrentHash).
-					Msg("[CROSSSEED] Hardlink mode: skipping auto-resume per add policy")
-				statusMsg += addPolicy.StatusSuffix()
 			case req.SkipAutoResume:
 				statusMsg += s.titleRescueMonitorSuffix(candidate.titleRescue, candidate.InstanceID, torrentHash)
 				// User requested to skip auto-resume - leave paused after recheck
@@ -15134,9 +15111,6 @@ func (s *Service) processHardlinkMode(
 				}
 			}
 		}
-	} else if addPolicy.ShouldSkipAutoResume() {
-		// Disc layout without extras - add policy status suffix
-		statusMsg += addPolicy.StatusSuffix()
 	}
 	if poolRegistrationErr != nil {
 		statusMsg += fmt.Sprintf(" - qBittorrent added torrent, but pooled registration failed: %v; torrent remains stopped for manual intervention", poolRegistrationErr)
@@ -15892,13 +15866,6 @@ func (s *Service) processReflinkMode(
 					Str("torrentHash", torrentHash).
 					Msg("[CROSSSEED] Reflink mode: failed to trigger recheck after add")
 				statusMsg += " - recheck failed, manual intervention required"
-			case addPolicy.ShouldSkipAutoResume():
-				statusMsg += s.titleRescueMonitorSuffix(candidate.titleRescue, candidate.InstanceID, torrentHash)
-				log.Debug().
-					Int("instanceID", candidate.InstanceID).
-					Str("torrentHash", torrentHash).
-					Msg("[CROSSSEED] Reflink mode: skipping auto-resume per add policy")
-				statusMsg += addPolicy.StatusSuffix()
 			case req.SkipAutoResume:
 				statusMsg += s.titleRescueMonitorSuffix(candidate.titleRescue, candidate.InstanceID, torrentHash)
 				// User requested to skip auto-resume - leave paused after recheck
@@ -15928,9 +15895,6 @@ func (s *Service) processReflinkMode(
 				}
 			}
 		}
-	} else if addPolicy.ShouldSkipAutoResume() {
-		// Disc layout without extras - add policy status suffix
-		statusMsg += addPolicy.StatusSuffix()
 	}
 
 	// Add note about low completion behavior


### PR DESCRIPTION
## Description

Removes the inactive auto-resume policy flag, its seven unreachable guards, and flag-only assertions. Production leaves the flag false in normal, hardlink, reflink, and directory-scan paths. User resume settings and disc recheck protections stay unchanged.

Closes #2623

<details>
<summary>Validation recorded before implementation</summary>

Baseline: `67753dc5`.

- Confirmed: [PolicyForSourceFiles](https://github.com/autobrr/qui/blob/67753dc51173c663420c0e48bda8ec990b39a7c1/internal/services/crossseed/add_policy.go#L40) returns a zero policy for ordinary files. Disc files set `ForcePaused`, `DiscLayout`, and `DiscMarker`, but leave `ForceSkipAutoResume=false`.
- Partly confirmed: all cross-seed service policies use that constructor. [Directory scanning](https://github.com/autobrr/qui/blob/67753dc51173c663420c0e48bda8ec990b39a7c1/internal/services/dirscan/inject.go#L736) also has a zero-value shortcut for missing parsed input. Neither path sets the flag true.
- Confirmed: repository searches found no policy mutation, decoding, configuration field, or manual entry point that enables the flag. The sole true construction was the getter test.
- Rejected: removing disc or user resume protections. Those controls remain active and unchanged.

Normal additions construct the policy at `service.go:5638`; the removed guards were at `6365`, `6403`, and `6428`. Hardlink and reflink additions construct it at `14897` and `15674`; their guards were at `15101`, `15137`, `15895`, and `15931`. No field changes between construction and those guards.

An ordinary `Example.2026.1080p.mkv` input produces a zero policy. `Example/BDMV/index.bdmv` and `Example/VIDEO_TS/VIDEO_TS.VOB` produce forced-paused disc policies with the flag false. These inputs cover all three modes. Recheck paths therefore fall through to the request setting or resume queue. Non-recheck paths receive the zero policy.

The retained tests cover disc detection, paused options, complete-disc resume queues, zero budgets, missing-files safeguards, and link recheck rules. The cleanup removes only flag-specific assertions and the getter test.

</details>

## How has this been tested?

Ran `./qui serve --config-dir "$PWD/.tmp-2623-field-20260907/app" --data-dir "$PWD/.tmp-2623-field-20260907/app"` with a temporary database against an isolated qBittorrent 5.2.3 instance with tracker-free synthetic torrents. Submitted generated torrent pairs through `POST /api/cross-seed/apply` and polled qBittorrent for 30 seconds per paused case. All 12 normal, hardlink, and reflink cases passed: complete matches resumed, user-skipped torrents stayed stopped, complete discs resumed after recheck, and corrupted discs stayed `stoppedDL` at 99.21875% with 32 KiB missing. Disc queue entries used a zero-byte budget with missing-files recovery disabled. All test processes, listeners, containers, and files were removed.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL
