### PR TITLE
fix(cross-seed): match games with later RAR volumes

### DIFF
--- a/internal/services/crossseed/content_prefilter.go
+++ b/internal/services/crossseed/content_prefilter.go
@@ -172,7 +172,7 @@ func (s *Service) contentPrefilterReleasesMatch(sourceRelease *rls.Release, sour
 		return false
 	}
 
-	sourceFileRelease := s.parseReleaseName(fileBaseName(sourceFileName))
+	sourceFileRelease := s.parseFileRelease(fileBaseName(sourceFileName))
 	matched, _ := s.releasesMatchWithReasonAndNames(sourceFileRelease, candidateRelease, fileBaseName(sourceFileName), candidateName, false)
 	return matched
 }

--- a/internal/services/crossseed/game_archive_test.go
+++ b/internal/services/crossseed/game_archive_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2025-2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package crossseed
+
+import (
+	"bytes"
+	"encoding/base64"
+	"testing"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/autobrr/go-torrent/bencode"
+	"github.com/autobrr/go-torrent/metainfo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/models"
+	"github.com/autobrr/qui/pkg/stringutils"
+)
+
+func TestCrossSeedGameArchiveVolumes(t *testing.T) {
+	const name = "Silver.Valley.2-CODEX"
+	for _, suffix := range []string{".r01", ".s01", ".S01", ".s97", ".s98", ".s99", ".t00", ".t01", ".t10", ".z99"} {
+		t.Run(suffix, func(t *testing.T) {
+			info := metainfo.Info{Name: name, PieceLength: 16 * 1024}
+			var files qbt.TorrentFiles
+			for _, volume := range []string{".rar", ".r99", ".s00", suffix} {
+				fileName := "codex-silver.valley.2" + volume
+				info.Files = append(info.Files, metainfo.FileInfo{Path: []string{fileName}, Length: 1024})
+				files = append(files, qbt.TorrentFile{Name: name + "/" + fileName, Size: 1024, Progress: 1})
+			}
+			sortTorrentFiles(info.Files)
+			infoBytes, err := bencode.Marshal(info)
+			require.NoError(t, err)
+			meta := metainfo.MetaInfo{InfoBytes: infoBytes}
+			var torrentBytes bytes.Buffer
+			require.NoError(t, meta.Write(&torrentBytes))
+
+			instance := &models.Instance{ID: 1, Name: "test"}
+			torrent := qbt.Torrent{Hash: "source", Name: name, Progress: 1, Size: 4096}
+			service := &Service{
+				instanceStore:    &fakeInstanceStore{instances: map[int]*models.Instance{1: instance}},
+				syncManager:      &applyFakeSyncManager{newFakeSyncManager(instance, []qbt.Torrent{torrent}, map[string]qbt.TorrentFiles{"source": files})},
+				releaseCache:     NewReleaseCache(),
+				stringNormalizer: stringutils.NewDefaultNormalizer(),
+			}
+			response, err := service.CrossSeed(t.Context(), &CrossSeedRequest{
+				TorrentData:                  base64.StdEncoding.EncodeToString(torrentBytes.Bytes()),
+				TargetInstanceIDs:            []int{1},
+				FindIndividualEpisodes:       true,
+				StartPaused:                  new(true),
+				SkipAutoResume:               true,
+				SkipPieceBoundarySafetyCheck: true,
+				SearchDecision:               searchDecisionProvenance{Class: searchCandidateClassStrict, SourceInstanceID: 1, SourceHash: "source"},
+			})
+			require.NoError(t, err)
+			require.True(t, response.Success, "identical complete game files must apply: %+v", response.Results)
+		})
+	}
+}
+
+func TestParseFileReleasePreservesTVStructure(t *testing.T) {
+	service := &Service{releaseCache: NewReleaseCache()}
+	for _, name := range []string{"Example.Show.S03E02-GRP.s01", "Example.Show.S03E02-GRP.mkv"} {
+		parsed := service.parseFileRelease(name)
+		require.Equal(t, 3, parsed.Series, name)
+		require.Equal(t, 2, parsed.Episode, name)
+	}
+	// A torrent title ending in .S01 still names a season.
+	require.Equal(t, 1, service.parseReleaseName("Example.Show.S01").Series)
+}

