### PR TITLE
fix(web): serve a static favicon so Firefox background tabs are not blank

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,7 @@
 <html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/x-icon" href="data:," data-dynamic-favicon="svg" />
+    <link rel="icon" type="image/png" href="/favicon.png" data-dynamic-favicon="svg" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/web/src/index-html-favicon.test.ts
+++ b/web/src/index-html-favicon.test.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025-2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import { existsSync, readFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+// web/ root, one level up from src/
+const webRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const html = readFileSync(resolve(webRoot, "index.html"), "utf8")
+const iconLink = html.match(/<link[^>]*\brel="icon"[^>]*>/)?.[0] ?? ""
+
+describe("static favicon in index.html", () => {
+  // The pre-JS icon must be a real file, not the old blank "data:," placeholder:
+  // Firefox defers useDynamicFavicon's setTimeout in background tabs, so whatever
+  // index.html ships is what a background tab shows until it gains focus.
+  it("ships a real static icon the browser can show before JS runs", () => {
+    const href = iconLink.match(/\bhref="([^"]+)"/)?.[1]
+    expect(href).toBe("/favicon.png")
+    expect(iconLink).toContain("image/png")
+    expect(existsSync(resolve(webRoot, "public", "favicon.png"))).toBe(true)
+  })
+
+  // useDynamicFavicon upgrades this same node to the themed icon by finding it via
+  // data-dynamic-favicon, so the attribute must survive for the upgrade to still work.
+  it("keeps the data-dynamic-favicon hook target", () => {
+    expect(iconLink).toContain("data-dynamic-favicon=\"svg\"")
+  })
+})


### PR DESCRIPTION
Fixes #2645

The tab icon is blank in Firefox background tabs until the tab is focused.

Root cause: index.html ships the initial icon as `href="data:,"`, an empty data URI, and relies on `useDynamicFavicon` to swap in the themed icon after render. That hook runs on `setTimeout(0)`, and Firefox defers background-tab timers, so in a tab that opens in the background the swap does not happen until the tab gains focus. Until then the browser shows the empty `data:,` placeholder, which renders as a blank icon.

Fix: point the initial icon at the real `/favicon.png` (which already exists in `web/public/` and is already served by the Go handler) instead of the blank data URI, and set the matching `type="image/png"`. A background tab now shows the real logo immediately, and `useDynamicFavicon` still upgrades the same node to the themed icon once JS runs, because it finds the link by its `data-dynamic-favicon` attribute, which is unchanged.

This mirrors the `apple-touch-icon` link on the next line, which already uses `/apple-touch-icon.png`. Base-path deploys are covered: `serveSPA` in internal/web/handler.go already rewrites `href="/favicon.png"` to the base prefix, the same as it does for the apple-touch icon.

Added web/src/index-html-favicon.test.ts, which fails on the old blank `data:,` icon and passes on the static PNG, and checks that the `data-dynamic-favicon` hook target survives.

Verification: pnpm exec tsc -b clean, biome lint clean, vitest passes (the new test included), pnpm build produces a dist/index.html carrying the static icon.

AI disclosure: this change was prepared with AI assistance and reviewed by a human before submission, per AGENTS.md.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the browser favicon to use a static PNG image for more reliable display across environments.
  - Preserved dynamic favicon behavior for spreadsheet themes, including blanking the static icon while the themed favicon is rendered.
  - Improved resilience when reading saved theme preferences.

- **Tests**
  - Added coverage for static, blank, and dynamic favicon behavior across supported themes, while retaining verification of runtime favicon updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->