### PR TITLE
fix(sse): retain page snapshots and avoid unnecessary reconnects

### DIFF
--- a/internal/api/sse/delta.go
+++ b/internal/api/sse/delta.go
@@ -65,6 +65,12 @@ func (g *subscriptionGroup) buildUpdatePayload(opts StreamOptions, resp *qbittor
 	// complete snapshot represented by this frame before retaining it for joiners.
 	// Explicit JSON null remains non-nil and therefore still clears preferences.
 	snapshot := *resp
+	if g.baselineSnapshot != nil && len(changedIdx) == 0 && slices.Equal(order, g.baselineOrder) {
+		snapshot.Torrents = g.baselineSnapshot.Torrents
+		snapshot.CrossInstanceTorrents = g.baselineSnapshot.CrossInstanceTorrents
+	} else {
+		detachSnapshotRows(&snapshot)
+	}
 	if g.baselineSnapshot != nil {
 		if snapshot.AppPreferences == nil {
 			snapshot.AppPreferences = g.baselineSnapshot.AppPreferences
@@ -174,7 +180,9 @@ func (g *subscriptionGroup) buildInitPayload(opts StreamOptions, resp *qbittorre
 
 	g.baselineFP = fp
 	g.baselineOrder = order
-	g.baselineSnapshot = resp
+	snapshot := *resp
+	detachSnapshotRows(&snapshot)
+	g.baselineSnapshot = &snapshot
 	g.version.Minor++
 
 	return &StreamPayload{
@@ -182,6 +190,33 @@ func (g *subscriptionGroup) buildInitPayload(opts StreamOptions, resp *qbittorre
 		Data:    g.baselineSnapshot,
 		Meta:    meta,
 		Version: new(g.version),
+	}
+}
+
+// Page rows can point into a full library allocation. Retain only the page.
+func detachSnapshotRows(snapshot *qbittorrent.TorrentResponse) {
+	snapshot.Torrents = slices.Clone(snapshot.Torrents)
+	snapshot.CrossInstanceTorrents = slices.Clone(snapshot.CrossInstanceTorrents)
+	torrents := make([]qbt.Torrent, len(snapshot.Torrents)+len(snapshot.CrossInstanceTorrents))
+	for i := range snapshot.Torrents {
+		if row := &snapshot.Torrents[i]; row.Torrent != nil {
+			torrents[i] = *row.Torrent
+			row.Torrent = &torrents[i]
+		}
+	}
+	views := make([]qbittorrent.TorrentView, len(snapshot.CrossInstanceTorrents))
+	for i := range snapshot.CrossInstanceTorrents {
+		row := &snapshot.CrossInstanceTorrents[i]
+		if row.TorrentView == nil {
+			continue
+		}
+		views[i] = *row.TorrentView
+		if row.Torrent != nil {
+			idx := len(snapshot.Torrents) + i
+			torrents[idx] = *row.Torrent
+			views[i].Torrent = &torrents[idx]
+		}
+		row.TorrentView = &views[i]
 	}
 }
 

--- a/internal/api/sse/delta.go
+++ b/internal/api/sse/delta.go
@@ -65,12 +65,7 @@ func (g *subscriptionGroup) buildUpdatePayload(opts StreamOptions, resp *qbittor
 	// complete snapshot represented by this frame before retaining it for joiners.
 	// Explicit JSON null remains non-nil and therefore still clears preferences.
 	snapshot := *resp
-	if g.baselineSnapshot != nil && len(changedIdx) == 0 && slices.Equal(order, g.baselineOrder) {
-		snapshot.Torrents = g.baselineSnapshot.Torrents
-		snapshot.CrossInstanceTorrents = g.baselineSnapshot.CrossInstanceTorrents
-	} else {
-		detachSnapshotRows(&snapshot)
-	}
+	detachSnapshotRows(&snapshot)
 	if g.baselineSnapshot != nil {
 		if snapshot.AppPreferences == nil {
 			snapshot.AppPreferences = g.baselineSnapshot.AppPreferences

--- a/internal/api/sse/delta_test.go
+++ b/internal/api/sse/delta_test.go
@@ -308,14 +308,14 @@ func TestInitUsesExactVersionedBaseline(t *testing.T) {
 	seeded.Counts = counts
 	seeded.AppPreferences = prefs
 	first := g.buildInitPayload(opts, seeded, &StreamMeta{})
-	require.Same(t, seeded, first.Data)
+	require.Equal(t, seeded, first.Data)
 	require.Equal(t, &StreamVersion{Major: 7, Minor: 1}, first.Version)
 
 	// This candidate was built later but does not represent the group's baseline.
 	joinerCandidate := singleResp(tv("a", "not-the-baseline"))
 	joinerCandidate.Counts = &qbittorrent.TorrentCounts{Total: 9}
 	joiner := g.buildInitPayload(opts, joinerCandidate, &StreamMeta{})
-	require.Same(t, seeded, joiner.Data)
+	require.Same(t, first.Data, joiner.Data)
 	require.Equal(t, first.Version, joiner.Version)
 
 	// Even an aggregate-only frame advances Minor. Its retained full snapshot keeps

--- a/internal/api/sse/snapshot_test.go
+++ b/internal/api/sse/snapshot_test.go
@@ -66,6 +66,42 @@ func TestBaselineOwnsPageRows(t *testing.T) {
 	}
 }
 
+func TestBaselineRefreshesVolatileFieldsWithoutResendingRows(t *testing.T) {
+	for _, cross := range []bool{false, true} {
+		t.Run(fmt.Sprintf("cross=%t", cross), func(t *testing.T) {
+			response := snapshotPage(1000, 1, cross)
+			opts := StreamOptions{InstanceID: 1}
+			if cross {
+				opts = StreamOptions{InstanceIDs: []int{1}}
+			}
+			group := &subscriptionGroup{}
+			first := group.buildInitPayload(opts, response, &StreamMeta{})
+			var source, original *qbt.Torrent
+			if cross {
+				source = response.CrossInstanceTorrents[0].Torrent
+				original = first.Data.CrossInstanceTorrents[0].Torrent
+			} else {
+				source = response.Torrents[0].Torrent
+				original = first.Data.Torrents[0].Torrent
+			}
+			before := *original
+			source.NumSeeds = 7
+			source.TimeActive = 102
+			source.Reannounce = 1798
+
+			delta := group.buildUpdatePayload(opts, response, &StreamMeta{})
+			require.Equal(t, streamEventDelta, delta.Type)
+			require.Empty(t, delta.Data.Torrents)
+			require.Empty(t, delta.Data.CrossInstanceTorrents)
+			require.Nil(t, delta.Delta.Order)
+			latest := group.buildInitPayload(opts, nil, &StreamMeta{})
+			require.Equal(t, response, latest.Data)
+			require.Equal(t, delta.Version, latest.Version)
+			require.Equal(t, before, *original)
+		})
+	}
+}
+
 func BenchmarkBuildUpdatePayload(b *testing.B) {
 	for _, cross := range []bool{false, true} {
 		for _, pageSize := range []int{1, 300, 2000} {

--- a/internal/api/sse/snapshot_test.go
+++ b/internal/api/sse/snapshot_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package sse
+
+import (
+	"fmt"
+	"testing"
+
+	qbt "github.com/autobrr/go-qbittorrent"
+	"github.com/stretchr/testify/require"
+
+	"github.com/autobrr/qui/internal/qbittorrent"
+)
+
+// Each page row points into the full filtered library returned by qBittorrent.
+func snapshotPage(librarySize, pageSize int, cross bool) *qbittorrent.TorrentResponse {
+	library := make([]qbt.Torrent, librarySize)
+	for i := range library {
+		library[i] = qbt.Torrent{Hash: fmt.Sprintf("%040x", i), Name: "Synthetic torrent", State: qbt.TorrentStateStalledUp, Size: 1 << 30}
+	}
+	response := &qbittorrent.TorrentResponse{Total: librarySize}
+	if cross {
+		all := make([]qbittorrent.CrossInstanceTorrentView, librarySize)
+		views := make([]qbittorrent.TorrentView, librarySize)
+		for i := range library {
+			views[i].Torrent = &library[i]
+			all[i] = qbittorrent.CrossInstanceTorrentView{TorrentView: &views[i], InstanceID: 1}
+		}
+		response.CrossInstanceTorrents = all[:pageSize]
+	} else {
+		response.Torrents = make([]qbittorrent.TorrentView, pageSize)
+		for i := range response.Torrents {
+			response.Torrents[i].Torrent = &library[i]
+		}
+	}
+	return response
+}
+
+func TestBaselineOwnsPageRows(t *testing.T) {
+	for _, cross := range []bool{false, true} {
+		for _, init := range []bool{false, true} {
+			t.Run(fmt.Sprintf("cross=%t/init=%t", cross, init), func(t *testing.T) {
+				response := snapshotPage(1000, 1, cross)
+				opts := StreamOptions{InstanceID: 1}
+				if cross {
+					opts = StreamOptions{InstanceIDs: []int{1}}
+				}
+				group := &subscriptionGroup{}
+				if init {
+					group.buildInitPayload(opts, response, &StreamMeta{})
+				} else {
+					group.buildUpdatePayload(opts, response, &StreamMeta{})
+				}
+				retained := group.buildInitPayload(opts, nil, &StreamMeta{}).Data
+				require.Equal(t, response, retained)
+				if cross {
+					require.NotSame(t, &response.CrossInstanceTorrents[0], &retained.CrossInstanceTorrents[0])
+					require.NotSame(t, response.CrossInstanceTorrents[0].TorrentView, retained.CrossInstanceTorrents[0].TorrentView)
+					require.NotSame(t, response.CrossInstanceTorrents[0].Torrent, retained.CrossInstanceTorrents[0].Torrent)
+				} else {
+					require.NotSame(t, response.Torrents[0].Torrent, retained.Torrents[0].Torrent)
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkBuildUpdatePayload(b *testing.B) {
+	for _, cross := range []bool{false, true} {
+		for _, pageSize := range []int{1, 300, 2000} {
+			for _, changed := range []int{0, min(10, pageSize)} {
+				b.Run(fmt.Sprintf("cross=%t/rows=%d/changed=%d", cross, pageSize, changed), func(b *testing.B) {
+					response := snapshotPage(20000, pageSize, cross)
+					opts := StreamOptions{InstanceID: 1}
+					if cross {
+						opts = StreamOptions{InstanceIDs: []int{1}}
+					}
+					group := &subscriptionGroup{}
+					group.buildInitPayload(opts, response, &StreamMeta{})
+					b.ReportAllocs()
+					for b.Loop() {
+						for i := range changed {
+							if cross {
+								response.CrossInstanceTorrents[i].UploadedSession++
+							} else {
+								response.Torrents[i].UploadedSession++
+							}
+						}
+						group.buildUpdatePayload(opts, response, &StreamMeta{})
+					}
+				})
+			}
+		}
+	}
+}

--- a/web/src/contexts/SyncStreamContext.test.tsx
+++ b/web/src/contexts/SyncStreamContext.test.tsx
@@ -4,6 +4,7 @@
  */
 
 import { api } from "@/lib/api"
+import { resolveStreamRow } from "@/lib/torrent-utils"
 import {
   createStreamKey,
   isClientConnectionErrorCode,
@@ -361,6 +362,50 @@ describe("SyncStreamContext", () => {
       expect(controls.getState().error).toBeNull()
       expect(controls.payloads).toHaveLength(1)
       expect(controls.payloads[0].type).toBe("update")
+    })
+
+    it("restores a listener's row baseline after a stream error without reconnecting", () => {
+      const { controls } = renderSubscriber(BASE_PARAMS)
+      flushConnectionQueue()
+      const source = MockEventSource.instances[0]
+      const key = createStreamKey(BASE_PARAMS)
+      const row = { hash: "a", name: "Synthetic torrent", ratio: 2 }
+      act(() => {
+        source.emitOpen()
+        source.emit("init", {
+          type: "init", version: { major: 1, minor: 1 },
+          meta: { streamKey: key }, data: { torrents: [row], total: 1 },
+        })
+        source.emit("stream-error", {
+          type: "stream-error", error: "Temporary sync failure", meta: { streamKey: key },
+        })
+      })
+      expect(controls.getState().connected).toBe(false)
+      expect(controls.getState().initialized).toBe(true)
+      act(() => source.emit("delta", {
+        type: "delta", version: { major: 1, minor: 2 },
+        delta: { baseVersion: { major: 1, minor: 1 } },
+        meta: { streamKey: key }, data: { torrents: [], total: 1 },
+      }))
+      expect(controls.payloads.map(payload => payload.type)).toEqual(["init", "stream-error", "init"])
+      expect(resolveStreamRow(null, controls.payloads[2].data!)).toEqual(row)
+      expect(controls.payloads[2].version).toEqual({ major: 1, minor: 2 })
+      expect(controls.payloads[2].delta).toBeUndefined()
+      expect(source.closed).toBe(false)
+      expect(controls.getState().connected).toBe(true)
+      expect(controls.getState().retryAttempt).toBe(0)
+      act(() => {
+        source.emit("stream-error", {
+          type: "stream-error", error: "Temporary sync failure", meta: { streamKey: key },
+        })
+        source.emit("delta", {
+          type: "delta", version: { major: 1, minor: 4 },
+          delta: { baseVersion: { major: 1, minor: 3 } },
+          meta: { streamKey: key }, data: { torrents: [], total: 0 },
+        })
+      })
+      expect(source.closed).toBe(true)
+      expect(controls.getState().retryAttempt).toBe(1)
     })
 
     it("coalesces recovery when a delta does not continue the accepted version", () => {
@@ -1113,19 +1158,20 @@ describe("SyncStreamContext", () => {
       expect(controlsB.getState().connected).toBe(true)
     })
 
-    it("requests one shared init when a listener remounts without a baseline", () => {
+    it.each([false, true])("replays the current snapshot on remount without reconnecting, cross=%s", async cross => {
+      const params = makeParams(cross ? { instanceId: 0, instanceIds: [1] } : {})
+      const field = cross ? "cross_instance_torrents" : "torrents"
+      const row = { hash: "a", name: "Original", ...(cross ? { instance_id: 1, instance_name: "Synthetic" } : {}) }
       const controlsA: HarnessControls = { getState: () => DEFAULT, payloads: [] }
       const controlsB: HarnessControls = { getState: () => DEFAULT, payloads: [] }
       let setMounted: (mounted: boolean) => void = () => {}
-
       function Subscriber({ controls }: { controls: HarnessControls }) {
-        const state = useSyncStream(makeParams(), {
+        const state = useSyncStream(params, {
           onMessage: payload => controls.payloads.push(payload),
         })
         controls.getState = () => state
         return null
       }
-
       function Root() {
         const [mounted, updateMounted] = useState(true)
         setMounted = updateMounted
@@ -1136,50 +1182,34 @@ describe("SyncStreamContext", () => {
           </TestProviders>
         )
       }
-
-      act(() => {
-        render(<Root />)
-      })
+      render(<Root />)
       flushConnectionQueue()
-
-      const key = createStreamKey(makeParams())
-      const first = MockEventSource.instances[0]
+      const key = createStreamKey(params)
+      const source = MockEventSource.instances[0]
       act(() => {
-        first.emitOpen()
-        first.emit("init", {
-          type: "init",
-          version: { major: 4, minor: 1 },
-          meta: { instanceId: 1, timestamp: "now", streamKey: key },
-          data: { torrents: [], total: 0 },
+        source.emitOpen()
+        source.emit("init", {
+          type: "init", version: { major: 4, minor: 1 }, meta: { streamKey: key },
+          data: { [field]: [row], total: 1, counts: { total: 1 } },
+        })
+        source.emit("delta", {
+          type: "delta", version: { major: 4, minor: 2 },
+          delta: { baseVersion: { major: 4, minor: 1 } }, meta: { streamKey: key },
+          data: { [field]: [{ ...row, name: "Updated" }], total: 1 },
         })
       })
-      expect(controlsA.payloads).toHaveLength(1)
-      expect(controlsB.payloads).toHaveLength(1)
-
       act(() => setMounted(false))
-      act(() => setMounted(true))
-      expect(controlsA.getState().initialized).toBe(false)
+      await act(async () => setMounted(true))
       flushConnectionQueue()
-
-      expect(first.closed).toBe(true)
-      expect(MockEventSource.instances).toHaveLength(2)
-      const replacement = MockEventSource.instances[1]
-      act(() => {
-        replacement.emitOpen()
-        replacement.emit("init", {
-          type: "init",
-          version: { major: 4, minor: 1 },
-          meta: { instanceId: 1, timestamp: "now", streamKey: key },
-          data: { torrents: [], total: 0 },
-        })
-      })
-
-      // The already-mounted listener receives the same replacement baseline; it
-      // is not left on a different sequence when the remounted listener recovers.
-      expect(controlsA.payloads.map(payload => payload.type)).toEqual(["init", "init"])
-      expect(controlsB.payloads.map(payload => payload.type)).toEqual(["init", "init"])
+      expect(source.closed).toBe(false)
+      expect(MockEventSource.instances).toHaveLength(1)
       expect(controlsA.getState().initialized).toBe(true)
-      expect(controlsB.getState().initialized).toBe(true)
+      expect(controlsA.payloads.map(payload => payload.type)).toEqual(["init", "delta"])
+      expect(controlsB.payloads.map(payload => payload.type)).toEqual(["init", "delta", "init"])
+      expect(controlsB.payloads.at(-1)).toMatchObject({
+        version: { major: 4, minor: 2 },
+        data: { [field]: [{ ...row, name: "Updated" }], total: 1, counts: { total: 1 } },
+      })
     })
 
     it("opens distinct EventSources for differing params", () => {

--- a/web/src/contexts/SyncStreamContext.test.tsx
+++ b/web/src/contexts/SyncStreamContext.test.tsx
@@ -1158,7 +1158,7 @@ describe("SyncStreamContext", () => {
       expect(controlsB.getState().connected).toBe(true)
     })
 
-    it.each([false, true])("replays the current snapshot on remount without reconnecting, cross=%s", async cross => {
+    it.each([false, true])("replays healthy snapshots on remount and waits for recovery after errors, cross=%s", async cross => {
       const params = makeParams(cross ? { instanceId: 0, instanceIds: [1] } : {})
       const field = cross ? "cross_instance_torrents" : "torrents"
       const row = { hash: "a", name: "Original", ...(cross ? { instance_id: 1, instance_name: "Synthetic" } : {}) }
@@ -1190,12 +1190,12 @@ describe("SyncStreamContext", () => {
         source.emitOpen()
         source.emit("init", {
           type: "init", version: { major: 4, minor: 1 }, meta: { streamKey: key },
-          data: { [field]: [row], total: 1, counts: { total: 1 } },
+          data: { [field]: [row], total: 1, counts: { total: 1 }, activeTaskCount: 1 },
         })
         source.emit("delta", {
           type: "delta", version: { major: 4, minor: 2 },
           delta: { baseVersion: { major: 4, minor: 1 } }, meta: { streamKey: key },
-          data: { [field]: [{ ...row, name: "Updated" }], total: 1 },
+          data: { [field]: [{ ...row, name: "Updated" }], total: 1, activeTaskCount: 1 },
         })
       })
       act(() => setMounted(false))
@@ -1210,6 +1210,30 @@ describe("SyncStreamContext", () => {
         version: { major: 4, minor: 2 },
         data: { [field]: [{ ...row, name: "Updated" }], total: 1, counts: { total: 1 } },
       })
+
+      act(() => setMounted(false))
+      act(() => source.emit("stream-error", {
+        type: "stream-error", error: "Temporary sync failure", meta: { streamKey: key },
+      }))
+      await act(async () => setMounted(true))
+      flushConnectionQueue()
+      expect(controlsB.payloads).toHaveLength(3)
+      expect(controlsB.getState()).toMatchObject({ connected: false, initialized: true, error: "Temporary sync failure" })
+      expect(source.closed).toBe(false)
+      expect(MockEventSource.instances).toHaveLength(1)
+
+      act(() => source.emit("delta", {
+        type: "delta", version: { major: 4, minor: 3 },
+        delta: { baseVersion: { major: 4, minor: 2 } }, meta: { streamKey: key },
+        data: { [field]: [], total: 1, activeTaskCount: 0 },
+      }))
+      expect(controlsB.payloads).toHaveLength(4)
+      expect(controlsB.payloads.at(-1)).toMatchObject({
+        type: "init", version: { major: 4, minor: 3 },
+        data: { [field]: [{ ...row, name: "Updated" }], total: 1, counts: { total: 1 }, activeTaskCount: 0 },
+      })
+      expect(controlsB.getState()).toMatchObject({ connected: true, initialized: true, error: null, retryAttempt: 0 })
+      expect(MockEventSource.instances).toHaveLength(1)
     })
 
     it("opens distinct EventSources for differing params", () => {

--- a/web/src/contexts/SyncStreamContext.tsx
+++ b/web/src/contexts/SyncStreamContext.tsx
@@ -5,7 +5,8 @@
 
 import { api } from "@/lib/api"
 import { invalidateAllActivity, invalidateForActivity } from "@/lib/activity-invalidation"
-import type { ActivityEvent, ActivityStreamPayload, TorrentFilters, TorrentStreamMeta, TorrentStreamPayload, TorrentStreamVersion } from "@/types"
+import { applyStreamDelta, normalizeStreamedSnapshot } from "@/lib/cross-instance-torrents"
+import type { ActivityEvent, ActivityStreamPayload, TorrentFilters, TorrentResponse, TorrentStreamMeta, TorrentStreamPayload, TorrentStreamVersion } from "@/types"
 import { useQueryClient } from "@tanstack/react-query"
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react"
 
@@ -132,6 +133,7 @@ interface StreamEntry {
   error: string | null
   lastMeta?: TorrentStreamMeta
   version?: TorrentStreamVersion
+  snapshot?: TorrentResponse
   handoffTimer?: number
   handoffPending?: boolean
   // Set once the replacement connection's socket has demonstrably opened during a
@@ -597,7 +599,6 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
         if (payload.type === "stream-error" && payload.error) {
           entry.error = payload.error
           entry.connected = false
-          entry.initialized = false
         } else if (payload.type === "init" || payload.type === "update" || payload.type === "delta") {
           const nextVersion = payload.version
           const baseVersion = payload.delta?.baseVersion
@@ -624,10 +625,20 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
             return
           }
 
+          const restoreSnapshot = payload.type === "delta" && Boolean(entry.error)
           entry.error = null
           entry.connected = true
           entry.initialized = true
           entry.version = nextVersion
+          if (payload.data) {
+            entry.snapshot = payload.type === "delta" && entry.snapshot
+              ? applyStreamDelta(entry.snapshot, payload, Boolean(entry.params.instanceIds?.length)).data
+              : normalizeStreamedSnapshot(payload.data)
+          }
+          if (restoreSnapshot && entry.snapshot) {
+            // Some listeners discard their row baseline while fallback polling runs.
+            payload = { ...payload, type: "init", data: entry.snapshot, delta: undefined }
+          }
           if (connection.recovering && normalized.every(({ key }) => {
             const candidate = streamsRef.current[key]
             return !candidate || candidate.initialized
@@ -945,7 +956,19 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
       const entry = ensureStream(params, options)
       const needsInit = entry.connected || entry.initialized
       entry.listeners.add(listener)
-      if (needsInit) {
+      if (entry.initialized && entry.snapshot) {
+        // Let mount effects reset their local state before replaying the baseline.
+        queueMicrotask(() => {
+          if (!entry.listeners.has(listener) || !entry.initialized || !entry.snapshot) {
+            return
+          }
+          try {
+            listener({ type: "init", data: entry.snapshot, version: entry.version, meta: entry.lastMeta })
+          } catch (err) {
+            console.error("SyncStream snapshot listener failed", err)
+          }
+        })
+      } else if (needsInit) {
         entry.initialized = false
         entry.version = undefined
         queueConnectionUpdate({ preserveState: true, force: true })

--- a/web/src/contexts/SyncStreamContext.tsx
+++ b/web/src/contexts/SyncStreamContext.tsx
@@ -959,7 +959,7 @@ export function SyncStreamProvider({ children }: { children: React.ReactNode }) 
       if (entry.initialized && entry.snapshot) {
         // Let mount effects reset their local state before replaying the baseline.
         queueMicrotask(() => {
-          if (!entry.listeners.has(listener) || !entry.initialized || !entry.snapshot) {
+          if (!entry.listeners.has(listener) || !entry.initialized || !entry.snapshot || !entry.connected || entry.error) {
             return
           }
           try {


### PR DESCRIPTION
## Description

Retain only the displayed torrent page and reuse valid browser snapshots to reduce SSE memory use and unnecessary reconnects after errors or subscriber remounts.

Follow-up to #2506. Recovery restores the snapshot for listeners that discard their rows during fallback polling. Missing update versions still trigger a reconnect.

## How has this been tested?

Ran both production builds against a local qBittorrent stub with 20,000 synthetic torrents. Chromium loaded the 300-row table five times per build. Injected a temporary stream error and observed normal updates resume without reconnecting in the fixed build. The table stayed visible. The discarded detail-row case has a focused regression test. It was not verified through the full details UI.

Follow-up `029732be` prevents snapshot replay while the stream is unhealthy. The rebuilt binary started on loopback and returned HTTP 200. The browser check did not reach the synthetic torrent table, so the live mobile error/remount path remains unverified.

The snapshot freshness follow-up was checked with the built binary and a loopback qBittorrent stub. Single-instance and cross-instance streams each sent three deltas with no torrent rows while seed count changed from 3 to 7. New subscribers then received seed count 7, active time 102, and reannounce time 1798. All test processes, listeners, configuration, and helpers were removed.

## Performance

Reviewed `internal/api/sse/delta.go`, `web/src/contexts/SyncStreamContext.tsx`, and their callers. The server retained full-library allocations through page-row pointers. The browser restarted the shared connection after temporary errors and warm subscriber remounts. The fix copies the displayed page on every tick so late subscribers receive fresh counters without retaining the full library. It retains the browser snapshot and reuses the existing delta reconstruction helper.

Baseline: merge-base `538147e2df7a071163ff975e841681dfdd974052`. Browser measurement revision: `85f00cd8373ba4a9766d92610dc09f95519c2d51`. Browser measurements used both production builds on Linux amd64, Ryzen 7 8745HS, Go 1.27.1, Chromium 152.0.7977.82, 1440×1000 viewport, and disabled HTTP caching. All services ran on loopback. External browser requests were blocked.

| Measurement | Before | After | Difference |
|---|---:|---:|---:|
| First table row visible, median of 5 loads | 576 ms | 553 ms | -23 ms |
| First contentful paint, median of 5 loads | 172 ms | 160 ms | -12 ms |
| Sampled live Go heap after GC | 101.50 MiB | 74.20 MiB | -27.30 MiB |
| Recovery after injected stream error | 6.17 s to fresh init | 2.13 s to next delta | -4.04 s |
| Extra connections after that error | 1 | 0 | -1 |

Five loads do not establish a small loading-speed change. Heap results are one sample per build, not process RSS. The 23.50 MiB of retained full-library slice copies disappeared from the profile. The error was injected through the real EventSource listeners; this does not simulate a broken network connection.

Go delta benchmarks were repeated for the final snapshot freshness fix at `8544ca42ad5969504ce5ee54c463b7860818225a` against merge-base `538147e2`, with the same benchmark and source files selected through Go's `-overlay` flag. Linux amd64, Ryzen 7 8745HS, Go 1.27.1, `GOMAXPROCS=4`; 20,000 synthetic source rows, page sizes 1, 300, and 2,000, idle or up to 10 changed rows, five 200 ms runs without `-race`. The table shows medians for the default 300-row page.

| Delta construction | Merge-base | Final fix | Difference |
|---|---:|---:|---:|
| Single instance, idle | 123.95 µs | 146.33 µs | +22.38 µs, +18.1% |
| Single instance, 10 changed rows | 122.70 µs | 146.93 µs | +24.23 µs, +19.7% |
| Cross instance, idle | 138.19 µs | 162.74 µs | +24.55 µs, +17.8% |
| Cross instance, 10 changed rows | 137.91 µs | 162.59 µs | +24.68 µs, +17.9% |
| Single instance, idle allocation | 20,208 B/op, 14 allocs | 220,912 B/op, 16 allocs | +200,704 B/op, +2 allocs |
| Single instance, changed allocation | 20,816 B/op, 17 allocs | 221,520 B/op, 19 allocs | +200,704 B/op, +2 allocs |
| Cross instance, idle allocation | 34,608 B/op, 314 allocs | 245,040 B/op, 317 allocs | +210,432 B/op, +3 allocs |
| Cross instance, changed allocation | 35,120 B/op, 317 allocs | 245,552 B/op, 320 allocs | +210,432 B/op, +3 allocs |

The freshness fix adds 18.62 µs per single-instance idle tick or 21.31 µs per cross-instance idle tick compared with the prior PR head `029732be`. Changed-row timings remain close to that revision. At 2,000 displayed rows, the final idle path costs 1.034 ms / 1.46 MB (single) or 1.102 ms / 1.62 MB (cross), versus 0.828 ms / 0.14 MB and 0.937 ms / 0.24 MB at the merge-base.

This trades about 0.2 MB of temporary allocation per default-page tick for a fresh, independent snapshot. At the default two-second interval, that is about 0.1 MB/s per subscription group. The retained snapshot still owns only the page, which avoids retaining roughly 12 MiB of full-library storage per small-page subscription with 20,000 torrents. The earlier live heap figures above were not remeasured for this follow-up. The maintainer accepted the measured additional idle CPU and allocation cost.

Follow-up `029732be` adds two constant-time health checks when a subscriber mounts. It adds no allocations, delta reconstruction, or requests. That frontend guard leaves the measured steady-state browser path unchanged. The browser remount comparison was blocked before the synthetic table loaded, so there is no new browser measurement for this guard.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL
- [x] I completed the [mandatory performance checks](https://github.com/autobrr/qui/blob/develop/AGENTS.md#mandatory-performance-checks) and recorded the outcome in Performance


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved live synchronization recovery after stream errors, restoring current data without reconnecting.
  - Existing listeners now retain their latest synchronized data during temporary stream failures.
  - Reconnecting or remounting views receive the latest available snapshot without requiring a full refresh.
  - Improved consistency across regular and cross-instance views.
  - Improved snapshot isolation so updates do not unintentionally affect previously received data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

