### PR TITLE
fix(ci): limit Postgres job to integration tests

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -140,7 +140,7 @@ Run all non-integration tests:
 go test -v ./...
 ```
 
-Run all backend tests with a temporary Postgres server:
+Run Postgres integration tests with a temporary server:
 
 ```shell
 make test-postgres
@@ -148,6 +148,7 @@ make test-postgres
 
 This command downloads and caches Postgres 17 on first use, then stops the server after the tests finish.
 Each Postgres test keeps its isolated schema. CI runs this command on Linux.
+Use `PostgresIntegration` in the names of tests that need a Postgres server so this command selects them.
 Set `QUI_TEST_POSTGRES_DSN` to use an existing test database instead.
 To select tests, pass Go test arguments to `go run ./internal/testutil/postgres`.
 

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ test:
 	@echo "Running tests..."
 	go test -race -v ./...
 
-# Run all backend tests with a temporary Postgres server.
+# Run Postgres integration tests with a temporary server.
 test-postgres:
 	go run ./internal/testutil/postgres
 
@@ -251,7 +251,7 @@ help:
 	@echo ""
 	@echo "Testing:"
 	@echo "  make test           - Run all Go tests with race detection"
-	@echo "  make test-postgres  - Run all Go tests with a temporary Postgres server"
+	@echo "  make test-postgres  - Run Postgres integration tests with a temporary server"
 	@echo "  make test-frontend  - Run frontend vitest suite"
 	@echo "  make test-openapi   - Validate OpenAPI specification"
 	@echo ""

--- a/internal/database/cross_seed_run_counters_migration_test.go
+++ b/internal/database/cross_seed_run_counters_migration_test.go
@@ -13,10 +13,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// The counter rename must carry old torrents_added values into
-// cross_seeds_added: old rows counted applies under that name.
-func TestCrossSeedRunCountersMigrationBackfillsCrossSeedsAdded(t *testing.T) {
+func TestCrossSeedRunCountersMigrationBackfillsCrossSeedsAddedSQLite(t *testing.T) {
 	t.Parallel()
+
+	conn, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "test.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+	checkCrossSeedRunCountersMigration(t.Context(), t, conn, migrationsFS, "migrations/096_rename_cross_seed_run_counters.sql")
+}
+
+func TestCrossSeedRunCountersMigrationBackfillsCrossSeedsAddedPostgresIntegration(t *testing.T) {
+	t.Parallel()
+
+	ctx, dsn := openPostgresTestSchema(t)
+	conn, err := sql.Open("pgx", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+	checkCrossSeedRunCountersMigration(ctx, t, conn, postgresMigrationsFS, "postgres_migrations/097_rename_cross_seed_run_counters.sql")
+}
+
+// Old torrents_added values counted cross-seeds, so the rename must preserve them.
+func checkCrossSeedRunCountersMigration(ctx context.Context, t *testing.T, conn *sql.DB, fsys fs.ReadFileFS, migration string) {
+	t.Helper()
 
 	const legacySchema = `
 		CREATE TABLE cross_seed_search_runs (
@@ -37,39 +55,19 @@ func TestCrossSeedRunCountersMigrationBackfillsCrossSeedsAdded(t *testing.T) {
 		INSERT INTO cross_seed_runs (id, torrents_added, torrents_failed, torrents_skipped) VALUES (1, 4, 5, 6);
 	`
 
-	check := func(t *testing.T, ctx context.Context, conn *sql.DB, fsys fs.ReadFileFS, migration string) {
-		t.Helper()
-		_, err := conn.ExecContext(ctx, legacySchema)
-		require.NoError(t, err)
-		body, err := fsys.ReadFile(migration)
-		require.NoError(t, err)
-		_, err = conn.ExecContext(ctx, string(body))
-		require.NoError(t, err)
+	_, err := conn.ExecContext(ctx, legacySchema)
+	require.NoError(t, err)
+	body, err := fsys.ReadFile(migration)
+	require.NoError(t, err)
+	_, err = conn.ExecContext(ctx, string(body))
+	require.NoError(t, err)
 
-		var crossSeedsAdded, torrentsWithCrossSeeds int
-		require.NoError(t, conn.QueryRowContext(ctx, "SELECT cross_seeds_added, torrents_with_cross_seeds FROM cross_seed_search_runs WHERE id = 1").Scan(&crossSeedsAdded, &torrentsWithCrossSeeds))
-		require.Equal(t, 7, crossSeedsAdded)
-		require.Equal(t, 7, torrentsWithCrossSeeds)
+	var crossSeedsAdded, torrentsWithCrossSeeds int
+	require.NoError(t, conn.QueryRowContext(ctx, "SELECT cross_seeds_added, torrents_with_cross_seeds FROM cross_seed_search_runs WHERE id = 1").Scan(&crossSeedsAdded, &torrentsWithCrossSeeds))
+	require.Equal(t, 7, crossSeedsAdded)
+	require.Equal(t, 7, torrentsWithCrossSeeds)
 
-		var rssAdded, rssFailed, rssSkipped int
-		require.NoError(t, conn.QueryRowContext(ctx, "SELECT cross_seeds_added, candidates_failed, candidates_skipped FROM cross_seed_runs WHERE id = 1").Scan(&rssAdded, &rssFailed, &rssSkipped))
-		require.Equal(t, []int{4, 5, 6}, []int{rssAdded, rssFailed, rssSkipped})
-	}
-
-	t.Run("sqlite", func(t *testing.T) {
-		t.Parallel()
-		conn, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "test.db"))
-		require.NoError(t, err)
-		t.Cleanup(func() { require.NoError(t, conn.Close()) })
-		check(t, t.Context(), conn, migrationsFS, "migrations/096_rename_cross_seed_run_counters.sql")
-	})
-
-	t.Run("postgres", func(t *testing.T) {
-		t.Parallel()
-		ctx, dsn := openPostgresTestSchema(t)
-		conn, err := sql.Open("pgx", dsn)
-		require.NoError(t, err)
-		t.Cleanup(func() { require.NoError(t, conn.Close()) })
-		check(t, ctx, conn, postgresMigrationsFS, "postgres_migrations/097_rename_cross_seed_run_counters.sql")
-	})
+	var rssAdded, rssFailed, rssSkipped int
+	require.NoError(t, conn.QueryRowContext(ctx, "SELECT cross_seeds_added, candidates_failed, candidates_skipped FROM cross_seed_runs WHERE id = 1").Scan(&rssAdded, &rssFailed, &rssSkipped))
+	require.Equal(t, []int{4, 5, 6}, []int{rssAdded, rssFailed, rssSkipped})
 }

