### PR TITLE
refactor(cache): migrate ttlcache to autobrr/go-cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/andybalholm/brotli v1.2.3
 	github.com/autobrr/autobrr v1.85.0
 	github.com/autobrr/go-bdinfo v0.4.3-0.20260905142019-c391e265ec72
+	github.com/autobrr/go-cache v1.0.0-rc1
 	github.com/autobrr/go-mediainfo v0.8.0
 	github.com/autobrr/go-qbittorrent v1.18.1-0.20260825200055-b0abc1c0134d
 	github.com/autobrr/go-torrent v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/autobrr/autobrr v1.85.0 h1:VwPob7J8ZRHcKggL6+VNTMiQgFJq5gPFfjxGJYOj0L
 github.com/autobrr/autobrr v1.85.0/go.mod h1:G0g9AN/A512KYmV7iQwCxhZybfY9gxZoHxd+kMvMiJ4=
 github.com/autobrr/go-bdinfo v0.4.3-0.20260905142019-c391e265ec72 h1:fQnXBwvj6HC4ahCgBNDn178ywMMlqD1oEcnrV8Lw7dI=
 github.com/autobrr/go-bdinfo v0.4.3-0.20260905142019-c391e265ec72/go.mod h1:OjpQR7TPcP7fBTo4GW1Yz1+biQG7YTo1OZH7KXX5gS0=
+github.com/autobrr/go-cache v1.0.0-rc1 h1:xqghz7o+4jvTOlyFq08JflUFps7eF9REdIjGkaHCqCY=
+github.com/autobrr/go-cache v1.0.0-rc1/go.mod h1:4dDdnZll98Xuz/ebmGALBeK3DiLXmJd7fwUSEWsw/l0=
 github.com/autobrr/go-mediainfo v0.8.0 h1:XzsjHvBOlGx2BnwYCqwCOIJsmrFy4BJb0jgoB2qKuR0=
 github.com/autobrr/go-mediainfo v0.8.0/go.mod h1:P3LGxIPznO2TLKV/e58YgN0/ozP5pLCAncFzsdxMDcY=
 github.com/autobrr/go-qbittorrent v1.18.1-0.20260825200055-b0abc1c0134d h1:oWXjEZZrc74m0/Cbmy7Yyeim97VjFUTekotsAC6v7uU=

--- a/internal/api/handlers/torrents_field_test.go
+++ b/internal/api/handlers/torrents_field_test.go
@@ -16,7 +16,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/autobrr/autobrr/pkg/ttlcache"
+	"github.com/autobrr/go-cache/ttlcache"
 	qbt "github.com/autobrr/go-qbittorrent"
 	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/require"
@@ -394,7 +394,7 @@ func newStaleCachedClient(t *testing.T, host string, torrents []qbt.Torrent) *qu
 	setUnexportedField(t, client, "isHealthy", true)
 	setUnexportedField(t, client, "lastHealthCheck", time.Now())
 	setUnexportedField(t, client, "syncManager", syncManager)
-	setUnexportedField(t, client, "optimisticUpdates", ttlcache.New(ttlcache.Options[string, *quiqbt.OptimisticTorrentUpdate]{}))
+	setUnexportedField(t, client, "optimisticUpdates", ttlcache.New[string, *quiqbt.OptimisticTorrentUpdate]())
 
 	return client
 }

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -589,6 +589,15 @@ func secureDatabaseFiles(databasePath string) error {
 	return nil
 }
 
+func newStmtCache() *ttlcache.Cache[string, *sql.Stmt] {
+	return ttlcache.New[string, *sql.Stmt](
+		ttlcache.SetDefaultTTL(5*time.Minute),
+		ttlcache.SetDeallocationFunc(func(_ string, s *sql.Stmt, _ ttlcache.DeallocationReason) {
+			_ = s.Close()
+		}),
+	)
+}
+
 // New opens the SQLite database at databasePath, creating the parent directory
 // and applying any pending migrations. The returned DB routes writes through a
 // single serialized connection and reads through a read-only pool.

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -64,7 +64,7 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/autobrr/autobrr/pkg/ttlcache"
+	"github.com/autobrr/go-cache/ttlcache"
 	"github.com/rs/zerolog/log"
 	"modernc.org/sqlite"
 
@@ -476,20 +476,21 @@ func (t *Tx) promoteStatementsToCache() {
 			return
 		}
 
-		// Double-check it's not already cached (race condition protection)
 		if _, found := stmts.Get(boundQuery); found {
 			t.db.stmtMu.RUnlock()
 			continue
 		}
 
-		// Prepare and cache the statement
 		stmt, err := conn.PrepareContext(ctx, boundQuery)
 		if err != nil {
 			t.db.stmtMu.RUnlock()
 			continue // silently skip - caching is best-effort
 		}
 
-		stmts.Set(boundQuery, stmt, ttlcache.DefaultTTL)
+		// Lost the race to another preparer: close ours, keep the cached one.
+		if _, loaded := stmts.GetOrSet(boundQuery, stmt, ttlcache.DefaultTTL); loaded {
+			_ = stmt.Close()
+		}
 		t.db.stmtMu.RUnlock()
 	}
 }
@@ -660,28 +661,11 @@ func New(databasePath string) (*DB, error) {
 		return nil, err
 	}
 
-	// create ttlcache for prepared statements with 5 minute TTL and deallocation func
-	writerStmtOpts := ttlcache.Options[string, *sql.Stmt]{}.SetDefaultTTL(5 * time.Minute).
-		SetDeallocationFunc(func(k string, s *sql.Stmt, _ ttlcache.DeallocationReason) {
-			if s != nil {
-				_ = s.Close()
-			}
-		})
-	readerStmtOpts := ttlcache.Options[string, *sql.Stmt]{}.SetDefaultTTL(5 * time.Minute).
-		SetDeallocationFunc(func(k string, s *sql.Stmt, _ ttlcache.DeallocationReason) {
-			if s != nil {
-				_ = s.Close()
-			}
-		})
-
-	writerStmtsCache := ttlcache.New(writerStmtOpts)
-	readerStmtsCache := ttlcache.New(readerStmtOpts)
-
 	db := &DB{
 		writerConn:      writerConn,
 		readerPool:      readerPool,
-		writerStmts:     writerStmtsCache,
-		readerStmts:     readerStmtsCache,
+		writerStmts:     newStmtCache(),
+		readerStmts:     newStmtCache(),
 		dialect:         DialectSQLite,
 		serializeWrites: true,
 	}
