### PR TITLE
fix(jackett): reject non-torrent download responses

### DIFF
--- a/internal/services/crossseed/completion_exact_size_test.go
+++ b/internal/services/crossseed/completion_exact_size_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/autobrr/qui/internal/models"
-	"github.com/autobrr/qui/internal/services/jackett"
 	"github.com/autobrr/qui/pkg/stringutils"
 )
 
@@ -29,10 +28,18 @@ func TestExecuteCompletionSearchPropagatesExactSizeDecision(t *testing.T) {
 		candidateName = "Azure.Compass.S01E05.1080p.WEB-DL.H.265-KIRI"
 		reportedSize  = int64(2_147_483_648)
 	)
+	candidateData := createTestTorrent(t, candidateName, []string{"payload.mkv"}, 256*1024)
 
 	var searchRequests atomic.Int32
 	var server *httptest.Server
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/candidate.torrent" {
+			w.Header().Set("Content-Type", "application/x-bittorrent")
+			if _, err := w.Write(candidateData); err != nil {
+				t.Errorf("write candidate torrent: %v", err)
+			}
+			return
+		}
 		if r.URL.Query().Get("t") == "caps" {
 			w.Header().Set("Content-Type", "application/xml")
 			_, err := fmt.Fprint(w, `<caps><limits default="100" max="100"/><searching>
@@ -96,16 +103,13 @@ func TestExecuteCompletionSearchPropagatesExactSizeDecision(t *testing.T) {
 		automationSettingsLoader: func(context.Context) (*models.CrossSeedAutomationSettings, error) {
 			return settings, nil
 		},
-		torrentDownloadFunc: func(context.Context, jackett.TorrentDownloadRequest) ([]byte, error) {
-			return []byte("torrent"), nil
-		},
 		crossSeedInvoker: func(_ context.Context, request *CrossSeedRequest) (*CrossSeedResponse, error) {
 			captured = request
 			return &CrossSeedResponse{Success: true}, nil
 		},
 	}
 
-	err := service.executeCompletionSearch(context.Background(), instanceID, &source, settings, &models.InstanceCrossSeedCompletionSettings{
+	err := service.executeCompletionSearch(t.Context(), instanceID, &source, settings, &models.InstanceCrossSeedCompletionSettings{
 		InstanceID: instanceID,
 		Enabled:    true,
 		IndexerIDs: []int{indexerID},

--- a/internal/services/jackett/caps_rate_limit_test.go
+++ b/internal/services/jackett/caps_rate_limit_test.go
@@ -221,7 +221,7 @@ func TestQueryCooldownDoesNotBlockTorrentDownload(t *testing.T) {
 			return
 		}
 		downloadCalls.Add(1)
-		_, _ = w.Write([]byte("d4:name8:test.bine"))
+		_, _ = w.Write([]byte(testTorrentPayload))
 	}))
 	t.Cleanup(server.Close)
 
@@ -246,7 +246,7 @@ func TestQueryCooldownDoesNotBlockTorrentDownload(t *testing.T) {
 		DownloadURL: server.URL + "/download",
 	})
 	require.NoError(t, err)
-	assert.Equal(t, []byte("d4:name8:test.bine"), data)
+	assert.Equal(t, []byte(testTorrentPayload), data)
 	assert.Equal(t, int32(1), downloadCalls.Load())
 }
 

--- a/internal/services/jackett/caps_rate_limit_test.go
+++ b/internal/services/jackett/caps_rate_limit_test.go
@@ -221,7 +221,7 @@ func TestQueryCooldownDoesNotBlockTorrentDownload(t *testing.T) {
 			return
 		}
 		downloadCalls.Add(1)
-		_, _ = w.Write([]byte("torrent data"))
+		_, _ = w.Write([]byte("d4:name8:test.bine"))
 	}))
 	t.Cleanup(server.Close)
 
@@ -246,7 +246,7 @@ func TestQueryCooldownDoesNotBlockTorrentDownload(t *testing.T) {
 		DownloadURL: server.URL + "/download",
 	})
 	require.NoError(t, err)
-	assert.Equal(t, []byte("torrent data"), data)
+	assert.Equal(t, []byte("d4:name8:test.bine"), data)
 	assert.Equal(t, int32(1), downloadCalls.Load())
 }
 

--- a/internal/services/jackett/client.go
+++ b/internal/services/jackett/client.go
@@ -468,7 +468,10 @@ func (c *Client) Download(ctx context.Context, downloadURL string) ([]byte, erro
 		return nil, fmt.Errorf("torrent download exceeded %d bytes limit", maxTorrentDownloadBytes)
 	}
 	mi, parseErr := metainfo.Load(bytes.NewReader(data))
-	if parseErr != nil || len(mi.InfoBytes) == 0 {
+	if parseErr == nil {
+		_, parseErr = mi.UnmarshalInfo()
+	}
+	if parseErr != nil {
 		return nil, fmt.Errorf("%w (Content-Type: %q)", ErrInvalidTorrentPayload, resp.Header.Get("Content-Type"))
 	}
 

--- a/internal/services/jackett/client.go
+++ b/internal/services/jackett/client.go
@@ -4,6 +4,7 @@
 package jackett
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -15,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/autobrr/go-torrent/metainfo"
 	"github.com/rs/zerolog/log"
 
 	gojackett "github.com/autobrr/qui/pkg/gojackett"
@@ -27,7 +29,7 @@ import (
 
 const maxTorrentDownloadBytes int64 = 16 << 20 // 16 MiB safety limit for torrent blobs
 
-// ErrInvalidTorrentPayload identifies a response that is not a bencoded dictionary.
+// ErrInvalidTorrentPayload identifies a response that does not parse as torrent metainfo.
 var ErrInvalidTorrentPayload = errors.New("torrent download returned a web page or other non-torrent response")
 
 // DownloadError represents an HTTP error during torrent download.
@@ -465,7 +467,8 @@ func (c *Client) Download(ctx context.Context, downloadURL string) ([]byte, erro
 	if int64(len(data)) > maxTorrentDownloadBytes {
 		return nil, fmt.Errorf("torrent download exceeded %d bytes limit", maxTorrentDownloadBytes)
 	}
-	if len(data) == 0 || data[0] != 'd' {
+	mi, parseErr := metainfo.Load(bytes.NewReader(data))
+	if parseErr != nil || len(mi.InfoBytes) == 0 {
 		return nil, fmt.Errorf("%w (Content-Type: %q)", ErrInvalidTorrentPayload, resp.Header.Get("Content-Type"))
 	}
 

--- a/internal/services/jackett/client.go
+++ b/internal/services/jackett/client.go
@@ -27,6 +27,9 @@ import (
 
 const maxTorrentDownloadBytes int64 = 16 << 20 // 16 MiB safety limit for torrent blobs
 
+// ErrInvalidTorrentPayload identifies a response that is not a bencoded dictionary.
+var ErrInvalidTorrentPayload = errors.New("torrent download returned a web page or other non-torrent response")
+
 // DownloadError represents an HTTP error during torrent download.
 // It preserves the status code for rate-limit detection and retry logic.
 type DownloadError struct {
@@ -461,6 +464,9 @@ func (c *Client) Download(ctx context.Context, downloadURL string) ([]byte, erro
 	}
 	if int64(len(data)) > maxTorrentDownloadBytes {
 		return nil, fmt.Errorf("torrent download exceeded %d bytes limit", maxTorrentDownloadBytes)
+	}
+	if len(data) == 0 || data[0] != 'd' {
+		return nil, fmt.Errorf("%w (Content-Type: %q)", ErrInvalidTorrentPayload, resp.Header.Get("Content-Type"))
 	}
 
 	return data, nil

--- a/internal/services/jackett/client_test.go
+++ b/internal/services/jackett/client_test.go
@@ -208,6 +208,70 @@ func TestDownloadPreservesRateLimitResponse(t *testing.T) {
 	assert.Equal(t, "52", responseErr.RetryAfterHeader())
 }
 
+func TestDownloadRejectsNonTorrentPayloads(t *testing.T) {
+	const torrentBody = "d4:name8:test.bine"
+	tests := []struct {
+		name        string
+		contentType string
+		body        string
+		wantError   bool
+	}{
+		{name: "HTML login", contentType: "text/html; charset=utf-8", body: "<html>Login required</html>", wantError: true},
+		{name: "JSON error", contentType: "application/json", body: `{"error":"access denied"}`, wantError: true},
+		{name: "empty", contentType: "application/x-bittorrent", wantError: true},
+		{name: "magnet body", contentType: "text/plain", body: "magnet:?xt=urn:btih:0123456789012345678901234567890123456789", wantError: true},
+		{name: "HTML with torrent type", contentType: "application/x-bittorrent", body: "<html>Challenge</html>", wantError: true},
+		{name: "bencoded list", contentType: "application/x-bittorrent", body: "le", wantError: true},
+		{name: "torrent", contentType: "application/x-bittorrent", body: torrentBody},
+		{name: "plain text torrent", contentType: "text/plain", body: torrentBody},
+		{name: "torrent without content type", body: torrentBody},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				// An empty header disables net/http content sniffing.
+				w.Header()["Content-Type"] = []string{tt.contentType}
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			t.Cleanup(server.Close)
+
+			client := NewClient(server.URL, "test-api-secret", nil, nil, "jackett", 5)
+			data, err := client.Download(t.Context(), server.URL+"/download?apikey=test-api-secret&passkey=test-pass-secret&id=private-query-value")
+			if !tt.wantError {
+				require.NoError(t, err)
+				assert.Equal(t, []byte(tt.body), data)
+				return
+			}
+
+			require.ErrorIs(t, err, ErrInvalidTorrentPayload)
+			assert.Nil(t, data)
+			assert.Contains(t, err.Error(), "Content-Type: ")
+			assert.Contains(t, err.Error(), tt.contentType)
+			assert.Contains(t, err.Error(), "web page")
+			assert.NotContains(t, err.Error(), "test-api-secret")
+			assert.NotContains(t, err.Error(), "test-pass-secret")
+			assert.NotContains(t, err.Error(), "private-query-value")
+			assert.False(t, isRetryableDownloadError(err))
+		})
+	}
+}
+
+func TestDownloadPreservesMagnetRedirect(t *testing.T) {
+	const magnetURL = "magnet:?xt=urn:btih:0123456789012345678901234567890123456789"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, magnetURL, http.StatusFound)
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewClient(server.URL, "", nil, nil, "jackett", 5)
+	data, err := client.Download(t.Context(), server.URL+"/download")
+	magnetErr, ok := errors.AsType[*MagnetDownloadError](err)
+	require.True(t, ok, "expected MagnetDownloadError, got %v", err)
+	assert.Equal(t, magnetURL, magnetErr.MagnetURL)
+	assert.Nil(t, data)
+}
+
 func TestFetchCapsWithRetryDoesNotRetryRateLimit(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/jackett/client_test.go
+++ b/internal/services/jackett/client_test.go
@@ -208,8 +208,11 @@ func TestDownloadPreservesRateLimitResponse(t *testing.T) {
 	assert.Equal(t, "52", responseErr.RetryAfterHeader())
 }
 
+// testTorrentPayload is a minimal single-file torrent that parses as metainfo.
+const testTorrentPayload = "d4:infod6:lengthi1e4:name8:test.bin12:piece lengthi16384e6:pieces20:aaaaaaaaaaaaaaaaaaaaee"
+
 func TestDownloadRejectsNonTorrentPayloads(t *testing.T) {
-	const torrentBody = "d4:name8:test.bine"
+	const torrentBody = testTorrentPayload
 	tests := []struct {
 		name        string
 		contentType string
@@ -222,6 +225,8 @@ func TestDownloadRejectsNonTorrentPayloads(t *testing.T) {
 		{name: "magnet body", contentType: "text/plain", body: "magnet:?xt=urn:btih:0123456789012345678901234567890123456789", wantError: true},
 		{name: "HTML with torrent type", contentType: "application/x-bittorrent", body: "<html>Challenge</html>", wantError: true},
 		{name: "bencoded list", contentType: "application/x-bittorrent", body: "le", wantError: true},
+		{name: "dict-prefixed garbage", contentType: "application/x-bittorrent", body: "dnot-a-valid-torrent", wantError: true},
+		{name: "bencoded dict without info", contentType: "application/x-bittorrent", body: "d4:name8:test.bine", wantError: true},
 		{name: "torrent", contentType: "application/x-bittorrent", body: torrentBody},
 		{name: "plain text torrent", contentType: "text/plain", body: torrentBody},
 		{name: "torrent without content type", body: torrentBody},

--- a/internal/services/jackett/client_test.go
+++ b/internal/services/jackett/client_test.go
@@ -227,6 +227,7 @@ func TestDownloadRejectsNonTorrentPayloads(t *testing.T) {
 		{name: "bencoded list", contentType: "application/x-bittorrent", body: "le", wantError: true},
 		{name: "dict-prefixed garbage", contentType: "application/x-bittorrent", body: "dnot-a-valid-torrent", wantError: true},
 		{name: "bencoded dict without info", contentType: "application/x-bittorrent", body: "d4:name8:test.bine", wantError: true},
+		{name: "non-dictionary info", contentType: "application/x-bittorrent", body: "d4:info4:spame", wantError: true},
 		{name: "torrent", contentType: "application/x-bittorrent", body: torrentBody},
 		{name: "plain text torrent", contentType: "text/plain", body: torrentBody},
 		{name: "torrent without content type", body: torrentBody},

--- a/internal/services/jackett/download_test.go
+++ b/internal/services/jackett/download_test.go
@@ -168,7 +168,7 @@ func TestDownloadRateLimitUsesGrabScopeAndRetryAfter(t *testing.T) {
 }
 
 func TestDownloadTorrentDoesNotCacheRejectedPayload(t *testing.T) {
-	const torrentBody = "d4:name8:test.bine"
+	const torrentBody = testTorrentPayload
 	var calls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		if calls.Add(1) == 1 {

--- a/internal/services/jackett/download_test.go
+++ b/internal/services/jackett/download_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/internal/testutil/testdb"
 )
 
 func TestRateLimitError_Error(t *testing.T) {
@@ -163,6 +165,46 @@ func TestDownloadRateLimitUsesGrabScopeAndRetryAfter(t *testing.T) {
 	grabLimited, _ := service.rateLimiter.IsInCooldown(indexer.ID, rateLimitScopeGrab)
 	assert.False(t, queryLimited)
 	assert.True(t, grabLimited)
+}
+
+func TestDownloadTorrentDoesNotCacheRejectedPayload(t *testing.T) {
+	const torrentBody = "d4:name8:test.bine"
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if calls.Add(1) == 1 {
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte("<html>Login required</html>"))
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte(torrentBody))
+	}))
+	t.Cleanup(server.Close)
+
+	db := testdb.NewMigratedSQLite(t, "torrent-download-cache")
+	store, err := models.NewTorznabIndexerStore(db, make([]byte, 32))
+	require.NoError(t, err)
+	indexer, err := store.Create(t.Context(), "Test indexer", server.URL, "test-key", nil, nil, true, 0, 5)
+	require.NoError(t, err)
+	cache := models.NewTorznabTorrentCacheStore(db)
+	service := NewService(store, WithTorrentCache(cache))
+	t.Cleanup(service.searchScheduler.Stop)
+	req := TorrentDownloadRequest{IndexerID: indexer.ID, DownloadURL: server.URL + "/download", GUID: "test-release"}
+
+	data, err := service.DownloadTorrent(t.Context(), req)
+	require.ErrorIs(t, err, ErrInvalidTorrentPayload)
+	assert.Nil(t, data)
+	assert.Equal(t, int32(1), calls.Load(), "rejected payload must not trigger a retry")
+	_, found, err := cache.Fetch(t.Context(), indexer.ID, req.GUID, defaultTorrentCacheTTL)
+	require.NoError(t, err)
+	assert.False(t, found)
+
+	for range 2 {
+		data, err = service.DownloadTorrent(t.Context(), req)
+		require.NoError(t, err)
+		assert.Equal(t, []byte(torrentBody), data)
+		assert.Equal(t, int32(2), calls.Load(), "valid payload must be fetched once and then cached")
+	}
 }
 
 // timeoutError implements net.Error for testing timeout detection


### PR DESCRIPTION
## Description

Rejects indexer downloads that cannot parse as torrent metainfo and an info dictionary before they enter the torrent cache.

Closes #2609

## How has this been tested?

Ran `./qui serve` against a local fake indexer. Non-dictionary and missing info values returned a content-type error and left the cache empty. A valid torrent was fetched and cached, and a later request used the cache without another download. The add step failed as expected because the test had no qBittorrent instance.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid torrent downloads, including HTML, JSON, empty, malformed, and magnet responses, are now rejected instead of being treated as torrent files.
  - Valid torrent files are accepted regardless of whether the server provides a torrent, plain-text, or no content type.
  - Error messages provide clearer information while protecting sensitive credentials.
  - Magnet links preserve the original link and produce the appropriate error.
  - Rejected downloads are no longer cached or retried.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->