### PR TITLE
fix(automations): allow workflows to clear categories

### DIFF
--- a/documentation/docs/features/automations.md
+++ b/documentation/docs/features/automations.md
@@ -599,7 +599,7 @@ Quick troubleshooting:
 
 ### Category
 
-Move torrents to a different category.
+Move torrents to a different category. Select **Uncategorized** to remove their category.
 
 Options:
 

--- a/internal/api/handlers/automations.go
+++ b/internal/api/handlers/automations.go
@@ -337,11 +337,6 @@ func (h *AutomationHandler) validatePayload(ctx context.Context, instanceID int,
 	}
 	payload.Conditions.Normalize()
 
-	// Validate category action has a category name
-	if payload.Conditions.Category != nil && payload.Conditions.Category.Enabled && payload.Conditions.Category.Category == "" {
-		return http.StatusBadRequest, "Category action requires a category name", errors.New("category name required")
-	}
-
 	// Validate export to instance action
 	if payload.Conditions.ExportToInstance != nil && payload.Conditions.ExportToInstance.Enabled {
 		if payload.Conditions.ExportToInstance.TargetInstanceID <= 0 {

--- a/internal/api/handlers/automations_test.go
+++ b/internal/api/handlers/automations_test.go
@@ -18,6 +18,27 @@ import (
 	"github.com/autobrr/qui/internal/services/automations"
 )
 
+func TestAutomationValidatePayload_Category(t *testing.T) {
+	for _, category := range []string{"", "archive"} {
+		t.Run("target="+category, func(t *testing.T) {
+			handler := NewAutomationHandler(nil, nil, nil, nil, nil)
+			payload := &AutomationPayload{
+				Name:           "Category rule",
+				TrackerPattern: "*",
+				Conditions: &models.ActionConditions{
+					Category: &models.CategoryAction{Enabled: true, Category: category},
+				},
+			}
+
+			status, message, err := handler.validatePayload(t.Context(), 1, payload)
+			require.NoError(t, err)
+			require.Zero(t, status)
+			require.Empty(t, message)
+			require.Equal(t, category, payload.Conditions.Category.Category)
+		})
+	}
+}
+
 func TestAutomationDryRunNow(t *testing.T) {
 	newRequest := func(body string) *http.Request {
 		req := httptest.NewRequest(http.MethodPost, "/api/instances/1/automations/dry-run", strings.NewReader(body))

--- a/internal/models/automation.go
+++ b/internal/models/automation.go
@@ -961,7 +961,7 @@ type TagAction struct {
 // CategoryAction configures category assignment with optional conditions.
 type CategoryAction struct {
 	Enabled           bool   `json:"enabled"`
-	Category          string `json:"category"`                    // Target category name
+	Category          string `json:"category"`                    // Empty clears the category
 	IncludeCrossSeeds bool   `json:"includeCrossSeeds,omitempty"` // Also move cross-seeds to same category
 	GroupID           string `json:"groupId,omitempty"`           // Optional grouping ID for expanding category changes
 	// BlockIfCrossSeedInCategories prevents category changes when any other cross-seed torrent

--- a/internal/services/automations/processor.go
+++ b/internal/services/automations/processor.go
@@ -455,7 +455,7 @@ func processRuleForTorrent(rule *models.Automation, torrent qbt.Torrent, state *
 	}
 
 	// Category (last rule wins - just set desired, service will filter no-ops)
-	if conditions.Category != nil && conditions.Category.Enabled && conditions.Category.Category != "" {
+	if conditions.Category != nil && conditions.Category.Enabled {
 		shouldApply := conditions.Category.Condition == nil ||
 			EvaluateConditionWithContext(conditions.Category.Condition, torrent, evalCtx, 0)
 

--- a/internal/services/automations/processor_test.go
+++ b/internal/services/automations/processor_test.go
@@ -14,6 +14,85 @@ import (
 	"github.com/autobrr/qui/pkg/pathutil"
 )
 
+func TestProcessTorrents_Uncategorized(t *testing.T) {
+	sm := qbittorrent.NewSyncManager(nil, nil)
+	torrents := []qbt.Torrent{
+		{Hash: "source", Category: "archive", SavePath: "data", ContentPath: "data/show"},
+		{Hash: "peer", Category: "protected", SavePath: "data", ContentPath: "data/show"},
+		{Hash: "uncategorized", SavePath: "other", ContentPath: "other/show"},
+	}
+
+	for _, tc := range []struct {
+		name                string
+		enabled             bool
+		includeCrossSeeds   bool
+		protectedCategories []string
+		wantMatch           bool
+	}{
+		{name: "clear", enabled: true, wantMatch: true},
+		{name: "disabled"},
+		{name: "include cross-seeds", enabled: true, includeCrossSeeds: true, wantMatch: true},
+		{name: "protected cross-seed", enabled: true, includeCrossSeeds: true, protectedCategories: []string{"protected"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rule := &models.Automation{
+				ID:             1,
+				Enabled:        true,
+				TrackerPattern: "*",
+				Conditions: &models.ActionConditions{
+					Category: &models.CategoryAction{
+						Enabled:                      tc.enabled,
+						Category:                     "",
+						IncludeCrossSeeds:            tc.includeCrossSeeds,
+						BlockIfCrossSeedInCategories: tc.protectedCategories,
+						Condition:                    &models.RuleCondition{Field: models.FieldCategory, Operator: models.OperatorEqual, Value: "archive"},
+					},
+				},
+			}
+			states := processTorrents(torrents, []*models.Automation{rule}, nil, sm, nil, nil, nil)
+			if !tc.wantMatch {
+				require.Empty(t, states)
+				return
+			}
+			require.Len(t, states, 1)
+			require.NotNil(t, states["source"].category)
+			require.Empty(t, *states["source"].category)
+			require.Equal(t, tc.includeCrossSeeds, states["source"].categoryIncludeCrossSeeds)
+
+			service := &Service{syncManager: sm}
+			preview := newCategoryPreviewState("")
+			action := getCategoryAction(rule)
+			service.findDirectCategoryMatches(rule, torrents, nil, buildCrossSeedIndex(torrents), action, preview)
+			service.findCategoryCrossSeeds(torrents, action, preview)
+			require.Equal(t, map[string]struct{}{"source": {}}, preview.directMatchSet)
+			_, included := preview.crossSeedSet["peer"]
+			require.Equal(t, tc.includeCrossSeeds, included)
+		})
+	}
+}
+
+func TestProcessTorrents_UncategorizedLastRuleWins(t *testing.T) {
+	sm := qbittorrent.NewSyncManager(nil, nil)
+	torrents := []qbt.Torrent{{Hash: "source"}}
+	rules := []*models.Automation{
+		{ID: 1, Enabled: true, TrackerPattern: "*", Conditions: &models.ActionConditions{
+			Category: &models.CategoryAction{Enabled: true, Category: "archive"},
+		}},
+		{ID: 2, Enabled: true, TrackerPattern: "*", Conditions: &models.ActionConditions{
+			Category: &models.CategoryAction{Enabled: true, Category: ""},
+		}},
+	}
+	states := processTorrents(torrents, rules, nil, sm, nil, nil, nil)
+	require.NotNil(t, states["source"].category)
+	require.Empty(t, *states["source"].category)
+	require.Equal(t, 2, states["source"].categoryRuleID)
+
+	service := &Service{syncManager: sm}
+	preview := newCategoryPreviewState("")
+	service.findDirectCategoryMatches(rules[1], torrents, nil, nil, getCategoryAction(rules[1]), preview)
+	require.Empty(t, preview.directMatchSet)
+}
+
 func TestProcessTorrents_CategoryBlockedByCrossSeedCategory(t *testing.T) {
 	sm := qbittorrent.NewSyncManager(nil, nil)
 

--- a/internal/web/swagger/openapi.yaml
+++ b/internal/web/swagger/openapi.yaml
@@ -1,7 +1,11 @@
 openapi: 3.1.0
 info:
   title: qui API
-  description: qui API for managing multiple qBittorrent instances
+  description: |
+    qui API for managing multiple qBittorrent instances.
+    For automation create and update requests, set `conditions.category.enabled` to `true`
+    and `conditions.category.category` to an empty string to remove the torrent category.
+    Set `conditions.category.enabled` to `false` to disable the category action.
   version: 1.0.0
   license:
     name: GPL-2.0-or-later

--- a/web/src/components/instances/preferences/WorkflowDialog.test.tsx
+++ b/web/src/components/instances/preferences/WorkflowDialog.test.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import type { Automation } from "@/types"
+
+const mocks = vi.hoisted(() => {
+  const t = (key: string) => key
+  return {
+    query: { data: undefined },
+    translation: { t, i18n: { t, language: "en" } },
+    error: vi.fn(),
+    preview: vi.fn(),
+    save: vi.fn(),
+    dryRun: vi.fn().mockResolvedValue({ activities: [] }),
+  }
+})
+
+vi.mock("@tanstack/react-query", async (importOriginal) => ({
+  ...await importOriginal<typeof import("@tanstack/react-query")>(),
+  useQuery: () => mocks.query,
+}))
+vi.mock("@/hooks/useInstanceMetadata", () => ({ useInstanceMetadata: () => mocks.query }))
+vi.mock("@/hooks/useTrackerIcons", () => ({ useTrackerIcons: () => mocks.query }))
+vi.mock("react-i18next", async (importOriginal) => ({
+  ...await importOriginal<typeof import("react-i18next")>(),
+  useTranslation: () => mocks.translation,
+}))
+vi.mock("sonner", () => ({ toast: { error: mocks.error, success: vi.fn() } }))
+vi.mock("@/lib/api", () => ({
+  api: {
+    previewAutomation: mocks.preview,
+    updateAutomation: mocks.save,
+    dryRunAutomation: mocks.dryRun,
+  },
+}))
+
+const scrollIntoView = Object.getOwnPropertyDescriptor(Element.prototype, "scrollIntoView")
+
+afterEach(() => {
+  if (scrollIntoView) Object.defineProperty(Element.prototype, "scrollIntoView", scrollIntoView)
+  else Reflect.deleteProperty(Element.prototype, "scrollIntoView")
+  cleanup()
+  vi.clearAllMocks()
+  vi.restoreAllMocks()
+})
+
+import { WorkflowDialog } from "./WorkflowDialog"
+
+const rule: Automation = {
+  id: 1,
+  instanceId: 1,
+  name: "Category validation",
+  trackerPattern: "*",
+  conditions: { schemaVersion: "1", pause: { enabled: true } },
+  enabled: false,
+  dryRun: true,
+  notify: false,
+  sortOrder: 0,
+}
+
+const key = (suffix: string) => `preferences.workflowDialog.${suffix}`
+
+describe("WorkflowDialog category validation", () => {
+  it("rejects an unselected category for save, enable, and dry run, but accepts Uncategorized", async () => {
+    // Radix scrolls focused select options; jsdom has no layout.
+    Object.defineProperty(Element.prototype, "scrollIntoView", { configurable: true, value: vi.fn() })
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    render(
+      <QueryClientProvider client={client}>
+        <WorkflowDialog open onOpenChange={() => {}} instanceId={1} rule={rule} />
+      </QueryClientProvider>
+    )
+
+    fireEvent.keyDown(screen.getByText(key("actions.addAction")), { key: "ArrowDown" })
+    fireEvent.click(await screen.findByRole("option", { name: key("actions.category") }))
+
+    for (const control of [
+      screen.getByRole("button", { name: key("save") }),
+      screen.getByRole("switch", { name: key("footer.enabled") }),
+      screen.getByRole("button", { name: key("runDryRunNow") }),
+    ]) {
+      mocks.error.mockClear()
+      fireEvent.click(control)
+      expect(mocks.error).toHaveBeenCalledWith(key("toast.selectCategory"))
+      expect(mocks.save).not.toHaveBeenCalled()
+      expect(mocks.preview).not.toHaveBeenCalled()
+      expect(mocks.dryRun).not.toHaveBeenCalled()
+    }
+
+    fireEvent.keyDown(screen.getByText(key("category.selectCategory")), { key: "ArrowDown" })
+    fireEvent.click(await screen.findByRole("option", { name: key("uncategorized") }))
+    fireEvent.click(screen.getByRole("button", { name: key("runDryRunNow") }))
+    await waitFor(() => expect(mocks.dryRun).toHaveBeenCalledWith(1, expect.objectContaining({
+      conditions: expect.objectContaining({ category: expect.objectContaining({ enabled: true, category: "" }) }),
+    })))
+    client.clear()
+  })
+})

--- a/web/src/components/instances/preferences/WorkflowDialog.test.tsx
+++ b/web/src/components/instances/preferences/WorkflowDialog.test.tsx
@@ -47,6 +47,7 @@ afterEach(() => {
   cleanup()
   vi.clearAllMocks()
   vi.restoreAllMocks()
+  vi.unstubAllGlobals()
 })
 
 import { WorkflowDialog } from "./WorkflowDialog"
@@ -67,6 +68,11 @@ const key = (suffix: string) => `preferences.workflowDialog.${suffix}`
 
 describe("WorkflowDialog category validation", () => {
   it("rejects an unselected category for save, enable, and dry run, but accepts Uncategorized", async () => {
+    vi.stubGlobal("ResizeObserver", class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    })
     // Radix scrolls focused select options; jsdom has no layout.
     Object.defineProperty(Element.prototype, "scrollIntoView", { configurable: true, value: vi.fn() })
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })

--- a/web/src/components/instances/preferences/WorkflowDialog.tsx
+++ b/web/src/components/instances/preferences/WorkflowDialog.tsx
@@ -1345,6 +1345,14 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
     return true
   }, [hasLocalFilesystemAccess, supportsFreeSpacePathSource, t])
 
+  const validateCategory = useCallback((state: FormState): boolean => {
+    if (state.categoryEnabled && state.exprCategory === undefined) {
+      toast.error(t("preferences.workflowDialog.toast.selectCategory"))
+      return false
+    }
+    return true
+  }, [t])
+
   const hasValidFreeSpaceSourceForLivePreview = useCallback((state: FormState): boolean => {
     const usesFreeSpace = conditionUsesField(state.actionCondition, "FREE_SPACE")
     if (!usesFreeSpace || state.exprFreeSpaceSourceType !== "path") {
@@ -1792,6 +1800,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
     if (!open) return null
     if (!(isDeleteRule || isCategoryRule)) return null
     if (isDeleteRule && !formState.actionCondition) return null
+    if (isCategoryRule && formState.exprCategory === undefined) return null
     if (!formState.applyToAllTrackers && normalizeTrackerDomains(formState.trackerDomains).length === 0) return null
     if (!hasValidFreeSpaceSourceForLivePreview(formState)) return null
 
@@ -1856,6 +1865,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
   const handleRunDryRunNow = () => {
     const dryRunInput: FormState = { ...formState }
 
+    if (!validateCategory(dryRunInput)) return
     if (!validateFreeSpaceSource(dryRunInput)) return
     if (!dryRunInput.name.trim()) {
       toast.error(t("preferences.workflowDialog.toast.nameRequired"))
@@ -1920,6 +1930,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
       toast.error(t("preferences.workflowDialog.toast.deleteRequiresCondition"))
       return
     }
+    if (checked && !validateCategory(formState)) return
     if (checked && !validateExportTarget(formState)) {
       return
     }
@@ -1944,7 +1955,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
       enabled: checked,
       dryRun: options?.forceDryRun ? true : prev.dryRun,
     }))
-  }, [formState, isCategoryRule, isDeleteRule, startPreview, t, validateExportTarget, validateFreeSpaceSource])
+  }, [formState, isCategoryRule, isDeleteRule, startPreview, t, validateCategory, validateExportTarget, validateFreeSpaceSource])
 
   const handleEnabledToggle = useCallback((checked: boolean) => {
     if (checked && !formState.dryRun && !hasPromptedDryRun()) {
@@ -2142,12 +2153,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
         return
       }
     }
-    if (submitState.categoryEnabled) {
-      if (submitState.exprCategory === undefined) {
-        toast.error(t("preferences.workflowDialog.toast.selectCategory"))
-        return
-      }
-    }
+    if (!validateCategory(submitState)) return
     if (submitState.externalProgramEnabled) {
       if (!submitState.exprExternalProgramId) {
         toast.error(t("preferences.workflowDialog.toast.selectExternalProgram"))
@@ -2193,6 +2199,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
   }
 
   const handleConfirmSave = () => {
+    if (!validateCategory(formState)) return
     // Clear the stored value so onOpenChange won't restore it after successful save
     setEnabledBeforePreview(null)
     // Drop any preview still in flight; the user chose to save without it.

--- a/web/src/components/instances/preferences/WorkflowDialog.tsx
+++ b/web/src/components/instances/preferences/WorkflowDialog.tsx
@@ -488,7 +488,7 @@ type FormState = {
   // Tag action settings
   exprTagActions: TagActionForm[]
   // Category action settings
-  exprCategory: string
+  exprCategory: string | undefined
   exprIncludeCrossSeeds: boolean
   exprCategoryGroupId: string
   exprBlockIfCrossSeedInCategories: string[]
@@ -557,7 +557,7 @@ const emptyFormState: FormState = {
   exprFreeSpaceSourceType: "qbittorrent",
   exprFreeSpaceSourcePath: "",
   exprTagActions: [createDefaultTagAction()],
-  exprCategory: "",
+  exprCategory: undefined,
   exprIncludeCrossSeeds: false,
   exprCategoryGroupId: "",
   exprBlockIfCrossSeedInCategories: [],
@@ -798,7 +798,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
   // Build category options for the category action dropdown
   const categoryOptions = useMemo(() => {
     if (!metadata?.categories) return []
-    const selected = [formState.exprCategory, ...formState.exprBlockIfCrossSeedInCategories].filter(Boolean)
+    const selected = [formState.exprCategory, ...formState.exprBlockIfCrossSeedInCategories].filter((category): category is string => !!category)
     return buildCategorySelectOptions(metadata.categories, selected)
   }, [metadata?.categories, formState.exprCategory, formState.exprBlockIfCrossSeedInCategories])
 
@@ -1005,7 +1005,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
         let exprFreeSpaceSourceType: FormState["exprFreeSpaceSourceType"] = "qbittorrent"
         let exprFreeSpaceSourcePath = ""
         let exprTagActions: TagActionForm[] = [createDefaultTagAction()]
-        let exprCategory = ""
+        let exprCategory: string | undefined
         let exprIncludeCrossSeeds = false
         let exprBlockIfCrossSeedInCategories: string[] = []
         let sortingType: FormState["sortingType"] = "default"
@@ -1485,7 +1485,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
         conditions.tag = tagActions[0]
       }
     }
-    if (input.categoryEnabled) {
+    if (input.categoryEnabled && input.exprCategory !== undefined) {
       conditions.category = {
         enabled: true,
         category: input.exprCategory,
@@ -1616,6 +1616,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
   // Check if current form state represents a delete or category rule (both need previews)
   const isDeleteRule = formState.deleteEnabled
   const isCategoryRule = formState.categoryEnabled
+  const previewCategory = (previewInput?.exprCategory ?? formState.exprCategory) || t("preferences.workflowDialog.uncategorized")
 
   // Check if condition uses FREE_SPACE field (for free space source UI - shown regardless of action)
   const conditionUsesFreeSpace = useMemo(() => {
@@ -2142,7 +2143,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
       }
     }
     if (submitState.categoryEnabled) {
-      if (!submitState.exprCategory) {
+      if (submitState.exprCategory === undefined) {
         toast.error(t("preferences.workflowDialog.toast.selectCategory"))
         return
       }
@@ -3418,7 +3419,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
                           <div className="space-y-1">
                             <Label className="text-xs">{t("preferences.workflowDialog.category.moveToCategory")}</Label>
                             <Select
-                              value={formState.exprCategory === "" ? CATEGORY_UNCATEGORIZED_VALUE : formState.exprCategory}
+                              value={formState.exprCategory === "" ? CATEGORY_UNCATEGORIZED_VALUE : formState.exprCategory ?? ""}
                               onValueChange={(value) => setFormState(prev => ({
                                 ...prev,
                                 exprCategory: value === CATEGORY_UNCATEGORIZED_VALUE ? "" : value,
@@ -3441,7 +3442,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
                               </SelectContent>
                             </Select>
                           </div>
-                          {formState.exprCategory && (
+                          {formState.exprCategory !== undefined && (
                             <div className="flex items-center gap-2 mt-5">
                               <Switch
                                 id="include-crossseeds"
@@ -4192,7 +4193,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
         }}
         title={
           isDeleteRule? (formState.enabled? t("preferences.workflowDialog.preview.confirmDeleteRule"): t("preferences.workflowDialog.preview.previewDeleteRule")): t("preferences.workflowDialog.preview.confirmCategoryChange", {
-            category: previewInput?.exprCategory ?? formState.exprCategory,
+            category: previewCategory,
           })
         }
         description={
@@ -4221,7 +4222,7 @@ export function WorkflowDialog({ open, onOpenChange, instanceId, rule, onSuccess
                   {previewResult.crossSeedCount ? (
                     <> {t("preferences.workflowDialog.preview.and")} <strong>{previewResult.crossSeedCount}</strong> {t("preferences.workflowDialog.preview.crossSeeds", { count: previewResult.crossSeedCount })}</>
                   ) : null}
-                  {" "}{t("preferences.workflowDialog.preview.toCategory")} <strong>"{previewInput?.exprCategory ?? formState.exprCategory}"</strong>.
+                  {" "}{t("preferences.workflowDialog.preview.toCategory")} <strong>"{previewCategory}"</strong>.
                 </p>
                 <p className="text-muted-foreground text-sm">{t("preferences.workflowDialog.confirmSaveAndEnable")}</p>
               </>

--- a/web/src/components/instances/preferences/WorkflowsOverview.tsx
+++ b/web/src/components/instances/preferences/WorkflowsOverview.tsx
@@ -1902,7 +1902,7 @@ function RulePreview({
         {rule.conditions?.category?.enabled && (
           <Badge variant="outline" className="text-[10px] px-1.5 h-5 gap-0.5 cursor-default text-emerald-600 border-emerald-600/50">
             <Folder className="h-3 w-3" />
-            {rule.conditions.category.category}
+            {rule.conditions.category.category || t("preferences.workflowDialog.uncategorized")}
           </Badge>
         )}
         {rule.conditions?.move?.enabled && (


### PR DESCRIPTION
## Description

Allows automation workflows to clear torrent categories by selecting Uncategorized, while still rejecting an untouched category field.

Closes #2658

## How has this been tested?

Ran the production binary with temporary data and a localhost qBittorrent stub. The browser rejected an untouched category field, saved and reopened Uncategorized, exposed cross-seed controls, and displayed Uncategorized in the confirmation. A live dry run planned one category change and skipped the already uncategorized torrent. Automatic approval review blocked activation without dry run, so no category write was sent.

The follow-up also rejected an unselected Category beside Pause on Save, Enable, and Dry-run now; selecting Uncategorized saved both actions. The production workflow list displayed Uncategorized for an empty target and archive for a named target.

## Performance

Compared `e19a6ac1` with `e06c931d` using a temporary Go benchmark: one rule, 10,000 synthetic torrents, three runs per target, Linux amd64, Ryzen 7 8745HS, Go 1.27.1, no race detector. Median named-category processing was 5.632 ms before and 5.615 ms after (-0.3%), with 11.75 MB and 50,100 allocations per pass unchanged.

The latest develop merge (`33b71428`, merged as `d7a37b63`) changes only test infrastructure; the measured paths are identical. The validation follow-up (`5d0032ba`) adds scalar UI checks and skips automatic previews for unselected categories.

The empty target previously skipped action planning: 4.069 ms, 10.87 MB, 50,020 allocations. It now plans the requested changes: 5.475 ms, 11.75 MB, 50,100 allocations, comparable to a named category. The frontend changes scalar form state and labels without adding dependencies, scans, subscriptions, or requests.

## Screenshots (for UI changes)

Verified the production UI with synthetic torrents. No screenshot attached.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL
- [x] I completed the [mandatory performance checks](https://github.com/autobrr/qui/blob/develop/AGENTS.md#mandatory-performance-checks) and recorded the outcome in Performance


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automation category actions can target **Uncategorized** to remove a torrent’s category.
  - Uncategorized selections are supported when saving, previewing, or running automations.
  - Category actions now require a category selection before proceeding; **Uncategorized** remains a valid selection.
  - Automation overviews display the **Uncategorized** label for torrents without a category.

- **Documentation**
  - Updated user and API documentation to explain category removal and selection behavior.

- **Tests**
  - Added coverage for Uncategorized actions, validation, previews, and rule processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