--- a/internal/services/crossseed/layout.go
+++ b/internal/services/crossseed/layout.go
@@ -4,8 +4,8 @@
 package crossseed
 
 import (
-	"path/filepath"
-	"strconv"
+	"path"
+	"regexp"
 	"strings"
 
 	qbt "github.com/autobrr/go-qbittorrent"
@@ -23,25 +23,7 @@ const (
 	LayoutArchives TorrentLayout = "archives"
 )
 
-var archiveExtensions = buildArchiveExtensionSet()
-
-func buildArchiveExtensionSet() map[string]struct{} {
-	exts := map[string]struct{}{
-		".rar": {},
-		".zip": {},
-		".7z":  {},
-	}
-	for i := 0; i <= 99; i++ {
-		suffix := ""
-		if i < 10 {
-			suffix = ".r0" + strconv.Itoa(i)
-		} else {
-			suffix = ".r" + strconv.Itoa(i)
-		}
-		exts[suffix] = struct{}{}
-	}
-	return exts
-}
+var rarVolumeSuffix = regexp.MustCompile(`(?i)\.[r-z][0-9]{2}$`)
 
 // classifyTorrentLayout inspects the largest non-ignored file inside a torrent
 // to determine whether the content is stored as archives (.rar/.r00/etc.) or as
@@ -75,6 +57,10 @@ func classifyTorrentLayout(files qbt.TorrentFiles, normalizer *stringutils.Norma
 }
 
 func isArchiveFilename(nameLower string) bool {
+	if rarVolumeSuffix.MatchString(nameLower) {
+		return true
+	}
+
 	// Handle multi-part suffixes (e.g. .tar.gz) by checking against known
 	// suffix list before falling back to simple extension matching.
 	archiveSuffixes := []string{
@@ -89,8 +75,8 @@ func isArchiveFilename(nameLower string) bool {
 		}
 	}
 
-	ext := filepath.Ext(nameLower)
-	if _, ok := archiveExtensions[ext]; ok {
+	switch path.Ext(nameLower) {
+	case ".rar", ".zip", ".7z":
 		return true
 	}
 

--- a/internal/services/crossseed/layout_test.go
+++ b/internal/services/crossseed/layout_test.go
@@ -38,6 +38,34 @@ func TestClassifyTorrentLayout(t *testing.T) {
 			expect: LayoutArchives,
 		},
 		{
+			name: "rar volume after r99",
+			files: qbt.TorrentFiles{
+				{Name: "Release.s01", Size: 2 << 30},
+			},
+			expect: LayoutArchives,
+		},
+		{
+			name: "rar volume after s99",
+			files: qbt.TorrentFiles{
+				{Name: "Release.t00", Size: 2 << 30},
+			},
+			expect: LayoutArchives,
+		},
+		{
+			name: "uppercase rar volume",
+			files: qbt.TorrentFiles{
+				{Name: "Release.S01", Size: 2 << 30},
+			},
+			expect: LayoutArchives,
+		},
+		{
+			name: "last numbered rar volume",
+			files: qbt.TorrentFiles{
+				{Name: "Release.z99", Size: 2 << 30},
+			},
+			expect: LayoutArchives,
+		},
+		{
 			name: "gz archive",
 			files: qbt.TorrentFiles{
 				{Name: "Archive.tar.gz", Size: 1 << 30},

--- a/internal/services/crossseed/matching.go
+++ b/internal/services/crossseed/matching.go
@@ -117,6 +117,12 @@ func (s *Service) parseReleaseName(name string) *rls.Release {
 	return s.releaseCache.Parse(name)
 }
 
+// parseFileRelease removes RAR volume suffixes so .s01 does not become season 1.
+// Torrent titles use parseReleaseName because a trailing .S01 can name a season.
+func (s *Service) parseFileRelease(name string) *rls.Release {
+	return s.parseReleaseName(rarVolumeSuffix.ReplaceAllString(name, ""))
+}
+
 // String serializes the releaseKey into a stable string for caching purposes.
 func (k releaseKey) String() string {
 	return fmt.Sprintf("%d|%d|%d|%d|%d", k.series, k.episode, k.year, k.month, k.day)
@@ -824,7 +830,7 @@ func (s *Service) getMatchTypeFromTitle(targetName, candidateName string, target
 	candidateReleases := make(map[releaseKey]int64)
 	for _, cf := range candidateFiles {
 		if !shouldIgnoreFile(cf.Name, s.stringNormalizer) {
-			fileRelease := s.parseReleaseName(cf.Name)
+			fileRelease := s.parseFileRelease(cf.Name)
 			enrichedRelease := enrichReleaseFromTorrent(fileRelease, candidateRelease)
 
 			key := makeReleaseKey(enrichedRelease)
@@ -996,7 +1002,7 @@ func (s *Service) getMatchTypeWithReason(sourceRelease, candidateRelease *rls.Re
 			})
 			totalSourceSize += sf.Size
 
-			fileRelease := s.parseReleaseName(sf.Name)
+			fileRelease := s.parseFileRelease(sf.Name)
 			enrichedRelease := enrichReleaseFromTorrent(fileRelease, sourceRelease)
 			key := makeReleaseKey(enrichedRelease)
 			if key != (releaseKey{}) {
@@ -1016,7 +1022,7 @@ func (s *Service) getMatchTypeWithReason(sourceRelease, candidateRelease *rls.Re
 			})
 			totalCandidateSize += cf.Size
 
-			fileRelease := s.parseReleaseName(cf.Name)
+			fileRelease := s.parseFileRelease(cf.Name)
 			enrichedRelease := enrichReleaseFromTorrent(fileRelease, candidateRelease)
 			key := makeReleaseKey(enrichedRelease)
 			if key != (releaseKey{}) {
@@ -1242,7 +1248,7 @@ func (s *Service) getMatchType(sourceRelease, candidateRelease *rls.Release, sou
 			})
 			totalSourceSize += sf.Size
 
-			fileRelease := s.parseReleaseName(sf.Name)
+			fileRelease := s.parseFileRelease(sf.Name)
 			enrichedRelease := enrichReleaseFromTorrent(fileRelease, sourceRelease)
 			key := makeReleaseKey(enrichedRelease)
 			if key != (releaseKey{}) {
@@ -1263,7 +1269,7 @@ func (s *Service) getMatchType(sourceRelease, candidateRelease *rls.Release, sou
 			})
 			totalCandidateSize += cf.Size
 
-			fileRelease := s.parseReleaseName(cf.Name)
+			fileRelease := s.parseFileRelease(cf.Name)
 			enrichedRelease := enrichReleaseFromTorrent(fileRelease, candidateRelease)
 			key := makeReleaseKey(enrichedRelease)
 			if key != (releaseKey{}) {

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -7284,7 +7284,7 @@ func (s *Service) selectContentDetectionRelease(torrentName string, sourceReleas
 	// release name inside themselves, so parsing the full path makes rls read the title
 	// twice and invent a Group ("Azure Compass" -> "Compass"). Folder-only fields are
 	// backfilled from the torrent-name parse below.
-	largestRelease := s.releaseCache.Parse(path.Base(largestFile.Name))
+	largestRelease := s.parseFileRelease(path.Base(largestFile.Name))
 	largestRelease = enrichReleaseFromTorrent(largestRelease, sourceRelease)
 	if largestRelease.Type == rls.Unknown {
 		return sourceRelease, false

--- a/internal/services/crossseed/source_release_inference.go
+++ b/internal/services/crossseed/source_release_inference.go
@@ -173,7 +173,7 @@ func (s *Service) inferTVSeriesEpisodeFromFiles(torrentRelease *rls.Release, fil
 			continue
 		}
 
-		fileRelease := s.releaseCache.Parse(file.Name)
+		fileRelease := s.parseFileRelease(file.Name)
 		fileRelease = enrichReleaseFromTorrent(fileRelease, torrentRelease)
 		if fileRelease.Series <= 0 {
 			if fileRelease.Episode > 0 {


### PR DESCRIPTION
## Description

Fixes game cross-seeding when numbered RAR volumes such as `.s01` are mistaken for TV seasons. Search can find an exact-size candidate, but applying it fails with "No matching torrents found with required files".

### Specification

- Recognize `.r00` through `.z99`, including uppercase suffixes, as archive volumes.
- Remove the volume suffix only when parsing file metadata. Keep filenames and sizes intact for matching and alignment.
- Preserve real TV season and episode metadata, including torrent titles ending in `.S01`.
- Keep existing file, size, and piece checks. Add a synthetic apply regression for later RAR volumes, including the `.s99` to `.t00` boundary.

The fix stays in qui because torrent titles and archive filenames need different parsing rules.

## How has this been tested?

Tested locally with fresh qui databases, a mock indexer, and qBittorrent 5.2.3.

- **Without this fix:** search found a strict match, but apply failed with `no_match`.
- **With this fix:** apply added the same RAR set using the existing files. Auto-resume was disabled for the test. A separate, manually triggered recheck confirmed 100% completion with zero bytes downloaded.
- A candidate with a different-sized RAR volume was still rejected.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of multi-volume archive files, including uppercase and extended volume suffixes.
  * Corrected release-name parsing so archive volume labels are not mistaken for TV season numbers.
  * Improved cross-seeding matches and metadata detection for torrents containing archived game or TV content.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->