### PR TITLE
docs(agents): add code comment rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,14 @@ CI runs `make test` on every push. Run the full suite locally only when asked, o
 - Boolean classifiers should list exceptional `true`/error cases; let `default` handle common path.
 - Do not add documentation-only branches unless compiler/linter/tests enforce value.
 
+## Comments
+
+A comment caches what the code cannot show: why this shape, the bug a guard prevents, a coupling to another file. Caching what the line does buys nothing and rots first. One line is the norm.
+
+- Change a line, change its comment, in the same diff. A stale-comment finding from a review bot is right; a docstring coverage percentage is not.
+- An invariant a future change must hold is a test, not a sentence with "must not" in it.
+- Doc-comment an exported identifier when its name leaves the contract unclear.
+
 ## Paths / Security
 
 qui must work on Windows and Unix-like hosts.


### PR DESCRIPTION
## Description

Adds a code comment section to AGENTS.md so agents comment the reason for a shape instead of restating the line, and update a comment in the same diff as the code it describes.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidelines for writing and maintaining code comments.
  - Clarified expectations for documenting non-obvious rationale and exported identifiers.
  - Recommended expressing invariants through tests rather than prose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->