### PR TITLE
fix(gojackett): stop retrying once the caller's context ends

### DIFF
--- a/internal/services/crossseed/seasonpack_test.go
+++ b/internal/services/crossseed/seasonpack_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"maps"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -698,6 +699,15 @@ func TestMatchEpisodeCandidates_ExcludesIncompleteEpisodes(t *testing.T) {
 // candidates. The loop reads every cached episode, so a reason that means "belongs to
 // another show or another pack" must stay off the default level.
 func TestMatchEpisodeCandidates_FilterLogLevels(t *testing.T) {
+	// Run in a separate process so search goroutines cannot race with this test's logger.
+	if os.Getenv("QUI_TEST_FILTER_LOG_LEVELS_CHILD") != "1" {
+		cmd := exec.CommandContext(t.Context(), os.Args[0], "-test.run=^TestMatchEpisodeCandidates_FilterLogLevels$", "-test.timeout=30s")
+		cmd.Env = append(os.Environ(), "QUI_TEST_FILTER_LOG_LEVELS_CHILD=1")
+		output, err := cmd.CombinedOutput()
+		require.NoError(t, err, "%s", output)
+		return
+	}
+
 	parsedPack := rls.ParseString("Cool.Show.S03.1080p.WEB.x264-GRP")
 	packRelease := &parsedPack
 

--- a/pkg/gojackett/http.go
+++ b/pkg/gojackett/http.go
@@ -157,6 +157,7 @@ func (c *Client) retryDo(ctx context.Context, req *http.Request) (*http.Response
 		}),
 		retry.Attempts(5),
 		retry.MaxJitter(time.Second*1),
+		retry.Context(ctx),
 	)
 
 	if err != nil {

--- a/pkg/gojackett/http_test.go
+++ b/pkg/gojackett/http_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package jackett
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A cancelled caller must end the retry loop, not just the attempt in flight:
+// otherwise a search whose deadline passed keeps retrying in the background
+// and logs long after its caller has moved on.
+func TestRetryDoStopsWhenContextEnds(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	t.Cleanup(cancel)
+
+	client := NewClient(Config{Host: server.URL})
+	start := time.Now()
+	_, err := client.GetTorrentsCtx(ctx, "tracker", map[string]string{})
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.Less(t, elapsed, time.Second, "retry loop kept running after the context ended")
+}


### PR DESCRIPTION
## Description

`retry.Do` in `pkg/gojackett` ran with the default background context, so a request whose caller had already timed out still went through all five attempts with backoff. In production that is up to a few seconds of retries against an indexer nobody is waiting on. In the test suite it leaks a search goroutine past its test, and its final "Failed to search indexer" log races the next test that swaps the global logger, which is the data race CI reported in `TestMatchEpisodeCandidates_FilterLogLevels`.

The fix is `retry.Context(ctx)` on the `retry.Do` call. The new `TestRetryDoStopsWhenContextEnds` takes 3.4 s and fails without it, and passes in about 100 ms with it.

Not changed: the `retry.Delay(time.Second * 3)` call inside the retry closure discards its option and has never applied. Left alone so this PR does not change retry timing; it is noted on the issue.

Closes #2649

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

## Test plan

- [x] `go test -race -count=1 ./pkg/gojackett/ ./internal/services/jackett/` pass; the new test fails without the one-line fix
- [x] `make precommit`, `go build ./...`
- [x] `internal/services/crossseed` under `-race` locally: no data race reported (the partial-pool tests that fail on this macOS host fail identically on develop and are unrelated)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Network retry attempts now stop promptly when the caller’s context is canceled or times out, preventing unnecessary continued requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->