--- a/internal/database/postgres_integration_test.go
+++ b/internal/database/postgres_integration_test.go
@@ -20,28 +20,15 @@ import (
 	"github.com/autobrr/qui/internal/services/filesmanager"
 )
 
-func TestOpenPostgres(t *testing.T) {
+func TestCleanupUnusedStringsPostgresIntegration(t *testing.T) {
 	t.Parallel()
 
 	db, ctx := openPostgresTestDB(t)
-
-	if got := db.Dialect(); got != string(DialectPostgres) {
-		t.Fatalf("unexpected dialect: %s", got)
-	}
+	require.Equal(t, string(DialectPostgres), db.Dialect())
 
 	var count int
-	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM migrations").Scan(&count); err != nil {
-		t.Fatalf("query migrations table: %v", err)
-	}
-	if count == 0 {
-		t.Fatalf("expected at least one postgres migration row, got %d", count)
-	}
-}
-
-func TestCleanupUnusedStringsPostgres(t *testing.T) {
-	t.Parallel()
-
-	db, ctx := openPostgresTestDB(t)
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM migrations").Scan(&count))
+	require.Positive(t, count)
 
 	// Through the DB wrapper, not db.Conn(): the raw handle skips the ?-to-$n
 	// rebinding, so every placeholder below would reach Postgres verbatim.
@@ -70,7 +57,7 @@ func TestCleanupUnusedStringsPostgres(t *testing.T) {
 	require.Zero(t, deletedAgain)
 }
 
-func TestMigratedSQLiteFilesmanagerCleanupPostgres(t *testing.T) {
+func TestMigratedSQLiteFilesmanagerCleanupPostgresIntegration(t *testing.T) {
 	t.Parallel()
 
 	ctx, testDSN := openPostgresTestSchema(t)
@@ -217,13 +204,13 @@ func dsnWithSearchPath(t *testing.T, dsn string, schema string) string {
 	return parsed.String()
 }
 
-// TestPostgresImportForeignKeysIgnoreOtherSchemas pins both catalog queries to
+// TestImportForeignKeysIgnoreOtherSchemasPostgresIntegration pins both catalog queries to
 // the active schema. A foreign key referencing another schema's same-named
 // table used to survive: regclass text output qualifies only what search_path
 // cannot reach, and stripping that qualifier turned the reference into a local
 // one. That invents an import dependency (here a cycle, which fails the order)
 // and hands the row filter a parent table that is not the one being referenced.
-func TestPostgresImportForeignKeysIgnoreOtherSchemas(t *testing.T) {
+func TestImportForeignKeysIgnoreOtherSchemasPostgresIntegration(t *testing.T) {
 	t.Parallel()
 
 	ctx, testDSN := openPostgresTestSchema(t)

--- a/internal/models/crossseed_partial_pool_test.go
+++ b/internal/models/crossseed_partial_pool_test.go
@@ -505,7 +505,7 @@ func TestCrossSeedPartialPoolHardlinkRollbackTransitionIsAtomic(t *testing.T) {
 	require.Nil(t, member.Files[1].SourceFileID)
 }
 
-func TestCrossSeedPartialPoolConcurrentClaimsChooseOnePostgres(t *testing.T) {
+func TestCrossSeedPartialPoolConcurrentClaimsChooseOnePostgresIntegration(t *testing.T) {
 	db := testdb.NewMigratedPostgres(t, "partial-pool-concurrent-claims")
 	store, _, firstID, secondID := newPartialPoolTestStoreWithDB(t, db)
 	ctx := t.Context()
@@ -551,7 +551,7 @@ func TestCrossSeedPartialPoolConcurrentClaimsChooseOnePostgres(t *testing.T) {
 	require.Equal(t, 1, claimedCount, "all concurrent indexer members share one downloader owner")
 }
 
-func TestCrossSeedPartialPoolConcurrentRegistrationBlocksClaimPostgres(t *testing.T) {
+func TestCrossSeedPartialPoolConcurrentRegistrationBlocksClaimPostgresIntegration(t *testing.T) {
 	db := testdb.NewMigratedPostgres(t, "partial-pool-registration-claim")
 	store, _, firstID, secondID := newPartialPoolTestStoreWithDB(t, db)
 	ctx := t.Context()

--- a/internal/models/dirscan_file_prune_test.go
+++ b/internal/models/dirscan_file_prune_test.go
@@ -35,7 +35,7 @@ func TestDirScanStorePruneMissingFilesSQLite(t *testing.T) {
 	runDirScanPruneTests(t, testdb.NewMigratedSQLite(t, "dirscan-prune"))
 }
 
-func TestDirScanStorePruneMissingFilesPostgres(t *testing.T) {
+func TestDirScanStorePruneMissingFilesPostgresIntegration(t *testing.T) {
 	runDirScanPruneTests(t, testdb.NewMigratedPostgres(t, "dirscan-prune"))
 }
 

--- a/internal/models/disc_scan_test.go
+++ b/internal/models/disc_scan_test.go
@@ -18,7 +18,7 @@ func TestDiscScanStoreSQLite(t *testing.T) {
 	runDiscScanStoreTests(t, testdb.NewMigratedSQLite(t, "disc-scan"))
 }
 
-func TestDiscScanStorePostgres(t *testing.T) {
+func TestDiscScanStorePostgresIntegration(t *testing.T) {
 	runDiscScanStoreTests(t, testdb.NewMigratedPostgres(t, "disc-scan"))
 }
 

--- a/internal/services/filesmanager/repository_upsert_guard_test.go
+++ b/internal/services/filesmanager/repository_upsert_guard_test.go
@@ -14,30 +14,46 @@ import (
 	"github.com/autobrr/qui/internal/testutil/testdb"
 )
 
-// The upsert guard is SQL, and the two engines differ on null comparison and
-// numeric affinity, so every case below runs against both. The Postgres half
-// skips unless QUI_TEST_POSTGRES_DSN is set.
-func forEachBackend(t *testing.T, run func(ctx context.Context, t *testing.T, db *database.DB)) {
+type testDBOpener func(testing.TB, string) *database.DB
+
+func TestFilesmanagerSQLite(t *testing.T) {
+	t.Parallel()
+	runFilesmanagerTests(t, testdb.NewMigratedSQLite)
+}
+
+func TestFilesmanagerPostgresIntegration(t *testing.T) {
+	t.Parallel()
+	runFilesmanagerTests(t, testdb.NewMigratedPostgres)
+}
+
+func runFilesmanagerTests(t *testing.T, open testDBOpener) {
 	t.Helper()
 
-	backends := []struct {
+	tests := []struct {
 		name string
-		open func(t *testing.T) *database.DB
+		run  func(*testing.T, testDBOpener)
 	}{
-		{"sqlite", func(t *testing.T) *database.DB { return testdb.NewMigratedSQLite(t, "filesmanager-guard") }},
-		{"postgres", func(t *testing.T) *database.DB { return testdb.NewMigratedPostgres(t, "filesmanager-guard") }},
+		{"UpsertFilesSkipsUnchangedRows", testUpsertFilesSkipsUnchangedRows},
+		{"UpsertFilesWritesChangedRows", testUpsertFilesWritesChangedRows},
+		{"UpsertFilesGuardIsNullSafe", testUpsertFilesGuardIsNullSafe},
+		{"UpsertFilesGuardIsPerRowAcrossBatches", testUpsertFilesGuardIsPerRowAcrossBatches},
+		{"CacheFilesBatchAcrossQueryBatches", testCacheFilesBatchAcrossQueryBatches},
 	}
 
-	for _, backend := range backends {
-		t.Run(backend.name, func(t *testing.T) {
-			t.Parallel()
-
-			db := backend.open(t)
-			ctx := context.Background()
-			seedInstance(ctx, t, db)
-			run(ctx, t, db)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.run(t, open)
 		})
 	}
+}
+
+func withTestDB(t *testing.T, open testDBOpener, run func(context.Context, *testing.T, *database.DB)) {
+	t.Helper()
+
+	db := open(t, "filesmanager")
+	ctx := t.Context()
+	seedInstance(ctx, t, db)
+	run(ctx, t, db)
 }
 
 // seedInstance creates the instance row the cache rows point at.
@@ -91,10 +107,10 @@ func baseFile() CachedFile {
 
 // A complete, seeding torrent re-synced with identical data must produce no row
 // writes at all. This is the case that dominates a steady-state library.
-func TestUpsertFilesSkipsUnchangedRows(t *testing.T) {
+func testUpsertFilesSkipsUnchangedRows(t *testing.T, open testDBOpener) {
 	t.Parallel()
 
-	forEachBackend(t, func(ctx context.Context, t *testing.T, db *database.DB) {
+	withTestDB(t, open, func(ctx context.Context, t *testing.T, db *database.DB) {
 		repo := NewRepository(db)
 
 		files := []CachedFile{baseFile()}
@@ -107,7 +123,7 @@ func TestUpsertFilesSkipsUnchangedRows(t *testing.T) {
 }
 
 // Each guarded column must still let a real change through on its own.
-func TestUpsertFilesWritesChangedRows(t *testing.T) {
+func testUpsertFilesWritesChangedRows(t *testing.T, open testDBOpener) {
 	t.Parallel()
 
 	tests := []struct {
@@ -128,7 +144,7 @@ func TestUpsertFilesWritesChangedRows(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			forEachBackend(t, func(ctx context.Context, t *testing.T, db *database.DB) {
+			withTestDB(t, open, func(ctx context.Context, t *testing.T, db *database.DB) {
 				repo := NewRepository(db)
 
 				require.NoError(t, repo.UpsertFiles(ctx, []CachedFile{baseFile()}))
@@ -159,13 +175,13 @@ func TestUpsertFilesWritesChangedRows(t *testing.T) {
 
 // is_seed is nullable, so the guard must be null-safe. A plain `<>` would yield
 // NULL for these comparisons and silently drop the change.
-func TestUpsertFilesGuardIsNullSafe(t *testing.T) {
+func testUpsertFilesGuardIsNullSafe(t *testing.T, open testDBOpener) {
 	t.Parallel()
 
 	t.Run("null stays null", func(t *testing.T) {
 		t.Parallel()
 
-		forEachBackend(t, func(ctx context.Context, t *testing.T, db *database.DB) {
+		withTestDB(t, open, func(ctx context.Context, t *testing.T, db *database.DB) {
 			repo := NewRepository(db)
 
 			nullSeed := baseFile()
@@ -181,7 +197,7 @@ func TestUpsertFilesGuardIsNullSafe(t *testing.T) {
 	t.Run("null to value", func(t *testing.T) {
 		t.Parallel()
 
-		forEachBackend(t, func(ctx context.Context, t *testing.T, db *database.DB) {
+		withTestDB(t, open, func(ctx context.Context, t *testing.T, db *database.DB) {
 			repo := NewRepository(db)
 
 			nullSeed := baseFile()
@@ -203,7 +219,7 @@ func TestUpsertFilesGuardIsNullSafe(t *testing.T) {
 	t.Run("value to null", func(t *testing.T) {
 		t.Parallel()
 
-		forEachBackend(t, func(ctx context.Context, t *testing.T, db *database.DB) {
+		withTestDB(t, open, func(ctx context.Context, t *testing.T, db *database.DB) {
 			repo := NewRepository(db)
 
 			require.NoError(t, repo.UpsertFiles(ctx, []CachedFile{baseFile()}))
@@ -225,10 +241,10 @@ func TestUpsertFilesGuardIsNullSafe(t *testing.T) {
 
 // A sync sweep touches many torrents at once; only the rows that actually moved
 // should be written, and only within the batch that contains them.
-func TestUpsertFilesGuardIsPerRowAcrossBatches(t *testing.T) {
+func testUpsertFilesGuardIsPerRowAcrossBatches(t *testing.T, open testDBOpener) {
 	t.Parallel()
 
-	forEachBackend(t, func(ctx context.Context, t *testing.T, db *database.DB) {
+	withTestDB(t, open, func(ctx context.Context, t *testing.T, db *database.DB) {
 		repo := NewRepository(db)
 
 		// Span more than one batch so the guard is exercised on a full-batch query

--- a/internal/services/filesmanager/service_test.go
+++ b/internal/services/filesmanager/service_test.go
@@ -104,10 +104,10 @@ func TestCacheFilesBatch_MaintainsHashAlignment(t *testing.T) {
 	}
 }
 
-func TestCacheFilesBatchAcrossQueryBatches(t *testing.T) {
+func testCacheFilesBatchAcrossQueryBatches(t *testing.T, open testDBOpener) {
 	t.Parallel()
 
-	forEachBackend(t, func(ctx context.Context, t *testing.T, db *database.DB) {
+	withTestDB(t, open, func(ctx context.Context, t *testing.T, db *database.DB) {
 		svc := NewService(db)
 		hashes := make([]string, 801)
 		files := make(map[string]qbt.TorrentFiles, len(hashes))

--- a/internal/testutil/postgres/main.go
+++ b/internal/testutil/postgres/main.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2025-2026, s0up and the autobrr contributors.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-// Command postgres runs Go tests with a temporary Postgres server.
+// Command postgres runs Postgres integration tests with a temporary server.
 package main
 
 import (
@@ -79,7 +79,7 @@ func run(ctx context.Context, args []string) (runErr error) {
 	}
 
 	if len(args) == 0 {
-		args = []string{"-race", "-count=1", "-v", "-timeout=20m", "./..."}
+		args = []string{"-race", "-count=1", "-v", "-timeout=20m", "-run", "PostgresIntegration", "./..."}
 	}
 	cmd := exec.CommandContext(ctx, "go", append([]string{"test"}, args...)...) //nolint:gosec // Forward developer-supplied test arguments without a shell.
 	cmd.Env = append(os.Environ(), "QUI_TEST_POSTGRES_DSN="+dsn)


### PR DESCRIPTION
## Description

Limit `test-postgres` to tests that require a Postgres server so it does not repeat the full Go suite.

## How has this been tested?

Built the runner and used a local command stub to confirm its default test filter and unchanged argument forwarding.
Inspected the CI logs: all nine selected entry points ran, including the shared Postgres cases, with no skips.

## Performance

Affected paths: the Postgres test runner, database fixtures, and shared file-cache tests. Application code is unchanged.
The full Go suite remains in the release workflow; this job selects only tests that require Postgres.
The selected workload drops from 2,495 top-level test entries to nine integration entries, including the 14 file-cache cases.

Compared merge-base `e19a6ac1d8687f185c41deb06b651021aec457db` with PR commit `a1dfce0102c80579ce2bea2e99cafe70db9c1bf4`.
Ran the same `make test-postgres` workflow command twice at each revision, with race detection and uncached test results.
All four runs passed on GitHub-hosted Ubuntu 24.04 x64, Go 1.27.0, and temporary Postgres 17.5.0.
Both baseline runs and the first PR run used image `20260907.300.1`; the PR repeat used `20260831.293.1`.
All four restored the same Go dependency/build cache key.
The step measurement includes compilation, server startup, test execution, and server shutdown.

| Measurement | Baseline runs | PR runs | Median change |
| --- | --- | --- | --- |
| Postgres test step | 329s, 343s | 105s, 129s | 336s → 117s, 65% less |
| Complete Postgres job | 348s, 372s | 123s, 148s | 360s → 135.5s, 62% less |

Sources: [baseline first run](https://github.com/autobrr/qui/actions/runs/34448334951/job/102778016375), [baseline repeat](https://github.com/autobrr/qui/actions/runs/34448334951/job/102792885000), [PR first run](https://github.com/autobrr/qui/actions/runs/34453146098/job/102793284656), [PR repeat](https://github.com/autobrr/qui/actions/runs/34453146098/job/102794255145).

Both PR runs finished faster than both baseline runs. The reduction exceeds the observed variation between hosted runners.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL
- [x] I completed the [mandatory performance checks](https://github.com/autobrr/qui/blob/develop/AGENTS.md#mandatory-performance-checks) and recorded the outcome in Performance