@@ -780,19 +764,17 @@ func (db *DB) getStmt(ctx context.Context, query string, tx *Tx) (*sql.Stmt, err
 	}
 
 	// Slow path: prepare new statement
-	// Note: Multiple goroutines might prepare the same query simultaneously,
-	// but this is acceptable since:
-	// 1. It's rare (only on cache miss/eviction)
-	// 2. The extra statements will be garbage collected
-	// 3. TTL cache will eventually converge to one statement per query
 	s, err := conn.PrepareContext(ctx, query)
 	if err != nil {
 		return nil, err
 	}
 
-	// Cache the statement - if another goroutine already cached it,
-	// that's fine, this one will be closed by the deallocation function
-	stmts.Set(query, s, ttlcache.DefaultTTL)
+	// Concurrent misses race to cache the same query; the loser closes its
+	// own never-used statement so the driver does not leak it.
+	if existing, loaded := stmts.GetOrSet(query, s, ttlcache.DefaultTTL); loaded {
+		_ = s.Close()
+		s = existing
+	}
 
 	if tx != nil {
 		// Return transaction-specific statement
@@ -1298,18 +1280,12 @@ func (db *DB) Close() error {
 
 		db.stmtMu.Lock()
 
-		// Close statement caches (will close all prepared statements)
-		// Track closed caches to avoid double-closing the same cache instance
-		closedCaches := make(map[*ttlcache.Cache[string, *sql.Stmt]]bool)
-
-		if db.writerStmts != nil && !closedCaches[db.writerStmts] {
+		if db.writerStmts != nil {
 			db.writerStmts.Close()
-			closedCaches[db.writerStmts] = true
 			db.writerStmts = nil
 		}
-		if db.readerStmts != nil && !closedCaches[db.readerStmts] {
+		if db.readerStmts != nil {
 			db.readerStmts.Close()
-			closedCaches[db.readerStmts] = true
 			db.readerStmts = nil
 		}
 

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -950,19 +950,19 @@ func TestGetStmtConcurrentMissSharesOneStatement(t *testing.T) {
 	const query = "SELECT 1"
 
 	stmts := make([]*sql.Stmt, 32)
+	errs := make([]error, len(stmts))
 	var wg sync.WaitGroup
 	for i := range stmts {
 		wg.Go(func() {
-			s, err := db.getStmt(ctx, query, nil)
-			require.NoError(t, err)
-			stmts[i] = s
+			stmts[i], errs[i] = db.getStmt(ctx, query, nil)
 		})
 	}
 	wg.Wait()
 
 	cached, found := db.readerStmts.Get(query)
 	require.True(t, found)
-	for _, s := range stmts {
+	for i, s := range stmts {
+		require.NoError(t, errs[i])
 		require.Same(t, cached, s)
 		var n int
 		require.NoError(t, s.QueryRowContext(ctx).Scan(&n))

--- a/internal/database/db_test.go
+++ b/internal/database/db_test.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -939,4 +940,31 @@ func TestReadOnlyTransactionConcurrency(t *testing.T) {
 
 	// Commit the write transaction
 	require.NoError(t, txWrite.Commit())
+}
+
+// Concurrent misses on one query must converge on a single cached statement;
+// the losers close theirs instead of leaking a driver-side prepared statement.
+func TestGetStmtConcurrentMissSharesOneStatement(t *testing.T) {
+	db := openTestDatabase(t)
+	ctx := t.Context()
+	const query = "SELECT 1"
+
+	stmts := make([]*sql.Stmt, 32)
+	var wg sync.WaitGroup
+	for i := range stmts {
+		wg.Go(func() {
+			s, err := db.getStmt(ctx, query, nil)
+			require.NoError(t, err)
+			stmts[i] = s
+		})
+	}
+	wg.Wait()
+
+	cached, found := db.readerStmts.Get(query)
+	require.True(t, found)
+	for _, s := range stmts {
+		require.Same(t, cached, s)
+		var n int
+		require.NoError(t, s.QueryRowContext(ctx).Scan(&n))
+	}
 }

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -12,7 +12,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/autobrr/autobrr/pkg/ttlcache"
+	"github.com/autobrr/go-cache/ttlcache"
 	"github.com/rs/zerolog/log"
 
 	// Register pgx as database/sql driver.
@@ -101,13 +101,12 @@ func newPostgres(dsn string, opts OpenOptions) (*DB, error) {
 }
 
 func newStmtCache() *ttlcache.Cache[string, *sql.Stmt] {
-	opts := ttlcache.Options[string, *sql.Stmt]{}.SetDefaultTTL(5 * time.Minute).
-		SetDeallocationFunc(func(_ string, s *sql.Stmt, _ ttlcache.DeallocationReason) {
-			if s != nil {
-				_ = s.Close()
-			}
-		})
-	return ttlcache.New(opts)
+	return ttlcache.New[string, *sql.Stmt](
+		ttlcache.SetDefaultTTL(5*time.Minute),
+		ttlcache.SetDeallocationFunc(func(_ string, s *sql.Stmt, _ ttlcache.DeallocationReason) {
+			_ = s.Close()
+		}),
+	)
 }
 
 func (db *DB) migratePostgres() error {

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -12,7 +12,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/autobrr/go-cache/ttlcache"
 	"github.com/rs/zerolog/log"
 
 	// Register pgx as database/sql driver.
@@ -98,15 +97,6 @@ func newPostgres(dsn string, opts OpenOptions) (*DB, error) {
 	go db.stringPoolCleanupLoop(cleanupCtx)
 
 	return db, nil
-}
-
-func newStmtCache() *ttlcache.Cache[string, *sql.Stmt] {
-	return ttlcache.New[string, *sql.Stmt](
-		ttlcache.SetDefaultTTL(5*time.Minute),
-		ttlcache.SetDeallocationFunc(func(_ string, s *sql.Stmt, _ ttlcache.DeallocationReason) {
-			_ = s.Close()
-		}),
-	)
 }
 
 func (db *DB) migratePostgres() error {

--- a/internal/qbittorrent/client.go
+++ b/internal/qbittorrent/client.go
@@ -1129,8 +1129,7 @@ func (c *Client) clearTrackerExclusions(domains []string) {
 
 // getOptimisticUpdates returns all current optimistic updates
 func (c *Client) getOptimisticUpdates() map[string]*OptimisticTorrentUpdate {
-	updates := maps.Collect(c.optimisticUpdates.All())
-	return updates
+	return maps.Collect(c.optimisticUpdates.All())
 }
 
 // clearOptimisticUpdate removes an optimistic update for a specific torrent

--- a/internal/qbittorrent/client.go
+++ b/internal/qbittorrent/client.go
@@ -17,7 +17,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/autobrr/autobrr/pkg/ttlcache"
+	"github.com/autobrr/go-cache/ttlcache"
 	qbt "github.com/autobrr/go-qbittorrent"
 	"github.com/avast/retry-go"
 	"github.com/pkg/errors"
@@ -186,8 +186,8 @@ func NewClientWithTimeout(instanceID int, instanceHost, username, password, apiK
 		instanceID:      instanceID,
 		lastHealthCheck: time.Now(),
 		isHealthy:       true,
-		optimisticUpdates: ttlcache.New(ttlcache.Options[string, *OptimisticTorrentUpdate]{}.
-			SetDefaultTTL(30 * time.Second)), // Updates expire after 30 seconds
+		optimisticUpdates: ttlcache.New[string, *OptimisticTorrentUpdate](
+			ttlcache.SetDefaultTTL(30 * time.Second)), // Updates expire after 30 seconds
 		trackerExclusions: make(map[string]map[string]struct{}),
 		peerSyncManager:   make(map[string]*peerSyncEntry),
 		completionState:   make(map[string]bool),
@@ -1129,12 +1129,7 @@ func (c *Client) clearTrackerExclusions(domains []string) {
 
 // getOptimisticUpdates returns all current optimistic updates
 func (c *Client) getOptimisticUpdates() map[string]*OptimisticTorrentUpdate {
-	updates := make(map[string]*OptimisticTorrentUpdate)
-	for _, key := range c.optimisticUpdates.GetKeys() {
-		if val, found := c.optimisticUpdates.Get(key); found {
-			updates[key] = val
-		}
-	}
+	updates := maps.Collect(c.optimisticUpdates.All())
 	return updates
 }
 

--- a/internal/qbittorrent/pool.go
+++ b/internal/qbittorrent/pool.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/autobrr/autobrr/pkg/ttlcache"
+	"github.com/autobrr/go-cache/ttlcache"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 
@@ -158,8 +158,8 @@ type ClientPool struct {
 // creation budget.
 func NewClientPool(instanceStore *models.InstanceStore, errorStore *models.InstanceErrorStore, clientTimeout time.Duration) (*ClientPool, error) {
 	// Create cache with 30 second TTL since torrent data changes frequently
-	cache := ttlcache.New(ttlcache.Options[string, *TorrentResponse]{}.
-		SetDefaultTTL(30 * time.Second))
+	cache := ttlcache.New[string, *TorrentResponse](
+		ttlcache.SetDefaultTTL(30 * time.Second))
 
 	cp := &ClientPool{
 		clients:           make(map[int]*Client),

--- a/internal/qbittorrent/search_fastpath_test.go
+++ b/internal/qbittorrent/search_fastpath_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/autobrr/autobrr/pkg/ttlcache"
+	"github.com/autobrr/go-cache/ttlcache"
 	qbt "github.com/autobrr/go-qbittorrent"
 	"github.com/expr-lang/expr/vm"
 	"github.com/lithammer/fuzzysearch/fuzzy"
@@ -70,7 +70,7 @@ func TestRankFuzzyMatchesLibrary(t *testing.T) {
 // Expression filters had no coverage in this package, and the manual filter
 // loop now hands expr.Run a dereferenced pointer. Pin that the env still works.
 func TestApplyManualFiltersExprFilter(t *testing.T) {
-	sm := &SyncManager{exprCache: ttlcache.New(ttlcache.Options[string, *vm.Program]{}.SetDefaultTTL(5 * time.Minute))}
+	sm := &SyncManager{exprCache: ttlcache.New[string, *vm.Program](ttlcache.SetDefaultTTL(5 * time.Minute))}
 	torrents := []qbt.Torrent{
 		{Hash: "A", Name: "low", Ratio: 0.5},
 		{Hash: "B", Name: "high", Ratio: 2.5},

--- a/internal/qbittorrent/sync_manager.go
+++ b/internal/qbittorrent/sync_manager.go
@@ -22,7 +22,7 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/autobrr/autobrr/pkg/ttlcache"
+	"github.com/autobrr/go-cache/ttlcache"
 	qbt "github.com/autobrr/go-qbittorrent"
 	"github.com/expr-lang/expr"
 	"github.com/expr-lang/expr/vm"
@@ -73,7 +73,7 @@ type TorrentCompletionHandler func(ctx context.Context, instanceID int, torrent 
 type TorrentAddedHandler func(ctx context.Context, instanceID int, torrent qbt.Torrent)
 
 // Global URL cache for domain extraction - shared across all sync managers
-var urlCache = ttlcache.New(ttlcache.Options[string, string]{}.SetDefaultTTL(5 * time.Minute))
+var urlCache = ttlcache.New[string, string](ttlcache.SetDefaultTTL(5 * time.Minute))
 
 type filesCacheContextKey struct{}
 type filesCacheMaxAgeContextKey struct{}
@@ -466,7 +466,7 @@ func NewSyncManager(clientPool *ClientPool, trackerCustomizationStore TrackerCus
 	sm := &SyncManager{
 		clientPool:                clientPool,
 		trackerCustomizationStore: trackerCustomizationStore,
-		exprCache:                 ttlcache.New(ttlcache.Options[string, *vm.Program]{}.SetDefaultTTL(5 * time.Minute)),
+		exprCache:                 ttlcache.New[string, *vm.Program](ttlcache.SetDefaultTTL(5 * time.Minute)),
 		debouncedSyncTimers:       make(map[int]*time.Timer),
 		syncDebounceDelay:         200 * time.Millisecond,
 		syncDebounceMinJitter:     10 * time.Millisecond,
@@ -476,7 +476,7 @@ func NewSyncManager(clientPool *ClientPool, trackerCustomizationStore TrackerCus
 		trackerHealthCancel:       make(map[int]context.CancelFunc),
 		trackerHealthRefresh:      60 * time.Second,
 		validatedTrackerMapping:   make(map[int]*ValidatedTrackerMapping),
-		trackerDisplayNameCache:   ttlcache.New(ttlcache.Options[string, map[string]string]{}.SetDefaultTTL(60 * time.Second)),
+		trackerDisplayNameCache:   ttlcache.New[string, map[string]string](ttlcache.SetDefaultTTL(60 * time.Second)),
 	}
 
 	// Set up bidirectional reference for background task notifications

--- a/internal/services/crossseed/async_filtering_content_type_test.go
+++ b/internal/services/crossseed/async_filtering_content_type_test.go
@@ -16,7 +16,7 @@ import (
 	qbt "github.com/autobrr/go-qbittorrent"
 	"github.com/stretchr/testify/require"
 
-	"github.com/autobrr/autobrr/pkg/ttlcache"
+	"github.com/autobrr/go-cache/ttlcache"
 
 	"github.com/autobrr/qui/internal/models"
 	"github.com/autobrr/qui/internal/services/jackett"
@@ -82,7 +82,7 @@ func TestSearchIgnoresCachedFilteringStateForDifferentContentType(t *testing.T) 
 			}
 			settings := models.DefaultCrossSeedAutomationSettings()
 
-			filterCache := ttlcache.New(ttlcache.Options[string, *AsyncIndexerFilteringState]{})
+			filterCache := ttlcache.New[string, *AsyncIndexerFilteringState]()
 			filterCache.Set(asyncFilteringCacheKey(instanceID, sourceHash), &AsyncIndexerFilteringState{
 				CapabilitiesCompleted: true,
 				ContentCompleted:      true,
@@ -108,7 +108,7 @@ func TestSearchIgnoresCachedFilteringStateForDifferentContentType(t *testing.T) 
 				}),
 				asyncFilteringCache: filterCache,
 				releaseCache:        NewReleaseCache(),
-				searchResultCache:   ttlcache.New(ttlcache.Options[string, cachedTorrentSearchResults]{}),
+				searchResultCache:   ttlcache.New[string, cachedTorrentSearchResults](),
 				stringNormalizer:    stringutils.NewDefaultNormalizer(),
 				automationSettingsLoader: func(context.Context) (*models.CrossSeedAutomationSettings, error) {
 					return settings, nil
@@ -137,7 +137,7 @@ func TestFinishedWorkerCannotRestoreReplacedCacheEntry(t *testing.T) {
 	key := asyncFilteringCacheKey(instanceID, hash)
 
 	svc := &Service{
-		asyncFilteringCache: ttlcache.New(ttlcache.Options[string, *AsyncIndexerFilteringState]{}),
+		asyncFilteringCache: ttlcache.New[string, *AsyncIndexerFilteringState](),
 	}
 
 	stateA := &AsyncIndexerFilteringState{
@@ -190,7 +190,7 @@ func TestAnalyzeAsyncDoesNotCacheFailedIndexerDiscovery(t *testing.T) {
 		FilteredIndexers:      []int{7},
 		contentType:           "audiobook",
 	}
-	cache := ttlcache.New(ttlcache.Options[string, *AsyncIndexerFilteringState]{})
+	cache := ttlcache.New[string, *AsyncIndexerFilteringState]()
 	cache.Set(asyncFilteringCacheKey(instanceID, hash), staleState, ttlcache.DefaultTTL)
 
 	svc := &Service{
@@ -232,7 +232,7 @@ func TestAnalyzeAsyncReusesOnlyMatchingContentType(t *testing.T) {
 			FilteredIndexers:      []int{7},
 			contentType:           cachedType,
 		}
-		cache := ttlcache.New(ttlcache.Options[string, *AsyncIndexerFilteringState]{})
+		cache := ttlcache.New[string, *AsyncIndexerFilteringState]()
 		cache.Set(asyncFilteringCacheKey(instanceID, hash), cachedState, ttlcache.DefaultTTL)
 		return &Service{
 			instanceStore: &fakeInstanceStore{instances: map[int]*models.Instance{instanceID: instance}},

--- a/internal/services/crossseed/completion_exact_size_test.go
+++ b/internal/services/crossseed/completion_exact_size_test.go
@@ -11,7 +11,7 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/autobrr/autobrr/pkg/ttlcache"
+	"github.com/autobrr/go-cache/ttlcache"
 	qbt "github.com/autobrr/go-qbittorrent"
 	"github.com/stretchr/testify/require"
 
@@ -72,7 +72,7 @@ func TestExecuteCompletionSearchPropagatesExactSizeDecision(t *testing.T) {
 		Progress:  1,
 	}
 	settings := models.DefaultCrossSeedAutomationSettings()
-	filterCache := ttlcache.New(ttlcache.Options[string, *AsyncIndexerFilteringState]{})
+	filterCache := ttlcache.New[string, *AsyncIndexerFilteringState]()
 	filterCache.Set(asyncFilteringCacheKey(instanceID, sourceHash), &AsyncIndexerFilteringState{
 		CapabilitiesCompleted: true,
 		ContentCompleted:      true,
@@ -98,7 +98,7 @@ func TestExecuteCompletionSearchPropagatesExactSizeDecision(t *testing.T) {
 		}),
 		asyncFilteringCache: filterCache,
 		releaseCache:        NewReleaseCache(),
-		searchResultCache:   ttlcache.New(ttlcache.Options[string, cachedTorrentSearchResults]{}),
+		searchResultCache:   ttlcache.New[string, cachedTorrentSearchResults](),
 		stringNormalizer:    stringutils.NewDefaultNormalizer(),
 		automationSettingsLoader: func(context.Context) (*models.CrossSeedAutomationSettings, error) {
 			return settings, nil

--- a/internal/services/crossseed/find_individual_episodes_test.go
+++ b/internal/services/crossseed/find_individual_episodes_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/autobrr/autobrr/pkg/ttlcache"
+	"github.com/autobrr/go-cache/ttlcache"
 	qbt "github.com/autobrr/go-qbittorrent"
 	"github.com/stretchr/testify/require"
 
@@ -119,7 +119,7 @@ func TestApplyTorrentSearchResultsPropagatesEpisodeFlag(t *testing.T) {
 	service := &Service{
 		syncManager:         sync,
 		releaseCache:        NewReleaseCache(),
-		searchResultCache:   ttlcache.New(ttlcache.Options[string, cachedTorrentSearchResults]{}),
+		searchResultCache:   ttlcache.New[string, cachedTorrentSearchResults](),
 		torrentDownloadFunc: func(context.Context, jackett.TorrentDownloadRequest) ([]byte, error) { return []byte("torrent"), nil },
 		automationSettingsLoader: func(context.Context) (*models.CrossSeedAutomationSettings, error) {
 			settings := models.DefaultCrossSeedAutomationSettings()
@@ -189,7 +189,7 @@ func TestCacheSearchResultsEmptyResultsOverwritePrevious(t *testing.T) {
 	t.Parallel()
 
 	service := &Service{
-		searchResultCache: ttlcache.New(ttlcache.Options[string, cachedTorrentSearchResults]{}),
+		searchResultCache: ttlcache.New[string, cachedTorrentSearchResults](),
 	}
 
 	const (

--- a/internal/services/crossseed/search_candidate_match_test.go
+++ b/internal/services/crossseed/search_candidate_match_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/autobrr/autobrr/pkg/ttlcache"
+	"github.com/autobrr/go-cache/ttlcache"
 	qbt "github.com/autobrr/go-qbittorrent"
 	"github.com/moistari/rls"
 	"github.com/stretchr/testify/require"
@@ -1303,7 +1303,7 @@ func TestClassifySearchSizeEvidenceExactOnly(t *testing.T) {
 func TestSearchCandidateARRSourceTitlesSurviveResultCache(t *testing.T) {
 	service := &Service{
 		stringNormalizer:  stringutils.NewDefaultNormalizer(),
-		searchResultCache: ttlcache.New(ttlcache.Options[string, cachedTorrentSearchResults]{}),
+		searchResultCache: ttlcache.New[string, cachedTorrentSearchResults](),
 	}
 	const (
 		sourceName    = "La.Casa.De.Papel.S01E01.1080p.NF.WEB-DL.DDP5.1.H.264-NTb"
@@ -1717,7 +1717,7 @@ func TestApplyTorrentSearchResultsLimitsTitleRescueAttemptsPerSearch(t *testing.
 			{Hash: sourceHash, Name: "Source"},
 			{Hash: "existing", Name: "Existing"},
 		}, nil),
-		searchResultCache: ttlcache.New(ttlcache.Options[string, cachedTorrentSearchResults]{}),
+		searchResultCache: ttlcache.New[string, cachedTorrentSearchResults](),
 		torrentDownloadFunc: func(context.Context, jackett.TorrentDownloadRequest) ([]byte, error) {
 			return []byte("torrent"), nil
 		},
@@ -1801,7 +1801,7 @@ func TestApplyTorrentSearchResultsBlocksTitleRescueWhenSkipRecheck(t *testing.T)
 		syncManager: newFakeSyncManager(instance, []qbt.Torrent{
 			{Hash: sourceHash, Name: "Source"},
 		}, nil),
-		searchResultCache: ttlcache.New(ttlcache.Options[string, cachedTorrentSearchResults]{}),
+		searchResultCache: ttlcache.New[string, cachedTorrentSearchResults](),
 		torrentDownloadFunc: func(context.Context, jackett.TorrentDownloadRequest) ([]byte, error) {
 			downloads.Add(1)
 			return []byte("torrent"), nil
@@ -2429,7 +2429,7 @@ func TestARRAliasSurvivesSearchToManualAndAutomatedApply(t *testing.T) {
 		Size:     candidateSize,
 		Progress: 1,
 	}
-	filterCache := ttlcache.New(ttlcache.Options[string, *AsyncIndexerFilteringState]{})
+	filterCache := ttlcache.New[string, *AsyncIndexerFilteringState]()
 	filterCache.Set(asyncFilteringCacheKey(instanceID, sourceHash), &AsyncIndexerFilteringState{
 		CapabilitiesCompleted: true,
 		ContentCompleted:      false,
@@ -2461,7 +2461,7 @@ func TestARRAliasSurvivesSearchToManualAndAutomatedApply(t *testing.T) {
 		arrService:          arrLookup,
 		asyncFilteringCache: filterCache,
 		releaseCache:        NewReleaseCache(),
-		searchResultCache:   ttlcache.New(ttlcache.Options[string, cachedTorrentSearchResults]{}),
+		searchResultCache:   ttlcache.New[string, cachedTorrentSearchResults](),
 		stringNormalizer:    stringutils.NewDefaultNormalizer(),
 	}
 

--- a/internal/services/crossseed/search_trace_test.go
+++ b/internal/services/crossseed/search_trace_test.go
@@ -11,7 +11,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/autobrr/autobrr/pkg/ttlcache"
+	"github.com/autobrr/go-cache/ttlcache"
 	qbt "github.com/autobrr/go-qbittorrent"
 
 	"github.com/autobrr/qui/internal/models"
@@ -106,7 +106,7 @@ func TestSearchTorrentMatches_TraceCountsRawCandidates(t *testing.T) {
 		sourceName = "Example.Show.S01E01.1080p.WEB-DL.DDP5.1.H.264-GROUP"
 	)
 
-	filterCache := ttlcache.New(ttlcache.Options[string, *AsyncIndexerFilteringState]{})
+	filterCache := ttlcache.New[string, *AsyncIndexerFilteringState]()
 	cacheKey := asyncFilteringCacheKey(instanceID, sourceHash)
 	filterCache.Set(cacheKey, &AsyncIndexerFilteringState{
 		CapabilitiesCompleted: true,

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -35,7 +35,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/autobrr/autobrr/pkg/ttlcache"
+	"github.com/autobrr/go-cache/ttlcache"
 	mediainfo "github.com/autobrr/go-mediainfo"
 	qbt "github.com/autobrr/go-qbittorrent"
 	"github.com/autobrr/go-torrent/metainfo"
@@ -568,20 +568,21 @@ func NewService(
 	metadataCredsRevisionLoader func(ctx context.Context) (time.Time, error),
 	metadataCredentialLoader func(ctx context.Context) (apiKey, pin string, err error),
 ) *Service {
-	searchCache := ttlcache.New(ttlcache.Options[string, cachedTorrentSearchResults]{}.
-		SetDefaultTTL(searchResultCacheTTL))
+	searchCache := ttlcache.New[string, cachedTorrentSearchResults](
+		ttlcache.SetDefaultTTL(searchResultCacheTTL))
 
-	asyncFilteringCache := ttlcache.New(ttlcache.Options[string, *AsyncIndexerFilteringState]{}.
-		SetDefaultTTL(searchResultCacheTTL). // Use same TTL as search results
+	asyncFilteringCache := ttlcache.New[string, *AsyncIndexerFilteringState](
+		ttlcache.SetDefaultTTL(searchResultCacheTTL), // Use same TTL as search results
 		// The cache holds live state pointers; the TTL-refresh write-back on Get
 		// could restore a replaced entry (autobrr#2637), so disable it.
-		DisableUpdateTime(true))
-	indexerDomainCache := ttlcache.New(ttlcache.Options[string, string]{}.
-		SetDefaultTTL(indexerDomainCacheTTL))
-	contentFilesCache := ttlcache.New(ttlcache.Options[string, qbt.TorrentFiles]{}.
-		SetDefaultTTL(5 * time.Minute))
-	dedupCache := ttlcache.New(ttlcache.Options[string, *dedupCacheEntry]{}.
-		SetDefaultTTL(5 * time.Minute))
+		ttlcache.DisableUpdateTime(true),
+	)
+	indexerDomainCache := ttlcache.New[string, string](
+		ttlcache.SetDefaultTTL(indexerDomainCacheTTL))
+	contentFilesCache := ttlcache.New[string, qbt.TorrentFiles](
+		ttlcache.SetDefaultTTL(5 * time.Minute))
+	dedupCache := ttlcache.New[string, *dedupCacheEntry](
+		ttlcache.SetDefaultTTL(5 * time.Minute))
 
 	recheckCtx, recheckCancel := context.WithCancel(context.Background()) //nolint:gosec // G118: service-lifetime context, cancelled on shutdown
 	var arrLookup arrLookupService

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -572,11 +572,7 @@ func NewService(
 		ttlcache.SetDefaultTTL(searchResultCacheTTL))
 
 	asyncFilteringCache := ttlcache.New[string, *AsyncIndexerFilteringState](
-		ttlcache.SetDefaultTTL(searchResultCacheTTL), // Use same TTL as search results
-		// The cache holds live state pointers; the TTL-refresh write-back on Get
-		// could restore a replaced entry (autobrr#2637), so disable it.
-		ttlcache.DisableUpdateTime(true),
-	)
+		ttlcache.SetDefaultTTL(searchResultCacheTTL)) // Use same TTL as search results
 	indexerDomainCache := ttlcache.New[string, string](
 		ttlcache.SetDefaultTTL(indexerDomainCacheTTL))
 	contentFilesCache := ttlcache.New[string, qbt.TorrentFiles](

--- a/internal/services/crossseed/service.go
+++ b/internal/services/crossseed/service.go
@@ -572,7 +572,9 @@ func NewService(
 		ttlcache.SetDefaultTTL(searchResultCacheTTL))
 
 	asyncFilteringCache := ttlcache.New[string, *AsyncIndexerFilteringState](
-		ttlcache.SetDefaultTTL(searchResultCacheTTL)) // Use same TTL as search results
+		ttlcache.SetDefaultTTL(searchResultCacheTTL),
+		// The UI polls this state, so a refreshing Get would never let it expire.
+		ttlcache.DisableUpdateTime(true))
 	indexerDomainCache := ttlcache.New[string, string](
 		ttlcache.SetDefaultTTL(indexerDomainCacheTTL))
 	contentFilesCache := ttlcache.New[string, qbt.TorrentFiles](

--- a/internal/services/crossseed/service_duplicate_filtering_test.go
+++ b/internal/services/crossseed/service_duplicate_filtering_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/autobrr/autobrr/pkg/ttlcache"
+	"github.com/autobrr/go-cache/ttlcache"
 	qbt "github.com/autobrr/go-qbittorrent"
 	"github.com/stretchr/testify/require"
 
@@ -385,7 +385,7 @@ func TestBuildTorrentSearchResultsKeepsDuplicateRejectedByContentPrefilter(t *te
 				duplicateHash: existing,
 			},
 		},
-		asyncFilteringCache: ttlcache.New(ttlcache.Options[string, *AsyncIndexerFilteringState]{}),
+		asyncFilteringCache: ttlcache.New[string, *AsyncIndexerFilteringState](),
 	}
 	svc.asyncFilteringCache.Set(asyncFilteringCacheKey(instanceID, sourceHash), &AsyncIndexerFilteringState{
 		CapabilitiesCompleted: true,
@@ -441,7 +441,7 @@ func TestFilterSearchResultsByLateContentFilterMissingOrIncompleteStateLeavesRes
 		{Indexer: "Indexer One", IndexerID: 1, Title: "Source.Movie.2015.1080p.BluRay-GROUP"},
 	}
 	svc := &Service{
-		asyncFilteringCache: ttlcache.New(ttlcache.Options[string, *AsyncIndexerFilteringState]{}),
+		asyncFilteringCache: ttlcache.New[string, *AsyncIndexerFilteringState](),
 	}
 
 	filtered, snapshot, dropped := svc.filterSearchResultsByLateContentFilter(instanceID, source, results)
@@ -472,7 +472,7 @@ func TestFilterSearchResultsByLateContentFilterCompletedStateNoExcludedResultInd
 		{Indexer: "Indexer Two", IndexerID: 2, Title: "Source.Movie.2015.1080p.BluRay-GROUP"},
 	}
 	svc := &Service{
-		asyncFilteringCache: ttlcache.New(ttlcache.Options[string, *AsyncIndexerFilteringState]{}),
+		asyncFilteringCache: ttlcache.New[string, *AsyncIndexerFilteringState](),
 	}
 	svc.asyncFilteringCache.Set(asyncFilteringCacheKey(instanceID, source.Hash), &AsyncIndexerFilteringState{
 		CapabilitiesCompleted: true,
@@ -494,7 +494,7 @@ func TestFilterSearchResultsByLateContentFilterCompletedStateWithNoResultsReturn
 	const instanceID = 1
 	source := &qbt.Torrent{Hash: "sourcehash", Name: "Source.Movie.2015.1080p.BluRay-GROUP"}
 	svc := &Service{
-		asyncFilteringCache: ttlcache.New(ttlcache.Options[string, *AsyncIndexerFilteringState]{}),
+		asyncFilteringCache: ttlcache.New[string, *AsyncIndexerFilteringState](),
 	}
 	svc.asyncFilteringCache.Set(asyncFilteringCacheKey(instanceID, source.Hash), &AsyncIndexerFilteringState{
 		CapabilitiesCompleted: true,
@@ -542,7 +542,7 @@ func TestSearchTorrentMatchesRefreshesLateFilterStatus(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			filterCache := ttlcache.New(ttlcache.Options[string, *AsyncIndexerFilteringState]{})
+			filterCache := ttlcache.New[string, *AsyncIndexerFilteringState]()
 			cacheKey := asyncFilteringCacheKey(instanceID, sourceHash)
 			filterCache.Set(cacheKey, &AsyncIndexerFilteringState{
 				CapabilitiesCompleted: true,
@@ -627,7 +627,7 @@ func TestFilterSearchResultsByLateContentFilterDropsExcludedIndexers(t *testing.
 		{Indexer: "Indexer Three", IndexerID: 3, Title: "Source.Movie.2015.1080p.BluRay-GROUP"},
 	}
 	svc := &Service{
-		asyncFilteringCache: ttlcache.New(ttlcache.Options[string, *AsyncIndexerFilteringState]{}),
+		asyncFilteringCache: ttlcache.New[string, *AsyncIndexerFilteringState](),
 	}
 	svc.asyncFilteringCache.Set(asyncFilteringCacheKey(instanceID, source.Hash), &AsyncIndexerFilteringState{
 		CapabilitiesCompleted: true,
@@ -662,7 +662,7 @@ func TestFilterSearchResultsByLateContentFilterNearMissRegression(t *testing.T) 
 		{Indexer: "AllowedIndexer", IndexerID: 34, Title: releaseTitle},
 	}
 	svc := &Service{
-		asyncFilteringCache: ttlcache.New(ttlcache.Options[string, *AsyncIndexerFilteringState]{}),
+		asyncFilteringCache: ttlcache.New[string, *AsyncIndexerFilteringState](),
 	}
 	svc.asyncFilteringCache.Set(asyncFilteringCacheKey(instanceID, source.Hash), &AsyncIndexerFilteringState{
 		CapabilitiesCompleted: true,
@@ -709,7 +709,7 @@ func TestApplyTorrentSearchResultsSkipsCachedSelectionWhenInfohashExists(t *test
 			},
 		},
 		syncManager:       sync,
-		searchResultCache: ttlcache.New(ttlcache.Options[string, cachedTorrentSearchResults]{}),
+		searchResultCache: ttlcache.New[string, cachedTorrentSearchResults](),
 		torrentDownloadFunc: func(context.Context, jackett.TorrentDownloadRequest) ([]byte, error) {
 			downloadCalled.Store(true)
 			return []byte("torrent"), nil
@@ -774,8 +774,8 @@ func TestApplyTorrentSearchResultsFailsCachedSelectionWhenRejectedInfohashExists
 			},
 		},
 		syncManager:         sync,
-		asyncFilteringCache: ttlcache.New(ttlcache.Options[string, *AsyncIndexerFilteringState]{}),
-		searchResultCache:   ttlcache.New(ttlcache.Options[string, cachedTorrentSearchResults]{}),
+		asyncFilteringCache: ttlcache.New[string, *AsyncIndexerFilteringState](),
+		searchResultCache:   ttlcache.New[string, cachedTorrentSearchResults](),
 		torrentDownloadFunc: func(context.Context, jackett.TorrentDownloadRequest) ([]byte, error) {
 			downloadCalled.Store(true)
 			return []byte("torrent"), nil
@@ -852,8 +852,8 @@ func TestApplyTorrentSearchResultsSkipsCachedSelectionWhenRejectedInfohashExists
 			},
 		},
 		syncManager:         sync,
-		asyncFilteringCache: ttlcache.New(ttlcache.Options[string, *AsyncIndexerFilteringState]{}),
-		searchResultCache:   ttlcache.New(ttlcache.Options[string, cachedTorrentSearchResults]{}),
+		asyncFilteringCache: ttlcache.New[string, *AsyncIndexerFilteringState](),
+		searchResultCache:   ttlcache.New[string, cachedTorrentSearchResults](),
 		torrentDownloadFunc: func(context.Context, jackett.TorrentDownloadRequest) ([]byte, error) {
 			downloadCalled.Store(true)
 			return []byte("torrent"), nil
@@ -913,7 +913,7 @@ func TestExecuteCrossSeedSearchAttemptFailsExistingRejectedByPrefilterWithoutPer
 	var downloadCalled atomic.Bool
 	var invokerCalled atomic.Bool
 	svc := &Service{
-		asyncFilteringCache: ttlcache.New(ttlcache.Options[string, *AsyncIndexerFilteringState]{}),
+		asyncFilteringCache: ttlcache.New[string, *AsyncIndexerFilteringState](),
 		torrentDownloadFunc: func(context.Context, jackett.TorrentDownloadRequest) ([]byte, error) {
 			downloadCalled.Store(true)
 			return []byte("torrent"), nil
@@ -984,7 +984,7 @@ func TestExecuteCrossSeedSearchAttemptFailsKnownRejectedInfohashWithoutDownloadi
 	var downloadCalled atomic.Bool
 	var invokerCalled atomic.Bool
 	svc := &Service{
-		asyncFilteringCache: ttlcache.New(ttlcache.Options[string, *AsyncIndexerFilteringState]{}),
+		asyncFilteringCache: ttlcache.New[string, *AsyncIndexerFilteringState](),
 		torrentDownloadFunc: func(context.Context, jackett.TorrentDownloadRequest) ([]byte, error) {
 			downloadCalled.Store(true)
 			return []byte("torrent"), nil
@@ -1044,7 +1044,7 @@ func TestApplyTorrentSearchResultsPropagatesCachedDuplicateContextError(t *testi
 	var downloadCalled atomic.Bool
 	svc := &Service{
 		syncManager:       sync,
-		searchResultCache: ttlcache.New(ttlcache.Options[string, cachedTorrentSearchResults]{}),
+		searchResultCache: ttlcache.New[string, cachedTorrentSearchResults](),
 		torrentDownloadFunc: func(context.Context, jackett.TorrentDownloadRequest) ([]byte, error) {
 			downloadCalled.Store(true)
 			return []byte("torrent"), nil

--- a/pkg/releases/parser.go
+++ b/pkg/releases/parser.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/autobrr/autobrr/pkg/ttlcache"
+	"github.com/autobrr/go-cache/ttlcache"
 	"github.com/moistari/rls"
 
 	"github.com/autobrr/qui/pkg/stringutils"
@@ -40,8 +40,8 @@ type Parser struct {
 
 // NewParser returns a parser with the provided TTL for cached entries.
 func NewParser(ttl time.Duration) *Parser {
-	cache := ttlcache.New(ttlcache.Options[string, *rls.Release]{}.
-		SetDefaultTTL(ttl))
+	cache := ttlcache.New[string, *rls.Release](
+		ttlcache.SetDefaultTTL(ttl))
 	return &Parser{
 		cache:         cache,
 		keyNormalizer: stringutils.NewNormalizer(ttl, strings.TrimSpace),

--- a/pkg/stringutils/normalize.go
+++ b/pkg/stringutils/normalize.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/autobrr/autobrr/pkg/ttlcache"
+	"github.com/autobrr/go-cache/ttlcache"
 )
 
 const defaultNormalizerTTL = 5 * time.Minute
@@ -23,8 +23,8 @@ type Normalizer[K comparable, V any] struct {
 
 // NewNormalizer returns a normalizer with the provided TTL and transform function for cached entries.
 func NewNormalizer[K comparable, V any](ttl time.Duration, transform TransformFunc[K, V]) *Normalizer[K, V] {
-	cache := ttlcache.New(ttlcache.Options[K, V]{}.
-		SetDefaultTTL(ttl))
+	cache := ttlcache.New[K, V](
+		ttlcache.SetDefaultTTL(ttl))
 	return &Normalizer[K, V]{
 		cache:     cache,
 		transform: transform,


### PR DESCRIPTION
## Description

Replaces `github.com/autobrr/autobrr/pkg/ttlcache` with `github.com/autobrr/go-cache/ttlcache` v1.0.0-rc1. The autobrr copy predates the fixes for the `Set`-vs-expiry deadlock, the `Get`-refresh clobber that can resurrect a closed `*sql.Stmt` into the cache, half-empty `GetKeys` results, and panics on `Set`/`Get` after `Close`.

The statement caches now use `GetOrSet`, so the loser of a prepare race closes its own statement instead of leaking it driver-side. `Close` is idempotent in the new package, so the `closedCaches` guard is gone. `getOptimisticUpdates` iterates `All()` instead of `GetKeys` plus `Get`, so reading the optimistic updates no longer slides their 30s TTL; before, they never expired while the UI polled.

The autobrr dependency stays for `pkg/sharedhttp`.

## How has this been tested?

`TestGetStmtConcurrentMissSharesOneStatement` fails with the old `Set` path (32 goroutines get different `*sql.Stmt` pointers) and passes with `GetOrSet`. Booted the binary from a fresh config, created a user, and sent 30 concurrent logins: no panics, no `sql: statement is closed`, clean shutdown.

## Performance

The swap touches every cache `Get`/`Set` on hot paths (release parser, normalizer, torrent response cache, statement caches). Measured `Parser.Parse` on a warm cache of 1000 names, `go test -bench ParseCacheHit -count 6` without `-race`, merge-base `b308f7ce` vs `fe6d516c`, 16 threads:

| Benchmark | base (sec/op) | head (sec/op) | delta |
|---|---|---|---|
| ParseCacheHit-16 | 162.6n ± 34% | 121.0n ± 2% | -25.55% (p=0.002, n=6) |
| ParseCacheHitParallel-16 | 59.43n ± 1% | 37.35n ± 28% | -37.16% (p=0.002, n=6) |

0 B/op and 0 allocs/op on both. Cache hits are faster; the new `Get` checks the expiry under a read lock and only takes the write lock when the item needs a refresh, which is batched to the timer resolution. Deallocation callbacks now run outside the cache lock, so a statement `Close` no longer stalls other readers.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL
- [x] I completed the [mandatory performance checks](https://github.com/autobrr/qui/blob/develop/AGENTS.md#mandatory-performance-checks) and recorded the outcome in Performance



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrency handling for database statement caching, ensuring simultaneous requests share a single prepared statement.
  * Preserved existing cache expiration behavior across torrent management, cross-seeding, release parsing, and string normalization features.

* **Refactor**
  * Standardized internal caching on a shared cache implementation without changing user-visible cache behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->