### PR TITLE
fix(torrents): seed add-torrent options from preferences on a cold mount

### DIFF
--- a/web/src/components/torrents/AddTorrentDialog.test.tsx
+++ b/web/src/components/torrents/AddTorrentDialog.test.tsx
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { api } from "@/lib/api"
+import type { AppPreferences } from "@/types"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, expect, it, vi } from "vitest"
+import { AddTorrentDialog, type AddTorrentDropPayload } from "./AddTorrentDialog"
+
+const { metadataResult } = vi.hoisted(() => ({
+  metadataResult: { data: undefined as { categories: Record<string, never>; tags: string[]; preferences?: AppPreferences } | undefined },
+}))
+
+vi.mock("@/lib/api", () => ({ api: {
+  addTorrent: vi.fn(),
+  checkTorrentDuplicates: vi.fn(),
+} }))
+vi.mock("@/hooks/useInstanceMetadata", () => ({ useInstanceMetadata: () => metadataResult }))
+vi.mock("@/hooks/useInstanceCapabilities", () => ({ useInstanceCapabilities: () => ({ data: { supportsTorrentTmpPath: true, supportsPathAutocomplete: false } }) }))
+vi.mock("react-i18next", () => ({ useTranslation: () => ({ t: (key: string) => key }) }))
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), warning: vi.fn(), error: vi.fn() } }))
+
+beforeEach(() => {
+  // The tabs indicator measures itself through ResizeObserver, which jsdom lacks.
+  vi.stubGlobal("ResizeObserver", class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  metadataResult.data = undefined
+  vi.resetAllMocks()
+  vi.unstubAllGlobals()
+})
+
+const preferences = {
+  auto_tmm_enabled: false,
+  save_path: "/data/complete",
+  torrent_content_layout: "Subfolder",
+  temp_path_enabled: true,
+  temp_path: "/data/incomplete",
+} as AppPreferences
+
+const magnet = "magnet:?xt=urn:btih:0123456789abcdef0123456789abcdef01234567"
+
+// Mounts the dialog with no metadata yet, the way the /add magnet handler route does.
+function renderColdDialog() {
+  vi.mocked(api.checkTorrentDuplicates).mockResolvedValue({ duplicates: [] })
+  vi.mocked(api.addTorrent).mockResolvedValue({ added: 1, failed: 0, message: "" })
+
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+  const dialog = (dropPayload: AddTorrentDropPayload | null) => (
+    <QueryClientProvider client={client}>
+      <AddTorrentDialog instanceId={1} open onOpenChange={() => {}} dropPayload={dropPayload} />
+    </QueryClientProvider>
+  )
+
+  const ui = render(dialog({ type: "url", urls: [magnet] }))
+  return {
+    ...ui,
+    resolvePreferences(resolved: AppPreferences) {
+      metadataResult.data = { categories: {}, tags: [], preferences: resolved }
+      ui.rerender(dialog(null))
+    },
+    openAdvancedTab() {
+      fireEvent.mouseDown(ui.getByRole("tab", { name: "addTorrentDialog.tabs.advanced" }))
+    },
+  }
+}
+
+it("seeds the option defaults from preferences that resolve after a cold mount", async () => {
+  const ui = renderColdDialog()
+
+  ui.resolvePreferences(preferences)
+  ui.openAdvancedTab()
+
+  await waitFor(() => expect(ui.getByLabelText("addTorrentDialog.options.autoTmm").getAttribute("aria-checked")).toBe("false"))
+  expect((ui.getByLabelText("addTorrentDialog.options.savePath") as HTMLInputElement).value).toBe("/data/complete")
+  expect(ui.getByLabelText("addTorrentDialog.options.useTemporaryPath").getAttribute("aria-checked")).toBe("true")
+  expect((ui.getByLabelText("addTorrentDialog.options.tempPath") as HTMLInputElement).value).toBe("/data/incomplete")
+
+  fireEvent.click(ui.getByRole("button", { name: "addTorrentDialog.footer.add" }))
+
+  await waitFor(() => expect(api.addTorrent).toHaveBeenCalled())
+  expect(vi.mocked(api.addTorrent).mock.calls[0][1]).toMatchObject({
+    autoTMM: false,
+    savePath: "/data/complete",
+    contentLayout: "Subfolder",
+    // The late seed must leave the magnet the route injected alone.
+    urls: [magnet],
+  })
+})
+
+it("keeps a change made before preferences resolve", async () => {
+  const ui = renderColdDialog()
+  ui.openAdvancedTab()
+
+  // Cold mount falls back to autoTMM on; the user turns it off before preferences land.
+  const toggle = await waitFor(() => ui.getByLabelText("addTorrentDialog.options.autoTmm"))
+  expect(toggle.getAttribute("aria-checked")).toBe("true")
+  fireEvent.click(toggle)
+
+  ui.resolvePreferences({ ...preferences, auto_tmm_enabled: true })
+
+  expect(ui.getByLabelText("addTorrentDialog.options.autoTmm").getAttribute("aria-checked")).toBe("false")
+
+  fireEvent.click(ui.getByRole("button", { name: "addTorrentDialog.footer.add" }))
+  await waitFor(() => expect(api.addTorrent).toHaveBeenCalled())
+  expect(vi.mocked(api.addTorrent).mock.calls[0][1]).toMatchObject({ autoTMM: false })
+})

--- a/web/src/components/torrents/AddTorrentDialog.tsx
+++ b/web/src/components/torrents/AddTorrentDialog.tsx
@@ -42,7 +42,7 @@ import { usePersistedStartPaused } from "@/hooks/usePersistedStartPaused"
 import { api } from "@/lib/api"
 import { canOfferManualCrossSeed } from "@/lib/manual-cross-seed"
 import { cn } from "@/lib/utils"
-import type { AddTorrentResponse, Torrent } from "@/types"
+import type { AddTorrentResponse, AppPreferences, Torrent } from "@/types"
 import { useForm } from "@tanstack/react-form"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { AlertCircle, Link, Loader2, Plus, Upload, X } from "lucide-react"
@@ -95,6 +95,18 @@ async function parseTorrentFile(file: File): Promise<string | null> {
     return hash.toLowerCase()
   } catch {
     return null
+  }
+}
+
+// Option defaults the instance dictates. Kept in one place because the dialog seeds
+// them twice: once as form defaults, and again when preferences arrive after a cold mount.
+function preferenceDefaults(preferences: AppPreferences | undefined) {
+  return {
+    autoTMM: preferences?.auto_tmm_enabled ?? true,
+    savePath: preferences?.save_path || "",
+    contentLayout: preferences?.torrent_content_layout || "",
+    tempPathEnabled: preferences?.temp_path_enabled ?? false,
+    tempPath: preferences?.temp_path || "",
   }
 }
 
