### PR TITLE
docs(design): record field validation against a shared seedbox

### DIFF
--- a/docs/remote-backend-design.md
+++ b/docs/remote-backend-design.md
@@ -205,6 +205,10 @@ backend domain end to end.
   Mechanically this stays the product's one crypto pattern — the same
   AES-GCM/`sessionSecret` helpers the existing credential stores use,
   with an AAD argument those stores simply haven't passed before.
+- Key derivation: `GetEncryptionKey` truncates `sessionSecret` to 32 bytes
+  instead of deriving from it. Moving to HKDF with a decidable ciphertext
+  format is tracked in #2521 and should land with or right after #1917, so
+  the SSH columns are written once under the derived key.
 - Host key verification is TOFU with explicit confirmation: the first-seen
   key is held ephemeral and surfaced as a fingerprint via the ssh-test
   flow; it is persisted and enforced only after the user confirms it (or
@@ -295,6 +299,38 @@ exec dialect (`fsutil file queryfileid`, `fsutil hardlink list`,
 FileID form keeps that door open. Remote Windows paths surface in
 SFTP's `/C:/...` form and stay slash-delimited at the fsops boundary like
 every other remote path.
+
+## Field Validation
+
+The tier model above was checked against a commercial shared seedbox
+(Debian 11, OpenSSH 8.4p1) on 2026-08-23, before the remote backend
+implementation existed. The probe was read-only apart from two self-cleaned
+scratch directories and a temporarily added, uniquely tagged
+`authorized_keys` line.
+
+- `statvfs@openssh.com` and `hardlink@openssh.com` both work over the sftp
+  subsystem: `df` returned filesystem numbers and `ln` created a real
+  nlink=2 hardlink. `limits@openssh.com` is absent (it arrived in 8.5), so
+  the backend must tolerate that extension missing.
+- A `command="internal-sftp",restrict` key behaves exactly as the Security
+  section specifies: sftp works, exec is refused with "This service allows
+  sftp connections only." The recommended template holds as written.
+- The exec tier finds full GNU userland (findutils 4.8, coreutils 8.32), so
+  `find -printf` identity sweeps work without the BSD degradation path.
+- Hardlinks across directories keep consistent inode, device and nlink, and
+  `find -printf '%D %i %n'` reports them, so the exec-tier identity design
+  holds on the real filesystem.
+- Reflink is unsupported (XFS without reflink). Providers mostly do not
+  enable it on shared hosts, and where it exists it is a dedicated-host
+  option on request, so the design expectation is: probe it, assume off,
+  hardlink mode is the real path there.
+- Latency is the load-bearing number: about 740 ms per sftp readdir round
+  trip from a home connection, and 2.1 to 3.5 s per cold connect, auth and
+  exec.
+  A 500-directory walk is roughly six minutes serial over sftp against one
+  `find` exec round trip, which is why the batch methods, the exec tier and
+  the pooled persistent connection are all necessary rather than
+  optimizations.
 
 ## Rollout
 


### PR DESCRIPTION
## Description

Adds a Field Validation section to `docs/remote-backend-design.md` with the results of checking the capability-tier model against a real shared seedbox (Debian 11, OpenSSH 8.4p1) on 2026-08-23, before the remote backend implementation exists. Host, user and provider are deliberately not named.

What it records:

- `statvfs@openssh.com` and `hardlink@openssh.com` both work through the sftp subsystem, and `limits@openssh.com` is absent on 8.4, so the backend has to tolerate that.
- The `command="internal-sftp",restrict` template behaves exactly as the Security section specifies: sftp works, exec is refused.
- The exec tier gets full GNU userland, so the `find -printf` identity sweeps work without the BSD degradation path.
- Reflink is unsupported there, and the design expectation for shared hosts is now written down: probe it, assume off, hardlink mode is the real path.
- Measured latency, about 740 ms per sftp readdir round trip and 2.1 to 3.5 s per cold connect, which is the concrete reason the batch methods, the exec tier and the pooled connection are necessary rather than optimizations.

It also adds one Security bullet pointing at #2521 (key derivation) with the sequencing note relative to #1917.

Docs only, no code changes.

## How has this been tested?

Not applicable, documentation only. The measurements come from a read-only probe of the seedbox apart from two self-cleaned scratch directories and a temporarily added, uniquely tagged `authorized_keys` line that was removed afterwards.

## Checklist

- [x] My PR title follows the Conventional Commits format
- [x] I have read CONTRIBUTING.md
- [ ] I ran `make precommit` and the tests pass locally (docs only)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

## AI disclosure

Written with Claude Code. The probe was scripted and run by the model against my seedbox, every number and string in the section was cross-checked against the raw probe output, and the wording was reviewed by hand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the security design for deriving SSH keys from session secrets.
  - Added validation details covering SFTP capabilities, restricted keys, command execution, identity reporting, reflinks, and connection performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->