### PR TITLE
docs: require before/after performance results in PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,12 @@ Fixes # (issue)
 
 <!--- Only manual or live verification that CI cannot do. Delete this section if CI covers everything. --->
 
+## Performance
+
+<!--- Complete the mandatory benchmark steps in AGENTS.md#mandatory-benchmarks.
+      Record the performance risks and the required comparison here, or link to the benchmark results.
+      If no performance risk applies, explain why. Keep this section. --->
+
 ## Screenshots (for UI changes)
 
 <!--- Delete this section if your change has no visible UI.
@@ -18,6 +24,7 @@ Fixes # (issue)
 
 - [ ] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
 - [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL
+- [ ] I completed the [mandatory benchmark steps](https://github.com/autobrr/qui/blob/develop/AGENTS.md#mandatory-benchmarks) and recorded the outcome in Performance
 
 ## AI disclosure
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,8 +10,9 @@ Fixes # (issue)
 
 ## Performance
 
-<!--- Complete the mandatory benchmark steps in AGENTS.md#mandatory-benchmarks.
-      Record the performance risks and the required comparison here, or link to the benchmark results.
+<!--- Follow AGENTS.md#mandatory-performance-checks.
+      Include before/after measurements and a conclusion for changes that can affect performance.
+      Describe the workload and measurement method, or link to the results.
       If no performance risk applies, explain why. Keep this section. --->
 
 ## Screenshots (for UI changes)
@@ -24,7 +25,7 @@ Fixes # (issue)
 
 - [ ] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
 - [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL
-- [ ] I completed the [mandatory benchmark steps](https://github.com/autobrr/qui/blob/develop/AGENTS.md#mandatory-benchmarks) and recorded the outcome in Performance
+- [ ] I completed the [mandatory performance checks](https://github.com/autobrr/qui/blob/develop/AGENTS.md#mandatory-performance-checks) and recorded the outcome in Performance
 
 ## AI disclosure
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,17 @@ Before changing cross-module data flow, service boundaries, API routing, or long
 
 CI runs `make test` on every push. Run the full suite locally only when asked, or when one change crosses many packages.
 
+## Mandatory benchmarks
+
+Before opening or updating a PR, complete these steps for the full PR diff:
+
+1. Assess backend and frontend performance risks, including changes to shared helpers, dependencies, and configuration. Benchmarks are mandatory when a change can affect latency, CPU, memory, I/O, request volume, or bundle size. Examples include queries, caching, concurrency, polling, serialization, sorting, filtering, rendering, and virtualization. If the risk is unclear, run benchmarks. If no performance risk applies, explain why in the PR's Performance section.
+2. Select a benchmark for each affected path. Reuse existing benchmarks and tools. If coverage is missing, add the smallest repeatable benchmark or browser scenario that measures the risk. Use representative synthetic data, including large inputs where cost grows with data size. Use local stubs for external services.
+3. Compare the merge-base with the PR's target branch against the latest PR code. Use the same workload, hardware, runtime versions, and measurement settings for both revisions. Repeat runs to distinguish regressions from measurement noise.
+4. Measure the relevant cost. For Go, run targeted benchmarks with `-run '^$' -bench '<pattern>' -benchmem -count=5` and without `-race`. Compare time, bytes, and allocations per operation. For frontend logic, use a focused benchmark. For rendering, scrolling, or interaction changes, measure the browser with a production build. Record relevant timings, memory use, request counts, or bundle sizes. Unit tests and a visual smoke test do not measure performance.
+5. Record both commit IDs, commands or browser steps, workload size, environment, and before/after results in the PR's Performance section. Include the measured differences and your conclusion. CI benchmark results qualify only when they provide this comparison. Otherwise, run benchmarks locally, even when CI covers the tests.
+6. Investigate regressions beyond measurement noise. Fix them or obtain explicit maintainer acceptance of the measured cost before declaring the PR ready. After further code changes, repeat the affected benchmarks. If measurements are blocked, report the blocker and keep this step incomplete.
+
 ## Lint / Format
 
 - `make precommit` = fmt + gofix changed files + lint changed files.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,16 +35,15 @@ Before changing cross-module data flow, service boundaries, API routing, or long
 
 CI runs `make test` on every push. Run the full suite locally only when asked, or when one change crosses many packages.
 
-## Mandatory benchmarks
+## Mandatory performance checks
 
 Before opening or updating a PR, complete these steps for the full PR diff:
 
-1. Assess backend and frontend performance risks, including changes to shared helpers, dependencies, and configuration. Benchmarks are mandatory when a change can affect latency, CPU, memory, I/O, request volume, or bundle size. Examples include queries, caching, concurrency, polling, serialization, sorting, filtering, rendering, and virtualization. If the risk is unclear, run benchmarks. If no performance risk applies, explain why in the PR's Performance section.
-2. Select a benchmark for each affected path. Reuse existing benchmarks and tools. If coverage is missing, add the smallest repeatable benchmark or browser scenario that measures the risk. Use representative synthetic data, including large inputs where cost grows with data size. Use local stubs for external services.
-3. Compare the merge-base with the PR's target branch against the latest PR code. Use the same workload, hardware, runtime versions, and measurement settings for both revisions. Repeat runs to distinguish regressions from measurement noise.
-4. Measure the relevant cost. For Go, run targeted benchmarks with `-run '^$' -bench '<pattern>' -benchmem -count=5` and without `-race`. Compare time, bytes, and allocations per operation. For frontend logic, use a focused benchmark. For rendering, scrolling, or interaction changes, measure the browser with a production build. Record relevant timings, memory use, request counts, or bundle sizes. Unit tests and a visual smoke test do not measure performance.
-5. Record both commit IDs, commands or browser steps, workload size, environment, and before/after results in the PR's Performance section. Include the measured differences and your conclusion. CI benchmark results qualify only when they provide this comparison. Otherwise, run benchmarks locally, even when CI covers the tests.
-6. Investigate regressions beyond measurement noise. Fix them or obtain explicit maintainer acceptance of the measured cost before declaring the PR ready. After further code changes, repeat the affected benchmarks. If measurements are blocked, report the blocker and keep this step incomplete.
+1. Review changed code and its callers for backend and frontend performance risks. Include shared helpers, dependencies, and configuration. Consider call frequency and data size when assessing allocations, nested scans, queries, concurrency, rendering, and requests. If no performance risk applies, explain why in the PR's Performance section.
+2. If a change can affect performance, you must measure before and after. If the risk is unclear, measure it. Use the merge-base with the PR's target branch as the baseline. Compare it against the latest PR code under the same workload and environment. Use representative synthetic data and local stubs for external services. Repeat runs to distinguish regressions from measurement noise.
+3. Use existing benchmarks, profilers, or repeatable browser measurements. Temporary measurement code is sufficient. Committing benchmark files is optional. For Go benchmarks, measure without `-race`. For rendering and interaction changes, measure the browser with a production build.
+4. Record the affected paths, revisions, workload size, environment, and measurement method in the PR's Performance section. Include before/after numbers, the measured differences, and your conclusion. Choose relevant metrics, such as time, memory, allocations, request counts, or bundle size. CI results qualify only when they provide this comparison. Otherwise, measure locally, even when CI covers the tests.
+5. Investigate regressions beyond measurement noise. Fix them or obtain explicit maintainer acceptance of the measured cost before declaring the PR ready. After further code changes, repeat the affected measurements. If measurements are blocked, report the blocker and keep this step incomplete.
 
 ## Lint / Format
 


### PR DESCRIPTION
## Description

Requires before/after measurements in PRs that can affect backend or frontend performance. Benchmark files are optional.

## How has this been tested?

Reviewed the rules and template together, including the required PR results and the optional benchmark files.

## Performance

No performance risk applies because this PR changes only contributor instructions and the PR template.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL
- [x] I completed the [mandatory performance checks](https://github.com/autobrr/qui/blob/develop/AGENTS.md#mandatory-performance-checks) and recorded the outcome in Performance


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added mandatory performance-check guidance for code changes.
  * Added pull request checklist requirements to document performance validation, affected areas, and before-and-after measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->