@@ -605,8 +617,7 @@ export function AddTorrentDialog({ instanceId, open: controlledOpen, onOpenChang
       category: "",
       tags: [] as string[],
       startPaused: startPausedEnabled,
-      autoTMM: preferences?.auto_tmm_enabled ?? true,
-      savePath: preferences?.save_path || "",
+      ...preferenceDefaults(preferences),
       skipHashCheck: false,
       sequentialDownload: false,
       firstLastPiecePrio: false,
@@ -614,10 +625,7 @@ export function AddTorrentDialog({ instanceId, open: controlledOpen, onOpenChang
       limitDownloadSpeed: 0,
       limitRatio: 0,
       limitSeedTime: 0,
-      contentLayout: preferences?.torrent_content_layout || "",
       rename: "",
-      tempPathEnabled: preferences?.temp_path_enabled ?? false,
-      tempPath: preferences?.temp_path || "",
       indexerId: undefined as number | undefined,
     },
     onSubmit: async ({ value }) => {
@@ -626,6 +634,26 @@ export function AddTorrentDialog({ instanceId, open: controlledOpen, onOpenChang
       await mutation.mutateAsync({ ...value, tags: allTags })
     },
   })
+
+  // The dialog can mount before instance metadata resolves (magnet handler route),
+  // where defaultValues fall back to the hardcoded values. Seed the preference-derived
+  // fields again when preferences land, skipping anything the user already changed.
+  const seededInstanceRef = useRef<number | null>(null)
+  useEffect(() => {
+    if (!preferences || seededInstanceRef.current === instanceId) return
+    seededInstanceRef.current = instanceId
+
+    const defaults = preferenceDefaults(preferences)
+    // Seeding is not a user edit, so leave the field meta pristine.
+    const pristine = (field: keyof typeof defaults) => !form.getFieldMeta(field)?.isDirty
+    const opts = { dontUpdateMeta: true }
+
+    if (pristine("autoTMM")) form.setFieldValue("autoTMM", defaults.autoTMM, opts)
+    if (pristine("savePath")) form.setFieldValue("savePath", defaults.savePath, opts)
+    if (pristine("contentLayout")) form.setFieldValue("contentLayout", defaults.contentLayout, opts)
+    if (pristine("tempPathEnabled")) form.setFieldValue("tempPathEnabled", defaults.tempPathEnabled, opts)
+    if (pristine("tempPath")) form.setFieldValue("tempPath", defaults.tempPath, opts)
+  }, [form, instanceId, preferences])
 
   const setSavePath = useCallback((path: string) => {
     form.setFieldValue("savePath", path)


### PR DESCRIPTION
## Description

The Add Torrent dialog read instance preferences into its form defaults on first render only, so a cold mount on the `/add` magnet handler route fell back to Automatic Torrent Management on, an empty save path and content layout, and no temporary path, and adding from that route overrode the instance setting. The dialog now seeds those fields again when preferences arrive, and skips any field the user already changed.

TanStack Form's own `defaultValues` re-seed cannot do this: it replaces the whole values object, which would wipe the magnet the route just injected. A test pins that.

Fixes #2563

## How has this been tested?

Local rig: throwaway qBittorrent with `auto_tmm_enabled` off, save path `/downloads/complete`, temporary path on. A cold load of `/add?magnet=...` showed the toggle off with both paths filled from the instance, and the added torrent landed in qBittorrent with `auto_tmm: false`, `save_path: /downloads/complete`, `download_path: /downloads/incomplete`. The same rig on a `develop` build showed the toggle on and content layout "Use global setting".

## Screenshots (for UI changes)

Before and after captured on the rig above; I can attach them in a comment.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved torrent addition dialogs so preference-based fields populate correctly after metadata loads.
  - Preserved user-entered changes made before preferences become available.
  - Ensured magnet links remain intact during delayed preference initialization.

- **Tests**
  - Added coverage for delayed preference loading, default values, magnet preservation, and retaining user edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->