### PR TITLE
fix(crossseed): allow adult category mappings

### DIFF
--- a/documentation/docs/features/cross-seed/rules.md
+++ b/documentation/docs/features/cross-seed/rules.md
@@ -56,7 +56,7 @@ In both examples, the torrent is in a category that you control. A rule on that 
 4. Select or type one or more qBittorrent categories.
 5. Select the content type in the **search as** list.
 
-The content types are Movie, TV, Music, Audiobook, Book, Comic, Game, and App.
+The content types are Movie, TV, Music, Adult, Audiobook, Book, Comic, Game, and App.
 
 ### How rules match
 

--- a/internal/api/handlers/crossseed_categorymapping_test.go
+++ b/internal/api/handlers/crossseed_categorymapping_test.go
@@ -23,6 +23,11 @@ func TestNormalizeCategoryMappingRules(t *testing.T) {
 			want: []models.CategoryMappingRule{{Categories: []string{"music", "flac"}, ContentType: "music"}},
 		},
 		{
+			name: "accepts adult content type",
+			in:   []models.CategoryMappingRule{{Categories: []string{"adult"}, ContentType: "adult"}},
+			want: []models.CategoryMappingRule{{Categories: []string{"adult"}, ContentType: "adult"}},
+		},
+		{
 			name: "keeps category case, qBittorrent categories are case-sensitive",
 			in:   []models.CategoryMappingRule{{Categories: []string{"Music"}, ContentType: "music"}},
 			want: []models.CategoryMappingRule{{Categories: []string{"Music"}, ContentType: "music"}},

--- a/internal/models/crossseed.go
+++ b/internal/models/crossseed.go
@@ -43,7 +43,7 @@ type SeasonPackCategoryRule struct {
 // signal.
 type CategoryMappingRule struct {
 	Categories  []string `json:"categories"`  // qBittorrent category names, exact match
-	ContentType string   `json:"contentType"` // movie, tv, music, audiobook, book, comic, game, app
+	ContentType string   `json:"contentType"` // movie, tv, music, audiobook, book, comic, game, app, adult
 }
 
 // CrossSeedAutomationSettings controls automatic cross-seed behaviour.

--- a/internal/services/crossseed/category_routing_test.go
+++ b/internal/services/crossseed/category_routing_test.go
@@ -6,6 +6,7 @@ package crossseed
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 
 	"github.com/moistari/rls"
@@ -296,6 +297,7 @@ func TestContentTypeFromCategoryRule(t *testing.T) {
 			return &models.CrossSeedAutomationSettings{
 				CategoryMappingRules: []models.CategoryMappingRule{
 					{Categories: []string{"music"}, ContentType: "music"},
+					{Categories: []string{"adult"}, ContentType: "adult"},
 				},
 			}, nil
 		},
@@ -307,6 +309,14 @@ func TestContentTypeFromCategoryRule(t *testing.T) {
 	}
 	if info.ContentType != "music" || !info.IsMusic {
 		t.Errorf("contentTypeFromCategoryRule() = %+v, want music content info", info)
+	}
+
+	adultInfo, ok := svc.contentTypeFromCategoryRule(context.Background(), "adult")
+	if !ok {
+		t.Fatal("expected a match for the adult mapped category")
+	}
+	if adultInfo.ContentType != "adult" || adultInfo.SearchType != "search" || !slices.Equal(adultInfo.Categories, []int{6000}) {
+		t.Errorf("contentTypeFromCategoryRule() = %+v, want adult content info", adultInfo)
 	}
 
 	if _, ok := svc.contentTypeFromCategoryRule(context.Background(), "movies"); ok {

--- a/internal/services/crossseed/parsing.go
+++ b/internal/services/crossseed/parsing.go
@@ -266,6 +266,13 @@ func RuleContentTypeInfo(contentType string) (ContentTypeInfo, bool) {
 		releaseType = rls.Game
 	case "app":
 		releaseType = rls.App
+	case "adult":
+		return ContentTypeInfo{
+			ContentType:  "adult",
+			Categories:   []int{6000},
+			SearchType:   "search",
+			RequiredCaps: []string{},
+		}, true
 	default:
 		return ContentTypeInfo{}, false
 	}

--- a/internal/services/crossseed/parsing_test.go
+++ b/internal/services/crossseed/parsing_test.go
@@ -539,7 +539,7 @@ func TestRuleContentTypeInfo(t *testing.T) {
 		{contentType: "comic", wantSearch: "book"},
 		{contentType: "game", wantSearch: "search"},
 		{contentType: "app", wantSearch: "search"},
-		{contentType: "adult"},
+		{contentType: "adult", wantSearch: "search"},
 		{contentType: "unknown"},
 		{contentType: ""},
 	}
@@ -556,6 +556,10 @@ func TestRuleContentTypeInfo(t *testing.T) {
 			assert.Equal(t, tt.wantSearch, info.SearchType)
 			assert.Equal(t, tt.wantIsMusic, info.IsMusic)
 			assert.NotEmpty(t, info.Categories)
+			if tt.contentType == "adult" {
+				assert.Equal(t, []int{6000}, info.Categories)
+				assert.Empty(t, info.RequiredCaps)
+			}
 		})
 	}
 }

--- a/web/src/components/crossseed/CategoryMappingRulesEditor.tsx
+++ b/web/src/components/crossseed/CategoryMappingRulesEditor.tsx
@@ -13,7 +13,7 @@ import { useMemo } from "react"
 import { useTranslation } from "react-i18next"
 
 // Content types a rule may force (mirrors the backend list).
-const CONTENT_TYPE_OPTIONS = ["movie", "tv", "music", "audiobook", "book", "comic", "game", "app"] as const
+const CONTENT_TYPE_OPTIONS = ["movie", "tv", "music", "audiobook", "book", "comic", "game", "app", "adult"] as const
 
 interface CategoryMappingRulesEditorProps {
   value: CategoryMappingRule[]


### PR DESCRIPTION
## Description

Add `Adult` as a valid Cross-Seed Search Category Rule destination.

The UI now exposes Adult in the **search as** list, the API accepts and persists the mapping, and the search path routes Adult mappings to the Torznab Adult category (`6000`) with generic search mode.

## How has this been tested?

- `go test -race -count=1 ./internal/services/crossseed ./internal/api/handlers`
- Full frontend Vitest suite: 115 files and 1,144 tests passed
- `golangci-lint` v2.13.0: 0 issues
- Frontend lint: 0 errors (pre-existing warnings only)
- Production Docker image build completed successfully
- Live NAS validation: an Adult category mapping persisted successfully, and search analysis reported `adult` / `search` / Torznab category `6000`

## Screenshots (for UI changes)

Not included because the test instance contains private tracker configuration. The dropdown change is covered by the live NAS UI test.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [x] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL

## AI disclosure

Was any AI used in this PR? Yes. Codex (GPT-5) wrote the initial implementation and tests; the changes were reviewed, formatted, linted, unit-tested, built, and live-tested on a NAS instance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting and routing **Adult** content in cross-seed category mapping rules.
  * Adult content maps to the appropriate search category and is preserved when rules are processed.

* **Documentation**
  * Updated cross-seed documentation to include Adult as a supported content type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->