### PR TITLE
ci(test): cache the embedded Postgres binary

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,13 @@ jobs:
       - name: Create placeholder web dist for embed
         run: mkdir -p web/dist && touch web/dist/.gitkeep
 
+      # Maven Central intermittently refuses runner downloads of the Postgres binary.
+      - name: Cache embedded Postgres binary
+        uses: actions/cache@v6.1.0
+        with:
+          path: ~/.cache/qui/embedded-postgres/*/*/archives
+          key: embedded-postgres-${{ runner.os }}-${{ hashFiles('go.mod', 'internal/testutil/postgres/main.go') }}
+
       - name: Run tests (Postgres integration)
         run: make test-postgres
 


### PR DESCRIPTION
## Description

Caches the embedded Postgres binary archive on the test-postgres runner so CI downloads it from Maven Central once per version. Maven Central intermittently refuses runner downloads and the launcher reports that as `no version found matching 17.5.0`, which failed #2642 twice in one hour while develop passed.

## Performance

No runtime code changes. CI-only.

## Checklist

- [x] My PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (it becomes the squashed commit message)
- [ ] If this changes the database schema, I have added migrations for both SQLite and PostgreSQL
- [x] I completed the [mandatory performance checks](https://github.com/autobrr/qui/blob/develop/AGENTS.md#mandatory-performance-checks) and recorded the outcome in Performance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated test setup efficiency by caching the embedded PostgreSQL binary between workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->